### PR TITLE
Make zeek executable path configurable

### DIFF
--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -47,7 +47,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	logger := newLogger()
-	core := zqd.Core{Root: dataDir}
+	core := zqd.Core{Root: dataDir, ZeekExec: c.zeekExec}
 	handler := zqd.NewHandler(core)
 	ln, err := net.Listen("tcp", c.listenAddr)
 	if err != nil {

--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -47,7 +47,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	logger := newLogger()
-	core := zqd.Core{Root: dataDir, ZeekExec: c.zeekExec}
+	core := &zqd.Core{Root: dataDir, ZeekExec: c.zeekExec}
 	handler := zqd.NewHandler(core)
 	ln, err := net.Listen("tcp", c.listenAddr)
 	if err != nil {

--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -30,12 +30,14 @@ type Command struct {
 	*root.Command
 	listenAddr string
 	dataDir    string
+	zeekExec   string
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	f.StringVar(&c.listenAddr, "l", ":9867", "[addr]:port to listen on")
 	f.StringVar(&c.dataDir, "datadir", ".", "data directory")
+	f.StringVar(&c.zeekExec, "zeekpath", "", "path to the zeek executeable to use (defaults to zeek in $PATH)")
 	return c, nil
 }
 
@@ -45,7 +47,8 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	logger := newLogger()
-	handler := zqd.NewHandler(dataDir)
+	core := zqd.Core{Root: dataDir}
+	handler := zqd.NewHandler(core)
 	ln, err := net.Listen("tcp", c.listenAddr)
 	if err != nil {
 		return err

--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -37,7 +37,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	f.StringVar(&c.listenAddr, "l", ":9867", "[addr]:port to listen on")
 	f.StringVar(&c.dataDir, "datadir", ".", "data directory")
-	f.StringVar(&c.zeekExec, "zeekpath", "", "path to the zeek executeable to use (defaults to zeek in $PATH)")
+	f.StringVar(&c.zeekExec, "zeekpath", "", "path to the zeek executable to use (defaults to zeek in $PATH)")
 	return c, nil
 }
 

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -23,7 +23,7 @@ import (
 
 var taskCount int64
 
-func handleSearch(c Core, w http.ResponseWriter, r *http.Request) {
+func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	var req api.SearchRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -58,7 +58,7 @@ func handleSearch(c Core, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func handlePacketSearch(c Core, w http.ResponseWriter, r *http.Request) {
+func handlePacketSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	s := extractSpace(c, w, r)
 	if s == nil {
 		return
@@ -114,7 +114,7 @@ func handlePacketSearch(c Core, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func handleSpaceList(c Core, w http.ResponseWriter, r *http.Request) {
+func handleSpaceList(c *Core, w http.ResponseWriter, r *http.Request) {
 	info, err := ioutil.ReadDir(c.Root)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -138,7 +138,7 @@ func handleSpaceList(c Core, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func handleSpaceGet(c Core, w http.ResponseWriter, r *http.Request) {
+func handleSpaceGet(c *Core, w http.ResponseWriter, r *http.Request) {
 	s := extractSpace(c, w, r)
 	if s == nil {
 		return
@@ -195,7 +195,7 @@ func handleSpaceGet(c Core, w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(info)
 }
 
-func handleSpacePost(c Core, w http.ResponseWriter, r *http.Request) {
+func handleSpacePost(c *Core, w http.ResponseWriter, r *http.Request) {
 	var req api.SpacePostRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -220,7 +220,7 @@ func handleSpacePost(c Core, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func handleSpaceDelete(c Core, w http.ResponseWriter, r *http.Request) {
+func handleSpaceDelete(c *Core, w http.ResponseWriter, r *http.Request) {
 	s := extractSpace(c, w, r)
 	if s == nil {
 		return
@@ -232,7 +232,7 @@ func handleSpaceDelete(c Core, w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func handlePacketPost(c Core, w http.ResponseWriter, r *http.Request) {
+func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 	s := extractSpace(c, w, r)
 	if s == nil {
 		return
@@ -299,7 +299,7 @@ func handlePacketPost(c Core, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func extractSpace(c Core, w http.ResponseWriter, r *http.Request) *space.Space {
+func extractSpace(c *Core, w http.ResponseWriter, r *http.Request) *space.Space {
 	name := extractSpaceName(w, r)
 	if name == "" {
 		return nil

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -33,27 +33,27 @@ func TestSimpleSearch(t *testing.T) {
 0:[conn;1521911721.255387;C8Tful1TvM3Zf5x8fl;]
 `
 	space := "test"
-	root := createTempDir(t)
-	defer os.RemoveAll(root)
-	createSpaceWithData(t, root, space, src)
-	require.Equal(t, test.Trim(src), execSearch(t, root, space, "*"))
+	c := newCore(t)
+	defer os.RemoveAll(c.Root)
+	createSpaceWithData(t, c, space, src)
+	require.Equal(t, test.Trim(src), execSearch(t, c, space, "*"))
 }
 
 func TestSpaceList(t *testing.T) {
-	root := createTempDir(t)
-	defer os.RemoveAll(root)
-	sp1 := createSpace(t, root, "sp1", "")
-	sp2 := createSpace(t, root, "sp2", "")
-	sp3 := createSpace(t, root, "sp3", "")
-	sp4 := createSpace(t, root, "sp4", "")
+	c := newCore(t)
+	defer os.RemoveAll(c.Root)
+	sp1 := createSpace(t, c, "sp1", "")
+	sp2 := createSpace(t, c, "sp2", "")
+	sp3 := createSpace(t, c, "sp3", "")
+	sp4 := createSpace(t, c, "sp4", "")
 	// delete config.json from sp3
-	require.NoError(t, os.Remove(filepath.Join(root, sp3.Name, "config.json")))
+	require.NoError(t, os.Remove(filepath.Join(c.Root, sp3.Name, "config.json")))
 	expected := []string{
 		sp1.Name,
 		sp2.Name,
 		sp4.Name,
 	}
-	body := httpSuccess(t, zqd.NewHandler(root), "GET", "http://localhost:9867/space", nil)
+	body := httpSuccess(t, zqd.NewHandler(c), "GET", "http://localhost:9867/space", nil)
 	var list []string
 	err := json.NewDecoder(body).Decode(&list)
 	require.NoError(t, err)
@@ -66,9 +66,9 @@ func TestSpaceInfo(t *testing.T) {
 #0:record[_path:string,ts:time,uid:bstring]
 0:[conn;1521911723.205187;CBrzd94qfowOqJwCHa;]
 0:[conn;1521911721.255387;C8Tful1TvM3Zf5x8fl;]`
-	root := createTempDir(t)
-	defer os.RemoveAll(root)
-	createSpaceWithData(t, root, space, src)
+	c := newCore(t)
+	defer os.RemoveAll(c.Root)
+	createSpaceWithData(t, c, space, src)
 	min := nano.Unix(1521911721, 255387000)
 	max := nano.Unix(1521911723, 205187000)
 	expected := api.SpaceInfo{
@@ -79,7 +79,7 @@ func TestSpaceInfo(t *testing.T) {
 		PacketSupport: false,
 	}
 	u := fmt.Sprintf("http://localhost:9867/space/%s", space)
-	body := httpSuccess(t, zqd.NewHandler(root), "GET", u, nil)
+	body := httpSuccess(t, zqd.NewHandler(c), "GET", u, nil)
 	var info api.SpaceInfo
 	err := json.NewDecoder(body).Decode(&info)
 	require.NoError(t, err)
@@ -87,29 +87,29 @@ func TestSpaceInfo(t *testing.T) {
 }
 
 func TestSpacePostNameOnly(t *testing.T) {
-	root := createTempDir(t)
-	defer os.RemoveAll(root)
+	c := newCore(t)
+	defer os.RemoveAll(c.Root)
 	expected := api.SpacePostResponse{
 		Name:    "test",
-		DataDir: filepath.Join(root, "test"),
+		DataDir: filepath.Join(c.Root, "test"),
 	}
-	res := createSpace(t, root, "test", "")
+	res := createSpace(t, c, "test", "")
 	require.Equal(t, expected, res)
 }
 
 func TestSpacePostDataDirOnly(t *testing.T) {
-	run := func(name string, cb func(t *testing.T, tmp, root string) (string, api.SpacePostResponse)) {
+	run := func(name string, cb func(*testing.T, string, zqd.Core) (string, api.SpacePostResponse)) {
 		tmp := createTempDir(t)
 		defer os.RemoveAll(tmp)
-		root := filepath.Join(tmp, "spaces")
-		require.NoError(t, os.Mkdir(root, 0755))
+		c := zqd.Core{Root: filepath.Join(tmp, "spaces")}
+		require.NoError(t, os.Mkdir(c.Root, 0755))
 		t.Run(name, func(t *testing.T) {
-			datadir, expected := cb(t, tmp, root)
-			res := createSpace(t, root, "", datadir)
+			datadir, expected := cb(t, tmp, c)
+			res := createSpace(t, c, "", datadir)
 			require.Equal(t, expected, res)
 		})
 	}
-	run("Simple", func(t *testing.T, tmp, root string) (string, api.SpacePostResponse) {
+	run("Simple", func(t *testing.T, tmp string, c zqd.Core) (string, api.SpacePostResponse) {
 		datadir := filepath.Join(tmp, "mypcap.brim")
 		require.NoError(t, os.Mkdir(datadir, 0755))
 		return datadir, api.SpacePostResponse{
@@ -117,8 +117,8 @@ func TestSpacePostDataDirOnly(t *testing.T) {
 			DataDir: datadir,
 		}
 	})
-	run("DuplicateName", func(t *testing.T, tmp, root string) (string, api.SpacePostResponse) {
-		createSpace(t, root, "mypcap.brim", "")
+	run("DuplicateName", func(t *testing.T, tmp string, c zqd.Core) (string, api.SpacePostResponse) {
+		createSpace(t, c, "mypcap.brim", "")
 		datadir := filepath.Join(tmp, "mypcap.brim")
 		require.NoError(t, os.Mkdir(datadir, 0755))
 		return datadir, api.SpacePostResponse{
@@ -131,35 +131,47 @@ func TestSpacePostDataDirOnly(t *testing.T) {
 func TestSpaceDelete(t *testing.T) {
 	space := "myspace"
 	spaceUrl := fmt.Sprintf("http://localhost:9867/space/%s", space)
-	run := func(name string, cb func(t *testing.T, tmp, root string)) {
+	run := func(name string, cb func(*testing.T, string, zqd.Core)) {
 		tmp := createTempDir(t)
 		defer os.RemoveAll(tmp)
-		root := filepath.Join(tmp, "spaces")
-		require.NoError(t, os.Mkdir(root, 0755))
+		c := zqd.Core{Root: filepath.Join(tmp, "spaces")}
+		require.NoError(t, os.Mkdir(c.Root, 0755))
 		t.Run(name, func(t *testing.T) {
-			cb(t, tmp, root)
+			cb(t, tmp, c)
 			// make sure no spaces exist
-			r := httpSuccess(t, zqd.NewHandler(root), "GET", "http://localhost:9867/space", nil)
+			r := httpSuccess(t, zqd.NewHandler(c), "GET", "http://localhost:9867/space", nil)
 			body, err := ioutil.ReadAll(r)
 			require.NoError(t, err)
 			require.Equal(t, "[]\n", string(body))
 		})
 	}
-	run("Simple", func(t *testing.T, tmp, root string) {
-		createSpace(t, root, space, "")
-		httpSuccess(t, zqd.NewHandler(root), "DELETE", spaceUrl, nil)
+	run("Simple", func(t *testing.T, tmp string, c zqd.Core) {
+		createSpace(t, c, space, "")
+		httpSuccess(t, zqd.NewHandler(c), "DELETE", spaceUrl, nil)
 	})
-	run("DeletesOutsideDataDir", func(t *testing.T, tmp, root string) {
+	run("DeletesOutsideDataDir", func(t *testing.T, tmp string, c zqd.Core) {
 		datadir := filepath.Join(tmp, "datadir")
-		createSpace(t, root, space, datadir)
-		httpSuccess(t, zqd.NewHandler(root), "DELETE", spaceUrl, nil)
+		createSpace(t, c, space, datadir)
+		httpSuccess(t, zqd.NewHandler(c), "DELETE", spaceUrl, nil)
 		_, err := os.Stat(datadir)
 		require.Error(t, err)
 		require.Truef(t, os.IsNotExist(err), "expected error to be os.IsNotExist, got %v", err)
 	})
 }
 
-func execSearch(t *testing.T, root, space, prog string) string {
+func TestNoEndSlashSupport(t *testing.T) {
+	c := newCore(t)
+	defer os.RemoveAll(c.Root)
+
+	h := zqd.NewHandler(c)
+	r := httptest.NewRequest("GET", "http://localhost:9867/space/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	res := w.Result()
+	require.Equal(t, 404, res.StatusCode)
+}
+
+func execSearch(t *testing.T, c zqd.Core, space, prog string) string {
 	parsed, err := zql.ParseProc(prog)
 	require.NoError(t, err)
 	proc, err := json.Marshal(parsed)
@@ -171,7 +183,7 @@ func execSearch(t *testing.T, root, space, prog string) string {
 		Dir:   1,
 	}
 	// XXX Get rid of this format query param and use http headers instead.
-	body := httpSuccess(t, zqd.NewHandler(root), "POST", "http://localhost:9867/search?format=bzng", s)
+	body := httpSuccess(t, zqd.NewHandler(c), "POST", "http://localhost:9867/search?format=bzng", s)
 	buf := bytes.NewBuffer(nil)
 	w := zngio.NewWriter(buf)
 	r := bzngio.NewReader(body, resolver.NewContext())
@@ -185,28 +197,33 @@ func createTempDir(t *testing.T) string {
 	return dir
 }
 
-func createSpace(t *testing.T, root, spaceName, datadir string) api.SpacePostResponse {
+func newCore(t *testing.T) zqd.Core {
+	root := createTempDir(t)
+	return zqd.Core{Root: root}
+}
+
+func createSpace(t *testing.T, c zqd.Core, spaceName, datadir string) api.SpacePostResponse {
 	req := api.SpacePostRequest{
 		Name:    spaceName,
 		DataDir: datadir,
 	}
-	body := httpSuccess(t, zqd.NewHandler(root), "POST", "http://localhost:9867/space", req)
+	body := httpSuccess(t, zqd.NewHandler(c), "POST", "http://localhost:9867/space", req)
 	var res api.SpacePostResponse
 	require.NoError(t, json.NewDecoder(body).Decode(&res))
 	return res
 }
 
-// createSpace initiates a new space in the provided root and writes the zng
+// createSpace initiates a new space in the provided zqd.Core and writes the zng
 // source into said space.
-func createSpaceWithData(t *testing.T, root, spaceName, src string) {
-	res := createSpace(t, root, spaceName, "")
-	writeToSpace(t, root, res.Name, src)
+func createSpaceWithData(t *testing.T, c zqd.Core, spaceName, src string) {
+	res := createSpace(t, c, spaceName, "")
+	writeToSpace(t, c, res.Name, src)
 }
 
 // writeToSpace writes the provided zng source in to the provided space
 // directory.
-func writeToSpace(t *testing.T, root, spaceName, src string) {
-	s, err := space.Open(root, spaceName)
+func writeToSpace(t *testing.T, c zqd.Core, spaceName, src string) {
+	s, err := space.Open(c.Root, spaceName)
 	require.NoError(t, err)
 	f, err := s.CreateFile("all.bzng")
 	require.NoError(t, err)
@@ -234,16 +251,4 @@ func httpSuccess(t *testing.T, h http.Handler, method, url string, body interfac
 		require.Equal(t, http.StatusOK, res.StatusCode, string(body))
 	}
 	return res.Body
-}
-
-func TestNoEndSlashSupport(t *testing.T) {
-	root := createTempDir(t)
-	defer os.RemoveAll(root)
-
-	h := zqd.NewHandler(root)
-	r := httptest.NewRequest("GET", "http://localhost:9867/space/", nil)
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, r)
-	res := w.Result()
-	require.Equal(t, 404, res.StatusCode)
 }

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -25,7 +25,7 @@ func TestPacketPost(t *testing.T) {
 
 type PacketPostSuite struct {
 	suite.Suite
-	core     zqd.Core
+	core     *zqd.Core
 	space    string
 	pcapfile string
 	payloads []interface{}
@@ -75,7 +75,7 @@ func (s *PacketPostSuite) SetupTest() {
 	s.space = "test"
 	dir, err := ioutil.TempDir("", "PacketPostTest")
 	s.NoError(err)
-	s.core.Root = dir
+	s.core = &zqd.Core{Root: dir}
 	s.pcapfile = filepath.Join(".", "testdata/test.pcap")
 	s.payloads = createSpaceWithPcap(s.T(), s.core, s.space, s.pcapfile)
 }
@@ -84,7 +84,7 @@ func (s *PacketPostSuite) TearDownTest() {
 	os.RemoveAll(s.core.Root)
 }
 
-func createSpaceWithPcap(t *testing.T, core zqd.Core, spaceName, pcapfile string) []interface{} {
+func createSpaceWithPcap(t *testing.T, core *zqd.Core, spaceName, pcapfile string) []interface{} {
 	createSpace(t, core, spaceName, "")
 	req := api.PacketPostRequest{filepath.Join(".", pcapfile)}
 	u := fmt.Sprintf("http://localhost:9867/space/%s/packet", spaceName)

--- a/zqd/server.go
+++ b/zqd/server.go
@@ -7,6 +7,13 @@ import (
 	"github.com/gorilla/mux"
 )
 
+type Core struct {
+	Root string
+	// The exact path of the zeek executable. This is needed in the
+	// POST /space/:space/packet endpoint.
+	ZeekExec string
+}
+
 type VersionMessage struct {
 	Zqd string `json:"boomd"` //XXX boomd -> zqd
 	Zq  string `json:"zq"`
@@ -15,7 +22,7 @@ type VersionMessage struct {
 // This struct filled in by main from linker setting version strings.
 var Version VersionMessage
 
-func NewHandler(root string) http.Handler {
+func NewHandler(root Core) http.Handler {
 	r := mux.NewRouter()
 	r = r.UseEncodedPath()
 	r.Handle("/space", wrapRoot(root, handleSpaceList)).Methods("GET")
@@ -35,9 +42,9 @@ func NewHandler(root string) http.Handler {
 	return r
 }
 
-type handlerFunc func(root string, w http.ResponseWriter, r *http.Request)
+type handlerFunc func(root Core, w http.ResponseWriter, r *http.Request)
 
-func wrapRoot(root string, h handlerFunc) http.Handler {
+func wrapRoot(root Core, h handlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h(root, w, r)
 	})

--- a/zqd/server.go
+++ b/zqd/server.go
@@ -9,7 +9,8 @@ import (
 
 type Core struct {
 	Root string
-	// The exact path of the zeek executable. This is needed in the
+	// The exact path of the zeek executable. If this is an empty string zeek
+	// will be located from $PATH. This is needed in the
 	// POST /space/:space/packet endpoint.
 	ZeekExec string
 }

--- a/zqd/server.go
+++ b/zqd/server.go
@@ -22,7 +22,7 @@ type VersionMessage struct {
 // This struct filled in by main from linker setting version strings.
 var Version VersionMessage
 
-func NewHandler(root Core) http.Handler {
+func NewHandler(root *Core) http.Handler {
 	r := mux.NewRouter()
 	r = r.UseEncodedPath()
 	r.Handle("/space", wrapRoot(root, handleSpaceList)).Methods("GET")
@@ -42,9 +42,9 @@ func NewHandler(root Core) http.Handler {
 	return r
 }
 
-type handlerFunc func(root Core, w http.ResponseWriter, r *http.Request)
+type handlerFunc func(root *Core, w http.ResponseWriter, r *http.Request)
 
-func wrapRoot(root Core, h handlerFunc) http.Handler {
+func wrapRoot(root *Core, h handlerFunc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h(root, w, r)
 	})


### PR DESCRIPTION
Previously ingest pcap endpoint was using any available in path.
Provide added flexibility to by allowing users to specify a specific
zeek executable to run against. If no executable is provided zeek
if found use $PATH.