### PR TITLE
Enhancements to zql parser test tool

### DIFF
--- a/zql/Makefile
+++ b/zql/Makefile
@@ -12,6 +12,8 @@ PEGJS_INSTALLED = $(shell test -x $(PEGJS) && $(PEGJS) --version)
 PIGEON_INSTALLED = $(shell test -d $(deps) && (cd $(deps); go list -m -f {{.Version}} github.com/mna/pigeon || echo ""))
 GOIMPORTS_INSTALLED = $(shell test -d $(deps) && (cd $(deps); go list -m -f {{.Version}} golang.org/x/tools || echo ""))
 
+PEGJS_ARGS = --allowed-start-rules start,Expression
+
 all: zql.go zql.js
 
 run: all
@@ -52,4 +54,4 @@ zql.go: $(PIGEON) $(GOIMPORTS)
 
 .PHONY: zql.js
 zql.js: $(PEGJS)
-	cpp -E -P zql.peg | $(PEGJS) -o $@
+	cpp -E -P zql.peg | $(PEGJS) $(PEGJS_ARGS) -o $@

--- a/zql/main/main.go
+++ b/zql/main/main.go
@@ -13,8 +13,10 @@ import (
 	"github.com/peterh/liner"
 )
 
+var target = "start"
+
 func runGo(line string) error {
-	got, err := zql.Parse("", []byte(line))
+	got, err := zql.Parse("", []byte(line), zql.Entrypoint(target))
 	if err != nil {
 		return err
 	}
@@ -27,7 +29,7 @@ func runGo(line string) error {
 }
 
 func runJs(line string) error {
-	cmd := exec.Command("node", "./main/main.js")
+	cmd := exec.Command("node", "./main/main.js", "-e", target)
 	cmd.Stdin = strings.NewReader(line)
 	out, err := cmd.Output()
 	if err != nil {
@@ -38,7 +40,14 @@ func runJs(line string) error {
 	return nil
 }
 
+const targetCmd = "_target "
+
 func parse(line string) {
+	if strings.HasPrefix(line, targetCmd) {
+		target = line[len(targetCmd):]
+		return
+	}
+
 	if err := runGo(line); err != nil {
 		fmt.Println("go error:", err)
 	}
@@ -58,6 +67,7 @@ func iteractive() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		rl.AppendHistory(line)
 		parse(line)
 	}
 }

--- a/zql/main/main.js
+++ b/zql/main/main.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const fs = require('fs');
-
 const zql = require('../zql')
+
+let startRule = 'start';
 
 function show(obj) {
     console.log(JSON.stringify(obj, null, 4));
@@ -14,40 +15,29 @@ function wrap(e) {
 
 function parse_query(line) {
     try {
-        return zql.parse(line);
+        return zql.parse(line, {startRule});
     } catch (e) {
         return wrap(e);
     }
 }
 
-function parse_cli(line) {
-    try {
-        return zql.parse(line);
-    } catch (e) {
-        // XXX do nothing
-    }
-    return undefined;
-}
-
-function parse(src) {
-    let ast = parse_cli(src);
-    if (!ast) {
-        ast = parse_query(src);
-    }
-    return ast;
-}
-
 let filename = '/dev/stdin';
-let argv = process.argv;
-if (argv.length === 3) {
-    filename = argv[2];
+let argv = process.argv.slice(2);
+
+while (argv.length > 0) {
+    if (argv[0] === "-e" && argv.length > 1) {
+        startRule = argv[1];
+        argv = argv.slice(2);
+    } else {
+        filename = argv.shift();
+    }
 }
 
-let boom_src;
+let zql_src;
 try {
-    boom_src = fs.readFileSync(filename, 'utf8');
+    zql_src = fs.readFileSync(filename, 'utf8');
 } catch (e) {
     show(wrap(e));
     process.exit(1);
 }
-show(parse(boom_src));
+show(parse_query(zql_src));

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -138,7 +138,7 @@ function peg$parse(input, options) {
 
   var peg$FAILED = {},
 
-      peg$startRuleFunctions = { start: peg$parsestart },
+      peg$startRuleFunctions = { start: peg$parsestart, Expression: peg$parseExpression },
       peg$startRuleFunction  = peg$parsestart,
 
       peg$c0 = function(ast) { return ast },
@@ -4290,6 +4290,14 @@ function peg$parse(input, options) {
       s1 = peg$c202(s1);
     }
     s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseExpression() {
+    var s0;
+
+    s0 = peg$parseLogicalORExpression();
 
     return s0;
   }


### PR DESCRIPTION
A few enhancements to the repl wrapper around the zql parser (aka, the
thing that is executed when you run "make -C zql run").  No zql/zq/zqd
functional changes.

 - enable history
 - enable alternate parser entry points, set by typing "_target foo", eg:
  ```
   > _target Expression
   > x + 1
   Go raw result:
   &{{BinaryExpr} ...}
  ```