### PR TITLE
Cache min and max times

### DIFF
--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -51,7 +51,7 @@ func TestMuxDriver(t *testing.T) {
 		err = d.Run(flowgraph)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, cs[0].(*counter).n)
-		assert.Equal(t, 1, cs[0].(*counter).n)
+		assert.Equal(t, 1, cs[1].(*counter).n)
 	})
 
 	t.Run("Mismatched channels and writer counts", func(t *testing.T) {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -47,7 +47,7 @@ func TestMuxDriver(t *testing.T) {
 		flowgraph, err := Compile(query, scanner.NewScanner(reader, nil))
 		assert.NoError(t, err)
 		cs := []zbuf.Writer{&counter{}, &counter{}}
-		d := NewDemuxed(cs)
+		d := New(cs...)
 		err = d.Run(flowgraph)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, cs[0].(*counter).n)
@@ -58,7 +58,7 @@ func TestMuxDriver(t *testing.T) {
 		flowgraph, err := Compile(query, nil)
 		assert.NoError(t, err)
 		cs := []zbuf.Writer{&counter{}, &counter{}, &counter{}}
-		d := NewDemuxed(cs)
+		d := New(cs...)
 		err = d.Run(flowgraph)
 		assert.Error(t, err)
 	})

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -54,7 +54,7 @@ func TestMuxDriver(t *testing.T) {
 		assert.Equal(t, 1, cs[1].(*counter).n)
 	})
 
