### PR TITLE
Allow expressions to evaluate to complex types

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -190,10 +190,15 @@ func (v *NativeValue) toZngValue() (zng.Value, error) {
 	case zng.IdDuration:
 		d := v.value.(int64)
 		return zng.Value{zng.TypeDuration, zng.EncodeDuration(d)}, nil
-
-	default:
-		return zng.Value{}, errors.New("unknown type")
 	}
+
+	// Arrays, sets, and records are just zval encoded.
+	switch v.typ.(type) {
+	case *zng.TypeArray, *zng.TypeSet, *zng.TypeRecord:
+		return zng.Value{v.typ, v.value.(zcode.Bytes)}, nil
+	}
+
+	return zng.Value{}, errors.New("unknown type")
 }
 
 // CompileExpr tries to compile the given Expression into a function

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -133,6 +133,20 @@ func TestPrimitives(t *testing.T) {
 	testError(t, "doesnexist", record, expr.ErrNoSuchField, "referencing non-existent field")
 }
 
+func TestComplex(t *testing.T) {
+	// Test that an expression can evaluate to a complex type
+	record, err := parseOneRecord(`
+#0:record[r:record[s:string]]
+0:[[hello;]]`)
+	require.NoError(t, err)
+	result, err := evaluate("r", record)
+	require.NoError(t, err)
+	recType, ok := result.Type.(*zng.TypeRecord)
+	assert.True(t, ok, "result type is record")
+	assert.Equal(t, 1, len(recType.Columns), "result has one column")
+	assert.Equal(t, zng.TypeString, recType.Columns[0].Type, "result has string column")
+}
+
 func TestLogical(t *testing.T) {
 	record, err := parseOneRecord(`
 #0:record[t:bool,f:bool]


### PR DESCRIPTION
toZngValue() wasn't handling non-primitive types which means that
an expression that evaluates to an array, set, or record would fail.
Expressions can't yet create these types, but they can read existing
values so this should work.