### PR TITLE
Avoid fetching zql parser build tools unnecessarily

### DIFF
--- a/zql/Makefile
+++ b/zql/Makefile
@@ -4,12 +4,13 @@ PEGJS = $(deps)/bin/pegjs
 PIGEON = $(deps)/bin/pigeon
 GOIMPORTS = $(deps)/bin/goimports
 
-PEGJS_VERSION = $(shell test -x $(PEGJS) && $(PEGJS) --version)
-PEGJS_EXPECTED = 0.10.0
-PIGEON_VERSION = $(shell test -d $(deps) && cd $(deps); go list -m github.com/mna/pigeon || echo "")
-PIGEON_EXPECTED = v1.0.1-20190520151103-9fec3898cef8
-GOIMPORTS_VERSION = $(shell test -d $(deps) && cd $(deps); go list -m golang.org/x/tools || echo "")
-GOIMPORTS_EXPECTED = v0.0.0-20200204192400-7124308813f3
+PEGJS_VERSION = 0.10.0
+PIGEON_VERSION = v1.0.1-0.20190520151103-9fec3898cef8
+GOIMPORTS_VERSION = v0.0.0-20200204192400-7124308813f3
+
+PEGJS_INSTALLED = $(shell test -x $(PEGJS) && $(PEGJS) --version)
+PIGEON_INSTALLED = $(shell test -d $(deps) && (cd $(deps); go list -m -f {{.Version}} github.com/mna/pigeon || echo ""))
+GOIMPORTS_INSTALLED = $(shell test -d $(deps) && (cd $(deps); go list -m -f {{.Version}} golang.org/x/tools || echo ""))
 
 all: zql.go zql.js
 
@@ -17,19 +18,20 @@ run: all
 	go run ./main
 
 $(PEGJS):
-ifeq (,$(findstring $(PEGJS_EXPECTED),$(PEGJS_VERSION)))
+ifneq ($(PEGJS_VERSION),$(PEGJS_INSTALLED))
 	mkdir -p $(deps)
-	npm install --global --prefix $(deps) pegjs@0.10.0
+	npm install --global --prefix $(deps) pegjs@$(PEGJS_VERSION)
 endif
 
 GODEPS :=
-ifeq (,$(findstring $(PIGEON_EXPECTED),$(PIGEON_VERSION)))
-  GODEPS += github.com/mna/pigeon@v1.0.1-0.20190520151103-9fec3898cef8
+ifneq ($(PIGEON_VERSION),$(PIGEON_INSTALLED))
+  GODEPS += github.com/mna/pigeon@$(PIGEON_VERSION)
 endif
-ifeq (,$(findstring $(GOIMPORTS_EXPECTED),$(GOIMPORTS_VERSION)))
-  GODEPS += golang.org/x/tools/cmd/goimports@v0.0.0-20200204192400-7124308813f3
+ifneq ($(GOIMPORTS_VERSION),$(GOIMPORTS_INSTALLED))
+  GODEPS += golang.org/x/tools/cmd/goimports@$(GOIMPORTS_VERSION)
 endif
 
+.PHONY: $(PIGEON) $(GOIMPORTS)
 $(PIGEON) $(GOIMPORTS):
 ifneq (,$(GODEPS))
 	mkdir -p $(deps)

--- a/zql/Makefile
+++ b/zql/Makefile
@@ -1,21 +1,53 @@
 deps = $(CURDIR)/deps
 
+PEGJS = $(deps)/bin/pegjs
+PIGEON = $(deps)/bin/pigeon
+GOIMPORTS = $(deps)/bin/goimports
+
+PEGJS_VERSION = $(shell test -x $(PEGJS) && $(PEGJS) --version)
+PEGJS_EXPECTED = 0.10.0
+PIGEON_VERSION = $(shell test -d $(deps) && cd $(deps); go list -m github.com/mna/pigeon || echo "")
+PIGEON_EXPECTED = v1.0.1-20190520151103-9fec3898cef8
+GOIMPORTS_VERSION = $(shell test -d $(deps) && cd $(deps); go list -m golang.org/x/tools || echo "")
+GOIMPORTS_EXPECTED = v0.0.0-20200204192400-7124308813f3
+
 all: zql.go zql.js
 
 run: all
 	go run ./main
 
-.PHONY: zql.go
-zql.go:
+$(PEGJS):
+ifeq (,$(findstring $(PEGJS_EXPECTED),$(PEGJS_VERSION)))
+	mkdir -p $(deps)
+	npm install --global --prefix $(deps) pegjs@0.10.0
+endif
+
+GODEPS :=
+ifeq (,$(findstring $(PIGEON_EXPECTED),$(PIGEON_VERSION)))
+  GODEPS += github.com/mna/pigeon@v1.0.1-0.20190520151103-9fec3898cef8
+endif
+ifeq (,$(findstring $(GOIMPORTS_EXPECTED),$(GOIMPORTS_VERSION)))
+  GODEPS += golang.org/x/tools/cmd/goimports@v0.0.0-20200204192400-7124308813f3
+endif
+
+$(PIGEON) $(GOIMPORTS):
+ifneq (,$(GODEPS))
 	mkdir -p $(deps)
 	echo 'module deps' > $(deps)/go.mod
-	cd $(deps) && GOBIN=$(deps)/bin go get \
-		github.com/mna/pigeon@v1.0.1-0.20190520151103-9fec3898cef8 \
-		golang.org/x/tools/cmd/goimports@v0.0.0-20200204192400-7124308813f3
-	cpp -DGO -E -P zql.peg | $(deps)/bin/pigeon -o $@
-	$(deps)/bin/goimports -w $@
+	cd $(deps) && GOBIN=$(deps)/bin go get $(GODEPS)
+endif
+
+#
+# The actual parsers depend on additional files
+# (parser-support.*, reglob, etc.).  Actually building the parsers is
+# pretty cheap so just do that every time rather than trying to track
+# all the proper dependencies.
+#
+.PHONY: zql.go
+zql.go: $(PIGEON) $(GOIMPORTS)
+	cpp -DGO -E -P zql.peg | $(PIGEON) -o $@
+	$(GOIMPORTS) -w $@
 
 .PHONY: zql.js
-zql.js:
-	npm install --global --prefix $(deps) pegjs@0.10.0
-	cpp -E -P zql.peg | $(deps)/bin/pegjs -o $@
+zql.js: $(PEGJS)
+	cpp -E -P zql.peg | $(PEGJS) -o $@


### PR DESCRIPTION
Check the versions of pegjs, pigeon, and goimports rather than calling
"go get" and "npm install" every time we run make in the zql directory.