### PR TITLE
fix bug in TestContextSerialization

### DIFF
--- a/zio/bzngio/types_test.go
+++ b/zio/bzngio/types_test.go
@@ -19,7 +19,7 @@ func TestContextSerialization(t *testing.T) {
 	newCtx := resolver.NewContext()
 	err := bzngio.ReadTypeContext(reader, newCtx)
 	require.NoError(t, err)
-	r1, err := newCtx.LookupByName("record[a:int,b:int]")
+	r1, err := ctx.LookupByName("record[a:int,b:int]")
 	require.NoError(t, err)
 	r2, err := newCtx.LookupByName("record[a:int,b:int]")
 	require.NoError(t, err)


### PR DESCRIPTION
Test should make sure the before and after type IDs are consistent
rather than testing that two lookups in the after context give the
same ID.