### PR TITLE
Rename NativeValue -> Value

### DIFF
--- a/expr/functions.go
+++ b/expr/functions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/brimsec/zq/zngnative"
 )
 
-type Function func([]zngnative.NativeValue) (zngnative.NativeValue, error)
+type Function func([]zngnative.Value) (zngnative.Value, error)
 
 var ErrTooFewArgs = errors.New("too few arguments")
 var ErrTooManyArgs = errors.New("too many arguments")
@@ -25,7 +25,7 @@ var allFns = map[string]struct {
 	"Math.sqrt": {1, 1, mathSqrt},
 }
 
-func mathMax(args []zngnative.NativeValue) (zngnative.NativeValue, error) {
+func mathMax(args []zngnative.Value) (zngnative.Value, error) {
 	switch args[0].Type.ID() {
 	case zng.IdInt16, zng.IdInt32, zng.IdInt64:
 		ret := args[0].Value.(int64)
@@ -35,7 +35,7 @@ func mathMax(args []zngnative.NativeValue) (zngnative.NativeValue, error) {
 				ret = v
 			}
 		}
-		return zngnative.NativeValue{zng.TypeInt64, ret}, nil
+		return zngnative.Value{zng.TypeInt64, ret}, nil
 
 	case zng.IdByte, zng.IdUint16, zng.IdUint32, zng.IdUint64:
 		ret := args[0].Value.(uint64)
@@ -45,7 +45,7 @@ func mathMax(args []zngnative.NativeValue) (zngnative.NativeValue, error) {
 				ret = v
 			}
 		}
-		return zngnative.NativeValue{zng.TypeUint64, ret}, nil
+		return zngnative.Value{zng.TypeUint64, ret}, nil
 
 	case zng.IdFloat64:
 		ret := args[0].Value.(float64)
@@ -55,14 +55,14 @@ func mathMax(args []zngnative.NativeValue) (zngnative.NativeValue, error) {
 				ret = v
 			}
 		}
-		return zngnative.NativeValue{zng.TypeFloat64, ret}, nil
+		return zngnative.Value{zng.TypeFloat64, ret}, nil
 
 	default:
-		return zngnative.NativeValue{}, fmt.Errorf("Math.max: %w", ErrBadArgument)
+		return zngnative.Value{}, fmt.Errorf("Math.max: %w", ErrBadArgument)
 	}
 }
 
-func mathMin(args []zngnative.NativeValue) (zngnative.NativeValue, error) {
+func mathMin(args []zngnative.Value) (zngnative.Value, error) {
 	switch args[0].Type.ID() {
 	case zng.IdInt16, zng.IdInt32, zng.IdInt64:
 		ret := args[0].Value.(int64)
@@ -72,7 +72,7 @@ func mathMin(args []zngnative.NativeValue) (zngnative.NativeValue, error) {
 				ret = v
 			}
 		}
-		return zngnative.NativeValue{zng.TypeInt64, ret}, nil
+		return zngnative.Value{zng.TypeInt64, ret}, nil
 
 	case zng.IdByte, zng.IdUint16, zng.IdUint32, zng.IdUint64:
 		ret := args[0].Value.(uint64)
@@ -82,7 +82,7 @@ func mathMin(args []zngnative.NativeValue) (zngnative.NativeValue, error) {
 				ret = v
 			}
 		}
-		return zngnative.NativeValue{zng.TypeUint64, ret}, nil
+		return zngnative.Value{zng.TypeUint64, ret}, nil
 
 	case zng.IdFloat64:
 		ret := args[0].Value.(float64)
@@ -92,14 +92,14 @@ func mathMin(args []zngnative.NativeValue) (zngnative.NativeValue, error) {
 				ret = v
 			}
 		}
-		return zngnative.NativeValue{zng.TypeFloat64, ret}, nil
+		return zngnative.Value{zng.TypeFloat64, ret}, nil
 
 	default:
-		return zngnative.NativeValue{}, fmt.Errorf("Math.min: %w", ErrBadArgument)
+		return zngnative.Value{}, fmt.Errorf("Math.min: %w", ErrBadArgument)
 	}
 }
 
