### PR TITLE
Fix error handling in search endpoint handler

### DIFF
--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -43,6 +43,16 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 	defer cancel()
 
+	// XXX This always returns bad request but should return status codes
+	// that reflect the nature of the returned error.
+	w.Header().Set("Content-Type", "application/ndjson")
+	srch, err := search.NewSearch(ctx, s, req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer srch.Close()
+
 	var out search.Output
 	format := r.URL.Query().Get("format")
 	switch format {
@@ -56,12 +66,8 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("unsupported output format: %s", format), http.StatusBadRequest)
 		return
 	}
-	// XXX This always returns bad request but should return status codes
-	// that reflect the nature of the returned error.
-	w.Header().Set("Content-Type", "application/ndjson")
-	if err := search.Search(ctx, s, req, out); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+	if err = srch.Run(out); err != nil {
+		c.requestLogger(r).Warn("Error writing response", zap.Error(err))
 	}
 }
 

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -43,11 +43,10 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 	defer cancel()
 
-	// XXX This always returns bad request but should return status codes
-	// that reflect the nature of the returned error.
-	w.Header().Set("Content-Type", "application/ndjson")
 	srch, err := search.NewSearch(ctx, s, req)
 	if err != nil {
+		// XXX This always returns bad request but should return status codes
+		// that reflect the nature of the returned error.
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -66,6 +65,7 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("unsupported output format: %s", format), http.StatusBadRequest)
 		return
 	}
+	w.Header().Set("Content-Type", "application/ndjson")
 	if err = srch.Run(out); err != nil {
 		c.requestLogger(r).Warn("Error writing response", zap.Error(err))
 	}

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -56,6 +56,32 @@ func TestSearchEmptySpace(t *testing.T) {
 	require.Equal(t, "", res)
 }
 
+func TestSearchInvalidRequest(t *testing.T) {
+	src := `
+#0:record[_path:string,ts:time,uid:bstring]
+0:[conn;1521911723.205187;CBrzd94qfowOqJwCHa;]
+0:[conn;1521911721.255387;C8Tful1TvM3Zf5x8fl;]
+`
+	_, client, done := newCore(t)
+	defer done()
+	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
+	require.NoError(t, err)
+	_ = postSpaceLogs(t, client, sp.Name, nil, src)
+
+	parsed, err := zql.ParseProc("*")
+	require.NoError(t, err)
+	proc, err := json.Marshal(parsed)
+	require.NoError(t, err)
+	req := api.SearchRequest{
+		Space: "test",
+		Proc:  proc,
+		Span:  nano.MaxSpan,
+		Dir:   2,
+	}
+	_, err = client.Search(context.Background(), req)
+	require.Error(t, err)
+}
+
 func TestSpaceList(t *testing.T) {
 	ctx := context.Background()
 	c, client, done := newCore(t)

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -30,48 +30,56 @@ const DefaultMTU = 100
 
 const StatsInterval = time.Millisecond * 500
 
-func Search(ctx context.Context, s *space.Space, req api.SearchRequest, out Output) error {
-	// XXX These validation checks should result in 400 level status codes and
-	// thus shouldn't occur here.
+type Search struct {
+	mux *proc.MuxOutput
+	io.Closer
+}
+
+func NewSearch(ctx context.Context, s *space.Space, req api.SearchRequest) (*Search, error) {
 	if req.Span.Ts < 0 {
-		return errors.New("time span must have non-negative timestamp")
+		return nil, errors.New("time span must have non-negative timestamp")
 	}
 	if req.Span.Dur < 0 {
-		return errors.New("time span must have non-negative duration")
+		return nil, errors.New("time span must have non-negative duration")
 	}
 	// XXX allow either direction even through we do forward only right now
 	if req.Dir != 1 && req.Dir != -1 {
-		return errors.New("time direction must be 1 or -1")
+		return nil, errors.New("time direction must be 1 or -1")
 	}
 	query, err := UnpackQuery(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var f io.ReadCloser
 	f, err = s.OpenFile(space.AllBzngFile)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return err
+			return nil, err
 		}
 		f = ioutil.NopCloser(strings.NewReader(""))
 	}
-	defer f.Close()
 	zngReader, err := detector.LookupReader("bzng", f, resolver.NewContext())
 	if err != nil {
-		return err
+		f.Close()
+		return nil, err
 	}
 	zctx := resolver.NewContext()
 	mapper := scanner.NewMapper(zngReader, zctx)
 	mux, err := launch(ctx, query, mapper, zctx)
 	if err != nil {
-		return err
+		f.Close()
+		return nil, err
 	}
+	return &Search{mux, f}, nil
+}
+
+func (s *Search) Run(output Output) error {
 	d := &searchdriver{
-		output:    out,
+		output:    output,
 		startTime: nano.Now(),
 	}
 	d.start(0)
-	if err := driver.Run(mux, d, StatsInterval); err != nil {
+	if err := driver.Run(s.mux, d, StatsInterval); err != nil {
 		d.abort(0, err)
 		return err
 	}


### PR DESCRIPTION
Previously, the search endpoint could call http.Error() after
having sent data. This commit fixes that by breaking the search action
into a setup phase and a run phase.

If the setup phase fails, an HTTP error is returned. If the setup
phase succeeds, a 200 is returned, and  any error encountered during
the execution of the search will result in a TaskEnd message with the
error being sent to the client.

This PR should not change existing behavior, but it removes a possible no-op call to `http.Error()`, and makes the handler code better reflect the above.


closes #556 