### PR TITLE
bzngio API adjustments for stream boundaries

### DIFF
--- a/pkg/peeker/reader.go
+++ b/pkg/peeker/reader.go
@@ -28,6 +28,11 @@ func NewReader(reader io.Reader, size, max int) *Reader {
 	}
 }
 
+func (r *Reader) Reset() {
+	r.cursor = r.buffer[:0]
+	r.eof = false
+}
+
 func (r *Reader) fill(min int) error {
 	if min > r.limit {
 		return ErrBufferOverflow

--- a/zio/bzngio/reader.go
+++ b/zio/bzngio/reader.go
@@ -144,7 +144,6 @@ func (r *Reader) readUvarint() (int, error) {
 		return 0, zng.ErrBadFormat
 	}
 	_, err = r.read(n)
-	r.position += int64(n)
 	return int(v), err
 }
 

--- a/zio/bzngio/seeker.go
+++ b/zio/bzngio/seeker.go
@@ -11,7 +11,11 @@ type Seeker struct {
 	seeker io.ReadSeeker
 }
 
-func NewSeeker(s io.ReadSeeker, zctx *resolver.Context, framesize int) *Seeker {
+func NewSeeker(s io.ReadSeeker, zctx *resolver.Context) *Seeker {
+	return NewSeekerWithSize(s, zctx, ReadSize)
+}
+
+func NewSeekerWithSize(s io.ReadSeeker, zctx *resolver.Context, framesize int) *Seeker {
 	return &Seeker{
 		Reader: *NewReaderWithSize(s, zctx, framesize),
 		seeker: s,
@@ -21,7 +25,7 @@ func NewSeeker(s io.ReadSeeker, zctx *resolver.Context, framesize int) *Seeker {
 func (s *Seeker) Seek(offset int64) (int64, error) {
 	s.peeker.Reset()
 	s.zctx.Reset()
-	n, err := s.seeker.Seek(offset, 0)
+	n, err := s.seeker.Seek(offset, io.SeekStart)
 	s.position = n
 	return n, err
 }

--- a/zio/bzngio/seeker.go
+++ b/zio/bzngio/seeker.go
@@ -1,0 +1,27 @@
+package bzngio
+
+import (
+	"io"
+
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type Seeker struct {
+	Reader
+	seeker io.ReadSeeker
+}
+
+func NewSeeker(s io.ReadSeeker, zctx *resolver.Context, framesize int) *Seeker {
+	return &Seeker{
+		Reader: *NewReaderWithSize(s, zctx, framesize),
+		seeker: s,
+	}
+}
+
+func (s *Seeker) Seek(offset int64) (int64, error) {
+	s.peeker.Reset()
+	s.zctx.Reset()
+	n, err := s.seeker.Seek(offset, 0)
+	s.position = n
+	return n, err
+}

--- a/zio/zng_test.go
+++ b/zio/zng_test.go
@@ -300,4 +300,10 @@ func TestEOS(t *testing.T) {
 	rec, err = s.Read()
 	require.NoError(t, err)
 	assert.Equal(t, seekRec.Raw, rec.Raw)
+
+	r3 := bzngio.NewReader(bytes.NewReader(out.Buffer.Bytes()), resolver.NewContext())
+	rec, off, err := r3.SkipStream()
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	assert.Equal(t, off, seekPoint)
 }

--- a/zio/zng_test.go
+++ b/zio/zng_test.go
@@ -294,7 +294,7 @@ func TestEOS(t *testing.T) {
 	// Read back the bzng and make sure the streams are aligned after
 	// the first record.
 
-	s := bzngio.NewSeeker(bytes.NewReader(out.Buffer.Bytes()), resolver.NewContext(), 10000)
+	s := bzngio.NewSeeker(bytes.NewReader(out.Buffer.Bytes()), resolver.NewContext())
 	_, err = s.Seek(seekPoint)
 	require.NoError(t, err)
 	rec, err = s.Read()


### PR DESCRIPTION
This PR adds hooks the bzngio API to allow for querying and seeking to stream boundaries.  This will be used by zdx and the bzngio time index.