### PR TITLE
Error-tolerant log ingest

### DIFF
--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -112,7 +112,13 @@ type PacketPostStatus struct {
 
 type LogPostRequest struct {
 	Paths          []string             `json:"paths"`
+	StopErr        bool                 `json:"stop_err"`
 	JSONTypeConfig *ndjsonio.TypeConfig `json:"json_type_config"`
+}
+
+type LogPostWarning struct {
+	Type string `json:"type"`
+	Msg  string `json:"msg"`
 }
 
 type LogPostStatus struct {

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -116,9 +116,9 @@ type LogPostRequest struct {
 	JSONTypeConfig *ndjsonio.TypeConfig `json:"json_type_config"`
 }
 
-type LogPostWarning struct {
-	Type string `json:"type"`
-	Msg  string `json:"msg"`
+type LogPostWarnings struct {
+	Type     string   `json:"type"`
+	Warnings []string `json:"warnings"`
 }
 
 type LogPostStatus struct {

--- a/zqd/api/unpack.go
+++ b/zqd/api/unpack.go
@@ -34,8 +34,8 @@ func unpack(b []byte) (interface{}, error) {
 		out = &PacketPostStatus{}
 	case "LogPostStatus":
 		out = &LogPostStatus{}
-	case "LogPostWarning":
-		out = &LogPostWarning{}
+	case "LogPostWarnings":
+		out = &LogPostWarnings{}
 	case "":
 		return nil, fmt.Errorf("no type field in search result: %s", string(b))
 	default:

--- a/zqd/api/unpack.go
+++ b/zqd/api/unpack.go
@@ -34,6 +34,8 @@ func unpack(b []byte) (interface{}, error) {
 		out = &PacketPostStatus{}
 	case "LogPostStatus":
 		out = &LogPostStatus{}
+	case "LogPostWarning":
+		out = &LogPostWarning{}
 	case "":
 		return nil, fmt.Errorf("no type field in search result: %s", string(b))
 	default:

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -353,7 +353,7 @@ func handleLogPost(c *Core, w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 
 	pipe := api.NewJSONPipe(w)
-	err = ingest.Logs(ctx, pipe, s, req.Paths, req.JSONTypeConfig, c.SortLimit)
+	err = ingest.Logs(ctx, pipe, s, req, c.SortLimit)
 	if err != nil {
 		c.requestLogger(r).Warn("Error during log ingest", zap.Error(err))
 	}

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -333,10 +333,12 @@ func TestPostZngLogWarning(t *testing.T) {
 	require.NoError(t, err)
 
 	payloads := postSpaceLogs(t, client, spaceName, nil, false, strings.Join(src1, "\n"), strings.Join(src2, "\n"))
-	warn1 := payloads[1].(*api.LogPostWarning)
-	warn2 := payloads[2].(*api.LogPostWarning)
-	assert.True(t, strings.HasSuffix(warn1.Msg, ": malformed input"))
-	assert.True(t, strings.HasSuffix(warn2.Msg, ": line 3: bad format"))
+	warn1 := payloads[1].(*api.LogPostWarnings)
+	warn2 := payloads[2].(*api.LogPostWarnings)
+	assert.Len(t, warn1.Warnings, 1)
+	assert.Len(t, warn2.Warnings, 1)
+	assert.True(t, strings.HasSuffix(warn1.Warnings[0], ": malformed input"))
+	assert.True(t, strings.HasSuffix(warn2.Warnings[0], ": line 3: bad format"))
 
 	status := payloads[len(payloads)-2].(*api.LogPostStatus)
 	ts := nano.Ts(1e9)
@@ -434,10 +436,12 @@ func TestPostNDJSONLogWarning(t *testing.T) {
 	require.NoError(t, err)
 
 	payloads := postSpaceLogs(t, client, spaceName, &tc, false, src1, src2)
-	warn1 := payloads[1].(*api.LogPostWarning)
-	warn2 := payloads[2].(*api.LogPostWarning)
-	assert.True(t, strings.HasSuffix(warn1.Msg, ": line 1: descriptor not found"))
-	assert.True(t, strings.HasSuffix(warn2.Msg, ": line 2: descriptor not found"))
+	warn1 := payloads[1].(*api.LogPostWarnings)
+	warn2 := payloads[2].(*api.LogPostWarnings)
+	assert.Len(t, warn1.Warnings, 1)
+	assert.Len(t, warn2.Warnings, 1)
+	assert.True(t, strings.HasSuffix(warn1.Warnings[0], ": line 1: descriptor not found"))
+	assert.True(t, strings.HasSuffix(warn2.Warnings[0], ": line 2: descriptor not found"))
 
 	status := payloads[len(payloads)-2].(*api.LogPostStatus)
 	ts := nano.Ts(1e9)

--- a/zqd/ingest/driver.go
+++ b/zqd/ingest/driver.go
@@ -27,7 +27,10 @@ func (d *logdriver) Write(cid int, batch zbuf.Batch) error {
 }
 
 func (d *logdriver) Warn(warning string) error {
-	return nil
+	return d.pipe.Send(&api.LogPostWarning{
+		Type: "LogPostWarning",
+		Msg:  warning,
+	})
 }
 func (d *logdriver) Stats(stats api.ScannerStats) error {
 	return nil

--- a/zqd/ingest/driver.go
+++ b/zqd/ingest/driver.go
@@ -27,9 +27,9 @@ func (d *logdriver) Write(cid int, batch zbuf.Batch) error {
 }
 
 func (d *logdriver) Warn(warning string) error {
-	return d.pipe.Send(&api.LogPostWarning{
-		Type: "LogPostWarning",
-		Msg:  warning,
+	return d.pipe.Send(&api.LogPostWarnings{
+		Type:     "LogPostWarnings",
+		Warnings: []string{warning},
 	})
 }
 func (d *logdriver) Stats(stats api.ScannerStats) error {

--- a/zqd/ingest/log.go
+++ b/zqd/ingest/log.go
@@ -93,9 +93,9 @@ func ingestLogs(ctx context.Context, pipe *api.JSONPipe, s *space.Space, req api
 			if req.StopErr {
 				return err
 			}
-			pipe.Send(&api.LogPostWarning{
-				Type: "LogPostWarning",
-				Msg:  fmt.Sprintf("%s: %s", path, err.Error()),
+			pipe.Send(&api.LogPostWarnings{
+				Type:     "LogPostWarnings",
+				Warnings: []string{fmt.Sprintf("%s: %s", path, err.Error())},
 			})
 			continue
 		}

--- a/zqd/ingest/log_test.go
+++ b/zqd/ingest/log_test.go
@@ -44,11 +44,11 @@ func TestLogsErrInFlight(t *testing.T) {
 	errCh2 := make(chan error)
 	go func() {
 		p := api.NewJSONPipe(httptest.NewRecorder())
-		errCh1 <- Logs(context.Background(), p, s, []string{f}, nil, 10)
+		errCh1 <- Logs(context.Background(), p, s, api.LogPostRequest{Paths: []string{f}}, 10)
 	}()
 	go func() {
 		p := api.NewJSONPipe(httptest.NewRecorder())
-		errCh2 <- Logs(context.Background(), p, s, []string{f}, nil, 10)
+		errCh2 <- Logs(context.Background(), p, s, api.LogPostRequest{Paths: []string{f}}, 10)
 	}()
 	err1 := <-errCh1
 	err2 := <-errCh2


### PR DESCRIPTION
Switch log ingest to use the "error-tolerant" mode by default, where
upon encountering an error, the error'd file is closed, a warning sent
to client, and ingest continues reading from any other readers.

The "stop everything upon error" behavior can be selected by the
stop_err flag in the log post request.

closes #528 

~~(based on #577 ; will rebase to master when that one merges)~~ now this PR has been approved, I've re-based to master as i wanted to already resolve conflicts from the merge of #538. 
