### PR TITLE
add support for ICMP pcap search

### DIFF
--- a/cmd/pcap/slice/command.go
+++ b/cmd/pcap/slice/command.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"os"
 
@@ -147,7 +148,16 @@ func (c *Command) Run(args []string) error {
 	}
 	var search *pcap.Search
 	if filter {
-		search = pcap.NewFlowSearch(span, c.proto, flow)
+		switch c.proto {
+		default:
+			return fmt.Errorf("unknown protocol: %s", c.proto)
+		case "tcp":
+			search = pcap.NewTCPSearch(span, flow)
+		case "udp":
+			search = pcap.NewUDPSearch(span, flow)
+		case "icmp":
+			search = pcap.NewICMPSearch(span, flow.S0.IP, flow.S1.IP)
+		}
 	} else {
 		search = pcap.NewRangeSearch(span)
 	}

--- a/pcap/flow.go
+++ b/pcap/flow.go
@@ -21,6 +21,10 @@ type Flow struct {
 	S1 Socket
 }
 
+func NewFlow(src net.IP, srcPort int, dst net.IP, dstPort int) Flow {
+	return Flow{Socket{src, srcPort}, Socket{dst, dstPort}}
+}
+
 func (f Flow) String() string {
 	return f.S0.String() + "," + f.S1.String()
 }


### PR DESCRIPTION
This commit adds support for searching for ICMP flows in pcaps.
It also adds hooks to "pcap slice" and the zqd packet end point
for filtering on icmp.

The commit also cleans up the pcap filtering API and internals by
creating more modular closures for packet filtering  At some
point, we may want to create a Go DSL for creating BPF programs
and port the BPF virtual machine and data flow optimizer to Go.
This would allow for much more flexible filtering, but is not
a priority right now.