### PR TITLE
Crude prototype for zng archive (zar)

### DIFF
--- a/archive/finder.go
+++ b/archive/finder.go
@@ -1,7 +1,6 @@
 package archive
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,7 +9,6 @@ import (
 )
 
 func Find(dir string, pattern []byte) ([]string, error) {
-	nerr := 0
 	//XXX this should be parallelized with some locking presuming a little
 	// parallelism won't mess up the file system assumptions
 	var hits []string
@@ -31,11 +29,6 @@ func Find(dir string, pattern []byte) ([]string, error) {
 			hit, err := SearchFile(path, pattern)
 			if err != nil {
 				fmt.Printf("%s\n", err)
-				nerr++
-				if nerr > 10 {
-					//XXX
-					return errors.New("stopping after too many errors...")
-				}
 			}
 			if hit {
 				hits = append(hits, path)

--- a/archive/finder.go
+++ b/archive/finder.go
@@ -9,7 +9,6 @@ import (
 	"github.com/brimsec/zq/pkg/sst"
 )
 
-//XXX this is a test searches for IP addresses
 func Find(dir string, pattern []byte) ([]string, error) {
 	nerr := 0
 	//XXX this should be parallelized with some locking presuming a little
@@ -47,6 +46,7 @@ func Find(dir string, pattern []byte) ([]string, error) {
 	return hits, err
 }
 
+//XXX for now we hard code search for IP address.
 func SearchFile(path string, pattern []byte) (bool, error) {
 	subdir := path + zarExt
 	sstName := "sst:type:ip" //XXX

--- a/archive/finder.go
+++ b/archive/finder.go
@@ -1,0 +1,68 @@
+package archive
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/brimsec/zq/pkg/sst"
+)
+
+//XXX this is a test searches for IP addresses
+func Find(dir string, pattern []byte) ([]string, error) {
+	nerr := 0
+	//XXX this should be parallelized with some locking presuming a little
+	// parallelism won't mess up the file system assumptions
+	var hits []string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("%q: %v", path, err)
+		}
+		name := info.Name()
+		if info.IsDir() {
+			if filepath.Ext(name) == zarExt {
+				//XXX need to merge into or replace existing index
+				return filepath.SkipDir
+			}
+			// descend...
+			return nil
+		}
+		if filepath.Ext(name) == ".bzng" {
+			hit, err := SearchFile(path, pattern)
+			if err != nil {
+				fmt.Printf("%s\n", err)
+				nerr++
+				if nerr > 10 {
+					//XXX
+					return errors.New("stopping after too many errors...")
+				}
+			}
+			if hit {
+				hits = append(hits, path)
+			}
+		}
+		return nil
+	})
+	return hits, err
+}
+
+func SearchFile(path string, pattern []byte) (bool, error) {
+	subdir := path + zarExt
+	sstName := "sst:type:ip" //XXX
+	sstPath := filepath.Join(subdir, sstName)
+	finder, err := sst.NewFinder(sstPath)
+	if err != nil {
+		if err == os.ErrNotExist {
+			err = nil
+		} else {
+			err = fmt.Errorf("%s: %s", sstPath, err)
+		}
+		return false, err
+	}
+	v, err := finder.Lookup(pattern)
+	if err != nil {
+		err = fmt.Errorf("%s: %s", sstPath, err.Error())
+	}
+	return v != nil, err
+}

--- a/archive/indexer.go
+++ b/archive/indexer.go
@@ -1,0 +1,113 @@
+package archive
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/brimsec/zq/pkg/sst"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/detector"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+const zarExt = ".zar"
+
+// TBD
+type Indexer interface {
+	Create(*sst.Writer, zbuf.Reader)
+	//Search([]byte) bool
+}
+
+//XXX this is a test stub that creates simple indexes of IP addresses
+func CreateIndexes(dir string) error {
+	nerr := 0
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("%q: %v", path, err)
+		}
+		name := info.Name()
+		if info.IsDir() {
+			if filepath.Ext(name) == zarExt {
+				//XXX need to merge into or replace existing index
+				return filepath.SkipDir
+			}
+			// descend...
+			return nil
+		}
+		if filepath.Ext(name) == ".bzng" {
+			err = IndexLogFile(path)
+			if err != nil {
+				fmt.Printf("%s: %s\n", path, err)
+				nerr++
+				if nerr > 10 {
+					//XXX
+					return errors.New("stopping after too many errors...")
+				}
+			}
+			// drop through and continue
+		}
+		return nil
+	})
+	return err
+}
+
+func IndexLogFile(path string) error {
+	subdir := path + zarExt
+	sstName := "sst:type:ip"
+	sstPath := filepath.Join(subdir, sstName)
+	// XXX remove without warning, should have force flag
+	sst.Remove(sstPath)
+
+	fmt.Printf("%s: indexing as %s\n", path, sstPath)
+
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	reader, err := detector.LookupReader("bzng", file, resolver.NewContext())
+	if err != nil {
+		return err
+	}
+	table, err := indexTypeIP(reader)
+	if err != nil {
+		return err
+	}
+	if table.Size() == 0 {
+		//XXX
+		return errors.New("nothing to index")
+	}
+	// make subdirectory for index if it doesn't exist
+	if err := os.Mkdir(subdir, 0755); err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+	}
+	framesize := 32 * 1024
+	//XXX for now specify value size of 0, which means variable, but we always
+	// write nil values.  we should change the implementation to allow key-only SSTs.
+	writer, err := sst.NewWriter(sstPath, framesize, 0)
+	if err != nil {
+		return err
+	}
+	defer writer.Close()
+	return sst.Copy(writer, table)
+}
+
+func indexTypeIP(reader zbuf.Reader) (*sst.MemTable, error) {
+	table := sst.NewMemTable()
+	indexer := &TypeIndexer{Type: zng.TypeIP, Table: table}
+	for {
+		rec, err := reader.Read()
+		if err != nil {
+			return nil, err
+		}
+		if rec == nil {
+			return table, nil
+		}
+		indexer.record(rec.Type, rec.Raw)
+	}
+}

