### PR TITLE
space get endpoint: handle spaces w no data

### DIFF
--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -86,6 +86,23 @@ func TestSpaceInfo(t *testing.T) {
 	require.Equal(t, expected, info)
 }
 
+func TestSpaceInfoNoData(t *testing.T) {
+	space := "test"
+	root := createTempDir(t)
+	defer os.RemoveAll(root)
+	createSpace(t, root, space, "")
+	u := fmt.Sprintf("http://localhost:9867/space/%s", space)
+	body := httpSuccess(t, zqd.NewHandler(root), "GET", u, nil)
+	expected := api.SpaceInfo{
+		Name:          space,
+		Size:          0,
+		PacketSupport: false,
+	}
+	var info api.SpaceInfo
+	require.NoError(t, json.NewDecoder(body).Decode(&info))
+	require.Equal(t, expected, info)
+}
+
 func TestSpacePostNameOnly(t *testing.T) {
 	c := newCore(t)
 	defer os.RemoveAll(c.Root)

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -87,7 +87,7 @@ func TestSpaceInfo(t *testing.T) {
 }
 
 func TestSpaceInfoNoData(t *testing.T) {
-	space := "test"
+	const space = "test"
 	root := createTempDir(t)
 	defer os.RemoveAll(root)
 	createSpace(t, root, space, "")

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -88,11 +88,10 @@ func TestSpaceInfo(t *testing.T) {
 
 func TestSpaceInfoNoData(t *testing.T) {
 	const space = "test"
-	root := createTempDir(t)
-	defer os.RemoveAll(root)
-	createSpace(t, root, space, "")
+	c := newCore(t)
+	createSpace(t, c, space, "")
 	u := fmt.Sprintf("http://localhost:9867/space/%s", space)
-	body := httpSuccess(t, zqd.NewHandler(root), "GET", u, nil)
+	body := httpSuccess(t, zqd.NewHandler(c), "GET", u, nil)
 	expected := api.SpaceInfo{
 		Name:          space,
 		Size:          0,


### PR DESCRIPTION
Currently querying GET /space/:space results in a 500 error:
all.bzng does not exist. Make endpoint more robust and return
a 200 with a space info response with the "size" field set to 0.