### PR TITLE
Move zng open code from search into space

### DIFF
--- a/zbuf/zng.go
+++ b/zbuf/zng.go
@@ -11,6 +11,11 @@ type Reader interface {
 	Read() (*zng.Record, error)
 }
 
+type ReadCloser interface {
+	Reader
+	io.Closer
+}
+
 type Writer interface {
 	Write(*zng.Record) error
 }
@@ -35,6 +40,25 @@ func (nopFlusher) Flush() error { return nil }
 // the provided Writer w.
 func NopFlusher(w Writer) WriteFlusher {
 	return nopFlusher{w}
+}
+
+type nopReadCloser struct {
+	Reader
+}
+
+func (nopReadCloser) Close() error { return nil }
+
+func NopReadCloser(r Reader) ReadCloser {
+	return nopReadCloser{r}
+}
+
+type extReadCloser struct {
+	Reader
+	io.Closer
+}
+
+func NewReadCloser(r Reader, c io.Closer) ReadCloser {
+	return extReadCloser{r, c}
 }
 
 func CopyWithContext(ctx context.Context, dst WriteFlusher, src Reader) error {

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -48,12 +48,14 @@ func NewSearch(ctx context.Context, s *space.Space, req api.SearchRequest) (*Sea
 
 	zngReader, err := s.OpenZng(query.Span)
 	if err != nil {
+		f.Close()
 		return nil, err
 	}
 	zctx := resolver.NewContext()
 	mapper := scanner.NewMapper(zngReader, zctx)
 	mux, err := launch(ctx, query, mapper, zctx)
 	if err != nil {
+		f.Close()
 		return nil, err
 	}
 	return &Search{mux, zngReader}, nil

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -48,14 +48,13 @@ func NewSearch(ctx context.Context, s *space.Space, req api.SearchRequest) (*Sea
 
 	zngReader, err := s.OpenZng(query.Span)
 	if err != nil {
-		f.Close()
 		return nil, err
 	}
 	zctx := resolver.NewContext()
 	mapper := scanner.NewMapper(zngReader, zctx)
 	mux, err := launch(ctx, query, mapper, zctx)
 	if err != nil {
-		f.Close()
+		zngReader.Close()
 		return nil, err
 	}
 	return &Search{mux, zngReader}, nil

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -6,9 +6,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/brimsec/zq/ast"
@@ -16,7 +13,6 @@ import (
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqd/api"
 	"github.com/brimsec/zq/zqd/space"
@@ -49,27 +45,18 @@ func NewSearch(ctx context.Context, s *space.Space, req api.SearchRequest) (*Sea
 	if err != nil {
 		return nil, err
 	}
-	var f io.ReadCloser
-	f, err = s.OpenFile(space.AllBzngFile)
+
+	zngReader, err := s.OpenZng(query.Span)
 	if err != nil {
-		if !os.IsNotExist(err) {
-			return nil, err
-		}
-		f = ioutil.NopCloser(strings.NewReader(""))
-	}
-	zngReader, err := detector.LookupReader("bzng", f, resolver.NewContext())
-	if err != nil {
-		f.Close()
 		return nil, err
 	}
 	zctx := resolver.NewContext()
 	mapper := scanner.NewMapper(zngReader, zctx)
 	mux, err := launch(ctx, query, mapper, zctx)
 	if err != nil {
-		f.Close()
 		return nil, err
 	}
-	return &Search{mux, f}, nil
+	return &Search{mux, zngReader}, nil
 }
 
 func (s *Search) Run(output Output) error {


### PR DESCRIPTION
Based on suggestions from @alfred-landrum while reviewing the
time indexing branch, peeled off from there.