### PR TITLE
zapi: cli for interacting with zqd

### DIFF
--- a/cmd/zapi/cmd/api.go
+++ b/cmd/zapi/cmd/api.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/brimsec/zq/zqd/api"
+)
+
+// API wraps the client library and adds a few CLI-ish methods
+// such as checking if a space exists.
+type API struct {
+	*api.Connection
+}
+
+// newAPI creates a new client API object and parses the URL, returning
+// an error if the URL is not valid.  The object does not contact the server
+// until Connect is called.
+func newAPI(u string) (*API, error) {
+	url, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+	if url.Port() == "" {
+		url.Host += fmt.Sprintf(":%d", api.DefaultPort)
+	}
+	c := api.NewConnectionToURL("ZQD-CLI", url)
+	return &API{c}, nil
+}
+
+func (a API) Native() *api.Connection {
+	return a.Connection
+}
+
+func (a API) SpaceExists(name string) (bool, error) {
+	_, err := a.SpaceInfo(name)
+	if err == nil {
+		return true, nil
+	}
+	if err == api.ErrSpaceNotFound {
+		return false, nil
+	}
+	return false, err
+}

--- a/cmd/zapi/cmd/cli.go
+++ b/cmd/zapi/cmd/cli.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"syscall"
+
+	"github.com/brimsec/zq/pkg/catcher"
+	"github.com/brimsec/zq/pkg/repl"
+	"github.com/kballard/go-shellquote"
+	"github.com/mccanne/charm"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var Cli = &charm.Spec{
+	Name:          "zapi",
+	Usage:         "zapi [global options] command [options] [arguments...]",
+	Short:         "use zapi to talk to a zqd server",
+	RedactedFlags: "p",
+	HiddenFlags:   "nofancy",
+	Long:          "TODO",
+	New: func(parent charm.Command, flags *flag.FlagSet) (charm.Command, error) {
+		return New(flags)
+	},
+}
+
+func init() {
+	Cli.Add(charm.Help)
+}
+
+// version numbers set by main
+var Version string
+var ZqVersion string
+
+// set by get pacakge
+var Get *charm.Spec
+
+func New(f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{}
+	c.Version = Version
+	c.ZqVersion = ZqVersion
+
+	// if there's no state file or it became corrupted with an empty default,
+	// override the empty string
+	if c.Spacename == "" {
+		c.Spacename = "default"
+	}
+
+	// If not a terminal make nofancy on by default.
+	c.NoFancy = !terminal.IsTerminal(int(os.Stdout.Fd()))
+
+	defaultHost := "localhost:9867" //XXX
+	f.StringVar(&c.Host, "h", defaultHost, "<host[:port]>")
+	f.StringVar(&c.Spacename, "s", c.Spacename, "<space>")
+	f.BoolVar(&c.NoFancy, "nofancy", c.NoFancy, "turn off fancy formatting")
+
+	return c, nil
+}
+
+type Command struct {
+	api       *API
+	Done      bool
+	Version   string
+	ZqVersion string
+	Host      string
+	Spacename string
+	NoFancy   bool
+}
+
+// API returns the api object.  If it doesn't exist, it is allocated and
+// the server is contacted and authenticated.  If the user types in a new
+// password to auhenticate, then the password is saved in the credentials file.
+func (c *Command) API() (*API, error) {
+	if c.api == nil {
+		var err error
+		c.api, err = newAPI("http://" + c.Host)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c.api, nil
+}
+
+// Run is called by charm when there are no sub-commands on the main
+// zqd command line. We enter the REPL, which calls us back via the
+// REPL.Consumer interface.
+// XXX if there is no tty, we should allow something sensible like post data...
+// We could peak at the first line of the file and look for "#" (zeek) or "{" ndjson
+func (c *Command) Run(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unknown command: %s", args[0])
+	}
+	api, err := c.API()
+	if err != nil {
+		return fmt.Errorf("can't reach server: %s", err)
+	}
+	// we catch signals in the repl so we can cancel long running stuff
+	// and return to the REPL instead of returning to the shell
+	catch := catcher.NewSignalCatcher(syscall.SIGINT, syscall.SIGTERM)
+	api.SetCatcher(catch)
+	repl := repl.NewREPL(c)
+	err = repl.Run()
+	if err == io.EOF {
+		fmt.Println("")
+		err = nil
+	}
+	return err
+}
+
+func (c *Command) Consume(line string) bool {
+	args, err := shellquote.Split(line)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "parse error")
+		return c.Done
+	}
+	if len(args) == 0 {
+		return c.Done
+	}
+	switch args[0] {
+	case "quit", "exit", ".":
+		c.Done = true
+	default:
+		if err := Get.Exec(c, args); err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+		}
+	}
+	return c.Done
+}
+
+func (c *Command) Prompt() string {
+	return c.Spacename + "> "
+}
+
+func Errorf(spec string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, Cli.Name+": "+spec, args...)
+}

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -1,0 +1,243 @@
+package get
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zqd/api"
+	"github.com/brimsec/zq/zql"
+	"github.com/mccanne/charm"
+)
+
+var Get = &charm.Spec{
+	Name:  "get",
+	Usage: "get [options] <search>",
+	Short: "search data in zqd",
+	Long:  "TODO",
+	New:   New,
+}
+
+func init() {
+	cmd.Cli.Add(Get)
+	cmd.Get = Get
+}
+
+type Command struct {
+	*cmd.Command
+	format     string
+	protocol   string
+	dir        string
+	outputFile string
+	verbose    bool
+	reverse    bool
+	stats      bool
+	warnings   bool
+	nocache    bool
+	noindex    bool
+	wire       bool
+	zio.Flags
+	final *api.SearchStats
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*cmd.Command)}
+	f.StringVar(&c.format, "f", "text", "format for output data [bzng,ndjson,text,table,zeek,zng]")
+	f.StringVar(&c.protocol, "p", "bzng", "protocol to use for search request [json,bzng]")
+	f.StringVar(&c.dir, "d", "", "directory for output data files")
+	f.StringVar(&c.outputFile, "o", "", "write data to output file")
+	f.BoolVar(&c.verbose, "v", false, "show verbose details")
+	f.BoolVar(&c.reverse, "R", false, "reverse search order (from oldest to newest)")
+	f.BoolVar(&c.stats, "S", false, "display search stats on stderr")
+	f.BoolVar(&c.warnings, "W", false, "display warnings on stderr")
+	f.BoolVar(&c.ShowTypes, "T", false, "display field types in text output")
+	f.BoolVar(&c.ShowFields, "F", false, "display field names in text output")
+	f.BoolVar(&c.EpochDates, "E", false, "display epoch timestamps in text output")
+	f.BoolVar(&c.nocache, "C", false, "bypass the aggregations cache")
+	f.BoolVar(&c.noindex, "X", false, "search brute force without search index")
+	f.BoolVar(&c.wire, "w", false, "dump whats on the wire")
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	if !c.wire && c.protocol != "bzng" {
+		// XXX you can't get results right now with json unless you're
+		// looking at the wire since we previously removed the code that parses
+		// v2.Tuples into zbuf.Records.  Once we implement zjson, we'll
+		// have support for retrieving search results in json and we
+		// can get rid of this check.
+		return errors.New("json search results not yet supported unless -w is specified")
+	}
+	expr := "*"
+	if len(args) > 0 {
+		expr = strings.Join(args, " ")
+	}
+	api, err := c.API()
+	if err != nil {
+		return err
+	}
+	from, to, err := fromTo(api, c.Spacename)
+	if err != nil {
+		return fmt.Errorf("%s: no such space: %s", c.Spacename, err)
+	}
+	if from == 0 && to == 0 {
+		// this can happen for empty spaces
+		return fmt.Errorf("%s: space is empty", c.Spacename)
+	}
+	req, err := parseExpr(c.Spacename, expr, c.reverse)
+	if err != nil {
+		return fmt.Errorf("parse error: %s", err)
+	}
+	if ext := zio.Extension(c.format); ext == "" {
+		return fmt.Errorf("no such output format: %s", c.format)
+	}
+	writer, err := openOutput(c.dir, c.outputFile, c.format, &c.Flags)
+	if err != nil {
+		return err
+	}
+	stream, err := api.PostSearch(*req, c.protocol, nil)
+	if err != nil {
+		if err == context.Canceled {
+			err = errors.New("search interrupted")
+		} else {
+			err = fmt.Errorf("search error: %s", err)
+		}
+	} else {
+		if c.wire {
+			err = c.runWireSearch(writer, stream)
+		} else {
+			err = c.runSearch(writer, stream)
+		}
+	}
+	if e := writer.Close(); err == nil {
+		err = e
+	}
+	return err
+}
+
+// parseExpr creates an api.SearchRequest to be used with the client.
+func parseExpr(spaceName string, expr string, reverse bool) (*api.SearchRequest, error) {
+	search, err := zql.ParseProc(expr)
+	if err != nil {
+		return nil, err
+	}
+	proc, err := json.Marshal(search)
+	if err != nil {
+		return nil, err
+	}
+	return &api.SearchRequest{
+		Space: spaceName,
+		Proc:  proc,
+		Dir:   map[bool]int{true: 1, false: -1}[reverse],
+	}, nil
+}
+
+// XXX Net Yet
+// func printStats(stats *api.SearchStats) {
+// fmt.Fprintln(os.Stderr, format.StatsLine(*stats))
+// }
+
+func (c *Command) handleControl(ctrl interface{}) {
+	switch ctrl := ctrl.(type) {
+	case *api.SearchStats:
+		if c.stats {
+			if c.verbose {
+				// XXX Not yet
+				// printStats(ctrl)
+			} else {
+				c.final = ctrl
+			}
+		}
+	case *api.SearchWarnings:
+		if c.warnings {
+			for _, w := range ctrl.Warnings {
+				fmt.Fprintln(os.Stderr, w)
+			}
+		}
+	}
+}
+
+func (c *Command) runWireSearch(writer zbuf.WriteCloser, stream api.Search) error {
+	for {
+		batch, ctrl, err := stream.Pull()
+		switch {
+		case err != nil:
+			return err
+		case batch != nil:
+			// This isn't quite the wire format for bzng values
+			// and descriptors are stripped by the reader, but
+			// close enough.
+			for _, r := range batch.Records() {
+				fmt.Printf("%d:%s\n", r.Type.ID(), r.Raw.String())
+			}
+			batch.Unref()
+		case ctrl != nil:
+			b, err := json.MarshalIndent(ctrl, "", "    ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(b))
+		default:
+			return nil
+		}
+	}
+}
+
+func (c *Command) runSearch(writer zbuf.WriteCloser, stream api.Search) error {
+	for {
+		batch, ctrl, err := stream.Pull()
+		switch {
+		case err != nil:
+			return err
+		case batch != nil:
+			for _, r := range batch.Records() {
+				// XXX channel ID?
+				if err := writer.Write(r); err != nil {
+					return err
+				}
+			}
+			batch.Unref()
+		case ctrl != nil:
+			c.handleControl(ctrl)
+		default:
+			if c.final != nil {
+				// printStats(c.final)
+				c.final = nil
+			}
+			return nil
+		}
+	}
+}
+
+func fromTo(api *cmd.API, spacename string) (nano.Ts, nano.Ts, error) {
+	//XXX for now we run the search over the entire space
+	//XXX need to add time range control to the get command
+	info, err := api.SpaceInfo(spacename)
+	if err != nil {
+		return 0, 0, err
+	}
+	var min, max nano.Ts
+	if info.MinTime != nil {
+		min = *info.MinTime
+	}
+	if info.MaxTime != nil {
+		max = *info.MaxTime
+	}
+	return min, max, nil
+}
+
+func openOutput(dir, file, format string, flags *zio.Flags) (zbuf.WriteCloser, error) {
+	if dir != "" {
+		return emitter.NewDir(dir, file, format, os.Stderr, flags)
+	}
+	return emitter.NewFile(file, format, flags)
+}

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -42,8 +42,6 @@ type Command struct {
 	reverse    bool
 	stats      bool
 	warnings   bool
-	nocache    bool
-	noindex    bool
 	wire       bool
 	zio.Flags
 	final *api.SearchStats
@@ -62,9 +60,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	f.BoolVar(&c.ShowTypes, "T", false, "display field types in text output")
 	f.BoolVar(&c.ShowFields, "F", false, "display field names in text output")
 	f.BoolVar(&c.EpochDates, "E", false, "display epoch timestamps in text output")
-	f.BoolVar(&c.nocache, "C", false, "bypass the aggregations cache")
-	f.BoolVar(&c.noindex, "X", false, "search brute force without search index")
-	f.BoolVar(&c.wire, "w", false, "dump whats on the wire")
+	f.BoolVar(&c.wire, "w", false, "dump what's on the wire")
 	return c, nil
 }
 

--- a/cmd/zapi/cmd/glob.go
+++ b/cmd/zapi/cmd/glob.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/brimsec/zq/pkg/glob"
+)
+
+var ErrNoMatch = errors.New("no match")
+
+func SpaceGlob(api *API, patterns []string) ([]string, error) {
+	spaces, err := api.SpaceList()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't fetch spaces: %s", err)
+	}
+	if len(spaces) == 0 {
+		return nil, errors.New("no spaces exist")
+	}
+	var matches []string
+	if len(patterns) == 0 {
+		matches = spaces
+	} else {
+		matches, err = glob.Globv(patterns, spaces)
+		if err != nil {
+			return nil, err
+		}
+		if matches == nil || len(matches) == 0 {
+			return nil, ErrNoMatch
+		}
+	}
+	sort.Strings(matches)
+	return matches, nil
+}

