### PR TITLE
Improve string search performance

### DIFF
--- a/filter/compare.go
+++ b/filter/compare.go
@@ -257,27 +257,6 @@ func CompareFloat64(op string, pattern float64) (Predicate, error) {
 	}, nil
 }
 
-// stringSearch is like strings.Contains() but with case-insensitive
-// comparison.
-func stringSearch(a, b string) bool {
-	alen := len(a)
-	blen := len(b)
-
-	if blen > alen {
-		return false
-	}
-
-	end := alen - blen + 1
-	i := 0
-	for i < end {
-		if strings.EqualFold(a[i:i+blen], b) {
-			return true
-		}
-		i++
-	}
-	return false
-}
-
 var compareString = map[string]func(string, string) bool{
 	"eql":  func(a, b string) bool { return a == b },
 	"neql": func(a, b string) bool { return a != b },
@@ -285,11 +264,20 @@ var compareString = map[string]func(string, string) bool{
 	"gte":  func(a, b string) bool { return a >= b },
 	"lt":   func(a, b string) bool { return a < b },
 	"lte":  func(a, b string) bool { return a <= b },
-	//XXX this doesn't belong here.  primitive comparison vs container operator
-	"search": stringSearch,
 }
 
 func CompareBstring(op string, pattern zng.Bstring) (Predicate, error) {
+	if op == "search" {
+		lowerPattern := strings.ToLower(string(pattern))
+		return func(v zng.Value) bool {
+			switch v.Type.ID() {
+			case zng.IdBstring, zng.IdString:
+				lowerStr := strings.ToLower(byteconv.UnsafeString(v.Bytes))
+				return strings.Contains(lowerStr, lowerPattern)
+			}
+			return false
+		}, nil
+	}
 	compare, ok := compareString[op]
 	if !ok {
 		return nil, fmt.Errorf("unknown string comparator: %s", opTokens[op])


### PR DESCRIPTION
Before
```sh
$ git log -n1 --format=%H%d
87135a9aa04e2af33f4e07b27db0c824576f5dfa (HEAD -> master, origin/master, origin/HEAD)
$ make build && ./dist/zq 2> /dev/null
$ for i in {1..5}; do /usr/bin/time ./dist/zq "windows | count()" ~/sampledata/corelight/zeek-logs/http.log > /dev/null; done
        0.37 real         0.45 user         0.02 sys
        0.37 real         0.45 user         0.01 sys
        0.37 real         0.45 user         0.01 sys
        0.37 real         0.45 user         0.01 sys
        0.36 real         0.44 user         0.01 sys
```

After
```sh
$ git log -n1 --format=%H%d
fe5ed5e1d2ba1f6e4b6d8496beb380d1c486a651 (HEAD -> improve-string-search-performance, origin/improve-string-search-performance)
$ make build && ./dist/zq 2> /dev/null
$ for i in {1..5}; do /usr/bin/time ./dist/zq "windows | count()" ~/sampledata/corelight/zeek-logs/http.log > /dev/null; done
        0.32 real         0.42 user         0.02 sys
        0.32 real         0.42 user         0.01 sys
        0.32 real         0.42 user         0.01 sys
        0.32 real         0.43 user         0.01 sys
        0.32 real         0.42 user         0.01 sys
```