### PR TITLE
introduce make test-heavy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ jobs:
       - run:
           name: System Tests
           command: 'make test-system'
+      - run:
+          name: Heavy Tests
+          command: 'make test-heavy'
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,11 @@ sampledata: $(SAMPLEDATA)
 test-unit:
 	@go test -short ./...
 
-test-system: build $(SAMPLEDATA)
+test-system: build
 	@go test -v -tags=system ./tests -args PATH=$(shell pwd)/dist
+
+test-heavy: build $(SAMPLEDATA)
+	@go test -v -tags=heavy ./tests
 
 build:
 	@mkdir -p dist

--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ create-release-assets:
 clean:
 	@rm -rf dist
 
-.PHONY: vet fmt sampledata test-unit test-system build install create-release-assets clean
+.PHONY: vet fmt sampledata test-unit test-system test-heavy build install create-release-assets clean

--- a/tests/heavy_test.go
+++ b/tests/heavy_test.go
@@ -1,0 +1,27 @@
+// +build heavy
+
+package tests
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkdownExamples(t *testing.T) {
+	t.Parallel()
+	alltests, err := ZQExampleTestCases()
+	require.Equal(t, nil, err, "error loading test cases: %v", err)
+	for _, exampletest := range alltests {
+		exampletest := exampletest
+		t.Run(exampletest.Name, func(t *testing.T) {
+			t.Parallel()
+			c := exec.Command(exampletest.Command[0], exampletest.Command[1:]...)
+			cmdOutput, err := c.CombinedOutput()
+			require.Equal(t, nil, err, "error running command %v: %v", exampletest.Command, err)
+			assert.Equal(t, exampletest.Expected, string(cmdOutput), "output mismatch with command %v", exampletest.Command)
+		})
+	}
+}

--- a/tests/system_test.go
+++ b/tests/system_test.go
@@ -4,7 +4,6 @@ package tests
 
 import (
 	"errors"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -86,22 +85,6 @@ func TestFormats(t *testing.T) {
 			results, err := cmd.Run(zqpath)
 			require.NoError(t, err)
 			assert.Exactly(t, cmd.Expected, results, "Wrong command results")
-		})
-	}
-}
-
-func TestMarkdownExamples(t *testing.T) {
-	t.Parallel()
-	alltests, err := ZQExampleTestCases()
-	require.Equal(t, nil, err, "error loading test cases: %v", err)
-	for _, exampletest := range alltests {
-		exampletest := exampletest
-		t.Run(exampletest.Name, func(t *testing.T) {
-			t.Parallel()
-			c := exec.Command(exampletest.Command[0], exampletest.Command[1:]...)
-			cmdOutput, err := c.CombinedOutput()
-			require.Equal(t, nil, err, "error running command %v: %v", exampletest.Command, err)
-			assert.Equal(t, exampletest.Expected, string(cmdOutput), "output mismatch with command %v", exampletest.Command)
 		})
 	}
 }


### PR DESCRIPTION
Move the dependence of zq-sample-data to its own target, `make test-heavy`. The name heavy is chosen to imply dependence on a larger dataset. There is other testing besides markdown verification that can use this.

A separate make target requires a separate CircleCI step.