### PR TITLE
/search: return empty results if no all.bzng

### DIFF
--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -39,6 +39,14 @@ func TestSimpleSearch(t *testing.T) {
 	require.Equal(t, test.Trim(src), execSearch(t, c, space, "*"))
 }
 
+func TestSearchEmptySpace(t *testing.T) {
+	space := "test"
+	c := newCore(t)
+	defer os.RemoveAll(c.Root)
+	createSpace(t, c, space, "")
+	require.Equal(t, "", execSearch(t, c, space, "*"))
+}
+
 func TestSpaceList(t *testing.T) {
 	c := newCore(t)
 	defer os.RemoveAll(c.Root)

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -5,6 +5,10 @@ package search
 import (
 	"context"
 	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/brimsec/zq/ast"
@@ -43,9 +47,13 @@ func Search(ctx context.Context, s *space.Space, req api.SearchRequest, out Outp
 	if err != nil {
 		return err
 	}
-	f, err := s.OpenFile("all.bzng")
+	var f io.ReadCloser
+	f, err = s.OpenFile("all.bzng")
 	if err != nil {
-		return errors.New("no such space: " + query.Space)
+		if !os.IsNotExist(err) {
+			return err
+		}
+		f = ioutil.NopCloser(strings.NewReader(""))
 	}
 	defer f.Close()
 	zngReader, err := detector.LookupReader("bzng", f, resolver.NewContext())


### PR DESCRIPTION
Previously, /search was returning a "no such space" error when all.bzng couldn't be opened. Now, if all.bzng is missing, we return empty results. I ran into this issue while using Brim against zqd master. This was part of @mccanne 's design and should have been done in #402 .