--- a/cmd/zapi/cmd/info/info.go
+++ b/cmd/zapi/cmd/info/info.go
@@ -1,0 +1,91 @@
+package info
+
+import (
+	"flag"
+	"fmt"
+	"reflect"
+
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/cmd/zapi/format"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/mccanne/charm"
+)
+
+var Info = &charm.Spec{
+	Name:  "info",
+	Usage: "info [spacename]",
+	Short: "show information about a space",
+	Long: `The info command displays the configuration settings and other information
+about the currently selected space.`,
+	New: New,
+}
+
+func init() {
+	cmd.Cli.Add(Info)
+	cmd.Cli.Add(Ls)
+}
+
+type Command struct {
+	*cmd.Command
+}
+
+func New(parent charm.Command, flags *flag.FlagSet) (charm.Command, error) {
+	return &Command{Command: parent.(*cmd.Command)}, nil
+}
+
+// Run lists all spaces in the current zqd host or if a parameter
+// is provided (in glob style) lists the info about that space.
+func (c *Command) Run(args []string) error {
+	api, err := c.API()
+	if err != nil {
+		return err
+	}
+	if len(args) == 0 {
+		return printInfo(api, c.Spacename)
+	} else {
+		matches, err := cmd.SpaceGlob(api, args)
+		if err != nil {
+			return err
+		}
+		return printInfoList(api, matches)
+	}
+}
+
+func printInfoList(api *cmd.API, names []string) error {
+	for _, name := range names {
+		if err := printInfo(api, name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printInfo(api *cmd.API, name string) error {
+	info, err := api.SpaceInfo(name)
+	if err != nil {
+		return err
+	}
+	fmt.Println(info.Name)
+	infoVal := reflect.ValueOf(info).Elem()
+	for i := 0; i < infoVal.NumField(); i++ {
+		v := infoVal.Field(i)
+		t := infoVal.Type().Field(i)
+		name := cmd.JsonName(t)
+		if v.Kind() == reflect.Ptr && v.IsNil() {
+			fmt.Printf("  %s:\t%v\n", name, nil)
+			continue
+		}
+		v = reflect.Indirect(v)
+		vi := v.Interface()
+		switch t.Tag.Get("unit") {
+		case "bytes":
+			vi = format.Bytes(v.Int())
+		case "":
+			if v.Type() == reflect.TypeOf(nano.Ts(0)) {
+				vi = nano.Ts(v.Int()).Time()
+			}
+		}
+		fmt.Printf("  %s:\t%v\n", name, vi)
+	}
+	return nil
+}

--- a/cmd/zapi/cmd/info/ls.go
+++ b/cmd/zapi/cmd/info/ls.go
@@ -1,0 +1,76 @@
+package info
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/pkg/colw"
+	"github.com/mccanne/charm"
+	"github.com/mccanne/charm/pkg/termwidth"
+)
+
+var Ls = &charm.Spec{
+	Name:  "ls",
+	Usage: "ls [-l] [glob1 glob2 ...]",
+	Short: "list spaces or information about a space",
+	Long: `The ls command lists the names and information about spaces known to the system.
+When run with arguments, only the spaces that match the glob-style parameters are shown
+much like the traditional unix ls command.  When used with "-l", each space specified
+is listed with its detailed information as in the info command.`,
+	New: NewLs,
+}
+
+type LsCommand struct {
+	*cmd.Command
+	lflag bool
+}
+
+func NewLs(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &LsCommand{Command: parent.(*cmd.Command)}
+	f.BoolVar(&c.lflag, "l", false, "show detail information about each space listed")
+	return c, nil
+}
+
+func fmtSelected(spaces []string, selected string) {
+	for i, space := range spaces {
+		if selected == space {
+			spaces[i] = space + " \033[0;32m<-\033[0m" // make the selector green!
+		}
+	}
+}
+
+// Run lists all spaces in the current zqd host or if a parameter
+// is provided (in glob style) lists the info about that space.
+func (c *LsCommand) Run(args []string) error {
+	api, err := c.API()
+	if err != nil {
+		return err
+	}
+	matches, err := cmd.SpaceGlob(api, args)
+	if err != nil {
+		return err
+	}
+	if matches == nil || len(matches) == 0 {
+		return cmd.ErrNoMatch
+	}
+	if c.lflag {
+		// print details about each space
+		return printInfoList(api, matches)
+	} else {
+		// print listing laid out in columns like ls
+		width := termwidth.Width()
+		if !c.NoFancy {
+			fmtSelected(matches, c.Spacename)
+		}
+		err := colw.Write(os.Stdout, matches, width, 3)
+		if err == colw.ErrDoesNotFit {
+			fmt.Println(strings.Join(matches, "\n"))
+		} else if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/zapi/cmd/new/new.go
+++ b/cmd/zapi/cmd/new/new.go
@@ -1,0 +1,49 @@
+package new
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/mccanne/charm"
+)
+
+var New = &charm.Spec{
+	Name:  "new",
+	Usage: "new [spacename]",
+	Short: "create a new space",
+	Long: `The new command takes a single argument and creates a new, empty space
+named as specified.`,
+	New: func(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+		return &Command{Command: parent.(*cmd.Command)}, nil
+	},
+}
+
+func init() {
+	cmd.Cli.Add(New)
+}
+
+type Command struct {
+	*cmd.Command
+}
+
+func (c *Command) Run(args []string) error {
+	if len(args) > 1 {
+		return errors.New("too many arguments")
+	}
+	if len(args) != 1 {
+		return errors.New("must specify a space name")
+	}
+	api, err := c.API()
+	if err != nil {
+		return err
+	}
+	name := args[0]
+	_, err = api.SpacePost(name)
+	if err != nil {
+		return fmt.Errorf("couldn't create new space %s: %v", name, err)
+	}
+	fmt.Printf("%s: space created\n", name)
+	return nil
+}

--- a/cmd/zapi/cmd/pcap/post.go
+++ b/cmd/zapi/cmd/pcap/post.go
@@ -1,0 +1,104 @@
+package pcap
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"time"
+
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/cmd/zapi/format"
+	"github.com/brimsec/zq/pkg/display"
+	"github.com/brimsec/zq/zqd/api"
+	"github.com/mccanne/charm"
+)
+
+var PcapPost = &charm.Spec{
+	Name:  "pcappost",
+	Usage: "pcappost [options] path",
+	Short: "show information about a space",
+	Long: `The info command displays the configuration settings and other information
+about the currently selected space.`,
+	New: New,
+}
+
+func init() {
+	cmd.Cli.Add(PcapPost)
+}
+
+type Command struct {
+	*cmd.Command
+	force      bool
+	bytesRead  int64
+	bytesTotal int64
+	done       bool
+}
+
+func New(parent charm.Command, flags *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*cmd.Command)}
+	flags.BoolVar(&c.force, "f", false, "create space if specified space does not exist")
+	return c, nil
+}
+
+// Run lists all spaces in the current zqd host or if a parameter
+// is provided (in glob style) lists the info about that space.
+func (c *Command) Run(args []string) error {
+	client, err := c.API()
+	if err != nil {
+		return err
+	}
+	if len(args) == 0 {
+		return errors.New("pcap path arg required")
+	}
+	if c.force {
+		_, err := client.SpacePost(c.Spacename)
+		if err != nil && err != api.ErrSpaceExists {
+			return err
+		}
+	}
+	var dp *display.Display
+	if !c.NoFancy {
+		dp = display.New(c, time.Second)
+		go dp.Run()
+		defer dp.Close()
+	}
+
+	file := args[0]
+	stream, err := client.PostPacket(c.Spacename, api.PacketPostRequest{Path: file})
+	if err != nil {
+		return err
+	}
+	for {
+		res, err := stream.Next()
+		if err != nil {
+			return err
+		}
+		if res == nil {
+			return nil
+		}
+		switch typ := res.(type) {
+		case *api.TaskEnd:
+			if typ.Error == nil {
+				return nil
+			}
+			return typ.Error
+		case *api.PacketPostStatus:
+			atomic.StoreInt64(&c.bytesRead, typ.PacketReadSize)
+			atomic.StoreInt64(&c.bytesTotal, typ.PacketSize)
+		}
+	}
+}
+
+func (c *Command) Display(w io.Writer) bool {
+	total := atomic.LoadInt64(&c.bytesTotal)
+	if total == 0 {
+		io.WriteString(w, "posting...\n")
+		return true
+	}
+	read := atomic.LoadInt64(&c.bytesRead)
+	percent := float64(read) / float64(total) * 100
+	fmt.Fprintf(w, "%5.1f%% %s/%s\n", percent, format.Bytes(read), format.Bytes(total))
+	return true
+}

