### PR TITLE
add zng.Builder to easily build record values

### DIFF
--- a/zng/builder.go
+++ b/zng/builder.go
@@ -1,0 +1,42 @@
+package zng
+
+import (
+	"github.com/brimsec/zq/zcode"
+)
+
+// Builder provides a way of easily and efficiently building records
+// of the same type.
+type Builder struct {
+	zcode.Builder
+	Type *TypeRecord
+}
+
+func NewBuilder(typ *TypeRecord) *Builder {
+	return &Builder{Type: typ}
+}
+
+// Build encodes the top-level zcode.Bytes values as the Raw field
+// of a record and sets that field and the Type field of the passed-in record.
+// XXX This currently only works for zvals that are properly formatted for
+// the top-level scan of the record, e.g., if a field is record[id:[record:[orig_h:ip]]
+// then the zval passed in here for that field must have the proper encooding...
+// this works fine when values are extracted and inserted from the proper level
+// but when a leaf values are inserted we should have another method to handle this,
+// e.g., by encoding the dfs traversal of the record type with info about
+// primitive vs container insertions.  This could be the start of a whole pacakge
+// that provides different ways to build zng.Records via, e.g., a marshal API,
+// auto-gened stubs, etc
+func (b *Builder) Build(rec *Record, zvs ...zcode.Bytes) {
+	b.Reset()
+	cols := b.Type.Columns
+	for k, zv := range zvs {
+		if IsContainerType(cols[k].Type) {
+			b.AppendContainer(zv)
+		} else {
+			b.AppendPrimitive(zv)
+		}
+	}
+	// XXX rec.Ts, rec.volatile?
+	rec.Type = b.Type
+	rec.Raw = b.Bytes()
+}

--- a/zng/builder.go
+++ b/zng/builder.go
@@ -19,13 +19,13 @@ func NewBuilder(typ *TypeRecord) *Builder {
 // of a record and sets that field and the Type field of the passed-in record.
 // XXX This currently only works for zvals that are properly formatted for
 // the top-level scan of the record, e.g., if a field is record[id:[record:[orig_h:ip]]
-// then the zval passed in here for that field must have the proper encooding...
+// then the zval passed in here for that field must have the proper encoding...
 // this works fine when values are extracted and inserted from the proper level
-// but when a leaf values are inserted we should have another method to handle this,
+// but when leaf values are inserted we should have another method to handle this,
 // e.g., by encoding the dfs traversal of the record type with info about
-// primitive vs container insertions.  This could be the start of a whole pacakge
+// primitive vs container insertions.  This could be the start of a whole package
 // that provides different ways to build zng.Records via, e.g., a marshal API,
-// auto-gened stubs, etc
+// auto-generated stubs, etc.
 func (b *Builder) Build(rec *Record, zvs ...zcode.Bytes) {
 	b.Reset()
 	cols := b.Type.Columns

--- a/zng/builder_test.go
+++ b/zng/builder_test.go
@@ -1,0 +1,68 @@
+package zng_test
+
+import (
+	"bytes"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/stretchr/testify/assert"
+)
+
+const builder = `
+#0:record[key:ip]
+#1:record[a:int64,b:int64,c:int64]
+#2:record[a:int64,r:record[x:int64]]
+0:[1.2.3.4;]
+1:[1;2;3;]
+2:[7;[3;]]`
+
+func TestBuilder(t *testing.T) {
+	in := []byte(strings.TrimSpace(builder) + "\n")
+	r := zngio.NewReader(bytes.NewReader(in), resolver.NewContext())
+	r0, _ := r.Read()
+	r1, _ := r.Read()
+	r2, _ := r.Read()
+
+	var rec zng.Record
+	zctx := resolver.NewContext()
+
+	t0 := zctx.LookupTypeRecord([]zng.Column{
+		{"key", zng.TypeIP},
+	})
+	b0 := zng.NewBuilder(t0)
+	ip := net.ParseIP("1.2.3.4")
+	b0.Build(&rec, zng.EncodeIP(ip))
+	assert.Equal(t, r0.Raw, rec.Raw)
+
+	t1 := zctx.LookupTypeRecord([]zng.Column{
+		{"a", zng.TypeInt64},
+		{"b", zng.TypeInt64},
+		{"c", zng.TypeInt64},
+	})
+	b1 := zng.NewBuilder(t1)
+	b1.Build(&rec, zng.EncodeInt(1), zng.EncodeInt(2), zng.EncodeInt(3))
+	assert.Equal(t, r1.Raw, rec.Raw)
+
+	t2 := zctx.LookupTypeRecord([]zng.Column{
+		{"a", zng.TypeInt64},
+		{"r", zctx.LookupTypeRecord([]zng.Column{{"x", zng.TypeInt64}})},
+	})
+	b2 := zng.NewBuilder(t2)
+	// XXX this is where this package needs work
+	// the second column here is a container here and this is where it would
+	// be nice for the builder to know this structure and wrap appropriately,
+	// but for now we do the work outside of the builder, which is perfectly
+	// fine if you are extracting a container value from an existing place...
+	// you just grab the whole thing.  But if you just have the leaf vals
+	// of the record and want to build it up, it would be nice to have some
+	// easy way to do it all...
+	var rb zcode.Builder
+	rb.AppendPrimitive(zng.EncodeInt(3))
+	b2.Build(&rec, zng.EncodeInt(7), rb.Bytes())
+	assert.Equal(t, r2.Raw, rec.Raw)
+}

--- a/zng/builder_test.go
+++ b/zng/builder_test.go
@@ -1,7 +1,6 @@
 package zng_test
 
 import (
-	"bytes"
 	"net"
 	"strings"
 	"testing"
@@ -22,8 +21,7 @@ const builder = `
 2:[7;[3;]]`
 
 func TestBuilder(t *testing.T) {
-	in := []byte(strings.TrimSpace(builder) + "\n")
-	r := zngio.NewReader(bytes.NewReader(in), resolver.NewContext())
+	r := zngio.NewReader(strings.NewReader(builder), resolver.NewContext())
 	r0, _ := r.Read()
 	r1, _ := r.Read()
 	r2, _ := r.Read()


### PR DESCRIPTION
This PR introducers a Builder for package zng that constructs zng.Record.
This is a bare bones first cut and could be a very useful building block 
if fleshed out to handle lots of different record-building use cases.
The point here is you can create a builder and keep re-using it in the inner loop
without anything escaping to GC a la the builder design patter in Go.

For now,  the zdx port to zng will use this bare bones version.

