### PR TITLE
Derive space time span from pcap index

### DIFF
--- a/pcap/index.go
+++ b/pcap/index.go
@@ -7,11 +7,28 @@ import (
 	"io/ioutil"
 
 	"github.com/brimsec/zq/pcap/pcapio"
+	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/pkg/ranger"
 	"github.com/brimsec/zq/pkg/slicer"
 )
 
 type Index []Section
+
+// Span returns the entire time span covered by the index.
+func (i Index) Span() nano.Span {
+	var span nano.Span
+	for _, s := range i {
+		for _, bin := range s.Index {
+			binspan := nano.NewSpanTs(nano.Ts(bin.Range.Y0), nano.Ts(bin.Range.Y1))
+			if span.Ts == 0 {
+				span = binspan
+				continue
+			}
+			span = span.Union(binspan)
+		}
+	}
+	return span
+}
 
 // Section indicates the seek offset of a pcap section.  For legacy pcaps,
 // there is just one section at the beginning of the file.  For nextgen pcaps,

--- a/zqd/packet/packet.go
+++ b/zqd/packet/packet.go
@@ -19,7 +19,6 @@ import (
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/bzngio"
-	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqd/search"
 	"github.com/brimsec/zq/zqd/space"
@@ -241,15 +240,6 @@ func (p *IngestProcess) Done() <-chan struct{} {
 // should no longer be read from after Done() has emitted.
 func (p *IngestProcess) Snap() <-chan struct{} {
 	return p.snap
-}
-
-type recWriter struct {
-	r *zng.Record
-}
-
-func (rw *recWriter) Write(r *zng.Record) error {
-	rw.r = r
-	return nil
 }
 
 func (p *IngestProcess) createSnapshot(ctx context.Context) error {

--- a/zqd/packet/packet.go
+++ b/zqd/packet/packet.go
@@ -179,6 +179,11 @@ func (p *IngestProcess) indexPcap() error {
 		return err
 	}
 	f.Close()
+	// grab span from index and use to generate space info min/max time.
+	span := idx.Span()
+	if err = p.space.SetTimes(span.Ts, span.End()); err != nil {
+		return err
+	}
 	return os.Rename(tmppath, idxpath)
 }
 
@@ -271,10 +276,8 @@ func (p *IngestProcess) createSnapshot(ctx context.Context) error {
 		return err
 	}
 	zw := bzngio.NewWriter(bzngfile)
-	program := fmt.Sprintf("sort -limit %d -r ts | (filter *; head 1; tail 1)", p.sortLimit)
-	var headW, tailW recWriter
-
-	if err := search.Copy(ctx, []zbuf.Writer{zw, &headW, &tailW}, zr, program); err != nil {
+	program := fmt.Sprintf("sort -limit %d -r ts", p.sortLimit)
+	if err := search.Copy(ctx, []zbuf.Writer{zw}, zr, program); err != nil {
 		// If an error occurs here close and remove tmp bzngfile, lest we start
 		// leaking files and file descriptors.
 		bzngfile.Close()
@@ -283,13 +286,6 @@ func (p *IngestProcess) createSnapshot(ctx context.Context) error {
 	}
 	if err := bzngfile.Close(); err != nil {
 		return err
-	}
-	if tailW.r != nil {
-		minTs := tailW.r.Ts
-		maxTs := headW.r.Ts
-		if err = p.space.SetTimes(minTs, maxTs); err != nil {
-			return err
-		}
 	}
 	return os.Rename(bzngfile.Name(), p.space.DataPath("all.bzng"))
 }


### PR DESCRIPTION
Add a Span() func to pcap.Index that computes the total span of the
index. Use this functionality to report the min/max time of a space
ingesting a packet.