### PR TITLE
Fill in `record.Ts` when creating a record in the ndjson reader

### DIFF
--- a/tests/suite.go
+++ b/tests/suite.go
@@ -50,6 +50,7 @@ var scripts = []test.Shell{
 	jsontype.TestInferPath,
 	jsontype.TestSet,
 	jsontype.TestNoTs,
+	jsontype.TestTs,
 	pcap.Test1,
 	pcap.Test2,
 	pcap.Test3,

--- a/tests/suite/jsontype/test.go
+++ b/tests/suite/jsontype/test.go
@@ -157,3 +157,44 @@ const typesNoTs = `
 const zngNoTs = `
 #0:record[_path:string,name:bstring]
 0:[nots;foo;]`
+
+var TestTs = test.Shell{
+	Name:   "json-types-ts",
+	Script: `zq -j types.json "every 1d count()" in.ndjson > http.zng`,
+	Input: []test.File{
+		test.File{"in.ndjson", test.Trim(inputTs)},
+		test.File{"types.json", test.Trim(typesTs)},
+	},
+	Expected: []test.File{
+		test.File{"http.zng", test.Trim(zngTs)},
+	},
+}
+
+const inputTs = `{"ts":"2015-03-05T14:25:14.419939Z","_path":"ts"}`
+
+const typesTs = `
+{
+  "descriptors": {
+    "ts_log": [
+      {
+        "name": "_path",
+        "type": "string"
+      },
+      {
+        "name": "ts",
+        "type": "time"
+      }
+      ]
+     },
+  "rules": [
+    {
+      "name": "_path",
+      "value": "ts",
+      "descriptor": "ts_log"
+    }
+  ]
+}`
+
+const zngTs = `
+#0:record[ts:time,count:uint64]
+0:[1425513600;1;]`

--- a/zio/ndjsonio/reader.go
+++ b/zio/ndjsonio/reader.go
@@ -135,6 +135,5 @@ again:
 	if err := record.TypeCheck(); err != nil {
 		return nil, err
 	}
-	// Ignore error, which just means the point doesn't have a time-typed ts field
 	return record, nil
 }

--- a/zio/ndjsonio/reader.go
+++ b/zio/ndjsonio/reader.go
@@ -128,5 +128,14 @@ again:
 		return nil, fmt.Errorf("line %d: %w", r.scanner.Stats.Lines, err)
 	}
 	outType := r.zctx.LookupTypeRecord(zv.Type.(*zng.TypeRecord).Columns)
-	return zng.NewRecordCheck(outType, 0, zv.Bytes)
+	record, err := zng.NewRecordCheck(outType, 0, zv.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	ts, err := record.AccessTime("ts")
+	if err == nil {
+		record.Ts = ts
+	}
+	// Ignore error, which just means the point doesn't have a time-typed ts field
+	return record, nil
 }

--- a/zio/ndjsonio/reader.go
+++ b/zio/ndjsonio/reader.go
@@ -128,13 +128,12 @@ again:
 		return nil, fmt.Errorf("line %d: %w", r.scanner.Stats.Lines, err)
 	}
 	outType := r.zctx.LookupTypeRecord(zv.Type.(*zng.TypeRecord).Columns)
-	record, err := zng.NewRecordCheck(outType, 0, zv.Bytes)
+	record, err := zng.NewRecord(outType, zv.Bytes)
 	if err != nil {
 		return nil, err
 	}
-	ts, err := record.AccessTime("ts")
-	if err == nil {
-		record.Ts = ts
+	if err := record.TypeCheck(); err != nil {
+		return nil, err
 	}
 	// Ignore error, which just means the point doesn't have a time-typed ts field
 	return record, nil


### PR DESCRIPTION
Discovered this bug while working on #505 .