### PR TITLE
Ensure zqd transmits appropriate content-type header

### DIFF
--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -49,6 +49,7 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 	// XXX This always returns bad request but should return status codes
 	// that reflect the nature of the returned error.
+	w.Header().Set("Content-Type", "application/ndjson")
 	if err := search.Search(r.Context(), s, req, out); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -201,6 +202,7 @@ func handleSpacePost(c *Core, w http.ResponseWriter, r *http.Request) {
 		Name:    s.Name(),
 		DataDir: s.DataPath(),
 	}
+	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(res); err != nil {
 		// XXX Add zap here.
 		log.Println("Error writing response", err)
@@ -239,7 +241,6 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/ndjson")
-	w.Header().Set("Transfer-Encoding", "chunked")
 	w.WriteHeader(http.StatusAccepted)
 	pipe := api.NewJSONPipe(w)
 	taskID := c.getTaskID()

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -202,7 +202,10 @@ func (r *packetPostResult) postPcap(t *testing.T, file string) {
 	require.NoError(t, err)
 	r.body, r.statusCode = body, res.StatusCode
 	if r.statusCode == 202 {
+		require.Equal(t, "application/ndjson", res.Header.Get("Content-Type"))
 		r.readPayloads(t)
+	} else {
+		require.Equal(t, "text/plain; charset=utf-8", res.Header.Get("Content-Type"))
 	}
 }
 


### PR DESCRIPTION
If the response contains a json payload the response header should
be 'application/json'. For nd-json this should be 'application/ndjson'.
For error status codes we are currently returning simple text
messages; the content-type should be 'text/plain'.

Updates api tests to check for this.