-	t.Run("Mismatched channels and writer counts", func(t *testing.T) {
+	t.Run("mismatched channels and writer counts", func(t *testing.T) {
 		flowgraph, err := Compile(query, nil)
 		assert.NoError(t, err)
 		cs := []zbuf.Writer{&counter{}, &counter{}, &counter{}}

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -1,0 +1,64 @@
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/brimsec/zq/scanner"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zql"
+	"github.com/stretchr/testify/assert"
+)
+
+type counter struct {
+	n int
+}
+
+func (c *counter) Write(*zng.Record) error {
+	c.n++
+	return nil
+}
+
+func TestMuxDriver(t *testing.T) {
+	input := `#0:record[_path:string,ts:time]
+0:[conn;1425565514.419939;]`
+
+	zctx := resolver.NewContext()
+	query, err := zql.ParseProc("(tail 1; tail 1)")
+	assert.NoError(t, err)
+
+	t.Run("muxed into one writer", func(t *testing.T) {
+		reader := zngio.NewReader(strings.NewReader(input), zctx)
+		flowgraph, err := Compile(query, scanner.NewScanner(reader, nil))
+		assert.NoError(t, err)
+		c := counter{}
+		d := New(&c)
+		err = d.Run(flowgraph)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, c.n)
+	})
+
+	t.Run("muxed into individual writers", func(t *testing.T) {
+		reader := zngio.NewReader(strings.NewReader(input), zctx)
+		flowgraph, err := Compile(query, scanner.NewScanner(reader, nil))
+		assert.NoError(t, err)
+		cs := []zbuf.Writer{&counter{}, &counter{}}
+		d := NewDemuxed(cs)
+		err = d.Run(flowgraph)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, cs[0].(*counter).n)
+		assert.Equal(t, 1, cs[0].(*counter).n)
+	})
+
+	t.Run("Mismatched channels and writer counts", func(t *testing.T) {
+		flowgraph, err := Compile(query, nil)
+		assert.NoError(t, err)
+		cs := []zbuf.Writer{&counter{}, &counter{}, &counter{}}
+		d := NewDemuxed(cs)
+		err = d.Run(flowgraph)
+		assert.Error(t, err)
+	})
+}

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -23,7 +23,8 @@ func (c *counter) Write(*zng.Record) error {
 }
 
 func TestMuxDriver(t *testing.T) {
-	input := `#0:record[_path:string,ts:time]
+	input := `
+#0:record[_path:string,ts:time]
 0:[conn;1425565514.419939;]`
 
 	zctx := resolver.NewContext()

--- a/driver/run.go
+++ b/driver/run.go
@@ -10,13 +10,21 @@ import (
 )
 
 type Driver struct {
-	writer   zbuf.Writer
+	writers  []zbuf.Writer
 	warnings io.Writer
+	demux    bool
 }
 
 func New(w zbuf.Writer) *Driver {
 	return &Driver{
-		writer: w,
+		writers: []zbuf.Writer{w},
+	}
+}
+
+func NewDemuxed(ws []zbuf.Writer) *Driver {
+	return &Driver{
+		writers: ws,
+		demux:   true,
 	}
 }
 
@@ -25,8 +33,11 @@ func (d *Driver) SetWarningsWriter(w io.Writer) {
 }
 
 func (d *Driver) Write(cid int, arr zbuf.Batch) error {
+	if !d.demux {
+		cid = 0
+	}
 	for _, r := range arr.Records() {
-		if err := d.writer.Write(r); err != nil {
+		if err := d.writers[cid].Write(r); err != nil {
 			return err
 		}
 	}
@@ -44,6 +55,10 @@ func (d *Driver) WriteWarning(msg string) error {
 }
 
 func (d *Driver) Run(out *proc.MuxOutput) error {
+	if d.demux && len(d.writers) != out.N() {
+		return fmt.Errorf("Driver.Run(): Mismatched channels and writer counts")
+	}
+
 	for !out.Complete() {
 		res := out.Pull(time.After(time.Second * 10))
 		if res.Err == proc.ErrTimeout {

--- a/driver/run.go
+++ b/driver/run.go
@@ -12,19 +12,11 @@ import (
 type Driver struct {
 	writers  []zbuf.Writer
 	warnings io.Writer
-	demux    bool
 }
 
-func New(w zbuf.Writer) *Driver {
+func New(w ...zbuf.Writer) *Driver {
 	return &Driver{
-		writers: []zbuf.Writer{w},
-	}
-}
-
-func NewDemuxed(ws []zbuf.Writer) *Driver {
-	return &Driver{
-		writers: ws,
-		demux:   true,
+		writers: w,
 	}
 }
 
@@ -33,7 +25,7 @@ func (d *Driver) SetWarningsWriter(w io.Writer) {
 }
 
 func (d *Driver) Write(cid int, arr zbuf.Batch) error {
-	if !d.demux {
+	if len(d.writers) == 1 {
 		cid = 0
 	}
 	for _, r := range arr.Records() {
@@ -55,7 +47,7 @@ func (d *Driver) WriteWarning(msg string) error {
 }
 
 func (d *Driver) Run(out *proc.MuxOutput) error {
-	if d.demux && len(d.writers) != out.N() {
+	if len(d.writers) != 1 && len(d.writers) != out.N() {
 		return fmt.Errorf("Driver.Run(): Mismatched channels and writer counts")
 	}
 

--- a/proc/mux.go
+++ b/proc/mux.go
@@ -61,6 +61,10 @@ func (m *MuxOutput) Complete() bool {
 	return m.runners <= 0
 }
 
+func (m *MuxOutput) N() int {
+	return len(m.muxProcs)
+}
+
 //XXX
 var ErrTimeout = errors.New("timeout")
 

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/brimsec/zq/pcap"
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/brimsec/zq/zio/detector"
-	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqd/api"
 	"github.com/brimsec/zq/zqd/packet"
 	"github.com/brimsec/zq/zqd/search"
@@ -143,58 +141,17 @@ func handleSpaceGet(c *Core, w http.ResponseWriter, r *http.Request) {
 	if s == nil {
 		return
 	}
-	info := &api.SpaceInfo{
-		Name:          s.Name(),
-		PacketSupport: s.HasFile(packet.IndexFile),
-		PacketPath:    s.PacketPath(),
+	info, err := s.Info()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
-	if s.HasFile("all.bzng") {
-		f, err := s.OpenFile("all.bzng")
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		defer f.Close()
-		// XXX This is slow. Can easily cache result rather than scanning
-		// whole file each time.
-		reader, err := detector.LookupReader("bzng", f, resolver.NewContext())
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		minTs := nano.MaxTs
-		maxTs := nano.MinTs
-		var found bool
-		for {
-			rec, err := reader.Read()
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-			if rec == nil {
-				break
-			}
-			ts := rec.Ts
-			if ts < minTs {
-				minTs = ts
-			}
-			if ts > maxTs {
-				maxTs = ts
-			}
-			found = true
-		}
-		stat, err := f.Stat()
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		info.Size = stat.Size()
-		if found {
-			info.MinTime = &minTs
-			info.MaxTime = &maxTs
-		}
-	}
+	info.PacketSupport = s.HasFile(packet.IndexFile)
 	w.Header().Add("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(info)
+	if err := json.NewEncoder(w).Encode(info); err != nil {
+		// XXX Add zap here.
+		log.Println("Error writing response", err)
+	}
 }
 
 func handleSpacePost(c *Core, w http.ResponseWriter, r *http.Request) {

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -69,12 +69,11 @@ func TestSpaceInfo(t *testing.T) {
 	c := newCore(t)
 	defer os.RemoveAll(c.Root)
 	createSpaceWithData(t, c, space, src)
-	min := nano.Unix(1521911721, 255387000)
-	max := nano.Unix(1521911723, 205187000)
 	expected := api.SpaceInfo{
+		// MinTime and MaxTime are not present because the
+		// space is not populated via the regular pcap ingest
+		// process.
 		Name:          space,
-		MinTime:       &min,
-		MaxTime:       &max,
 		Size:          88,
 		PacketSupport: false,
 	}

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/pkg/test"
 	"github.com/brimsec/zq/zqd"
 	"github.com/brimsec/zq/zqd/api"
@@ -53,6 +54,8 @@ func (s *PacketPostSuite) TestSpaceInfo() {
 	s.NoError(err)
 	s.Equal(s.pcapfile, info.PacketPath)
 	s.True(info.PacketSupport)
+	s.Equal(nano.Ts(1501770877471635000), *info.MinTime)
+	s.Equal(nano.Ts(1501770880988247000), *info.MaxTime)
 }
 
 func (s *PacketPostSuite) TestWritesIndexFile() {

--- a/zqd/packet/packet.go
+++ b/zqd/packet/packet.go
@@ -233,8 +233,7 @@ func (p *IngestProcess) writeData(ctx context.Context) (nano.Ts, nano.Ts, error)
 	}
 	zw := bzngio.NewWriter(bzngfile)
 	const program = "sort -limit 10000000 ts | (filter *; head 1; tail 1)"
-	headW := recWriter{}
-	tailW := recWriter{}
+	var headW, tailW recWriter
 
 	if err := search.Copy(ctx, []zbuf.Writer{zw, &headW, &tailW}, zr, program); err != nil {
 		// If an error occurs here close and remove tmp bzngfile, lest we start

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -79,7 +79,7 @@ func Copy(ctx context.Context, w []zbuf.Writer, r zbuf.Reader, prog string) erro
 		d := zdriver.New(w[0])
 		return d.Run(mux)
 	}
-	d := zdriver.NewDemuxed(w)
+	d := zdriver.New(w...)
 	return d.Run(mux)
 }
 

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -75,10 +75,6 @@ func Copy(ctx context.Context, w []zbuf.Writer, r zbuf.Reader, prog string) erro
 	if err != nil {
 		return err
 	}
-	if len(w) == 1 {
-		d := zdriver.New(w[0])
-		return d.Run(mux)
-	}
 	d := zdriver.New(w...)
 	return d.Run(mux)
 }

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -61,7 +61,7 @@ func Search(ctx context.Context, s *space.Space, req api.SearchRequest, out Outp
 	return run(mux, out)
 }
 
-func Copy(ctx context.Context, w zbuf.Writer, r zbuf.Reader, prog string) error {
+func Copy(ctx context.Context, w []zbuf.Writer, r zbuf.Reader, prog string) error {
 	p, err := zql.ParseProc(prog)
 	if err != nil {
 		return err
@@ -75,7 +75,11 @@ func Copy(ctx context.Context, w zbuf.Writer, r zbuf.Reader, prog string) error 
 	if err != nil {
 		return err
 	}
-	d := zdriver.New(w)
+	if len(w) == 1 {
+		d := zdriver.New(w[0])
+		return d.Run(mux)
+	}
+	d := zdriver.NewDemuxed(w)
 	return d.Run(mux)
 }
 

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -166,6 +166,17 @@ func (s Space) SetTimes(minTs, maxTs nano.Ts) error {
 	return cur.save(s.conf.DataPath)
 }
 
+func (s Space) GetTimes() (*nano.Ts, *nano.Ts, error) {
+	i, err := loadInfo(s.conf.DataPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, nil, err
+		}
+		return nil, nil, nil
+	}
+	return &i.MinTime, &i.MaxTime, nil
+}
+
 // loadConfig loads the contents of config.json in a space's path.
 func loadConfig(spacePath string) (config, error) {
 	var c config

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -77,6 +77,7 @@ func (s Space) Info() (api.SpaceInfo, error) {
 	if err != nil {
 		return api.SpaceInfo{}, err
 	}
+	defer f.Close()
 	stat, err := f.Stat()
 	if err != nil {
 		return api.SpaceInfo{}, err

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -87,7 +87,7 @@ func (s Space) Info() (api.SpaceInfo, error) {
 		Size:       stat.Size(),
 		PacketPath: s.PacketPath(),
 	}
-	i, err := loadInfo(s.path)
+	i, err := loadInfo(s.conf.DataPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return api.SpaceInfo{}, err
@@ -154,7 +154,7 @@ type info struct {
 }
 
 func (s Space) SetTimes(minTs, maxTs nano.Ts) error {
-	cur, err := loadInfo(s.path)
+	cur, err := loadInfo(s.conf.DataPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return err
@@ -163,7 +163,7 @@ func (s Space) SetTimes(minTs, maxTs nano.Ts) error {
 	}
 	cur.MinTime = nano.Min(cur.MinTime, minTs)
 	cur.MaxTime = nano.Max(cur.MaxTime, maxTs)
-	return cur.save(s.path)
+	return cur.save(s.conf.DataPath)
 }
 
 // loadConfig loads the contents of config.json in a space's path.
@@ -198,9 +198,9 @@ func (c config) save(spacePath string) error {
 	return os.Rename(tmppath, path)
 }
 
-func loadInfo(spacePath string) (info, error) {
+func loadInfo(path string) (info, error) {
 	var i info
-	b, err := ioutil.ReadFile(filepath.Join(spacePath, infoFile))
+	b, err := ioutil.ReadFile(filepath.Join(path, infoFile))
 	if err != nil {
 		return info{}, err
 	}
@@ -210,8 +210,8 @@ func loadInfo(spacePath string) (info, error) {
 	return i, nil
 }
 
-func (i info) save(spacePath string) error {
-	path := filepath.Join(spacePath, infoFile)
+func (i info) save(path string) error {
+	path = filepath.Join(path, infoFile)
 	tmppath := path + ".tmp"
 	f, err := os.Create(tmppath)
 	if err != nil {


### PR DESCRIPTION
Space min and max times are now computed at ingest time and written into the space in a file named `info.json`. 

An alternate approach (which I initially started on) would have been to continue computing min/max upon receiving the first `GET /space/..` for that space, and writing it at that point, but that would lead to a first-time slow response which this approach avoids. (Also, it seems like extracting min/maxes upon ingest and updating the space with them will be a better model when we start to support adding data to a space).