### PR TITLE
Fix deadlock in parallel queries

### DIFF
--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -176,31 +176,27 @@ func NewGroupBy(c *Context, parent Proc, params GroupByParams) *GroupBy {
 }
 
 func (g *GroupBy) Pull() (zbuf.Batch, error) {
-	start := time.Now()
-	for {
-		batch, err := g.Get()
+	batch, err := g.Get()
+	if err != nil {
+		return nil, err
+	}
+	if batch == nil {
+		return g.agg.Results(true, g.MinTs, g.MaxTs), nil
+	}
+	for k := 0; k < batch.Length(); k++ {
+		err := g.agg.Consume(batch.Index(k))
 		if err != nil {
+			batch.Unref()
 			return nil, err
 		}
-		if batch == nil {
-			return g.agg.Results(true, g.MinTs, g.MaxTs), nil
-		}
-		for k := 0; k < batch.Length(); k++ {
-			err := g.agg.Consume(batch.Index(k))
-			if err != nil {
-				batch.Unref()
-				return nil, err
-			}
-		}
-		batch.Unref()
-		if g.timeBinned {
-			if f := g.agg.Results(false, g.MinTs, g.MaxTs); f != nil {
-				return f, nil
-			}
-		} else if g.interval > 0 && time.Since(start) >= g.interval {
-			return g.agg.Results(false, g.MinTs, g.MaxTs), nil
+	}
+	batch.Unref()
+	if g.timeBinned {
+		if f := g.agg.Results(false, g.MinTs, g.MaxTs); f != nil {
+			return f, nil
 		}
 	}
+	return zbuf.NewArray([]*zng.Record{}, batch.Span()), nil
 }
 
 func (g *GroupByAggregator) createRow(keyCols keyRow, ts nano.Ts, vals zcode.Bytes) *GroupByRow {


### PR DESCRIPTION
The reducer and groupby implementations of Pull() used to call Pull() on
their parent inside a for loop.  But this breaks the flow control system
when these procs are used in queries with independent branches than run in
parallel.

For instance, consider this query:  "(count(); filter *) | head 1"

The actual flowgraph for this query has an implicit "split" proc at the
front that duplicates source records and sends them to the "count()" and
"filter *" branches, and then an implicit "merge" proc that combines the
records that come out of these two branches.  The "split" proc does not
buffer an unlimited amount of data, so it relies on its downstream branches
calling Pull() repeatedly -- if any branch stops calling Pull(), split
stops reading data and the query deadlocks.

Similarly, the merge proc relies on receiving data from each of its
upstream branches -- if any branch doesn't return from Pull(), merge won't
call Pull() on all the other branches.

So when reducer and groupby called Pull() repatedly in a loop, their own
Pull() methods never returned.  This in turn caused merge to stop calling
Pull() on other branches, those calls never propagated up to split, so it
stopped reading data.  All together, this resulted in a deadlock.

The fix is to ensure that reducer and groupby match calls to their own
Pull() method to calls to their parents' Pull() methods one-to-one.

There are probably still some lurking issues here -- any proc that
doesn't match calls on its Pull() method with calls to its parent's
Pull() method would be in danger of getting out of sync with sibiling
branches when used in a parallel flowgraph and causing a deadlock.
Also, merge tries to sort timestamps, any proc that manipulates record
timestamps could potentially deadlock when used in a parallel flowgraph.
Still, these issues are less likely to happen in practice, this patch
fixes a deadlock in a scenario that's relatively easy to stumble onto.

Fixes #515
