### PR TITLE
Provide better errors on zeek related failures

### DIFF
--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -82,10 +82,8 @@ func TestPacketPostZeekFailImmediate(t *testing.T) {
 			Type:   "TaskEnd",
 			TaskID: 1,
 			Error: &api.Error{
-				Type: "Error",
-				// XXX This is not an informative failure message. Will fix in
-				// followup pr.
-				Message: "exit status 2",
+				Type:    "Error",
+				Message: "zeek exited with status 1: failed to start",
 			},
 		}
 		last := p.payloads[len(p.payloads)-1]
@@ -102,10 +100,8 @@ func TestPacketPostZeekFailAfterWrite(t *testing.T) {
 			Type:   "TaskEnd",
 			TaskID: 1,
 			Error: &api.Error{
-				Type: "Error",
-				// XXX This is not an informative failure message. Will fix in
-				// followup pr.
-				Message: "exit status 1",
+				Type:    "Error",
+				Message: "zeek exited with status 1: exit after writing logs",
 			},
 		}
 		last := p.payloads[len(p.payloads)-1]
@@ -119,6 +115,14 @@ func TestPacketPostZeekFailAfterWrite(t *testing.T) {
 			Name: p.space,
 		}
 		require.Equal(t, expected, info)
+	})
+}
+
+func TestPacketPostZeekNotFound(t *testing.T) {
+	exec := abspath(t, filepath.Join("testdata", "zeekdoesnotexist.sh"))
+	p := packetPost(t, exec, "./testdata/valid.pcap", 500)
+	t.Run("ErrorMessage", func(t *testing.T) {
+		require.Regexp(t, "zeek not found", string(p.body))
 	})
 }
 

--- a/zqd/packet/packet.go
+++ b/zqd/packet/packet.go
@@ -293,7 +293,7 @@ func (p *IngestProcess) startZeek(ctx context.Context, dir string) (*exec.Cmd, i
 	if err != nil {
 		return nil, nil, err
 	}
-	// capture stderr
+	// Capture stderr for error reporting.
 	cmd.Stderr = bytes.NewBuffer(nil)
 	return cmd, w, cmd.Start()
 }

--- a/zqd/testdata/zeekstartfail.sh
+++ b/zqd/testdata/zeekstartfail.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-exit 2
+echo "failed to start" 1>&2
+exit 1

--- a/zqd/testdata/zeekwritefail.sh
+++ b/zqd/testdata/zeekwritefail.sh
@@ -20,4 +20,5 @@ cat <<EOF > conn.log
 1521911724.896854	CFzn9A3l9ppbMBVin3	10.164.94.120	40659	10.47.8.208	3389	tcp	-	0.011922	147	19	RSTR	-	-	0	ShADTdtr	10	830	6	342	-
 EOF
 
+echo "exit after writing logs" 1>&2
 exit 1


### PR DESCRIPTION
Include any output from stderr in error message along with exit status
code and the fact that the error came from the zeek subprocess.

If zeek cannot be found, or the user does not have execute permissions 
the request will return with a 500 level errors. All other errors will occur after
the 2xx request headers are sent and thus will be streamed back in the json
TaskEnd payload.