### PR TITLE
Include "local" in zeek command-line

### DIFF
--- a/zqd/zeek/zeek.go
+++ b/zqd/zeek/zeek.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Logify(ctx context.Context, dir string, pcap io.Reader) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "zeek", "-C", "-r", "-")
+	cmd := exec.CommandContext(ctx, "zeek", "-C", "-r", "-", "local")
 	cmd.Stdin = pcap
 	cmd.Dir = dir
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Including `local` in the command-line we use for invoking `zeek` makes sure the logs have outputs we're accustomed to seeing, thanks to all the scripts loaded in `local.zeek`. For instance, without including `local`, I've observed that hits in the `pe.log` do not have their file hashes logged.