### PR TITLE
Fix test expectation in zqd.PacketPostSuite

### DIFF
--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -30,7 +30,7 @@ type PacketPostSuite struct {
 func (s *PacketPostSuite) TestCount() {
 	expected := `
 #0:record[count:uint64]
-0:[2;]`
+0:[4;]`
 	res := execSearch(s.T(), s.root, s.space, "count()")
 	s.Equal(test.Trim(expected), res)
 }


### PR DESCRIPTION
The test was expecting 2 records, but there should be (and are) 4:

```
(after manually running the test pcap through zeek)
$ cat *log | zq " _path!=packet_filter and _path!=loaded_scripts | count() by _path" -
#0:record[_path:string,count:uint64]
0:[conn;1;]
0:[http;1;]
0:[stats;1;]
0:[capture_loss;1;]
```