### PR TITLE
packet post sort limit reached error

### DIFF
--- a/proc/sort.go
+++ b/proc/sort.go
@@ -9,6 +9,12 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
+type ErrSortLimitReached int
+
+func (e ErrSortLimitReached) Error() string {
+	return fmt.Sprintf("sort limit hit (%d)", e)
+}
+
 type Sort struct {
 	Base
 	dir        int
@@ -84,7 +90,7 @@ func (s *Sort) Pull() (zbuf.Batch, error) {
 		}
 		if len(s.out)+batch.Length() > s.limit {
 			batch.Unref()
-			return nil, fmt.Errorf("sort limit hit (%d)", s.limit)
+			return nil, ErrSortLimitReached(s.limit)
 		}
 		// XXX this should handle group-by every ... need to change how we do this
 		s.consume(batch)

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -104,6 +104,12 @@ type SpacePostResponse SpacePostRequest
 
 type PacketPostRequest struct {
 	Path string `json:"path"`
+	// SortLimit specifies the limit of logs in posted pcap to sort. Its
+	// existence in the request is only as a hook for testing (though users
+	// running zqd in high memory environments may want to push this higher).
+	// Eventually zqd will sort an unlimited amount of logs and this can be
+	// taken out.
+	SortLimit int `json:"sort_limit,omitempty"`
 }
 
 type PacketPostStatus struct {

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -104,12 +104,6 @@ type SpacePostResponse SpacePostRequest
 
 type PacketPostRequest struct {
 	Path string `json:"path"`
-	// SortLimit specifies the limit of logs in posted pcap to sort. Its
-	// existence in the request is only as a hook for testing (though users
-	// running zqd in high memory environments may want to push this higher).
-	// Eventually zqd will sort an unlimited amount of logs and this can be
-	// taken out.
-	SortLimit int `json:"sort_limit,omitempty"`
 }
 
 type PacketPostStatus struct {

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -229,7 +229,7 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	proc, err := packet.IngestFile(r.Context(), s, req.Path, c.ZeekExec, req.SortLimit)
+	proc, err := packet.IngestFile(r.Context(), s, req.Path, c.ZeekExec, c.SortLimit)
 	if err != nil {
 		if errors.Is(err, pcapio.ErrCorruptPcap) {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -229,7 +229,7 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	proc, err := packet.IngestFile(r.Context(), s, req.Path, c.ZeekExec)
+	proc, err := packet.IngestFile(r.Context(), s, req.Path, c.ZeekExec, req.SortLimit)
 	if err != nil {
 		if errors.Is(err, pcapio.ErrCorruptPcap) {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -93,6 +93,15 @@ func TestPacketPostInvalidPcap(t *testing.T) {
 		// XXX Better error message here.
 		require.Regexp(t, "^bad pcap file*", string(p.body))
 	})
+	t.Run("EmptySpaceInfo", func(t *testing.T) {
+		u := fmt.Sprintf("http://localhost:9867/space/%s", p.space)
+		var info api.SpaceInfo
+		httpJSONSuccess(t, zqd.NewHandler(p.core), "GET", u, nil, &info)
+		expected := api.SpaceInfo{
+			Name: p.space,
+		}
+		require.Equal(t, expected, info)
+	})
 }
 
 func TestPacketPostZeekFailImmediate(t *testing.T) {

--- a/zqd/server.go
+++ b/zqd/server.go
@@ -13,7 +13,11 @@ type Core struct {
 	// The exact path of the zeek executable. If this is an empty string zeek
 	// will be located from $PATH. This is needed in the
 	// POST /space/:space/packet endpoint.
-	ZeekExec  string
+	ZeekExec string
+	// SortLimit specifies the limit of logs in posted pcap to sort. Its
+	// existence is only as a hook for testing.  Eventually zqd will sort an
+	// unlimited amount of logs and this can be taken out.
+	SortLimit int
 	taskCount int64
 }
 


### PR DESCRIPTION
Ensure that if the sort limit is reached in the packet post
endpoint that a sensible error message is returned.

For testing purpose add a SortLimit field to zqd.Core
allowing test cases to test on custom sort limits.