### PR TITLE
Fix sort comparison of two nulls

### DIFF
--- a/expr/sort.go
+++ b/expr/sort.go
@@ -38,7 +38,7 @@ func NewSortFn(nullsMax bool, fields ...FieldExprResolver) SortFn {
 			nullA := isNull(a)
 			nullB := isNull(b)
 			if nullA && nullB {
-				return 0
+				continue
 			}
 			if nullA {
 				if nullsMax {

--- a/tests/suite/sort/sort-first-field-always-null.yaml
+++ b/tests/suite/sort/sort-first-field-always-null.yaml
@@ -1,0 +1,13 @@
+zql: sort x, y
+
+input: |
+  #0:record[x:int64,y:int64]
+  0:[-;2;]
+  0:[-;1;]
+  0:[-;3;]
+
+output: |
+  #0:record[x:int64,y:int64]
+  0:[-;1;]
+  0:[-;2;]
+  0:[-;3;]


### PR DESCRIPTION
tests/suite/sort/sort-first-field-always-null.yaml fails without the accompanying change to expr/sort.go.