### PR TITLE
packet post endpoint: add snapshot counter

### DIFF
--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -112,6 +112,7 @@ type PacketPostStatus struct {
 	UpdateTime     nano.Ts  `json:"update_time"`
 	PacketSize     int64    `json:"packet_total_size" unit:"bytes"`
 	PacketReadSize int64    `json:"packet_read_size" unit:"bytes"`
+	SnapshotCount  int      `json:"snapshot_count"`
 	MinTime        *nano.Ts `json:"min_time,omitempty"`
 	MaxTime        *nano.Ts `json:"max_time,omitempty"`
 }

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -280,6 +280,7 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 			UpdateTime:     nano.Now(),
 			PacketSize:     proc.PcapSize,
 			PacketReadSize: proc.PcapReadSize(),
+			SnapshotCount:  proc.SnapshotCount(),
 			MinTime:        minTs,
 			MaxTime:        maxTs,
 		}

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -256,7 +256,7 @@ func execSearch(t *testing.T, c *zqd.Core, space, prog string) string {
 
 func createTempDir(t *testing.T) string {
 	// Replace '/' with '-' so it doesn't try to access dirs that don't exist.
-	// Apparantly "/" in a filepath for windows still tries to create a
+	// Apparently "/" in a filepath for windows still tries to create a
 	// directory; this solution works for windows as well.
 	name := strings.ReplaceAll(t.Name(), "/", "-")
 	dir, err := ioutil.TempDir("", name)

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -80,6 +80,7 @@ func TestPacketPostSuccess(t *testing.T) {
 		assert.Equal(t, status.Type, "PacketPostStatus")
 		assert.Equal(t, status.PacketSize, info.Size())
 		assert.Equal(t, status.PacketReadSize, info.Size())
+		assert.Equal(t, 1, status.SnapshotCount)
 		assert.Equal(t, nano.Unix(1501770877, 471635000), *status.MinTime)
 		assert.Equal(t, nano.Unix(1501770880, 988247000), *status.MaxTime)
 	})


### PR DESCRIPTION
Track the number of snapshots created during packet ingest into a space. 
Every time a snapshot is produced increment the counter. The current snapshot 
count is returned in the api.PacketPostStatus payload.