### PR TITLE
make space deletion cancel and await other operations

### DIFF
--- a/cmd/pcap/slice/command.go
+++ b/cmd/pcap/slice/command.go
@@ -2,6 +2,7 @@ package slice
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -166,5 +167,5 @@ func (c *Command) Run(args []string) error {
 	} else {
 		search = pcap.NewRangeSearch(span)
 	}
-	return search.Run(out, pcapReader)
+	return search.Run(context.TODO(), out, pcapReader)
 }

--- a/pcap/search.go
+++ b/pcap/search.go
@@ -1,6 +1,7 @@
 package pcap
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -137,10 +138,14 @@ func genICMPFilter(src, dst net.IP) PacketFilter {
 
 // XXX currently assumes legacy pcap is produced by the input reader
 // XXX need to handle searching over multiple pcap files
-func (s *Search) Run(w io.Writer, r pcapio.Reader) error {
+func (s *Search) Run(ctx context.Context, w io.Writer, r pcapio.Reader) error {
 	opts := gopacket.DecodeOptions{Lazy: true, NoCopy: true}
 	var npkt int
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		block, typ, err := r.Read()
 		if err != nil {
 			if err == io.EOF {

--- a/zqd/core.go
+++ b/zqd/core.go
@@ -84,7 +84,7 @@ func (c *Core) getTaskID() int64 {
 // If the space is pending deletion, the bool parameter returns false.
 // Otherwise, this returns a new context, and a done function that must
 // be called when the operation completes.
-func (c *Core) startSpaceOp(ctx context.Context, space string) (context.Context, func(), bool) {
+func (c *Core) startSpaceOp(ctx context.Context, space string) (context.Context, context.CancelFunc, bool) {
 	c.spaceOpsLock.Lock()
 	defer c.spaceOpsLock.Unlock()
 
@@ -132,7 +132,7 @@ func (c *Core) startSpaceOp(ctx context.Context, space string) (context.Context,
 // already pending deletion, the bool parameter returns false. Otherwise, it
 // returns a done function that must be called when the delete operation
 // completes.
-func (c *Core) haltSpaceOpsForDelete(space string) (func(), bool) {
+func (c *Core) haltSpaceOpsForDelete(space string) (context.CancelFunc, bool) {
 	c.spaceOpsLock.Lock()
 
 	state, ok := c.spaceOps[space]

--- a/zqd/core.go
+++ b/zqd/core.go
@@ -39,10 +39,10 @@ type Core struct {
 	taskCount int64
 	logger    *zap.Logger
 
-	// spaceOpsLock protects the spaceOps map and the active and
+	// spaceOpsMu protects the spaceOps map and the active and
 	// deletePending fields inside the spaceOpsState's.
-	spaceOpsLock sync.Mutex
-	spaceOps     map[string]*spaceOpsState
+	spaceOpsMu sync.Mutex
+	spaceOps   map[string]*spaceOpsState
 }
 
 type spaceOpsState struct {
@@ -85,8 +85,8 @@ func (c *Core) getTaskID() int64 {
 // Otherwise, this returns a new context, and a done function that must
 // be called when the operation completes.
 func (c *Core) startSpaceOp(ctx context.Context, space string) (context.Context, context.CancelFunc, bool) {
-	c.spaceOpsLock.Lock()
-	defer c.spaceOpsLock.Unlock()
+	c.spaceOpsMu.Lock()
+	defer c.spaceOpsMu.Unlock()
 
 	state, ok := c.spaceOps[space]
 	if !ok {
@@ -112,8 +112,8 @@ func (c *Core) startSpaceOp(ctx context.Context, space string) (context.Context,
 	}()
 
 	ingestDone := func() {
-		c.spaceOpsLock.Lock()
-		defer c.spaceOpsLock.Unlock()
+		c.spaceOpsMu.Lock()
+		defer c.spaceOpsMu.Unlock()
 
 		state.active--
 		if state.active == 0 {
@@ -133,7 +133,7 @@ func (c *Core) startSpaceOp(ctx context.Context, space string) (context.Context,
 // returns a done function that must be called when the delete operation
 // completes.
 func (c *Core) haltSpaceOpsForDelete(space string) (context.CancelFunc, bool) {
-	c.spaceOpsLock.Lock()
+	c.spaceOpsMu.Lock()
 
 	state, ok := c.spaceOps[space]
 	if !ok {
@@ -144,20 +144,20 @@ func (c *Core) haltSpaceOpsForDelete(space string) (context.CancelFunc, bool) {
 	}
 
 	if state.deletePending {
-		c.spaceOpsLock.Unlock()
+		c.spaceOpsMu.Unlock()
 		return func() {}, false
 	}
 
 	state.active++
 	state.deletePending = true
-	c.spaceOpsLock.Unlock()
+	c.spaceOpsMu.Unlock()
 
 	close(state.cancelChan)
 	state.wg.Wait()
 
 	return func() {
-		c.spaceOpsLock.Lock()
-		defer c.spaceOpsLock.Unlock()
+		c.spaceOpsMu.Lock()
+		defer c.spaceOpsMu.Unlock()
 
 		state.active--
 		if state.active == 0 {

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -36,12 +36,12 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, opDone, ok := c.startSpaceOp(r.Context(), s.Name())
+	ctx, cancel, ok := c.startSpaceOp(r.Context(), s.Name())
 	if !ok {
 		http.Error(w, "space is awaiting deletion", http.StatusConflict)
 		return
 	}
-	defer opDone()
+	defer cancel()
 
 	var out search.Output
 	format := r.URL.Query().Get("format")
@@ -71,12 +71,12 @@ func handlePacketSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, opDone, ok := c.startSpaceOp(r.Context(), s.Name())
+	ctx, cancel, ok := c.startSpaceOp(r.Context(), s.Name())
 	if !ok {
 		http.Error(w, "space is awaiting deletion", http.StatusConflict)
 		return
 	}
-	defer opDone()
+	defer cancel()
 
 	req := &api.PacketSearch{}
 	if err := req.FromQuery(r.URL.Query()); err != nil {
@@ -164,12 +164,12 @@ func handleSpaceGet(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, opDone, ok := c.startSpaceOp(r.Context(), s.Name())
+	_, cancel, ok := c.startSpaceOp(r.Context(), s.Name())
 	if !ok {
 		http.Error(w, "space is awaiting deletion", http.StatusConflict)
 		return
 	}
-	defer opDone()
+	defer cancel()
 
 	info := &api.SpaceInfo{
 		Name:          s.Name(),
@@ -221,12 +221,12 @@ func handleSpacePost(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, opDone, ok := c.startSpaceOp(r.Context(), req.Name)
+	_, cancel, ok := c.startSpaceOp(r.Context(), req.Name)
 	if !ok {
 		http.Error(w, "space is awaiting deletion", http.StatusConflict)
 		return
 	}
-	defer opDone()
+	defer cancel()
 
 	s, err := space.Create(c.Root, req.Name, req.DataDir)
 	if err != nil {
@@ -252,12 +252,12 @@ func handleSpaceDelete(c *Core, w http.ResponseWriter, r *http.Request) {
 	if s == nil {
 		return
 	}
-	deleteDone, ok := c.haltSpaceOpsForDelete(s.Name())
+	cancel, ok := c.haltSpaceOpsForDelete(s.Name())
 	if !ok {
 		http.Error(w, "space is awaiting deletion", http.StatusConflict)
 		return
 	}
-	defer deleteDone()
+	defer cancel()
 
 	if err := s.Delete(); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -278,12 +278,13 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, opDone, ok := c.startSpaceOp(r.Context(), s.Name())
+	ctx := r.Context()
+	ctx, cancel, ok := c.startSpaceOp(r.Context(), s.Name())
 	if !ok {
 		http.Error(w, "space is awaiting deletion", http.StatusConflict)
 		return
 	}
-	defer opDone()
+	defer cancel()
 
 	var req api.PacketPostRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -363,12 +364,12 @@ func handleLogPost(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, opDone, ok := c.startSpaceOp(r.Context(), s.Name())
+	ctx, cancel, ok := c.startSpaceOp(r.Context(), s.Name())
 	if !ok {
 		http.Error(w, "space is awaiting deletion", http.StatusConflict)
 		return
 	}
-	defer opDone()
+	defer cancel()
 
 	var req api.LogPostRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -368,8 +368,8 @@ func handleLogPost(c *Core, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "space is awaiting deletion", http.StatusConflict)
 		return
 	}
-
 	defer opDone()
+
 	var req api.LogPostRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -252,7 +252,11 @@ func handleSpaceDelete(c *Core, w http.ResponseWriter, r *http.Request) {
 	if s == nil {
 		return
 	}
-	deleteDone := c.haltSpaceOpsForDelete(s.Name())
+	deleteDone, ok := c.haltSpaceOpsForDelete(s.Name())
+	if !ok {
+		http.Error(w, "space is awaiting deletion", http.StatusConflict)
+		return
+	}
 	defer deleteDone()
 
 	if err := s.Delete(); err != nil {

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net/http/httptest"
 	"os"
@@ -20,6 +21,7 @@ import (
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zqd"
 	"github.com/brimsec/zq/zqd/api"
+	"github.com/brimsec/zq/zqd/zeek"
 	"github.com/brimsec/zq/zql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -457,4 +459,65 @@ func postSpaceLogs(t *testing.T, c *api.Connection, spaceName string, logs ...st
 		payloads = append(payloads, p)
 	}
 	return payloads
+}
+
+func testZeekLauncher(start, wait procFn) zeek.Launcher {
+	return func(ctx context.Context, r io.Reader, dir string) (zeek.Process, error) {
+		p := &testZeekProcess{
+			ctx:    ctx,
+			reader: r,
+			wd:     dir,
+			wait:   wait,
+			start:  start,
+		}
+		return p, p.Start()
+	}
+}
+
+type procFn func(t *testZeekProcess) error
+
+type testZeekProcess struct {
+	ctx    context.Context
+	reader io.Reader
+	wd     string
+	start  procFn
+	wait   procFn
+}
+
+func (p *testZeekProcess) Start() error {
+	if p.start != nil {
+		return p.start(p)
+	}
+	return nil
+}
+
+func (p *testZeekProcess) Wait() error {
+	if p.wait != nil {
+		return p.wait(p)
+	}
+	return nil
+}
+
+func writeLogsFn(logs []string) procFn {
+	return func(t *testZeekProcess) error {
+		for _, log := range logs {
+			r, err := os.Open(log)
+			if err != nil {
+				return err
+			}
+			defer r.Close()
+			base := filepath.Base(r.Name())
+			w, err := os.Create(filepath.Join(t.wd, base))
+			if err != nil {
+				return err
+			}
+			defer w.Close()
+			if _, err = io.Copy(w, r); err != nil {
+				return err
+			}
+		}
+		// drain the reader
+		_, err := io.Copy(ioutil.Discard, t.reader)
+		return err
+	}
 }

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -362,10 +362,10 @@ func TestDeleteDuringPacketPost(t *testing.T) {
 				taskEnd = te
 			}
 		}
-		if taskEnd == nil || taskEnd.Error.Message != "context canceled" {
-			return errors.New("missing or unexpected taskEnd error")
+		if taskEnd == nil {
+			return errors.New("no TaskEnd payload")
 		}
-		return nil
+		return *taskEnd.Error
 	}
 	go func() {
 		packetPostErr <- doPost()
@@ -375,7 +375,7 @@ func TestDeleteDuringPacketPost(t *testing.T) {
 	err = client.SpaceDelete(context.Background(), spaceName)
 	require.NoError(t, err)
 
-	require.NoError(t, <-packetPostErr)
+	require.Error(t, <-packetPostErr, "context canceled")
 }
 
 func zngSearch(t *testing.T, client *api.Connection, space, prog string) string {


### PR DESCRIPTION
When a space delete API call is made, signal other active operations to
cancel and wait for them to do so, preventing further operations
until the deletion is done.

This uses zqd.Core as the holder of the necessary state. Eventually, I
think this would better live in a dedicated space manager, but that's a
much larger change, and I think this code will move there easily.

This is a part of addressing ingest cancellation during application
shutdown on Windows, as we currently see "file in use" errors there when
a delete is called concurrently with ingest.
