### PR TITLE
Move pcap index search logic into space pkg

### DIFF
--- a/pcap/search.go
+++ b/pcap/search.go
@@ -138,8 +138,7 @@ func genICMPFilter(src, dst net.IP) PacketFilter {
 
 // XXX need to handle searching over multiple pcap files
 func (s *Search) Run(ctx context.Context, w io.Writer, r pcapio.Reader) error {
-	reader := s.Reader(r)
-	_, err := reader.WriteToWithContext(ctx, w)
+	_, err := s.Reader(r).WriteToWithContext(ctx, w)
 	return err
 }
 

--- a/pcap/search.go
+++ b/pcap/search.go
@@ -151,7 +151,7 @@ type SearchReader struct {
 	buf    []byte
 }
 
-func (s *Search) Reader(r pcapio.Reader) io.Reader {
+func (s *Search) Reader(r pcapio.Reader) *SearchReader {
 	opts := gopacket.DecodeOptions{Lazy: true, NoCopy: true}
 	return &SearchReader{Search: s, reader: r, opts: opts}
 }
@@ -160,7 +160,7 @@ func (s *SearchReader) Read(p []byte) (n int, err error) {
 	if len(s.buf) == 0 {
 		s.buf, err = s.next()
 		if err != nil {
-			return n, err
+			return 0, err
 		}
 		if len(s.buf) == 0 {
 			return 0, io.EOF

--- a/pkg/ctxio/ctxio.go
+++ b/pkg/ctxio/ctxio.go
@@ -1,0 +1,50 @@
+// Package ctxio provides functionality similar to package io but with the
+// ability to abort long running operations by passing through a
+// context.Context.
+package ctxio
+
+import (
+	"context"
+	"io"
+)
+
+type writer struct {
+	io.Writer
+	ctx context.Context
+}
+
+func NewWriter(ctx context.Context, w io.Writer) io.Writer {
+	return &writer{w, ctx}
+}
+
+func (w *writer) Write(p []byte) (n int, err error) {
+	if err = w.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return w.Writer.Write(p)
+}
+
+type reader struct {
+	io.Reader
+	ctx context.Context
+}
+
+func NewReader(ctx context.Context, r io.Reader) io.Reader {
+	return &reader{r, ctx}
+}
+
+func (r *reader) Read(p []byte) (n int, err error) {
+	if err = r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.Reader.Read(p)
+}
+
+func Copy(ctx context.Context, dst io.Writer, src io.Reader) (n int64, err error) {
+	if _, ok := src.(io.WriterTo); ok {
+		dst = NewWriter(ctx, dst)
+	} else {
+		src = NewReader(ctx, src)
+	}
+	return io.Copy(dst, src)
+}

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -160,7 +160,6 @@ func (ps *PacketSearch) ToQuery() url.Values {
 	if ps.DstPort != 0 {
 		q.Add("dst_port", strconv.Itoa(int(ps.DstPort)))
 	}
-
 	return q
 }
 
@@ -200,6 +199,11 @@ func (ps *PacketSearch) FromQuery(v url.Values) error {
 	}
 	ps.Span = span
 	ps.Proto = v.Get("proto")
+	switch ps.Proto {
+	case "tcp", "udp", "icmp":
+	default:
+		return fmt.Errorf("unsupported proto: %s", ps.Proto)
+	}
 	if ps.SrcHost = net.ParseIP(v.Get("src_host")); ps.SrcHost == nil {
 		return fmt.Errorf("invalid ip: %s", ps.SrcHost)
 	}

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -83,14 +83,14 @@ func handlePacketSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	reader, id, err := s.PcapSearch(req)
+	reader, err := s.PcapSearch(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	defer reader.Close()
 	w.Header().Set("Content-Type", "application/vnd.tcpdump.pcap")
-	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=%s.pcap", id))
+	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=%s.pcap", reader.ID()))
 	_, err = ctxio.Copy(ctx, w, reader)
 	if err != nil {
 		if err == pcap.ErrNoPacketsFound {

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -77,7 +77,7 @@ func handlePacketSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 	defer cancel()
 
-	req := api.PacketSearch{}
+	var req api.PacketSearch
 	if err := req.FromQuery(r.URL.Query()); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/brimsec/zq/pcap"
@@ -78,59 +77,25 @@ func handlePacketSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 	defer cancel()
 
-	req := &api.PacketSearch{}
+	req := api.PacketSearch{}
 	if err := req.FromQuery(r.URL.Query()); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
-	}
-	if s.PacketPath() == "" || !s.HasFile(ingest.PcapIndexFile) {
-		http.Error(w, "space has no pcaps", http.StatusNotFound)
 		return
 	}
-	index, err := pcap.LoadIndex(s.DataPath(ingest.PcapIndexFile))
+	reader, closer, err := s.PcapSearch(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	f, err := os.Open(s.PacketPath())
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	defer f.Close()
-	slicer, err := pcap.NewSlicer(f, index, req.Span)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	pcapReader, err := pcapio.NewReader(slicer)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	var search *pcap.Search
-	switch req.Proto {
-	default:
-		msg := fmt.Sprintf("unsupported proto type: %s", req.Proto)
-		http.Error(w, msg, http.StatusBadRequest)
-		return
-	case "tcp":
-		flow := pcap.NewFlow(req.SrcHost, int(req.SrcPort), req.DstHost, int(req.DstPort))
-		search = pcap.NewTCPSearch(req.Span, flow)
-	case "udp":
-		flow := pcap.NewFlow(req.SrcHost, int(req.SrcPort), req.DstHost, int(req.DstPort))
-		search = pcap.NewUDPSearch(req.Span, flow)
-	case "icmp":
-		search = pcap.NewICMPSearch(req.Span, req.SrcHost, req.DstHost)
-	}
+	defer closer.Close()
 	w.Header().Set("Content-Type", "application/vnd.tcpdump.pcap")
-	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=%s.pcap", search.ID()))
-	err = search.Run(ctx, w, pcapReader)
+	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=%s.pcap", reader.ID()))
+	_, err = reader.WriteToWithContext(ctx, w)
 	if err != nil {
 		if err == pcap.ErrNoPacketsFound {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		} else {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 	}
 }

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/brimsec/zq/pkg/test"
 	"github.com/brimsec/zq/zqd"
 	"github.com/brimsec/zq/zqd/api"
-	"github.com/brimsec/zq/zqd/ingest"
+	"github.com/brimsec/zq/zqd/space"
 	"github.com/brimsec/zq/zqd/zeek"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,7 +65,7 @@ func TestPacketPostSuccess(t *testing.T) {
 		assert.Equal(t, p.pcapfile, info.PacketPath)
 	})
 	t.Run("PacketIndexExists", func(t *testing.T) {
-		require.FileExists(t, filepath.Join(p.core.Root, p.space, ingest.PcapIndexFile))
+		require.FileExists(t, filepath.Join(p.core.Root, p.space, space.PcapIndexFile))
 	})
 	t.Run("TaskStartMessage", func(t *testing.T) {
 		status := p.payloads[0].(*api.TaskStart)

--- a/zqd/ingest/pcap.go
+++ b/zqd/ingest/pcap.go
@@ -29,7 +29,6 @@ var (
 )
 
 const (
-	PcapIndexFile    = "packets.idx.json"
 	DefaultSortLimit = 10000000
 	tmpIngestDir     = ".tmp.ingest"
 )
@@ -82,11 +81,11 @@ func Pcap(ctx context.Context, s *space.Space, pcap string, zlauncher zeek.Launc
 		sortLimit: sortLimit,
 	}
 	if err = p.indexPcap(); err != nil {
-		os.Remove(p.space.DataPath(PcapIndexFile))
+		os.Remove(p.space.DataPath(space.PcapIndexFile))
 		return nil, err
 	}
 	if err = p.space.SetPacketPath(p.pcapPath); err != nil {
-		os.Remove(p.space.DataPath(PcapIndexFile))
+		os.Remove(p.space.DataPath(space.PcapIndexFile))
 		return nil, err
 	}
 	go func() {
@@ -107,7 +106,7 @@ func (p *Process) run(ctx context.Context) error {
 
 	abort := func() {
 		os.RemoveAll(p.logdir)
-		os.Remove(p.space.DataPath(PcapIndexFile))
+		os.Remove(p.space.DataPath(space.PcapIndexFile))
 		os.Remove(p.space.DataPath(space.AllBzngFile))
 		p.space.SetPacketPath("")
 		p.space.UnsetTimes()
@@ -161,7 +160,7 @@ func (p *Process) indexPcap() error {
 	if err != nil {
 		return err
 	}
-	idxpath := p.space.DataPath(PcapIndexFile)
+	idxpath := p.space.DataPath(space.PcapIndexFile)
 	tmppath := idxpath + ".tmp"
 	f, err := os.Create(tmppath)
 	if err != nil {

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -17,16 +17,16 @@ import (
 )
 
 const (
-	PcapIndexFile = "packets.idx.json"
+	AllBzngFile   = "all.bzng"
 	configFile    = "config.json"
 	infoFile      = "info.json"
-	AllBzngFile   = "all.bzng"
+	PcapIndexFile = "packets.idx.json"
 )
 
 var (
-	ErrSpaceNotExist       = errors.New("space does not exist")
-	ErrSpaceExists         = errors.New("space exists")
 	ErrPcapOpsNotSupported = errors.New("space does not support pcap operations")
+	ErrSpaceExists         = errors.New("space exists")
+	ErrSpaceNotExist       = errors.New("space does not exist")
 )
 
 type Space struct {

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -3,24 +3,30 @@ package space
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	"github.com/brimsec/zq/pcap"
+	"github.com/brimsec/zq/pcap/pcapio"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zqd/api"
 )
 
 const (
-	configFile  = "config.json"
-	infoFile    = "info.json"
-	AllBzngFile = "all.bzng"
+	PcapIndexFile = "packets.idx.json"
+	configFile    = "config.json"
+	infoFile      = "info.json"
+	AllBzngFile   = "all.bzng"
 )
 
 var (
-	ErrSpaceNotExist = errors.New("space does not exist")
-	ErrSpaceExists   = errors.New("space exists")
+	ErrSpaceNotExist       = errors.New("space does not exist")
+	ErrSpaceExists         = errors.New("space exists")
+	ErrPcapOpsNotSupported = errors.New("space does not support pcap operations")
 )
 
 type Space struct {
@@ -99,6 +105,47 @@ func (s Space) Info() (api.SpaceInfo, error) {
 		return api.SpaceInfo{}, err
 	}
 	return spaceInfo, nil
+}
+
+// PcapSearch returns a *pcap.SearchReader that streams all the packets meeting
+// the provided search request. If pcaps are not supported in this Space
+// ErrPcapOpsNotSupported is returned.
+func (s Space) PcapSearch(req api.PacketSearch) (*pcap.SearchReader, io.Closer, error) {
+	if s.PacketPath() == "" || !s.HasFile(PcapIndexFile) {
+		return nil, nil, ErrPcapOpsNotSupported
+	}
+	index, err := pcap.LoadIndex(s.DataPath(PcapIndexFile))
+	if err != nil {
+		return nil, nil, err
+	}
+	var search *pcap.Search
+	switch req.Proto {
+	case "tcp":
+		flow := pcap.NewFlow(req.SrcHost, int(req.SrcPort), req.DstHost, int(req.DstPort))
+		search = pcap.NewTCPSearch(req.Span, flow)
+	case "udp":
+		flow := pcap.NewFlow(req.SrcHost, int(req.SrcPort), req.DstHost, int(req.DstPort))
+		search = pcap.NewUDPSearch(req.Span, flow)
+	case "icmp":
+		search = pcap.NewICMPSearch(req.Span, req.SrcHost, req.DstHost)
+	default:
+		return nil, nil, fmt.Errorf("unsupported proto type: %s", req.Proto)
+	}
+	f, err := os.Open(s.PacketPath())
+	if err != nil {
+		return nil, nil, err
+	}
+	slicer, err := pcap.NewSlicer(f, index, req.Span)
+	if err != nil {
+		f.Close()
+		return nil, nil, err
+	}
+	pcapReader, err := pcapio.NewReader(slicer)
+	if err != nil {
+		f.Close()
+		return nil, nil, err
+	}
+	return search.Reader(pcapReader), f, nil
 }
 
 // LogSize returns the size in bytes of the logs in space.


### PR DESCRIPTION
This is part of a series of prs aimed simplifying the space api
and moving logic out of the http handlers. Handlers should only be
concerned with translation between the http protocol and the underlying
services and facilities that make up zqd.

Also:
- Refactor pcap search to make it pull based instead of push based. This was necessary in order to have `space.PcapSearch` return a byte stream that could be copied to the `http.ResponseWriter`