### PR TITLE
test annotated examples in markdown docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 tests/test-root
+zq-sample-data
 zql/deps/

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,17 @@ fmt:
 		exit 1; \
 	fi
 
+SAMPLEDATA:=zq-sample-data/README.md
+
+$(SAMPLEDATA):
+	git clone --depth=1 https://github.com/brimsec/zq-sample-data $(@D)
+
+sampledata: $(SAMPLEDATA)
+
 test-unit:
 	@go test -short ./...
 
-test-system: build
+test-system: build $(SAMPLEDATA)
 	@go test -v -tags=system ./tests -args PATH=$(shell pwd)/dist
 
 build:
@@ -41,4 +48,4 @@ create-release-assets:
 clean:
 	@rm -rf dist
 
-.PHONY: vet fmt test-unit test-system build install create-release-assets clean
+.PHONY: vet fmt sampledata test-unit test-system build install create-release-assets clean

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mccanne/joe v0.0.0-20181124064909-25770742c256
 	github.com/peterh/liner v1.1.0
 	github.com/stretchr/testify v1.4.0
+	github.com/yuin/goldmark v1.1.22
 	go.uber.org/zap v1.12.0
 	golang.org/x/text v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/yuin/goldmark v1.1.22 h1:0e0f6Zee9SAQ5yOZGNMWaOxqVvcc/9/kUWu/Kl91Jk8=
+github.com/yuin/goldmark v1.1.22/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.uber.org/atomic v1.5.0 h1:OI5t8sDa1Or+q8AeE+yKeB/SDYioSHAgcVljj9JIETY=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/multierr v1.3.0 h1:sFPn2GLc3poCkfrpIXGhBD2X0CMIo4Q/zSULXrj/+uc=

--- a/tests/path.go
+++ b/tests/path.go
@@ -1,0 +1,46 @@
+package tests
+
+import (
+	"path/filepath"
+)
+
+/*
+RepoAbsPath returns the absolute path of the repository. If a different package
+uses this, this function may return the wrong result. This is based on verbiage
+in "go help testflag":
+
+	When 'go test' runs a test binary, it does so from within the
+	corresponding package's source code directory.
+*/
+func RepoAbsPath() (string, error) {
+	// This file is one-deep, so we can return a directory that is one up
+	// from this file. This is immune from assumed values of os.Getwd().
+	return filepath.Abs("..")
+}
+
+// DistAbsPath returns the absolute path of the dist/ subdirectory.
+func DistAbsPath() (string, error) {
+	repo, err := RepoAbsPath()
+	if err != nil {
+		return repo, err
+	}
+	return filepath.Join(repo, "dist"), nil
+}
+
+// ZQAbsPath returns the absolute path of the zq binary in dist/.
+func ZQAbsPath() (string, error) {
+	distdir, err := DistAbsPath()
+	if err != nil {
+		return distdir, err
+	}
+	return filepath.Join(distdir, "zq"), nil
+}
+
+// ZQSampleDataAbsPath returns the absolute path of zq-sample-data.
+func ZQSampleDataAbsPath() (string, error) {
+	repo, err := RepoAbsPath()
+	if err != nil {
+		return repo, err
+	}
+	return filepath.Join(repo, "zq-sample-data"), nil
+}

--- a/tests/path_test.go
+++ b/tests/path_test.go
@@ -1,0 +1,17 @@
+package tests
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepoAbsPathLocation(t *testing.T) {
+	t.Parallel()
+	dir, err := RepoAbsPath()
+	require.Equal(t, nil, err)
+	f := filepath.Join(dir, "tests", "path.go")
+	assert.FileExists(t, f, "%s not in expected repo path pkg/test/path.go", f)
+}

