### PR TITLE
condense main workflow into single job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,17 +36,6 @@ jobs:
       - run:
           name: Build
           command: 'make build'
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
-  system_test:
-    docker:
-      - image: circleci/golang:1.13-buster
-    steps:
-      - log_date
-      - attach_workspace:
-          at: .
       - run:
           name: System Tests
           command: 'make test-system'
@@ -59,6 +48,3 @@ workflows:
   main:
     jobs:
       - build
-      - system_test:
-          requires:
-            - build


### PR DESCRIPTION
Back in #14 when using btest it made sense to have a separate job, as a
different executor was needed. But since #87, when the executor was made
the same for both jobs, it no longer makes sense to have separate CI
jobs.

This removes a bit of complexity, the cost of job-to-job workspace
transfer, and 1 container initialization.