### PR TITLE
Fix "pcap help slice" text

### DIFF
--- a/cmd/pcap/slice/command.go
+++ b/cmd/pcap/slice/command.go
@@ -42,8 +42,8 @@ If a flow filter is specified in the format "ip:port ip:port",
 along with a protocol ("tcp" or "udp" specified with -p), then only packets
 from that flow are matched.
 
-The time format for -from and -to is currently integer nanoseconds.  We will
-support more flexible time formats in the future.
+The time format for -from and -to is currently float seconds since 1970-01-01.
+We will support more flexible time formats in the future.
 `,
 	New: New,
 }


### PR DESCRIPTION
When trying `pcap slice` for the first time, I was thrown by the help text indicating that `-from` and `-to` were in "integer nanoseconds". I can see from https://github.com/brimsec/zq/blob/master/tests/suite/pcap/test.go that these are actually float seconds, so I've adjusted the help text here. I've matched the wording to Wireshark's menu.

![image](https://user-images.githubusercontent.com/5934157/75293144-6f4c9b80-57da-11ea-8338-d6b307a1c70a.png)
