### PR TITLE
JSON: error on incomplete descriptors

### DIFF
--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -269,11 +269,10 @@ func TestNDJSONTypeErrors(t *testing.T) {
 		},
 		{
 			name:   "Extra field",
-			result: typeStats{IncompleteDescriptor: 2, FirstBadLine: 1},
-			input: `{"ts":"2017-03-24T19:59:23.306076Z","uid":"CXY9a54W2dLZwzPXf1","id.orig_h":"10.10.7.65","_path":"http", "extra_field": 1}
-{"ts":"2017-03-24T19:59:23.306076Z","uid":"CXY9a54W2dLZwzPXf1","id.orig_h":"10.10.7.65","_path":"http"}
+			result: typeStats{IncompleteDescriptor: 1, FirstBadLine: 2},
+			input: `{"ts":"2017-03-24T19:59:23.306076Z","uid":"CXY9a54W2dLZwzPXf1","id.orig_h":"10.10.7.65","_path":"http"}
 {"ts":"2017-03-24T19:59:24.306076Z","uid":"CXY9a54W2dLZwzPXf1","id.orig_h":"10.10.7.65","_path":"http", "extra_field": 1}`,
-			success: true,
+			success: false,
 		},
 		{
 			name:   "Bad line number",

--- a/zio/ndjsonio/typeparser.go
+++ b/zio/ndjsonio/typeparser.go
@@ -33,9 +33,10 @@ type typeParser struct {
 }
 
 var (
-	ErrDescriptorNotFound = errors.New("descriptor not found")
-	ErrMissingPath        = errors.New("missing path field")
-	ErrBadFormat          = errors.New("bad format")
+	ErrDescriptorNotFound   = errors.New("descriptor not found")
+	ErrMissingPath          = errors.New("missing path field")
+	ErrBadFormat            = errors.New("bad format")
+	ErrIncompleteDescriptor = errors.New("incomplete descriptor")
 )
 
 // Information about the correspondence between the flattened structure
@@ -269,6 +270,7 @@ func (p *typeParser) parseObject(b []byte) (zng.Value, error) {
 	}
 	if dropped > 0 {
 		incr(&p.stats.IncompleteDescriptor)
+		return zng.Value{}, ErrIncompleteDescriptor
 	}
 
 	return zng.Value{ti.descriptor, raw}, nil

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -409,7 +409,7 @@ func TestPostNDJSONLogWarning(t *testing.T) {
 	const src1 = `{"ts":"1000","_path":"nosuchpath"}
 {"ts":"2000","_path":"http"}`
 	const src2 = `{"ts":"1000","_path":"http"}
-{"ts":"2000","_path":"nosuchpath"}`
+{"ts":"1000","_path":"http","extra": "foo"}`
 	tc := ndjsonio.TypeConfig{
 		Descriptors: map[string][]interface{}{
 			"http_log": []interface{}{
@@ -437,7 +437,7 @@ func TestPostNDJSONLogWarning(t *testing.T) {
 	warn1 := payloads[1].(*api.LogPostWarning)
 	warn2 := payloads[2].(*api.LogPostWarning)
 	assert.Regexp(t, ": line 1: descriptor not found$", warn1.Warning)
-	assert.Regexp(t, ": line 2: descriptor not found$", warn2.Warning)
+	assert.Regexp(t, ": line 2: incomplete descriptor", warn2.Warning)
 
 	status := payloads[len(payloads)-2].(*api.LogPostStatus)
 	ts := nano.Ts(1e9)

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -409,7 +409,7 @@ func TestPostNDJSONLogWarning(t *testing.T) {
 	const src1 = `{"ts":"1000","_path":"nosuchpath"}
 {"ts":"2000","_path":"http"}`
 	const src2 = `{"ts":"1000","_path":"http"}
-{"ts":"1000","_path":"http","extra": "foo"}`
+{"ts":"1000","_path":"http","extra":"foo"}`
 	tc := ndjsonio.TypeConfig{
 		Descriptors: map[string][]interface{}{
 			"http_log": []interface{}{


### PR DESCRIPTION
Previously, incomplete descriptors did not lead to any user-visible
notification. (A stats counter is increased, but flowgraph stats are
not currently hooked up to anything, see #555).

This PR turns incomplete descriptors into errors (like other json type
errors), which will lead to their notification in the Brim app and on
the CLI.