### PR TITLE
log post endpoint

### DIFF
--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -117,6 +117,10 @@ type PacketPostStatus struct {
 	MaxTime        *nano.Ts `json:"max_time,omitempty"`
 }
 
+type LogPostRequest struct {
+	Paths []string `json:"paths"`
+}
+
 // PacketSearch are the query string args to the packet endpoint when searching
 // for packets within a connection 5-tuple.
 type PacketSearch struct {

--- a/zqd/api/connection.go
+++ b/zqd/api/connection.go
@@ -194,10 +194,22 @@ func (c *Connection) Search(ctx context.Context, search SearchRequest) (Search, 
 
 func (c *Connection) PostPacket(ctx context.Context, space string, payload PacketPostRequest) (*Stream, error) {
 	req := c.Request(ctx).
-		SetBody(payload).
-		SetHeader("format", "bzng")
+		SetBody(payload)
 	req.Method = http.MethodPost
 	req.URL = path.Join("/space", url.PathEscape(space), "packet")
+	r, err := c.stream(req)
+	if err != nil {
+		return nil, err
+	}
+	jsonpipe := NewJSONPipeScanner(r)
+	return NewStream(jsonpipe), nil
+}
+
+func (c *Connection) PostLogs(ctx context.Context, space string, payload LogPostRequest) (*Stream, error) {
+	req := c.Request(ctx).
+		SetBody(payload)
+	req.Method = http.MethodPost
+	req.URL = path.Join("/space", url.PathEscape(space), "log")
 	r, err := c.stream(req)
 	if err != nil {
 		return nil, err

--- a/zqd/api/connection.go
+++ b/zqd/api/connection.go
@@ -192,7 +192,7 @@ func (c *Connection) Search(ctx context.Context, search SearchRequest) (Search, 
 	return NewBzngSearch(r), nil
 }
 
-func (c *Connection) PostPacket(ctx context.Context, space string, payload PacketPostRequest) (*Stream, error) {
+func (c *Connection) PacketPost(ctx context.Context, space string, payload PacketPostRequest) (*Stream, error) {
 	req := c.Request(ctx).
 		SetBody(payload)
 	req.Method = http.MethodPost
@@ -205,7 +205,7 @@ func (c *Connection) PostPacket(ctx context.Context, space string, payload Packe
 	return NewStream(jsonpipe), nil
 }
 
-func (c *Connection) PostLogs(ctx context.Context, space string, payload LogPostRequest) (*Stream, error) {
+func (c *Connection) LogPost(ctx context.Context, space string, payload LogPostRequest) (*Stream, error) {
 	req := c.Request(ctx).
 		SetBody(payload)
 	req.Method = http.MethodPost

--- a/zqd/handler.go
+++ b/zqd/handler.go
@@ -36,6 +36,7 @@ func NewHandlerWithLogger(core *Core, logger *zap.Logger) http.Handler {
 	h.Handle("/space/{space}", handleSpaceDelete).Methods("DELETE")
 	h.Handle("/space/{space}/packet", handlePacketSearch).Methods("GET")
 	h.Handle("/space/{space}/packet", handlePacketPost).Methods("POST")
+	h.Handle("/space/{space}/log", handleLogPost).Methods("POST")
 	h.Handle("/search", handleSearch).Methods("POST")
 	h.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -314,7 +314,7 @@ func postSpaceData(t *testing.T, c *api.Connection, spaceName, data string) *api
 	_, err = f.WriteString(data)
 	require.NoError(t, err)
 	ctx := context.Background()
-	s, err := c.PostLogs(ctx, spaceName, api.LogPostRequest{[]string{name}})
+	s, err := c.LogPost(ctx, spaceName, api.LogPostRequest{[]string{name}})
 	require.NoError(t, err)
 	var payloads []interface{}
 	for {

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -227,7 +227,7 @@ func (r *packetPostResult) postPcap(t *testing.T, file string) {
 	_, err := r.client.SpacePost(context.Background(), api.SpacePostRequest{Name: r.space})
 	require.NoError(t, err)
 	var stream *api.Stream
-	stream, r.err = r.client.PostPacket(context.Background(), r.space, api.PacketPostRequest{r.pcapfile})
+	stream, r.err = r.client.PacketPost(context.Background(), r.space, api.PacketPostRequest{r.pcapfile})
 	if r.err == nil {
 		r.readPayloads(t, stream)
 	}

--- a/zqd/ingest/log.go
+++ b/zqd/ingest/log.go
@@ -1,0 +1,67 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/brimsec/zq/scanner"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/bzngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zqd/search"
+	"github.com/brimsec/zq/zqd/space"
+)
+
+// Logs ingests the provided list of files into the provided space.
+func Logs(ctx context.Context, s *space.Space, paths []string, sortLimit int) error {
+	if sortLimit == 0 {
+		sortLimit = DefaultSortLimit
+	}
+	if err := ingestLogs(ctx, s, paths, sortLimit); err != nil {
+		os.Remove(s.DataPath("all.bzng"))
+		return err
+	}
+	return nil
+}
+
+type recWriter struct {
+	r *zng.Record
+}
+
+func (rw *recWriter) Write(r *zng.Record) error {
+	rw.r = r
+	return nil
+}
+
+func ingestLogs(ctx context.Context, s *space.Space, paths []string, sortLimit int) error {
+	zr, err := scanner.OpenFiles(resolver.NewContext(), paths...)
+	if err != nil {
+		return err
+	}
+	defer zr.Close()
+	bzngfile, err := s.CreateFile("all.bzng.tmp")
+	if err != nil {
+		return err
+	}
+	zw := bzngio.NewWriter(bzngfile)
+	program := fmt.Sprintf("sort -limit %d -r ts | (filter *; head 1; tail 1)", sortLimit)
+	var headW, tailW recWriter
+	if err := search.Copy(ctx, []zbuf.Writer{zw, &headW, &tailW}, zr, program); err != nil {
+		bzngfile.Close()
+		os.Remove(bzngfile.Name())
+		return err
+	}
+	if err := bzngfile.Close(); err != nil {
+		return err
+	}
+	if tailW.r != nil {
+		minTs := tailW.r.Ts
+		maxTs := headW.r.Ts
+		if err = s.SetTimes(minTs, maxTs); err != nil {
+			return err
+		}
+	}
+	return os.Rename(bzngfile.Name(), s.DataPath("all.bzng"))
+}

--- a/zqd/ingest/pcap.go
+++ b/zqd/ingest/pcap.go
@@ -30,6 +30,7 @@ var (
 const (
 	PcapIndexFile    = "packets.idx.json"
 	DefaultSortLimit = 10000000
+	tmpIngestDir     = ".tmp.ingest"
 )
 
 type Process struct {
@@ -53,9 +54,10 @@ type Process struct {
 // directory. If zeekExec is an empty string, this will attempt to resolve zeek
 // from $PATH.
 func Pcap(ctx context.Context, s *space.Space, pcap string, zlauncher zeek.Launcher, sortLimit int) (*Process, error) {
-	logdir := s.DataPath(".tmp.zeeklogs")
+	logdir := s.DataPath(tmpIngestDir)
 	if err := os.Mkdir(logdir, 0700); err != nil {
 		if os.IsExist(err) {
+			// could be in use by pcap or log ingest
 			return nil, ErrIngestProcessInFlight
 		}
 		return nil, err


### PR DESCRIPTION
This PR adds a `POST /space/{space}/log` endpoint to post a list of log files that are to be ingested into a space. Files can be in any format supported by `zq`. 

Like for the pcap endpoint, each ingest operation truncates the space and concurrent ingest operations into a space are rejected.

Unlike for the pcap endpoint, streaming stats are not sent during ingest, but we could add them as/when they become necessary. In fact a likely first step might be to send a single stats update before the final `TaskEnd`, which would be useful for clients; but this can come in follow-on work.

This PR has some very basic test coverage in `zqd/handlers_test.go`;  more complete tests will come later.