### PR TITLE
Improve scanner.Combiner error messages

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -282,6 +282,15 @@ func (c *Command) errorf(format string, args ...interface{}) {
 	_, _ = fmt.Fprintf(os.Stderr, format, args...)
 }
 
+type namedReader struct {
+	zbuf.Reader
+	name string
+}
+
+func (r namedReader) String() string {
+	return r.name
+}
+
 func (c *Command) inputReaders(paths []string) ([]zbuf.Reader, error) {
 	var readers []zbuf.Reader
 	for _, path := range paths {
@@ -319,7 +328,7 @@ func (c *Command) inputReaders(paths []string) ([]zbuf.Reader, error) {
 				return nil, err
 			}
 		}
-		readers = append(readers, zr)
+		readers = append(readers, namedReader{zr, path})
 	}
 	return readers, nil
 }

--- a/scanner/combiner.go
+++ b/scanner/combiner.go
@@ -49,7 +49,7 @@ func (c *Combiner) Read() (*zng.Record, error) {
 			if tup == nil {
 				c.done[k] = true
 				if err := c.closeReader(l); err != nil {
-					return nil, err
+					return nil, fmt.Errorf("%s: %w", c.readers[k], err)
 				}
 				continue
 			}

--- a/tests/suite.go
+++ b/tests/suite.go
@@ -43,6 +43,7 @@ var commands = []test.Exec{
 }
 
 var scripts = []test.Shell{
+	errors.Combiner,
 	diropt.Test,
 	diropt.Test2,
 	jsontype.Test,

--- a/tests/suite/errors/combiner.go
+++ b/tests/suite/errors/combiner.go
@@ -1,0 +1,42 @@
+package errors
+
+import (
+	"github.com/brimsec/zq/pkg/test"
+)
+
+var Combiner = test.Shell{
+	Name:   "combiner-error-has-name",
+	Script: `zq -j types.json "*" *.ndjson > http.zng`,
+	Input: []test.File{
+		test.File{"http.ndjson", test.Trim(http)},
+		test.File{"badpath.ndjson", test.Trim(badpath)},
+		test.File{"types.json", test.Trim(types)},
+	},
+	ExpectedStderrRE: "badpath.ndjson.*",
+}
+
+const http = `{"ts":"2017-03-24T19:59:23.306076Z","_path":"http"}`
+const badpath = `{"ts":"2017-03-24T19:59:23.306076Z","_path":"badpath"}`
+
+const types = `
+{
+  "descriptors": {
+    "http_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      }
+      ]
+     },
+  "rules": [
+    {
+      "name": "_path",
+      "value": "http",
+      "descriptor": "http_log"
+    }
+  ]
+}`

--- a/tests/system_test.go
+++ b/tests/system_test.go
@@ -55,9 +55,10 @@ func TestScripts(t *testing.T) {
 		t.Run(script.Name, func(t *testing.T) {
 			shell := test.NewShellTest(script)
 			_, stderr, err := shell.Run(RootDir, path)
-			assert.NoError(t, err)
 			if script.ExpectedStderrRE != "" {
 				assert.Regexp(t, regexp.MustCompile(script.ExpectedStderrRE), stderr)
+			} else {
+				assert.NoError(t, err)
 			}
 			for _, file := range script.Expected {
 				actual, err := shell.Read(file.Name)


### PR DESCRIPTION
`scanner.Combiner` error strings previously included a string representation of
the `zbuf.Reader` go struct from which the error-causing line
originated. Remove this, and prefix the remaining (useful) error
message with the name of the file that had the error.