### PR TITLE
Packet post endpoint: Return 400 on bad pcap

### DIFF
--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -2,6 +2,7 @@ package zqd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -230,6 +231,10 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 	proc, err := packet.IngestFile(r.Context(), s, req.Path, c.ZeekExec)
 	if err != nil {
+		if errors.Is(err, pcapio.ErrCorruptPcap) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -65,7 +65,7 @@ func TestPacketPostSuccess(t *testing.T) {
 }
 
 func TestPacketPostInvalidPcap(t *testing.T) {
-	p := packetPost(t, zeekpath, "./testdata/invalid.pcap", 500)
+	p := packetPost(t, zeekpath, "./testdata/invalid.pcap", 400)
 	defer p.cleanup()
 	t.Run("ErrorMessage", func(t *testing.T) {
 		// XXX Better error message here.


### PR DESCRIPTION
If we are unable to read the posted pcap return a 400 error.
Ideally it would be nice to have some better error information about
why the pcap wasn't readable (e.g. unsupported major/minor version,
unrecorgnized magic number, etc), that said perhaps these are
extreme edge cases and package `pcapio` can read the vast majority
of pcap/ngpcap files out there.