### PR TITLE
Make space available for querying during ingest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f
 	github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e
-	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/google/gopacket v1.1.17
 	github.com/gorilla/mux v1.7.4
 	github.com/mccanne/charm v0.0.3-0.20191224190439-b05e1b7b1be3
@@ -16,6 +15,5 @@ require (
 	github.com/yuin/goldmark v1.1.22
 	go.uber.org/zap v1.12.0
 	golang.org/x/text v0.3.0
-	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71
 )

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc h1:8WFBn63wegobsYAX0YjD+8suexZDga5CctH4CCTx2+8=
 github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
-github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/google/gopacket v1.1.17 h1:rMrlX2ZY2UbvT+sdz3+6J+pp2z+msCq9MxTU6ymxbBY=
 github.com/google/gopacket v1.1.17/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -82,8 +80,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
-gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71 h1:Xe2gvTZUJpsvOWUnvmL/tmhVBZUmHSvLbMjRj6NUUKo=

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -107,11 +107,13 @@ type PacketPostRequest struct {
 }
 
 type PacketPostStatus struct {
-	Type           string  `json:"type"`
-	StartTime      nano.Ts `json:"start_time"`
-	UpdateTime     nano.Ts `json:"update_time"`
-	PacketSize     int64   `json:"packet_total_size" unit:"bytes"`
-	PacketReadSize int64   `json:"packet_read_size" unit:"bytes"`
+	Type           string   `json:"type"`
+	StartTime      nano.Ts  `json:"start_time"`
+	UpdateTime     nano.Ts  `json:"update_time"`
+	PacketSize     int64    `json:"packet_total_size" unit:"bytes"`
+	PacketReadSize int64    `json:"packet_read_size" unit:"bytes"`
+	MinTime        *nano.Ts `json:"min_time,omitempty"`
+	MaxTime        *nano.Ts `json:"max_time,omitempty"`
 }
 
 // PacketSearch are the query string args to the packet endpoint when searching

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -252,11 +252,10 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 		case <-ticker.C:
 		}
 
-		var minTs, maxTs nano.Time
+		var minTs, maxTs *nano.Ts
 		if minTs, maxTs, err = s.GetTimes(); err != nil {
 			break
 		}
-
 		status := api.PacketPostStatus{
 			Type:           "PacketPostStatus",
 			StartTime:      proc.StartTime,

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -248,14 +248,23 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-proc.Done():
 			done = true
+		case <-proc.Snap():
 		case <-ticker.C:
 		}
+
+		var minTs, maxTs nano.Time
+		if minTs, maxTs, err = s.GetTimes(); err != nil {
+			break
+		}
+
 		status := api.PacketPostStatus{
 			Type:           "PacketPostStatus",
 			StartTime:      proc.StartTime,
 			UpdateTime:     nano.Now(),
 			PacketSize:     proc.PcapSize,
 			PacketReadSize: proc.PcapReadSize(),
+			MinTime:        minTs,
+			MaxTime:        maxTs,
 		}
 		if err := pipe.Send(status); err != nil {
 			// XXX This should be zap instead.

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -231,7 +231,7 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/ndjson")
 	w.Header().Set("Transfer-Encoding", "chunked")
-	w.WriteHeader(http.StatusCreated)
+	w.WriteHeader(http.StatusAccepted)
 	pipe := api.NewJSONPipe(w)
 	taskId := atomic.AddInt64(&taskCount, 1)
 	taskStart := api.TaskStart{Type: "TaskStart", TaskID: taskId}

--- a/zqd/packet/packet.go
+++ b/zqd/packet/packet.go
@@ -237,6 +237,9 @@ func (p *IngestProcess) writeData(ctx context.Context) error {
 	if err != nil {
 		panic(err)
 	}
+	if len(files) == 0 {
+		return nil
+	}
 	// convert logs into sorted bzng
 	zr, err := scanner.OpenFiles(resolver.NewContext(), files...)
 	if err != nil {

--- a/zqd/packet/packet.go
+++ b/zqd/packet/packet.go
@@ -116,7 +116,7 @@ outer:
 			break outer
 		case t := <-ticker.C:
 			if t.After(start.Add(next)) {
-				if err := p.writeData(ctx); err != nil {
+				if err := p.createSnapshot(ctx); err != nil {
 					abort()
 					return err
 				}
@@ -132,7 +132,7 @@ outer:
 		abort()
 		return slurpErr
 	}
-	if err := p.writeData(ctx); err != nil {
+	if err := p.createSnapshot(ctx); err != nil {
 		abort()
 		return err
 	}
@@ -226,7 +226,7 @@ func (rw *recWriter) Write(r *zng.Record) error {
 	return nil
 }
 
-func (p *IngestProcess) writeData(ctx context.Context) error {
+func (p *IngestProcess) createSnapshot(ctx context.Context) error {
 	files, err := filepath.Glob(filepath.Join(p.logdir, "*.log"))
 	// Per filepath.Glob documentation the only possible error would be due to
 	// an invalid glob pattern. Ok to panic.

--- a/zqd/packet/packet.go
+++ b/zqd/packet/packet.go
@@ -75,7 +75,7 @@ func IngestFile(ctx context.Context, s *space.Space, pcap, zeekExec string) (*In
 		snap:      make(chan struct{}),
 		zeekExec:  zeekExec,
 	}
-	if err = p.indexPcap(ctx); err != nil {
+	if err = p.indexPcap(); err != nil {
 		os.Remove(p.space.DataPath(IndexFile))
 		return nil, err
 	}
@@ -143,7 +143,7 @@ outer:
 	return nil
 }
 
-func (p *IngestProcess) indexPcap(ctx context.Context) error {
+func (p *IngestProcess) indexPcap() error {
 	pcapfile, err := os.Open(p.pcapPath)
 	if err != nil {
 		return err

--- a/zqd/packet/packet.go
+++ b/zqd/packet/packet.go
@@ -149,11 +149,7 @@ func (p *IngestProcess) indexPcap() error {
 		return err
 	}
 	defer pcapfile.Close()
-	iw := pcap.NewIndexWriter(10000)
-	if _, err := io.Copy(iw, pcapfile); err != nil {
-		return err
-	}
-	idx, err := iw.Close()
+	idx, err := pcap.CreateIndex(pcapfile, 10000)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adjusts the ingest process following @mccanne's design to make data available for querying as it is processed, rather than waiting for everything to land before allowing anything to be queried.

The main changes are:
   - Indexing and zeek processing of the pcap now happen sequentially. Indexing is first; a HTTP 2xx is returned upon successful index creation.
  - Instead of waiting for all zeek logs to be ready, and then running a one-time bzng conversion job after that, we now take "snapshots" of the zeek logs as they are being generated, and make these snapshots
available for regular querying while zeek processing continues. A final snapshot is done after all logs have been processed.

@mccanne, I did not implement the "stable" scheme in this PR, as I had a question that raised offline (on the issue). I can add it here once that's resolved or in a different PR. 

This change needs tests. I'm waiting for #399 to get in and will add those after that.