--- a/archive/type.go
+++ b/archive/type.go
@@ -1,0 +1,216 @@
+package archive
+
+import (
+	"errors"
+
+	"github.com/brimsec/zq/pkg/sst"
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+)
+
+var ErrSyntax = errors.New("syntax/format error encountered parsing zng data")
+
+type TypeIndexer struct {
+	Type  zng.Type
+	Table *sst.MemTable
+}
+
+// XXX we should create a field visitor pattern for a zng.Record/
+// for now this is copied from the type checking code in zng/recordval.go
+
+func (t *TypeIndexer) vector(typ *zng.TypeArray, body zcode.Bytes) error {
+	if body == nil {
+		return nil
+	}
+	inner := zng.InnerType(zng.AliasedType(typ))
+	if inner != t.Type {
+		return nil
+	}
+	it := zcode.Iter(body)
+	for !it.Done() {
+		body, container, err := it.Next()
+		if err != nil {
+			return err
+		}
+		switch v := inner.(type) {
+		case *zng.TypeRecord:
+			if !container {
+				return ErrSyntax
+			}
+			if err := t.record(v, body); err != nil {
+				return err
+			}
+		case *zng.TypeArray:
+			if !container {
+				return ErrSyntax
+			}
+			if err := t.vector(v, body); err != nil {
+				return err
+			}
+		case *zng.TypeSet:
+			if !container {
+				return ErrSyntax
+			}
+			if err := t.set(v, body); err != nil {
+				return err
+			}
+		case *zng.TypeUnion:
+			if !container {
+				return ErrSyntax
+			}
+			if err := t.union(v, body); err != nil {
+				return err
+			}
+		default:
+			if container {
+				return ErrSyntax
+			}
+			t.value(body)
+		}
+	}
+	return nil
+}
+
+func (t *TypeIndexer) union(typ *zng.TypeUnion, body zcode.Bytes) error {
+	if len(body) == 0 {
+		return nil
+	}
+	it := zcode.Iter(body)
+	v, container, err := it.Next()
+	if err != nil {
+		return err
+	}
+	if container {
+		return ErrSyntax
+	}
+	index := zcode.DecodeCountedUvarint(v)
+	inner, err := typ.TypeIndex(int(index))
+	if err != nil {
+		return err
+	}
+	body, container, err = it.Next()
+	if err != nil {
+		return err
+	}
+	switch v := zng.AliasedType(inner).(type) {
+	case *zng.TypeRecord:
+		if !container {
+			return ErrSyntax
+		}
+		if err := t.record(v, body); err != nil {
+			return err
+		}
+	case *zng.TypeArray:
+		if !container {
+			return ErrSyntax
+		}
+		if err := t.vector(v, body); err != nil {
+			return err
+		}
+	case *zng.TypeSet:
+		if !container {
+			return ErrSyntax
+		}
+		if err := t.set(v, body); err != nil {
+			return err
+		}
+	case *zng.TypeUnion:
+		if !container {
+			return ErrSyntax
+		}
+		if err := t.union(v, body); err != nil {
+			return err
+		}
+	default:
+		if container {
+			return ErrSyntax
+		}
+		if inner == t.Type {
+			t.value(body)
+		}
+	}
+	return nil
+}
+
+func (t *TypeIndexer) set(typ *zng.TypeSet, body zcode.Bytes) error {
+	if body == nil {
+		return nil
+	}
+	inner := zng.AliasedType(zng.InnerType(typ))
+	if zng.IsContainerType(inner) {
+		return ErrSyntax
+	}
+	if t.Type != inner {
+		return nil
+	}
+	it := zcode.Iter(body)
+	for !it.Done() {
+		body, container, err := it.Next()
+		if err != nil {
+			return err
+		}
+		if container {
+			return ErrSyntax
+		}
+		t.value(body)
+	}
+	return nil
+}
+
+func (t *TypeIndexer) record(typ *zng.TypeRecord, body zcode.Bytes) error {
+	if body == nil {
+		return nil
+	}
+	it := zcode.Iter(body)
+	for _, col := range typ.Columns {
+		if it.Done() {
+			return ErrSyntax
+		}
+		body, container, err := it.Next()
+		if err != nil {
+			return err
+		}
+		switch colType := zng.AliasedType(col.Type).(type) {
+		case *zng.TypeRecord:
+			if !container {
+				return ErrSyntax
+			}
+			if err := t.record(colType, body); err != nil {
+				return err
+			}
+		case *zng.TypeArray:
+			if !container {
+				return ErrSyntax
+			}
+			if err := t.vector(colType, body); err != nil {
+				return err
+			}
+		case *zng.TypeSet:
+			if !container {
+				return ErrSyntax
+			}
+			if err := t.set(colType, body); err != nil {
+				return err
+			}
+		case *zng.TypeUnion:
+			if !container {
+				return ErrSyntax
+			}
+			if err := t.union(colType, body); err != nil {
+				return err
+			}
+		default:
+			if container {
+				return ErrSyntax
+			}
+			if colType == t.Type {
+				t.value(body)
+			}
+		}
+	}
+	return nil
+}
+
+func (t *TypeIndexer) value(body zcode.Bytes) {
+	t.Table.Enter(string(body), nil)
+}

--- a/cmd/sst/create/command.go
+++ b/cmd/sst/create/command.go
@@ -1,0 +1,63 @@
+package create
+
+import (
+	"errors"
+	"flag"
+	"os"
+
+	"github.com/brimsec/zq/cmd/sst/root"
+	"github.com/brimsec/zq/pkg/sst"
+	"github.com/mccanne/charm"
+)
+
+var Create = &charm.Spec{
+	Name:  "create",
+	Usage: "create [-f framesize] [ -o file ] <key-value-file>",
+	Short: "generate an sst file from a tsv file",
+	Long: `
+The create command generates an sst containing string keys and binary values.
+Each line in the input file constists of key as a hex string optionally
+followed by a colon and a hex string the key's value.  A nil value is represented
+with no characters (i.e., string key, colon, then newline)`,
+	New: newCreateCommand,
+}
+
+func init() {
+	root.Sst.Add(Create)
+}
+
+type CreateCommand struct {
+	*root.Command
+	framesize  int
+	outputFile string
+	inputFile  string
+}
+
+func newCreateCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &CreateCommand{Command: parent.(*root.Command)}
+	f.IntVar(&c.framesize, "f", 32*1024, "minimum frame size used in SST file")
+	f.StringVar(&c.outputFile, "o", "sst", "output file name")
+	return c, nil
+}
+
+func (c *CreateCommand) Run(args []string) error {
+	if len(args) != 1 {
+		return errors.New("must specify a single input file containing keys and optional values")
+	}
+	path := args[0]
+	in, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	table := NewTable()
+	if err := table.Scan(in); err != nil {
+		return err
+	}
+	writer, err := sst.NewWriter(c.outputFile, c.framesize, 0)
+	if err != nil {
+		return err
+	}
+	defer writer.Close()
+	return sst.Copy(writer, table)
+}

--- a/cmd/sst/create/table.go
+++ b/cmd/sst/create/table.go
@@ -1,0 +1,92 @@
+package create
+
+import (
+	"bufio"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/brimsec/zq/pkg/sst"
+)
+
+// Table reads a TSV file with a key and value expressed as hex strings and
+// implements the sst.Reader interface to enumerate the key/value pairs found.
+// If just a key without any integers is listed on a line, then an empty value
+// is assumed.
+type Table struct {
+	table  map[string][]byte
+	keys   []string
+	offset int
+}
+
+func NewTable() *Table {
+	return &Table{
+		table: make(map[string][]byte),
+	}
+}
+
+func (t *Table) Scan(f *os.File) error {
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fmt.Println(scanner.Text())
+		if err := t.parse(scanner.Text()); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}
+
+func (t *Table) parse(line string) error {
+	keyval := strings.Split(line, ":")
+	var value []byte
+	switch len(keyval) {
+	default:
+		//XXX bad input... ignore for now
+		return nil
+	case 1:
+		// value is empty
+	case 2:
+		var err error
+		value, err = hex.DecodeString(keyval[1])
+		if err != nil {
+			return err
+		}
+	}
+	key := keyval[0]
+	t.table[key] = value
+	return nil
+}
+
+func (t *Table) Read() (sst.Pair, error) {
+	off := t.offset
+	if off >= len(t.keys) {
+		return sst.Pair{}, nil
+	}
+	key := t.keys[off]
+	t.offset = off + 1
+	// note value can be nil
+	return sst.Pair{[]byte(key), t.table[key]}, nil
+}
+
+func (t *Table) Open() error {
+	n := len(t.table)
+	if n == 0 {
+		return nil
+	}
+	t.keys = make([]string, n)
+	k := 0
+	for key := range t.table {
+		t.keys[k] = key
+		k++
+	}
+	sort.Strings(t.keys)
+	t.offset = 0
+	return nil
+}
+
+func (t *Table) Close() error {
+	t.keys = nil
+	return nil
+}

--- a/cmd/sst/dump/command.go
+++ b/cmd/sst/dump/command.go
@@ -1,0 +1,100 @@
+package dump
+
+import (
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/brimsec/zq/cmd/sst/root"
+	"github.com/brimsec/zq/pkg/sst"
+	"github.com/mccanne/charm"
+)
+
+var Dump = &charm.Spec{
+	Name:  "dump",
+	Usage: "dump [-l level] [-k key] <file>",
+	Short: "dump the contents of an sst index or file",
+	Long: `
+The dump command prints out the keys and offsets of a frame in an sst file,
+or the keys within a frame indicated by the key parameter as hex strings.
+If level is 0, then the key/value pairs are displayed.  If level is 1 or higher,
+then the index is displayed as a sequence of base keys and file offsets where
+the offset is the offset in the file below the index one lower in the hierarchy
+where that key is defined.`,
+	New: newDumpCommand,
+}
+
+func init() {
+	root.Sst.Add(Dump)
+}
+
+type DumpCommand struct {
+	*root.Command
+	level int
+}
+
+func newDumpCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &DumpCommand{Command: parent.(*root.Command)}
+	f.IntVar(&c.level, "l", 0, "sst level to dump")
+	return c, nil
+}
+
+func (c *DumpCommand) dumpBase(path string) error {
+	reader := sst.NewReader(path)
+	if err := reader.Open(); err != nil {
+		return err
+	}
+	defer reader.Close()
+	for {
+		pair, err := reader.Read()
+		if err != nil {
+			return err
+		}
+		if pair.Key == nil {
+			return nil
+		}
+		fmt.Printf("%s:%s\n", format(pair.Key), format(pair.Value))
+	}
+	return nil
+}
+
+func (c *DumpCommand) dumpIndex(path string, level int) error {
+	reader := sst.NewIndexReader(path, level)
+	if err := reader.Open(); err != nil {
+		return err
+	}
+	defer reader.Close()
+	for {
+		key, off, err := reader.Read()
+		if err != nil {
+			return err
+		}
+		if key == nil {
+			return nil
+		}
+		fmt.Printf("%s:%d\n", format(key), off)
+	}
+	return nil
+}
+
+func (c *DumpCommand) Run(args []string) error {
+	if len(args) != 1 {
+		return errors.New("sst dump: must be run with a single file argument")
+	}
+	path := args[0]
+	if c.level == 0 {
+		return c.dumpBase(path)
+	} else {
+		return c.dumpIndex(path, c.level)
+	}
+	return nil
+}
+
+func format(b []byte) string {
+	if len(b) == 0 {
+		//XXX should just omit the value for these
+		return "<empty>"
+	}
+	return hex.EncodeToString(b)
+}

