### PR TITLE
better handling of pcap "no packets" condition

### DIFF
--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -105,7 +105,11 @@ func handlePacketSearch(root string, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=%s.pcap", search.ID()))
 	err = search.Run(w, slicer)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		if err == pcap.ErrNoPacketsFound {
+			http.Error(w, err.Error(), http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
 	}
 }
 


### PR DESCRIPTION
When no packets are found during a pcap search,
instead of sending a pcap header with no data
then an error, we just send the error.