### PR TITLE
add Localize method to resolver.Context

### DIFF
--- a/zng/resolver/context.go
+++ b/zng/resolver/context.go
@@ -340,6 +340,15 @@ func (c *Context) LookupByName(in string) (zng.Type, error) {
 	return typ, err
 }
 
+// Localize takes a type from another context and creates and returns that
+// type in this context.
+func (c *Context) Localize(foreign zng.Type) zng.Type {
+	// there can't be an error here since the type string
+	// is generated internally
+	typ, _ := c.LookupByName(foreign.String())
+	return typ
+}
+
 func (c *Context) parseType(in string) (string, zng.Type, error) {
 	in = strings.TrimSpace(in)
 	c.mu.RLock()


### PR DESCRIPTION
This commit adds a method too resolver.Context to localize
a record type from another type context.  This emphasizes
the design pattern here where all types live within a
type context and if you have a foreign type it is easily
translated into the local context, and it's important to do so.