### PR TITLE
Add waterfall logger

### DIFF
--- a/cmd/zqd/logger/waterfall.go
+++ b/cmd/zqd/logger/waterfall.go
@@ -1,0 +1,64 @@
+package logger
+
+import (
+	"go.uber.org/multierr"
+	"go.uber.org/zap/zapcore"
+)
+
+type waterfallCore []zapcore.Core
+
+// NewWaterfall creates a new core that distributes logs to the underlying cores
+// in a waterfall pattern; for each log entry the core will iterate through each
+// core, in order, stopping when it finds a core that will accept the log entry.
+func NewWaterfall(cores ...zapcore.Core) zapcore.Core {
+	switch len(cores) {
+	case 0:
+		return zapcore.NewNopCore()
+	case 1:
+		return cores[0]
+	default:
+		return waterfallCore(cores)
+	}
+}
+
+func (mc waterfallCore) With(fields []zapcore.Field) zapcore.Core {
+	clone := make(waterfallCore, len(mc))
+	for i := range mc {
+		clone[i] = mc[i].With(fields)
+	}
+	return clone
+}
+
+func (mc waterfallCore) Enabled(lvl zapcore.Level) bool {
+	for i := range mc {
+		if mc[i].Enabled(lvl) {
+			return true
+		}
+	}
+	return false
+}
+
+func (mc waterfallCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	for i := range mc {
+		if out := mc[i].Check(ent, nil); out != nil {
+			return ce.AddCore(ent, mc[i])
+		}
+	}
+	return ce
+}
+
+func (mc waterfallCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	var err error
+	for i := range mc {
+		err = multierr.Append(err, mc[i].Write(ent, fields))
+	}
+	return err
+}
+
+func (mc waterfallCore) Sync() error {
+	var err error
+	for i := range mc {
+		err = multierr.Append(err, mc[i].Sync())
+	}
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.4.0
 	github.com/yuin/goldmark v1.1.22
+	go.uber.org/multierr v1.3.0
 	go.uber.org/zap v1.12.0
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/text v0.3.0

--- a/zqd/handler.go
+++ b/zqd/handler.go
@@ -21,11 +21,7 @@ func (h *handler) Handle(path string, f handlerFunc) *mux.Route {
 	})
 }
 
-func NewHandler(root *Core) http.Handler {
-	return NewHandlerWithLogger(root, root.logger)
-}
-
-func NewHandlerWithLogger(core *Core, logger *zap.Logger) http.Handler {
+func NewHandler(core *Core, logger *zap.Logger) http.Handler {
 	h := handler{Router: mux.NewRouter(), core: core}
 	h.Use(requestIDMiddleware())
 	h.Use(accessLogMiddleware(logger))

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -282,7 +282,7 @@ func newCoreAtDir(t *testing.T, dir string) (*zqd.Core, *api.Connection, func())
 	}
 	require.NoError(t, os.MkdirAll(dir, 0755))
 	c := zqd.NewCore(conf)
-	h := zqd.NewHandler(c)
+	h := zqd.NewHandler(c, conf.Logger)
 	ts := httptest.NewServer(h)
 	return c, api.NewConnectionTo(ts.URL), func() {
 		os.RemoveAll(dir)

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -182,8 +183,11 @@ func packetPost(t *testing.T, pcapfile string, l zeek.Launcher) packetPostResult
 }
 
 func packetPostWithConfig(t *testing.T, conf zqd.Config, pcapfile string) packetPostResult {
+	if conf.Logger == nil {
+		conf.Logger = zaptest.NewLogger(t, zaptest.Level(zapcore.WarnLevel))
+	}
 	c := setCoreRoot(t, conf)
-	ts := httptest.NewServer(zqd.NewHandler(c))
+	ts := httptest.NewServer(zqd.NewHandler(c, conf.Logger))
 	client := api.NewConnectionTo(ts.URL)
 	res := packetPostResult{
 		core:     c,

--- a/zqd/middleware.go
+++ b/zqd/middleware.go
@@ -69,7 +69,6 @@ func accessLogMiddleware(logger *zap.Logger) mux.MiddlewareFunc {
 }
 
 func panicCatchMiddleware(logger *zap.Logger) mux.MiddlewareFunc {
-	logger = logger.Named("zqd")
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
@@ -78,7 +77,7 @@ func panicCatchMiddleware(logger *zap.Logger) mux.MiddlewareFunc {
 					return
 				}
 				rstr := fmt.Sprint(r)
-				logger.Error("panic", zap.String("error", rstr))
+				logger.DPanic("panic", zap.String("error", rstr))
 				http.Error(w, rstr, http.StatusInternalServerError)
 			}()
 


### PR DESCRIPTION
The waterfall logger distributes logs to the underlying loggers
in a waterfall pattern; for each log entry the logger will iterate through
each of its children, in order, stopping when it finds a logger that will
accept the log entry.

The waterfall logger will allow us to send named loggers to different
destinations (e.g. The noisy http.access logger) without having to
write complicated ! rules on the default logger.

Also:
- Make the namespace of the default logger ""