### PR TITLE
add github actions ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+name: "Tests"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13'
+      - uses: actions/checkout@v1
+      - run: go mod download
+      - run: make fmt
+      - run: make vet
+      - run: make test-unit
+      - run: make test-system
+      - run: make test-heavy


### PR DESCRIPTION
Github Actions equivalent of the CircleCI tests. Example run here:
https://github.com/brimsec/zq/actions/runs/47950707