--- a/cmd/sst/lookup/command.go
+++ b/cmd/sst/lookup/command.go
@@ -1,0 +1,66 @@
+package lookup
+
+import (
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/brimsec/zq/cmd/sst/root"
+	"github.com/brimsec/zq/pkg/sst"
+	"github.com/mccanne/charm"
+)
+
+var Lookup = &charm.Spec{
+	Name:  "lookup",
+	Usage: "lookup -k <key> <file>",
+	Short: "lookup a key in an sst file and print value as hex bytes",
+	Long: `
+The lookup command uses the index files of an sst hierarchy to locate the
+specified key in the base sst file and displays the value as bytes.`,
+	New: newLookupCommand,
+}
+
+func init() {
+	root.Sst.Add(Lookup)
+}
+
+type LookupCommand struct {
+	*root.Command
+	key string
+}
+
+func newLookupCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &LookupCommand{Command: parent.(*root.Command)}
+	f.StringVar(&c.key, "k", "", "key to search")
+	return c, nil
+}
+
+func (c *LookupCommand) Run(args []string) error {
+	if len(args) != 1 {
+		return errors.New("sst dump: must be run with a single file argument")
+	}
+	path := args[0]
+	if c.key == "" {
+		return errors.New("must specify a key")
+	}
+	key, err := hex.DecodeString(c.key)
+	if err != nil {
+		return err
+	}
+	finder, err := sst.NewFinder(path)
+	if err != nil {
+		return err
+	}
+	defer finder.Close()
+	val, err := finder.Lookup(key)
+	if err != nil {
+		return err
+	}
+	if val == nil {
+		fmt.Println("not found")
+	} else {
+		fmt.Println(hex.EncodeToString(val))
+	}
+	return nil
+}

--- a/cmd/sst/main.go
+++ b/cmd/sst/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	_ "github.com/brimsec/zq/cmd/sst/create"
+	_ "github.com/brimsec/zq/cmd/sst/dump"
+	_ "github.com/brimsec/zq/cmd/sst/lookup"
+	_ "github.com/brimsec/zq/cmd/sst/merge"
+	"github.com/brimsec/zq/cmd/sst/root"
+)
+
+func main() {
+	//XXX Seed
+	rand.Seed(time.Now().UTC().UnixNano())
+	_, err := root.Sst.ExecRoot(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/sst/merge/command.go
+++ b/cmd/sst/merge/command.go
@@ -1,0 +1,68 @@
+package merge
+
+import (
+	"errors"
+	"flag"
+
+	"github.com/brimsec/zq/cmd/sst/root"
+	"github.com/brimsec/zq/pkg/sst"
+	"github.com/mccanne/charm"
+)
+
+var Merge = &charm.Spec{
+	Name:  "merge",
+	Usage: "merge [ -f framesize ] -o file file1, file2, ...  ",
+	Short: "merge two or sst files into the output file",
+	Long: `
+The merge command takes two or more sst files as input and presumes the
+values are roaring bitmaps.  It merges the input files into
+a new file, as specified by the -o argument, while preserving
+the lexicographic order of the keys and performing a bitwise OR of the roaring
+bitmap values.`,
+	New: newMergeCommand,
+}
+
+func init() {
+	root.Sst.Add(Merge)
+}
+
+type MergeCommand struct {
+	*root.Command
+	oflag     string
+	framesize int
+}
+
+func newMergeCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &MergeCommand{Command: parent.(*root.Command)}
+	f.IntVar(&c.framesize, "f", 32*1024, "minimum frame size used in the output sst file")
+	f.StringVar(&c.oflag, "o", "", "output file name")
+	return c, nil
+}
+
+// The combine function depends on the underlying data type but here as
+// an example, we simply contenate the values.
+func combine(a, b []byte) []byte {
+	out := make([]byte, 0, len(a)+len(b))
+	out = append(out, a...)
+	return append(out, b...)
+}
+
+func (c *MergeCommand) Run(args []string) error {
+	if len(args) < 2 {
+		return errors.New("must specify at least two input files")
+	}
+	if c.oflag == "" {
+		return errors.New("must specify output file with -o")
+	}
+	var files []sst.Stream
+	for _, fname := range args {
+		files = append(files, sst.NewReader(fname))
+	}
+	combiner := sst.NewCombiner(files, combine)
+	defer combiner.Close()
+	writer, err := sst.NewWriter(c.oflag, c.framesize, 0)
+	if err != nil {
+		return err
+	}
+	return sst.Copy(writer, combiner)
+}

--- a/cmd/sst/merge/command.go
+++ b/cmd/sst/merge/command.go
@@ -17,8 +17,7 @@ var Merge = &charm.Spec{
 The merge command takes two or more sst files as input and presumes the
 values are roaring bitmaps.  It merges the input files into
 a new file, as specified by the -o argument, while preserving
-the lexicographic order of the keys and performing a bitwise OR of the roaring
-bitmap values.`,
+the lexicographic order of the keys and concatenating the values.`,
 	New: newMergeCommand,
 }
 

--- a/cmd/sst/root/command.go
+++ b/cmd/sst/root/command.go
@@ -1,0 +1,29 @@
+package root
+
+import (
+	"flag"
+
+	"github.com/mccanne/charm"
+)
+
+var Sst = &charm.Spec{
+	Name:  "sst",
+	Usage: "sst <command> [options] [arguments...]",
+	Short: "use sst to test/debug boom sst files",
+	Long: `
+sst is command-line utility useful for debugging the sst packaging and
+interrogating sst files that are corrected by a client of sst.`,
+	New: func(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+		return &Command{}, nil
+	},
+}
+
+func init() {
+	Sst.Add(charm.Help)
+}
+
+type Command struct{}
+
+func (c *Command) Run(args []string) error {
+	return charm.ErrNoRun
+}

--- a/cmd/zar/find/command.go
+++ b/cmd/zar/find/command.go
@@ -1,0 +1,67 @@
+package index
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+
+	"github.com/brimsec/zq/archive"
+	"github.com/brimsec/zq/cmd/zar/root"
+	"github.com/mccanne/charm"
+)
+
+var Find = &charm.Spec{
+	Name:  "find",
+	Usage: "find [-d dir] <ip>",
+	Short: "look through zar index files and displays matches",
+	Long: `
+"zar find" descends the directory given by the argument looking for bzng files that have
+a corresponding zar index and if that index contains the <ip> argument,
+then the path of the zng file is printed.
+The current version supports only IP address, but this will soon change.
+`,
+	New: New,
+}
+
+func init() {
+	root.Zar.Add(Find)
+}
+
+type Command struct {
+	*root.Command
+	dir string
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	f.StringVar(&c.dir, "d", ".", "directory to descend")
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	if len(args) != 1 {
+		return errors.New("zar find: no search pattern provided")
+	}
+	//XXX presume ip address
+	pattern := net.ParseIP(args[0])
+	if pattern == nil {
+		//XXX
+		return errors.New("zar find: invalid IP address: " + args[0])
+	}
+	// Convert IP to 4-byte version as this is how IP keys are stored
+	ip := pattern.To4()
+	if ip != nil {
+		pattern = ip
+	}
+	hits, err := archive.Find(c.dir, pattern)
+	if err != nil {
+		return err
+	}
+	//XX should stream hits as they are found instead of collecting them
+	// all up them dumping the slice to stdout
+	for _, hit := range hits {
+		fmt.Println(hit)
+	}
+	return nil
+}

