### PR TITLE
unescape space path name

### DIFF
--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -299,7 +300,12 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 }
 
 func extractSpace(c *Core, w http.ResponseWriter, r *http.Request) *space.Space {
-	name := extractSpaceName(w, r)
+	rawName := extractSpaceName(w, r)
+	name, err := url.PathUnescape(rawName)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return nil
+	}
 	if name == "" {
 		return nil
 	}

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"time"
 
@@ -300,12 +299,7 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 }
 
 func extractSpace(c *Core, w http.ResponseWriter, r *http.Request) *space.Space {
-	rawName := extractSpaceName(w, r)
-	name, err := url.PathUnescape(rawName)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return nil
-	}
+	name := extractSpaceName(w, r)
 	if name == "" {
 		return nil
 	}

--- a/zqd/server.go
+++ b/zqd/server.go
@@ -35,7 +35,6 @@ var Version VersionMessage
 
 func NewHandler(root *Core) http.Handler {
 	r := mux.NewRouter()
-	r = r.UseEncodedPath()
 	r.Handle("/space", wrapRoot(root, handleSpaceList)).Methods("GET")
 	r.Handle("/space", wrapRoot(root, handleSpacePost)).Methods("POST")
 	r.Handle("/space/{space}", wrapRoot(root, handleSpaceGet)).Methods("GET")


### PR DESCRIPTION
decodes the url path and allows us to use spaces with otherwise url-encoded chars (like `' '` spaces)

Signed-off-by: Mason Fish <mason@looky.cloud>