### PR TITLE
Fix combine for multiple bzng inputs

### DIFF
--- a/tests/suite/input/multiple.yaml
+++ b/tests/suite/input/multiple.yaml
@@ -1,0 +1,17 @@
+zql: 'count()'
+
+input:
+  - !!binary |
+      gAQGb3JpZ19oDQZvcmlnX3AOBnJlc3BfaA0GcmVzcF9wDoQFemVudW0JgAcFX3BhdGgJA
+      nRzEAN1aWQLAmlkFwVwcm90bxgIYW5hbHl6ZXILDmZhaWx1cmVfcmVhc29uCxlSCGRwZB
+      LgZfg9S9U9KiZDWUdPblYzQklkb2lXS3ZlWGcjCgqkXngGjUsKCi8I2gYAUAh0Y3AKSFR
+      UUDBub3QgYSBodHRwIHJlcXVlc3QgbGluZQ==
+  - !!binary |
+      gAQGb3JpZ19oDQZvcmlnX3AOBnJlc3BfaA0GcmVzcF9wDoAIBV9wYXRoCQJ0cxADdWlkC
+      wJpZBcDcnR0EQpuYW1lZF9waXBlCwhlbmRwb2ludAsJb3BlcmF0aW9uCxhQEGRjZV9ycG
+      MSYGd2N03VPSomQ2d4c05BMXAyZDBCdXJYZDdjIwoKpF54Bo8jCgovA5cGBAYIMCcNCjE
+      wMzAKc2FtchpTYW1yQ29ubmVjdDI=
+
+output: |
+  #0:record[count:uint64]
+  0:[2;]

