### PR TITLE
Perf comparison script should do a shallow clone of zq-sample-data

### DIFF
--- a/scripts/comparison-test.sh
+++ b/scripts/comparison-test.sh
@@ -11,7 +11,7 @@ DATA_REPO="https://github.com/brimsec/zq-sample-data.git"
 if [ -d "$DATA" ]; then
   (cd "$DATA"&& git pull) || exit 1
 else
-  git clone "$DATA_REPO"
+  git clone --depth=1 "$DATA_REPO"
 fi
 find "$DATA" -name \*.gz -exec gunzip -f {} \;
 ln -sfn zeek-default "$DATA/zeek"


### PR DESCRIPTION
@alfred-landrum made me hip to the fact that we were doing the `git clone --depth=1` in @mikesbrown's docs automation to deal with the bulky history there. That made me realize I should do the same in other contexts, such as this script that can be used to check current `zq` perf when working with the various formats.