### PR TITLE
Change zqd API warning responses to carry one warning

### DIFF
--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -46,9 +46,9 @@ type SearchRecords struct {
 	Records   []zjsonio.Record `json:"records"`
 }
 
-type SearchWarnings struct {
-	Type     string   `json:"type"`
-	Warnings []string `json:"warnings"`
+type SearchWarning struct {
+	Type    string `json:"type"`
+	Warning string `json:"warning"`
 }
 
 type SearchEnd struct {
@@ -116,9 +116,9 @@ type LogPostRequest struct {
 	JSONTypeConfig *ndjsonio.TypeConfig `json:"json_type_config"`
 }
 
-type LogPostWarnings struct {
-	Type     string   `json:"type"`
-	Warnings []string `json:"warnings"`
+type LogPostWarning struct {
+	Type    string `json:"type"`
+	Warning string `json:"warning"`
 }
 
 type LogPostStatus struct {

--- a/zqd/api/unpack.go
+++ b/zqd/api/unpack.go
@@ -24,8 +24,8 @@ func unpack(b []byte) (interface{}, error) {
 		out = &TaskEnd{}
 	case "SearchRecords":
 		out = &SearchRecords{}
-	case "SearchWarnings":
-		out = &SearchWarnings{}
+	case "SearchWarning":
+		out = &SearchWarning{}
 	case "SearchStats":
 		out = &SearchStats{}
 	case "SearchEnd":
@@ -34,8 +34,8 @@ func unpack(b []byte) (interface{}, error) {
 		out = &PacketPostStatus{}
 	case "LogPostStatus":
 		out = &LogPostStatus{}
-	case "LogPostWarnings":
-		out = &LogPostWarnings{}
+	case "LogPostWarning":
+		out = &LogPostWarning{}
 	case "":
 		return nil, fmt.Errorf("no type field in search result: %s", string(b))
 	default:

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -333,12 +333,10 @@ func TestPostZngLogWarning(t *testing.T) {
 	require.NoError(t, err)
 
 	payloads := postSpaceLogs(t, client, spaceName, nil, false, strings.Join(src1, "\n"), strings.Join(src2, "\n"))
-	warn1 := payloads[1].(*api.LogPostWarnings)
-	warn2 := payloads[2].(*api.LogPostWarnings)
-	assert.Len(t, warn1.Warnings, 1)
-	assert.Len(t, warn2.Warnings, 1)
-	assert.True(t, strings.HasSuffix(warn1.Warnings[0], ": malformed input"))
-	assert.True(t, strings.HasSuffix(warn2.Warnings[0], ": line 3: bad format"))
+	warn1 := payloads[1].(*api.LogPostWarning)
+	warn2 := payloads[2].(*api.LogPostWarning)
+	assert.Regexp(t, ": malformed input$", warn1.Warning)
+	assert.Regexp(t, ": line 3: bad format$", warn2.Warning)
 
 	status := payloads[len(payloads)-2].(*api.LogPostStatus)
 	ts := nano.Ts(1e9)
@@ -436,12 +434,10 @@ func TestPostNDJSONLogWarning(t *testing.T) {
 	require.NoError(t, err)
 
 	payloads := postSpaceLogs(t, client, spaceName, &tc, false, src1, src2)
-	warn1 := payloads[1].(*api.LogPostWarnings)
-	warn2 := payloads[2].(*api.LogPostWarnings)
-	assert.Len(t, warn1.Warnings, 1)
-	assert.Len(t, warn2.Warnings, 1)
-	assert.True(t, strings.HasSuffix(warn1.Warnings[0], ": line 1: descriptor not found"))
-	assert.True(t, strings.HasSuffix(warn2.Warnings[0], ": line 2: descriptor not found"))
+	warn1 := payloads[1].(*api.LogPostWarning)
+	warn2 := payloads[2].(*api.LogPostWarning)
+	assert.Regexp(t, ": line 1: descriptor not found$", warn1.Warning)
+	assert.Regexp(t, ": line 2: descriptor not found$", warn2.Warning)
 
 	status := payloads[len(payloads)-2].(*api.LogPostStatus)
 	ts := nano.Ts(1e9)

--- a/zqd/ingest/driver.go
+++ b/zqd/ingest/driver.go
@@ -27,9 +27,9 @@ func (d *logdriver) Write(cid int, batch zbuf.Batch) error {
 }
 
 func (d *logdriver) Warn(warning string) error {
-	return d.pipe.Send(&api.LogPostWarnings{
-		Type:     "LogPostWarnings",
-		Warnings: []string{warning},
+	return d.pipe.Send(&api.LogPostWarning{
+		Type:    "LogPostWarning",
+		Warning: warning,
 	})
 }
 func (d *logdriver) Stats(stats api.ScannerStats) error {

--- a/zqd/ingest/log.go
+++ b/zqd/ingest/log.go
@@ -93,9 +93,9 @@ func ingestLogs(ctx context.Context, pipe *api.JSONPipe, s *space.Space, req api
 			if req.StopErr {
 				return err
 			}
-			pipe.Send(&api.LogPostWarnings{
-				Type:     "LogPostWarnings",
-				Warnings: []string{fmt.Sprintf("%s: %s", path, err.Error())},
+			pipe.Send(&api.LogPostWarning{
+				Type:    "LogPostWarning",
+				Warning: fmt.Sprintf("%s: %s", path, err),
 			})
 			continue
 		}

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -123,9 +123,9 @@ func (d *searchdriver) abort(id int64, err error) error {
 }
 
 func (d *searchdriver) Warn(warning string) error {
-	v := api.SearchWarnings{
-		Type:     "SearchWarnings",
-		Warnings: []string{warning},
+	v := api.SearchWarning{
+		Type:    "SearchWarning",
+		Warning: warning,
 	}
 	return d.output.SendControl(v)
 }


### PR DESCRIPTION
Neither zqd/api.LogPostWarnings nor .SearchWarnings needs to carry
multiple warnings since zqd can instead send multiple response objects.

JSON response objects for warnings now look like this:

    { "type": "LogPostWarning", "warning": "..." }
    { "type": "SearchWarning", "warning": "..." }

This is a followup to https://github.com/brimsec/zq/pull/582#discussion_r409044834.