### PR TITLE
Remove CompareUint64()

### DIFF
--- a/zx/compare.go
+++ b/zx/compare.go
@@ -151,46 +151,6 @@ func CompareInt64(op string, pattern int64) (Predicate, error) {
 	}, nil
 }
 
-func CompareUint64(op string, pattern uint64) (Predicate, error) {
-	CompareUint, ok1 := compareUint[op]
-	CompareFloat, ok2 := compareFloat[op]
-	if !ok1 || !ok2 {
-		return nil, fmt.Errorf("unknown int comparator: %s", op)
-	}
-	// many different zeek data types can be compared with integers
-	return func(val zng.Value) bool {
-		zv := val.Bytes
-		switch val.Type.ID() {
-		case zng.IdInt16, zng.IdInt32, zng.IdInt64:
-			v, err := zng.DecodeInt(zv)
-			if err == nil && v > 0 {
-				return CompareUint(uint64(v), pattern)
-			}
-		case zng.IdUint16, zng.IdUint32, zng.IdUint64:
-			v, err := zng.DecodeUint(zv)
-			if err == nil {
-				return CompareUint(v, pattern)
-			}
-		case zng.IdFloat64:
-			v, err := zng.DecodeFloat64(zv)
-			if err == nil {
-				return CompareFloat(v, float64(pattern))
-			}
-		case zng.IdTime:
-			ts, err := zng.DecodeTime(zv)
-			if err == nil {
-				return CompareUint(uint64(ts), pattern*1e9)
-			}
-		case zng.IdDuration:
-			v, err := zng.DecodeInt(zv)
-			if err == nil {
-				return CompareUint(uint64(v), pattern*1e9)
-			}
-		}
-		return false
-	}, nil
-}
-
 func CompareContainerLen(op string, len int64) (Predicate, error) {
 	compare, ok := compareInt[op]
 	if !ok {
@@ -513,7 +473,5 @@ func Comparison(op string, literal ast.Literal) (Predicate, error) {
 		return ComparePort(op, uint32(v))
 	case int64:
 		return CompareInt64(op, v)
-	case uint64:
-		return CompareUint64(op, v)
 	}
 }


### PR DESCRIPTION
This was erroneously introduced in #325.  The CompareFoo methods are
called on the type of the literal that appears on the RHS of a filter
with a comparison operator but there's no way to create an unsigned
literal in zql so this code is all unreachable.