### PR TITLE
Attach taskCount to zqd.Core

### DIFF
--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -79,10 +79,8 @@ func TestPacketPostZeekFailImmediate(t *testing.T) {
 	defer p.cleanup()
 	t.Run("TaskEndError", func(t *testing.T) {
 		expected := &api.TaskEnd{
-			Type: "TaskEnd",
-			// XXX This is dependent on execution order. TaskID is global when
-			// should be attached to instance of core.
-			TaskID: 2,
+			Type:   "TaskEnd",
+			TaskID: 1,
 			Error: &api.Error{
 				Type: "Error",
 				// XXX This is not an informative failure message. Will fix in
@@ -101,10 +99,8 @@ func TestPacketPostZeekFailAfterWrite(t *testing.T) {
 	defer p.cleanup()
 	t.Run("TaskEndError", func(t *testing.T) {
 		expected := &api.TaskEnd{
-			Type: "TaskEnd",
-			// XXX This is dependent on execution order. TaskID is global when
-			// should be attached to instance of core.
-			TaskID: 3,
+			Type:   "TaskEnd",
+			TaskID: 1,
 			Error: &api.Error{
 				Type: "Error",
 				// XXX This is not an informative failure message. Will fix in

--- a/zqd/server.go
+++ b/zqd/server.go
@@ -3,6 +3,7 @@ package zqd
 import (
 	"encoding/json"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/gorilla/mux"
 )
@@ -12,7 +13,12 @@ type Core struct {
 	// The exact path of the zeek executable. If this is an empty string zeek
 	// will be located from $PATH. This is needed in the
 	// POST /space/:space/packet endpoint.
-	ZeekExec string
+	ZeekExec  string
+	taskCount int64
+}
+
+func (c *Core) getTaskID() int64 {
+	return atomic.AddInt64(&c.taskCount, 1)
 }
 
 type VersionMessage struct {


### PR DESCRIPTION
Previously taskCount was a global variable. This made testing
difficult because the task_id returned by an api call was dependent
on the order in which the call was made. Instead have each instance
of zqd.Core have its own taskCount var.