--- a/tests/system_test.go
+++ b/tests/system_test.go
@@ -4,6 +4,7 @@ package tests
 
 import (
 	"errors"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -85,6 +86,22 @@ func TestFormats(t *testing.T) {
 			results, err := cmd.Run(zqpath)
 			require.NoError(t, err)
 			assert.Exactly(t, cmd.Expected, results, "Wrong command results")
+		})
+	}
+}
+
+func TestMarkdownExamples(t *testing.T) {
+	t.Parallel()
+	alltests, err := ZQExampleTestCases()
+	require.Equal(t, nil, err, "error loading test cases: %v", err)
+	for _, exampletest := range alltests {
+		exampletest := exampletest
+		t.Run(exampletest.Name, func(t *testing.T) {
+			t.Parallel()
+			c := exec.Command(exampletest.Command[0], exampletest.Command[1:]...)
+			cmdOutput, err := c.CombinedOutput()
+			require.Equal(t, nil, err, "error running command %v: %v", exampletest.Command, err)
+			assert.Equal(t, exampletest.Expected, string(cmdOutput), "output mismatch with command %v", exampletest.Command)
 		})
 	}
 }

--- a/tests/zq_example.go
+++ b/tests/zq_example.go
@@ -1,0 +1,305 @@
+package tests
+
+/*
+Find valid ZQ examples in markdown, run them against
+https://github.com/brimsec/zq-sample-data/zeek-default, and compare results in
+docs with results produced.
+
+In separate patches:
+- Deal with examples that need head
+- Find files as opposed to hard-coding them
+
+Use markers in markdown fenced code blocks to denote either a zq command or
+output from zq. Use is like:
+
+```zq-command
+zq "* | count()
+```
+```zq-output
+1234
+```
+
+This is in compliance with https://spec.commonmark.org/0.29/#example-113
+
+Doc authors MUST pair off each command and output in their own fenced code blocks.
+
+A zq-command code block MUST be one line after the leading line, which includes
+the info string. A zq-command MUST start with "zq". A zq-command MUST quote the
+full zql with single quotes. The zql MAY contain double quotes, but it MUST NOT
+contain single quotes.
+
+Examples:
+
+zql '* | count()' *.log.gz  # ok
+zql  * | count()  *.log.gz  # not ok
+zql "* | count()" *.log.gz  # not ok
+
+zql 'field="value"   | count()' *.log.gz  # ok
+zql 'field=\'value\' | count()' *.log.gz  # not ok
+zql 'field='value'   | count()' *.log.gz  # not ok
+zql "field=\"value\" | count()" *.log.gz  # not ok
+
+A zq-command MUST reference one or more files or globs, expanded at
+zq-sample-data/zeek-default.
+
+Examples:
+
+zql '* | count()' *.log.gz                # ok
+zql '* | count()' conn.log.gz             # ok
+zql '* | count()' conn.log.gz http.log.gz # ok
+zql '* | count()' c*.log.gz d*.log.gz     # ok
+zql '* | count()'                         # not ok
+
+A zq-command MAY contain a sh-compliant comment string (denoted by '#') on the
+line. Everything including and after the first # is stripped away.
+
+A zq-output fenced code block MAY be multiple lines. zq-output MUST be verbatim
+from the actual zq output.
+
+TODO: Support doc authors' desire to request and receive head(1) semantics
+without including head as a proc. Related, also support ellipsis on the last
+line to allow a doc author to convey continuation of records not shown. The
+CommonMark spec allows this. Github supports the CommonMark spec, and goldmark
+passes all CommonMark tests.
+
+Proposed syntax Example:
+
+```zq-command head:10
+zq -f table "* | count() by query" dns.log.gz
+```
+```zq-output
+QUERY                                                     COUNT
+-                                                         2
+goo                                                       20
+t.co                                                      8
+tmsc                                                      70
+da.gd                                                     4
+local                                                     12
+bit.ly                                                    10
+goo.gl                                                    4
+(empty)                                                   12
+...
+```
+... and the result still be correct. There are actually over 1000 lines when
+actually running this command.
+
+See https://gist.github.com/mikesbrown/f77cb939a43f80f2e019afba212c8c05 for how
+Github shows these.
+*/
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+type ZQExampleBlockType string
+
+const (
+	ZQCommand ZQExampleBlockType = "zq-command"
+	ZQOutput  ZQExampleBlockType = "zq-output"
+)
+
+// ZQExamplePair holds a ZQ example as found in markdown.
+type ZQExamplePair struct {
+	command *ast.FencedCodeBlock
+	output  *ast.FencedCodeBlock
+}
+
+// ZQExampleTest holds a ZQ example as a testcase found from mardown, derived
+// from a ZQExamplePair.
+type ZQExampleTest struct {
+	Name     string
+	Command  []string
+	Expected string
+}
+
+// CollectExamples returns a zq-command / zq-output pairs from a single
+// markdown source after parsing it as a goldmark AST.
+func CollectExamples(node ast.Node, source []byte) ([]ZQExamplePair, error) {
+	var examples []ZQExamplePair
+	var command *ast.FencedCodeBlock
+
+	err := ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		// Walk() calls its walker func twice. Once when entering and
+		// once before exiting, after walking any children. We need
+		// only do this processing once.
+		if !entering || n == nil || n.Kind() != ast.KindFencedCodeBlock {
+			return ast.WalkContinue, nil
+		}
+
+		fcb, ok := n.(*ast.FencedCodeBlock)
+		if !ok {
+			return ast.WalkStop,
+				fmt.Errorf("likely goldmark bug: Kind() reports a " +
+					"FencedCodeBlock, but the type assertion failed")
+		}
+		bt := ZQExampleBlockType(fcb.Language(source))
+		switch bt {
+		case ZQCommand:
+			if command != nil {
+				return ast.WalkStop,
+					fmt.Errorf("subsequent %s after another %s", bt, ZQCommand)
+			}
+			command = fcb
+		case ZQOutput:
+			if command == nil {
+				return ast.WalkStop,
+					fmt.Errorf("%s without a preceeding %s", bt, ZQCommand)
+			}
+			examples = append(examples, ZQExamplePair{command, fcb})
+			command = nil
+			// A fenced code block need not specify an info string, or it
+			// could be arbitrary. The default case is to ignore everything
+			// else.
+		}
+		return ast.WalkContinue, nil
+	})
+
+	if command != nil && err == nil {
+		err = fmt.Errorf("%s without a following %s", ZQCommand, ZQOutput)
+	}
+	return examples, err
+}
+
+// BlockString returns the text of a ast.FencedCodeBlock as a string.
+func BlockString(fcb *ast.FencedCodeBlock, source []byte) string {
+	var b strings.Builder
+	for i := 0; i < fcb.Lines().Len(); i++ {
+		line := fcb.Lines().At(i)
+		b.Write(line.Value(source))
+	}
+	return b.String()
+}
+
+// QualifyCommand translates a zq-command example to a runnable command,
+// including abspath to zq binary and globs turned into absolute file paths.
+func QualifyCommand(command string) ([]string, error) {
+	command = strings.TrimSpace(command)
+	command = strings.Split(command, "#")[0]
+
+	pieces := strings.Split(command, "'")
+	if len(pieces) != 3 {
+		return nil, fmt.Errorf("could not split zq command 3 tokens: %s", command)
+	}
+
+	command_and_flags := strings.Split(strings.TrimSpace(pieces[0]), " ")
+	if command_and_flags[0] != "zq" {
+		return nil, fmt.Errorf("command does not start with zq: %s", command)
+	}
+	// Nice, but this makes unit testing more complicated.
+	zq, err := ZQAbsPath()
+	if err != nil {
+		return nil, err
+	}
+	command_and_flags[0] = zq
+
+	zql := strings.TrimSpace(pieces[1])
+
+	var fileargs []string
+	sampledata, err := ZQSampleDataAbsPath()
+	if err != nil {
+		return nil, err
+	}
+	for _, relglobarg := range strings.Split(strings.TrimSpace(pieces[2]), " ") {
+		files, err := filepath.Glob(filepath.Join(sampledata, "zeek-default", relglobarg))
+		if err != nil {
+			return nil, err
+		}
+		fileargs = append(fileargs, files...)
+	}
+
+	finalized := command_and_flags
+	finalized = append(finalized, zql)
+	finalized = append(finalized, fileargs...)
+	return finalized, nil
+}
+
+// TestcasesFromFile returns ZQ example test cases from ZQ example pairs found
+// in a file.
+func TestcasesFromFile(filename string) ([]ZQExampleTest, error) {
+	var tests []ZQExampleTest
+	var examples []ZQExamplePair
+	absfilename, err := filepath.Abs(filename)
+	if err != nil {
+		return nil, err
+	}
+	repopath, err := RepoAbsPath()
+	if err != nil {
+		return nil, err
+	}
+	source, err := ioutil.ReadFile(absfilename)
+	if err != nil {
+		return nil, err
+	}
+	reader := text.NewReader(source)
+	parser := goldmark.DefaultParser()
+	doc := parser.Parse(reader)
+	examples, err = CollectExamples(doc, source)
+	if err != nil {
+		return nil, err
+	}
+	for i, example := range examples {
+		// Convert strings like
+		// /home/user/zql/docs/processors/README.md to
+		// /zql/docs/processors/README.md . RepoAbsPath() does not
+		// include a trailing filepath.Separator in its return.
+		testname := strings.TrimPrefix(absfilename, repopath)
+		// Now convert strings like /zql/docs/processors/README.md to
+		// zql/docs/processors/README.md1 go test will call such a test
+		// something like
+		// TestMarkdownExamples/zql/docs/processors/README.md1
+		testname = strings.TrimPrefix(testname, string(filepath.Separator)) + strconv.Itoa(i+1)
+
+		command, err := QualifyCommand(BlockString(example.command, source))
+		if err != nil {
+			return tests, err
+		}
+
+		output := strings.TrimSuffix(BlockString(example.output, source), "...\n")
+
+		tests = append(tests, ZQExampleTest{testname, command, output})
+	}
+	return tests, nil
+}
+
+// DocMarkdownFiles returns markdown files to inspect.
+func DocMarkdownFiles() ([]string, error) {
+	// This needs to find markdown files in the repo. Right now we just
+	// declare them directly.
+	files := []string{
+		"zql/docs/processors/README.md",
+		"zql/docs/search-syntax/README.md",
+	}
+	repopath, err := RepoAbsPath()
+	if err != nil {
+		return nil, err
+	}
+	for i, file := range files {
+		files[i] = filepath.Join(repopath, file)
+	}
+	return files, nil
+}
+
+// ZQExampleTestCases returns all test cases derived from doc examples.
+func ZQExampleTestCases() ([]ZQExampleTest, error) {
+	var alltests []ZQExampleTest
+	files, err := DocMarkdownFiles()
+	if err != nil {
+		return nil, err
+	}
+	for _, filename := range files {
+		tests, err := TestcasesFromFile(filename)
+		if err != nil {
+			return nil, err
+		}
+		alltests = append(alltests, tests...)
+	}
+	return alltests, nil
+}

