### PR TITLE
Typed NDJSON reader

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/brimsec/zq/ast"
@@ -14,6 +17,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
+	"github.com/brimsec/zq/zio/ndjsonio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
 	"github.com/mccanne/charm"
@@ -71,16 +75,17 @@ func init() {
 }
 
 type Command struct {
-	zctx        *resolver.Context
-	ifmt        string
-	ofmt        string
-	dir         string
-	path        string
-	outputFile  string
-	verbose     bool
-	stats       bool
-	quiet       bool
-	showVersion bool
+	zctx         *resolver.Context
+	ifmt         string
+	ofmt         string
+	dir          string
+	path         string
+	jsonTypePath string
+	outputFile   string
+	verbose      bool
+	stats        bool
+	quiet        bool
+	showVersion  bool
 	zio.Flags
 }
 
@@ -92,6 +97,7 @@ func New(f *flag.FlagSet) (charm.Command, error) {
 	f.StringVar(&c.path, "p", cwd, "path for input")
 	f.StringVar(&c.dir, "d", "", "directory for output data files")
 	f.StringVar(&c.outputFile, "o", "", "write data to output file")
+	f.StringVar(&c.jsonTypePath, "j", "", "path to json types file")
 	f.BoolVar(&c.verbose, "v", false, "show verbose details")
 	f.BoolVar(&c.stats, "S", false, "display search stats on stderr")
 	f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
@@ -159,6 +165,19 @@ func (c *Command) printVersion() error {
 	return nil
 }
 
+func (c *Command) loadJsonTypes() (*ndjsonio.TypeConfig, error) {
+	data, err := ioutil.ReadFile(c.jsonTypePath)
+	if err != nil {
+		return nil, err
+	}
+	var tc ndjsonio.TypeConfig
+	err = json.Unmarshal(data, &tc)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unmarshaling error: %s", c.jsonTypePath, err)
+	}
+	return &tc, nil
+}
+
 func (c *Command) Run(args []string) error {
 	if c.showVersion {
 		return c.printVersion()
@@ -193,9 +212,30 @@ func (c *Command) Run(args []string) error {
 		c.ofmt = "null"
 		defer logger.Close()
 	}
-	var reader zbuf.Reader
-	if reader, err = c.loadFiles(paths); err != nil {
+	var tc *ndjsonio.TypeConfig
+	if c.jsonTypePath != "" {
+		if tc, err = c.loadJsonTypes(); err != nil {
+			return err
+		}
+	}
+
+	var readers []zbuf.Reader
+	if readers, err = c.inputReaders(paths); err != nil {
 		return err
+	}
+	for _, r := range readers {
+		if ndjr, ok := r.(*ndjsonio.Reader); ok && (tc != nil) {
+			if err = ndjr.SetTypeConfig(*tc); err != nil {
+				return err
+			}
+		}
+	}
+
+	var reader zbuf.Reader
+	if len(readers) == 1 {
+		reader = readers[0]
+	} else {
+		reader = scanner.NewCombiner(readers)
 	}
 	writer, err := c.openOutput()
 	if err != nil {
@@ -217,34 +257,41 @@ func (c *Command) errorf(format string, args ...interface{}) {
 	_, _ = fmt.Fprintf(os.Stderr, format, args...)
 }
 
-func (c *Command) loadFiles(paths []string) (zbuf.Reader, error) {
+func (c *Command) inputReaders(paths []string) ([]zbuf.Reader, error) {
 	var readers []zbuf.Reader
 	for _, path := range paths {
 		var zr zbuf.Reader
+		var f *os.File
 		if path == "-" {
-			r := detector.GzipReader(os.Stdin)
+			f = os.Stdin
+		} else {
 			var err error
-			if c.ifmt == "auto" {
-				zr, err = detector.NewReader(r, c.zctx)
-			} else {
-				zr, err = detector.LookupReader(c.ifmt, r, c.zctx)
-			}
+			info, err := os.Stat(path)
 			if err != nil {
 				return nil, err
 			}
-		} else {
-			var err error
-			zr, err = scanner.OpenFile(c.zctx, path, c.ifmt)
+			if info.IsDir() {
+				return nil, errors.New("is a directory")
+			}
+			f, err = os.Open(path)
 			if err != nil {
 				return nil, err
 			}
 		}
+		r := detector.GzipReader(f)
+		var err error
+		if c.ifmt == "auto" {
+			zr, err = detector.NewReader(r, c.zctx)
+		} else {
+			zr, err = detector.LookupReader(c.ifmt, r, c.zctx)
+		}
+		if err != nil {
+			return nil, err
+		}
+
 		readers = append(readers, zr)
 	}
-	if len(readers) == 1 {
-		return readers[0], nil
-	}
-	return scanner.NewCombiner(readers), nil
+	return readers, nil
 }
 
 func (c *Command) openOutput() (zbuf.WriteCloser, error) {

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -212,21 +212,21 @@ func (c *Command) Run(args []string) error {
 		c.ofmt = "null"
 		defer logger.Close()
 	}
-	var tc *ndjsonio.TypeConfig
-	if c.jsonTypePath != "" {
-		if tc, err = c.loadJsonTypes(); err != nil {
-			return err
-		}
-	}
 
-	var readers []zbuf.Reader
-	if readers, err = c.inputReaders(paths); err != nil {
+	readers, err := c.inputReaders(paths)
+	if err != nil {
 		return err
 	}
-	for _, r := range readers {
-		if ndjr, ok := r.(*ndjsonio.Reader); ok && (tc != nil) {
-			if err = ndjr.SetTypeConfig(*tc); err != nil {
-				return err
+	if c.jsonTypePath != "" {
+		tc, err := c.loadJsonTypes()
+		if err != nil {
+			return err
+		}
+		for _, r := range readers {
+			if ndjr, ok := r.(*ndjsonio.Reader); ok {
+				if err := ndjr.SetTypeConfig(*tc); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/zeek/README.md
+++ b/zeek/README.md
@@ -1,0 +1,6 @@
+This directory contains json type definitions for typed decoding of zeek ndjson logs.
+
+Currently it contains types.json, which was computed using the [print-types.zeek](https://github.com/brimsec/zeek/blob/master/brim/print-types.zeek) script running on Zeek 3.1.
+
+In the future it is expected to contain additional versions, generated on different versions/configurations of Zeek.
+

--- a/zeek/types.json
+++ b/zeek/types.json
@@ -1,0 +1,3545 @@
+{
+  "descriptors": {
+    "tunnel_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "tunnel_type",
+        "type": "zenum"
+      },
+      {
+        "name": "action",
+        "type": "zenum"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "radius_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "username",
+        "type": "bstring"
+      },
+      {
+        "name": "mac",
+        "type": "bstring"
+      },
+      {
+        "name": "framed_addr",
+        "type": "ip"
+      },
+      {
+        "name": "tunnel_client",
+        "type": "bstring"
+      },
+      {
+        "name": "connect_info",
+        "type": "bstring"
+      },
+      {
+        "name": "reply_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "result",
+        "type": "bstring"
+      },
+      {
+        "name": "ttl",
+        "type": "duration"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "software_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "host",
+        "type": "ip"
+      },
+      {
+        "name": "host_p",
+        "type": "port"
+      },
+      {
+        "name": "software_type",
+        "type": "zenum"
+      },
+      {
+        "name": "name",
+        "type": "bstring"
+      },
+      {
+        "name": "version",
+        "type": [
+          {
+            "name": "major",
+            "type": "uint64"
+          },
+          {
+            "name": "minor",
+            "type": "uint64"
+          },
+          {
+            "name": "minor2",
+            "type": "uint64"
+          },
+          {
+            "name": "minor3",
+            "type": "uint64"
+          },
+          {
+            "name": "addl",
+            "type": "bstring"
+          }
+        ]
+      },
+      {
+        "name": "unparsed_version",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "syslog_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "proto",
+        "type": "zenum"
+      },
+      {
+        "name": "facility",
+        "type": "bstring"
+      },
+      {
+        "name": "severity",
+        "type": "bstring"
+      },
+      {
+        "name": "message",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "config_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "id",
+        "type": "bstring"
+      },
+      {
+        "name": "old_value",
+        "type": "bstring"
+      },
+      {
+        "name": "new_value",
+        "type": "bstring"
+      },
+      {
+        "name": "location",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "files_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "tx_hosts",
+        "type": "set[ip]"
+      },
+      {
+        "name": "rx_hosts",
+        "type": "set[ip]"
+      },
+      {
+        "name": "conn_uids",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "source",
+        "type": "bstring"
+      },
+      {
+        "name": "depth",
+        "type": "uint64"
+      },
+      {
+        "name": "analyzers",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "mime_type",
+        "type": "bstring"
+      },
+      {
+        "name": "filename",
+        "type": "bstring"
+      },
+      {
+        "name": "duration",
+        "type": "duration"
+      },
+      {
+        "name": "local_orig",
+        "type": "bool"
+      },
+      {
+        "name": "is_orig",
+        "type": "bool"
+      },
+      {
+        "name": "seen_bytes",
+        "type": "uint64"
+      },
+      {
+        "name": "total_bytes",
+        "type": "uint64"
+      },
+      {
+        "name": "missing_bytes",
+        "type": "uint64"
+      },
+      {
+        "name": "overflow_bytes",
+        "type": "uint64"
+      },
+      {
+        "name": "timedout",
+        "type": "bool"
+      },
+      {
+        "name": "parent_fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "md5",
+        "type": "bstring"
+      },
+      {
+        "name": "sha1",
+        "type": "bstring"
+      },
+      {
+        "name": "sha256",
+        "type": "bstring"
+      },
+      {
+        "name": "extracted",
+        "type": "bstring"
+      },
+      {
+        "name": "extracted_cutoff",
+        "type": "bool"
+      },
+      {
+        "name": "extracted_size",
+        "type": "uint64"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "reporter_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "level",
+        "type": "zenum"
+      },
+      {
+        "name": "message",
+        "type": "bstring"
+      },
+      {
+        "name": "location",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "signatures_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "src_addr",
+        "type": "ip"
+      },
+      {
+        "name": "src_port",
+        "type": "port"
+      },
+      {
+        "name": "dst_addr",
+        "type": "ip"
+      },
+      {
+        "name": "dst_port",
+        "type": "port"
+      },
+      {
+        "name": "note",
+        "type": "zenum"
+      },
+      {
+        "name": "sig_id",
+        "type": "bstring"
+      },
+      {
+        "name": "event_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "sub_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "sig_count",
+        "type": "uint64"
+      },
+      {
+        "name": "host_count",
+        "type": "uint64"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "dce_rpc_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "rtt",
+        "type": "duration"
+      },
+      {
+        "name": "named_pipe",
+        "type": "bstring"
+      },
+      {
+        "name": "endpoint",
+        "type": "bstring"
+      },
+      {
+        "name": "operation",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "ntp_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "version",
+        "type": "uint64"
+      },
+      {
+        "name": "mode",
+        "type": "uint64"
+      },
+      {
+        "name": "stratum",
+        "type": "uint64"
+      },
+      {
+        "name": "poll",
+        "type": "duration"
+      },
+      {
+        "name": "precision",
+        "type": "duration"
+      },
+      {
+        "name": "root_delay",
+        "type": "duration"
+      },
+      {
+        "name": "root_disp",
+        "type": "duration"
+      },
+      {
+        "name": "ref_id",
+        "type": "bstring"
+      },
+      {
+        "name": "ref_time",
+        "type": "time"
+      },
+      {
+        "name": "org_time",
+        "type": "time"
+      },
+      {
+        "name": "rec_time",
+        "type": "time"
+      },
+      {
+        "name": "xmt_time",
+        "type": "time"
+      },
+      {
+        "name": "num_exts",
+        "type": "uint64"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "rfb_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "client_major_version",
+        "type": "bstring"
+      },
+      {
+        "name": "client_minor_version",
+        "type": "bstring"
+      },
+      {
+        "name": "server_major_version",
+        "type": "bstring"
+      },
+      {
+        "name": "server_minor_version",
+        "type": "bstring"
+      },
+      {
+        "name": "authentication_method",
+        "type": "bstring"
+      },
+      {
+        "name": "auth",
+        "type": "bool"
+      },
+      {
+        "name": "share_flag",
+        "type": "bool"
+      },
+      {
+        "name": "desktop_name",
+        "type": "bstring"
+      },
+      {
+        "name": "width",
+        "type": "uint64"
+      },
+      {
+        "name": "height",
+        "type": "uint64"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "smb_mapping_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "path",
+        "type": "bstring"
+      },
+      {
+        "name": "service",
+        "type": "bstring"
+      },
+      {
+        "name": "native_file_system",
+        "type": "bstring"
+      },
+      {
+        "name": "share_type",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "ftp_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "user",
+        "type": "bstring"
+      },
+      {
+        "name": "password",
+        "type": "bstring"
+      },
+      {
+        "name": "command",
+        "type": "bstring"
+      },
+      {
+        "name": "arg",
+        "type": "bstring"
+      },
+      {
+        "name": "mime_type",
+        "type": "bstring"
+      },
+      {
+        "name": "file_size",
+        "type": "uint64"
+      },
+      {
+        "name": "reply_code",
+        "type": "uint64"
+      },
+      {
+        "name": "reply_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "data_channel",
+        "type": [
+          {
+            "name": "passive",
+            "type": "bool"
+          },
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "intel_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "seen",
+        "type": [
+          {
+            "name": "indicator",
+            "type": "bstring"
+          },
+          {
+            "name": "indicator_type",
+            "type": "zenum"
+          },
+          {
+            "name": "where",
+            "type": "zenum"
+          },
+          {
+            "name": "node",
+            "type": "bstring"
+          }
+        ]
+      },
+      {
+        "name": "matched",
+        "type": "set[zenum]"
+      },
+      {
+        "name": "sources",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "file_mime_type",
+        "type": "bstring"
+      },
+      {
+        "name": "file_desc",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "kerberos_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "request_type",
+        "type": "bstring"
+      },
+      {
+        "name": "client",
+        "type": "bstring"
+      },
+      {
+        "name": "service",
+        "type": "bstring"
+      },
+      {
+        "name": "success",
+        "type": "bool"
+      },
+      {
+        "name": "error_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "from",
+        "type": "time"
+      },
+      {
+        "name": "till",
+        "type": "time"
+      },
+      {
+        "name": "cipher",
+        "type": "bstring"
+      },
+      {
+        "name": "forwardable",
+        "type": "bool"
+      },
+      {
+        "name": "renewable",
+        "type": "bool"
+      },
+      {
+        "name": "client_cert_subject",
+        "type": "bstring"
+      },
+      {
+        "name": "client_cert_fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "server_cert_subject",
+        "type": "bstring"
+      },
+      {
+        "name": "server_cert_fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "socks_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "version",
+        "type": "uint64"
+      },
+      {
+        "name": "user",
+        "type": "bstring"
+      },
+      {
+        "name": "password",
+        "type": "bstring"
+      },
+      {
+        "name": "status",
+        "type": "bstring"
+      },
+      {
+        "name": "request",
+        "type": [
+          {
+            "name": "host",
+            "type": "ip"
+          },
+          {
+            "name": "name",
+            "type": "bstring"
+          }
+        ]
+      },
+      {
+        "name": "request_p",
+        "type": "port"
+      },
+      {
+        "name": "bound",
+        "type": [
+          {
+            "name": "host",
+            "type": "ip"
+          },
+          {
+            "name": "name",
+            "type": "bstring"
+          }
+        ]
+      },
+      {
+        "name": "bound_p",
+        "type": "port"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "irc_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "nick",
+        "type": "bstring"
+      },
+      {
+        "name": "user",
+        "type": "bstring"
+      },
+      {
+        "name": "command",
+        "type": "bstring"
+      },
+      {
+        "name": "value",
+        "type": "bstring"
+      },
+      {
+        "name": "addl",
+        "type": "bstring"
+      },
+      {
+        "name": "dcc_file_name",
+        "type": "bstring"
+      },
+      {
+        "name": "dcc_file_size",
+        "type": "uint64"
+      },
+      {
+        "name": "dcc_mime_type",
+        "type": "bstring"
+      },
+      {
+        "name": "fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "netcontrol_drop_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "rule_id",
+        "type": "bstring"
+      },
+      {
+        "name": "orig_h",
+        "type": "ip"
+      },
+      {
+        "name": "orig_p",
+        "type": "port"
+      },
+      {
+        "name": "resp_h",
+        "type": "ip"
+      },
+      {
+        "name": "resp_p",
+        "type": "port"
+      },
+      {
+        "name": "expire",
+        "type": "duration"
+      },
+      {
+        "name": "location",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "dnp3_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "fc_request",
+        "type": "bstring"
+      },
+      {
+        "name": "fc_reply",
+        "type": "bstring"
+      },
+      {
+        "name": "iin",
+        "type": "uint64"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "netcontrol_shunt_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "rule_id",
+        "type": "bstring"
+      },
+      {
+        "name": "f",
+        "type": [
+          {
+            "name": "src_h",
+            "type": "ip"
+          },
+          {
+            "name": "src_p",
+            "type": "port"
+          },
+          {
+            "name": "dst_h",
+            "type": "ip"
+          },
+          {
+            "name": "dst_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "expire",
+        "type": "duration"
+      },
+      {
+        "name": "location",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "http_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "trans_depth",
+        "type": "uint64"
+      },
+      {
+        "name": "method",
+        "type": "bstring"
+      },
+      {
+        "name": "host",
+        "type": "bstring"
+      },
+      {
+        "name": "uri",
+        "type": "bstring"
+      },
+      {
+        "name": "referrer",
+        "type": "bstring"
+      },
+      {
+        "name": "version",
+        "type": "bstring"
+      },
+      {
+        "name": "user_agent",
+        "type": "bstring"
+      },
+      {
+        "name": "origin",
+        "type": "bstring"
+      },
+      {
+        "name": "request_body_len",
+        "type": "uint64"
+      },
+      {
+        "name": "response_body_len",
+        "type": "uint64"
+      },
+      {
+        "name": "status_code",
+        "type": "uint64"
+      },
+      {
+        "name": "status_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "info_code",
+        "type": "uint64"
+      },
+      {
+        "name": "info_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "tags",
+        "type": "set[zenum]"
+      },
+      {
+        "name": "username",
+        "type": "bstring"
+      },
+      {
+        "name": "password",
+        "type": "bstring"
+      },
+      {
+        "name": "proxied",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "orig_fuids",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "orig_filenames",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "orig_mime_types",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "resp_fuids",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "resp_filenames",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "resp_mime_types",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "broker_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "ty",
+        "type": "zenum"
+      },
+      {
+        "name": "ev",
+        "type": "bstring"
+      },
+      {
+        "name": "peer",
+        "type": [
+          {
+            "name": "address",
+            "type": "bstring"
+          },
+          {
+            "name": "bound_port",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "message",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "cluster_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "node",
+        "type": "bstring"
+      },
+      {
+        "name": "message",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "packet_filter_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "node",
+        "type": "bstring"
+      },
+      {
+        "name": "filter",
+        "type": "bstring"
+      },
+      {
+        "name": "init",
+        "type": "bool"
+      },
+      {
+        "name": "success",
+        "type": "bool"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "ssh_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "version",
+        "type": "uint64"
+      },
+      {
+        "name": "auth_success",
+        "type": "bool"
+      },
+      {
+        "name": "auth_attempts",
+        "type": "uint64"
+      },
+      {
+        "name": "direction",
+        "type": "zenum"
+      },
+      {
+        "name": "client",
+        "type": "bstring"
+      },
+      {
+        "name": "server",
+        "type": "bstring"
+      },
+      {
+        "name": "cipher_alg",
+        "type": "bstring"
+      },
+      {
+        "name": "mac_alg",
+        "type": "bstring"
+      },
+      {
+        "name": "compression_alg",
+        "type": "bstring"
+      },
+      {
+        "name": "kex_alg",
+        "type": "bstring"
+      },
+      {
+        "name": "host_key_alg",
+        "type": "bstring"
+      },
+      {
+        "name": "host_key",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "weird_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "name",
+        "type": "bstring"
+      },
+      {
+        "name": "addl",
+        "type": "bstring"
+      },
+      {
+        "name": "notice",
+        "type": "bool"
+      },
+      {
+        "name": "peer",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "mysql_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "cmd",
+        "type": "bstring"
+      },
+      {
+        "name": "arg",
+        "type": "bstring"
+      },
+      {
+        "name": "success",
+        "type": "bool"
+      },
+      {
+        "name": "rows",
+        "type": "uint64"
+      },
+      {
+        "name": "response",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "ntlm_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "username",
+        "type": "bstring"
+      },
+      {
+        "name": "hostname",
+        "type": "bstring"
+      },
+      {
+        "name": "domainname",
+        "type": "bstring"
+      },
+      {
+        "name": "server_nb_computer_name",
+        "type": "bstring"
+      },
+      {
+        "name": "server_dns_computer_name",
+        "type": "bstring"
+      },
+      {
+        "name": "server_tree_name",
+        "type": "bstring"
+      },
+      {
+        "name": "success",
+        "type": "bool"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "smb_files_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "action",
+        "type": "zenum"
+      },
+      {
+        "name": "path",
+        "type": "bstring"
+      },
+      {
+        "name": "name",
+        "type": "bstring"
+      },
+      {
+        "name": "size",
+        "type": "uint64"
+      },
+      {
+        "name": "prev_name",
+        "type": "bstring"
+      },
+      {
+        "name": "times",
+        "type": [
+          {
+            "name": "modified",
+            "type": "time"
+          },
+          {
+            "name": "accessed",
+            "type": "time"
+          },
+          {
+            "name": "created",
+            "type": "time"
+          },
+          {
+            "name": "changed",
+            "type": "time"
+          }
+        ]
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "snmp_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "duration"
+      },
+      {
+        "name": "version",
+        "type": "bstring"
+      },
+      {
+        "name": "community",
+        "type": "bstring"
+      },
+      {
+        "name": "get_requests",
+        "type": "uint64"
+      },
+      {
+        "name": "get_bulk_requests",
+        "type": "uint64"
+      },
+      {
+        "name": "get_responses",
+        "type": "uint64"
+      },
+      {
+        "name": "set_requests",
+        "type": "uint64"
+      },
+      {
+        "name": "display_string",
+        "type": "bstring"
+      },
+      {
+        "name": "up_since",
+        "type": "time"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "dhcp_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uids",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "client_addr",
+        "type": "ip"
+      },
+      {
+        "name": "server_addr",
+        "type": "ip"
+      },
+      {
+        "name": "mac",
+        "type": "bstring"
+      },
+      {
+        "name": "host_name",
+        "type": "bstring"
+      },
+      {
+        "name": "client_fqdn",
+        "type": "bstring"
+      },
+      {
+        "name": "domain",
+        "type": "bstring"
+      },
+      {
+        "name": "requested_addr",
+        "type": "ip"
+      },
+      {
+        "name": "assigned_addr",
+        "type": "ip"
+      },
+      {
+        "name": "lease_time",
+        "type": "duration"
+      },
+      {
+        "name": "client_message",
+        "type": "bstring"
+      },
+      {
+        "name": "server_message",
+        "type": "bstring"
+      },
+      {
+        "name": "msg_types",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "duration",
+        "type": "duration"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "modbus_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "func",
+        "type": "bstring"
+      },
+      {
+        "name": "exception",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "netcontrol_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "rule_id",
+        "type": "bstring"
+      },
+      {
+        "name": "category",
+        "type": "zenum"
+      },
+      {
+        "name": "cmd",
+        "type": "bstring"
+      },
+      {
+        "name": "state",
+        "type": "zenum"
+      },
+      {
+        "name": "action",
+        "type": "bstring"
+      },
+      {
+        "name": "target",
+        "type": "zenum"
+      },
+      {
+        "name": "entity_type",
+        "type": "bstring"
+      },
+      {
+        "name": "entity",
+        "type": "bstring"
+      },
+      {
+        "name": "mod",
+        "type": "bstring"
+      },
+      {
+        "name": "msg",
+        "type": "bstring"
+      },
+      {
+        "name": "priority",
+        "type": "int64"
+      },
+      {
+        "name": "expire",
+        "type": "duration"
+      },
+      {
+        "name": "location",
+        "type": "bstring"
+      },
+      {
+        "name": "plugin",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "rdp_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "cookie",
+        "type": "bstring"
+      },
+      {
+        "name": "result",
+        "type": "bstring"
+      },
+      {
+        "name": "security_protocol",
+        "type": "bstring"
+      },
+      {
+        "name": "client_channels",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "keyboard_layout",
+        "type": "bstring"
+      },
+      {
+        "name": "client_build",
+        "type": "bstring"
+      },
+      {
+        "name": "client_name",
+        "type": "bstring"
+      },
+      {
+        "name": "client_dig_product_id",
+        "type": "bstring"
+      },
+      {
+        "name": "desktop_width",
+        "type": "uint64"
+      },
+      {
+        "name": "desktop_height",
+        "type": "uint64"
+      },
+      {
+        "name": "requested_color_depth",
+        "type": "bstring"
+      },
+      {
+        "name": "cert_type",
+        "type": "bstring"
+      },
+      {
+        "name": "cert_count",
+        "type": "uint64"
+      },
+      {
+        "name": "cert_permanent",
+        "type": "bool"
+      },
+      {
+        "name": "encryption_level",
+        "type": "bstring"
+      },
+      {
+        "name": "encryption_method",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "x509_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "id",
+        "type": "bstring"
+      },
+      {
+        "name": "certificate",
+        "type": [
+          {
+            "name": "version",
+            "type": "uint64"
+          },
+          {
+            "name": "serial",
+            "type": "bstring"
+          },
+          {
+            "name": "subject",
+            "type": "bstring"
+          },
+          {
+            "name": "issuer",
+            "type": "bstring"
+          },
+          {
+            "name": "not_valid_before",
+            "type": "time"
+          },
+          {
+            "name": "not_valid_after",
+            "type": "time"
+          },
+          {
+            "name": "key_alg",
+            "type": "bstring"
+          },
+          {
+            "name": "sig_alg",
+            "type": "bstring"
+          },
+          {
+            "name": "key_type",
+            "type": "bstring"
+          },
+          {
+            "name": "key_length",
+            "type": "uint64"
+          },
+          {
+            "name": "exponent",
+            "type": "bstring"
+          },
+          {
+            "name": "curve",
+            "type": "bstring"
+          }
+        ]
+      },
+      {
+        "name": "san",
+        "type": [
+          {
+            "name": "dns",
+            "type": "array[bstring]"
+          },
+          {
+            "name": "uri",
+            "type": "array[bstring]"
+          },
+          {
+            "name": "email",
+            "type": "array[bstring]"
+          },
+          {
+            "name": "ip",
+            "type": "array[ip]"
+          }
+        ]
+      },
+      {
+        "name": "basic_constraints",
+        "type": [
+          {
+            "name": "ca",
+            "type": "bool"
+          },
+          {
+            "name": "path_len",
+            "type": "uint64"
+          }
+        ]
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "notice_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "file_mime_type",
+        "type": "bstring"
+      },
+      {
+        "name": "file_desc",
+        "type": "bstring"
+      },
+      {
+        "name": "proto",
+        "type": "zenum"
+      },
+      {
+        "name": "note",
+        "type": "zenum"
+      },
+      {
+        "name": "msg",
+        "type": "bstring"
+      },
+      {
+        "name": "sub",
+        "type": "bstring"
+      },
+      {
+        "name": "src",
+        "type": "ip"
+      },
+      {
+        "name": "dst",
+        "type": "ip"
+      },
+      {
+        "name": "p",
+        "type": "port"
+      },
+      {
+        "name": "n",
+        "type": "uint64"
+      },
+      {
+        "name": "peer_descr",
+        "type": "bstring"
+      },
+      {
+        "name": "actions",
+        "type": "set[zenum]"
+      },
+      {
+        "name": "suppress_for",
+        "type": "duration"
+      },
+      {
+        "name": "remote_location",
+        "type": [
+          {
+            "name": "country_code",
+            "type": "bstring"
+          },
+          {
+            "name": "region",
+            "type": "bstring"
+          },
+          {
+            "name": "city",
+            "type": "bstring"
+          },
+          {
+            "name": "latitude",
+            "type": "float64"
+          },
+          {
+            "name": "longitude",
+            "type": "float64"
+          }
+        ]
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "notice_alarm_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "file_mime_type",
+        "type": "bstring"
+      },
+      {
+        "name": "file_desc",
+        "type": "bstring"
+      },
+      {
+        "name": "proto",
+        "type": "zenum"
+      },
+      {
+        "name": "note",
+        "type": "zenum"
+      },
+      {
+        "name": "msg",
+        "type": "bstring"
+      },
+      {
+        "name": "sub",
+        "type": "bstring"
+      },
+      {
+        "name": "src",
+        "type": "ip"
+      },
+      {
+        "name": "dst",
+        "type": "ip"
+      },
+      {
+        "name": "p",
+        "type": "port"
+      },
+      {
+        "name": "n",
+        "type": "uint64"
+      },
+      {
+        "name": "peer_descr",
+        "type": "bstring"
+      },
+      {
+        "name": "actions",
+        "type": "set[zenum]"
+      },
+      {
+        "name": "suppress_for",
+        "type": "duration"
+      },
+      {
+        "name": "remote_location",
+        "type": [
+          {
+            "name": "country_code",
+            "type": "bstring"
+          },
+          {
+            "name": "region",
+            "type": "bstring"
+          },
+          {
+            "name": "city",
+            "type": "bstring"
+          },
+          {
+            "name": "latitude",
+            "type": "float64"
+          },
+          {
+            "name": "longitude",
+            "type": "float64"
+          }
+        ]
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "sip_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "trans_depth",
+        "type": "uint64"
+      },
+      {
+        "name": "method",
+        "type": "bstring"
+      },
+      {
+        "name": "uri",
+        "type": "bstring"
+      },
+      {
+        "name": "date",
+        "type": "bstring"
+      },
+      {
+        "name": "request_from",
+        "type": "bstring"
+      },
+      {
+        "name": "request_to",
+        "type": "bstring"
+      },
+      {
+        "name": "response_from",
+        "type": "bstring"
+      },
+      {
+        "name": "response_to",
+        "type": "bstring"
+      },
+      {
+        "name": "reply_to",
+        "type": "bstring"
+      },
+      {
+        "name": "call_id",
+        "type": "bstring"
+      },
+      {
+        "name": "seq",
+        "type": "bstring"
+      },
+      {
+        "name": "subject",
+        "type": "bstring"
+      },
+      {
+        "name": "request_path",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "response_path",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "user_agent",
+        "type": "bstring"
+      },
+      {
+        "name": "status_code",
+        "type": "uint64"
+      },
+      {
+        "name": "status_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "warning",
+        "type": "bstring"
+      },
+      {
+        "name": "request_body_len",
+        "type": "uint64"
+      },
+      {
+        "name": "response_body_len",
+        "type": "uint64"
+      },
+      {
+        "name": "content_type",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "ssl_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "version",
+        "type": "bstring"
+      },
+      {
+        "name": "cipher",
+        "type": "bstring"
+      },
+      {
+        "name": "curve",
+        "type": "bstring"
+      },
+      {
+        "name": "server_name",
+        "type": "bstring"
+      },
+      {
+        "name": "resumed",
+        "type": "bool"
+      },
+      {
+        "name": "last_alert",
+        "type": "bstring"
+      },
+      {
+        "name": "next_protocol",
+        "type": "bstring"
+      },
+      {
+        "name": "established",
+        "type": "bool"
+      },
+      {
+        "name": "cert_chain_fuids",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "client_cert_chain_fuids",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "subject",
+        "type": "bstring"
+      },
+      {
+        "name": "issuer",
+        "type": "bstring"
+      },
+      {
+        "name": "client_subject",
+        "type": "bstring"
+      },
+      {
+        "name": "client_issuer",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "conn_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "proto",
+        "type": "zenum"
+      },
+      {
+        "name": "service",
+        "type": "bstring"
+      },
+      {
+        "name": "duration",
+        "type": "duration"
+      },
+      {
+        "name": "orig_bytes",
+        "type": "uint64"
+      },
+      {
+        "name": "resp_bytes",
+        "type": "uint64"
+      },
+      {
+        "name": "conn_state",
+        "type": "bstring"
+      },
+      {
+        "name": "local_orig",
+        "type": "bool"
+      },
+      {
+        "name": "local_resp",
+        "type": "bool"
+      },
+      {
+        "name": "missed_bytes",
+        "type": "uint64"
+      },
+      {
+        "name": "history",
+        "type": "bstring"
+      },
+      {
+        "name": "orig_pkts",
+        "type": "uint64"
+      },
+      {
+        "name": "orig_ip_bytes",
+        "type": "uint64"
+      },
+      {
+        "name": "resp_pkts",
+        "type": "uint64"
+      },
+      {
+        "name": "resp_ip_bytes",
+        "type": "uint64"
+      },
+      {
+        "name": "tunnel_parents",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "dpd_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "proto",
+        "type": "zenum"
+      },
+      {
+        "name": "analyzer",
+        "type": "bstring"
+      },
+      {
+        "name": "failure_reason",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "pe_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "id",
+        "type": "bstring"
+      },
+      {
+        "name": "machine",
+        "type": "bstring"
+      },
+      {
+        "name": "compile_ts",
+        "type": "time"
+      },
+      {
+        "name": "os",
+        "type": "bstring"
+      },
+      {
+        "name": "subsystem",
+        "type": "bstring"
+      },
+      {
+        "name": "is_exe",
+        "type": "bool"
+      },
+      {
+        "name": "is_64bit",
+        "type": "bool"
+      },
+      {
+        "name": "uses_aslr",
+        "type": "bool"
+      },
+      {
+        "name": "uses_dep",
+        "type": "bool"
+      },
+      {
+        "name": "uses_code_integrity",
+        "type": "bool"
+      },
+      {
+        "name": "uses_seh",
+        "type": "bool"
+      },
+      {
+        "name": "has_import_table",
+        "type": "bool"
+      },
+      {
+        "name": "has_export_table",
+        "type": "bool"
+      },
+      {
+        "name": "has_cert_table",
+        "type": "bool"
+      },
+      {
+        "name": "has_debug_data",
+        "type": "bool"
+      },
+      {
+        "name": "section_names",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "dns_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "proto",
+        "type": "zenum"
+      },
+      {
+        "name": "trans_id",
+        "type": "uint64"
+      },
+      {
+        "name": "rtt",
+        "type": "duration"
+      },
+      {
+        "name": "query",
+        "type": "bstring"
+      },
+      {
+        "name": "qclass",
+        "type": "uint64"
+      },
+      {
+        "name": "qclass_name",
+        "type": "bstring"
+      },
+      {
+        "name": "qtype",
+        "type": "uint64"
+      },
+      {
+        "name": "qtype_name",
+        "type": "bstring"
+      },
+      {
+        "name": "rcode",
+        "type": "uint64"
+      },
+      {
+        "name": "rcode_name",
+        "type": "bstring"
+      },
+      {
+        "name": "AA",
+        "type": "bool"
+      },
+      {
+        "name": "TC",
+        "type": "bool"
+      },
+      {
+        "name": "RD",
+        "type": "bool"
+      },
+      {
+        "name": "RA",
+        "type": "bool"
+      },
+      {
+        "name": "Z",
+        "type": "uint64"
+      },
+      {
+        "name": "answers",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "TTLs",
+        "type": "array[duration]"
+      },
+      {
+        "name": "rejected",
+        "type": "bool"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "smtp_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "trans_depth",
+        "type": "uint64"
+      },
+      {
+        "name": "helo",
+        "type": "bstring"
+      },
+      {
+        "name": "mailfrom",
+        "type": "bstring"
+      },
+      {
+        "name": "rcptto",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "date",
+        "type": "bstring"
+      },
+      {
+        "name": "from",
+        "type": "bstring"
+      },
+      {
+        "name": "to",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "cc",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "reply_to",
+        "type": "bstring"
+      },
+      {
+        "name": "msg_id",
+        "type": "bstring"
+      },
+      {
+        "name": "in_reply_to",
+        "type": "bstring"
+      },
+      {
+        "name": "subject",
+        "type": "bstring"
+      },
+      {
+        "name": "x_originating_ip",
+        "type": "ip"
+      },
+      {
+        "name": "first_received",
+        "type": "bstring"
+      },
+      {
+        "name": "second_received",
+        "type": "bstring"
+      },
+      {
+        "name": "last_reply",
+        "type": "bstring"
+      },
+      {
+        "name": "path",
+        "type": "array[ip]"
+      },
+      {
+        "name": "user_agent",
+        "type": "bstring"
+      },
+      {
+        "name": "tls",
+        "type": "bool"
+      },
+      {
+        "name": "fuids",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ]
+  },
+  "matching_rules": [
+    {
+      "match": {
+        "_path": "broker"
+      },
+      "descriptor": "broker_log"
+    },
+    {
+      "match": {
+        "_path": "cluster"
+      },
+      "descriptor": "cluster_log"
+    },
+    {
+      "match": {
+        "_path": "config"
+      },
+      "descriptor": "config_log"
+    },
+    {
+      "match": {
+        "_path": "conn"
+      },
+      "descriptor": "conn_log"
+    },
+    {
+      "match": {
+        "_path": "dce_rpc"
+      },
+      "descriptor": "dce_rpc_log"
+    },
+    {
+      "match": {
+        "_path": "dhcp"
+      },
+      "descriptor": "dhcp_log"
+    },
+    {
+      "match": {
+        "_path": "dnp3"
+      },
+      "descriptor": "dnp3_log"
+    },
+    {
+      "match": {
+        "_path": "dns"
+      },
+      "descriptor": "dns_log"
+    },
+    {
+      "match": {
+        "_path": "dpd"
+      },
+      "descriptor": "dpd_log"
+    },
+    {
+      "match": {
+        "_path": "files"
+      },
+      "descriptor": "files_log"
+    },
+    {
+      "match": {
+        "_path": "ftp"
+      },
+      "descriptor": "ftp_log"
+    },
+    {
+      "match": {
+        "_path": "http"
+      },
+      "descriptor": "http_log"
+    },
+    {
+      "match": {
+        "_path": "intel"
+      },
+      "descriptor": "intel_log"
+    },
+    {
+      "match": {
+        "_path": "irc"
+      },
+      "descriptor": "irc_log"
+    },
+    {
+      "match": {
+        "_path": "kerberos"
+      },
+      "descriptor": "kerberos_log"
+    },
+    {
+      "match": {
+        "_path": "modbus"
+      },
+      "descriptor": "modbus_log"
+    },
+    {
+      "match": {
+        "_path": "mysql"
+      },
+      "descriptor": "mysql_log"
+    },
+    {
+      "match": {
+        "_path": "netcontrol"
+      },
+      "descriptor": "netcontrol_log"
+    },
+    {
+      "match": {
+        "_path": "netcontrol_drop"
+      },
+      "descriptor": "netcontrol_drop_log"
+    },
+    {
+      "match": {
+        "_path": "netcontrol_shunt"
+      },
+      "descriptor": "netcontrol_shunt_log"
+    },
+    {
+      "match": {
+        "_path": "notice"
+      },
+      "descriptor": "notice_log"
+    },
+    {
+      "match": {
+        "_path": "notice_alarm"
+      },
+      "descriptor": "notice_alarm_log"
+    },
+    {
+      "match": {
+        "_path": "ntlm"
+      },
+      "descriptor": "ntlm_log"
+    },
+    {
+      "match": {
+        "_path": "ntp"
+      },
+      "descriptor": "ntp_log"
+    },
+    {
+      "match": {
+        "_path": "packet_filter"
+      },
+      "descriptor": "packet_filter_log"
+    },
+    {
+      "match": {
+        "_path": "pe"
+      },
+      "descriptor": "pe_log"
+    },
+    {
+      "match": {
+        "_path": "radius"
+      },
+      "descriptor": "radius_log"
+    },
+    {
+      "match": {
+        "_path": "rdp"
+      },
+      "descriptor": "rdp_log"
+    },
+    {
+      "match": {
+        "_path": "reporter"
+      },
+      "descriptor": "reporter_log"
+    },
+    {
+      "match": {
+        "_path": "rfb"
+      },
+      "descriptor": "rfb_log"
+    },
+    {
+      "match": {
+        "_path": "signatures"
+      },
+      "descriptor": "signatures_log"
+    },
+    {
+      "match": {
+        "_path": "sip"
+      },
+      "descriptor": "sip_log"
+    },
+    {
+      "match": {
+        "_path": "smb_files"
+      },
+      "descriptor": "smb_files_log"
+    },
+    {
+      "match": {
+        "_path": "smb_mapping"
+      },
+      "descriptor": "smb_mapping_log"
+    },
+    {
+      "match": {
+        "_path": "smtp"
+      },
+      "descriptor": "smtp_log"
+    },
+    {
+      "match": {
+        "_path": "snmp"
+      },
+      "descriptor": "snmp_log"
+    },
+    {
+      "match": {
+        "_path": "socks"
+      },
+      "descriptor": "socks_log"
+    },
+    {
+      "match": {
+        "_path": "software"
+      },
+      "descriptor": "software_log"
+    },
+    {
+      "match": {
+        "_path": "ssh"
+      },
+      "descriptor": "ssh_log"
+    },
+    {
+      "match": {
+        "_path": "ssl"
+      },
+      "descriptor": "ssl_log"
+    },
+    {
+      "match": {
+        "_path": "syslog"
+      },
+      "descriptor": "syslog_log"
+    },
+    {
+      "match": {
+        "_path": "tunnel"
+      },
+      "descriptor": "tunnel_log"
+    },
+    {
+      "match": {
+        "_path": "weird"
+      },
+      "descriptor": "weird_log"
+    },
+    {
+      "match": {
+        "_path": "x509"
+      },
+      "descriptor": "x509_log"
+    }
+  ]
+}

--- a/zeek/types.json
+++ b/zeek/types.json
@@ -1,6 +1,6 @@
 {
   "descriptors": {
-    "tunnel_log": [
+    "intel_log": [
       {
         "name": "_path",
         "type": "string"
@@ -35,19 +35,122 @@
         ]
       },
       {
-        "name": "tunnel_type",
-        "type": "zenum"
+        "name": "seen",
+        "type": [
+          {
+            "name": "indicator",
+            "type": "bstring"
+          },
+          {
+            "name": "indicator_type",
+            "type": "zenum"
+          },
+          {
+            "name": "where",
+            "type": "zenum"
+          },
+          {
+            "name": "node",
+            "type": "bstring"
+          }
+        ]
       },
       {
-        "name": "action",
-        "type": "zenum"
+        "name": "matched",
+        "type": "set[zenum]"
+      },
+      {
+        "name": "sources",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "file_mime_type",
+        "type": "bstring"
+      },
+      {
+        "name": "file_desc",
+        "type": "bstring"
       },
       {
         "name": "_write_ts",
         "type": "time"
       }
     ],
-    "radius_log": [
+    "netcontrol_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "rule_id",
+        "type": "bstring"
+      },
+      {
+        "name": "category",
+        "type": "zenum"
+      },
+      {
+        "name": "cmd",
+        "type": "bstring"
+      },
+      {
+        "name": "state",
+        "type": "zenum"
+      },
+      {
+        "name": "action",
+        "type": "bstring"
+      },
+      {
+        "name": "target",
+        "type": "zenum"
+      },
+      {
+        "name": "entity_type",
+        "type": "bstring"
+      },
+      {
+        "name": "entity",
+        "type": "bstring"
+      },
+      {
+        "name": "mod",
+        "type": "bstring"
+      },
+      {
+        "name": "msg",
+        "type": "bstring"
+      },
+      {
+        "name": "priority",
+        "type": "int64"
+      },
+      {
+        "name": "expire",
+        "type": "duration"
+      },
+      {
+        "name": "location",
+        "type": "bstring"
+      },
+      {
+        "name": "plugin",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "ntp_log": [
       {
         "name": "_path",
         "type": "string"
@@ -82,36 +185,1082 @@
         ]
       },
       {
-        "name": "username",
+        "name": "version",
+        "type": "uint64"
+      },
+      {
+        "name": "mode",
+        "type": "uint64"
+      },
+      {
+        "name": "stratum",
+        "type": "uint64"
+      },
+      {
+        "name": "poll",
+        "type": "duration"
+      },
+      {
+        "name": "precision",
+        "type": "duration"
+      },
+      {
+        "name": "root_delay",
+        "type": "duration"
+      },
+      {
+        "name": "root_disp",
+        "type": "duration"
+      },
+      {
+        "name": "ref_id",
         "type": "bstring"
       },
       {
-        "name": "mac",
+        "name": "ref_time",
+        "type": "time"
+      },
+      {
+        "name": "org_time",
+        "type": "time"
+      },
+      {
+        "name": "rec_time",
+        "type": "time"
+      },
+      {
+        "name": "xmt_time",
+        "type": "time"
+      },
+      {
+        "name": "num_exts",
+        "type": "uint64"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "pe_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "id",
         "type": "bstring"
       },
       {
-        "name": "framed_addr",
+        "name": "machine",
+        "type": "bstring"
+      },
+      {
+        "name": "compile_ts",
+        "type": "time"
+      },
+      {
+        "name": "os",
+        "type": "bstring"
+      },
+      {
+        "name": "subsystem",
+        "type": "bstring"
+      },
+      {
+        "name": "is_exe",
+        "type": "bool"
+      },
+      {
+        "name": "is_64bit",
+        "type": "bool"
+      },
+      {
+        "name": "uses_aslr",
+        "type": "bool"
+      },
+      {
+        "name": "uses_dep",
+        "type": "bool"
+      },
+      {
+        "name": "uses_code_integrity",
+        "type": "bool"
+      },
+      {
+        "name": "uses_seh",
+        "type": "bool"
+      },
+      {
+        "name": "has_import_table",
+        "type": "bool"
+      },
+      {
+        "name": "has_export_table",
+        "type": "bool"
+      },
+      {
+        "name": "has_cert_table",
+        "type": "bool"
+      },
+      {
+        "name": "has_debug_data",
+        "type": "bool"
+      },
+      {
+        "name": "section_names",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "weird_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "name",
+        "type": "bstring"
+      },
+      {
+        "name": "addl",
+        "type": "bstring"
+      },
+      {
+        "name": "notice",
+        "type": "bool"
+      },
+      {
+        "name": "peer",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "netcontrol_shunt_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "rule_id",
+        "type": "bstring"
+      },
+      {
+        "name": "f",
+        "type": [
+          {
+            "name": "src_h",
+            "type": "ip"
+          },
+          {
+            "name": "src_p",
+            "type": "port"
+          },
+          {
+            "name": "dst_h",
+            "type": "ip"
+          },
+          {
+            "name": "dst_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "expire",
+        "type": "duration"
+      },
+      {
+        "name": "location",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "netcontrol_drop_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "rule_id",
+        "type": "bstring"
+      },
+      {
+        "name": "orig_h",
         "type": "ip"
       },
       {
-        "name": "tunnel_client",
-        "type": "bstring"
+        "name": "orig_p",
+        "type": "port"
       },
       {
-        "name": "connect_info",
-        "type": "bstring"
+        "name": "resp_h",
+        "type": "ip"
       },
       {
-        "name": "reply_msg",
-        "type": "bstring"
+        "name": "resp_p",
+        "type": "port"
       },
       {
-        "name": "result",
-        "type": "bstring"
-      },
-      {
-        "name": "ttl",
+        "name": "expire",
         "type": "duration"
+      },
+      {
+        "name": "location",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "dpd_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "proto",
+        "type": "zenum"
+      },
+      {
+        "name": "analyzer",
+        "type": "bstring"
+      },
+      {
+        "name": "failure_reason",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "kerberos_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "request_type",
+        "type": "bstring"
+      },
+      {
+        "name": "client",
+        "type": "bstring"
+      },
+      {
+        "name": "service",
+        "type": "bstring"
+      },
+      {
+        "name": "success",
+        "type": "bool"
+      },
+      {
+        "name": "error_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "from",
+        "type": "time"
+      },
+      {
+        "name": "till",
+        "type": "time"
+      },
+      {
+        "name": "cipher",
+        "type": "bstring"
+      },
+      {
+        "name": "forwardable",
+        "type": "bool"
+      },
+      {
+        "name": "renewable",
+        "type": "bool"
+      },
+      {
+        "name": "client_cert_subject",
+        "type": "bstring"
+      },
+      {
+        "name": "client_cert_fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "server_cert_subject",
+        "type": "bstring"
+      },
+      {
+        "name": "server_cert_fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "smb_mapping_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "path",
+        "type": "bstring"
+      },
+      {
+        "name": "service",
+        "type": "bstring"
+      },
+      {
+        "name": "native_file_system",
+        "type": "bstring"
+      },
+      {
+        "name": "share_type",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "snmp_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "duration",
+        "type": "duration"
+      },
+      {
+        "name": "version",
+        "type": "bstring"
+      },
+      {
+        "name": "community",
+        "type": "bstring"
+      },
+      {
+        "name": "get_requests",
+        "type": "uint64"
+      },
+      {
+        "name": "get_bulk_requests",
+        "type": "uint64"
+      },
+      {
+        "name": "get_responses",
+        "type": "uint64"
+      },
+      {
+        "name": "set_requests",
+        "type": "uint64"
+      },
+      {
+        "name": "display_string",
+        "type": "bstring"
+      },
+      {
+        "name": "up_since",
+        "type": "time"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "smb_files_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "action",
+        "type": "zenum"
+      },
+      {
+        "name": "path",
+        "type": "bstring"
+      },
+      {
+        "name": "name",
+        "type": "bstring"
+      },
+      {
+        "name": "size",
+        "type": "uint64"
+      },
+      {
+        "name": "prev_name",
+        "type": "bstring"
+      },
+      {
+        "name": "times",
+        "type": [
+          {
+            "name": "modified",
+            "type": "time"
+          },
+          {
+            "name": "accessed",
+            "type": "time"
+          },
+          {
+            "name": "created",
+            "type": "time"
+          },
+          {
+            "name": "changed",
+            "type": "time"
+          }
+        ]
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "mysql_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "cmd",
+        "type": "bstring"
+      },
+      {
+        "name": "arg",
+        "type": "bstring"
+      },
+      {
+        "name": "success",
+        "type": "bool"
+      },
+      {
+        "name": "rows",
+        "type": "uint64"
+      },
+      {
+        "name": "response",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "rfb_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "client_major_version",
+        "type": "bstring"
+      },
+      {
+        "name": "client_minor_version",
+        "type": "bstring"
+      },
+      {
+        "name": "server_major_version",
+        "type": "bstring"
+      },
+      {
+        "name": "server_minor_version",
+        "type": "bstring"
+      },
+      {
+        "name": "authentication_method",
+        "type": "bstring"
+      },
+      {
+        "name": "auth",
+        "type": "bool"
+      },
+      {
+        "name": "share_flag",
+        "type": "bool"
+      },
+      {
+        "name": "desktop_name",
+        "type": "bstring"
+      },
+      {
+        "name": "width",
+        "type": "uint64"
+      },
+      {
+        "name": "height",
+        "type": "uint64"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "smtp_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "trans_depth",
+        "type": "uint64"
+      },
+      {
+        "name": "helo",
+        "type": "bstring"
+      },
+      {
+        "name": "mailfrom",
+        "type": "bstring"
+      },
+      {
+        "name": "rcptto",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "date",
+        "type": "bstring"
+      },
+      {
+        "name": "from",
+        "type": "bstring"
+      },
+      {
+        "name": "to",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "cc",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "reply_to",
+        "type": "bstring"
+      },
+      {
+        "name": "msg_id",
+        "type": "bstring"
+      },
+      {
+        "name": "in_reply_to",
+        "type": "bstring"
+      },
+      {
+        "name": "subject",
+        "type": "bstring"
+      },
+      {
+        "name": "x_originating_ip",
+        "type": "ip"
+      },
+      {
+        "name": "first_received",
+        "type": "bstring"
+      },
+      {
+        "name": "second_received",
+        "type": "bstring"
+      },
+      {
+        "name": "last_reply",
+        "type": "bstring"
+      },
+      {
+        "name": "path",
+        "type": "array[ip]"
+      },
+      {
+        "name": "user_agent",
+        "type": "bstring"
+      },
+      {
+        "name": "tls",
+        "type": "bool"
+      },
+      {
+        "name": "fuids",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "x509_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "id",
+        "type": "bstring"
+      },
+      {
+        "name": "certificate",
+        "type": [
+          {
+            "name": "version",
+            "type": "uint64"
+          },
+          {
+            "name": "serial",
+            "type": "bstring"
+          },
+          {
+            "name": "subject",
+            "type": "bstring"
+          },
+          {
+            "name": "issuer",
+            "type": "bstring"
+          },
+          {
+            "name": "not_valid_before",
+            "type": "time"
+          },
+          {
+            "name": "not_valid_after",
+            "type": "time"
+          },
+          {
+            "name": "key_alg",
+            "type": "bstring"
+          },
+          {
+            "name": "sig_alg",
+            "type": "bstring"
+          },
+          {
+            "name": "key_type",
+            "type": "bstring"
+          },
+          {
+            "name": "key_length",
+            "type": "uint64"
+          },
+          {
+            "name": "exponent",
+            "type": "bstring"
+          },
+          {
+            "name": "curve",
+            "type": "bstring"
+          }
+        ]
+      },
+      {
+        "name": "san",
+        "type": [
+          {
+            "name": "dns",
+            "type": "array[bstring]"
+          },
+          {
+            "name": "uri",
+            "type": "array[bstring]"
+          },
+          {
+            "name": "email",
+            "type": "array[bstring]"
+          },
+          {
+            "name": "ip",
+            "type": "array[ip]"
+          }
+        ]
+      },
+      {
+        "name": "basic_constraints",
+        "type": [
+          {
+            "name": "ca",
+            "type": "bool"
+          },
+          {
+            "name": "path_len",
+            "type": "uint64"
+          }
+        ]
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "config_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "id",
+        "type": "bstring"
+      },
+      {
+        "name": "old_value",
+        "type": "bstring"
+      },
+      {
+        "name": "new_value",
+        "type": "bstring"
+      },
+      {
+        "name": "location",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "cluster_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "node",
+        "type": "bstring"
+      },
+      {
+        "name": "message",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "packet_filter_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "node",
+        "type": "bstring"
+      },
+      {
+        "name": "filter",
+        "type": "bstring"
+      },
+      {
+        "name": "init",
+        "type": "bool"
+      },
+      {
+        "name": "success",
+        "type": "bool"
       },
       {
         "name": "_write_ts",
@@ -177,7 +1326,7 @@
         "type": "time"
       }
     ],
-    "syslog_log": [
+    "ssh_log": [
       {
         "name": "_path",
         "type": "string"
@@ -212,49 +1361,51 @@
         ]
       },
       {
-        "name": "proto",
+        "name": "version",
+        "type": "uint64"
+      },
+      {
+        "name": "auth_success",
+        "type": "bool"
+      },
+      {
+        "name": "auth_attempts",
+        "type": "uint64"
+      },
+      {
+        "name": "direction",
         "type": "zenum"
       },
       {
-        "name": "facility",
+        "name": "client",
         "type": "bstring"
       },
       {
-        "name": "severity",
+        "name": "server",
         "type": "bstring"
       },
       {
-        "name": "message",
+        "name": "cipher_alg",
         "type": "bstring"
       },
       {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "config_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "id",
+        "name": "mac_alg",
         "type": "bstring"
       },
       {
-        "name": "old_value",
+        "name": "compression_alg",
         "type": "bstring"
       },
       {
-        "name": "new_value",
+        "name": "kex_alg",
         "type": "bstring"
       },
       {
-        "name": "location",
+        "name": "host_key_alg",
+        "type": "bstring"
+      },
+      {
+        "name": "host_key",
         "type": "bstring"
       },
       {
@@ -372,33 +1523,7 @@
         "type": "time"
       }
     ],
-    "reporter_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "level",
-        "type": "zenum"
-      },
-      {
-        "name": "message",
-        "type": "bstring"
-      },
-      {
-        "name": "location",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "signatures_log": [
+    "modbus_log": [
       {
         "name": "_path",
         "type": "string"
@@ -412,44 +1537,143 @@
         "type": "bstring"
       },
       {
-        "name": "src_addr",
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "func",
+        "type": "bstring"
+      },
+      {
+        "name": "exception",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "radius_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "username",
+        "type": "bstring"
+      },
+      {
+        "name": "mac",
+        "type": "bstring"
+      },
+      {
+        "name": "framed_addr",
         "type": "ip"
       },
       {
-        "name": "src_port",
-        "type": "port"
+        "name": "tunnel_client",
+        "type": "bstring"
       },
       {
-        "name": "dst_addr",
-        "type": "ip"
+        "name": "connect_info",
+        "type": "bstring"
       },
       {
-        "name": "dst_port",
-        "type": "port"
+        "name": "reply_msg",
+        "type": "bstring"
       },
       {
-        "name": "note",
+        "name": "result",
+        "type": "bstring"
+      },
+      {
+        "name": "ttl",
+        "type": "duration"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "broker_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "ty",
         "type": "zenum"
       },
       {
-        "name": "sig_id",
+        "name": "ev",
         "type": "bstring"
       },
       {
-        "name": "event_msg",
+        "name": "peer",
+        "type": [
+          {
+            "name": "address",
+            "type": "bstring"
+          },
+          {
+            "name": "bound_port",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "message",
         "type": "bstring"
-      },
-      {
-        "name": "sub_msg",
-        "type": "bstring"
-      },
-      {
-        "name": "sig_count",
-        "type": "uint64"
-      },
-      {
-        "name": "host_count",
-        "type": "uint64"
       },
       {
         "name": "_write_ts",
@@ -511,7 +1735,7 @@
         "type": "time"
       }
     ],
-    "ntp_log": [
+    "dns_log": [
       {
         "name": "_path",
         "type": "string"
@@ -546,1605 +1770,76 @@
         ]
       },
       {
-        "name": "version",
-        "type": "uint64"
-      },
-      {
-        "name": "mode",
-        "type": "uint64"
-      },
-      {
-        "name": "stratum",
-        "type": "uint64"
-      },
-      {
-        "name": "poll",
-        "type": "duration"
-      },
-      {
-        "name": "precision",
-        "type": "duration"
-      },
-      {
-        "name": "root_delay",
-        "type": "duration"
-      },
-      {
-        "name": "root_disp",
-        "type": "duration"
-      },
-      {
-        "name": "ref_id",
-        "type": "bstring"
-      },
-      {
-        "name": "ref_time",
-        "type": "time"
-      },
-      {
-        "name": "org_time",
-        "type": "time"
-      },
-      {
-        "name": "rec_time",
-        "type": "time"
-      },
-      {
-        "name": "xmt_time",
-        "type": "time"
-      },
-      {
-        "name": "num_exts",
-        "type": "uint64"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "rfb_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "client_major_version",
-        "type": "bstring"
-      },
-      {
-        "name": "client_minor_version",
-        "type": "bstring"
-      },
-      {
-        "name": "server_major_version",
-        "type": "bstring"
-      },
-      {
-        "name": "server_minor_version",
-        "type": "bstring"
-      },
-      {
-        "name": "authentication_method",
-        "type": "bstring"
-      },
-      {
-        "name": "auth",
-        "type": "bool"
-      },
-      {
-        "name": "share_flag",
-        "type": "bool"
-      },
-      {
-        "name": "desktop_name",
-        "type": "bstring"
-      },
-      {
-        "name": "width",
-        "type": "uint64"
-      },
-      {
-        "name": "height",
-        "type": "uint64"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "smb_mapping_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "path",
-        "type": "bstring"
-      },
-      {
-        "name": "service",
-        "type": "bstring"
-      },
-      {
-        "name": "native_file_system",
-        "type": "bstring"
-      },
-      {
-        "name": "share_type",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "ftp_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "user",
-        "type": "bstring"
-      },
-      {
-        "name": "password",
-        "type": "bstring"
-      },
-      {
-        "name": "command",
-        "type": "bstring"
-      },
-      {
-        "name": "arg",
-        "type": "bstring"
-      },
-      {
-        "name": "mime_type",
-        "type": "bstring"
-      },
-      {
-        "name": "file_size",
-        "type": "uint64"
-      },
-      {
-        "name": "reply_code",
-        "type": "uint64"
-      },
-      {
-        "name": "reply_msg",
-        "type": "bstring"
-      },
-      {
-        "name": "data_channel",
-        "type": [
-          {
-            "name": "passive",
-            "type": "bool"
-          },
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "fuid",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "intel_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "seen",
-        "type": [
-          {
-            "name": "indicator",
-            "type": "bstring"
-          },
-          {
-            "name": "indicator_type",
-            "type": "zenum"
-          },
-          {
-            "name": "where",
-            "type": "zenum"
-          },
-          {
-            "name": "node",
-            "type": "bstring"
-          }
-        ]
-      },
-      {
-        "name": "matched",
-        "type": "set[zenum]"
-      },
-      {
-        "name": "sources",
-        "type": "set[bstring]"
-      },
-      {
-        "name": "fuid",
-        "type": "bstring"
-      },
-      {
-        "name": "file_mime_type",
-        "type": "bstring"
-      },
-      {
-        "name": "file_desc",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "kerberos_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "request_type",
-        "type": "bstring"
-      },
-      {
-        "name": "client",
-        "type": "bstring"
-      },
-      {
-        "name": "service",
-        "type": "bstring"
-      },
-      {
-        "name": "success",
-        "type": "bool"
-      },
-      {
-        "name": "error_msg",
-        "type": "bstring"
-      },
-      {
-        "name": "from",
-        "type": "time"
-      },
-      {
-        "name": "till",
-        "type": "time"
-      },
-      {
-        "name": "cipher",
-        "type": "bstring"
-      },
-      {
-        "name": "forwardable",
-        "type": "bool"
-      },
-      {
-        "name": "renewable",
-        "type": "bool"
-      },
-      {
-        "name": "client_cert_subject",
-        "type": "bstring"
-      },
-      {
-        "name": "client_cert_fuid",
-        "type": "bstring"
-      },
-      {
-        "name": "server_cert_subject",
-        "type": "bstring"
-      },
-      {
-        "name": "server_cert_fuid",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "socks_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "version",
-        "type": "uint64"
-      },
-      {
-        "name": "user",
-        "type": "bstring"
-      },
-      {
-        "name": "password",
-        "type": "bstring"
-      },
-      {
-        "name": "status",
-        "type": "bstring"
-      },
-      {
-        "name": "request",
-        "type": [
-          {
-            "name": "host",
-            "type": "ip"
-          },
-          {
-            "name": "name",
-            "type": "bstring"
-          }
-        ]
-      },
-      {
-        "name": "request_p",
-        "type": "port"
-      },
-      {
-        "name": "bound",
-        "type": [
-          {
-            "name": "host",
-            "type": "ip"
-          },
-          {
-            "name": "name",
-            "type": "bstring"
-          }
-        ]
-      },
-      {
-        "name": "bound_p",
-        "type": "port"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "irc_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "nick",
-        "type": "bstring"
-      },
-      {
-        "name": "user",
-        "type": "bstring"
-      },
-      {
-        "name": "command",
-        "type": "bstring"
-      },
-      {
-        "name": "value",
-        "type": "bstring"
-      },
-      {
-        "name": "addl",
-        "type": "bstring"
-      },
-      {
-        "name": "dcc_file_name",
-        "type": "bstring"
-      },
-      {
-        "name": "dcc_file_size",
-        "type": "uint64"
-      },
-      {
-        "name": "dcc_mime_type",
-        "type": "bstring"
-      },
-      {
-        "name": "fuid",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "netcontrol_drop_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "rule_id",
-        "type": "bstring"
-      },
-      {
-        "name": "orig_h",
-        "type": "ip"
-      },
-      {
-        "name": "orig_p",
-        "type": "port"
-      },
-      {
-        "name": "resp_h",
-        "type": "ip"
-      },
-      {
-        "name": "resp_p",
-        "type": "port"
-      },
-      {
-        "name": "expire",
-        "type": "duration"
-      },
-      {
-        "name": "location",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "dnp3_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "fc_request",
-        "type": "bstring"
-      },
-      {
-        "name": "fc_reply",
-        "type": "bstring"
-      },
-      {
-        "name": "iin",
-        "type": "uint64"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "netcontrol_shunt_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "rule_id",
-        "type": "bstring"
-      },
-      {
-        "name": "f",
-        "type": [
-          {
-            "name": "src_h",
-            "type": "ip"
-          },
-          {
-            "name": "src_p",
-            "type": "port"
-          },
-          {
-            "name": "dst_h",
-            "type": "ip"
-          },
-          {
-            "name": "dst_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "expire",
-        "type": "duration"
-      },
-      {
-        "name": "location",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "http_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "trans_depth",
-        "type": "uint64"
-      },
-      {
-        "name": "method",
-        "type": "bstring"
-      },
-      {
-        "name": "host",
-        "type": "bstring"
-      },
-      {
-        "name": "uri",
-        "type": "bstring"
-      },
-      {
-        "name": "referrer",
-        "type": "bstring"
-      },
-      {
-        "name": "version",
-        "type": "bstring"
-      },
-      {
-        "name": "user_agent",
-        "type": "bstring"
-      },
-      {
-        "name": "origin",
-        "type": "bstring"
-      },
-      {
-        "name": "request_body_len",
-        "type": "uint64"
-      },
-      {
-        "name": "response_body_len",
-        "type": "uint64"
-      },
-      {
-        "name": "status_code",
-        "type": "uint64"
-      },
-      {
-        "name": "status_msg",
-        "type": "bstring"
-      },
-      {
-        "name": "info_code",
-        "type": "uint64"
-      },
-      {
-        "name": "info_msg",
-        "type": "bstring"
-      },
-      {
-        "name": "tags",
-        "type": "set[zenum]"
-      },
-      {
-        "name": "username",
-        "type": "bstring"
-      },
-      {
-        "name": "password",
-        "type": "bstring"
-      },
-      {
-        "name": "proxied",
-        "type": "set[bstring]"
-      },
-      {
-        "name": "orig_fuids",
-        "type": "array[bstring]"
-      },
-      {
-        "name": "orig_filenames",
-        "type": "array[bstring]"
-      },
-      {
-        "name": "orig_mime_types",
-        "type": "array[bstring]"
-      },
-      {
-        "name": "resp_fuids",
-        "type": "array[bstring]"
-      },
-      {
-        "name": "resp_filenames",
-        "type": "array[bstring]"
-      },
-      {
-        "name": "resp_mime_types",
-        "type": "array[bstring]"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "broker_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "ty",
+        "name": "proto",
         "type": "zenum"
       },
       {
-        "name": "ev",
-        "type": "bstring"
-      },
-      {
-        "name": "peer",
-        "type": [
-          {
-            "name": "address",
-            "type": "bstring"
-          },
-          {
-            "name": "bound_port",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "message",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "cluster_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "node",
-        "type": "bstring"
-      },
-      {
-        "name": "message",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "packet_filter_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "node",
-        "type": "bstring"
-      },
-      {
-        "name": "filter",
-        "type": "bstring"
-      },
-      {
-        "name": "init",
-        "type": "bool"
-      },
-      {
-        "name": "success",
-        "type": "bool"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "ssh_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "version",
+        "name": "trans_id",
         "type": "uint64"
       },
       {
-        "name": "auth_success",
-        "type": "bool"
-      },
-      {
-        "name": "auth_attempts",
-        "type": "uint64"
-      },
-      {
-        "name": "direction",
-        "type": "zenum"
-      },
-      {
-        "name": "client",
-        "type": "bstring"
-      },
-      {
-        "name": "server",
-        "type": "bstring"
-      },
-      {
-        "name": "cipher_alg",
-        "type": "bstring"
-      },
-      {
-        "name": "mac_alg",
-        "type": "bstring"
-      },
-      {
-        "name": "compression_alg",
-        "type": "bstring"
-      },
-      {
-        "name": "kex_alg",
-        "type": "bstring"
-      },
-      {
-        "name": "host_key_alg",
-        "type": "bstring"
-      },
-      {
-        "name": "host_key",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "weird_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "name",
-        "type": "bstring"
-      },
-      {
-        "name": "addl",
-        "type": "bstring"
-      },
-      {
-        "name": "notice",
-        "type": "bool"
-      },
-      {
-        "name": "peer",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "mysql_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "cmd",
-        "type": "bstring"
-      },
-      {
-        "name": "arg",
-        "type": "bstring"
-      },
-      {
-        "name": "success",
-        "type": "bool"
-      },
-      {
-        "name": "rows",
-        "type": "uint64"
-      },
-      {
-        "name": "response",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "ntlm_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "username",
-        "type": "bstring"
-      },
-      {
-        "name": "hostname",
-        "type": "bstring"
-      },
-      {
-        "name": "domainname",
-        "type": "bstring"
-      },
-      {
-        "name": "server_nb_computer_name",
-        "type": "bstring"
-      },
-      {
-        "name": "server_dns_computer_name",
-        "type": "bstring"
-      },
-      {
-        "name": "server_tree_name",
-        "type": "bstring"
-      },
-      {
-        "name": "success",
-        "type": "bool"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "smb_files_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "fuid",
-        "type": "bstring"
-      },
-      {
-        "name": "action",
-        "type": "zenum"
-      },
-      {
-        "name": "path",
-        "type": "bstring"
-      },
-      {
-        "name": "name",
-        "type": "bstring"
-      },
-      {
-        "name": "size",
-        "type": "uint64"
-      },
-      {
-        "name": "prev_name",
-        "type": "bstring"
-      },
-      {
-        "name": "times",
-        "type": [
-          {
-            "name": "modified",
-            "type": "time"
-          },
-          {
-            "name": "accessed",
-            "type": "time"
-          },
-          {
-            "name": "created",
-            "type": "time"
-          },
-          {
-            "name": "changed",
-            "type": "time"
-          }
-        ]
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "snmp_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "duration",
+        "name": "rtt",
         "type": "duration"
       },
       {
-        "name": "version",
+        "name": "query",
         "type": "bstring"
       },
       {
-        "name": "community",
-        "type": "bstring"
-      },
-      {
-        "name": "get_requests",
+        "name": "qclass",
         "type": "uint64"
       },
       {
-        "name": "get_bulk_requests",
+        "name": "qclass_name",
+        "type": "bstring"
+      },
+      {
+        "name": "qtype",
         "type": "uint64"
       },
       {
-        "name": "get_responses",
+        "name": "qtype_name",
+        "type": "bstring"
+      },
+      {
+        "name": "rcode",
         "type": "uint64"
       },
       {
-        "name": "set_requests",
+        "name": "rcode_name",
+        "type": "bstring"
+      },
+      {
+        "name": "AA",
+        "type": "bool"
+      },
+      {
+        "name": "TC",
+        "type": "bool"
+      },
+      {
+        "name": "RD",
+        "type": "bool"
+      },
+      {
+        "name": "RA",
+        "type": "bool"
+      },
+      {
+        "name": "Z",
         "type": "uint64"
       },
       {
-        "name": "display_string",
-        "type": "bstring"
-      },
-      {
-        "name": "up_since",
-        "type": "time"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "dhcp_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uids",
-        "type": "set[bstring]"
-      },
-      {
-        "name": "client_addr",
-        "type": "ip"
-      },
-      {
-        "name": "server_addr",
-        "type": "ip"
-      },
-      {
-        "name": "mac",
-        "type": "bstring"
-      },
-      {
-        "name": "host_name",
-        "type": "bstring"
-      },
-      {
-        "name": "client_fqdn",
-        "type": "bstring"
-      },
-      {
-        "name": "domain",
-        "type": "bstring"
-      },
-      {
-        "name": "requested_addr",
-        "type": "ip"
-      },
-      {
-        "name": "assigned_addr",
-        "type": "ip"
-      },
-      {
-        "name": "lease_time",
-        "type": "duration"
-      },
-      {
-        "name": "client_message",
-        "type": "bstring"
-      },
-      {
-        "name": "server_message",
-        "type": "bstring"
-      },
-      {
-        "name": "msg_types",
+        "name": "answers",
         "type": "array[bstring]"
       },
       {
-        "name": "duration",
-        "type": "duration"
+        "name": "TTLs",
+        "type": "array[duration]"
       },
       {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "modbus_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "func",
-        "type": "bstring"
-      },
-      {
-        "name": "exception",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "netcontrol_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "rule_id",
-        "type": "bstring"
-      },
-      {
-        "name": "category",
-        "type": "zenum"
-      },
-      {
-        "name": "cmd",
-        "type": "bstring"
-      },
-      {
-        "name": "state",
-        "type": "zenum"
-      },
-      {
-        "name": "action",
-        "type": "bstring"
-      },
-      {
-        "name": "target",
-        "type": "zenum"
-      },
-      {
-        "name": "entity_type",
-        "type": "bstring"
-      },
-      {
-        "name": "entity",
-        "type": "bstring"
-      },
-      {
-        "name": "mod",
-        "type": "bstring"
-      },
-      {
-        "name": "msg",
-        "type": "bstring"
-      },
-      {
-        "name": "priority",
-        "type": "int64"
-      },
-      {
-        "name": "expire",
-        "type": "duration"
-      },
-      {
-        "name": "location",
-        "type": "bstring"
-      },
-      {
-        "name": "plugin",
-        "type": "bstring"
+        "name": "rejected",
+        "type": "bool"
       },
       {
         "name": "_write_ts",
@@ -2254,112 +1949,7 @@
         "type": "time"
       }
     ],
-    "x509_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "id",
-        "type": "bstring"
-      },
-      {
-        "name": "certificate",
-        "type": [
-          {
-            "name": "version",
-            "type": "uint64"
-          },
-          {
-            "name": "serial",
-            "type": "bstring"
-          },
-          {
-            "name": "subject",
-            "type": "bstring"
-          },
-          {
-            "name": "issuer",
-            "type": "bstring"
-          },
-          {
-            "name": "not_valid_before",
-            "type": "time"
-          },
-          {
-            "name": "not_valid_after",
-            "type": "time"
-          },
-          {
-            "name": "key_alg",
-            "type": "bstring"
-          },
-          {
-            "name": "sig_alg",
-            "type": "bstring"
-          },
-          {
-            "name": "key_type",
-            "type": "bstring"
-          },
-          {
-            "name": "key_length",
-            "type": "uint64"
-          },
-          {
-            "name": "exponent",
-            "type": "bstring"
-          },
-          {
-            "name": "curve",
-            "type": "bstring"
-          }
-        ]
-      },
-      {
-        "name": "san",
-        "type": [
-          {
-            "name": "dns",
-            "type": "array[bstring]"
-          },
-          {
-            "name": "uri",
-            "type": "array[bstring]"
-          },
-          {
-            "name": "email",
-            "type": "array[bstring]"
-          },
-          {
-            "name": "ip",
-            "type": "array[ip]"
-          }
-        ]
-      },
-      {
-        "name": "basic_constraints",
-        "type": [
-          {
-            "name": "ca",
-            "type": "bool"
-          },
-          {
-            "name": "path_len",
-            "type": "uint64"
-          }
-        ]
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "notice_log": [
+    "irc_log": [
       {
         "name": "_path",
         "type": "string"
@@ -2394,92 +1984,47 @@
         ]
       },
       {
-        "name": "fuid",
+        "name": "nick",
         "type": "bstring"
       },
       {
-        "name": "file_mime_type",
+        "name": "user",
         "type": "bstring"
       },
       {
-        "name": "file_desc",
+        "name": "command",
         "type": "bstring"
       },
       {
-        "name": "proto",
-        "type": "zenum"
-      },
-      {
-        "name": "note",
-        "type": "zenum"
-      },
-      {
-        "name": "msg",
+        "name": "value",
         "type": "bstring"
       },
       {
-        "name": "sub",
+        "name": "addl",
         "type": "bstring"
       },
       {
-        "name": "src",
-        "type": "ip"
+        "name": "dcc_file_name",
+        "type": "bstring"
       },
       {
-        "name": "dst",
-        "type": "ip"
-      },
-      {
-        "name": "p",
-        "type": "port"
-      },
-      {
-        "name": "n",
+        "name": "dcc_file_size",
         "type": "uint64"
       },
       {
-        "name": "peer_descr",
+        "name": "dcc_mime_type",
         "type": "bstring"
       },
       {
-        "name": "actions",
-        "type": "set[zenum]"
-      },
-      {
-        "name": "suppress_for",
-        "type": "duration"
-      },
-      {
-        "name": "remote_location",
-        "type": [
-          {
-            "name": "country_code",
-            "type": "bstring"
-          },
-          {
-            "name": "region",
-            "type": "bstring"
-          },
-          {
-            "name": "city",
-            "type": "bstring"
-          },
-          {
-            "name": "latitude",
-            "type": "float64"
-          },
-          {
-            "name": "longitude",
-            "type": "float64"
-          }
-        ]
+        "name": "fuid",
+        "type": "bstring"
       },
       {
         "name": "_write_ts",
         "type": "time"
       }
     ],
-    "notice_alarm_log": [
+    "reporter_log": [
       {
         "name": "_path",
         "type": "string"
@@ -2489,110 +2034,16 @@
         "type": "time"
       },
       {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "fuid",
-        "type": "bstring"
-      },
-      {
-        "name": "file_mime_type",
-        "type": "bstring"
-      },
-      {
-        "name": "file_desc",
-        "type": "bstring"
-      },
-      {
-        "name": "proto",
+        "name": "level",
         "type": "zenum"
       },
       {
-        "name": "note",
-        "type": "zenum"
-      },
-      {
-        "name": "msg",
+        "name": "message",
         "type": "bstring"
       },
       {
-        "name": "sub",
+        "name": "location",
         "type": "bstring"
-      },
-      {
-        "name": "src",
-        "type": "ip"
-      },
-      {
-        "name": "dst",
-        "type": "ip"
-      },
-      {
-        "name": "p",
-        "type": "port"
-      },
-      {
-        "name": "n",
-        "type": "uint64"
-      },
-      {
-        "name": "peer_descr",
-        "type": "bstring"
-      },
-      {
-        "name": "actions",
-        "type": "set[zenum]"
-      },
-      {
-        "name": "suppress_for",
-        "type": "duration"
-      },
-      {
-        "name": "remote_location",
-        "type": [
-          {
-            "name": "country_code",
-            "type": "bstring"
-          },
-          {
-            "name": "region",
-            "type": "bstring"
-          },
-          {
-            "name": "city",
-            "type": "bstring"
-          },
-          {
-            "name": "latitude",
-            "type": "float64"
-          },
-          {
-            "name": "longitude",
-            "type": "float64"
-          }
-        ]
       },
       {
         "name": "_write_ts",
@@ -2817,6 +2268,654 @@
         "type": "time"
       }
     ],
+    "tunnel_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "tunnel_type",
+        "type": "zenum"
+      },
+      {
+        "name": "action",
+        "type": "zenum"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "dhcp_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uids",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "client_addr",
+        "type": "ip"
+      },
+      {
+        "name": "server_addr",
+        "type": "ip"
+      },
+      {
+        "name": "mac",
+        "type": "bstring"
+      },
+      {
+        "name": "host_name",
+        "type": "bstring"
+      },
+      {
+        "name": "client_fqdn",
+        "type": "bstring"
+      },
+      {
+        "name": "domain",
+        "type": "bstring"
+      },
+      {
+        "name": "requested_addr",
+        "type": "ip"
+      },
+      {
+        "name": "assigned_addr",
+        "type": "ip"
+      },
+      {
+        "name": "lease_time",
+        "type": "duration"
+      },
+      {
+        "name": "client_message",
+        "type": "bstring"
+      },
+      {
+        "name": "server_message",
+        "type": "bstring"
+      },
+      {
+        "name": "msg_types",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "duration",
+        "type": "duration"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "ftp_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "user",
+        "type": "bstring"
+      },
+      {
+        "name": "password",
+        "type": "bstring"
+      },
+      {
+        "name": "command",
+        "type": "bstring"
+      },
+      {
+        "name": "arg",
+        "type": "bstring"
+      },
+      {
+        "name": "mime_type",
+        "type": "bstring"
+      },
+      {
+        "name": "file_size",
+        "type": "uint64"
+      },
+      {
+        "name": "reply_code",
+        "type": "uint64"
+      },
+      {
+        "name": "reply_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "data_channel",
+        "type": [
+          {
+            "name": "passive",
+            "type": "bool"
+          },
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "notice_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "file_mime_type",
+        "type": "bstring"
+      },
+      {
+        "name": "file_desc",
+        "type": "bstring"
+      },
+      {
+        "name": "proto",
+        "type": "zenum"
+      },
+      {
+        "name": "note",
+        "type": "zenum"
+      },
+      {
+        "name": "msg",
+        "type": "bstring"
+      },
+      {
+        "name": "sub",
+        "type": "bstring"
+      },
+      {
+        "name": "src",
+        "type": "ip"
+      },
+      {
+        "name": "dst",
+        "type": "ip"
+      },
+      {
+        "name": "p",
+        "type": "port"
+      },
+      {
+        "name": "n",
+        "type": "uint64"
+      },
+      {
+        "name": "peer_descr",
+        "type": "bstring"
+      },
+      {
+        "name": "actions",
+        "type": "set[zenum]"
+      },
+      {
+        "name": "suppress_for",
+        "type": "duration"
+      },
+      {
+        "name": "remote_location",
+        "type": [
+          {
+            "name": "country_code",
+            "type": "bstring"
+          },
+          {
+            "name": "region",
+            "type": "bstring"
+          },
+          {
+            "name": "city",
+            "type": "bstring"
+          },
+          {
+            "name": "latitude",
+            "type": "float64"
+          },
+          {
+            "name": "longitude",
+            "type": "float64"
+          }
+        ]
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "socks_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "version",
+        "type": "uint64"
+      },
+      {
+        "name": "user",
+        "type": "bstring"
+      },
+      {
+        "name": "password",
+        "type": "bstring"
+      },
+      {
+        "name": "status",
+        "type": "bstring"
+      },
+      {
+        "name": "request",
+        "type": [
+          {
+            "name": "host",
+            "type": "ip"
+          },
+          {
+            "name": "name",
+            "type": "bstring"
+          }
+        ]
+      },
+      {
+        "name": "request_p",
+        "type": "port"
+      },
+      {
+        "name": "bound",
+        "type": [
+          {
+            "name": "host",
+            "type": "ip"
+          },
+          {
+            "name": "name",
+            "type": "bstring"
+          }
+        ]
+      },
+      {
+        "name": "bound_p",
+        "type": "port"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "syslog_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "proto",
+        "type": "zenum"
+      },
+      {
+        "name": "facility",
+        "type": "bstring"
+      },
+      {
+        "name": "severity",
+        "type": "bstring"
+      },
+      {
+        "name": "message",
+        "type": "bstring"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "dnp3_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "fc_request",
+        "type": "bstring"
+      },
+      {
+        "name": "fc_reply",
+        "type": "bstring"
+      },
+      {
+        "name": "iin",
+        "type": "uint64"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "notice_alarm_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "fuid",
+        "type": "bstring"
+      },
+      {
+        "name": "file_mime_type",
+        "type": "bstring"
+      },
+      {
+        "name": "file_desc",
+        "type": "bstring"
+      },
+      {
+        "name": "proto",
+        "type": "zenum"
+      },
+      {
+        "name": "note",
+        "type": "zenum"
+      },
+      {
+        "name": "msg",
+        "type": "bstring"
+      },
+      {
+        "name": "sub",
+        "type": "bstring"
+      },
+      {
+        "name": "src",
+        "type": "ip"
+      },
+      {
+        "name": "dst",
+        "type": "ip"
+      },
+      {
+        "name": "p",
+        "type": "port"
+      },
+      {
+        "name": "n",
+        "type": "uint64"
+      },
+      {
+        "name": "peer_descr",
+        "type": "bstring"
+      },
+      {
+        "name": "actions",
+        "type": "set[zenum]"
+      },
+      {
+        "name": "suppress_for",
+        "type": "duration"
+      },
+      {
+        "name": "remote_location",
+        "type": [
+          {
+            "name": "country_code",
+            "type": "bstring"
+          },
+          {
+            "name": "region",
+            "type": "bstring"
+          },
+          {
+            "name": "city",
+            "type": "bstring"
+          },
+          {
+            "name": "latitude",
+            "type": "float64"
+          },
+          {
+            "name": "longitude",
+            "type": "float64"
+          }
+        ]
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
     "conn_log": [
       {
         "name": "_path",
@@ -2916,247 +3015,7 @@
         "type": "time"
       }
     ],
-    "dpd_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "proto",
-        "type": "zenum"
-      },
-      {
-        "name": "analyzer",
-        "type": "bstring"
-      },
-      {
-        "name": "failure_reason",
-        "type": "bstring"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "pe_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "id",
-        "type": "bstring"
-      },
-      {
-        "name": "machine",
-        "type": "bstring"
-      },
-      {
-        "name": "compile_ts",
-        "type": "time"
-      },
-      {
-        "name": "os",
-        "type": "bstring"
-      },
-      {
-        "name": "subsystem",
-        "type": "bstring"
-      },
-      {
-        "name": "is_exe",
-        "type": "bool"
-      },
-      {
-        "name": "is_64bit",
-        "type": "bool"
-      },
-      {
-        "name": "uses_aslr",
-        "type": "bool"
-      },
-      {
-        "name": "uses_dep",
-        "type": "bool"
-      },
-      {
-        "name": "uses_code_integrity",
-        "type": "bool"
-      },
-      {
-        "name": "uses_seh",
-        "type": "bool"
-      },
-      {
-        "name": "has_import_table",
-        "type": "bool"
-      },
-      {
-        "name": "has_export_table",
-        "type": "bool"
-      },
-      {
-        "name": "has_cert_table",
-        "type": "bool"
-      },
-      {
-        "name": "has_debug_data",
-        "type": "bool"
-      },
-      {
-        "name": "section_names",
-        "type": "array[bstring]"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "dns_log": [
-      {
-        "name": "_path",
-        "type": "string"
-      },
-      {
-        "name": "ts",
-        "type": "time"
-      },
-      {
-        "name": "uid",
-        "type": "bstring"
-      },
-      {
-        "name": "id",
-        "type": [
-          {
-            "name": "orig_h",
-            "type": "ip"
-          },
-          {
-            "name": "orig_p",
-            "type": "port"
-          },
-          {
-            "name": "resp_h",
-            "type": "ip"
-          },
-          {
-            "name": "resp_p",
-            "type": "port"
-          }
-        ]
-      },
-      {
-        "name": "proto",
-        "type": "zenum"
-      },
-      {
-        "name": "trans_id",
-        "type": "uint64"
-      },
-      {
-        "name": "rtt",
-        "type": "duration"
-      },
-      {
-        "name": "query",
-        "type": "bstring"
-      },
-      {
-        "name": "qclass",
-        "type": "uint64"
-      },
-      {
-        "name": "qclass_name",
-        "type": "bstring"
-      },
-      {
-        "name": "qtype",
-        "type": "uint64"
-      },
-      {
-        "name": "qtype_name",
-        "type": "bstring"
-      },
-      {
-        "name": "rcode",
-        "type": "uint64"
-      },
-      {
-        "name": "rcode_name",
-        "type": "bstring"
-      },
-      {
-        "name": "AA",
-        "type": "bool"
-      },
-      {
-        "name": "TC",
-        "type": "bool"
-      },
-      {
-        "name": "RD",
-        "type": "bool"
-      },
-      {
-        "name": "RA",
-        "type": "bool"
-      },
-      {
-        "name": "Z",
-        "type": "uint64"
-      },
-      {
-        "name": "answers",
-        "type": "array[bstring]"
-      },
-      {
-        "name": "TTLs",
-        "type": "array[duration]"
-      },
-      {
-        "name": "rejected",
-        "type": "bool"
-      },
-      {
-        "name": "_write_ts",
-        "type": "time"
-      }
-    ],
-    "smtp_log": [
+    "http_log": [
       {
         "name": "_path",
         "type": "string"
@@ -3195,80 +3054,221 @@
         "type": "uint64"
       },
       {
-        "name": "helo",
+        "name": "method",
         "type": "bstring"
       },
       {
-        "name": "mailfrom",
+        "name": "host",
         "type": "bstring"
       },
       {
-        "name": "rcptto",
-        "type": "set[bstring]"
-      },
-      {
-        "name": "date",
+        "name": "uri",
         "type": "bstring"
       },
       {
-        "name": "from",
+        "name": "referrer",
         "type": "bstring"
       },
       {
-        "name": "to",
-        "type": "set[bstring]"
-      },
-      {
-        "name": "cc",
-        "type": "set[bstring]"
-      },
-      {
-        "name": "reply_to",
+        "name": "version",
         "type": "bstring"
-      },
-      {
-        "name": "msg_id",
-        "type": "bstring"
-      },
-      {
-        "name": "in_reply_to",
-        "type": "bstring"
-      },
-      {
-        "name": "subject",
-        "type": "bstring"
-      },
-      {
-        "name": "x_originating_ip",
-        "type": "ip"
-      },
-      {
-        "name": "first_received",
-        "type": "bstring"
-      },
-      {
-        "name": "second_received",
-        "type": "bstring"
-      },
-      {
-        "name": "last_reply",
-        "type": "bstring"
-      },
-      {
-        "name": "path",
-        "type": "array[ip]"
       },
       {
         "name": "user_agent",
         "type": "bstring"
       },
       {
-        "name": "tls",
+        "name": "origin",
+        "type": "bstring"
+      },
+      {
+        "name": "request_body_len",
+        "type": "uint64"
+      },
+      {
+        "name": "response_body_len",
+        "type": "uint64"
+      },
+      {
+        "name": "status_code",
+        "type": "uint64"
+      },
+      {
+        "name": "status_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "info_code",
+        "type": "uint64"
+      },
+      {
+        "name": "info_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "tags",
+        "type": "set[zenum]"
+      },
+      {
+        "name": "username",
+        "type": "bstring"
+      },
+      {
+        "name": "password",
+        "type": "bstring"
+      },
+      {
+        "name": "proxied",
+        "type": "set[bstring]"
+      },
+      {
+        "name": "orig_fuids",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "orig_filenames",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "orig_mime_types",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "resp_fuids",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "resp_filenames",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "resp_mime_types",
+        "type": "array[bstring]"
+      },
+      {
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "ntlm_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "orig_h",
+            "type": "ip"
+          },
+          {
+            "name": "orig_p",
+            "type": "port"
+          },
+          {
+            "name": "resp_h",
+            "type": "ip"
+          },
+          {
+            "name": "resp_p",
+            "type": "port"
+          }
+        ]
+      },
+      {
+        "name": "username",
+        "type": "bstring"
+      },
+      {
+        "name": "hostname",
+        "type": "bstring"
+      },
+      {
+        "name": "domainname",
+        "type": "bstring"
+      },
+      {
+        "name": "server_nb_computer_name",
+        "type": "bstring"
+      },
+      {
+        "name": "server_dns_computer_name",
+        "type": "bstring"
+      },
+      {
+        "name": "server_tree_name",
+        "type": "bstring"
+      },
+      {
+        "name": "success",
         "type": "bool"
       },
       {
-        "name": "fuids",
-        "type": "array[bstring]"
+        "name": "_write_ts",
+        "type": "time"
+      }
+    ],
+    "signatures_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      },
+      {
+        "name": "uid",
+        "type": "bstring"
+      },
+      {
+        "name": "src_addr",
+        "type": "ip"
+      },
+      {
+        "name": "src_port",
+        "type": "port"
+      },
+      {
+        "name": "dst_addr",
+        "type": "ip"
+      },
+      {
+        "name": "dst_port",
+        "type": "port"
+      },
+      {
+        "name": "note",
+        "type": "zenum"
+      },
+      {
+        "name": "sig_id",
+        "type": "bstring"
+      },
+      {
+        "name": "event_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "sub_msg",
+        "type": "bstring"
+      },
+      {
+        "name": "sig_count",
+        "type": "uint64"
+      },
+      {
+        "name": "host_count",
+        "type": "uint64"
       },
       {
         "name": "_write_ts",
@@ -3276,269 +3276,225 @@
       }
     ]
   },
-  "matching_rules": [
+  "rules": [
     {
-      "match": {
-        "_path": "broker"
-      },
+      "name": "_path",
+      "value": "broker",
       "descriptor": "broker_log"
     },
     {
-      "match": {
-        "_path": "cluster"
-      },
+      "name": "_path",
+      "value": "cluster",
       "descriptor": "cluster_log"
     },
     {
-      "match": {
-        "_path": "config"
-      },
+      "name": "_path",
+      "value": "config",
       "descriptor": "config_log"
     },
     {
-      "match": {
-        "_path": "conn"
-      },
+      "name": "_path",
+      "value": "conn",
       "descriptor": "conn_log"
     },
     {
-      "match": {
-        "_path": "dce_rpc"
-      },
+      "name": "_path",
+      "value": "dce_rpc",
       "descriptor": "dce_rpc_log"
     },
     {
-      "match": {
-        "_path": "dhcp"
-      },
+      "name": "_path",
+      "value": "dhcp",
       "descriptor": "dhcp_log"
     },
     {
-      "match": {
-        "_path": "dnp3"
-      },
+      "name": "_path",
+      "value": "dnp3",
       "descriptor": "dnp3_log"
     },
     {
-      "match": {
-        "_path": "dns"
-      },
+      "name": "_path",
+      "value": "dns",
       "descriptor": "dns_log"
     },
     {
-      "match": {
-        "_path": "dpd"
-      },
+      "name": "_path",
+      "value": "dpd",
       "descriptor": "dpd_log"
     },
     {
-      "match": {
-        "_path": "files"
-      },
+      "name": "_path",
+      "value": "files",
       "descriptor": "files_log"
     },
     {
-      "match": {
-        "_path": "ftp"
-      },
+      "name": "_path",
+      "value": "ftp",
       "descriptor": "ftp_log"
     },
     {
-      "match": {
-        "_path": "http"
-      },
+      "name": "_path",
+      "value": "http",
       "descriptor": "http_log"
     },
     {
-      "match": {
-        "_path": "intel"
-      },
+      "name": "_path",
+      "value": "intel",
       "descriptor": "intel_log"
     },
     {
-      "match": {
-        "_path": "irc"
-      },
+      "name": "_path",
+      "value": "irc",
       "descriptor": "irc_log"
     },
     {
-      "match": {
-        "_path": "kerberos"
-      },
+      "name": "_path",
+      "value": "kerberos",
       "descriptor": "kerberos_log"
     },
     {
-      "match": {
-        "_path": "modbus"
-      },
+      "name": "_path",
+      "value": "modbus",
       "descriptor": "modbus_log"
     },
     {
-      "match": {
-        "_path": "mysql"
-      },
+      "name": "_path",
+      "value": "mysql",
       "descriptor": "mysql_log"
     },
     {
-      "match": {
-        "_path": "netcontrol"
-      },
+      "name": "_path",
+      "value": "netcontrol",
       "descriptor": "netcontrol_log"
     },
     {
-      "match": {
-        "_path": "netcontrol_drop"
-      },
+      "name": "_path",
+      "value": "netcontrol_drop",
       "descriptor": "netcontrol_drop_log"
     },
     {
-      "match": {
-        "_path": "netcontrol_shunt"
-      },
+      "name": "_path",
+      "value": "netcontrol_shunt",
       "descriptor": "netcontrol_shunt_log"
     },
     {
-      "match": {
-        "_path": "notice"
-      },
+      "name": "_path",
+      "value": "notice",
       "descriptor": "notice_log"
     },
     {
-      "match": {
-        "_path": "notice_alarm"
-      },
+      "name": "_path",
+      "value": "notice_alarm",
       "descriptor": "notice_alarm_log"
     },
     {
-      "match": {
-        "_path": "ntlm"
-      },
+      "name": "_path",
+      "value": "ntlm",
       "descriptor": "ntlm_log"
     },
     {
-      "match": {
-        "_path": "ntp"
-      },
+      "name": "_path",
+      "value": "ntp",
       "descriptor": "ntp_log"
     },
     {
-      "match": {
-        "_path": "packet_filter"
-      },
+      "name": "_path",
+      "value": "packet_filter",
       "descriptor": "packet_filter_log"
     },
     {
-      "match": {
-        "_path": "pe"
-      },
+      "name": "_path",
+      "value": "pe",
       "descriptor": "pe_log"
     },
     {
-      "match": {
-        "_path": "radius"
-      },
+      "name": "_path",
+      "value": "radius",
       "descriptor": "radius_log"
     },
     {
-      "match": {
-        "_path": "rdp"
-      },
+      "name": "_path",
+      "value": "rdp",
       "descriptor": "rdp_log"
     },
     {
-      "match": {
-        "_path": "reporter"
-      },
+      "name": "_path",
+      "value": "reporter",
       "descriptor": "reporter_log"
     },
     {
-      "match": {
-        "_path": "rfb"
-      },
+      "name": "_path",
+      "value": "rfb",
       "descriptor": "rfb_log"
     },
     {
-      "match": {
-        "_path": "signatures"
-      },
+      "name": "_path",
+      "value": "signatures",
       "descriptor": "signatures_log"
     },
     {
-      "match": {
-        "_path": "sip"
-      },
+      "name": "_path",
+      "value": "sip",
       "descriptor": "sip_log"
     },
     {
-      "match": {
-        "_path": "smb_files"
-      },
+      "name": "_path",
+      "value": "smb_files",
       "descriptor": "smb_files_log"
     },
     {
-      "match": {
-        "_path": "smb_mapping"
-      },
+      "name": "_path",
+      "value": "smb_mapping",
       "descriptor": "smb_mapping_log"
     },
     {
-      "match": {
-        "_path": "smtp"
-      },
+      "name": "_path",
+      "value": "smtp",
       "descriptor": "smtp_log"
     },
     {
-      "match": {
-        "_path": "snmp"
-      },
+      "name": "_path",
+      "value": "snmp",
       "descriptor": "snmp_log"
     },
     {
-      "match": {
-        "_path": "socks"
-      },
+      "name": "_path",
+      "value": "socks",
       "descriptor": "socks_log"
     },
     {
-      "match": {
-        "_path": "software"
-      },
+      "name": "_path",
+      "value": "software",
       "descriptor": "software_log"
     },
     {
-      "match": {
-        "_path": "ssh"
-      },
+      "name": "_path",
+      "value": "ssh",
       "descriptor": "ssh_log"
     },
     {
-      "match": {
-        "_path": "ssl"
-      },
+      "name": "_path",
+      "value": "ssl",
       "descriptor": "ssl_log"
     },
     {
-      "match": {
-        "_path": "syslog"
-      },
+      "name": "_path",
+      "value": "syslog",
       "descriptor": "syslog_log"
     },
     {
-      "match": {
-        "_path": "tunnel"
-      },
+      "name": "_path",
+      "value": "tunnel",
       "descriptor": "tunnel_log"
     },
     {
-      "match": {
-        "_path": "weird"
-      },
+      "name": "_path",
+      "value": "weird",
       "descriptor": "weird_log"
     },
     {
-      "match": {
-        "_path": "x509"
-      },
+      "name": "_path",
+      "value": "x509",
       "descriptor": "x509_log"
     }
   ]

--- a/zio/detector/lookup.go
+++ b/zio/detector/lookup.go
@@ -61,7 +61,7 @@ func LookupReader(format string, r io.Reader, zctx *resolver.Context) (zbuf.Read
 	case "zeek":
 		return zeekio.NewReader(r, zctx)
 	case "ndjson":
-		return ndjsonio.NewReader(r, zctx), nil
+		return ndjsonio.NewReader(r, zctx)
 	case "zjson":
 		return zjsonio.NewReader(r, zctx), nil
 	case "bzng":

--- a/zio/detector/reader.go
+++ b/zio/detector/reader.go
@@ -40,8 +40,12 @@ func NewReader(r io.Reader, zctx *resolver.Context) (zbuf.Reader, error) {
 	}
 	track.Reset()
 	// ndjson must come after zjson since zjson is a subset of ndjson
-	if match(ndjsonio.NewReader(track, resolver.NewContext())) {
-		return ndjsonio.NewReader(recorder, zctx), nil
+	nr, err := ndjsonio.NewReader(track, resolver.NewContext())
+	if err != nil {
+		return nil, err
+	}
+	if match(nr) {
+		return ndjsonio.NewReader(recorder, zctx)
 	}
 	track.Reset()
 	if match(bzngio.NewReader(track, resolver.NewContext())) {

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -156,6 +156,7 @@ func NDJSONEq(t *testing.T, expected string, actual string) {
 		require.JSONEq(t, expectedLines[i], actualLines[i])
 	}
 }
+
 func TestNewRawFromJSON(t *testing.T) {
 	type testcase struct {
 		name, zng, json string

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -192,6 +192,7 @@ func TestNewRawFromJSON(t *testing.T) {
 			ti := &typeInfo{
 				flatDesc:   typ,
 				descriptor: typ,
+				jsonVals:   make([]jsonVal, len(typ.Columns)),
 			}
 			raw, _, err := ti.newRawFromJSON([]byte(c.json))
 			require.NoError(t, err)

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -257,7 +257,7 @@ func TestNDJSONTypeErrors(t *testing.T) {
 		},
 		{
 			"Extra field",
-			typeStats{JSONIncompleteDescriptor: 1, FirstBadLine: 1},
+			typeStats{IncompleteDescriptor: 1, FirstBadLine: 1},
 			`{"ts":"2017-03-24T19:59:23.306076Z","uid":"CXY9a54W2dLZwzPXf1","id.orig_h":"10.10.7.65","_path":"http", "extra_field": 1}`,
 			true,
 		},
@@ -275,13 +275,13 @@ func TestNDJSONTypeErrors(t *testing.T) {
 		},
 		{
 			"Missing _path",
-			typeStats{JSONMissingPath: 1, FirstBadLine: 1},
+			typeStats{MissingPath: 1, FirstBadLine: 1},
 			`{"ts":"2017-03-24T19:59:23.306076Z","uid":"CXY9a54W2dLZwzPXf1","id.orig_h":"10.10.7.65"}` + "\n",
 			true,
 		},
 		{
 			"Valid (inferred)",
-			typeStats{JSONDescriptorNotFound: 1, FirstBadLine: 1},
+			typeStats{DescriptorNotFound: 1, FirstBadLine: 1},
 			`{"ts":"2017-03-24T19:59:23.306076Z","uid":"CXY9a54W2dLZwzPXf1","id.orig_h":"10.10.7.65","_path":"inferred"}`,
 			true,
 		},

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -1,4 +1,4 @@
-package ndjsonio_test
+package ndjsonio
 
 import (
 	"bufio"
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio/ndjsonio"
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/require"
@@ -50,7 +49,7 @@ func TestNDJSONWriter(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			var out bytes.Buffer
-			w := ndjsonio.NewWriter(&out)
+			w := NewWriter(&out)
 			r := zngio.NewReader(strings.NewReader(c.input), resolver.NewContext())
 			require.NoError(t, zbuf.Copy(zbuf.NopFlusher(w), r))
 			NDJSONEq(t, c.output, out.String())
@@ -125,8 +124,8 @@ func TestNDJSON(t *testing.T) {
 
 func runtestcase(t *testing.T, input, output string) {
 	var out bytes.Buffer
-	w := ndjsonio.NewWriter(&out)
-	r, err := ndjsonio.NewReader(strings.NewReader(input), resolver.NewContext())
+	w := NewWriter(&out)
+	r, err := NewReader(strings.NewReader(input), resolver.NewContext())
 	require.NoError(t, err)
 	require.NoError(t, zbuf.Copy(zbuf.NopFlusher(w), r))
 	NDJSONEq(t, output, out.String())

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -126,7 +126,8 @@ func TestNDJSON(t *testing.T) {
 func runtestcase(t *testing.T, input, output string) {
 	var out bytes.Buffer
 	w := ndjsonio.NewWriter(&out)
-	r := ndjsonio.NewReader(strings.NewReader(input), resolver.NewContext())
+	r, err := ndjsonio.NewReader(strings.NewReader(input), resolver.NewContext())
+	require.NoError(t, err)
 	require.NoError(t, zbuf.Copy(zbuf.NopFlusher(w), r))
 	NDJSONEq(t, output, out.String())
 }

--- a/zio/ndjsonio/reader.go
+++ b/zio/ndjsonio/reader.go
@@ -77,8 +77,8 @@ type typeRules struct {
 // SetTypeConfig adds a TypeConfig to the reader. Its use is optional,
 // but if used, it should be called before records are processed.  In
 // the absence of a TypeConfig, records are all parsed with the
-// inferParser. If a TypeConfig is present, records are first parsed
-// with the typeParser, and if that fails, with the inferParser.
+// inferParser. If a TypeConfig is present, records are parsed
+// with the typeParser.
 func (r *Reader) SetTypeConfig(tc TypeConfig) error {
 	tr := typeRules{
 		descriptors: make(map[string]*zng.TypeRecord),
@@ -121,9 +121,7 @@ func (r *Reader) Parse(b []byte) (zng.Value, error) {
 		return zng.Value{}, fmt.Errorf("expected JSON type to be Object but got %s", typ)
 	}
 	if r.typ != nil {
-		if zv, err := r.typ.parseObject(val); err == nil {
-			return zv, nil
-		}
+		return r.typ.parseObject(val)
 	}
 	return r.inf.parseObject(val)
 }

--- a/zio/ndjsonio/reader.go
+++ b/zio/ndjsonio/reader.go
@@ -121,18 +121,9 @@ func (r *Reader) Parse(b []byte) (zng.Value, error) {
 		return zng.Value{}, fmt.Errorf("expected JSON type to be Object but got %s", typ)
 	}
 	if r.typ != nil {
-		zv, err := r.typ.parseObject(val)
-		if err != nil {
-			return zng.Value{}, err
-		}
-		return zv, nil
+		return r.typ.parseObject(val)
 	}
-
-	zv, err := r.inf.parseObject(val)
-	if err != nil {
-		return zng.Value{}, err
-	}
-	return zv, nil
+	return r.inf.parseObject(val)
 }
 
 func (r *Reader) Read() (*zng.Record, error) {

--- a/zio/ndjsonio/reader.go
+++ b/zio/ndjsonio/reader.go
@@ -1,3 +1,7 @@
+// Package ndjsonio parses ndjson records. It can do basic
+// transcription of json types into the corresponding zng types, or
+// more advanced mapping into zng types using definitions in a
+// TypeConfig.
 package ndjsonio
 
 import (
@@ -6,8 +10,11 @@ import (
 	"io"
 
 	"github.com/brimsec/zq/pkg/skim"
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zio/zjsonio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
+	"github.com/buger/jsonparser"
 )
 
 const (
@@ -15,19 +22,112 @@ const (
 	MaxLineSize = 50 * 1024 * 1024
 )
 
-type Reader struct {
-	scanner *skim.Scanner
-	parser  *Parser
-	zctx    *resolver.Context
+type ReadStats struct {
+	*skim.Stats
+	*typeStats
 }
 
-func NewReader(reader io.Reader, zctx *resolver.Context) *Reader {
-	buffer := make([]byte, ReadSize)
-	return &Reader{
-		scanner: skim.NewScanner(reader, buffer, MaxLineSize),
-		parser:  NewParser(zctx),
-		zctx:    zctx,
+type Reader struct {
+	scanner *skim.Scanner
+	inf     inferParser
+	typ     *typeParser
+	zctx    *resolver.Context
+	stats   ReadStats
+}
+
+func NewReader(reader io.Reader, zctx *resolver.Context) (*Reader, error) {
+	_, err := zctx.LookupTypeAlias("zenum", zng.TypeString)
+	if err != nil {
+		return nil, err
 	}
+
+	buffer := make([]byte, ReadSize)
+	scanner := skim.NewScanner(reader, buffer, MaxLineSize)
+	return &Reader{
+		scanner: scanner,
+		stats:   ReadStats{Stats: &scanner.Stats, typeStats: &typeStats{}},
+		inf:     inferParser{zctx},
+		zctx:    zctx,
+	}, nil
+}
+
+// A Rule contains one or more matches and the name of a descriptor
+// key (in the companion Descriptors map).
+type Rule struct {
+	Match      map[string]string `json:"match"`
+	Descriptor string            `json:"descriptor"`
+}
+
+// A TypeConfig contains a map of Descriptors, keyed by name, and a
+// list of rules defining which records should be mapped into which
+// descriptor.
+type TypeConfig struct {
+	Descriptors   map[string][]interface{} `json:"descriptors"`
+	MatchingRules []Rule                   `json:"matching_rules"`
+}
+
+// typeRules is used internally and is derived from TypeConfig by
+// converting its descriptors into *zng.TypeRecord s for use by the
+// ndjson typed parser.
+type typeRules struct {
+	descriptors map[string]*zng.TypeRecord
+	rules       []Rule
+}
+
+// SetTypeConfig adds a TypeConfig to the reader. Its use is optional,
+// but if used, it should be called before records are processed.  In
+// the absence of a TypeConfig, records are all parsed with the
+// inferParser. If a TypeConfig is present, records are first parsed
+// with the typeParser, and if that fails, with the inferParser.
+func (r *Reader) SetTypeConfig(tc TypeConfig) error {
+	tr := typeRules{
+		descriptors: make(map[string]*zng.TypeRecord),
+		rules:       tc.MatchingRules,
+	}
+
+	for key, columns := range tc.Descriptors {
+		typeName, err := zjsonio.DecodeType(columns)
+		if err != nil {
+			return fmt.Errorf("error decoding type \"%s\": %s", typeName, err)
+		}
+		typ, err := r.zctx.LookupByName(typeName)
+		if err != nil {
+			return err
+		}
+		recType, ok := typ.(*zng.TypeRecord)
+		if !ok {
+			return fmt.Errorf("type not a record: \"%s\"", typeName)
+		}
+		tr.descriptors[key] = recType
+	}
+	r.typ = &typeParser{zctx: r.zctx, tr: tr, stats: r.stats.typeStats}
+	return nil
+}
+
+// Parse returns a zng.Encoding slice as well as an inferred zng.Type
+// from the provided JSON input. The function expects the input json to be an
+// object, otherwise an error is returned.
+func (r *Reader) Parse(b []byte) (zcode.Bytes, zng.Type, error) {
+	val, typ, _, err := jsonparser.Get(b)
+	if err != nil {
+		return nil, nil, err
+	}
+	if typ != jsonparser.Object {
+		return nil, nil, fmt.Errorf("expected JSON type to be Object but got %s", typ)
+	}
+	if r.typ != nil {
+		zv, err := r.typ.parseObject(val)
+		if err != nil {
+			return nil, nil, err
+		}
+		return zv.Bytes, zv.Type, nil
+	}
+
+	zv, err := r.inf.parseObject(val)
+	if err != nil {
+		return nil, nil, err
+	}
+	return zv.Bytes, zv.Type, nil
 }
 
 func (r *Reader) Read() (*zng.Record, error) {
@@ -41,7 +141,7 @@ again:
 	if len(line) == 0 {
 		goto again
 	}
-	raw, typ, err := r.parser.Parse(line)
+	raw, typ, err := r.Parse(line)
 	if err != nil {
 		return nil, fmt.Errorf("line %d: %w", r.scanner.Stats.Lines, err)
 	}

--- a/zio/ndjsonio/reader.go
+++ b/zio/ndjsonio/reader.go
@@ -54,16 +54,17 @@ func NewReader(reader io.Reader, zctx *resolver.Context) (*Reader, error) {
 // A Rule contains one or more matches and the name of a descriptor
 // key (in the companion Descriptors map).
 type Rule struct {
-	Match      map[string]string `json:"match"`
-	Descriptor string            `json:"descriptor"`
+	Name       string `json:"name"`
+	Value      string `json:"value"`
+	Descriptor string `json:"descriptor"`
 }
 
 // A TypeConfig contains a map of Descriptors, keyed by name, and a
 // list of rules defining which records should be mapped into which
 // descriptor.
 type TypeConfig struct {
-	Descriptors   map[string][]interface{} `json:"descriptors"`
-	MatchingRules []Rule                   `json:"matching_rules"`
+	Descriptors map[string][]interface{} `json:"descriptors"`
+	Rules       []Rule                   `json:"rules"`
 }
 
 // typeRules is used internally and is derived from TypeConfig by
@@ -82,7 +83,7 @@ type typeRules struct {
 func (r *Reader) SetTypeConfig(tc TypeConfig) error {
 	tr := typeRules{
 		descriptors: make(map[string]*zng.TypeRecord),
-		rules:       tc.MatchingRules,
+		rules:       tc.Rules,
 	}
 
 	for key, columns := range tc.Descriptors {

--- a/zio/ndjsonio/reader.go
+++ b/zio/ndjsonio/reader.go
@@ -100,7 +100,12 @@ func (r *Reader) SetTypeConfig(tc TypeConfig) error {
 		}
 		tr.descriptors[key] = recType
 	}
-	r.typ = &typeParser{zctx: r.zctx, tr: tr, stats: r.stats.typeStats}
+	r.typ = &typeParser{
+		zctx:          r.zctx,
+		tr:            tr,
+		stats:         r.stats.typeStats,
+		typeInfoCache: make(map[int]*typeInfo),
+	}
 	return nil
 }
 

--- a/zio/ndjsonio/reader.go
+++ b/zio/ndjsonio/reader.go
@@ -121,7 +121,9 @@ func (r *Reader) Parse(b []byte) (zng.Value, error) {
 		return zng.Value{}, fmt.Errorf("expected JSON type to be Object but got %s", typ)
 	}
 	if r.typ != nil {
-		return r.typ.parseObject(val)
+		if zv, err := r.typ.parseObject(val); err == nil {
+			return zv, nil
+		}
 	}
 	return r.inf.parseObject(val)
 }

--- a/zio/ndjsonio/typeparser.go
+++ b/zio/ndjsonio/typeparser.go
@@ -1,0 +1,326 @@
+package ndjsonio
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zio/zeekio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/buger/jsonparser"
+)
+
+type typeStats struct {
+	BadFormat                int `json:"events_bad_format,omitempty"`
+	BadMetaData              int `json:"events_bad_meta_data,omitempty"`
+	LineTooLong              int `json:"events_line_too_long,omitempty"`
+	FirstBadLine             int `json:"events_first_bad_line,omitempty"`
+	JSONDescriptorNotFound   int `json:"events_json_descriptor_not_found,omitempty"`
+	JSONIncompleteDescriptor int `json:"events_json_incomplete_descriptor,omitempty"`
+	JSONMissingPath          int `json:"events_json_missing_path,omitempty"`
+}
+
+type typeParser struct {
+	zctx        *resolver.Context
+	tr          typeRules
+	defaultPath string
+	stats       *typeStats
+}
+
+var (
+	ErrDescriptorNotFound = errors.New("descriptor not found")
+	ErrMissingPath        = errors.New("missing path field")
+	ErrBadFormat          = errors.New("bad format")
+)
+
+// Information about the correspondence between the flattened structure
+// of a JSON object and its zng representation (which may include
+// nested record fields). The two descriptors here represent the same data
+// in the same order, flatDescriptor describes the data as it appears in
+// JSON, descriptor describes it as it appears in zng values.
+type typeInfo struct {
+	descriptor *zng.TypeRecord
+	flatDesc   *zng.TypeRecord
+	path       []byte
+}
+
+func getUnsafeDefault(data []byte, defaultValue string, key string) (string, error) {
+	val, err := jsonparser.GetUnsafeString(data, key)
+	if err != nil {
+		// This is always a KeyPathNotFoundError, including if the json was invalid.
+		if defaultValue == "" {
+			return "", jsonparser.KeyPathNotFoundError
+		}
+		return defaultValue, nil
+	}
+	return val, nil
+}
+
+func lookupTypeInfo(zctx *resolver.Context, desc *zng.TypeRecord, path string) *typeInfo {
+	flatCols := zeekio.FlattenColumns(desc.Columns)
+	flatDesc := zctx.LookupTypeRecord(flatCols)
+	info := typeInfo{desc, flatDesc, []byte(path)}
+	return &info
+}
+
+// findTypeInfo returns the typeInfo struct matching an input json
+// object.  If no match is found, an error is returned. If defaultPath
+// is non-zero, it is used as the default _path if the object has no
+// such field. (we could at some point make this a bit more generic by
+// passing in a "defaultFieldValues" map... but not needed now).
+func findTypeInfo(zctx *resolver.Context, jobj []byte, tr typeRules, defaultPath string) (*typeInfo, error) {
+	var fieldName, fieldVal, path string
+	for _, r := range tr.rules {
+		if len(r.Match) != 1 {
+			// This will turn into a panic when we do validation upon loading json types
+			return nil, fmt.Errorf("Rule %v with length %d", r, len(r.Match))
+		}
+
+		var name, val string
+		for n, v := range r.Match {
+			name = n
+			val = v
+		}
+
+		// we keep track of the last field value we extracted
+		// to avoid re-parsing the json object many times to
+		// lift out the same field, as would be the case with
+		// a typical zeek typing config where all rules refer
+		// to the field "_path".
+		if fieldName != name {
+			fieldName = name
+			var err error
+			if name == "_path" {
+				fieldVal, err = getUnsafeDefault(jobj, defaultPath, name)
+				path = fieldVal
+			} else {
+				// jsonparser.Get will return the key even for
+				// some invalid json. For example Get('x{"a":
+				// "b"}', "a") returns "b". This is ok because
+				// these errors will later be caught by ObjectEach.
+				fieldVal, err = jsonparser.GetUnsafeString(jobj, name)
+			}
+			if err != nil {
+				continue
+			}
+		}
+		if val == fieldVal {
+			return lookupTypeInfo(zctx, tr.descriptors[r.Descriptor], path), nil
+		}
+	}
+	if path == "" {
+		return nil, ErrMissingPath
+	}
+	return nil, ErrDescriptorNotFound
+}
+
+// newRawFromJSON builds a raw value from a descriptor and the JSON object
+// in data.  It works in two steps.  First, it constructs a slice of views onto
+// the underlying JSON values.  This slice follows the order of the flattened
+// columns.  Second, it builds the full encoded value and building nested
+// records as necessary.
+func (info *typeInfo) newRawFromJSON(data []byte) (zcode.Bytes, int, error) {
+	var droppedFields int
+	type jsonVal struct {
+		val []byte
+		typ jsonparser.ValueType
+	}
+	jsonVals := make([]jsonVal, 32) // Fixed size for stack allocation.
+	if len(info.flatDesc.Columns) > 32 {
+		jsonVals = make([]jsonVal, len(info.flatDesc.Columns))
+	}
+
+	// path is always the first field (typings config is validated
+	// for this, and inferred TDs are sorted with _path first).
+	jsonVals[0] = jsonVal{info.path, jsonparser.String}
+
+	var prefix []string
+
+	// callback can't be declared in one line due to golang/go#226
+	var callback func(key []byte, val []byte, typ jsonparser.ValueType, offset int) error
+	callback = func(key []byte, val []byte, typ jsonparser.ValueType, offset int) error {
+		skey := string(key)
+		if typ == jsonparser.Object {
+			prefix = append(prefix, skey)
+			err := jsonparser.ObjectEach(val, callback)
+			prefix = prefix[0 : len(prefix)-1]
+			return err
+		}
+
+		fullkey := strings.Join(append(prefix, skey), ".")
+
+		if col, ok := info.flatDesc.ColumnOfField(fullkey); ok {
+			jsonVals[col] = jsonVal{val, typ}
+		} else {
+			droppedFields++
+		}
+		return nil
+	}
+	if err := jsonparser.ObjectEach(data, callback); err != nil {
+		return nil, 0, err
+	}
+
+	builder := zcode.NewBuilder()
+	colno := 0
+	nestedColno := 0
+	nestedColumns := info.descriptor.Columns
+	flatColumns := info.flatDesc.Columns
+	for i := range flatColumns {
+		val := jsonVals[i].val
+		if i == info.descriptor.TsCol {
+			ts, err := parseJSONTimestamp(val)
+			if err != nil {
+				return nil, 0, err
+			}
+			if ts < 0 {
+				return nil, 0, fmt.Errorf("negative ts")
+			}
+		}
+
+		recType, isRecord := nestedColumns[colno].Type.(*zng.TypeRecord)
+		if isRecord && nestedColno == 0 {
+			builder.BeginContainer()
+		}
+
+		switch jsonVals[i].typ {
+		case jsonparser.Array:
+			builder.BeginContainer()
+			ztyp := zng.InnerType(flatColumns[i].Type)
+			var iterErr error
+			callback := func(v []byte, typ jsonparser.ValueType, offset int, _ error) {
+				zv, err := parseSimpleType(v, ztyp)
+				if err != nil {
+					iterErr = err
+				} else {
+					builder.AppendPrimitive(zv)
+				}
+			}
+			if _, err := jsonparser.ArrayEach(val, callback); err != nil {
+				return nil, 0, err
+			}
+			if iterErr != nil {
+				return nil, 0, iterErr
+			}
+			builder.EndContainer()
+		case jsonparser.NotExist, jsonparser.Null:
+			switch flatColumns[i].Type.(type) {
+			case *zng.TypeSet, *zng.TypeArray:
+				builder.AppendContainer(nil)
+			default:
+				builder.AppendPrimitive(nil)
+			}
+		default:
+			zv, err := parseSimpleType(val, flatColumns[i].Type)
+			if err != nil {
+				return nil, 0, err
+			}
+			builder.AppendPrimitive(zv)
+		}
+
+		if isRecord {
+			nestedColno += 1
+			if nestedColno == len(recType.Columns) {
+				builder.EndContainer()
+				nestedColno = 0
+				colno += 1
+			}
+		} else {
+			colno += 1
+		}
+
+	}
+	return builder.Bytes(), droppedFields, nil
+}
+
+func (p *typeParser) parseObject(b []byte) (zng.Value, error) {
+
+	var lineNo int
+	incr := func(stat *int) {
+		(*stat)++
+		if p.stats.FirstBadLine == 0 {
+			p.stats.FirstBadLine = lineNo
+		}
+	}
+
+	lineNo++
+	// calling findTypeInfo for each line is costly and we
+	// could optimize for the common case where a
+	// single-type log is posted.
+	ti, err := findTypeInfo(p.zctx, b, p.tr, p.defaultPath)
+	if err != nil {
+		switch err {
+		case ErrDescriptorNotFound:
+			incr(&p.stats.JSONDescriptorNotFound)
+		case ErrMissingPath:
+			incr(&p.stats.JSONMissingPath)
+		default:
+			panic("unhandled error")
+		}
+		return zng.Value{}, err
+	}
+	if ti.flatDesc.TsCol < 0 {
+		incr(&p.stats.BadFormat)
+		return zng.Value{}, ErrBadFormat
+	}
+
+	raw, dropped, err := ti.newRawFromJSON(b)
+	if err != nil {
+		incr(&p.stats.BadFormat)
+		return zng.Value{}, ErrBadFormat
+	}
+	if dropped > 0 {
+		incr(&p.stats.JSONIncompleteDescriptor)
+	}
+
+	return zng.Value{ti.descriptor, raw}, nil
+}
+
+func parseSimpleType(value []byte, typ zng.Type) ([]byte, error) {
+	switch typ {
+	case zng.TypeTime:
+		ts, err := parseJSONTimestamp(value)
+		if err != nil {
+			return nil, err
+		}
+		return zng.EncodeTime(ts), nil
+	case zng.TypeDuration:
+		// cannot use nano.Parse because javascript floats values can have
+		// greater precision than 10e-9.
+		f, err := strconv.ParseFloat(string(value), 10)
+		if err != nil {
+			return nil, err
+		}
+		return zng.EncodeInt(int64(f * 1e9)), nil
+	default:
+		b, err := typ.Parse(value)
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	}
+}
+
+// parseJSONTimestamp interprets data as a timestamp and returns its value as
+// both a nano.Ts and the standard Zeek format (a decimal floating-point number
+// representing seconds since the Unix epoch).
+//
+// parseJSONTimestamp understands the three timestamp formats that Zeek's ASCII
+// log writer can produce when LogAscii::use_json is true.  These formats
+// correspond to the three possible values for LogAscii::json_timestamps:
+// JSON::TS_EPOCH, JSON::TS_ISO8601, and JSON::TS_MILLIS.  For descriptions, see
+// https://docs.zeek.org/en/stable/scripts/base/init-bare.zeek.html#type-JSON::TimestampFormat.
+func parseJSONTimestamp(data []byte) (nano.Ts, error) {
+	switch {
+	case bytes.Contains(data, []byte{'-'}): // JSON::TS_ISO8601
+		return nano.ParseRFC3339Nano(data)
+	case bytes.Contains(data, []byte{'.'}): // JSON::TS_EPOCH
+		return nano.Parse(data)
+	default: // JSON::TS_MILLIS
+		return nano.ParseMillis(data)
+	}
+}

--- a/zio/ndjsonio/typeparser.go
+++ b/zio/ndjsonio/typeparser.go
@@ -66,7 +66,7 @@ func getUnsafeDefault(data []byte, defaultValue string, key string) (string, err
 	return val, nil
 }
 
-func lookupTypeInfo(zctx *resolver.Context, desc *zng.TypeRecord, path string) *typeInfo {
+func newTypeInfo(zctx *resolver.Context, desc *zng.TypeRecord, path string) *typeInfo {
 	flatCols := zeekio.FlattenColumns(desc.Columns)
 	flatDesc := zctx.LookupTypeRecord(flatCols)
 	info := typeInfo{desc, flatDesc, []byte(path), make([]jsonVal, len(flatDesc.Columns))}
@@ -226,7 +226,7 @@ func (p *typeParser) findTypeInfo(zctx *resolver.Context, jobj []byte, tr typeRu
 			if ti, ok := p.typeInfoCache[desc.ID()]; ok {
 				return ti, nil
 			}
-			ti := lookupTypeInfo(zctx, desc, path)
+			ti := newTypeInfo(zctx, desc, path)
 			p.typeInfoCache[desc.ID()] = ti
 			return ti, nil
 		}
@@ -238,7 +238,6 @@ func (p *typeParser) findTypeInfo(zctx *resolver.Context, jobj []byte, tr typeRu
 }
 
 func (p *typeParser) parseObject(b []byte) (zng.Value, error) {
-
 	incr := func(stat *int) {
 		(*stat)++
 		if p.stats.FirstBadLine == 0 {

--- a/zio/ndjsonio/typeparser.go
+++ b/zio/ndjsonio/typeparser.go
@@ -16,13 +16,11 @@ import (
 )
 
 type typeStats struct {
-	BadFormat                int `json:"events_bad_format,omitempty"`
-	BadMetaData              int `json:"events_bad_meta_data,omitempty"`
-	LineTooLong              int `json:"events_line_too_long,omitempty"`
-	FirstBadLine             int `json:"events_first_bad_line,omitempty"`
-	JSONDescriptorNotFound   int `json:"events_json_descriptor_not_found,omitempty"`
-	JSONIncompleteDescriptor int `json:"events_json_incomplete_descriptor,omitempty"`
-	JSONMissingPath          int `json:"events_json_missing_path,omitempty"`
+	BadFormat            int
+	FirstBadLine         int
+	DescriptorNotFound   int
+	IncompleteDescriptor int
+	MissingPath          int
 }
 
 type typeParser struct {
@@ -253,9 +251,9 @@ func (p *typeParser) parseObject(b []byte) (zng.Value, error) {
 	if err != nil {
 		switch err {
 		case ErrDescriptorNotFound:
-			incr(&p.stats.JSONDescriptorNotFound)
+			incr(&p.stats.DescriptorNotFound)
 		case ErrMissingPath:
-			incr(&p.stats.JSONMissingPath)
+			incr(&p.stats.MissingPath)
 		default:
 			panic("unhandled error")
 		}
@@ -272,7 +270,7 @@ func (p *typeParser) parseObject(b []byte) (zng.Value, error) {
 		return zng.Value{}, ErrBadFormat
 	}
 	if dropped > 0 {
-		incr(&p.stats.JSONIncompleteDescriptor)
+		incr(&p.stats.IncompleteDescriptor)
 	}
 
 	return zng.Value{ti.descriptor, raw}, nil

--- a/zio/ndjsonio/typeparser.go
+++ b/zio/ndjsonio/typeparser.go
@@ -70,7 +70,7 @@ func lookupTypeInfo(zctx *resolver.Context, desc *zng.TypeRecord, path string) *
 
 // findTypeInfo returns the typeInfo struct matching an input json
 // object.  If no match is found, an error is returned. If defaultPath
-// is non-zero, it is used as the default _path if the object has no
+// is not empty, it is used as the default _path if the object has no
 // such field. (we could at some point make this a bit more generic by
 // passing in a "defaultFieldValues" map... but not needed now).
 func findTypeInfo(zctx *resolver.Context, jobj []byte, tr typeRules, defaultPath string) (*typeInfo, error) {

--- a/zio/ndjsonio/typeparser.go
+++ b/zio/ndjsonio/typeparser.go
@@ -284,7 +284,7 @@ func parseSimpleType(value []byte, typ zng.Type) ([]byte, error) {
 		return zng.EncodeTime(ts), nil
 	case zng.TypeDuration:
 		// cannot use nano.Parse because javascript floats values can have
-		// greater precision than 10e-9.
+		// greater precision than 1e-9.
 		f, err := strconv.ParseFloat(string(value), 10)
 		if err != nil {
 			return nil, err

--- a/zio/zeekio/flatten.go
+++ b/zio/zeekio/flatten.go
@@ -63,7 +63,7 @@ func (f *Flattener) Flatten(r *zng.Record) (*zng.Record, error) {
 	id := r.Type.ID()
 	flatType := f.mapper.Map(id)
 	if flatType == nil {
-		cols := flattenColumns(r.Type.Columns)
+		cols := FlattenColumns(r.Type.Columns)
 		flatType = f.zctx.LookupTypeRecord(cols)
 		f.mapper.EnterTypeRecord(id, flatType)
 	}
@@ -81,9 +81,9 @@ func (f *Flattener) Flatten(r *zng.Record) (*zng.Record, error) {
 
 }
 
-// flattenColumns turns nested records into a series of columns of
+// FlattenColumns turns nested records into a series of columns of
 // the form "outer.inner".  XXX It only works for one level of nesting.
-func flattenColumns(cols []zng.Column) []zng.Column {
+func FlattenColumns(cols []zng.Column) []zng.Column {
 	ret := make([]zng.Column, 0)
 	for _, c := range cols {
 		recType, isRecord := c.Type.(*zng.TypeRecord)

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -64,7 +64,7 @@ func (r *Reader) Read() (*zng.Record, error) {
 		if v.Aliases != nil {
 			r.parseAliases(v.Aliases)
 		}
-		typeName, err := decodeType(v.Type)
+		typeName, err := DecodeType(v.Type)
 		if err != nil {
 			return nil, err
 		}
@@ -130,7 +130,7 @@ func (r *Reader) parseAliases(aliases []Alias) error {
 }
 
 // decode a nested JSON object into a zeek type string and return the string.
-func decodeType(columns []interface{}) (string, error) {
+func DecodeType(columns []interface{}) (string, error) {
 	s := "record["
 	comma := ""
 	for _, o := range columns {
@@ -158,7 +158,7 @@ func decodeType(columns []interface{}) (string, error) {
 				return "", errors.New("zjson type field contains invalid type")
 			}
 			var err error
-			typeName, err = decodeType(childColumns)
+			typeName, err = DecodeType(childColumns)
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
This commit introduces a typed ndjson reader. This reader uses side-information describing the zng types of different ndjson records in order to decode ndjson into rich zng types rather than into the subset of zng types that can be inferred from json.

This type side-information is stored in a json file that is presented to the zq tool using the `-j` flag. For example:
```sh
zq -j types.json conn.ndjson
```
If no `-j` flag is present, ndjson input is read via the existing mechanism that projects json types onto the subset of corresponding zng types.