### PR TITLE
Fix pcap slicer

### DIFF
--- a/cmd/pcap/slice/command.go
+++ b/cmd/pcap/slice/command.go
@@ -134,7 +134,7 @@ func (c *Command) Run(args []string) error {
 	}
 	out := io.Writer(os.Stdout)
 	if c.outputFile != "-" {
-		f, err := os.OpenFile(c.outputFile, os.O_RDWR|os.O_CREATE, 0644)
+		f, err := os.OpenFile(c.outputFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return err
 		}

--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -150,7 +150,7 @@ again:
 	}
 	r.Offset += uint64(caplen + packetHeaderLen)
 	ts := r.TsFromHeader(hdr)
-	if !span.Contains(ts) {
+	if !span.ContainsClosed(ts) {
 		goto again
 	}
 	return pkt, nil

--- a/pkg/nano/span.go
+++ b/pkg/nano/span.go
@@ -161,6 +161,12 @@ func (s Span) Contains(ts Ts) bool {
 	return ts >= s.Ts && ts < s.End()
 }
 
+// ContainsClose returns true if the timestamp is in the time interval including
+// the end of interval.
+func (s Span) ContainsClosed(ts Ts) bool {
+	return ts >= s.Ts && ts <= s.End()
+}
+
 // Covers returns true if the passed span is covered by s.
 func (s Span) Covers(covered Span) bool {
 	return s.Ts <= covered.Ts && s.End() >= covered.End()


### PR DESCRIPTION
The logic to read slices from an underlying pcap file was wrong as
io.SectionReader didn't work as I expected.  This commit fixes
the Slicer to simply use seek on the underlying file to implement
the Read interface for the sections desired.
