### PR TITLE
Mv scanner.Combiner to pkg zbuf

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -255,7 +255,7 @@ func (c *Command) errorf(format string, args ...interface{}) {
 }
 
 func (c *Command) loadFiles(paths []string) (zbuf.Reader, error) {
-	var readers []scanner.Reader
+	var readers []zbuf.Reader
 	for _, path := range paths {
 		r, err := c.loadFile(path)
 		if err != nil {
@@ -265,12 +265,12 @@ func (c *Command) loadFiles(paths []string) (zbuf.Reader, error) {
 			}
 			return nil, err
 		}
-		readers = append(readers, scanner.Reader{r, path})
+		readers = append(readers, zbuf.NamedReader(r, path))
 	}
 	if len(readers) == 1 {
 		return readers[0], nil
 	}
-	return scanner.NewCombiner(readers), nil
+	return zbuf.NewCombiner(readers), nil
 }
 
 func (c *Command) openOutput() (zbuf.WriteCloser, error) {

--- a/zbuf/combiner.go
+++ b/zbuf/combiner.go
@@ -1,16 +1,10 @@
-package scanner
+package zbuf
 
 import (
 	"fmt"
 
-	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng"
 )
-
-type Reader struct {
-	zbuf.Reader
-	Name string
-}
 
 type Combiner struct {
 	readers []Reader
@@ -35,7 +29,7 @@ func (c *Combiner) Read() (*zng.Record, error) {
 		if c.hol[k] == nil {
 			tup, err := l.Read()
 			if err != nil {
-				return nil, fmt.Errorf("%s: %w", c.readers[k].Name, err)
+				return nil, fmt.Errorf("%s: %w", c.readers[k], err)
 			}
 			if tup == nil {
 				c.done[k] = true

--- a/zbuf/zng.go
+++ b/zbuf/zng.go
@@ -2,6 +2,7 @@ package zbuf
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/brimsec/zq/pkg/nano"
@@ -36,6 +37,19 @@ func (nopFlusher) Flush() error { return nil }
 // the provided Writer w.
 func NopFlusher(w Writer) WriteFlusher {
 	return nopFlusher{w}
+}
+
+type namedReader struct {
+	Reader
+	name string
+}
+
+func (n namedReader) String() string {
+	return fmt.Sprintf("reader<%s>", n.name)
+}
+
+func NamedReader(r Reader, name string) Reader {
+	return namedReader{r, name}
 }
 
 // Batch is an inteface to a bundle of Records.

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -231,19 +231,19 @@ func run(zq, ZQL, outputFormat string, inputs ...string) (string, error) {
 }
 
 func loadInputs(inputs []string, zctx *resolver.Context) (zbuf.Reader, error) {
-	var readers []scanner.Reader
+	var readers []zbuf.Reader
 	for i, input := range inputs {
 		name := fmt.Sprintf("input%d", i+1)
 		zr, err := detector.NewReader(detector.GzipReader(strings.NewReader(input)), zctx)
 		if err != nil {
 			return nil, err
 		}
-		readers = append(readers, scanner.Reader{Reader: zr, Name: name})
+		readers = append(readers, zbuf.NamedReader(zr, name))
 	}
 	if len(readers) == 1 {
 		return readers[0], nil
 	}
-	return scanner.NewCombiner(readers), nil
+	return zbuf.NewCombiner(readers), nil
 }
 
 func tmpInputFiles(inputs []string) (string, []string, error) {


### PR DESCRIPTION
I think this package makes more sense in zbuf rather than scanner.
Remove scanner.Reader and replace with zbuf.NamedReader which can
be used to print out the file name (or other identifier of a reader)
should the need arise.