### PR TITLE
Fix ugly bug in bzng encoder

### DIFF
--- a/zng/resolver/encoder.go
+++ b/zng/resolver/encoder.go
@@ -50,7 +50,7 @@ func (e *Encoder) isEncoded(id int) bool {
 // the new type into the buffer provided.
 func (e *Encoder) Encode(dst []byte, external zng.Type) ([]byte, zng.Type, error) {
 	dst, typ, err := e.encodeType(dst, external)
-	if err != nil {
+	if err == nil {
 		e.enter(external.ID(), typ)
 	}
 	return dst, typ, err

--- a/zng/resolver/encoder.go
+++ b/zng/resolver/encoder.go
@@ -50,9 +50,10 @@ func (e *Encoder) isEncoded(id int) bool {
 // the new type into the buffer provided.
 func (e *Encoder) Encode(dst []byte, external zng.Type) ([]byte, zng.Type, error) {
 	dst, typ, err := e.encodeType(dst, external)
-	if err == nil {
-		e.enter(external.ID(), typ)
+	if err != nil {
+		return nil, nil, err
 	}
+	e.enter(external.ID(), typ)
 	return dst, typ, err
 }
 


### PR DESCRIPTION
There was a logic error that was causing us to not call Encoder.enter()
on typedefs.  This was only noticed indirectly via the perf regression
reported in #352.