### PR TITLE
fix offset calculation in legacy pcap reader

### DIFF
--- a/pcap/pcapio/read.go
+++ b/pcap/pcapio/read.go
@@ -103,7 +103,6 @@ func (r *PcapReader) readHeader() error {
 	}
 	r.header = make([]byte, fileHeaderLen)
 	copy(r.header, hdr)
-	r.offset += fileHeaderLen
 	if magic := binary.LittleEndian.Uint32(hdr[0:4]); magic == magicNanoseconds {
 		r.byteOrder = binary.LittleEndian
 		r.nanoSecsFactor = 1
@@ -141,6 +140,7 @@ func (r *PcapReader) Read() ([]byte, BlockType, error) {
 	header := r.header
 	if header != nil {
 		r.header = nil
+		r.offset += uint64(len(header))
 		return header, TypeSection, nil
 	}
 	hdr, err := r.Reader.Peek(packetHeaderLen)


### PR DESCRIPTION
This commit fixes a bug with the pcap reader's offset calculation
at the beginning of the file.  The offset should be adjusted only
when the bytes are actually read instead of when the header is
read into a temporary buffer.  Otherwise, the offset for the pcap
header is incorrect when building a pcap index.  This used to
work because the header offset logic was wired to 0 in the pcap
indexer prior to support for pcap-ng.