### PR TITLE
fix bugs in parsing and search pcap-ng sections

### DIFF
--- a/pcap/index.go
+++ b/pcap/index.go
@@ -72,7 +72,7 @@ func CreateIndex(r io.Reader, size int) (Index, error) {
 				index = append(index, *section)
 			}
 			slice := slicer.Slice{
-				Offset: 0,
+				Offset: off,
 				Length: uint64(len(block)),
 			}
 			section = &Section{

--- a/pcap/slicer.go
+++ b/pcap/slicer.go
@@ -25,13 +25,14 @@ func GenerateSlices(index Index, span nano.Span) ([]slicer.Slice, error) {
 	var slices []slicer.Slice
 	for _, section := range index {
 		pslice, err := FindPacketSlice(section.Index, span)
+		if err == ErrNoPacketsFound {
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}
 		for _, slice := range section.Blocks {
-			if !pslice.Overlaps(slice) {
-				slices = append(slices, slice)
-			}
+			slices = append(slices, slice)
 		}
 		slices = append(slices, pslice)
 	}


### PR DESCRIPTION
This commit fixes some silly/embarrassing bugs on the pcap indexing and searching code relating to how pcap-ng sections are handled.   Thanks to @philrz for tracking this down.
