### PR TITLE
scanner.Combiner: don't close readers implicitly

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"regexp"
@@ -206,6 +207,12 @@ func (c *Command) Run(args []string) error {
 	} else {
 		reader = scanner.NewCombiner(readers)
 	}
+	defer func() {
+		if closer, ok := reader.(io.Closer); ok {
+			closer.Close()
+		}
+	}()
+
 	writer, err := c.openOutput()
 	if err != nil {
 		return err

--- a/scanner/combiner.go
+++ b/scanner/combiner.go
@@ -48,9 +48,6 @@ func (c *Combiner) Read() (*zng.Record, error) {
 			}
 			if tup == nil {
 				c.done[k] = true
-				if err := c.closeReader(l); err != nil {
-					return nil, fmt.Errorf("%s: %w", c.readers[k], err)
-				}
 				continue
 			}
 			c.hol[k] = tup
@@ -79,9 +76,6 @@ func (c *Combiner) closeReader(r zbuf.Reader) error {
 func (c *Combiner) Close() error {
 	var err error
 	for k, r := range c.readers {
-		if c.done[k] {
-			continue
-		}
 		c.done[k] = true
 		// Return only the first error, but closing everything else if there is
 		// an error.

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -309,6 +309,11 @@ func run(zq, ZQL, outputFormat, outputFlags string, inputs ...string) (out strin
 	if err != nil {
 		return "", "", err
 	}
+	defer func() {
+		if closer, ok := zr.(io.Closer); ok {
+			closer.Close()
+		}
+	}()
 	if outputFormat == "types" {
 		outputFormat = "null"
 		zctx.SetLogger(&emitter.TypeLogger{WriteCloser: &nopCloser{&outbuf}})


### PR DESCRIPTION
A combiner is a Reader, and Readers don't usually close themselves upon a final read. 

Our uses of Combiner in zqd already expect this. This PR also fixes a fd leak in ztest.