### PR TITLE
Typed ndjson: accept Ts-less points

### DIFF
--- a/tests/suite.go
+++ b/tests/suite.go
@@ -49,6 +49,7 @@ var scripts = []test.Shell{
 	jsontype.Test,
 	jsontype.TestInferPath,
 	jsontype.TestSet,
+	jsontype.TestNoTs,
 	pcap.Test1,
 	pcap.Test2,
 	pcap.Test3,

--- a/tests/suite/jsontype/test.go
+++ b/tests/suite/jsontype/test.go
@@ -116,3 +116,44 @@ const typesSet = `
 const zngSet = `
 #0:record[_path:string,ts:time,uids:set[bstring]]
 0:[sets;1490385563.306076;[a;b;]]`
+
+var TestNoTs = test.Shell{
+	Name:   "json-types-nots",
+	Script: `zq -j types.json "*" in.ndjson > out.zng`,
+	Input: []test.File{
+		test.File{"in.ndjson", test.Trim(inputNoTs)},
+		test.File{"types.json", test.Trim(typesNoTs)},
+	},
+	Expected: []test.File{
+		test.File{"out.zng", test.Trim(zngNoTs)},
+	},
+}
+
+const inputNoTs = `{"name": "foo","_path":"nots"}`
+
+const typesNoTs = `
+{
+  "descriptors": {
+    "nots_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "name",
+        "type": "bstring"
+      }
+      ]
+     },
+  "rules": [
+    {
+      "name": "_path",
+      "value": "nots",
+      "descriptor": "nots_log"
+    }
+  ]
+}`
+
+const zngNoTs = `
+#0:record[_path:string,name:bstring]
+0:[nots;foo;]`

--- a/tests/suite/jsontype/test.go
+++ b/tests/suite/jsontype/test.go
@@ -118,7 +118,7 @@ const zngSet = `
 0:[sets;1490385563.306076;[a;b;]]`
 
 var TestNoTs = test.Shell{
-	Name:   "json-types-nots",
+	Name:   "json-types-no-ts",
 	Script: `zq -j types.json "*" in.ndjson > out.zng`,
 	Input: []test.File{
 		test.File{"in.ndjson", test.Trim(inputNoTs)},

--- a/zio/ndjsonio/typeparser.go
+++ b/zio/ndjsonio/typeparser.go
@@ -261,10 +261,6 @@ func (p *typeParser) parseObject(b []byte) (zng.Value, error) {
 		}
 		return zng.Value{}, err
 	}
-	if ti.flatDesc.TsCol < 0 {
-		incr(&p.stats.BadFormat)
-		return zng.Value{}, ErrBadFormat
-	}
 
 	raw, dropped, err := ti.newRawFromJSON(b)
 	if err != nil {


### PR DESCRIPTION
Fix ndjson typed reader to handle Ts-less points, like other readers.