### PR TITLE
create release assets for any v* tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,9 @@ jobs:
       with:
         go-version: '1.13'
     - uses: actions/checkout@v1
-    - name: run unit tests
-      run: make test-unit
-    - name: run system tests
-      run: make test-system
-    - name: create release assets
-      run: make create-release-assets
+    - run: make test-unit
+    - run: make test-system
+    - run: make create-release-assets
     - name: upload release assets
       uses: svenstaro/upload-release-action@1.1.0
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: release assets
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v1
+      with:
+        go-version: '1.13'
+    - uses: actions/checkout@v1
+    - name: run unit tests
+      run: make test-unit
+    - name: run system tests
+      run: make test-system
+    - name: create release assets
+      run: make create-release-assets
+    - name: upload release assets
+      uses: svenstaro/upload-release-action@1.1.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref }}
+        file: dist/release/*
+        file_glob: true
+        overwrite: true

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,19 @@ build:
 install:
 	@go install -ldflags='$(LDFLAGS)' ./cmd/...
 
+create-release-assets:
+	for os in darwin linux windows; do \
+		zqdir=zq-$(VERSION).$${os}-amd64 ; \
+		rm -rf dist/$${zqdir} ; \
+		mkdir -p dist/$${zqdir} ; \
+		GOOS=$${os} GOARCH=amd64 go build -ldflags='$(LDFLAGS)' -o dist/$${zqdir} ./cmd/... ; \
+	done
+	rm -rf dist/release && mkdir -p dist/release
+	cd dist && for d in zq-$(VERSION)* ; do \
+		zip -r release/$${d}.zip $${d} ; \
+	done
+
 clean:
 	@rm -rf dist
 
-.PHONY: vet test-unit test-system clean build
+.PHONY: vet fmt test-unit test-system build install create-release-assets clean


### PR DESCRIPTION
    When any tag matching a "v*" pattern is pushed to the repo, including
    when a Github release is created, this action will create per-platform
    zip files containing the binaries built from cmd/... . The zip files
    will be attached to the Github release as release assets.

    If the tag push was not due to a Release creation, this will create a
    Github release and attach the zip files as assets. I'm not using an
    action to explicitly create a release, as I didn't find anything yet
    that would automatically pull the release changes text from the
    changelog file; we can add that later.


The content of the zip files is a top level directory with the version name & platform OS and architecture:
```
$ unzip -t dist/release/zq-v0.1.0-3-gd3cda09-dirty.darwin-amd64.zip
Archive:  dist/release/zq-v0.1.0-3-gd3cda09-dirty.darwin-amd64.zip
    testing: zq-v0.1.0-3-gd3cda09-dirty.darwin-amd64/   OK
    testing: zq-v0.1.0-3-gd3cda09-dirty.darwin-amd64/zq   OK
    testing: zq-v0.1.0-3-gd3cda09-dirty.darwin-amd64/zqd   OK
```

Here's an example (and temporary) release from this action:

https://github.com/brimsec/zq/releases/tag/v0-asset-test