### PR TITLE
fix for-loop bug in pcap cut

### DIFF
--- a/cmd/pcap/cut/command.go
+++ b/cmd/pcap/cut/command.go
@@ -140,14 +140,11 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	for {
-		if err := cut(out, reader, cuts, n); err != nil {
-			if err == io.EOF {
-				err = nil
-			}
-			return err
-		}
+	err = cut(out, reader, cuts, n)
+	if err == io.EOF {
+		err = nil
 	}
+	return err
 }
 
 func cut(w io.Writer, r pcapio.Reader, cuts []int, n int) error {


### PR DESCRIPTION
There was a bogus for-loop in "pcap cut", a leftover vestige from
a different design, that caused it to kept reading after it was done
and thus report bogus errors.  This commit removes the bogus for-loop.