--- a/tests/zq_example_test.go
+++ b/tests/zq_example_test.go
@@ -1,0 +1,91 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/text"
+)
+
+type markdownunittest struct {
+	name     string
+	markdown string
+	strerror string
+	items    int
+}
+
+func TestCollectExamples(t *testing.T) {
+	t.Parallel()
+	tests := []markdownunittest{
+		markdownunittest{
+			name: "zq-command only",
+			markdown: `
+~~~zq-command only
+1234
+~~~
+~~~
+other code block
+~~~
+`,
+			strerror: "zq-command without a following zq-output"},
+		markdownunittest{
+			name: "zq-output only",
+			markdown: `
+~~~zq-output only
+1234
+~~~
+~~~
+other code block
+~~~
+`,
+			strerror: "zq-output without a preceeding zq-command"},
+		markdownunittest{
+			name: "two commands",
+			markdown: `
+~~~zq-command 1
+block 1
+~~~
+~~~zq-command 2
+block 2
+~~~
+~~~zq-output 2
+block 3
+~~~
+`,
+			strerror: "subsequent zq-command after another zq-command"},
+		markdownunittest{
+			name: "two items",
+			markdown: `
+~~~zq-command 1
+block 1
+~~~
+~~~zq-output 1
+block 2
+~~~
+~~~zq-command 2
+block 3
+~~~
+~~~zq-output 2
+block 4
+~~~
+`,
+			items: 2},
+	}
+	for _, testcase := range tests {
+		testcase := testcase
+		t.Run(testcase.name, func(t *testing.T) {
+			source := []byte(testcase.markdown)
+			reader := text.NewReader(source)
+			parser := goldmark.DefaultParser()
+			doc := parser.Parse(reader)
+			examples, err := CollectExamples(doc, source)
+			if testcase.strerror != "" {
+				assert.EqualError(t, err, testcase.strerror)
+			}
+			if testcase.items != 0 {
+				assert.Equal(t, len(examples), testcase.items)
+			}
+		})
+	}
+}

