### PR TITLE
Add space delete endpoint.

### DIFF
--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -262,6 +262,18 @@ func handleSpacePost(root string, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func handleSpaceDelete(root string, w http.ResponseWriter, r *http.Request) {
+	s := extractSpace(root, w, r)
+	if s == nil {
+		return
+	}
+	if err := s.Delete(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func handlePacketPost(root string, w http.ResponseWriter, r *http.Request) {
 	s := extractSpace(root, w, r)
 	if s == nil {

--- a/zqd/server.go
+++ b/zqd/server.go
@@ -21,6 +21,7 @@ func NewHandler(root string) http.Handler {
 	r.Handle("/space", wrapRoot(root, handleSpaceList)).Methods("GET")
 	r.Handle("/space", wrapRoot(root, handleSpacePost)).Methods("POST")
 	r.Handle("/space/{space}", wrapRoot(root, handleSpaceGet)).Methods("GET")
+	r.Handle("/space/{space}", wrapRoot(root, handleSpaceDelete)).Methods("DELETE")
 	r.Handle("/space/{space}/packet", wrapRoot(root, handlePacketSearch)).Methods("GET")
 	r.Handle("/space/{space}/packet", wrapRoot(root, handlePacketPost)).Methods("POST")
 	r.Handle("/search", wrapRoot(root, handleSearch)).Methods("POST")

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -102,6 +102,15 @@ func (s Space) PacketPath() string {
 	return s.conf.PacketPath
 }
 
+// Delete removes the space's path and data dir (should the data dir be
+// different then the space's path).
+func (s Space) Delete() error {
+	if err := os.RemoveAll(s.path); err != nil {
+		return err
+	}
+	return os.RemoveAll(s.conf.DataPath)
+}
+
 type config struct {
 	DataPath   string `json:"data_path"`
 	PacketPath string `json:"packet_path"`


### PR DESCRIPTION
The directory created for the space in the zqd's datadir is deleted.
If the space contains a separate data dir, this will also be deleted.