### PR TITLE
Perf comparison script referenced from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,4 +54,4 @@ create-release-assets:
 clean:
 	@rm -rf dist
 
-.PHONY: vet fmt sampledata test-unit test-system test-heavy build install create-release-assets clean
+.PHONY: vet fmt sampledata test-unit test-system test-heavy perf-compare build install create-release-assets clean

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ test-system: build
 test-heavy: build $(SAMPLEDATA)
 	@go test -v -tags=heavy ./tests
 
+perf-compare: build $(SAMPLEDATA)
+	scripts/comparison-test.sh
+
 build:
 	@mkdir -p dist
 	@go build -ldflags='$(LDFLAGS)' -o dist ./cmd/...

--- a/performance/README.md
+++ b/performance/README.md
@@ -3,9 +3,8 @@
 The tables below provide a summary of simple operations and how `zq`
 performs at them relative to `zeek-cut` and `jq`. All operations were performed
 on a Google Cloud `n1-standard-8` VM (8 vCPUs, 30 GB memory) with the logs
-stored on a local SSD. The [`comparison-test.sh`](../scripts/comparison-test.sh)
-script (which uses the [zq-sample-data](https://github.com/brimsec/zq-sample-data))
-was used to generate the results.
+stored on a local SSD. The script executed via `make perf-compare` was used
+to generate the results.
 
 As there are many results to sift through, here's a few key summary take-aways:
 

--- a/performance/README.md
+++ b/performance/README.md
@@ -3,8 +3,7 @@
 The tables below provide a summary of simple operations and how `zq`
 performs at them relative to `zeek-cut` and `jq`. All operations were performed
 on a Google Cloud `n1-standard-8` VM (8 vCPUs, 30 GB memory) with the logs
-stored on a local SSD. The script executed via `make perf-compare` was used
-to generate the results.
+stored on a local SSD. `make perf-compare` was used to generate the results.
 
 As there are many results to sift through, here's a few key summary take-aways:
 

--- a/scripts/comparison-test.sh
+++ b/scripts/comparison-test.sh
@@ -6,14 +6,7 @@ set -eo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR" || exit 1
 
-DATA="zq-sample-data"
-DATA_REPO="https://github.com/brimsec/zq-sample-data.git"
-if [ -d "$DATA" ]; then
-  (cd "$DATA"&& git pull) || exit 1
-else
-  git clone --depth=1 "$DATA_REPO"
-fi
-find "$DATA" -name \*.gz -exec gunzip -f {} \;
+DATA="../zq-sample-data"
 ln -sfn zeek-default "$DATA/zeek"
 ln -sfn zeek-ndjson "$DATA/ndjson"
 


### PR DESCRIPTION
@mikesbrown correctly pointed out in https://github.com/brimsec/zq/pull/334 that the automated doc example checker and my perf comparison script were each cloning their own copy of zq-sample-data. Here I've taken a shot at removing the redundancy by making the the perf comparison script a Makefile target and having it work off the same single copy of the sample data.

While I was in there, I noticed that the perf comparison script hadn't been touched in the time since we started supporting GZIP'ed input files, so I've updated that to simplify.

I did retest this works on both macOS and Linux, but there's a catch: There's a known open bug right now with BZNG input format that makes this script fail to run to completion. I've made a note-to-self to re-run this when that bug is fixed, at which point I'll put up a PR with updated perf numbers.