--- a/cmd/zar/index/command.go
+++ b/cmd/zar/index/command.go
@@ -15,7 +15,7 @@ var Index = &charm.Spec{
 	Short: "creates index files for bzng files",
 	Long: `
 zar find descends the directory argument looking for bzng files and creates an index
-file for IP addresses for each bzng file encountered.  An index is writted to
+file for IP addresses for each bzng file encountered.  An index is written to
 a sub-directory of the directory containing each encountered bzng file, where the
 name of the sub-directory is a concatenation of the bzng file name and the suffix
 ".zar".

--- a/cmd/zar/index/command.go
+++ b/cmd/zar/index/command.go
@@ -1,0 +1,46 @@
+package index
+
+import (
+	"errors"
+	"flag"
+
+	"github.com/brimsec/zq/archive"
+	"github.com/brimsec/zq/cmd/zar/root"
+	"github.com/mccanne/charm"
+)
+
+var Index = &charm.Spec{
+	Name:  "index",
+	Usage: "index dir",
+	Short: "creates index files for bzng files",
+	Long: `
+zar find descends the directory argument looking for bzng files and creates an index
+file for IP addresses for each bzng file encountered.  An index is writted to
+a sub-directory of the directory containing each encountered bzng file, where the
+name of the sub-directory is a concatenation of the bzng file name and the suffix
+".zar".
+The current version supports only IP address, but this will soon change.
+`,
+	New: New,
+}
+
+func init() {
+	root.Zar.Add(Index)
+}
+
+type Command struct {
+	*root.Command
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	if len(args) != 1 {
+		return errors.New("zar index: exactly one directory must be specified")
+	}
+	dir := args[0]
+	return archive.CreateIndexes(dir)
+}

--- a/cmd/zar/main.go
+++ b/cmd/zar/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	_ "github.com/brimsec/zq/cmd/zar/find"
+	_ "github.com/brimsec/zq/cmd/zar/index"
+	"github.com/brimsec/zq/cmd/zar/root"
+)
+
+// Version is set via the Go linker.
+var version = "unknown"
+
+func main() {
+	//XXX
+	//root.Version = version
+	if _, err := root.Zar.ExecRoot(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/zar/root/command.go
+++ b/cmd/zar/root/command.go
@@ -1,0 +1,33 @@
+package root
+
+import (
+	"flag"
+
+	"github.com/mccanne/charm"
+)
+
+var Zar = &charm.Spec{
+	Name:  "zar",
+	Usage: "zar [global options] command [options] [arguments...]",
+	Short: "create and search zng archives",
+	Long: `
+zar creates and searches index files for zng files.
+`,
+	New: New,
+}
+
+type Command struct {
+	charm.Command
+}
+
+func init() {
+	Zar.Add(charm.Help)
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	return &Command{}, nil
+}
+
+func (c *Command) Run(args []string) error {
+	return Zar.Exec(c, []string{"help"})
+}

--- a/pkg/sst/combiner.go
+++ b/pkg/sst/combiner.go
@@ -1,0 +1,90 @@
+package sst
+
+import (
+	"bytes"
+)
+
+type Combine func([]byte, []byte) []byte
+
+// Combiner reads from two or more Streams, implementing a new Stream from
+// the merged streams, while preserving the lexicographic order of the keys.
+// It calls the combine function to merge values that have the same key.
+type Combiner struct {
+	combine func([]byte, []byte) []byte
+	streams []Stream
+	done    []bool
+	hol     []Pair // head of line for each stream
+}
+
+// NewCombiner returns a new combiner
+func NewCombiner(streams []Stream, f Combine) *Combiner {
+	return &Combiner{
+		combine: f,
+		streams: streams,
+		hol:     make([]Pair, len(streams)),
+		done:    make([]bool, len(streams)),
+	}
+}
+
+func (c *Combiner) Open() error {
+	for k, s := range c.streams {
+		if err := s.Open(); err != nil {
+			return err
+		}
+		c.hol[k].Value = nil
+		c.done[k] = false
+	}
+	return nil
+}
+
+func (c *Combiner) Read() (Pair, error) {
+	// XXX if this gets big, we can optimize by creating a mergesort tree...
+	var minkey []byte
+	for k := range c.streams {
+		if c.done[k] {
+			continue
+		}
+		if c.hol[k].Value == nil {
+			pair, err := c.streams[k].Read()
+			if err != nil {
+				return Pair{}, err
+			}
+			if pair.Value == nil {
+				c.done[k] = true
+				continue
+			}
+			c.hol[k] = pair
+		}
+		if minkey == nil || bytes.Compare(c.hol[k].Key, minkey) < 0 {
+			minkey = c.hol[k].Key
+		}
+	}
+	if minkey == nil {
+		return Pair{}, nil
+	}
+	var val []byte
+	for k := range c.streams {
+		if c.hol[k].Value != nil && bytes.Equal(minkey, c.hol[k].Key) {
+			if val == nil {
+				val = c.hol[k].Value
+			} else {
+				// XXX this could be more efficient if we bundle
+				// multiple values to be combined all at once
+				// in the client domain rather than converting
+				// to/from byte slice
+				val = c.combine(val, c.hol[k].Value)
+			}
+			c.hol[k].Value = nil
+		}
+	}
+	return Pair{minkey, val}, nil
+}
+
+func (c *Combiner) Close() error {
+	for _, s := range c.streams {
+		if err := s.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/sst/combiner_test.go
+++ b/pkg/sst/combiner_test.go
@@ -1,0 +1,45 @@
+package sst_test
+
+import (
+	"testing"
+
+	"github.com/brimsec/zq/pkg/sst"
+	"github.com/stretchr/testify/assert"
+)
+
+func pair(key string) sst.Pair {
+	return sst.Pair{[]byte(key), []byte("value")}
+}
+
+type streamtest []sst.Pair
+
+func (s streamtest) Open() error  { return nil }
+func (s streamtest) Close() error { return nil }
+
+func (s *streamtest) Read() (sst.Pair, error) {
+	var pair sst.Pair
+	slice := *s
+	if len(slice) > 0 {
+		pair = slice[0]
+		*s = slice[1:]
+	}
+	return pair, nil
+}
+
+func TestCombinerOrder(t *testing.T) {
+	s1 := &streamtest{pair("1"), pair("3"), pair("5")}
+	s2 := &streamtest{pair("2"), pair("4"), pair("6")}
+	c := sst.NewCombiner([]sst.Stream{s1, s2}, func(a, b []byte) []byte {
+		return []byte("combined")
+	})
+	assert.NoError(t, c.Open())
+	var keys []string
+	for {
+		p, _ := c.Read()
+		if p.Key == nil {
+			break
+		}
+		keys = append(keys, string(p.Key))
+	}
+	assert.Equal(t, []string{"1", "2", "3", "4", "5", "6"}, keys)
+}

--- a/pkg/sst/counter.go
+++ b/pkg/sst/counter.go
@@ -1,0 +1,22 @@
+package sst
+
+import "sync/atomic"
+
+// Counter wraps a Stream and provides a method to return the number
+// of Pairs read from the stream.
+type Counter struct {
+	Stream
+	counter *int64
+}
+
+func NewCounter(s Stream, p *int64) Stream {
+	return &Counter{Stream: s, counter: p}
+}
+
+func (c *Counter) Read() (Pair, error) {
+	p, err := c.Stream.Read()
+	if p.Key != nil {
+		atomic.AddInt64(c.counter, 1)
+	}
+	return p, err
+}

--- a/pkg/sst/finder.go
+++ b/pkg/sst/finder.go
@@ -1,0 +1,115 @@
+package sst
+
+import (
+	"bytes"
+	"os"
+)
+
+// Finder looks up values in an SST file using the hierarchical index files.
+type Finder struct {
+	files []*FrameReader
+}
+
+// NewFinder returns an object that is used to lookup keys in an SST.
+func NewFinder(path string) (*Finder, error) {
+	level := 0
+	f := &Finder{}
+	for {
+		r := NewFrameReader(path, level)
+		if err := r.Open(); err != nil {
+			if os.IsNotExist(err) {
+				break
+			}
+			if len(f.files) > 0 {
+				// Ignore this error; the prior is more
+				// interesting.
+				_ = f.Close()
+			}
+			return nil, err
+		}
+		level += 1
+		f.files = append(f.files, r)
+	}
+	if len(f.files) == 0 {
+		return nil, os.ErrNotExist
+	}
+	return f, nil
+}
+
+func (f *Finder) Close() error {
+	for _, r := range f.files {
+		if err := r.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// find the largest key that is smaller than the input key and
+// return the value interpreted as a 6-byte offset
+func lookupOffset(key, buf []byte) (int64, error) {
+	var lastOff int64 = -1
+	for len(buf) > 10 {
+		k, off, n := DecodeIndex(buf)
+		if k == nil {
+			return -1, ErrCorruptFile
+		}
+		if bytes.Compare(key, k) < 0 {
+			break
+		}
+		lastOff = off
+		buf = buf[n:]
+	}
+	return lastOff, nil
+}
+
+// find an exact match for the key and return the corresponding value
+// if no match exists, return nil
+func lookupValue(key, buf []byte) ([]byte, error) {
+	for len(buf) > 8 {
+		pair, n := DecodePair(buf)
+		if pair.Key == nil {
+			return nil, ErrCorruptFile
+		}
+		if bytes.Equal(key, pair.Key) {
+			return pair.Value, nil
+		}
+		buf = buf[n:]
+	}
+	return nil, nil
+}
+
+func (f *Finder) Lookup(key []byte) ([]byte, error) {
+	n := len(f.files)
+	if n == 0 {
+		//XXX
+		return nil, ErrCorruptFile
+	}
+	// We start with the topmost file (which always is one frame) and
+	// find the greatest key smaller than the lookup key then repeat
+	// the process for that frame in the next index file till we get to the
+	// base file and we look for the exact key.
+	level := n - 1
+	off := int64(FileHeaderLen)
+	for level > 0 {
+		frame, err := f.files[level].ReadFrameAt(off)
+		if err != nil {
+			return nil, err
+		}
+		off, err = lookupOffset(key, frame)
+		if err != nil {
+			return nil, err
+		}
+		if off == -1 {
+			// This key can't be in the sst since it is smaller than
+			// the smallest key in the sst's index files.
+			return nil, nil
+		}
+		level -= 1
+	}
+	frame, err := f.files[level].ReadFrameAt(off)
+	if err != nil {
+		return nil, err
+	}
+	return lookupValue(key, frame)
+}

--- a/pkg/sst/mem.go
+++ b/pkg/sst/mem.go
@@ -1,0 +1,59 @@
+package sst
+
+import (
+	"errors"
+	"sort"
+)
+
+// MemTable implements a simple stub for an in-memory SST Reader.  This is
+// useful for testing and reference.  An SST client will typically implement its
+// own in-memory data structure that provides a Reader implementation to convert
+// custom key/value pairs into string/byte-slice pairs.
+type MemTable struct {
+	table  map[string][]byte
+	keys   []string
+	offset int
+}
+
+func NewMemTable() *MemTable {
+	return &MemTable{table: make(map[string][]byte)}
+}
+
+func (t *MemTable) Read() (Pair, error) {
+	off := t.offset
+	if off >= len(t.keys) {
+		return Pair{nil, nil}, nil
+	}
+	key := t.keys[off]
+	value := t.table[key]
+	t.offset = off + 1
+	return Pair{[]byte(key), value}, nil
+}
+
+func (t *MemTable) Size() int {
+	return len(t.table)
+}
+
+func (t *MemTable) Open() error {
+	n := len(t.table)
+	if n == 0 {
+		return errors.New("no data")
+	}
+	t.keys = make([]string, n)
+	k := 0
+	for key := range t.table {
+		t.keys[k] = key
+		k++
+	}
+	sort.Strings(t.keys)
+	t.offset = 0
+	return nil
+}
+
+func (t *MemTable) Close() error {
+	return nil
+}
+
+func (t *MemTable) Enter(key string, value []byte) {
+	t.table[key] = value
+}

--- a/pkg/sst/peeker.go
+++ b/pkg/sst/peeker.go
@@ -1,0 +1,32 @@
+package sst
+
+// Peeker wraps a Stream while adding a Peek method, which allows inspection
+// of the next item to be read without actually reading it.
+type Peeker struct {
+	Stream
+	cache Pair
+}
+
+func NewPeeker(s Stream) *Peeker {
+	return &Peeker{Stream: s}
+}
+
+func (p *Peeker) Peek() (Pair, error) {
+	if p.cache.Key == nil {
+		var err error
+		p.cache, err = p.Stream.Read()
+		if err != nil {
+			return Pair{}, err
+		}
+	}
+	return p.cache, nil
+}
+
+func (p *Peeker) Read() (Pair, error) {
+	v := p.cache
+	if v.Key != nil {
+		p.cache = Pair{}
+		return v, nil
+	}
+	return p.Stream.Read()
+}

--- a/pkg/sst/reader.go
+++ b/pkg/sst/reader.go
@@ -1,0 +1,241 @@
+package sst
+
+import (
+	"io"
+	"os"
+)
+
+type reader struct {
+	filename string
+	file     *os.File
+	frame    []byte
+	valsize  int
+}
+
+// Reader reads an SST file and implements the Stream interface.
+type Reader struct {
+	reader
+	in []byte
+}
+
+func (r *reader) init(path string, level int) {
+	r.filename = filename(path, level)
+}
+
+// NewReader returns a Reader ready to read an SST file.
+// Close() should be called when done.
+func NewReader(path string) *Reader {
+	r := &Reader{}
+	r.init(path, 0)
+	return r
+}
+
+func (r *reader) Open() error {
+	var err error
+	if r.file, err = os.Open(r.filename); err != nil {
+		return err
+	}
+	return r.readFileHeader()
+}
+
+func (r *reader) readFileHeader() error {
+	var hdr [FileHeaderLen]byte
+	n, err := r.file.Read(hdr[:])
+	if err != nil {
+		return err
+	}
+	if n != FileHeaderLen {
+		return ErrCorruptFile
+	}
+	if decodeInt(hdr[0:4]) != magic {
+		return ErrBadMagic
+	}
+	if versionMajor != hdr[4] || versionMinor != hdr[5] {
+		return ErrFileVersion
+	}
+	r.valsize = decodeInt(hdr[6:10])
+	//XXX
+	if r.valsize > 10*1024*1024 {
+		return ErrCorruptFile
+	}
+	framesize := decodeInt(hdr[10:14])
+	//XXX
+	if framesize > 10*1024*1024 {
+		return ErrCorruptFile
+	}
+	r.frame = make([]byte, 0, framesize)
+	return nil
+}
+
+func (r *reader) Close() error {
+	err := r.file.Close()
+	r.file = nil
+	return err
+}
+
+func (r *Reader) readInt() (int, error) {
+	if len(r.in) < 4 {
+		return 0, ErrCorruptFile
+	}
+	v := decodeInt(r.in)
+	r.in = r.in[4:]
+	return v, nil
+}
+
+func (r *Reader) decode() ([]byte, error) {
+	n, err := r.readInt()
+	if err != nil {
+		return nil, err
+	}
+	if n > len(r.in) {
+		return nil, ErrCorruptFile
+	}
+	value := r.in[:n]
+	r.in = r.in[n:]
+	return value, nil
+}
+
+func (r *Reader) Read() (Pair, error) {
+	if len(r.in) == 0 {
+		if err := r.readFrame(); err != nil {
+			if err == io.EOF {
+				return Pair{}, nil
+			}
+			return Pair{}, err
+		}
+	}
+	key, err := r.decode()
+	if err != nil {
+		return Pair{}, err
+	}
+	value, err := r.decode()
+	if err != nil {
+		return Pair{}, err
+	}
+	// this key and value point into the frame buffer so the caller
+	// needs to copy them before the next call to read
+	// XXX for a merge we don't need to convert to a string
+	return Pair{key, value}, nil
+}
+
+func (r *reader) grow(target int) {
+	size := cap(r.frame)
+	for size < target {
+		size *= 2
+	}
+	r.frame = make([]byte, 0, target)
+}
+
+func (r *Reader) readFrame() error {
+	var hdr [5]byte
+	hdr[0] = 0 // compression type XXX
+	n, err := r.file.Read(hdr[:])
+	if err != nil {
+		return err
+	}
+	if n < 5 {
+		return ErrCorruptFile
+	}
+	flen := decodeInt(hdr[1:])
+	if cap(r.frame) < flen {
+		r.grow(flen)
+	}
+	r.in = r.frame[:flen]
+	n, err = r.file.Read(r.in)
+	if err != nil {
+		return err
+	}
+	if n != flen {
+		return ErrCorruptFile
+	}
+	return nil
+}
+
+type FrameReader struct {
+	reader
+}
+
+func NewFrameReader(path string, level int) *FrameReader {
+	r := &FrameReader{}
+	r.init(path, level)
+	return r
+}
+
+func (r *FrameReader) ReadFrameAt(off int64) ([]byte, error) {
+	var hdr [FrameHeaderLen]byte
+	n, err := r.file.ReadAt(hdr[:], off)
+	if err != nil {
+		return nil, err
+	}
+	if n != FrameHeaderLen {
+		return nil, ErrCorruptFile
+	}
+	framelen := decodeInt(hdr[1:5])
+	//XXX
+	if framelen > 10*1024*1024 {
+		return nil, ErrCorruptFile
+	}
+	r.grow(framelen)
+	n, err = r.file.ReadAt(r.frame[0:framelen], off+FrameHeaderLen)
+	if err != nil {
+		return nil, err
+	}
+	if n != framelen {
+		return nil, ErrCorruptFile
+	}
+	return r.frame[:framelen], nil
+}
+
+func (r *FrameReader) ReadFrame() ([]byte, error) {
+	var hdr [FrameHeaderLen]byte
+	n, err := r.file.Read(hdr[:])
+	if err != nil {
+		return nil, err
+	}
+	if n != FrameHeaderLen {
+		return nil, ErrCorruptFile
+	}
+	framelen := decodeInt(hdr[1:5])
+	//XXX
+	if framelen > 10*1024*1024 {
+		return nil, ErrCorruptFile
+	}
+	r.grow(framelen)
+	n, err = r.file.Read(r.frame[0:framelen])
+	if err != nil {
+		return nil, err
+	}
+	if n != framelen {
+		return nil, ErrCorruptFile
+	}
+	return r.frame[:framelen], nil
+}
+
+type IndexReader struct {
+	Reader
+}
+
+func NewIndexReader(path string, level int) *IndexReader {
+	r := &IndexReader{}
+	r.init(path, level)
+	return r
+}
+
+func (r *IndexReader) Read() ([]byte, int64, error) {
+	if len(r.in) == 0 {
+		if err := r.readFrame(); err != nil {
+			if err == io.EOF {
+				return nil, 0, nil
+			}
+			return nil, 0, err
+		}
+	}
+	key, off, n := DecodeIndex(r.in)
+	if off < 0 {
+		return nil, 0, ErrCorruptFile
+	}
+	r.in = r.in[n:]
+	// this key and value point into the frame buffer so the caller
+	// needs to copy them before the next call to read
+	return key, off, nil
+}

--- a/pkg/sst/sst.go
+++ b/pkg/sst/sst.go
@@ -1,0 +1,251 @@
+// Package sst provides an API for creating, merging, indexing, and querying sorted string
+// tables (SST), a la LSM trees, where an SST holds a sequence of key,value pairs
+// and the pairs are sorted by key.  The keys and the values are stored as
+// byte slices.
+//
+// A table always starts out in memory then is written to storage using
+// a Writer.  Tables can be combined with a Combiner.  They are merged in an
+// efficient LSM like fashion.
+//
+// A table on disk consists of the base table with zero or more index files.
+// These files are all named with the same path prefix, e.g., "sst", where the
+// base table is sst and the index files, if any, are sst.1, sst.2, sst.3,
+// and so forth.  The index files can always be recreated from the base table.
+//
+// A file constists of a sequence of frames, where each frame consists of a
+// frame header, indicating its length (on disk) and compression type, followed
+// by a possibly compressed body, where the body costs of a sequence of key, value
+// pairs.  Each key and each value is encoded as a 4-byte length and sequence of bytes
+// representing the key's string or the value's byte slice.  The body is compressed
+// according to the compression type.
+//
+// When an SST file has values of all the same length, the length is indicated
+// in the file header and omitted from each key-value pair.  XXX we could do
+// the same for the key, but haven't done so yet.
+//
+// An index file contains a key,value pair for each frame in the file below
+// in the hiearchy where the key is the first key found in that frame and
+// the value is the offset or the frame in the file below.  Each frame in an
+// index file is terminated with an end-of-frame key whose value is the
+// beginning key of the next frame.
+package sst
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+)
+
+var (
+	ErrCorruptFile = errors.New("corrupt SST file")
+	ErrValueSize   = errors.New("bad value size")
+	ErrBadMagic    = errors.New("bad magic number in header of SST file")
+	ErrFileVersion = errors.New("unsupported version number in SST file")
+	ErrPairTooBig  = errors.New("length of a single key/value larger than frame")
+)
+
+const (
+	magic        = 0xfeed2019
+	versionMajor = 1
+	versionMinor = 0
+
+	// File header format is in big-endian format comprising:
+	// 4 bytes of magic
+	// one byte of major version
+	// one byte of minor version
+	// 4 bytes length of the values, when all the
+	//     values have the same size (in which case we don't need to encode
+	//     the value length with each value), or 0 for variable length values.
+	// 4 bytes length of the minimum frame size
+	FileHeaderLen = 14
+
+	// Frame header format is in big-endian format comprising:
+	// one byte of compression type
+	// 4 bytes length of the frame (in uncompressed bytes)
+	FrameHeaderLen = 5
+)
+
+type Pair struct {
+	Key   []byte
+	Value []byte
+}
+
+// Stream is an interface to enumerate all the key/values from an SST.
+// A stream may be generated from an in-memory table, from a table on disk,
+// from a combiner that combines two or more such tables from memory and/or disk,
+// or from a custom implementation of the interface.
+type Stream interface {
+	// Open positions the reader at the lowest valued key so that Read() may
+	// enumerate all the keys from the SST in sorted order.  Close() should
+	// be called after the caller is done reading, at which time, Open() can
+	// be called again.
+	Open() error
+	// Read returns the next key/value pair (or an error) in the enumeration
+	// of key/values from the SST and returns zero values at end of table.
+	// The byte slices of the pair should be copied by the caller if the
+	// want to be retained beyond the next call to Read.
+	Read() (Pair, error)
+	// Close releases the underlying resources associated with the Stream
+	Close() error
+}
+
+func filename(path string, level int) string {
+	if level == 0 {
+		return path
+	}
+	return fmt.Sprintf("%s.%d", path, level)
+}
+
+func Remove(path string) error {
+	level := 0
+	for {
+		err := os.Remove(filename(path, level))
+		if err != nil {
+			if os.IsNotExist(err) {
+				err = nil
+			}
+			return err
+		}
+		level++
+	}
+}
+
+func Rename(oldpath, newpath string) error {
+	level := 0
+	for {
+		err := os.Rename(filename(oldpath, level), filename(newpath, level))
+		if err != nil {
+			if os.IsNotExist(err) {
+				err = nil
+			}
+			return err
+		}
+		level++
+	}
+}
+
+func encodeInt(dst []byte, v int) {
+	// assume cap(dst) >= 4
+	dst[0] = byte(v >> 24)
+	dst[1] = byte(v >> 16)
+	dst[2] = byte(v >> 8)
+	dst[3] = byte(v)
+}
+
+func encodeInt48(dst []byte, v int64) {
+	// assume cap(dst) >= 6
+	dst[0] = byte(v >> 40)
+	dst[1] = byte(v >> 32)
+	dst[2] = byte(v >> 24)
+	dst[3] = byte(v >> 16)
+	dst[4] = byte(v >> 8)
+	dst[5] = byte(v)
+}
+
+func decodeInt(buf []byte) int {
+	v := int(buf[0]) << 24
+	v |= int(buf[1]) << 16
+	v |= int(buf[2]) << 8
+	v |= int(buf[3])
+	return v
+}
+
+func decodeInt48(buf []byte) int64 {
+	v := int64(buf[0]) << 40
+	v |= int64(buf[1]) << 32
+	v |= int64(buf[2]) << 24
+	v |= int64(buf[3]) << 16
+	v |= int64(buf[4]) << 8
+	v |= int64(buf[5])
+	return v
+}
+
+func decodeCounted(buf []byte) []byte {
+	n := decodeInt(buf[0:4])
+	buf = buf[4:]
+	if n > len(buf) {
+		return nil
+	}
+	return buf[:n]
+}
+
+// Copy copies src to dst a la io.Copy.  The src stream is opened, read from,
+// and closed in accordance with the interface.  The dst writer is written to
+// and closed.
+func Copy(dst *Writer, src Stream) error {
+	return CopyWithContext(context.Background(), dst, src)
+}
+
+// CopyWithContext is just like Copy except it will abruptly end and return
+// the context's error if it is canceled.  If the src was successfully opened,
+// it will be closed whether or not errors or canceled context arise.
+func CopyWithContext(ctx context.Context, dst *Writer, src Stream) error {
+	if err := src.Open(); err != nil {
+		return err
+	}
+	var err error
+	for ctx.Err() == nil {
+		var pair Pair
+		pair, err = src.Read()
+		if err != nil {
+			return err
+		}
+		if pair.Key == nil {
+			break
+		}
+		err = dst.Write(pair)
+		if err != nil {
+			return err
+		}
+	}
+	return ctx.Err()
+}
+
+//XXX
+func FirstKey(frame []byte) []byte {
+	return decodeCounted(frame)
+}
+
+// DecodePair decodes a key and a value from the base sst file.
+// To do so, it decodes a counted key and a counted value and returns
+// the key and value byte slices as a Pair.  If the buffer is
+// not large enough to decode these items, then the underlying data is
+// corrupt and a zero-valued Pair is returned.  The second return
+// value is the number of bytes consumed in decoding the Pair.
+func DecodePair(buf []byte) (Pair, int) {
+	n1 := decodeInt(buf[0:4])
+	if n1+4 > len(buf) {
+		return Pair{}, 0
+	}
+	n2 := decodeInt(buf[n1+4:])
+	n := n1 + n2 + 8
+	if n > len(buf) {
+		return Pair{}, 0
+	}
+	return Pair{buf[4 : n1+4], buf[n1+8 : n]}, n
+}
+
+// DecodeIndex decodes a key and a file offset where this entry points
+// to frame in that file (at the given offset) where keys with that
+// same key begin.  To do so, it decodes a counted key and a 6-byte
+// encoded offset and returns the key and the offset.  If the buffer is
+// not large enough to decode these items, then the underlying data is
+// corrupt and nil is returned for the key.  The third return value
+// is the number of bytes consumed in decoding the key,offset pair.
+func DecodeIndex(buf []byte) ([]byte, int64, int) {
+	n := decodeInt(buf[0:4])
+	if n+10 > len(buf) {
+		return nil, -1, 0
+	}
+	key := buf[4 : n+4]
+	off := decodeInt48(buf[n+4 : n+10])
+	return key, off, n + 10
+}
+
+// Equal returns true iff the underlying byte slice contents of the two keys and
+// and two values are equal to eachother.
+func (p Pair) Equal(v Pair) bool {
+	return bytes.Equal(p.Key, v.Key) && bytes.Equal(p.Value, v.Value)
+}

--- a/pkg/sst/sst_test.go
+++ b/pkg/sst/sst_test.go
@@ -1,0 +1,246 @@
+package sst_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/brimsec/zq/pkg/sst"
+	"github.com/stretchr/testify/assert"
+)
+
+type entryStream struct {
+	entries []sst.Pair
+	cursor  int
+}
+
+func newEntryStream(size int) *entryStream {
+	entries := make([]sst.Pair, size)
+	for i := 0; i < size; i++ {
+		entries[i] = sst.Pair{[]byte(fmt.Sprintf("port:port:%d", i)), []byte(fmt.Sprintf("%d", i))}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return bytes.Compare(entries[i].Key, entries[j].Key) < 0
+	})
+	return &entryStream{entries: entries}
+}
+
+func (s *entryStream) Open() error {
+	s.cursor = 0
+	return nil
+}
+
+func (s *entryStream) Close() error {
+	return nil
+}
+
+func (s entryStream) Len() int {
+	return len(s.entries)
+}
+
+func (s *entryStream) Read() (sst.Pair, error) {
+	if s.cursor >= len(s.entries) {
+		return sst.Pair{}, nil
+	}
+	e := s.entries[s.cursor]
+	s.cursor++
+	return e, nil
+}
+
+func buildTestTable(t *testing.T, entries []sst.Pair) string {
+	dir, err := ioutil.TempDir("", "table_test")
+	if err != nil {
+		t.Error(err)
+	}
+	path := filepath.Join(dir, "sst")
+	stream := &entryStream{entries: entries}
+	writer, err := sst.NewWriter(path, 32*1024, 0)
+	if err != nil {
+		t.Error(err)
+	}
+	defer writer.Close()
+	if err := sst.Copy(writer, stream); err != nil {
+		t.Error(err)
+	}
+	return path
+}
+
+/* XXX this goes in system tests?
+func TestReal(t *testing.T) {
+	tab, err := table.OpenTable("/Users/nibs/.boomd/wrccdc/2018/03/24/0/0/0/2i.sst")
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Println("searching for", ":port=63054")
+	value := tab.Search([]byte(":port=63054"))
+	fmt.Println("value", string(value))
+}
+
+func TestRead(t *testing.T) {
+	tab, err := table.OpenTable("/Users/nibs/.boomd/wrccdc/2018/03/24/0/0/0/2i.sst")
+	if err != nil {
+		t.Error(err)
+	}
+	itr := tab.Iterator()
+	for key, _ := itr.Next(); key != ""; key, _ = itr.Next() {
+		fmt.Println(string(key))
+	}
+	key, _ := itr.Next()
+	fmt.Println("lastone", key)
+	key, _ = itr.Next()
+	fmt.Println("lastone", key)
+}
+*/
+
+func sixPairs() []sst.Pair {
+	return []sst.Pair{
+		{[]byte("key1"), []byte("value1")},
+		{[]byte("key2"), []byte("value2")},
+		{[]byte("key3"), []byte("value3")},
+		{[]byte("key4"), []byte("value4")},
+		{[]byte("key5"), []byte("value5")},
+		{[]byte("key6"), []byte("value6")},
+	}
+}
+
+func TestSearch(t *testing.T) {
+	entries := sixPairs()
+	path := buildTestTable(t, entries)
+	defer os.RemoveAll(path) // nolint:errcheck
+	finder, err := sst.NewFinder(path)
+	if err != nil {
+		t.Error(err)
+	}
+	value, err := finder.Lookup([]byte("key2"))
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(value, []byte("value2")) {
+		t.Error("key lookup failed")
+	}
+}
+
+func TestPeeker(t *testing.T) {
+	stream := &entryStream{entries: sixPairs()}
+	peeker := sst.NewPeeker(stream)
+	pair1, err := peeker.Peek()
+	if err != nil {
+		t.Error(err)
+	}
+	pair2, err := peeker.Peek()
+	if err != nil {
+		t.Error(err)
+	}
+	if !pair1.Equal(pair2) {
+		t.Error("pair1 != pair2")
+	}
+	pair3, err := peeker.Read()
+	if err != nil {
+		t.Error(err)
+	}
+	if !pair1.Equal(pair3) {
+		t.Error("pair1 != pair3")
+	}
+	pair4, err := peeker.Peek()
+	if err != nil {
+		t.Error(err)
+	}
+	if pair3.Equal(pair4) {
+		t.Error("pair3 == pair4")
+	}
+	pair5, err := peeker.Read()
+	if err != nil {
+		t.Error(err)
+	}
+	if !pair4.Equal(pair5) {
+		t.Error("pair4 != pair5")
+	}
+}
+
+func TestSST(t *testing.T) {
+	dir, err := ioutil.TempDir("", "sst_test")
+	if err != nil {
+		t.Error(err)
+	}
+	const N = 5
+	defer os.RemoveAll(dir) //nolint:errcheck
+	path := filepath.Join(dir, "sst")
+	stream := newEntryStream(N)
+
+	writer, err := sst.NewWriter(path, 32*1024, 0)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := sst.Copy(writer, stream); err != nil {
+		t.Error(err)
+	}
+	writer.Close()
+	reader := sst.NewReader(path)
+	if err := reader.Open(); err != nil {
+		t.Error(err)
+	}
+	defer reader.Close() //nolint:errcheck
+	n := 0
+	for {
+		pair, err := reader.Read()
+		if pair.Key == nil {
+			break
+		}
+		if err != nil {
+			t.Error(err)
+		}
+		n++
+	}
+	assert.Exactly(t, N, n, "number of pairs read from sst file doesn't match number written")
+}
+
+/* not yet
+func BenchmarkWrite(b *testing.B) {
+	stream := newEntryStream(5 << 20)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dir, err := ioutil.TempDir("", "table_test")
+		if err != nil {
+			b.Error(err)
+		}
+		defer os.RemoveAll(dir)
+		path := filepath.Join(dir, "table.sst")
+		if err := table.BuildTable(path, stream); err != nil {
+			b.Error(err)
+		}
+		// tab, err := table.OpenTable(path)
+		// if err != nil {
+		// b.Error(err)
+		// }
+		// fmt.Println("table size: ", tab.Size())
+	}
+}
+
+func BenchmarkRead(b *testing.B) {
+	dir, err := ioutil.TempDir("", "table_test")
+	if err != nil {
+		b.Error(err)
+	}
+	defer os.RemoveAll(dir)
+	path := filepath.Join(dir, "table.sst")
+	stream := newEntryStream(5 << 20)
+	if err := table.BuildTable(path, stream); err != nil {
+		b.Error(err)
+	}
+	tab, err := table.OpenTable(path)
+	if err != nil {
+		b.Error(err)
+	}
+	// fmt.Println("table size: ", tab.Size())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		itr := tab.Iterator()
+		for key, _ := itr.Next(); key != ""; key, _ = itr.Next() {
+		}
+	}
+}
+*/

--- a/pkg/sst/writer.go
+++ b/pkg/sst/writer.go
@@ -1,0 +1,206 @@
+package sst
+
+import (
+	"os"
+)
+
+// Writer creates an SST file and related index files.
+// An SST file is a sequence of key,value pairs sorted lexicographically
+// by key.  On disk, the key is a counted string and the value is a counted
+// byte array (unless all the value sizes are the same, then the length is
+// encoded in the file header).
+// After the file is written, the index files comprise a
+// constant B-Tree to make key lookups efficient.  The index files
+// are written in the same fashion as the base SST file since an index
+// is simply an SST where the key is the key and the value is the offset
+// into the child file where that key is located.  The framesize parameter
+// indicates how many bytes to consume for before terminating a frame and
+// thus causing an index key to be written to the parent index file.
+// This process is repeated until the topmost parent file
+// has a sequence of key/offset pairs that fit in framesize bytes.
+type Writer struct {
+	path      string
+	framesize int // XXX we might want different sizes for base and index
+	level     int
+	file      *os.File
+	parent    *Writer
+	frame     []byte
+	frameKey  []byte
+	offset    int64
+	valsize   int
+	Stats     Stats
+}
+
+type Stats struct {
+	Count      int64
+	KeyBytes   int64
+	ValueBytes int64
+}
+
+// NewWriter returns a Writer ready to write an SST file and related
+// index files via subsequent calls to Write(), or it returns an error.
+// All files will be written to the directory indicated by path
+// with the form $path, $path.1, and so forth.  Calls to Write must
+// provide keys in increasing lexicographic order.  Duplicate keys are not
+// allowed but will not be detected.  Close() must be called when done writing.
+func NewWriter(path string, framesize, valSize int) (*Writer, error) {
+	return newWriter(path, framesize, valSize, 0)
+}
+
+func newWriter(path string, framesize, valsize, level int) (*Writer, error) {
+	if level > 5 {
+		panic("something wrong")
+	}
+	name := filename(path, level)
+	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return nil, err
+	}
+	w := &Writer{
+		path:      path,
+		framesize: framesize,
+		level:     level,
+		file:      f,
+		// avoid realloc with 2*framesize
+		frame:   make([]byte, 0, 2*framesize),
+		valsize: valsize,
+	}
+	if err := w.writeFileHeader(valsize, framesize); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+func (w *Writer) writeFileHeader(valsize, framesize int) error {
+	var hdr [FileHeaderLen]byte
+	encodeInt(hdr[0:4], magic)
+	hdr[4] = versionMajor
+	hdr[5] = versionMinor
+	encodeInt(hdr[6:10], valsize)
+	encodeInt(hdr[10:14], framesize)
+	_, err := w.file.Write(hdr[:])
+	w.offset = FileHeaderLen
+	return err
+}
+
+func (w *Writer) Close() error {
+	if len(w.frame) > 0 {
+		// Make sure to pass up framekeys to parent trees, even though frames aren't
+		// full.
+		var err error
+		if w.parent != nil {
+			err = w.writeFrame()
+		} else {
+			err = w.flushFrame()
+		}
+		if err != nil {
+			return err
+		}
+	}
+	if err := w.file.Close(); err != nil {
+		return err
+	}
+	if w.parent != nil {
+		return w.parent.Close()
+	}
+	return nil
+}
+
+func (w *Writer) grow(target int) {
+	off := len(w.frame)
+	size := cap(w.frame)
+	for size < target {
+		size *= 2
+	}
+	p := make([]byte, off, size)
+	copy(p, w.frame)
+	w.frame = p
+}
+
+func (w *Writer) encode(v []byte) {
+	off := len(w.frame)
+	n := len(v)
+	if off+n > cap(w.frame) {
+		//XXX this should be very rare and happens only
+		// when keys and/or values are very large
+		w.grow(off + n)
+	}
+	copy(w.frame[off:off+n], v)
+	w.frame = w.frame[:off+n]
+}
+
+func (w *Writer) encodeCounted(v []byte) {
+	var cnt [4]byte
+	encodeInt(cnt[:], len(v))
+	w.encode(cnt[:])
+	w.encode(v)
+}
+
+func (w *Writer) Write(pair Pair) error {
+	if len(pair.Key)+len(pair.Value)+8 > w.framesize && w.level > 0 {
+		// encoding a single pair in a frame larger than
+		// the framesize will cause an infinite loop writing
+		// an index files that hold just the one pair
+		return ErrPairTooBig
+	}
+	w.Stats.Count++
+	w.Stats.KeyBytes += int64(len(pair.Key))
+	w.Stats.ValueBytes += int64(len(pair.Value))
+	if len(w.frame) >= w.framesize {
+		// the frame in place is already big enough... flush it and
+		// start going on the next
+		if err := w.writeFrame(); err != nil {
+			return err
+		}
+	}
+	if len(w.frame) == 0 {
+		w.frameKey = append(w.frameKey[:0], pair.Key...)
+	}
+	//XXX should use unsafe pointer
+	w.encodeCounted([]byte(pair.Key))
+	if w.valsize != 0 {
+		if w.valsize != len(pair.Value) {
+			return ErrValueSize
+		}
+		w.encode(pair.Value)
+	} else {
+		w.encodeCounted(pair.Value)
+	}
+	return nil
+}
+
+func (w *Writer) flushFrame() error {
+	var hdr [FrameHeaderLen]byte
+	hdr[0] = 0 // compression type XXX
+	//XXX need to compress frame here
+	encodeInt(hdr[1:5], len(w.frame))
+	if _, err := w.file.Write(hdr[:]); err != nil {
+		return err
+	}
+	if _, err := w.file.Write(w.frame); err != nil {
+		return err
+	}
+	w.offset += int64(len(hdr) + len(w.frame))
+	w.frame = w.frame[:0]
+	return nil
+}
+
+func (w *Writer) writeFrame() error {
+	if err := w.writeIndex(w.frameKey, w.offset); err != nil {
+		return err
+	}
+	return w.flushFrame()
+}
+
+func (w *Writer) writeIndex(key []byte, offset int64) error {
+	if w.parent == nil {
+		var err error
+		w.parent, err = newWriter(w.path, w.framesize, 6, w.level+1)
+		if err != nil {
+			return err
+		}
+	}
+	var val [6]byte
+	encodeInt48(val[:], offset)
+	return w.parent.Write(Pair{key, val[:]})
+}


### PR DESCRIPTION
This commit adds a zar command for createing and searching
bzng index files.  The index files are organized as sorted
string tables and use the sst package.

The current protoype is very early and and currently only
indexes IP addresses as a hard-wired configuration.  The code
however is set up to do more flexible indexing soon.

The sst package uses a simple binary format for framing
keys and values as arbitrary byte sequences but we realized
it could be a very powerful foundation to store the sst
files as bzng.  We will implement this change in a future PR.