### PR TITLE
make pkg/test.Exec work with windows

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,0 +1,17 @@
+name: "windows-testing"
+
+on:
+  push:
+    branches:
+      - "windows-testing"
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13'
+      - uses: actions/checkout@v1
+      - run: go test -short ./...
+      - run: go test -v -tags=system ./tests

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -14,4 +14,6 @@ jobs:
           go-version: '1.13'
       - uses: actions/checkout@v1
       - run: go test -short ./...
+      - run: mkdir dist -ea 0
+      - run: go build -o dist ./cmd/...
       - run: go test -v -tags=system ./tests

--- a/pkg/test/exec.go
+++ b/pkg/test/exec.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -14,11 +15,16 @@ type Exec struct {
 }
 
 func (e *Exec) Run(path string) (string, error) {
-	src := e.Command
+	args := strings.Fields(e.Command)
 	if path != "" {
-		src = "PATH=" + path + ":$PATH " + src
+		abspath, err := filepath.Abs(path)
+		if err != nil {
+			return "", err
+		}
+		args[0] = filepath.Join(abspath, args[0])
 	}
-	cmd := exec.Command("/bin/bash", "-c", src)
+
+	cmd := exec.Command(args[0], args[1:]...)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/tests/system_test.go
+++ b/tests/system_test.go
@@ -4,10 +4,8 @@ package tests
 
 import (
 	"errors"
-	"path/filepath"
 	"testing"
 
-	"github.com/brimsec/zq/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,39 +36,6 @@ func TestCommands(t *testing.T) {
 			results, err := cmd.Run(zqpath)
 			require.NoError(t, err)
 			assert.Exactly(t, cmd.Expected, results, "Wrong command results")
-		})
-	}
-}
-
-func TestScripts(t *testing.T) {
-	t.Parallel()
-	path, err := filepath.Abs(zqpath)
-	require.NoError(t, err)
-	for _, script := range scripts {
-		t.Run(script.Name, func(t *testing.T) {
-			var fail bool
-			shell := test.NewShellTest(script)
-			_, _, err := shell.Run(RootDir, path)
-			if err != nil {
-				fail = true
-			}
-			require.NoError(t, err)
-			for _, file := range script.Expected {
-				actual, err := shell.Read(file.Name)
-				if err != nil {
-					fail = true
-				}
-				require.NoError(t, err)
-				if !assert.Exactly(t, file.Data, actual, "Wrong shell script results") {
-					fail = true
-				}
-			}
-			if !fail {
-				// Remove the testdir on success.  If test fails,  we
-				// leave it behind in testroot for debugging.  These
-				// failed test directories have to be manually removed.
-				shell.Cleanup()
-			}
 		})
 	}
 }

--- a/tests/system_unix_test.go
+++ b/tests/system_unix_test.go
@@ -1,0 +1,46 @@
+// +build linux darwin
+// +build system
+
+package tests
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/brimsec/zq/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScripts(t *testing.T) {
+	t.Parallel()
+	path, err := filepath.Abs(zqpath)
+	require.NoError(t, err)
+	for _, script := range scripts {
+		t.Run(script.Name, func(t *testing.T) {
+			var fail bool
+			shell := test.NewShellTest(script)
+			_, _, err := shell.Run(RootDir, path)
+			if err != nil {
+				fail = true
+			}
+			require.NoError(t, err)
+			for _, file := range script.Expected {
+				actual, err := shell.Read(file.Name)
+				if err != nil {
+					fail = true
+				}
+				require.NoError(t, err)
+				if !assert.Exactly(t, file.Data, actual, "Wrong shell script results") {
+					fail = true
+				}
+			}
+			if !fail {
+				// Remove the testdir on success.  If test fails,  we
+				// leave it behind in testroot for debugging.  These
+				// failed test directories have to be manually removed.
+				shell.Cleanup()
+			}
+		})
+	}
+}


### PR DESCRIPTION
Remove the reference to bash and call the command directly. Make sure the path arg to exec.Command is a path, not just a command name, otherwise we'll trigger the usage of exec.LookPath on windows, which expects to use the PATH in the current process environment, and can't be overridden without an os.Setenv.