### PR TITLE
Remove defer from proc.(*Sort).Pull loop

### DIFF
--- a/proc/sort.go
+++ b/proc/sort.go
@@ -82,12 +82,13 @@ func (s *Sort) Pull() (zbuf.Batch, error) {
 		if batch == nil {
 			return s.sort(), nil
 		}
-		defer batch.Unref()
 		if len(s.out)+batch.Length() > s.limit {
+			batch.Unref()
 			return nil, fmt.Errorf("sort limit hit (%d)", s.limit)
 		}
 		// XXX this should handle group-by every ... need to change how we do this
 		s.consume(batch)
+		batch.Unref()
 	}
 }
 


### PR DESCRIPTION
Each loop iteration in proc.(*Sort).Pull defers a call to batch.Unref.
The accumulated runtime.newdefer allocations consume memory proportional
to the number of batches produced by the parent proc.  Remove the defer
to eliminate those allocations.