### PR TITLE
add zbuf.Peeker

### DIFF
--- a/zbuf/peeker.go
+++ b/zbuf/peeker.go
@@ -1,0 +1,33 @@
+package zbuf
+
+import (
+	"github.com/brimsec/zq/zng"
+)
+
+// Peeker wraps a Stream while adding a Peek method, which allows inspection
+// of the next item to be read without actually reading it.
+type Peeker struct {
+	Reader
+	cache *zng.Record
+}
+
+func NewPeeker(reader Reader) *Peeker {
+	return &Peeker{Reader: reader}
+}
+
+func (p *Peeker) Peek() (*zng.Record, error) {
+	var err error
+	if p.cache == nil {
+		p.cache, err = p.Reader.Read()
+	}
+	return p.cache, err
+}
+
+func (p *Peeker) Read() (*zng.Record, error) {
+	v := p.cache
+	if v != nil {
+		p.cache = nil
+		return v, nil
+	}
+	return p.Reader.Read()
+}

--- a/zbuf/peeker_test.go
+++ b/zbuf/peeker_test.go
@@ -1,0 +1,62 @@
+package zbuf_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+func newTextReader(logs string) *zngio.Reader {
+	logs = strings.TrimSpace(logs) + "\n"
+	return zngio.NewReader(strings.NewReader(logs), resolver.NewContext())
+}
+
+const input = `
+#0:record[key:string,value:string]
+0:[key1;value1;]
+0:[key2;value2;]
+0:[key3;value3;]
+0:[key4;value4;]
+0:[key5;value5;]
+0:[key6;value6;]`
+
+func TestPeeker(t *testing.T) {
+	stream := newTextReader(input)
+	peeker := zbuf.NewPeeker(stream)
+	rec1, err := peeker.Peek()
+	if err != nil {
+		t.Error(err)
+	}
+	rec2, err := peeker.Peek()
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(rec1.Raw, rec2.Raw) {
+		t.Error("rec1 != rec2")
+	}
+	rec3, err := peeker.Read()
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(rec1.Raw, rec3.Raw) {
+		t.Error("rec1 != rec3")
+	}
+	rec4, err := peeker.Peek()
+	if err != nil {
+		t.Error(err)
+	}
+	if bytes.Equal(rec3.Raw, rec4.Raw) {
+		t.Error("rec3 == rec4")
+	}
+	rec5, err := peeker.Read()
+	if err != nil {
+		t.Error(err)
+	}
+	if !bytes.Equal(rec4.Raw, rec5.Raw) {
+		t.Error("rec4 != rec5")
+	}
+}


### PR DESCRIPTION
This commit adds a generic zbuf.Peeker that wraps a zbuf.Reader and allows you 
to inspect the next zng.Record in the stream without actually reading it.

This code came from the port of sst to zng.  It is not currently used anywhere in the 
zq repo but is a useful, general functionality for the framework.

