### PR TITLE
fix bug where snaplen = 0

### DIFF
--- a/pcap/pcapio/read.go
+++ b/pcap/pcapio/read.go
@@ -152,7 +152,7 @@ func (r *PcapReader) Read() ([]byte, BlockType, error) {
 	}
 	caplen := int(r.byteOrder.Uint32(hdr[8:12]))
 	fullLength := int(r.byteOrder.Uint32(hdr[12:16]))
-	if caplen > int(r.snaplen) {
+	if int(r.snaplen) != 0 && caplen > int(r.snaplen) {
 		return nil, 0, fmt.Errorf("capture length exceeds snap length: %d > %d", caplen, r.snaplen)
 	}
 	if caplen > fullLength {

--- a/pcap/pcapio/read.go
+++ b/pcap/pcapio/read.go
@@ -152,7 +152,7 @@ func (r *PcapReader) Read() ([]byte, BlockType, error) {
 	}
 	caplen := int(r.byteOrder.Uint32(hdr[8:12]))
 	fullLength := int(r.byteOrder.Uint32(hdr[12:16]))
-	if int(r.snaplen) != 0 && caplen > int(r.snaplen) {
+	if r.snaplen != 0 && caplen > int(r.snaplen) {
 		return nil, 0, fmt.Errorf("capture length exceeds snap length: %d > %d", caplen, r.snaplen)
 	}
 	if caplen > fullLength {


### PR DESCRIPTION
A pcap file with snaplen=0 means that there was no capture length
restriction and all packets are captured at full size.  There was
a check inherited from gopacket that raised an error if the
captured length was larger than the snaplen, which is a bug for
snaplen=0.  The fix is to change this check to check alsoo that
snaplen isn't zero.