-func mathSqrt(args []zngnative.NativeValue) (zngnative.NativeValue, error) {
+func mathSqrt(args []zngnative.Value) (zngnative.Value, error) {
 	var x float64
 	switch args[0].Type.ID() {
 	case zng.IdFloat64:
@@ -109,7 +109,7 @@ func mathSqrt(args []zngnative.NativeValue) (zngnative.NativeValue, error) {
 	case zng.IdByte, zng.IdUint16, zng.IdUint32, zng.IdUint64:
 		x = float64(args[0].Value.(uint64))
 	default:
-		return zngnative.NativeValue{}, fmt.Errorf("Math.sqrt: %w", ErrBadArgument)
+		return zngnative.Value{}, fmt.Errorf("Math.sqrt: %w", ErrBadArgument)
 	}
 
 	r := math.Sqrt(x)
@@ -117,8 +117,8 @@ func mathSqrt(args []zngnative.NativeValue) (zngnative.NativeValue, error) {
 		// For now we can't represent non-numeric values in a float64,
 		// we will revisit this but it has implications for file
 		// formats, zql, etc.
-		return zngnative.NativeValue{}, fmt.Errorf("Math.sqrt: %w", ErrBadArgument)
+		return zngnative.Value{}, fmt.Errorf("Math.sqrt: %w", ErrBadArgument)
 	}
 
-	return zngnative.NativeValue{zng.TypeFloat64, r}, nil
+	return zngnative.Value{zng.TypeFloat64, r}, nil
 }

--- a/zngnative/coerce.go
+++ b/zngnative/coerce.go
@@ -18,7 +18,7 @@ func CoerceToFloat64(in zng.Value) (float64, bool) {
 	return CoerceNativeToFloat64(native)
 }
 
-func CoerceNativeToFloat64(in NativeValue) (float64, bool) {
+func CoerceNativeToFloat64(in Value) (float64, bool) {
 	switch in.Type.ID() {
 	case zng.IdFloat64:
 		return in.Value.(float64), true
@@ -46,7 +46,7 @@ func CoerceToInt(in zng.Value) (int64, bool) {
 	return CoerceNativeToInt(native)
 }
 
-func CoerceNativeToInt(in NativeValue) (int64, bool) {
+func CoerceNativeToInt(in Value) (int64, bool) {
 	switch in.Type.ID() {
 	case zng.IdFloat64:
 		f := in.Value.(float64)
@@ -85,7 +85,7 @@ func CoerceToUint(in zng.Value) (uint64, bool) {
 	return CoerceNativeToUint(native)
 }
 
-func CoerceNativeToUint(in NativeValue) (uint64, bool) {
+func CoerceNativeToUint(in Value) (uint64, bool) {
 	switch in.Type.ID() {
 	case zng.IdFloat64:
 		f := in.Value.(float64)

--- a/zngnative/native.go
+++ b/zngnative/native.go
@@ -10,111 +10,111 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
-type NativeValue struct {
+type Value struct {
 	Type  zng.Type
 	Value interface{}
 }
 
-func ToNativeValue(zv zng.Value) (NativeValue, error) {
+func ToNativeValue(zv zng.Value) (Value, error) {
 	switch zv.Type.ID() {
 	case zng.IdBool:
 		b, err := zng.DecodeBool(zv.Bytes)
 		if err != nil {
-			return NativeValue{}, err
+			return Value{}, err
 		}
-		return NativeValue{zng.TypeBool, b}, nil
+		return Value{zng.TypeBool, b}, nil
 
 	case zng.IdByte:
 		b, err := zng.DecodeByte(zv.Bytes)
 		if err != nil {
-			return NativeValue{}, err
+			return Value{}, err
 		}
-		return NativeValue{zng.TypeByte, uint64(b)}, nil
+		return Value{zng.TypeByte, uint64(b)}, nil
 
 	case zng.IdInt16, zng.IdInt32, zng.IdInt64:
 		v, err := zng.DecodeInt(zv.Bytes)
 		if err != nil {
-			return NativeValue{}, err
+			return Value{}, err
 		}
-		return NativeValue{zv.Type, v}, nil
+		return Value{zv.Type, v}, nil
 
 	case zng.IdUint16, zng.IdUint32, zng.IdUint64:
 		v, err := zng.DecodeUint(zv.Bytes)
 		if err != nil {
-			return NativeValue{}, err
+			return Value{}, err
 		}
-		return NativeValue{zv.Type, v}, nil
+		return Value{zv.Type, v}, nil
 
 	case zng.IdFloat64:
 		v, err := zng.DecodeFloat64(zv.Bytes)
 		if err != nil {
-			return NativeValue{}, err
+			return Value{}, err
 		}
-		return NativeValue{zv.Type, v}, nil
+		return Value{zv.Type, v}, nil
 
 	case zng.IdString:
 		s, err := zng.DecodeString(zv.Bytes)
 		if err != nil {
-			return NativeValue{}, err
+			return Value{}, err
 		}
-		return NativeValue{zv.Type, s}, nil
+		return Value{zv.Type, s}, nil
 
 	case zng.IdBstring:
 		s, err := zng.DecodeBstring(zv.Bytes)
 		if err != nil {
-			return NativeValue{}, err
+			return Value{}, err
 		}
-		return NativeValue{zv.Type, s}, nil
+		return Value{zv.Type, s}, nil
 
 	case zng.IdIP:
 		a, err := zng.DecodeIP(zv.Bytes)
 		if err != nil {
-			return NativeValue{}, err
+			return Value{}, err
 		}
-		return NativeValue{zv.Type, a}, nil
+		return Value{zv.Type, a}, nil
 
 	case zng.IdPort:
 		p, err := zng.DecodePort(zv.Bytes)
 		if err != nil {
-			return NativeValue{}, err
+			return Value{}, err
 		}
-		return NativeValue{zv.Type, uint64(p)}, nil
+		return Value{zv.Type, uint64(p)}, nil
 
 	case zng.IdNet:
 		n, err := zng.DecodeNet(zv.Bytes)
 		if err != nil {
-			return NativeValue{}, err
+			return Value{}, err
 		}
-		return NativeValue{zv.Type, n}, nil
+		return Value{zv.Type, n}, nil
 
 	case zng.IdTime:
 		t, err := zng.DecodeTime(zv.Bytes)
 		if err != nil {
-			return NativeValue{}, nil
+			return Value{}, nil
 		}
-		return NativeValue{zv.Type, int64(t)}, nil
+		return Value{zv.Type, int64(t)}, nil
 
 	case zng.IdDuration:
 		d, err := zng.DecodeDuration(zv.Bytes)
 		if err != nil {
-			return NativeValue{}, nil
+			return Value{}, nil
 		}
-		return NativeValue{zv.Type, d}, nil
+		return Value{zv.Type, d}, nil
 	}
 
 	// Keep arrays, sets, and records in their zval encoded form.
-	// The purpose of NativeValue is to avoid encoding temporary
+	// The purpose of Value is to avoid encoding temporary
 	// values but since we can't construct these types in expressions,
 	// this just lets us lazily decode them.
 	switch zv.Type.(type) {
 	case *zng.TypeArray, *zng.TypeSet, *zng.TypeRecord:
-		return NativeValue{zv.Type, zv.Bytes}, nil
+		return Value{zv.Type, zv.Bytes}, nil
 	}
 
-	return NativeValue{}, fmt.Errorf("unknown type %s", zv.Type)
+	return Value{}, fmt.Errorf("unknown type %s", zv.Type)
 }
 
-func (v *NativeValue) ToZngValue() (zng.Value, error) {
+func (v *Value) ToZngValue() (zng.Value, error) {
 	switch v.Type.ID() {
 	case zng.IdBool:
 		b := v.Value.(bool)


### PR DESCRIPTION
Now that NativeValue is in the zngnative package, Native in the name
is redundant and bulky, streamline it a bit here.