### PR TITLE
Clarify sorting on aliases

### DIFF
--- a/expr/sort.go
+++ b/expr/sort.go
@@ -57,7 +57,7 @@ func NewSortFn(nullsMax bool, fields ...FieldExprResolver) SortFn {
 
 			// If values are of different types, just compare
 			// the native representation of the type
-			if !zng.SameType(a.Type, b.Type) {
+			if a.Type.ID() != b.Type.ID() {
 				return bytes.Compare([]byte(a.Type.String()), []byte(b.Type.String()))
 			}
 
@@ -156,12 +156,12 @@ func lookupSorter(typ zng.Type) comparefn {
 			}
 		}
 	}
-	switch typ {
+	switch typ.ID() {
 	default:
 		return func(a, b zcode.Bytes) int {
 			return bytes.Compare(a, b)
 		}
-	case zng.TypeBool:
+	case zng.IdBool:
 		return func(a, b zcode.Bytes) int {
 			va, err := zng.DecodeBool(a)
 			if err != nil {
@@ -180,12 +180,12 @@ func lookupSorter(typ zng.Type) comparefn {
 			return -1
 		}
 
-	case zng.TypeString:
+	case zng.IdString:
 		return func(a, b zcode.Bytes) int {
 			return bytes.Compare(a, b)
 		}
 
-	case zng.TypeInt16, zng.TypeInt32, zng.TypeInt64:
+	case zng.IdInt16, zng.IdInt32, zng.IdInt64:
 		return func(a, b zcode.Bytes) int {
 			va, err := zng.DecodeInt(a)
 			if err != nil {
@@ -203,7 +203,7 @@ func lookupSorter(typ zng.Type) comparefn {
 			return 0
 		}
 
-	case zng.TypeUint16, zng.TypeUint32, zng.TypeUint64:
+	case zng.IdUint16, zng.IdUint32, zng.IdUint64:
 		return func(a, b zcode.Bytes) int {
 			va, err := zng.DecodeUint(a)
 			if err != nil {
@@ -225,7 +225,7 @@ func lookupSorter(typ zng.Type) comparefn {
 	// to docs but we've only encountered ints in data files.
 	// need to fix this.  XXX also we should break this sorts
 	// into the different types.
-	case zng.TypePort:
+	case zng.IdPort:
 		return func(a, b zcode.Bytes) int {
 			va, err := zng.DecodePort(a)
 			if err != nil {
@@ -243,7 +243,7 @@ func lookupSorter(typ zng.Type) comparefn {
 			return 0
 		}
 
-	case zng.TypeFloat64:
+	case zng.IdFloat64:
 		return func(a, b zcode.Bytes) int {
 			va, err := zng.DecodeFloat64(a)
 			if err != nil {
@@ -261,7 +261,7 @@ func lookupSorter(typ zng.Type) comparefn {
 			return 0
 		}
 
-	case zng.TypeTime:
+	case zng.IdTime:
 		return func(a, b zcode.Bytes) int {
 			va, err := zng.DecodeTime(a)
 			if err != nil {
@@ -279,7 +279,7 @@ func lookupSorter(typ zng.Type) comparefn {
 			return 0
 		}
 
-	case zng.TypeDuration:
+	case zng.IdDuration:
 		return func(a, b zcode.Bytes) int {
 			va, err := zng.DecodeDuration(a)
 			if err != nil {
@@ -297,7 +297,7 @@ func lookupSorter(typ zng.Type) comparefn {
 			return 0
 		}
 
-	case zng.TypeIP:
+	case zng.IdIP:
 		return func(a, b zcode.Bytes) int {
 			va, err := zng.DecodeIP(a)
 			if err != nil {

--- a/proc/sort_test.go
+++ b/proc/sort_test.go
@@ -128,20 +128,6 @@ const chooseOut3 = `
 4:[c;a;]
 `
 
-const sortAliasIn = `
-#0:record[host:ip]
-0:[127.0.0.2;]
-#ipaddr=ip
-#1:record[host:ipaddr]
-1:[127.0.0.1;]
-`
-
-const sortAliasOut = `
-#0:record[host:ip]
-0:[127.0.0.2;]
-0:[127.0.0.1;]
-`
-
 func TestSort(t *testing.T) {
 	// Test simple sorting of integers.
 	proc.TestOneProc(t, unsortedInts, ascendingInts, "sort foo")
@@ -169,9 +155,6 @@ func TestSort(t *testing.T) {
 	// Test sorting on multiple fields.
 	proc.TestOneProc(t, multiIn, foobarOut, "sort foo, bar")
 	proc.TestOneProc(t, multiIn, barfooOut, "sort bar, foo")
-
-	// Test sorting on aliases.
-	proc.TestOneProc(t, sortAliasIn, sortAliasOut, "sort host")
 
 	// Test that choosing a field when none is provided works.
 	proc.TestOneProc(t, chooseIn1, chooseOut1, "sort")

--- a/tests/suite.go
+++ b/tests/suite.go
@@ -58,6 +58,7 @@ var internals = []test.Internal{
 	sort.Internal4_2,
 	sort.Internal4_3,
 	sort.Internal4_4,
+	sort.SortAlias,
 	time.Internal,
 	zeek.Test,
 }

--- a/tests/suite/sort/test.go
+++ b/tests/suite/sort/test.go
@@ -193,3 +193,27 @@ var Internal4_4 = test.Internal{
 	OutputFormat: "zng",
 	Expected:     test.Trim(out4_4),
 }
+
+const inAlias = `
+#0:record[host:ip]
+0:[127.0.0.2;]
+#ipaddr=ip
+#1:record[host:ipaddr]
+1:[127.0.0.1;]
+`
+
+const outAlias = `
+#ipaddr=ip
+#0:record[host:ipaddr]
+0:[127.0.0.1;]
+#1:record[host:ip]
+1:[127.0.0.2;]
+`
+
+var SortAlias = test.Internal{
+	Name:         "sort alias",
+	Query:        "sort host",
+	Input:        test.Trim(inAlias),
+	OutputFormat: "zng",
+	Expected:     test.Trim(outAlias),
+}


### PR DESCRIPTION
If the sort proc receives an aliased type, it compares and sorts using
the underlying value rather than handling aliases separately.  Also
convert the sort test to use pkg/test so we can verify that alias
information is maintained as records pass through sort.