### PR TITLE
send status 200 for successful pcap search

### DIFF
--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -144,7 +144,6 @@ func handlePacketSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer reader.Close()
-	w.WriteHeader(http.StatusAccepted)
 	w.Header().Set("Content-Type", "application/vnd.tcpdump.pcap")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=%s.pcap", reader.ID()))
 	_, err = ctxio.Copy(ctx, w, reader)


### PR DESCRIPTION
Our ndjson responses return a 202, because there's the possibility of an error later via TaskEnd. However, this pcap search route is a download route that either returns nothing (via 404) or a pcap.
