### PR TITLE
Require aliases to be unique

### DIFF
--- a/tests/suite.go
+++ b/tests/suite.go
@@ -35,6 +35,7 @@ var internals = []test.Internal{
 	errors.TypeNull,
 	errors.EmptySetType,
 	errors.EmptyUnionType,
+	errors.RedefineAlias,
 	regexp.Internal,
 	filter.EscapedEqual,
 	filter.EscapedAsterisk,

--- a/tests/suite/errors/alias.go
+++ b/tests/suite/errors/alias.go
@@ -1,0 +1,23 @@
+package errors
+
+import (
+	"github.com/brimsec/zq/pkg/test"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+const inputRedefineAlias = `
+#alias=addr
+#0:record[orig_h:alias]
+0:[127.0.0.1;]
+#alias=count
+#1:record[count:alias]
+1:[25;]
+`
+
+var RedefineAlias = test.Internal{
+	Name:        "redefine alias",
+	Query:       "*",
+	InputFormat: "zng",
+	Input:       test.Trim(inputRedefineAlias),
+	ExpectedErr: resolver.ErrAliasExists,
+}

--- a/zio/bzngio/reader.go
+++ b/zio/bzngio/reader.go
@@ -236,7 +236,10 @@ func (r *Reader) readTypeAlias() error {
 	if err != nil {
 		return err
 	}
-	r.zctx.LookupTypeAlias(name, inner)
+	_, err = r.zctx.LookupTypeAlias(name, inner)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/zio/bzngio/writer.go
+++ b/zio/bzngio/writer.go
@@ -27,9 +27,13 @@ func (w *Writer) Write(r *zng.Record) error {
 	typ := w.encoder.Lookup(r.Type)
 	if typ == nil {
 		var b []byte
-		b, typ = w.encoder.Encode(w.buffer[:0], r.Type)
+		var err error
+		b, typ, err = w.encoder.Encode(w.buffer[:0], r.Type)
+		if err != nil {
+			return err
+		}
 		w.buffer = b
-		_, err := w.Writer.Write(b)
+		_, err = w.Writer.Write(b)
 		if err != nil {
 			return err
 		}

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -121,7 +121,10 @@ func (r *Reader) parseAliases(aliases []Alias) error {
 		if err != nil {
 			return fmt.Errorf("unknown type: \"%s\"", alias.Type)
 		}
-		r.zctx.LookupTypeAlias(alias.Name, typ)
+		_, err = r.zctx.LookupTypeAlias(alias.Name, typ)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -152,7 +152,10 @@ func (r *Reader) parseAlias(line []byte) error {
 	if err != nil {
 		return err
 	}
-	r.zctx.LookupTypeAlias(string(alias), typ)
+	_, err = r.zctx.LookupTypeAlias(string(alias), typ)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/zio/zngio/reader_test.go
+++ b/zio/zngio/reader_test.go
@@ -73,14 +73,6 @@ func TestAlias(t *testing.T) {
 0:[bro;127.0.0.1;]
 #1:record[foo:string,orig_h:addr]
 1:[bar;127.0.0.1;]`)
-
-	boomerang(t, "redefine-alias", `
-#alias=addr
-#0:record[orig_h:alias]
-0:[127.0.0.1;]
-#alias=count
-#1:record[count:alias]
-1:[25;]`)
 }
 
 func TestAliasErr(t *testing.T) {

--- a/zio/zson_test.go
+++ b/zio/zson_test.go
@@ -222,13 +222,6 @@ func TestAlias(t *testing.T) {
 #1:record[foo:string,resp_h:ip]
 1:[bro;127.0.0.1;]`
 
-	const redefine = `#alias=addr
-#0:record[orig_h:alias]
-0:[127.0.0.1;]
-#alias=count
-#1:record[count:alias]
-1:[25;]`
-
 	t.Run("Bzng", func(t *testing.T) {
 		t.Run("simple", func(t *testing.T) {
 			boomerang(t, simple)
@@ -238,9 +231,6 @@ func TestAlias(t *testing.T) {
 		})
 		t.Run("alias-in-different-records", func(t *testing.T) {
 			boomerang(t, multipleRecords)
-		})
-		t.Run("redefine", func(t *testing.T) {
-			boomerang(t, redefine)
 		})
 	})
 	t.Run("ZJSON", func(t *testing.T) {
@@ -252,9 +242,6 @@ func TestAlias(t *testing.T) {
 		})
 		t.Run("alias-in-different-records", func(t *testing.T) {
 			boomerangZJSON(t, multipleRecords)
-		})
-		t.Run("redefine", func(t *testing.T) {
-			boomerangZJSON(t, redefine)
 		})
 	})
 }

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -485,9 +485,8 @@ This form defines an alias mapping the identifier to the indicated type.
 `<type-name>` is an identifier with semantics as defined in Section 2.1.1.4.
 
 It is an error to define an alias that has the same name as a primitive type.
-
-If an alias appears that has the same name as a previously defined alias,
-then the new alias takes precedent for all subsequent values.
+It is also an error to redefine a previously defined alias with a
+type that differs from the original definition.
 
 ### 3.1.3 Application-specific Payload
 


### PR DESCRIPTION
Update the ZNG spec and the implementation to require that aliases be
unique.  The actual change is small but there's a bunch of churn in
propagating and checking for errors in code paths that previously either
couldn't fail or didn't check for errors.