### PR TITLE
zql js parser sort proc: parse limit as int

### DIFF
--- a/zql/parser-support.js
+++ b/zql/parser-support.js
@@ -69,8 +69,8 @@ function makeSortProc(args, fields) {
   }
 
   let sortdir = argsMap.has("r") ? -1 : 1;
-  let limit = argsMap.get("limit");
   let nullsfirst = (argsMap.get("nulls") === "first");
+  let limit = parseInt(argsMap.get("limit"));
   return { op: "SortProc", fields, sortdir, limit, nullsfirst };
 }
 

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -7340,8 +7340,8 @@ function peg$parse(input, options) {
     }
 
     let sortdir = argsMap.has("r") ? -1 : 1;
-    let limit = argsMap.get("limit");
     let nullsfirst = (argsMap.get("nulls") === "first");
+    let limit = parseInt(argsMap.get("limit"));
     return { op: "SortProc", fields, sortdir, limit, nullsfirst };
   }
 


### PR DESCRIPTION
The js parser was parsing SortPorc -limit as a string while the go
parser was parsing it as an int. Fix this.