--- a/zql/docs/processors/README.md
+++ b/zql/docs/processors/README.md
@@ -73,12 +73,12 @@ TS                UID
 
 An alternative syntax for our [`and` operator example](#../search-syntax/README.md#and):
 
-```
-zq -f table '* | filter www.*cdn*.com _path=ssl' *.log
+```zq-command
+zq -f table '* | filter www.*cdn*.com _path=ssl' *.log.gz
 ```
 
 #### Output:
-```
+```zq-output
 _PATH TS                UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H    ID.RESP_P VERSION CIPHER                                CURVE     SERVER_NAME       RESUMED LAST_ALERT NEXT_PROTOCOL ESTABLISHED CERT_CHAIN_FUIDS                                                            CLIENT_CERT_CHAIN_FUIDS SUBJECT            ISSUER                                  CLIENT_SUBJECT CLIENT_ISSUER VALIDATION_STATUS
 ssl   1521912180.244457 CUG0fiQAzL4rNWxai  10.47.2.100 36150     52.85.83.228 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 secp256r1 www.herokucdn.com F       -          h2            T           FXKmyTbr7HlvyL1h8,FADhCTvkq1ILFnD3j,FoVjYR16c3UIuXj4xk,FmiRYe1P53KOolQeVi   (empty)                 CN=*.herokucdn.com CN=Amazon,OU=Server CA 1B,O=Amazon,C=US -              -             ok
 ssl   1521912240.189735 CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85.83.215 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 secp256r1 www.herokucdn.com F       -          h2            T           FuW2cZ3leE606wXSia,Fu5kzi1BUwnF0bSCsd,FyTViI32zPvCmNXgSi,FwV6ff3JGj4NZcVPE4 (empty)                 CN=*.herokucdn.com CN=Amazon,OU=Server CA 1B,O=Amazon,C=US -              -             ok
@@ -100,26 +100,26 @@ ssl   1521912240.189735 CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85.83.215 44
 
 To see the first `dns` event:
 
-```
-zq -f table '* | head' dns.log
+```zq-command
+zq -f table '* | head' dns.log.gz
 ```
 
 #### Output:
-```
-_PATH TS                UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY          QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                        TTLS                     REJECTED
-dns   1521911720.865716 C2zK5f13SbCtKcyiW5 10.47.1.100 41772     10.0.0.100 53        udp   36329    0.000870 ise.wrccdc.org 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 ise.wrccdc.cpp.edu,134.71.3.16 2230.000000,41830.000000 F
+```zq-output
+_PATH TS                UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT     QUERY          QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                        TTLS       REJECTED
+dns   1521911720.865716 C2zK5f13SbCtKcyiW5 10.47.1.100 41772     10.0.0.100 53        udp   36329    0.00087 ise.wrccdc.org 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 ise.wrccdc.cpp.edu,134.71.3.16 2230,41830 F
 ```
 
 #### Example #2:
 
 To see the first five `conn` events with activity on port `80`:
 
-```
-zq -f table ':80 | head 5' conn.log
+```zq-command
+zq -f table ':80 | head 5' conn.log.gz
 ```
 
 #### Output:
-```
+```zq-output
 _PATH TS                UID                ID.ORIG_H     ID.ORIG_P ID.RESP_H   ID.RESP_P PROTO SERVICE DURATION ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY   ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  1521911720.602122 C4RZ6d4r5mJHlSYFI6 10.164.94.120 33299     10.47.3.200 80        tcp   -       0.003077 0          235        RSTO       -          -          0            ^dtfAR    4         208           4         678           -
 conn  1521911720.606178 CnKmhv4RfyAZ3fVc8b 10.164.94.120 36125     10.47.3.200 80        tcp   -       0.000002 0          0          RSTOS0     -          -          0            R         2         104           0         0             -
@@ -145,7 +145,7 @@ conn  1521911720.607695 CpjMvj2Cvj048u6bF1 10.164.94.120 39169     10.47.3.200 8
 To sort `x509` events by `certificate.subject`:
 
 ```
-zq -f table 'sort certificate.subject' x509.log
+zq -f table 'sort certificate.subject' x509.log.gz
 ```
 
 #### Output:
@@ -208,29 +208,20 @@ ID.ORIG_H                COUNT
 
 In this example we count the number of times each distinct username appears in `http` records, but deliberately put the unset username at the front of the list:
 
-```
-zq -f table "count() by username | sort -nulls first username" http.log
+```zq-command
+zq -f table 'count() by username | sort -nulls first username' http.log.gz
 ```
 
 #### Output:
-```
-USERNAME                     COUNT
--                            65428
-' or '1=1                    4
-(empty)                      4
--r nessus                    1
-3sadmin                      1
-6666                         4
-ADMIN                        1
-Admin                        1
-a a 1\x0anew 1234567890 root 1
-admin                        5
-comcomcom                    1
-piranha                      2
-q1ki9                        2
-root                         1
-servlet                      1
-support                      1
+```zq-output
+USERNAME     COUNT
+-            139175
+M32318       4854
+agloop       1
+cbucket      1
+mteavee      1
+poompaloompa 1
+wwonka       1
 ```
 
 
@@ -269,12 +260,12 @@ conn  1521911720.601314 CL31Wl4WQoDATEz5Z8 10.164.94.120  34261     10.47.8.208 
 
 To see the last `dns` event:
 
-```
-zq -f table '* | tail' dns.log
+```zq-command
+zq -f table '* | tail' dns.log.gz
 ```
 
 #### Output:
-```
+```zq-output
 _PATH TS                UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H ID.RESP_P PROTO TRANS_ID RTT QUERY           QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS TTLS REJECTED
 dns   1521912990.151237 C0ybvu4HG3yWv6H5cb 172.31.255.5 60878     10.0.0.1  53        udp   36243    -   talk.google.com 1      C_INTERNET  1     A          -     -          F  F  T  F  0 -       -    F
 ```
@@ -283,12 +274,12 @@ dns   1521912990.151237 C0ybvu4HG3yWv6H5cb 172.31.255.5 60878     10.0.0.1  53  
 
 To see the last five `conn` events with activity on port `80`:
 
-```
-zq -f table ':80 | tail 5' conn.log
+```zq-command
+zq -f table ':80 | tail 5' conn.log.gz
 ```
 
 #### Output:
-```
+```zq-output
 _PATH TS                UID                ID.ORIG_H      ID.ORIG_P ID.RESP_H    ID.RESP_P PROTO SERVICE DURATION  ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY    ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  1521912803.087149 CqPl942ft1MCpuNQgk 10.218.221.240 63812     10.47.2.20   80        tcp   -       15.607782 0          0          S1         -          -          0            Sh         2         88            10        440           -
 conn  1521912985.557756 CKCuBO2N2sY6m8qkv6 10.128.0.247   30549     10.47.22.65  80        tcp   http    0.006639  334        271        SF         -          -          0            ShADTftFa  10        1092          6         806           -

--- a/zql/docs/search-syntax/README.md
+++ b/zql/docs/search-syntax/README.md
@@ -229,13 +229,13 @@ Regexps are a detailed topic all their own. For details, reference the [document
 The search result can be narrowed to include only events that contain a certain value in a particular named field. For example, the following search will only match events containing the field called `uid` where it is set to the precise value `ChhAfsfyuz4n2hFMe`.
 
 #### Example:
-```
-zq -f table 'uid=ChhAfsfyuz4n2hFMe' *.log
+```zq-command
+zq -f table 'uid=ChhAfsfyuz4n2hFMe' *.log.gz
 ```
 
 #### Output:
 
-```
+```zq-output
 _PATH TS                UID               ID.ORIG_H    ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO SERVICE DURATION ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  1521912990.158539 ChhAfsfyuz4n2hFMe 10.239.34.35 56602     10.47.6.51 873       tcp   -       0.000004 0          0          S0         -          -          0            S       2         88            0         0             -
 ```
@@ -255,8 +255,10 @@ See the [Data Types](./data-types/README.md) page for more details on types and 
 An important distinction is that a "bare" field/value match is treated as an _exact_ match. If we take one of the results from our [bare word value match](#bare-word) example and attempt to look for `Widgits`, but only on a field named `certificate.subject`, there will be no matches. This is because `Widgits` only happens to appear as a _substring_ of `certificate.subject` fields in our sample data.
 
 #### Example:
+```zq-command
+zq -f table 'certificate.subject=Widgits' *.log.gz         # Produces no output
 ```
-zq -f table 'certificate.subject=Widgits' *.log         # Produces no output
+```zq-output
 ```
 
 To achieve this with a field/value match, we can use [glob wildcards](#glob-wildcards).
@@ -286,12 +288,12 @@ In addition to testing for equality via `=`, other common comparison operators `
 For example, the following search finds connections that have transferred many bytes.
 
 #### Example: 
-```
-zq -f table 'orig_bytes > 1000000' *.log
+```zq-command
+zq -f table 'orig_bytes > 1000000' *.log.gz
 ```
 
 #### Output:
-```
+```zq-output
 _PATH TS                UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H    ID.RESP_P PROTO SERVICE DURATION    ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY          ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  1521912315.208232 CVimRo24ubbKqFvNu7 172.30.255.1 11        10.128.0.207 0         icmp  -       100.721937  1647088    0          OTH        -          -          0            -                44136     2882896       0         0             -
 conn  1521911720.630818 CO0MhB2NCc08xWaly8 10.47.1.154  49814     134.71.3.17  443       tcp   -       1269.512465 1618740    12880888   OTH        -          -          0            ^dtADTatTtTtTtT  110169    7594230       111445    29872050      -
@@ -303,17 +305,17 @@ conn  1521912785.415532 Cy3R5w2pfv8oSEpa2j 10.47.8.19   49376     10.128.0.214 4
 The same operators also work when comparing characters in `string`-type values, such as this search that finds DNS requests that were issued for hostnames at the high end of the alphabet.
 
 #### Example:
-```
-zq -f table 'query > zippy' *.log
+```zq-command
+zq -f table 'query > zippy' *.log.gz
 ```
 
 #### Output:
-```
-_PATH TS                UID               ID.ORIG_H  ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY                                                    QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                                                                TTLS                            REJECTED
-dns   1521912609.841740 Csx7ymPvWeqIOHPi6 10.47.1.1  59144     10.10.1.1  53        udp   53970    0.001694 zn_9nquvazst1xipkt-cbs.siteintercept.qualtrics.com       1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                                                0.000000                        F
-dns   1521912609.841742 Csx7ymPvWeqIOHPi6 10.47.1.1  59144     10.10.1.1  53        udp   53970    0.001697 zn_9nquvazst1xipkt-cbs.siteintercept.qualtrics.com       1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                                                0.000000                        F
-dns   1521912892.637234 CN9X7Y36SH6faoh8t 10.47.8.10 58340     10.0.0.100 53        udp   43239    0.019491 zn_0pxrmhobblncaad-hpsupport.siteintercept.qualtrics.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 cloud.qualtrics.com.edgekey.net,e3672.ksd.akamaiedge.net,23.55.215.198 3600.000000,17.000000,20.000000 F
-dns   1521912892.637238 CN9X7Y36SH6faoh8t 10.47.8.10 58340     10.0.0.100 53        udp   43239    0.019493 zn_0pxrmhobblncaad-hpsupport.siteintercept.qualtrics.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 cloud.qualtrics.com.edgekey.net,e3672.ksd.akamaiedge.net,23.55.215.198 3600.000000,17.000000,20.000000 F
+```zq-output
+_PATH TS                UID               ID.ORIG_H  ID.ORIG_P ID.RESP_H  ID.RESP_P PROTO TRANS_ID RTT      QUERY                                                    QCLASS QCLASS_NAME QTYPE QTYPE_NAME RCODE RCODE_NAME AA TC RD RA Z ANSWERS                                                                TTLS       REJECTED
+dns   1521912609.841740 Csx7ymPvWeqIOHPi6 10.47.1.1  59144     10.10.1.1  53        udp   53970    0.001694 zn_9nquvazst1xipkt-cbs.siteintercept.qualtrics.com       1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                                                0          F
+dns   1521912609.841742 Csx7ymPvWeqIOHPi6 10.47.1.1  59144     10.10.1.1  53        udp   53970    0.001697 zn_9nquvazst1xipkt-cbs.siteintercept.qualtrics.com       1      C_INTERNET  1     A          0     NOERROR    F  F  T  F  0 0.0.0.0                                                                0          F
+dns   1521912892.637234 CN9X7Y36SH6faoh8t 10.47.8.10 58340     10.0.0.100 53        udp   43239    0.019491 zn_0pxrmhobblncaad-hpsupport.siteintercept.qualtrics.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 cloud.qualtrics.com.edgekey.net,e3672.ksd.akamaiedge.net,23.55.215.198 3600,17,20 F
+dns   1521912892.637238 CN9X7Y36SH6faoh8t 10.47.8.10 58340     10.0.0.100 53        udp   43239    0.019493 zn_0pxrmhobblncaad-hpsupport.siteintercept.qualtrics.com 1      C_INTERNET  1     A          0     NOERROR    F  F  T  T  0 cloud.qualtrics.com.edgekey.net,e3672.ksd.akamaiedge.net,23.55.215.198 3600,17,20 F
 ```
 
 ### Wildcard Field Names
@@ -378,12 +380,12 @@ If you enter multiple [value match](#value-match) or [field/value match](#fieldv
 For example, when introducing [glob wildcard](#glob-wildcards), we performed a search for `www.*cdn*.com` that returned mostly `dns` events along with a couple `ssl` events. You could quickly isolate just the the SSL events by leveraging this implicit `and`.
 
 #### Example:
-```
-zq -f table 'www.*cdn*.com _path=ssl' *.log
+```zq-command
+zq -f table 'www.*cdn*.com _path=ssl' *.log.gz
 ```
 
 #### Output:
-```
+```zq-output
 _PATH TS                UID                ID.ORIG_H   ID.ORIG_P ID.RESP_H    ID.RESP_P VERSION CIPHER                                CURVE     SERVER_NAME       RESUMED LAST_ALERT NEXT_PROTOCOL ESTABLISHED CERT_CHAIN_FUIDS                                                            CLIENT_CERT_CHAIN_FUIDS SUBJECT            ISSUER                                  CLIENT_SUBJECT CLIENT_ISSUER VALIDATION_STATUS
 ssl   1521912180.244457 CUG0fiQAzL4rNWxai  10.47.2.100 36150     52.85.83.228 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 secp256r1 www.herokucdn.com F       -          h2            T           FXKmyTbr7HlvyL1h8,FADhCTvkq1ILFnD3j,FoVjYR16c3UIuXj4xk,FmiRYe1P53KOolQeVi   (empty)                 CN=*.herokucdn.com CN=Amazon,OU=Server CA 1B,O=Amazon,C=US -              -             ok
 ssl   1521912240.189735 CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85.83.215 443       TLSv12  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 secp256r1 www.herokucdn.com F       -          h2            T           FuW2cZ3leE606wXSia,Fu5kzi1BUwnF0bSCsd,FyTViI32zPvCmNXgSi,FwV6ff3JGj4NZcVPE4 (empty)                 CN=*.herokucdn.com CN=Amazon,OU=Server CA 1B,O=Amazon,C=US -              -             ok


### PR DESCRIPTION
Add a test that combs markdown for annotated fenced code blocks. The doc examples use zq-sample-data. Add a new dependency on test-system that grabs the sample data if needed. The target is written in such a way that it performs a one-time download but does not update it after that.

Doc authors can annotate their examples like so. What was once:

~~~
```
zq -f table '* | count()' *.log
```
```
COUNT
1234
```
~~~

Can now be:
~~~
```zq-command
zq -f table '* | count()' *.log
```
```zq-output
COUNT
1234
```
~~~
This is based on the [CommonMark spec]( https://spec.commonmark.org/0.29/) which [Github uses](https://github.github.com/gfm/). The spec allows fenced code blocks to specify an [info string](https://github.github.com/gfm/#example-113). In practice this is used to denote the language. In our case we can parse markdown and look for such strings to denote zq examples.

[Goldmark](https://github.com/yuin/goldmark) was the most suitable package for parsing markdown, walking an AST, and finding fenced code blocks.

I've annotated all the examples that do not require record truncation.