### PR TITLE
Centralize flowgraph compile

### DIFF
--- a/driver/compile.go
+++ b/driver/compile.go
@@ -72,5 +72,5 @@ func inputProc(reader zbuf.Reader, fltast *ast.FilterProc, span nano.Span) (proc
 			return nil, err
 		}
 	}
-	return scanner.NewFilteredScanner(reader, f, span), nil
+	return scanner.NewScanner(reader, f, span), nil
 }

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -4,21 +4,67 @@ import (
 	"context"
 
 	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/filter"
+	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/proc"
+	"github.com/brimsec/zq/scanner"
+	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"go.uber.org/zap"
 )
 
-func Compile(program ast.Proc, input proc.Proc) (*proc.MuxOutput, error) {
-	ctx := &proc.Context{
-		Context:     context.Background(),
+// Compile takes an AST, an input proc, and configuration parameters,
+// and compiles it into a runnable flowgraph, returning a
+// proc.MuxOutput that which brings together all of the flowgraphs
+// tails, and is ready to be Pull()'d from.
+func Compile(ctx context.Context, program ast.Proc, input proc.Proc, reverse bool, logger *zap.Logger) (*proc.MuxOutput, error) {
+	pctx := &proc.Context{
+		Context:     ctx,
 		TypeContext: resolver.NewContext(),
-		Logger:      zap.NewNop(),
+		Logger:      logger,
 		Warnings:    make(chan string, 5),
 	}
-	leaves, err := proc.CompileProc(nil, program, ctx, input)
+	leaves, err := proc.CompileProc(nil, program, pctx, input)
 	if err != nil {
 		return nil, err
 	}
-	return proc.NewMuxOutput(ctx, leaves), nil
+	return proc.NewMuxOutput(pctx, leaves), nil
+}
+
+// LiftFilter removes the filter at the head of the flowgraph AST, if
+// one is present, and returns it and the modified flowgraph AST. If
+// the flowgraph does not start with a filter, it returns nil and the
+// unmodified flowgraph.
+func LiftFilter(p ast.Proc) (*ast.FilterProc, ast.Proc) {
+	if fp, ok := p.(*ast.FilterProc); ok {
+		pass := &ast.PassProc{
+			Node: ast.Node{"PassProc"},
+		}
+		return fp, pass
+	}
+	seq, ok := p.(*ast.SequentialProc)
+	if ok && len(seq.Procs) > 0 {
+		if fp, ok := seq.Procs[0].(*ast.FilterProc); ok {
+			rest := &ast.SequentialProc{
+				Node:  ast.Node{"SequentialProc"},
+				Procs: seq.Procs[1:],
+			}
+			return fp, rest
+		}
+	}
+	return nil, p
+}
+
+// InputProc takes a Reader, optional Filter AST, and timespan, and
+// constructs an input proc that can be used as the head of a
+// flowgraph.
+func InputProc(reader zbuf.Reader, fltast *ast.FilterProc, span nano.Span) (proc.Proc, error) {
+	var f filter.Filter
+	if fltast != nil {
+		var err error
+		if f, err = filter.Compile(fltast.Filter); err != nil {
+			return nil, err
+		}
+	}
+	return scanner.NewFilteredScanner(reader, f, span), nil
 }

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -35,7 +35,7 @@ func TestMuxDriver(t *testing.T) {
 
 	t.Run("muxed into one writer", func(t *testing.T) {
 		reader := zngio.NewReader(strings.NewReader(input), zctx)
-		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader), false, nano.MaxSpan, nil)
+		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader, nil, nano.MaxSpan), false, nano.MaxSpan, nil)
 		assert.NoError(t, err)
 		c := counter{}
 		d := New(&c)
@@ -46,7 +46,7 @@ func TestMuxDriver(t *testing.T) {
 
 	t.Run("muxed into individual writers", func(t *testing.T) {
 		reader := zngio.NewReader(strings.NewReader(input), zctx)
-		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader), false, nano.MaxSpan, nil)
+		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader, nil, nano.MaxSpan), false, nano.MaxSpan, nil)
 		assert.NoError(t, err)
 		cs := []zbuf.Writer{&counter{}, &counter{}}
 		d := New(cs...)

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -33,7 +34,7 @@ func TestMuxDriver(t *testing.T) {
 
 	t.Run("muxed into one writer", func(t *testing.T) {
 		reader := zngio.NewReader(strings.NewReader(input), zctx)
-		flowgraph, err := Compile(query, scanner.NewScanner(reader, nil))
+		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader), false, nil)
 		assert.NoError(t, err)
 		c := counter{}
 		d := New(&c)
@@ -44,7 +45,7 @@ func TestMuxDriver(t *testing.T) {
 
 	t.Run("muxed into individual writers", func(t *testing.T) {
 		reader := zngio.NewReader(strings.NewReader(input), zctx)
-		flowgraph, err := Compile(query, scanner.NewScanner(reader, nil))
+		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader), false, nil)
 		assert.NoError(t, err)
 		cs := []zbuf.Writer{&counter{}, &counter{}}
 		d := New(cs...)
@@ -55,7 +56,7 @@ func TestMuxDriver(t *testing.T) {
 	})
 
 	t.Run("mismatched channels and writer counts", func(t *testing.T) {
-		flowgraph, err := Compile(query, nil)
+		flowgraph, err := Compile(context.Background(), query, nil, false, nil)
 		assert.NoError(t, err)
 		cs := []zbuf.Writer{&counter{}, &counter{}, &counter{}}
 		d := New(cs...)

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/zngio"
@@ -34,7 +35,7 @@ func TestMuxDriver(t *testing.T) {
 
 	t.Run("muxed into one writer", func(t *testing.T) {
 		reader := zngio.NewReader(strings.NewReader(input), zctx)
-		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader), false, nil)
+		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader), false, nano.MaxSpan, nil)
 		assert.NoError(t, err)
 		c := counter{}
 		d := New(&c)
@@ -45,7 +46,7 @@ func TestMuxDriver(t *testing.T) {
 
 	t.Run("muxed into individual writers", func(t *testing.T) {
 		reader := zngio.NewReader(strings.NewReader(input), zctx)
-		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader), false, nil)
+		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader), false, nano.MaxSpan, nil)
 		assert.NoError(t, err)
 		cs := []zbuf.Writer{&counter{}, &counter{}}
 		d := New(cs...)
@@ -56,7 +57,7 @@ func TestMuxDriver(t *testing.T) {
 	})
 
 	t.Run("mismatched channels and writer counts", func(t *testing.T) {
-		flowgraph, err := Compile(context.Background(), query, nil, false, nil)
+		flowgraph, err := Compile(context.Background(), query, nil, false, nano.MaxSpan, nil)
 		assert.NoError(t, err)
 		cs := []zbuf.Writer{&counter{}, &counter{}, &counter{}}
 		d := New(cs...)

--- a/pkg/test/internal.go
+++ b/pkg/test/internal.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
+	"go.uber.org/zap"
 )
 
 type Internal struct {
@@ -58,7 +60,7 @@ func (i *Internal) Run() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	mux, err := driver.Compile(program, scanner.NewScanner(reader, nil))
+	mux, err := driver.Compile(context.Background(), program, scanner.NewScanner(reader), false, zap.NewNop())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/test/internal.go
+++ b/pkg/test/internal.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
-	"github.com/brimsec/zq/scanner"
+	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
@@ -60,7 +60,7 @@ func (i *Internal) Run() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	mux, err := driver.Compile(context.Background(), program, scanner.NewScanner(reader), false, zap.NewNop())
+	mux, err := driver.Compile(context.Background(), program, reader, false, nano.MaxSpan, zap.NewNop())
 	if err != nil {
 		return "", err
 	}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -8,21 +8,26 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
+// Scanner implements the proc.Proc interface
 type Scanner struct {
 	reader zbuf.Reader
 	filter filter.Filter
 	span   nano.Span
 }
 
-func NewScanner(reader zbuf.Reader, f filter.Filter) *Scanner {
+func NewScanner(reader zbuf.Reader) *Scanner {
 	return &Scanner{
 		reader: reader,
-		filter: f,
+		span:   nano.MaxSpan,
 	}
 }
 
-func (s *Scanner) SetSpan(span nano.Span) {
-	s.span = span
+func NewFilteredScanner(reader zbuf.Reader, f filter.Filter, s nano.Span) *Scanner {
+	return &Scanner{
+		reader: reader,
+		filter: f,
+		span:   s,
+	}
 }
 
 const batchSize = 100
@@ -39,7 +44,7 @@ func (s *Scanner) Read() (*zng.Record, error) {
 		if err != nil || rec == nil {
 			return nil, err
 		}
-		if s.span.Dur != 0 && !s.span.Contains(rec.Ts) ||
+		if s.span != nano.MaxSpan && !s.span.Contains(rec.Ts) ||
 			s.filter != nil && !s.filter(rec) {
 			continue
 		}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -15,14 +15,7 @@ type Scanner struct {
 	span   nano.Span
 }
 
-func NewScanner(reader zbuf.Reader) *Scanner {
-	return &Scanner{
-		reader: reader,
-		span:   nano.MaxSpan,
-	}
-}
-
-func NewFilteredScanner(reader zbuf.Reader, f filter.Filter, s nano.Span) *Scanner {
+func NewScanner(reader zbuf.Reader, f filter.Filter, s nano.Span) *Scanner {
 	return &Scanner{
 		reader: reader,
 		filter: f,
@@ -44,7 +37,7 @@ func (s *Scanner) Read() (*zng.Record, error) {
 		if err != nil || rec == nil {
 			return nil, err
 		}
-		if !s.span.Contains(rec.Ts) ||
+		if s.span != nano.MaxSpan && !s.span.Contains(rec.Ts) ||
 			s.filter != nil && !s.filter(rec) {
 			continue
 		}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -8,7 +8,7 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
-// Scanner implements the proc.Proc interface
+// Scanner implements the proc.Proc interface.
 type Scanner struct {
 	reader zbuf.Reader
 	filter filter.Filter
@@ -44,7 +44,7 @@ func (s *Scanner) Read() (*zng.Record, error) {
 		if err != nil || rec == nil {
 			return nil, err
 		}
-		if s.span != nano.MaxSpan && !s.span.Contains(rec.Ts) ||
+		if !s.span.Contains(rec.Ts) ||
 			s.filter != nil && !s.filter(rec) {
 			continue
 		}

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -73,12 +73,7 @@ func Copy(ctx context.Context, w []zbuf.Writer, r zbuf.Reader, prog string) erro
 	if err != nil {
 		return err
 	}
-	filterAst, program := zdriver.LiftFilter(p)
-	input, err := zdriver.InputProc(r, filterAst, nano.MaxSpan)
-	if err != nil {
-		return nil
-	}
-	mux, err := zdriver.Compile(ctx, program, input, false, zap.NewNop())
+	mux, err := zdriver.Compile(ctx, p, r, false, nano.MaxSpan, zap.NewNop())
 	if err != nil {
 		return err
 	}
@@ -224,11 +219,6 @@ func launch(ctx context.Context, query *Query, reader zbuf.Reader, zctx *resolve
 	if span == (nano.Span{}) {
 		span = nano.MaxSpan
 	}
-	filterAst, program := zdriver.LiftFilter(query.Proc)
-	input, err := zdriver.InputProc(reader, filterAst, span)
-	if err != nil {
-		return nil, err
-	}
 	reverse := query.Dir < 0
-	return zdriver.Compile(context.Background(), program, input, reverse, zap.NewNop())
+	return zdriver.Compile(context.Background(), query.Proc, reader, reverse, span, zap.NewNop())
 }

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -258,8 +258,7 @@ func compile(ctx *proc.Context, program ast.Proc, reader zbuf.Reader, span nano.
 		}
 		program = rest
 	}
-	input := scanner.NewScanner(reader, f)
-	input.SetSpan(span)
+	input := scanner.NewFilteredScanner(reader, f, span)
 	leaves, err := proc.CompileProc(nil, program, ctx, input)
 	if err != nil {
 		return nil, err

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -57,6 +57,7 @@ package ztest
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"flag"
@@ -81,6 +82,7 @@ import (
 	"github.com/brimsec/zq/zql"
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
 
@@ -310,7 +312,7 @@ func run(zq, ZQL, outputFormat, outputFlags string, inputs ...string) (out strin
 		outputFormat = "null"
 		zctx.SetLogger(&emitter.TypeLogger{WriteCloser: &nopCloser{&outbuf}})
 	}
-	muxOutput, err := driver.Compile(proc, scanner.NewScanner(zr, nil))
+	muxOutput, err := driver.Compile(context.Background(), proc, scanner.NewScanner(zr), false, zap.NewNop())
 	if err != nil {
 		return "", "", err
 	}

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -74,6 +74,7 @@ import (
 
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
@@ -312,7 +313,7 @@ func run(zq, ZQL, outputFormat, outputFlags string, inputs ...string) (out strin
 		outputFormat = "null"
 		zctx.SetLogger(&emitter.TypeLogger{WriteCloser: &nopCloser{&outbuf}})
 	}
-	muxOutput, err := driver.Compile(context.Background(), proc, scanner.NewScanner(zr), false, zap.NewNop())
+	muxOutput, err := driver.Compile(context.Background(), proc, zr, false, nano.MaxSpan, zap.NewNop())
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
Move compilation and parsing to a single place, used by zq, tests, and zqd.

That single place is `driver/`, which seems like the best home for it for now (I also considered `proc/` but it seemed slightly off-topic there, and a new `compile/` dir but I don't think this deserves it's own top-level package).


Part of #493 (addresses the compile & parse pieces... refactoring the driver piece will come separately).