### PR TITLE
Sort in reverse on ts when creating all.bzng

### DIFF
--- a/zqd/packet/packet.go
+++ b/zqd/packet/packet.go
@@ -239,8 +239,8 @@ func (p *IngestProcess) writeData(ctx context.Context) error {
 		return err
 	}
 
-	minTs := headW.r.Ts
-	maxTs := tailW.r.Ts
+	minTs := tailW.r.Ts
+	maxTs := headW.r.Ts
 
 	if err := bzngfile.Close(); err != nil {
 		return err

--- a/zqd/packet/packet.go
+++ b/zqd/packet/packet.go
@@ -228,7 +228,7 @@ func (p *IngestProcess) writeData(ctx context.Context) error {
 		return err
 	}
 	zw := bzngio.NewWriter(bzngfile)
-	const program = "sort -limit 10000000 ts | (filter *; head 1; tail 1)"
+	const program = "sort -limit 10000000 -r ts | (filter *; head 1; tail 1)"
 	var headW, tailW recWriter
 
 	if err := search.Copy(ctx, []zbuf.Writer{zw, &headW, &tailW}, zr, program); err != nil {


### PR DESCRIPTION
In https://github.com/brimsec/zq/pull/378, we accidentally lost the reverse sorting on the `ts` field when generating the `all.bzng`, which results in an incorrect histogram view. E.g. for one of our sample data sets:

![image](https://user-images.githubusercontent.com/5934157/76151768-7e024080-606d-11ea-965c-53b2a61c5311.png)
