### PR TITLE
Add space POST endpoint

### DIFF
--- a/pkg/file/unique.go
+++ b/pkg/file/unique.go
@@ -7,6 +7,11 @@ import (
 	"strings"
 )
 
+// UniquePath determines a unique path given the desired name and parent
+// directory. For instanace of the desired path in /usr/mypath but such a path
+// already exists, the path /usr/mypath_01 is returned (and so on).
+// File extensions are respected and the unique number is appended before any
+// extensions (e.g. mypath.txt -> mypath_01.txt).
 func UniquePath(parent, name string) (string, error) {
 	ext := filepath.Ext(name)
 	base := strings.TrimSuffix(name, ext)
@@ -17,7 +22,6 @@ func UniquePath(parent, name string) (string, error) {
 	if len(matches) > 0 {
 		slice := sort.StringSlice(matches)
 		slice.Sort()
-
 		for i := 1; true; i++ {
 			name = fmt.Sprintf("%s_%02d%s", base, i, ext)
 			if n := slice.Search(base); n == slice.Len() {

--- a/pkg/file/unique.go
+++ b/pkg/file/unique.go
@@ -1,0 +1,29 @@
+package file
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func UniquePath(parent, name string) (string, error) {
+	ext := filepath.Ext(name)
+	base := strings.TrimSuffix(name, ext)
+	matches, err := filepath.Glob(filepath.Join(parent, base+"*"+ext))
+	if err != nil {
+		return "", err
+	}
+	if len(matches) > 0 {
+		slice := sort.StringSlice(matches)
+		slice.Sort()
+
+		for i := 1; true; i++ {
+			name = fmt.Sprintf("%s_%02d%s", base, i, ext)
+			if n := slice.Search(base); n == slice.Len() {
+				break
+			}
+		}
+	}
+	return name, nil
+}

--- a/pkg/fs/unique.go
+++ b/pkg/fs/unique.go
@@ -1,4 +1,4 @@
-package file
+package fs
 
 import (
 	"fmt"

--- a/pkg/fs/unique.go
+++ b/pkg/fs/unique.go
@@ -8,7 +8,7 @@ import (
 )
 
 // UniquePath determines a unique path given the desired name and parent
-// directory. For instanace of the desired path in /usr/mypath but such a path
+// directory. For instance if the desired path is /usr/mypath but such a path
 // already exists, the path /usr/mypath_01 is returned (and so on).
 // File extensions are respected and the unique number is appended before any
 // extensions (e.g. mypath.txt -> mypath_01.txt).

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -80,6 +80,16 @@ type StatusResponse struct {
 	Version string `json:"version"`
 }
 
+type SpacePostRequest struct {
+	Name    string `json:"name"`
+	DataDir string `json:"data_dir"`
+}
+
+type SpacePostResponse struct {
+	Name    string `json:"name"`
+	DataDir string `json:"data_dir"`
+}
+
 // PacketSearch are the query string args to the packet endpoint when searching
 // for packets within a connection 5-tuple.
 type PacketSearch struct {

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -85,11 +85,7 @@ type SpacePostRequest struct {
 	DataDir string `json:"data_dir"`
 }
 
-type SpacePostResponse struct {
-	Name    string `json:"name"`
-	DataDir string `json:"data_dir"`
-}
-
+type SpacePostResponse SpacePostRequest
 // PacketSearch are the query string args to the packet endpoint when searching
 // for packets within a connection 5-tuple.
 type PacketSearch struct {

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -86,6 +86,7 @@ type SpacePostRequest struct {
 }
 
 type SpacePostResponse SpacePostRequest
+
 // PacketSearch are the query string args to the packet endpoint when searching
 // for packets within a connection 5-tuple.
 type PacketSearch struct {

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -103,13 +103,11 @@ func TestSpacePostDataDirOnly(t *testing.T) {
 		defer os.RemoveAll(tmp)
 		root := filepath.Join(tmp, "spaces")
 		require.NoError(t, os.Mkdir(root, 0755))
-		var datadir string
-		var expected api.SpacePostResponse
 		t.Run(name, func(t *testing.T) {
-			datadir, expected = cb(t, tmp, root)
+			datadir, expected := cb(t, tmp, root)
+			res := createSpace(t, root, "", datadir)
+			require.Equal(t, expected, res)
 		})
-		res := createSpace(t, root, "", datadir)
-		require.Equal(t, expected, res)
 	}
 	run("Simple", func(t *testing.T, tmp, root string) (string, api.SpacePostResponse) {
 		datadir := filepath.Join(tmp, "mypcap.brim")

--- a/zqd/server.go
+++ b/zqd/server.go
@@ -19,6 +19,7 @@ func NewHandler(root string) http.Handler {
 	r := mux.NewRouter()
 	r = r.UseEncodedPath()
 	r.Handle("/space", wrapRoot(root, handleSpaceList)).Methods("GET")
+	r.Handle("/space", wrapRoot(root, handleSpacePost)).Methods("POST")
 	r.Handle("/space/{space}", wrapRoot(root, handleSpaceGet)).Methods("GET")
 	r.Handle("/space/{space}/packet", wrapRoot(root, handlePacketSearch)).Methods("GET")
 	r.Handle("/search", wrapRoot(root, handleSearch)).Methods("POST")

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -37,20 +37,20 @@ func Create(root, name, dataPath string) (*Space, error) {
 	if name == "" && dataPath == "" {
 		return nil, errors.New("must supply non-empty name or dataPath")
 	}
+	var path string
 	if name == "" {
-		name = filepath.Base(dataPath)
 		var err error
-		name, err = fs.UniquePath(root, name)
-		if err != nil {
+		if path, err = fs.UniqueDir(root, filepath.Base(dataPath)); err != nil {
 			return nil, err
 		}
-	}
-	path := filepath.Join(root, name)
-	if err := os.Mkdir(path, 0755); err != nil {
-		if os.IsExist(err) {
-			return nil, ErrSpaceExists
+	} else {
+		path = filepath.Join(root, name)
+		if err := os.Mkdir(path, 0700); err != nil {
+			if os.IsExist(err) {
+				return nil, ErrSpaceExists
+			}
+			return nil, err
 		}
-		return nil, err
 	}
 	if dataPath == "" {
 		dataPath = path

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -6,14 +6,16 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/brimsec/zq/pkg/file"
 )
 
 var (
 	ErrSpaceNotExist = errors.New("space does not exist")
+	ErrSpaceExists   = errors.New("space exists")
 )
 
 type Space struct {
-	name     string
 	path     string
 	dataPath string
 }
@@ -27,12 +29,27 @@ func Open(root, name string) (*Space, error) {
 		}
 		return nil, err
 	}
-	return &Space{name: name, path: path, dataPath: dataPath}, nil
+	return &Space{path: path, dataPath: dataPath}, nil
 }
 
 func Create(root, name, dataPath string) (*Space, error) {
+	// XXX this should be validated before reaching here.
+	if name == "" && dataPath == "" {
+		return nil, errors.New("must supply non-empty name or dataPath")
+	}
+	if name == "" {
+		name = filepath.Base(dataPath)
+		var err error
+		name, err = file.UniquePath(root, name)
+		if err != nil {
+			return nil, err
+		}
+	}
 	path := filepath.Join(root, name)
 	if err := os.Mkdir(path, 0755); err != nil {
+		if os.IsExist(err) {
+			return nil, ErrSpaceExists
+		}
 		return nil, err
 	}
 	if dataPath == "" {
@@ -42,11 +59,11 @@ func Create(root, name, dataPath string) (*Space, error) {
 		os.RemoveAll(path)
 		return nil, err
 	}
-	return &Space{name, path, dataPath}, nil
+	return &Space{path, dataPath}, nil
 }
 
 func (s Space) Name() string {
-	return s.name
+	return filepath.Base(s.path)
 }
 
 func (s Space) DataPath(elem ...string) string {

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/brimsec/zq/pkg/file"
+	"github.com/brimsec/zq/pkg/fs"
 )
 
 var (
@@ -40,7 +40,7 @@ func Create(root, name, dataPath string) (*Space, error) {
 	if name == "" {
 		name = filepath.Base(dataPath)
 		var err error
-		name, err = file.UniquePath(root, name)
+		name, err = fs.UniquePath(root, name)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Add the ability to create a new empty space via the space post
endpoint. The space post endpoint requires either a space name or
a space data dir (additionally both can be provided).

If a space data dir is specified, with no space name, a new space
is created given the name of data dir's base directory. If the name
collides with an exisiting space, a unique name is generated and
returned in the request response.