--- a/cmd/zapi/cmd/reflect.go
+++ b/cmd/zapi/cmd/reflect.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"reflect"
+	"strings"
+)
+
+// FieldByJSONName returns the struct field with the given JSON name and a
+// boolean indicating whether the field was found.
+func FieldByJSONName(v reflect.Value, name string) (reflect.Value, bool) {
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		if JsonName(t.Field(i)) == name {
+			return v.Field(i), true
+		}
+	}
+	return reflect.Value{}, false
+}
+
+// JsonName returns the JSON name of the field.  It returns the empty string if
+// the field is always omitted (i.e., it has a json:"-" tag).
+func JsonName(s reflect.StructField) string {
+	tag := s.Tag.Get("json")
+	if tag == "-" {
+		return ""
+	}
+	if n := strings.Split(tag, ",")[0]; n != "" {
+		return n
+	}
+	return s.Name
+}

--- a/cmd/zapi/format/format.go
+++ b/cmd/zapi/format/format.go
@@ -1,0 +1,105 @@
+package format
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+)
+
+const (
+	Checkbox = "\u2713"
+	Warning  = "\u26a0"
+
+	KB = 1000
+	MB = 1000 * KB
+	GB = 1000 * MB
+	TB = 1000 * GB
+
+	NS  = 1
+	US  = 1000 * NS
+	MS  = 1000 * US
+	SEC = 1000 * MS
+	MIN = 60 * SEC
+	HR  = 60 * MIN
+	DAY = 24 * HR
+)
+
+func prec(m float64) int {
+	switch {
+	case m >= 1000:
+		return 0
+	case m >= 100:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func abbrev(size int64) (string, string) {
+	switch {
+	case size < KB:
+		return strconv.FormatInt(size, 10), "bytes"
+	case size < MB:
+		v := float64(size) / KB
+		return strconv.FormatFloat(v, 'f', prec(v), 64), "KB"
+	case size < GB:
+		v := float64(size) / MB
+		return strconv.FormatFloat(v, 'f', prec(v), 64), "MB"
+	case size < TB:
+		v := float64(size) / GB
+		return strconv.FormatFloat(v, 'f', prec(v), 64), "GB"
+	default:
+		v := float64(size) / TB
+		return strconv.FormatFloat(v, 'f', prec(v), 64), "TB"
+	}
+}
+
+func Bytes(size int64) string {
+	val, suffix := abbrev(size)
+	if suffix == "bytes" {
+		suffix = ""
+	}
+	return val + suffix
+}
+
+func Rate(size int64) string {
+	val, suffix := abbrev(size)
+	return fmt.Sprintf("%s %s/s", val, suffix)
+}
+
+func dur(ns int64) (string, string) {
+	switch {
+	case ns < US:
+		return strconv.FormatInt(ns, 10), "ns"
+	case ns < MS:
+		v := float64(ns) / US
+		return strconv.FormatFloat(v, 'f', prec(v), 64), "us"
+	case ns < SEC:
+		v := float64(ns) / MS
+		return strconv.FormatFloat(v, 'f', prec(v), 64), "ms"
+	case ns < MIN:
+		v := float64(ns) / SEC
+		return strconv.FormatFloat(v, 'f', prec(v), 64), "s"
+	case ns < HR:
+		v := float64(ns) / MIN
+		return strconv.FormatFloat(v, 'f', prec(v), 64), "min"
+	case ns < DAY:
+		v := float64(ns) / HR
+		return strconv.FormatFloat(v, 'f', prec(v), 64), "hr"
+	default:
+		v := float64(ns) / DAY
+		return strconv.FormatFloat(v, 'f', prec(v), 64), "days"
+	}
+}
+
+func Duration(ns int64) string {
+	val, suffix := dur(ns)
+	return val + suffix
+}
+
+func Percent(p float64) string {
+	if p < 1 {
+		return fmt.Sprintf("%.2f%%", p)
+	}
+	return fmt.Sprintf("%d%%", int(math.Round(p)))
+}

--- a/cmd/zapi/main.go
+++ b/cmd/zapi/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	_ "github.com/brimsec/zq/cmd/zapi/cmd/get"
+	_ "github.com/brimsec/zq/cmd/zapi/cmd/info"
+	_ "github.com/brimsec/zq/cmd/zapi/cmd/new"
+	_ "github.com/brimsec/zq/cmd/zapi/cmd/pcap"
+)
+
+// These variables are populated via the Go linker.
+var (
+	version   = "unknown"
+	zqVersion = "unknown"
+)
+
+func main() {
+	cmd.Version = version
+	cmd.ZqVersion = zqVersion
+	_, err := cmd.Cli.ExecRoot(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e
 	github.com/google/gopacket v1.1.17
 	github.com/gorilla/mux v1.7.4
+	github.com/gosuri/uilive v0.0.4
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mccanne/charm v0.0.3-0.20191224190439-b05e1b7b1be3
 	github.com/mccanne/joe v0.0.0-20181124064909-25770742c256
 	github.com/peterh/liner v1.1.0
@@ -14,6 +16,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/yuin/goldmark v1.1.22
 	go.uber.org/zap v1.12.0
+	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529
 	golang.org/x/text v0.3.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/gosuri/uilive v0.0.4
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mccanne/charm v0.0.3-0.20191224190439-b05e1b7b1be3
 	github.com/mccanne/joe v0.0.0-20181124064909-25770742c256
 	github.com/peterh/liner v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,11 @@ github.com/google/gopacket v1.1.17/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8v
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gosuri/uilive v0.0.4 h1:hUEBpQDj8D8jXgtCdBu7sWsy5sbW/5GhuO8KBwJ2jyY=
+github.com/gosuri/uilive v0.0.4/go.mod h1:V/epo5LjjlDE5RJUcqx8dbw+zc93y5Ya3yg8tfZ74VI=
 github.com/influxdata/influxdb v1.7.6/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mccanne/charm v0.0.3-0.20191224190439-b05e1b7b1be3 h1:Sj9zugMeJDXrKpOZgiQXhm0Z87vPF2QfUMWE41lwcRQ=
@@ -71,6 +73,8 @@ golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/pkg/catcher/catcher.go
+++ b/pkg/catcher/catcher.go
@@ -1,0 +1,49 @@
+// package catcher is a convient wrapper to interconnect signals with
+// contexts, etc
+package catcher
+
+import (
+	"context"
+	"os"
+	"os/signal"
+)
+
+type Catcher interface {
+	Catch(ctx context.Context) (context.Context, context.CancelFunc)
+}
+
+type SignalCatcher struct {
+	sigs []os.Signal
+}
+
+func NewSignalCatcher(sigs ...os.Signal) *SignalCatcher {
+	return &SignalCatcher{sigs: sigs}
+}
+
+func (s *SignalCatcher) Catch(ctx context.Context) (context.Context, context.CancelFunc) {
+	//XXX this could be made more efficient by having the signal handler
+	// be a parent of each context created and keeping just one signal
+	// channel around.  then when we get the signal, we cancel the parent
+	// context and all the children get canceled.
+	// but for now, this is ok
+	signals := make(chan os.Signal, 1)
+	for _, sig := range s.sigs {
+		signal.Notify(signals, sig)
+	}
+	childctx, cancel := context.WithCancel(ctx)
+	go func() {
+		// The for loop waits until we get a signal or a done.
+		// When we're done, we return and this goroutine exits.
+		// When we get a signal, we call cancel and continue the
+		// loop and wait for the done to finally make us leave.
+		for {
+			select {
+			case <-signals:
+				cancel()
+			case <-childctx.Done():
+				return
+			}
+		}
+	}()
+	return childctx, cancel
+}

--- a/pkg/colw/colw.go
+++ b/pkg/colw/colw.go
@@ -1,0 +1,106 @@
+// Package colw lays out columns for display of a list when you don't know
+// ahead of time how many columns should exist.  Kind of like what ls does.
+package colw
+
+import (
+	"errors"
+	"io"
+)
+
+// ErrDoesNotFit is returned when the items do not fit in the supplied width.
+// The only way this happens is if there is at least one item larger than the
+// width less padding.  Otherwise, you would get one column taking up all the width.
+var ErrDoesNotFit = errors.New("items do not fit")
+
+func slen(in []string, pad int) []int {
+	out := make([]int, 0, len(in))
+	for _, s := range in {
+		out = append(out, len(s)+pad)
+	}
+	return out
+}
+
+func build(lens []int, ncol int) []int {
+	widths := make([]int, ncol)
+	for k, v := range lens {
+		colno := k % ncol
+		if v > widths[colno] {
+			widths[colno] = v
+		}
+	}
+	return widths
+}
+
+func fit(trial []int, budget int) bool {
+	var n int
+	for _, v := range trial {
+		n += v
+	}
+	return n <= budget
+}
+
+// Layout takes a list of strings, a pad for each column, and a total
+// width of each row and computes the layout with the largest number of
+// columns that will fit in the given row width if the strings are displayed
+// in left to right order a row a time.
+func Layout(in []string, width, pad int) (widths []int) {
+	lens := slen(in, pad)
+	var result []int
+	for ncol := 1; ncol < width; ncol++ {
+		next := build(lens, ncol)
+		if !fit(next, width) {
+			return result
+		}
+		result = next
+	}
+	return nil
+}
+
+func makePadding(n int, padchar byte) []byte {
+	b := make([]byte, n)
+	for k := 0; k < n; k++ {
+		b[k] = padchar
+	}
+	return b
+}
+
+var newline = []byte{'\n'}
+
+// Write writes the list of strings to the given writer with padding and
+// newlines according to Layout
+func Write(w io.Writer, in []string, width, pad int) error {
+	widths := Layout(in, width, pad)
+	if widths == nil {
+		return ErrDoesNotFit
+	}
+	ncol := len(widths)
+	padding := makePadding(width, ' ')
+	for k, s := range in {
+		_, err := w.Write([]byte(s))
+		if err != nil {
+			return err
+		}
+		if k == len(in)-1 {
+			_, err := w.Write(newline)
+			return err
+		}
+		colno := k % ncol
+		if colno == ncol-1 {
+			_, err := w.Write(newline)
+			if err != nil {
+				return err
+			}
+		} else {
+			width := widths[colno]
+			pad := width - len(s)
+			if pad > 0 {
+				_, err := w.Write(padding[0:pad])
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -1,0 +1,68 @@
+package display
+
+import (
+	"bytes"
+	"io"
+	"time"
+
+	//XXX need to review uilive
+	"github.com/gosuri/uilive"
+)
+
+type Displayer interface {
+	Display(io.Writer) bool
+}
+
+type Display struct {
+	live     *uilive.Writer
+	interval time.Duration
+	updater  Displayer
+	buffer   *bytes.Buffer
+	close    chan struct{}
+}
+
+func New(updater Displayer, interval time.Duration) *Display {
+	d := &Display{
+		live:     uilive.New(),
+		interval: interval,
+		updater:  updater,
+		buffer:   &bytes.Buffer{},
+		close:    make(chan struct{}),
+	}
+	return d
+}
+
+func (d *Display) update() bool {
+	d.buffer.Reset()
+	cont := d.updater.Display(d.buffer)
+	// Ignore any errors.
+	_, _ = io.Copy(d.live, d.buffer)
+	_ = d.live.Flush()
+	return cont
+}
+
+func (d *Display) Run() {
+	for {
+		if !d.update() {
+			close(d.close)
+		}
+		select {
+		case <-d.close:
+			return
+		case <-time.After(d.interval):
+		}
+	}
+}
+
+func (d *Display) Close() {
+	close(d.close)
+	d.update()
+}
+
+func (d *Display) Wait() {
+	<-d.close
+}
+
+func (d *Display) Done() chan struct{} {
+	return d.close
+}

--- a/pkg/glob/glob.go
+++ b/pkg/glob/glob.go
@@ -1,0 +1,47 @@
+// Package glob implements glob-style pattern matching
+package glob
+
+import (
+	"regexp"
+
+	"github.com/brimsec/zq/reglob"
+)
+
+func Glob(matches []string, pattern string, candidates []string) ([]string, error) {
+	// transform a glob-style pattern into a regular expression
+	pattern = reglob.Reglob(pattern)
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	for _, candidate := range candidates {
+		if re.MatchString(candidate) {
+			matches = append(matches, candidate)
+		}
+	}
+	return matches, nil
+}
+
+func uniq(v []string) []string {
+	m := make(map[string]interface{})
+	for _, s := range v {
+		m[s] = nil
+	}
+	out := make([]string, 0, len(m))
+	for key := range m {
+		out = append(out, key)
+	}
+	return out
+}
+
+func Globv(patterns, candidates []string) ([]string, error) {
+	var matches []string
+	for _, pattern := range patterns {
+		var err error
+		matches, err = Glob(matches, pattern, candidates)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return uniq(matches), nil
+}

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -1,0 +1,71 @@
+// Package repl is a simple read-eval-print loop.  It calls the Consumer
+// to do all the eval work.
+package repl
+
+import (
+	"io"
+
+	"github.com/peterh/liner"
+)
+
+type Consumer interface {
+	Consume(line string) bool
+	Prompt() string
+}
+
+type REPL struct {
+	consumer Consumer
+}
+
+func NewREPL(c Consumer) *REPL {
+	return &REPL{consumer: c}
+}
+
+// Run executes the REPL.
+func (r *REPL) Run() error {
+	l := liner.NewLiner()
+	defer l.Close() //nolint:errcheck
+	l.SetMultiLineMode(true)
+	for {
+		line, e := l.Prompt(r.consumer.Prompt())
+		if e == io.EOF {
+			return io.EOF
+		} else if e != nil {
+			// Ignore this error; the prior is more interesting.
+			return e
+		}
+		done := r.consumer.Consume(line)
+		if done {
+			return nil
+		}
+		l.AppendHistory(line)
+	}
+}
+
+func Ask(prompt string) (string, error) {
+	l := liner.NewLiner()
+	defer l.Close() //nolint:errcheck
+	answer, err := l.Prompt(prompt)
+	if err != nil {
+		return "", err
+	}
+	return answer, nil
+}
+
+func AskForPassword() (string, error) {
+	l := liner.NewLiner()
+	defer l.Close() //nolint:errcheck
+	return l.PasswordPrompt("Password:")
+}
+
+func AskForUserPass() (string, string, error) {
+	user, err := Ask("User: ")
+	if err != nil {
+		return "", "", err
+	}
+	password, err := AskForPassword()
+	if err != nil {
+		return "", "", err
+	}
+	return user, password, nil
+}

--- a/zqd/api/bzng.go
+++ b/zqd/api/bzng.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/bzngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type BzngSearch struct {
+	reader *bzngio.Reader
+	cancel context.CancelFunc
+	ctrl   interface{}
+	err    error
+}
+
+func NewBzngSearch(body io.Reader, cancel context.CancelFunc) *BzngSearch {
+	if cancel == nil {
+		cancel = func() {}
+	}
+	return &BzngSearch{
+		reader: bzngio.NewReader(body, resolver.NewContext()),
+		cancel: cancel,
+	}
+}
+
+//XXX
+const mtu = 100
+
+func (r *BzngSearch) Pull() (zbuf.Batch, interface{}, error) {
+	v := r.ctrl
+	if v != nil {
+		r.ctrl = nil
+		return nil, v, nil
+	}
+	minTs, maxTs := nano.MaxTs, nano.MinTs
+	var out []*zng.Record
+	for len(out) < mtu {
+		rec, b, err := r.reader.ReadPayload()
+		if err != nil {
+			r.cancel()
+			return nil, nil, err
+		}
+		if rec == nil && b == nil {
+			break
+		}
+		if b != nil {
+			if !bytes.HasPrefix(b, []byte("json:")) {
+				// We expect only json control payloads.
+				// XXX should log error if something else,
+				// but just skip for now.
+				continue
+			}
+			ctrl, err := unpack(b[5:])
+			if err != nil {
+				r.cancel()
+				return nil, nil, err
+			}
+			if end, ok := v.(*TaskEnd); ok {
+				// We remember the error to return at end of connection.
+				// We return nil error for the TaskEnd message
+				// even if it contains an error, then we return
+				// that error at end of connection.
+				r.err = end.Error
+			}
+			if len(out) > 0 {
+				// Save this control message for the next Read
+				// and return the current batch.
+				r.ctrl = ctrl
+				break
+			}
+			return nil, ctrl, nil
+		}
+		if rec.Ts < minTs {
+			minTs = rec.Ts
+		}
+		if rec.Ts > maxTs {
+			maxTs = rec.Ts
+		}
+		rec = rec.Keep()
+		out = append(out, rec)
+	}
+	if len(out) > 0 {
+		return zbuf.NewArray(out, nano.NewSpanTs(minTs, maxTs)), nil, nil
+	}
+	r.cancel()
+	return nil, nil, r.err
+}

--- a/zqd/api/connection.go
+++ b/zqd/api/connection.go
@@ -1,0 +1,389 @@
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"path"
+	"strconv"
+	"strings"
+
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"time"
+
+	"github.com/brimsec/zq/pkg/catcher"
+)
+
+const (
+	// DefaultPort zqd port to connect with.
+	DefaultPort = 9867
+)
+
+var (
+	// ErrSpaceNotFound returns when specified space does not exist.
+	ErrSpaceNotFound = errors.New("space not found")
+	// ErrSpaceExists returns when specified the space already exists.
+	ErrSpaceExists = errors.New("space exists")
+)
+
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type Connection struct {
+	httpClient
+	url       *url.URL
+	useragent string
+	transport *http.Transport
+	catcher   catcher.Catcher
+}
+
+func newConnection(useragent string, client httpClient) *Connection {
+	return &Connection{
+		httpClient: client,
+		useragent:  useragent,
+	}
+}
+
+// NewConnection creates a new connection with the given useragent string
+// and a base URL set up to talk to http://localhost:defaultport
+func NewConnection(useragent string) *Connection {
+	u, _ := url.Parse("http://localhost:" + strconv.Itoa(DefaultPort))
+	return NewConnectionToURL(useragent, u)
+}
+
+// NewConnectionTo creates a new connection with the given useragent string
+// and a base URL derived from the hostURL argument.
+func NewConnectionTo(useragent string, hostURL string) (*Connection, error) {
+	url, err := url.Parse(hostURL)
+	if err != nil {
+		return nil, err
+	}
+	return NewConnectionToURL(useragent, url), nil
+}
+
+// NewConnectionToURL creates a new connection object with the given useragent string
+// and a base URL specified by the url argument.
+func NewConnectionToURL(useragent string, url *url.URL) *Connection {
+	c := newConnection(useragent, &http.Client{})
+	c.url = url
+	return c
+}
+
+type testHttpClient struct {
+	handler http.Handler
+}
+
+func (t testHttpClient) Do(req *http.Request) (*http.Response, error) {
+	w := httptest.NewRecorder()
+	t.handler.ServeHTTP(w, req)
+	return w.Result(), nil
+}
+
+func NewTestConnection(useragent string, h http.Handler) *Connection {
+	c := newConnection(useragent, testHttpClient{h})
+	c.url, _ = url.Parse("http://localhost:" + strconv.Itoa(DefaultPort))
+	return c
+}
+
+// SetTimeout sets the underlying http request timeout to the given duration
+func (c *Connection) SetTimeout(to time.Duration) {
+	if client, ok := c.httpClient.(*http.Client); ok {
+		client.Timeout = to
+	}
+}
+
+func (c *Connection) URL() *url.URL {
+	return c.url
+}
+
+func (c *Connection) SetURL(u *url.URL) {
+	c.url = u
+}
+
+func (c *Connection) SetCatcher(p catcher.Catcher) {
+	c.catcher = p
+}
+
+func (c *Connection) SetTLS(proxy func(req *http.Request) (*url.URL, error), skipVerify bool) {
+	c.transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: skipVerify,
+		},
+		Proxy: proxy,
+	}
+	c.url.Scheme = "https" //XXX
+}
+
+// bodyToReader takes the body argument and figures out if it's already
+// a reader, and if not, tries to encode it as json into a bytes buffer
+// and returns the result as a reader.
+func bodyToReader(body interface{}) (io.Reader, error) {
+	if body == nil {
+		return nil, nil
+	}
+	reader, ok := body.(io.Reader)
+	if ok {
+		return reader, nil
+	}
+	// encode the body data structure into json as a bytes.Buffer so
+	// it can be turned around and read by the http request
+	buf := &bytes.Buffer{}
+	if err := json.NewEncoder(buf).Encode(body); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// Request constructs and returns a http.Request using the zqd connection info
+// provided to the client.
+func (c *Connection) Request(method, path string, hdr http.Header, body interface{}) (*http.Request, error) {
+	u, err := c.url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader, err := bodyToReader(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(method, u.String(), bodyReader)
+	if err != nil {
+		return nil, err
+	}
+	if hdr != nil {
+		req.Header = hdr
+	}
+	if c.useragent != "" {
+		req.Header.Set("User-Agent", c.useragent)
+	}
+	return req, nil
+}
+
+// _call transmits a request to the server and waits for a response and
+// returns the http.Response.  The request is constructed from method, path, body.
+// The body can be an io.Reader for the big stuff.  Body can also be an arbitrary
+// gc protocol object type-aligned to the expected parameter.
+func (c *Connection) _call(ctx context.Context, method, path string, hdr http.Header, body interface{}) (*http.Response, context.CancelFunc, error) {
+	req, err := c.Request(method, path, hdr, body)
+	if err != nil {
+		return nil, nil, err
+	}
+	var cancel context.CancelFunc
+	if c.catcher != nil {
+		ctx, cancel = c.catcher.Catch(ctx)
+	}
+	req = req.WithContext(ctx)
+	resp, err := c.Do(req)
+	if err != nil {
+		if cancel != nil {
+			cancel()
+		}
+		return resp, nil, err
+	}
+	err = responseError(resp)
+	if err != nil {
+		if cancel != nil {
+			cancel()
+		}
+		return resp, nil, err
+	}
+	return resp, cancel, nil
+}
+
+// call transmits a request to the server and waits for a response and
+// returns the response in the provided result object represented here
+// as an empty interface.  The request is constructed from method, path, body.
+// If a result is expected, then the result value is filled in.  Otherwise,
+// result should be nil.
+func (c *Connection) call(method, path string, hdr http.Header, body, result interface{}) (status int, err error) {
+	resp, cancel, err := c._call(context.Background(), method, path, hdr, body)
+	if cancel != nil {
+		cancel()
+	}
+	if resp != nil {
+		status = resp.StatusCode
+	}
+	if err != nil {
+		return status, err
+	}
+	if result == nil {
+		return status, nil
+	}
+	err = json.NewDecoder(resp.Body).Decode(result)
+	err2 := resp.Body.Close()
+	if err != nil {
+		return status, err
+	}
+	return status, err2
+}
+
+// stream transmits a request to the server and returns a bufio.Scanner that
+// parses double-newline chunks of data and returns them as byte slices.
+// It's up to the caller to wrap a decoder around this scanner.
+func (c *Connection) stream(ctx context.Context, method, path string, hdr http.Header, body interface{}) (*bufio.Scanner, context.CancelFunc, error) {
+	resp, cancel, err := c._call(ctx, method, path, hdr, body)
+	if err != nil {
+		// cancel is nil
+		return nil, nil, err
+	}
+	return NewJSONPipeScanner(resp.Body), cancel, nil
+}
+
+func responseError(resp *http.Response) error {
+	if resp.StatusCode < 400 {
+		return nil
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	var apierr Error
+	if strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json") {
+		err := json.Unmarshal(body, &apierr)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		apierr.Type = "Error"
+		apierr.Message = string(body)
+	}
+	return &apierr
+}
+
+// Ping checks to see if the server and measure the time it takes to
+// get back the response.
+func (c *Connection) Ping() (time.Duration, error) {
+	now := time.Now()
+	if _, err := c.call("GET", "/status", nil, nil, nil); err != nil {
+		return 0, err
+	}
+	return time.Since(now), nil
+}
+
+// SpaceInfo retrieves information about the specified space.
+func (c *Connection) SpaceInfo(spaceID string) (*SpaceInfo, error) {
+	path := path.Join("/space", spaceID)
+	var res SpaceInfo
+	if status, err := c.call("GET", path, nil, nil, &res); err != nil {
+		if status == http.StatusNotFound {
+			return nil, ErrSpaceNotFound
+		}
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (c *Connection) SpacePost(spaceName string) (*SpaceInfo, error) {
+	body := &SpacePostRequest{Name: spaceName}
+	var res SpaceInfo
+	if status, err := c.call("POST", "/space", nil, body, &res); err != nil {
+		if status == http.StatusConflict {
+			return nil, ErrSpaceExists
+		}
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (c *Connection) SpaceList() ([]string, error) {
+	var res []string
+	_, err := c.call("GET", "/space", nil, nil, &res)
+	return res, err
+}
+
+// Not Yet
+// func (c *Connection) SpaceDelete(spaceName string) (err error) {
+// path := "/space/" + spaceName
+// _, err = c.call("DELETE", path, nil, nil, nil)
+// return err
+// }
+
+/* not yet
+
+// Packets xxx
+func (c *Connection) Packets(spaceName string, s *gc.PacketSearch) ([]byte, error) {
+	path := "/space/" + spaceName + "/packet"
+	t.Method = "GET"
+	// XXX need to add s.ToQuery() to path XXX
+	//t.Query = s.ToQuery() XXX
+
+	if err := t.send(); err != nil {
+		return nil, err
+	}
+	//XXX this should stream a pcap not read the whole thing and send it
+	return t.recv()
+}
+
+// SearchSync xxx.
+func (c *Connection) SearchSync(s gc.SearchRequest) ([]*tuple.Tuple, error) {
+	return c.newTask().SearchSync(s)
+}
+*/
+
+// Close releases the connection's resources.
+func (c *Connection) Close() error {
+	// notyet c.transport.CloseIdleConnections()
+	return nil
+}
+
+func gzHeader() http.Header {
+	hdr := make(http.Header)
+	hdr.Set("Accept-Encoding", "identity")
+	hdr.Set("Content-Encoding", "gzip")
+	return hdr
+}
+
+// PostSearch sends a search task to the server and returns a Search interface
+// that the caller uses to stream back results via the Pull method.
+func (c *Connection) PostSearch(req SearchRequest, format string, params url.Values) (Search, error) {
+	return c.PostSearchWithContext(context.Background(), req, format, params)
+}
+
+// PostSearchWithContext is like PostSearch, except that it takes a
+// context that will be used in the underlying http request.
+func (c *Connection) PostSearchWithContext(ctx context.Context, req SearchRequest, format string, params url.Values) (Search, error) {
+	// XXX Format is passed in here as an option separate from the query params
+	// since we will change this to a content-encoding header instead of a
+	// query param (PROD-1189).
+	if format == "" {
+		format = "bzng"
+	}
+	if params == nil {
+		params = url.Values{}
+	}
+	params.Set("format", format)
+	path := "/search"
+	if params.Encode() != "" {
+		path += "?" + params.Encode()
+	}
+	resp, cancel, err := c._call(ctx, "POST", path, nil, req)
+	if err != nil {
+		return nil, err
+	}
+	switch format {
+	default:
+		// POST should catch this above
+		return nil, errors.New("bad search format requested: " + format)
+	case "json", "zjson":
+		return NewJsonSearch(resp.Body, cancel), nil
+	case "bzng":
+		return NewBzngSearch(resp.Body, cancel), nil
+	}
+}
+
+func (c *Connection) PostPacket(space string, req PacketPostRequest) (*Stream, error) {
+	u := path.Join("/space", space, "packet")
+	jsonpipe, cancel, err := c.stream(context.Background(), "POST", u, nil, req)
+	if err != nil {
+		return nil, err
+	}
+	return NewStream(jsonpipe, cancel), nil
+}

--- a/zqd/api/json.go
+++ b/zqd/api/json.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"context"
+	"io"
+
+	"github.com/brimsec/zq/zbuf"
+)
+
+type JsonSearch struct {
+	stream *Stream
+}
+
+func NewJsonSearch(body io.Reader, cancel context.CancelFunc) *JsonSearch {
+	scanner := NewJSONPipeScanner(body)
+	return &JsonSearch{
+		stream: NewStream(scanner, cancel),
+	}
+}
+
+// Pull returns the next search item.  Here, we also return search results
+// as empty interface and it's up to the caller to be prepared to pull the
+// data out of a v2.SearchResults.
+func (s *JsonSearch) Pull() (zbuf.Batch, interface{}, error) {
+	v, err := s.stream.Next()
+	return nil, v, err
+}

--- a/zqd/api/search.go
+++ b/zqd/api/search.go
@@ -1,0 +1,9 @@
+package api
+
+import (
+	"github.com/brimsec/zq/zbuf"
+)
+
+type Search interface {
+	Pull() (zbuf.Batch, interface{}, error)
+}


### PR DESCRIPTION
The zapi is command line interface for issuing requests against
the zqd api. Currently the cli allows for:
- creating/delete/viewing spaces
- running searches on spaces
- post pcap files to spaces

This also includes a fully functioning go client for making requests
against the zqd api.