### PR TITLE
recover from panics from procs

### DIFF
--- a/tests/suite/put/put-6.yaml
+++ b/tests/suite/put/put-6.yaml
@@ -1,0 +1,8 @@
+# Tests integer division by zero error
+zql: put y = x / 0
+
+input: |
+  #0:record[x:int32]
+  0:[1;]
+
+errorRE: divide by zero


### PR DESCRIPTION
If a panic occurs during proc runtime, recover from it inside the mux, and report it as an error. I verified by adding support to ztest for an expected error regex, and trigger an integer division by zero panic with put.

