### PR TITLE
Avoid crashing on Stat() errors

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -123,7 +123,7 @@ func fileExists(path string) bool {
 		return true
 	}
 	info, err := os.Stat(path)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
 	return !info.IsDir()


### PR DESCRIPTION
Don't try to read the stat buffer if Stat() fails for any reason.
Fixes #531
