### PR TITLE
move slicer to its own package

### DIFF
--- a/pcap/slicer.go
+++ b/pcap/slicer.go
@@ -1,77 +1,20 @@
 package pcap
 
 import (
-	"encoding/json"
 	"errors"
-	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/pkg/ranger"
+	"github.com/brimsec/zq/pkg/slicer"
 )
 
-// Slicer implements io.Reader reading the sliced regions provided to it from
-// the underlying file thus extracting subsets of an underlying file without
-// modifying or copying the file.
-type Slicer struct {
-	slices []Slice
-	slice  Slice
-	file   *os.File
-	eof    bool
-}
-
-func NewSlicer(file *os.File, index *Index, span nano.Span) (*Slicer, error) {
+func NewSlicer(file *os.File, index *Index, span nano.Span) (*slicer.Reader, error) {
 	slices, err := GenerateSlices(index, span)
 	if err != nil {
 		return nil, err
 	}
-	s := &Slicer{
-		slices: slices,
-		file:   file,
-	}
-	return s, s.next()
-}
-
-func (s *Slicer) next() error {
-	if len(s.slices) == 0 {
-		s.eof = true
-		return nil
-	}
-	s.slice = s.slices[0]
-	s.slices = s.slices[1:]
-	_, err := s.file.Seek(int64(s.slice.Offset), 0)
-	return err
-}
-
-func (s *Slicer) Read(b []byte) (int, error) {
-	if s.eof {
-		return 0, io.EOF
-	}
-	p := b
-	if uint64(len(p)) > s.slice.Length {
-		p = p[:s.slice.Length]
-	}
-	n, err := s.file.Read(p)
-	if n != 0 {
-		if err == io.EOF {
-			err = nil
-		}
-		s.slice.Length -= uint64(n)
-		if s.slice.Length == 0 {
-			err = s.next()
-		}
-	}
-	return n, err
-}
-
-type Slice struct {
-	Offset uint64
-	Length uint64
-}
-
-func (s Slice) Overlaps(x Slice) bool {
-	return x.Offset >= s.Offset && x.Offset < s.Offset+x.Length
+	return slicer.NewReader(file, slices)
 }
 
 // GenerateSlices takes an index and time span and generates a list of
@@ -79,8 +22,8 @@ func (s Slice) Overlaps(x Slice) bool {
 // underlying pcap file.  Extra packets may appear in the resulting stream
 // but all packets that fall within the time range will be produced, i.e.,
 // another layering of time filtering should be applied to resulting packets.
-func GenerateSlices(index *Index, span nano.Span) ([]Slice, error) {
-	var slices []Slice
+func GenerateSlices(index *Index, span nano.Span) ([]slicer.Slice, error) {
+	var slices []slicer.Slice
 	for _, section := range index.Sections {
 		pslice, err := FindPacketSlice(section.Index, span)
 		if err != nil {
@@ -96,21 +39,11 @@ func GenerateSlices(index *Index, span nano.Span) ([]Slice, error) {
 	return slices, nil
 }
 
-func FindPacketSlice(e ranger.Envelope, span nano.Span) (Slice, error) {
+func FindPacketSlice(e ranger.Envelope, span nano.Span) (slicer.Slice, error) {
 	if len(e) == 0 {
-		return Slice{}, errors.New("no packets")
+		return slicer.Slice{}, errors.New("no packets")
 	}
 	d := e.FindSmallestDomain(ranger.Range{uint64(span.Ts), uint64(span.End())})
 	//XXX check for empty domain.. though seems like this will do the right thing
-	return Slice{d.X0, d.X1 - d.X0}, nil
-}
-
-func LoadIndex(path string) (*Index, error) {
-	b, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	var index *Index
-	err = json.Unmarshal(b, &index)
-	return index, err
+	return slicer.Slice{d.X0, d.X1 - d.X0}, nil
 }

--- a/pkg/slicer/reader.go
+++ b/pkg/slicer/reader.go
@@ -1,0 +1,60 @@
+// Package slicer provides a mechanism to read a single large file as
+// a sequence of smaller slices that are essentially extracted from the
+// large file on the fly to make the reader appear to produce a smaller file
+// comprised of the slices.
+package slicer
+
+import (
+	"io"
+	"os"
+)
+
+// Reader implements io.Reader reading the sliced regions provided to it from
+// the underlying file thus extracting subsets of an underlying file without
+// modifying or copying the file.
+type Reader struct {
+	slices []Slice
+	slice  Slice
+	file   *os.File
+	eof    bool
+}
+
+func NewReader(file *os.File, slices []Slice) (*Reader, error) {
+	r := &Reader{
+		slices: slices,
+		file:   file,
+	}
+	return r, r.next()
+}
+
+func (r *Reader) next() error {
+	if len(r.slices) == 0 {
+		r.eof = true
+		return nil
+	}
+	r.slice = r.slices[0]
+	r.slices = r.slices[1:]
+	_, err := r.file.Seek(int64(r.slice.Offset), 0)
+	return err
+}
+
+func (r *Reader) Read(b []byte) (int, error) {
+	if r.eof {
+		return 0, io.EOF
+	}
+	p := b
+	if uint64(len(p)) > r.slice.Length {
+		p = p[:r.slice.Length]
+	}
+	n, err := r.file.Read(p)
+	if n != 0 {
+		if err == io.EOF {
+			err = nil
+		}
+		r.slice.Length -= uint64(n)
+		if r.slice.Length == 0 {
+			err = r.next()
+		}
+	}
+	return n, err
+}

--- a/pkg/slicer/slice.go
+++ b/pkg/slicer/slice.go
@@ -1,0 +1,10 @@
+package slicer
+
+type Slice struct {
+	Offset uint64
+	Length uint64
+}
+
+func (s Slice) Overlaps(x Slice) bool {
+	return x.Offset >= s.Offset && x.Offset < s.Offset+x.Length
+}


### PR DESCRIPTION
This commit cleans up the slicer logic by moving the reader into
its own package.  We also moved LoadIndex from pcap/slicer.go
to pcap/index.go.

This is the first refactor toward adding support for pcap-ng.