### PR TITLE
fix bug extracting timestamp in pcap reader

### DIFF
--- a/pcap/pcap.go
+++ b/pcap/pcap.go
@@ -144,12 +144,13 @@ again:
 	if caplen > fullLength {
 		return nil, fmt.Errorf("capture length exceeds original packet length: %d > %d", caplen, fullLength)
 	}
+	// pull out timestamp before reading rest of packet as header can get clobbered
+	ts := r.TsFromHeader(hdr)
 	pkt, err := r.Reader.Read(caplen + packetHeaderLen)
 	if err != nil {
 		return nil, err
 	}
 	r.Offset += uint64(caplen + packetHeaderLen)
-	ts := r.TsFromHeader(hdr)
 	if !span.ContainsClosed(ts) {
 		goto again
 	}


### PR DESCRIPTION
This commit fixes a bug where the pcap header was read as a
slice pointing to the peeker buffer, then the packet body was
read, then the timestamp was pulled out of the header slice
violating the semantics of the peeker Read interface.
The fix is to pull the timestamp out of the header before
reading the body of the packet.