### PR TITLE
Exclude _path=loaded_scripts when assembling all.bzng

### DIFF
--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -265,7 +265,7 @@ func handlePacketPost(root string, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	zw := bzngio.NewWriter(bzngfile)
-	const program = "_path != packet_filter | sort -limit 1000000000 -r ts"
+	const program = "_path != packet_filter _path != loaded_scripts | sort -limit 1000000000 -r ts"
 	if err := search.Copy(r.Context(), zw, zr, program); err != nil {
 		// If an error occurs here close and remove tmp bzngfile, lest we start
 		// leaking files and file descriptors.


### PR DESCRIPTION
https://github.com/brimsec/zq/pull/366 fixed one issue, but introduced another problem: The `local.zeek` triggers the creation of the `loaded_scripts.log`, which are a bunch of `ts`-free points that the Brim app treats as `ts=0`, making the X axis begin all the way back in 1970 and all the bad side-effects of that. Ideally we should be treating this as "session metadata" and store/display it in a non-disruptive way, but for now we can just exclude `_path=loaded_scripts` when creating the `all.bzng`.