--- a/zio/bzngio/types.go
+++ b/zio/bzngio/types.go
@@ -96,6 +96,7 @@ func (t *TypeFile) Dirty() bool {
 
 func ReadTypeContext(r io.Reader, zctx *resolver.Context) error {
 	reader := NewReader(r, zctx)
+	reader.zctx = zctx
 	for {
 		rec, err := reader.Read()
 		if err != nil {

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -70,6 +70,7 @@ import (
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
 	"github.com/brimsec/zq/scanner"
+	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
@@ -83,7 +84,7 @@ import (
 func Run(t *testing.T, dirname string) {
 	zq := os.Getenv("ZTEST_ZQ")
 	if zq != "" {
-		if out, err := run(zq, "*", "", "null"); err != nil {
+		if out, err := run(zq, "*", ""); err != nil {
 			if out != "" {
 				out = fmt.Sprintf(" with output %q", out)
 			}
@@ -111,7 +112,7 @@ func Run(t *testing.T, dirname string) {
 			if err != nil {
 				t.Fatalf("%s: %s", filename, err)
 			}
-			out, err := run(zq, zt.ZQL, zt.Input, zt.OutputFormat)
+			out, err := run(zq, zt.ZQL, zt.OutputFormat, zt.Input...)
 			if err != nil {
 				if out != "" {
 					out = "\noutput:\n" + out
@@ -135,9 +136,26 @@ func Run(t *testing.T, dirname string) {
 // ZTest defines a ztest.
 type ZTest struct {
 	ZQL          string `yaml:"zql"`
-	Input        string `yaml:"input"`
+	Input        Inputs `yaml:"input"`
 	OutputFormat string `yaml:"output-format,omitempty"`
 	Output       string `yaml:"output"`
+}
+
+type Inputs []string
+
+func (i *Inputs) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.SequenceNode {
+		var inputs []string
+		err := value.Decode(&inputs)
+		*i = inputs
+		return err
+	}
+	var input string
+	if err := value.Decode(&input); err != nil {
+		return err
+	}
+	*i = append(*i, input)
+	return nil
 }
 
 // FromYAMLFile loads a ZTest from the YAML file named filename.
@@ -167,10 +185,15 @@ func FromYAMLFile(filename string) (*ZTest, error) {
 // auto" and maybe be gzip-compressed.  outputFormat may be any string accepted
 // by "zq -f".  If zq is empty, the query runs in the current process.  If zq is
 // not empty, it specifies a zq executable that will be used to run the query.
-func run(zq, ZQL, input, outputFormat string) (string, error) {
+func run(zq, ZQL, outputFormat string, inputs ...string) (string, error) {
 	if zq != "" {
-		cmd := exec.Command(zq, "-f", outputFormat, ZQL, "-")
-		cmd.Stdin = strings.NewReader(input)
+		tmpdir, err := tmpInputFiles(inputs)
+		if err != nil {
+			return "", err
+		}
+		defer os.RemoveAll(tmpdir)
+		cmd := exec.Command(zq, "-f", outputFormat, ZQL, filepath.Join(tmpdir, "*"))
+		cmd.Dir = tmpdir
 		out, err := cmd.CombinedOutput()
 		return string(out), err
 	}
@@ -179,7 +202,7 @@ func run(zq, ZQL, input, outputFormat string) (string, error) {
 		return "", err
 	}
 	zctx := resolver.NewContext()
-	zr, err := detector.NewReader(detector.GzipReader(strings.NewReader(input)), zctx)
+	zr, err := loadInputs(inputs, zctx)
 	if err != nil {
 		return "", err
 	}
@@ -203,6 +226,40 @@ func run(zq, ZQL, input, outputFormat string) (string, error) {
 		err = err2
 	}
 	return buf.String(), err
+}
+
+func loadInputs(inputs []string, zctx *resolver.Context) (zbuf.Reader, error) {
+	var readers []scanner.Reader
+	for i, input := range inputs {
+		name := fmt.Sprintf("input%d", i+1)
+		zr, err := detector.NewReader(detector.GzipReader(strings.NewReader(input)), zctx)
+		if err != nil {
+			return nil, err
+		}
+		readers = append(readers, scanner.Reader{Reader: zr, Name: name})
+	}
+	if len(readers) == 1 {
+		return readers[0], nil
+	}
+	return scanner.NewCombiner(readers), nil
+}
+
+func tmpInputFiles(inputs []string) (string, error) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return "", err
+	}
+	var files []string
+	for i, input := range inputs {
+		name := fmt.Sprintf("input%d", i+1)
+		file := filepath.Join(dir, name)
+		err := ioutil.WriteFile(file, []byte(input), 0644)
+		if err != nil {
+			return "", err
+		}
+		files = append(files, file)
+	}
+	return dir, nil
 }
 
 type nopCloser struct{ io.Writer }

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -141,6 +141,8 @@ type ZTest struct {
 	Output       string `yaml:"output"`
 }
 
+// Inputs is an array of strings. Its only purpose is to support parsing of
+// both single string and array yaml values for the field ZTest.Input.
 type Inputs []string
 
 func (i *Inputs) UnmarshalYAML(value *yaml.Node) error {
@@ -180,8 +182,8 @@ func FromYAMLFile(filename string) (*ZTest, error) {
 	return &z, nil
 }
 
-// Run runs the query in ZQL over input and returns the output formatted
-// according to outputFormat.  input may be in any format recognized by "zq -i
+// Run runs the query in ZQL over inputs and returns the output formatted
+// according to outputFormat. inputs may be in any format recognized by "zq -i
 // auto" and maybe be gzip-compressed.  outputFormat may be any string accepted
 // by "zq -f".  If zq is empty, the query runs in the current process.  If zq is
 // not empty, it specifies a zq executable that will be used to run the query.

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -257,6 +257,7 @@ func tmpInputFiles(inputs []string) (string, []string, error) {
 		file := filepath.Join(dir, name)
 		err := ioutil.WriteFile(file, []byte(input), 0644)
 		if err != nil {
+			os.RemoveAll(dir)
 			return "", nil, err
 		}
 		files = append(files, file)


### PR DESCRIPTION
Have bzng readers keep their own internal context and use a
resolve.Mapper to map return Records to the shared context.

Also:
- Augment package `ztest` to support array arguments for
the input field.