### PR TITLE
pcap.SearchReader: empty results

### DIFF
--- a/pcap/search.go
+++ b/pcap/search.go
@@ -151,7 +151,6 @@ type SearchReader struct {
 	*Search
 	reader pcapio.Reader
 	opts   gopacket.DecodeOptions
-	npkt   int
 	window []byte
 	buf    []byte
 }

--- a/pcap/search.go
+++ b/pcap/search.go
@@ -139,7 +139,11 @@ func genICMPFilter(src, dst net.IP) PacketFilter {
 
 // XXX need to handle searching over multiple pcap files
 func (s *Search) Run(ctx context.Context, w io.Writer, r pcapio.Reader) error {
-	_, err := ctxio.Copy(ctx, w, s.Reader(r))
+	reader, err := s.Reader(ctx, r)
+	if err != nil {
+		return err
+	}
+	_, err = ctxio.Copy(ctx, w, reader)
 	return err
 }
 
@@ -148,37 +152,50 @@ type SearchReader struct {
 	reader pcapio.Reader
 	opts   gopacket.DecodeOptions
 	npkt   int
+	window []byte
 	buf    []byte
 }
 
-func (s *Search) Reader(r pcapio.Reader) *SearchReader {
+func (s *Search) Reader(ctx context.Context, r pcapio.Reader) (*SearchReader, error) {
 	opts := gopacket.DecodeOptions{Lazy: true, NoCopy: true}
-	return &SearchReader{Search: s, reader: r, opts: opts}
+	reader := &SearchReader{Search: s, reader: r, opts: opts}
+	err := reader.fill(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(reader.window) == 0 {
+		return nil, ErrNoPacketsFound
+	}
+	return reader, nil
 }
 
 func (s *SearchReader) Read(p []byte) (n int, err error) {
-	if len(s.buf) == 0 {
-		s.buf, err = s.next()
+	if len(s.window) == 0 {
+		err = s.fill(context.Background())
 		if err != nil {
 			return 0, err
 		}
-		if len(s.buf) == 0 {
+		if len(s.window) == 0 {
 			return 0, io.EOF
 		}
 	}
-	n = copy(p, s.buf)
-	s.buf = s.buf[n:]
+	n = copy(p, s.window)
+	s.window = s.window[n:]
 	return n, err
 }
 
-func (s *SearchReader) next() ([]byte, error) {
+func (s *SearchReader) fill(ctx context.Context) error {
+	s.buf = s.buf[:0]
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		block, typ, err := s.reader.Read()
 		if err != nil {
 			if err == io.EOF {
 				break
 			}
-			return nil, err
+			return err
 		}
 		if block == nil {
 			break
@@ -190,25 +207,27 @@ func (s *SearchReader) next() ([]byte, error) {
 		// by looking for sections headers, a buffering unnwritten sections
 		// until we get to the first packet and never writing the blocksa
 		// for sections that have no packets.
-		if typ != pcapio.TypePacket {
-			return block, nil
+		switch typ {
+		case pcapio.TypeSection:
+			s.buf = append(s.buf[:0], block...)
+		case pcapio.TypeInterface:
+			s.buf = append(s.buf, block...)
+		default:
+			pktBuf, ts, linkType := s.reader.Packet(block)
+			if pktBuf == nil {
+				return pcapio.ErrCorruptPcap
+			}
+			if !s.span.ContainsClosed(ts) {
+				continue
+			}
+			packet := gopacket.NewPacket(pktBuf, linkType, s.opts)
+			if s.filter != nil && !s.filter(packet) {
+				continue
+			}
+			s.buf = append(s.buf, block...)
+			s.window = s.buf[:]
+			return nil
 		}
-		pktBuf, ts, linkType := s.reader.Packet(block)
-		if pktBuf == nil {
-			return nil, pcapio.ErrCorruptPcap
-		}
-		if !s.span.ContainsClosed(ts) {
-			continue
-		}
-		packet := gopacket.NewPacket(pktBuf, linkType, s.opts)
-		if s.filter != nil && !s.filter(packet) {
-			continue
-		}
-		s.npkt++
-		return block, nil
 	}
-	if s.npkt == 0 {
-		return nil, ErrNoPacketsFound
-	}
-	return nil, nil
+	return nil
 }

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/brimsec/zq/pcap"
 	"github.com/brimsec/zq/pkg/ctxio"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zqd/api"
@@ -133,7 +134,11 @@ func handlePacketSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 		respondError(c, w, r, zqe.E(zqe.Invalid, err))
 		return
 	}
-	reader, err := s.PcapSearch(req)
+	reader, err := s.PcapSearch(ctx, req)
+	if err == pcap.ErrNoPacketsFound {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
 	if err != nil {
 		respondError(c, w, r, err)
 		return

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -136,7 +136,7 @@ func handlePacketSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 	reader, err := s.PcapSearch(ctx, req)
 	if err == pcap.ErrNoPacketsFound {
-		http.Error(w, err.Error(), http.StatusNotFound)
+		respondError(c, w, r, zqe.E(zqe.NotFound, err))
 		return
 	}
 	if err != nil {

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -1,6 +1,7 @@
 package space
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -114,7 +115,7 @@ func (s Space) Info() (api.SpaceInfo, error) {
 // PcapSearch returns a *pcap.SearchReader that streams all the packets meeting
 // the provided search request. If pcaps are not supported in this Space,
 // ErrPcapOpsNotSupported is returned.
-func (s Space) PcapSearch(req api.PacketSearch) (*SearchReadCloser, error) {
+func (s Space) PcapSearch(ctx context.Context, req api.PacketSearch) (*SearchReadCloser, error) {
 	if s.PacketPath() == "" || !s.HasFile(PcapIndexFile) {
 		return nil, ErrPcapOpsNotSupported
 	}
@@ -149,7 +150,11 @@ func (s Space) PcapSearch(req api.PacketSearch) (*SearchReadCloser, error) {
 		f.Close()
 		return nil, err
 	}
-	r := search.Reader(pcapReader)
+	r, err := search.Reader(ctx, pcapReader)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
 	return &SearchReadCloser{r, f}, nil
 
 }


### PR DESCRIPTION
Previously the pcap.SearchReader would include in its output section
headers for pcap files even when no packet would matched the search
request. Adjust pcap.Search.NewReader to scan and find the first
result on creation, returning ErrNoPacketsFound if no packets
captures are found.

Also:
- Adjust pcap search api to return 404 before writing pcap headers

closes #563 #551 #550