### PR TITLE
Zx cleanup

### DIFF
--- a/expr/functions.go
+++ b/expr/functions.go
@@ -6,9 +6,10 @@ import (
 	"math"
 
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zngnative"
 )
 
-type Function func([]NativeValue) (NativeValue, error)
+type Function func([]zngnative.NativeValue) (zngnative.NativeValue, error)
 
 var ErrWrongArgc = errors.New("wrong number of arguments")
 var ErrBadArgument = errors.New("bad argument")
@@ -17,21 +18,21 @@ var allFns = map[string]Function{
 	"Math.sqrt": mathSqrt,
 }
 
-func mathSqrt(args []NativeValue) (NativeValue, error) {
+func mathSqrt(args []zngnative.NativeValue) (zngnative.NativeValue, error) {
 	if len(args) < 1 || len(args) > 1 {
-		return NativeValue{}, fmt.Errorf("Math.sqrt: %w", ErrWrongArgc)
+		return zngnative.NativeValue{}, fmt.Errorf("Math.sqrt: %w", ErrWrongArgc)
 	}
 
 	var x float64
-	switch args[0].typ.ID() {
+	switch args[0].Type.ID() {
 	case zng.IdFloat64:
-		x = args[0].value.(float64)
+		x = args[0].Value.(float64)
 	case zng.IdInt16, zng.IdInt32, zng.IdInt64:
-		x = float64(args[0].value.(int64))
+		x = float64(args[0].Value.(int64))
 	case zng.IdByte, zng.IdUint16, zng.IdUint32, zng.IdUint64:
-		x = float64(args[0].value.(uint64))
+		x = float64(args[0].Value.(uint64))
 	default:
-		return NativeValue{}, fmt.Errorf("Math.sqrt: %w", ErrBadArgument)
+		return zngnative.NativeValue{}, fmt.Errorf("Math.sqrt: %w", ErrBadArgument)
 	}
 
 	r := math.Sqrt(x)
@@ -39,8 +40,8 @@ func mathSqrt(args []NativeValue) (NativeValue, error) {
 		// For now we can't represent non-numeric values in a float64,
 		// we will revisit this but it has implications for file
 		// formats, zql, etc.
-		return NativeValue{}, fmt.Errorf("Math.sqrt: %w", ErrBadArgument)
+		return zngnative.NativeValue{}, fmt.Errorf("Math.sqrt: %w", ErrBadArgument)
 	}
 
-	return NativeValue{zng.TypeFloat64, r}, nil
+	return zngnative.NativeValue{zng.TypeFloat64, r}, nil
 }

--- a/filter/compare.go
+++ b/filter/compare.go
@@ -1,4 +1,4 @@
-package zx
+package filter
 
 import (
 	"bytes"

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -25,7 +25,7 @@ func LogicalNot(expr Filter) Filter {
 	return func(p *zng.Record) bool { return !expr(p) }
 }
 
-func combine(res expr.FieldExprResolver, pred zx.Predicate) Filter {
+func combine(res expr.FieldExprResolver, pred Predicate) Filter {
 	return func(r *zng.Record) bool {
 		v := res(r)
 		if v.Type == nil {
@@ -55,7 +55,7 @@ func CompileFieldCompare(node *ast.CompareField) (Filter, error) {
 		if err != nil {
 			return nil, err
 		}
-		comparison, err := zx.CompareContainerLen(node.Comparator, i)
+		comparison, err := CompareContainerLen(node.Comparator, i)
 		if err != nil {
 			return nil, err
 		}
@@ -66,7 +66,7 @@ func CompileFieldCompare(node *ast.CompareField) (Filter, error) {
 		return combine(resolver, comparison), nil
 	}
 
-	comparison, err := zx.Comparison(node.Comparator, literal)
+	comparison, err := Comparison(node.Comparator, literal)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func CompileFieldCompare(node *ast.CompareField) (Filter, error) {
 	return combine(resolver, comparison), nil
 }
 
-func EvalAny(eval zx.Predicate, recursive bool) Filter {
+func EvalAny(eval Predicate, recursive bool) Filter {
 	if !recursive {
 		return func(r *zng.Record) bool {
 			it := r.ZvalIter()
@@ -156,8 +156,8 @@ func Compile(node ast.BooleanExpr) (Filter, error) {
 			if err != nil {
 				return nil, err
 			}
-			eql, _ := zx.Comparison("eql", v.Value)
-			comparison := zx.Contains(eql)
+			eql, _ := Comparison("eql", v.Value)
+			comparison := Contains(eql)
 			return combine(resolver, comparison), nil
 		}
 
@@ -165,24 +165,24 @@ func Compile(node ast.BooleanExpr) (Filter, error) {
 
 	case *ast.CompareAny:
 		if v.Comparator == "in" {
-			compare, err := zx.Comparison("eql", v.Value)
+			compare, err := Comparison("eql", v.Value)
 			if err != nil {
 				return nil, err
 			}
-			contains := zx.Contains(compare)
+			contains := Contains(compare)
 			return EvalAny(contains, v.Recursive), nil
 		}
 		//XXX this is messed up
 		if v.Comparator == "searchin" {
-			search, err := zx.Comparison("search", v.Value)
+			search, err := Comparison("search", v.Value)
 			if err != nil {
 				return nil, err
 			}
-			contains := zx.Contains(search)
+			contains := Contains(search)
 			return EvalAny(contains, v.Recursive), nil
 		}
 
-		comparison, err := zx.Comparison(v.Comparator, v.Value)
+		comparison, err := Comparison(v.Comparator, v.Value)
 		if err != nil {
 			return nil, err
 		}

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -47,13 +47,9 @@ func CompileFieldCompare(node *ast.CompareField) (Filter, error) {
 		if err != nil {
 			return nil, err
 		}
-		v64, ok := zx.Coerce(v, zng.TypeInt64)
+		i, ok := zx.CoerceToInt(v)
 		if !ok {
 			return nil, errors.New("cannot compare len() with non-integer")
-		}
-		i, err := zng.DecodeInt(v64.Bytes)
-		if err != nil {
-			return nil, err
 		}
 		comparison, err := CompareContainerLen(node.Comparator, i)
 		if err != nil {

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -8,7 +8,7 @@ import (
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zx"
+	"github.com/brimsec/zq/zngnative"
 )
 
 type Filter func(*zng.Record) bool
@@ -47,7 +47,7 @@ func CompileFieldCompare(node *ast.CompareField) (Filter, error) {
 		if err != nil {
 			return nil, err
 		}
-		i, ok := zx.CoerceToInt(v)
+		i, ok := zngnative.CoerceToInt(v)
 		if !ok {
 			return nil, errors.New("cannot compare len() with non-integer")
 		}

--- a/reducer/avg.go
+++ b/reducer/avg.go
@@ -3,7 +3,7 @@ package reducer
 import (
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zx"
+	"github.com/brimsec/zq/zngnative"
 )
 
 type AvgProto struct {
@@ -39,7 +39,7 @@ func (a *Avg) Consume(r *zng.Record) {
 	if v.Bytes == nil {
 		return
 	}
-	d, ok := zx.CoerceToFloat64(v)
+	d, ok := zngnative.CoerceToFloat64(v)
 	if !ok {
 		a.TypeMismatch++
 		return

--- a/reducer/field/double.go
+++ b/reducer/field/double.go
@@ -3,7 +3,7 @@ package field
 import (
 	"github.com/brimsec/zq/streamfn"
 	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zx"
+	"github.com/brimsec/zq/zngnative"
 )
 
 type Double struct {
@@ -21,7 +21,7 @@ func (d *Double) Result() zng.Value {
 }
 
 func (d *Double) Consume(v zng.Value) error {
-	dd, ok := zx.CoerceToFloat64(v)
+	dd, ok := zngnative.CoerceToFloat64(v)
 	if !ok {
 		return zng.ErrTypeMismatch
 	}

--- a/reducer/field/int.go
+++ b/reducer/field/int.go
@@ -21,12 +21,8 @@ func (i *Int) Result() zng.Value {
 }
 
 func (i *Int) Consume(v zng.Value) error {
-	if v, ok := zx.CoerceToInt(v, zng.TypeInt64); ok {
-		arg, err := zng.DecodeInt(v.Bytes)
-		if err != nil {
-			return zng.ErrBadValue
-		}
-		i.fn.Update(arg)
+	if v, ok := zx.CoerceToInt(v); ok {
+		i.fn.Update(v)
 		return nil
 	}
 	return zng.ErrTypeMismatch

--- a/reducer/field/int.go
+++ b/reducer/field/int.go
@@ -3,7 +3,7 @@ package field
 import (
 	"github.com/brimsec/zq/streamfn"
 	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zx"
+	"github.com/brimsec/zq/zngnative"
 )
 
 type Int struct {
@@ -21,7 +21,7 @@ func (i *Int) Result() zng.Value {
 }
 
 func (i *Int) Consume(v zng.Value) error {
-	if v, ok := zx.CoerceToInt(v); ok {
+	if v, ok := zngnative.CoerceToInt(v); ok {
 		i.fn.Update(v)
 		return nil
 	}

--- a/reducer/field/interval.go
+++ b/reducer/field/interval.go
@@ -3,7 +3,7 @@ package field
 import (
 	"github.com/brimsec/zq/streamfn"
 	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zx"
+	"github.com/brimsec/zq/zngnative"
 )
 
 type Duration struct {
@@ -21,7 +21,7 @@ func (d *Duration) Result() zng.Value {
 }
 
 func (d *Duration) Consume(v zng.Value) error {
-	if interval, ok := zx.CoerceToDuration(v); ok {
+	if interval, ok := zngnative.CoerceToDuration(v); ok {
 		d.fn.Update(interval)
 		return nil
 	}

--- a/reducer/field/time.go
+++ b/reducer/field/time.go
@@ -3,7 +3,7 @@ package field
 import (
 	"github.com/brimsec/zq/streamfn"
 	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zx"
+	"github.com/brimsec/zq/zngnative"
 )
 
 type Time struct {
@@ -21,7 +21,7 @@ func (t *Time) Result() zng.Value {
 }
 
 func (t *Time) Consume(v zng.Value) error {
-	if ts, ok := zx.CoerceToTime(v); ok {
+	if ts, ok := zngnative.CoerceToTime(v); ok {
 		t.fn.Update(ts)
 		return nil
 	}

--- a/reducer/field/uint.go
+++ b/reducer/field/uint.go
@@ -3,7 +3,7 @@ package field
 import (
 	"github.com/brimsec/zq/streamfn"
 	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zx"
+	"github.com/brimsec/zq/zngnative"
 )
 
 type Uint struct {
@@ -21,7 +21,7 @@ func (u *Uint) Result() zng.Value {
 }
 
 func (u *Uint) Consume(v zng.Value) error {
-	if v, ok := zx.CoerceToUint(v); ok {
+	if v, ok := zngnative.CoerceToUint(v); ok {
 		u.fn.Update(v)
 		return nil
 	}

--- a/reducer/field/uint.go
+++ b/reducer/field/uint.go
@@ -21,12 +21,8 @@ func (u *Uint) Result() zng.Value {
 }
 
 func (u *Uint) Consume(v zng.Value) error {
-	if v, ok := zx.CoerceToUint(v, zng.TypeUint64); ok {
-		i, err := zng.DecodeUint(v.Bytes)
-		if err != nil {
-			return zng.ErrBadValue
-		}
-		u.fn.Update(i)
+	if v, ok := zx.CoerceToUint(v); ok {
+		u.fn.Update(v)
 		return nil
 	}
 	return zng.ErrTypeMismatch

--- a/zngnative/coerce.go
+++ b/zngnative/coerce.go
@@ -1,4 +1,4 @@
-package zx
+package zngnative
 
 import (
 	"math"
@@ -60,10 +60,10 @@ func CoerceToFloat64(in zng.Value) (float64, bool) {
 // unsigned integers so long as they are not greater than MaxInt64.
 // A float64 may be coerced only if the value is equivalent.
 // Time and Intervals are converted as their nanosecond values.
-func CoerceToInt(in Value) (int64, bool) {
+func CoerceToInt(in zng.Value) (int64, bool) {
 	switch in.Type.ID() {
-	case IdFloat64:
-		v, err := DecodeFloat64(in.Bytes)
+	case zng.IdFloat64:
+		v, err := zng.DecodeFloat64(in.Bytes)
 		if err != nil {
 			return 0, false
 		}
@@ -72,32 +72,32 @@ func CoerceToInt(in Value) (int64, bool) {
 			return 0, false
 		}
 		return i, true
-	case IdTime:
-		v, err := DecodeTime(in.Bytes)
+	case zng.IdTime:
+		v, err := zng.DecodeTime(in.Bytes)
 		if err != nil {
 			return 0, false
 		}
 		return int64(v / 1e9), true
-	case IdDuration:
-		v, err := DecodeDuration(in.Bytes)
+	case zng.IdDuration:
+		v, err := zng.DecodeDuration(in.Bytes)
 		if err != nil {
 			return 0, false
 		}
 		return int64(v / 1e9), true
-	case IdByte:
-		b, err := DecodeByte(in.Bytes)
+	case zng.IdByte:
+		b, err := zng.DecodeByte(in.Bytes)
 		if err != nil {
 			return 0, false
 		}
 		return int64(b), true
-	case IdInt16, IdInt32, IdInt64:
-		i, err := DecodeInt(in.Bytes)
+	case zng.IdInt16, zng.IdInt32, zng.IdInt64:
+		i, err := zng.DecodeInt(in.Bytes)
 		if err != nil {
 			return 0, false
 		}
 		return i, true
-	case IdUint16, IdUint32, IdUint64:
-		u, err := DecodeUint(in.Bytes)
+	case zng.IdUint16, zng.IdUint32, zng.IdUint64:
+		u, err := zng.DecodeUint(in.Bytes)
 		if err != nil {
 			return 0, false
 		}
@@ -118,10 +118,10 @@ func CoerceToInt(in Value) (int64, bool) {
 // signed integers so long as they are not negative.
 // A float64 may be coerced only if the value is equivalent.
 // Time and Intervals are converted as their nanosecond values.
-func CoerceToUint(in Value) (uint64, bool) {
+func CoerceToUint(in zng.Value) (uint64, bool) {
 	switch in.Type.ID() {
-	case IdFloat64:
-		v, err := DecodeFloat64(in.Bytes)
+	case zng.IdFloat64:
+		v, err := zng.DecodeFloat64(in.Bytes)
 		if err != nil {
 			return 0, false
 		}
@@ -130,26 +130,26 @@ func CoerceToUint(in Value) (uint64, bool) {
 			return 0, false
 		}
 		return i, true
-	case IdTime:
-		v, err := DecodeTime(in.Bytes)
+	case zng.IdTime:
+		v, err := zng.DecodeTime(in.Bytes)
 		if err != nil {
 			return 0, false
 		}
 		return uint64(v / 1e9), true
-	case IdDuration:
-		v, err := DecodeDuration(in.Bytes)
+	case zng.IdDuration:
+		v, err := zng.DecodeDuration(in.Bytes)
 		if err != nil {
 			return 0, false
 		}
 		return uint64(v / 1e9), true
-	case IdByte:
-		b, err := DecodeByte(in.Bytes)
+	case zng.IdByte:
+		b, err := zng.DecodeByte(in.Bytes)
 		if err != nil {
 			return 0, false
 		}
 		return uint64(b), true
-	case IdInt16, IdInt32, IdInt64:
-		si, err := DecodeInt(in.Bytes)
+	case zng.IdInt16, zng.IdInt32, zng.IdInt64:
+		si, err := zng.DecodeInt(in.Bytes)
 		if err != nil {
 			return 0, false
 		}
@@ -157,8 +157,8 @@ func CoerceToUint(in Value) (uint64, bool) {
 			return 0, false
 		}
 		return uint64(si), true
-	case IdUint16, IdUint32, IdUint64:
-		i, err := DecodeUint(in.Bytes)
+	case zng.IdUint16, zng.IdUint32, zng.IdUint64:
+		i, err := zng.DecodeUint(in.Bytes)
 		if err != nil {
 			return 0, false
 		}

--- a/zngnative/coerce_test.go
+++ b/zngnative/coerce_test.go
@@ -1,10 +1,10 @@
-package zx_test
+package zngnative_test
 
 import (
 	"testing"
 
 	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zx"
+	"github.com/brimsec/zq/zngnative"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +20,7 @@ func TestCoerceDuration(t *testing.T) {
 
 func runcase(t *testing.T, name string, in zng.Value, expected int64) {
 	t.Run(name, func(t *testing.T) {
-		val, ok := zx.CoerceToDuration(in)
+		val, ok := zngnative.CoerceToDuration(in)
 		require.True(t, ok, "coercion succeeded")
 		require.Equal(t, expected, val, "coerced value is correct")
 	})
@@ -28,7 +28,7 @@ func runcase(t *testing.T, name string, in zng.Value, expected int64) {
 
 func notcase(t *testing.T, name string, in zng.Value) {
 	t.Run(name, func(t *testing.T) {
-		_, ok := zx.CoerceToDuration(in)
+		_, ok := zngnative.CoerceToDuration(in)
 		require.False(t, ok, "coercion should have failed")
 	})
 }

--- a/zngnative/native.go
+++ b/zngnative/native.go
@@ -1,0 +1,191 @@
+package zngnative
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+)
+
+type NativeValue struct {
+	Type  zng.Type
+	Value interface{}
+}
+
+func ToNativeValue(zv zng.Value) (NativeValue, error) {
+	switch zv.Type.ID() {
+	case zng.IdBool:
+		b, err := zng.DecodeBool(zv.Bytes)
+		if err != nil {
+			return NativeValue{}, err
+		}
+		return NativeValue{zng.TypeBool, b}, nil
+
+	case zng.IdByte:
+		b, err := zng.DecodeByte(zv.Bytes)
+		if err != nil {
+			return NativeValue{}, err
+		}
+		return NativeValue{zng.TypeByte, uint64(b)}, nil
+
+	case zng.IdInt16, zng.IdInt32, zng.IdInt64:
+		v, err := zng.DecodeInt(zv.Bytes)
+		if err != nil {
+			return NativeValue{}, err
+		}
+		return NativeValue{zv.Type, v}, nil
+
+	case zng.IdUint16, zng.IdUint32, zng.IdUint64:
+		v, err := zng.DecodeUint(zv.Bytes)
+		if err != nil {
+			return NativeValue{}, err
+		}
+		return NativeValue{zv.Type, v}, nil
+
+	case zng.IdFloat64:
+		v, err := zng.DecodeFloat64(zv.Bytes)
+		if err != nil {
+			return NativeValue{}, err
+		}
+		return NativeValue{zv.Type, v}, nil
+
+	case zng.IdString:
+		s, err := zng.DecodeString(zv.Bytes)
+		if err != nil {
+			return NativeValue{}, err
+		}
+		return NativeValue{zv.Type, s}, nil
+
+	case zng.IdBstring:
+		s, err := zng.DecodeBstring(zv.Bytes)
+		if err != nil {
+			return NativeValue{}, err
+		}
+		return NativeValue{zv.Type, s}, nil
+
+	case zng.IdIP:
+		a, err := zng.DecodeIP(zv.Bytes)
+		if err != nil {
+			return NativeValue{}, err
+		}
+		return NativeValue{zv.Type, a}, nil
+
+	case zng.IdPort:
+		p, err := zng.DecodePort(zv.Bytes)
+		if err != nil {
+			return NativeValue{}, err
+		}
+		return NativeValue{zv.Type, uint64(p)}, nil
+
+	case zng.IdNet:
+		n, err := zng.DecodeNet(zv.Bytes)
+		if err != nil {
+			return NativeValue{}, err
+		}
+		return NativeValue{zv.Type, n}, nil
+
+	case zng.IdTime:
+		t, err := zng.DecodeTime(zv.Bytes)
+		if err != nil {
+			return NativeValue{}, nil
+		}
+		return NativeValue{zv.Type, int64(t)}, nil
+
+	case zng.IdDuration:
+		d, err := zng.DecodeDuration(zv.Bytes)
+		if err != nil {
+			return NativeValue{}, nil
+		}
+		return NativeValue{zv.Type, d}, nil
+	}
+
+	// Keep arrays, sets, and records in their zval encoded form.
+	// The purpose of NativeValue is to avoid encoding temporary
+	// values but since we can't construct these types in expressions,
+	// this just lets us lazily decode them.
+	switch zv.Type.(type) {
+	case *zng.TypeArray, *zng.TypeSet, *zng.TypeRecord:
+		return NativeValue{zv.Type, zv.Bytes}, nil
+	}
+
+	return NativeValue{}, fmt.Errorf("unknown type %s", zv.Type)
+}
+
+func (v *NativeValue) ToZngValue() (zng.Value, error) {
+	switch v.Type.ID() {
+	case zng.IdBool:
+		b := v.Value.(bool)
+		return zng.Value{zng.TypeBool, zng.EncodeBool(b)}, nil
+
+	case zng.IdByte:
+		b := v.Value.(uint64)
+		return zng.Value{zng.TypeByte, zng.EncodeByte(byte(b))}, nil
+
+	case zng.IdInt16:
+		i := v.Value.(int64)
+		return zng.Value{zng.TypeInt16, zng.EncodeInt(i)}, nil
+
+	case zng.IdInt32:
+		i := v.Value.(int64)
+		return zng.Value{zng.TypeInt32, zng.EncodeInt(i)}, nil
+
+	case zng.IdInt64:
+		i := v.Value.(int64)
+		return zng.Value{zng.TypeInt64, zng.EncodeInt(i)}, nil
+
+	case zng.IdUint16:
+		i := v.Value.(uint64)
+		return zng.Value{zng.TypeUint16, zng.EncodeUint(i)}, nil
+
+	case zng.IdUint32:
+		i := v.Value.(uint64)
+		return zng.Value{zng.TypeUint32, zng.EncodeUint(i)}, nil
+
+	case zng.IdUint64:
+		i := v.Value.(uint64)
+		return zng.Value{zng.TypeUint64, zng.EncodeUint(i)}, nil
+
+	case zng.IdFloat64:
+		f := v.Value.(float64)
+		return zng.Value{zng.TypeFloat64, zng.EncodeFloat64(f)}, nil
+
+	case zng.IdString:
+		s := v.Value.(string)
+		return zng.Value{zng.TypeString, zng.EncodeString(s)}, nil
+
+	case zng.IdBstring:
+		s := v.Value.(string)
+		return zng.Value{zng.TypeBstring, zng.EncodeBstring(s)}, nil
+
+	case zng.IdIP:
+		i := v.Value.(net.IP)
+		return zng.Value{zng.TypeIP, zng.EncodeIP(i)}, nil
+
+	case zng.IdPort:
+		p := v.Value.(uint64)
+		return zng.Value{zng.TypePort, zng.EncodePort(uint32(p))}, nil
+
+	case zng.IdNet:
+		n := v.Value.(*net.IPNet)
+		return zng.Value{zng.TypeNet, zng.EncodeNet(n)}, nil
+
+	case zng.IdTime:
+		t := nano.Ts(v.Value.(int64))
+		return zng.Value{zng.TypeTime, zng.EncodeTime(t)}, nil
+
+	case zng.IdDuration:
+		d := v.Value.(int64)
+		return zng.Value{zng.TypeDuration, zng.EncodeDuration(d)}, nil
+	}
+
+	// Arrays, sets, and records are just zval encoded.
+	switch v.Type.(type) {
+	case *zng.TypeArray, *zng.TypeSet, *zng.TypeRecord:
+		return zng.Value{v.Type, v.Value.(zcode.Bytes)}, nil
+	}
+
+	return zng.Value{}, errors.New("unknown type")
+}

--- a/zx/coerce.go
+++ b/zx/coerce.go
@@ -1,7 +1,6 @@
 package zx
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/brimsec/zq/pkg/nano"
@@ -56,154 +55,118 @@ func CoerceToFloat64(in zng.Value) (float64, bool) {
 	return out, true
 }
 
-// CoerceToInt and CoerceToUint attempt to convert a value to the given
-// integer type.  Integer types (byte, int*, uint*) can be coerced
-// to another integer type if the value is in range.  float64 may
-// be coerced to an integer type only if the value is equivalent.
-// Time and Intervals are converted to an Int as their nanosecond
-// values.
-func CoerceToInt(in zng.Value, typ zng.Type) (zng.Value, bool) {
-	var i int64
-	var err error
-
+// CoerceToInt attempts to convert a value to a signed integer.
+// This always succeeds for signed integer types and succeeds for
+// unsigned integers so long as they are not greater than MaxInt64.
+// A float64 may be coerced only if the value is equivalent.
+// Time and Intervals are converted as their nanosecond values.
+func CoerceToInt(in Value) (int64, bool) {
 	switch in.Type.ID() {
-	case zng.IdFloat64:
-		var v float64
-		v, err = zng.DecodeFloat64(in.Bytes)
+	case IdFloat64:
+		v, err := DecodeFloat64(in.Bytes)
 		if err != nil {
-			return zng.Value{}, false
+			return 0, false
 		}
-		i = int64(v)
+		i := int64(v)
 		if float64(i) != v {
-			return zng.Value{}, false
+			return 0, false
 		}
-	case zng.IdTime:
-		var v nano.Ts
-		v, err = zng.DecodeTime(in.Bytes)
+		return i, true
+	case IdTime:
+		v, err := DecodeTime(in.Bytes)
 		if err != nil {
-			return zng.Value{}, false
+			return 0, false
 		}
-		i = int64(v / 1e9)
-	case zng.IdDuration:
-		var v int64
-		v, err = zng.DecodeDuration(in.Bytes)
+		return int64(v / 1e9), true
+	case IdDuration:
+		v, err := DecodeDuration(in.Bytes)
 		if err != nil {
-			return zng.Value{}, false
+			return 0, false
 		}
-		i = int64(v / 1e9)
-	case zng.IdByte:
-		var b byte
-		b, err = zng.DecodeByte(in.Bytes)
+		return int64(v / 1e9), true
+	case IdByte:
+		b, err := DecodeByte(in.Bytes)
 		if err != nil {
-			return zng.Value{}, false
+			return 0, false
 		}
-		i = int64(b)
-	case zng.IdInt16, zng.IdInt32, zng.IdInt64:
-		i, err = zng.DecodeInt(in.Bytes)
+		return int64(b), true
+	case IdInt16, IdInt32, IdInt64:
+		i, err := DecodeInt(in.Bytes)
 		if err != nil {
-			return zng.Value{}, false
+			return 0, false
 		}
-	case zng.IdUint16, zng.IdUint32, zng.IdUint64:
-		u, err := zng.DecodeUint(in.Bytes)
+		return i, true
+	case IdUint16, IdUint32, IdUint64:
+		u, err := DecodeUint(in.Bytes)
 		if err != nil {
-			return zng.Value{}, false
+			return 0, false
 		}
 		// Further checking on the desired type happens below but
 		// first make sure this fits in a signed int64 type.
 		if u > math.MaxInt64 {
-			return zng.Value{}, false
+			return 0, false
 		}
-		i = int64(u)
+		return int64(u), true
 	default:
 		// can't be cast to integer
-		return zng.Value{}, false
+		return 0, false
 	}
-
-	switch typ.ID() {
-	case zng.IdInt16:
-		if i < math.MinInt16 || i > math.MaxInt16 {
-			return zng.Value{}, false
-		}
-	case zng.IdInt32:
-		if i < math.MinInt32 || i > math.MaxInt32 {
-			return zng.Value{}, false
-		}
-	case zng.IdInt64:
-		// it already fits, no checking needed
-
-	default:
-		panic(fmt.Sprintf("Called CoerceToInt on non-integer type %s", typ))
-	}
-
-	return zng.Value{typ, zng.EncodeInt(i)}, true
 }
 
-func CoerceToUint(in zng.Value, typ zng.Type) (zng.Value, bool) {
-	var i uint64
-	var err error
-
+// CoerceToUint attempts to convert a value to an unsigned integer.
+// This always succeeds for unsigned integer types and succeeds for
+// signed integers so long as they are not negative.
+// A float64 may be coerced only if the value is equivalent.
+// Time and Intervals are converted as their nanosecond values.
+func CoerceToUint(in Value) (uint64, bool) {
 	switch in.Type.ID() {
-	case zng.IdFloat64:
-		var v float64
-		v, err = zng.DecodeFloat64(in.Bytes)
-		i = uint64(v)
+	case IdFloat64:
+		v, err := DecodeFloat64(in.Bytes)
+		if err != nil {
+			return 0, false
+		}
+		i := uint64(v)
 		if float64(i) != v {
-			return zng.Value{}, false
+			return 0, false
 		}
-	case zng.IdTime:
-		var v nano.Ts
-		v, err = zng.DecodeTime(in.Bytes)
-		i = uint64(v / 1e9)
-	case zng.IdDuration:
-		var v int64
-		v, err = zng.DecodeDuration(in.Bytes)
-		i = uint64(v / 1e9)
-	case zng.IdByte:
-		var b byte
-		b, err = zng.DecodeByte(in.Bytes)
+		return i, true
+	case IdTime:
+		v, err := DecodeTime(in.Bytes)
 		if err != nil {
-			return zng.Value{}, false
+			return 0, false
 		}
-		i = uint64(b)
-	case zng.IdInt16, zng.IdInt32, zng.IdInt64:
-		var si int64
-		si, err = zng.DecodeInt(in.Bytes)
+		return uint64(v / 1e9), true
+	case IdDuration:
+		v, err := DecodeDuration(in.Bytes)
 		if err != nil {
-			return zng.Value{}, false
+			return 0, false
 		}
-		// Further checking on the desired type happens below but
-		// first make sure the value isn't negative.
+		return uint64(v / 1e9), true
+	case IdByte:
+		b, err := DecodeByte(in.Bytes)
+		if err != nil {
+			return 0, false
+		}
+		return uint64(b), true
+	case IdInt16, IdInt32, IdInt64:
+		si, err := DecodeInt(in.Bytes)
+		if err != nil {
+			return 0, false
+		}
 		if si < 0 {
-			return zng.Value{}, false
+			return 0, false
 		}
-		i = uint64(si)
-	case zng.IdUint16, zng.IdUint32, zng.IdUint64:
-		i, err = zng.DecodeUint(in.Bytes)
+		return uint64(si), true
+	case IdUint16, IdUint32, IdUint64:
+		i, err := DecodeUint(in.Bytes)
 		if err != nil {
-			return zng.Value{}, false
+			return 0, false
 		}
+		return i, true
 	default:
-		// can't be cast to integer
-		return zng.Value{}, false
+		// can't be cast to unsigned integer
+		return 0, false
 	}
-
-	switch typ.ID() {
-	case zng.IdUint16:
-		if i > math.MaxUint16 {
-			return zng.Value{}, false
-		}
-	case zng.IdUint32:
-		if i > math.MaxUint32 {
-			return zng.Value{}, false
-		}
-	case zng.IdUint64:
-		// it already fits, no checking needed
-
-	default:
-		panic(fmt.Sprintf("Called CoerceToInt on non-integer type %s", typ))
-	}
-
-	return zng.Value{typ, zng.EncodeUint(i)}, true
 }
 
 // CoerceToDuration attempts to convert a value to a duration.  Int
@@ -322,48 +285,4 @@ func CoerceToString(in zng.Value) (string, bool) {
 	case zng.IdString, zng.IdBstring, zng.IdEnum:
 		return string(in.Bytes), true
 	}
-}
-
-// TBD
-// Coerce tries to convert this value to an equal value of a different
-// type.  For example, calling Coerce(TypeDouble) on a value that is
-// an int(100) will return a double(100.0).
-// XXX this doesn't seem valid:  If the coercion cannot be
-// performed such that v.Coerce(t1).Coerce(v.Type).String() == v.String(),
-// then nil is returned.
-func Coerce(v zng.Value, to zng.Type) (zng.Value, bool) {
-	if v.Type == to {
-		return v, true
-	}
-	switch to.ID() {
-	case zng.IdFloat64:
-		if d, ok := CoerceToFloat64(v); ok {
-			return zng.NewFloat64(d), true
-		}
-	case zng.IdInt16, zng.IdInt32, zng.IdInt64:
-		return CoerceToInt(v, to)
-	case zng.IdUint16, zng.IdUint32, zng.IdUint64:
-		return CoerceToUint(v, to)
-	case zng.IdDuration:
-		if i, ok := CoerceToDuration(v); ok {
-			return zng.NewDuration(i), true
-		}
-	case zng.IdPort:
-		if p, ok := CoerceToPort(v); ok {
-			return zng.NewPort(p), true
-		}
-	case zng.IdTime:
-		if i, ok := CoerceToTime(v); ok {
-			return zng.NewTime(i), true
-		}
-	case zng.IdString:
-		if s, ok := CoerceToString(v); ok {
-			return zng.NewString(s), true
-		}
-	case zng.IdBstring:
-		if s, ok := CoerceToString(v); ok {
-			return zng.NewBstring(s), true
-		}
-	}
-	return zng.Value{}, false
 }

--- a/zx/coerce_test.go
+++ b/zx/coerce_test.go
@@ -9,26 +9,26 @@ import (
 )
 
 func TestCoerceDuration(t *testing.T) {
-	interval := zng.NewDuration(60 * 1e9)
+	var interval int64 = 60_000_000_000
 	runcase(t, "Uint64", zng.NewUint64(60), interval)
 	runcase(t, "Float64", zng.NewFloat64(60), interval)
 	runcase(t, "Duration", zng.NewDuration(60*1e9), interval)
 
 	// can't coerce
-	notcase(t, "NotPort", zng.NewPort(60), zng.TypeDuration)
+	notcase(t, "NotPort", zng.NewPort(60))
 }
 
-func runcase(t *testing.T, name string, in zng.Value, expected zng.Value) {
+func runcase(t *testing.T, name string, in zng.Value, expected int64) {
 	t.Run(name, func(t *testing.T) {
-		val, ok := zx.Coerce(in, expected.Type)
-		require.Equal(t, true, ok)
-		require.Equal(t, expected, val)
+		val, ok := zx.CoerceToDuration(in)
+		require.True(t, ok, "coercion succeeded")
+		require.Equal(t, expected, val, "coerced value is correct")
 	})
 }
 
-func notcase(t *testing.T, name string, in zng.Value, typ zng.Type) {
+func notcase(t *testing.T, name string, in zng.Value) {
 	t.Run(name, func(t *testing.T) {
-		_, ok := zx.Coerce(in, typ)
-		require.Equal(t, false, ok)
+		_, ok := zx.CoerceToDuration(in)
+		require.False(t, ok, "coercion should have failed")
 	})
 }


### PR DESCRIPTION
This is a baby step toward unifying filters and expressions.  Move existing code out of zx/ into more appropriate directories and clean up the type coercion interface for integers.
