### PR TITLE
Rename zng->tzng

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The [ZNG specification](zng/docs/spec.md) describes the significance of the
 `_path` field.  By leveraging this, diverse Zeek logs can be combined into a single
 file.
 ```
-zq *.log > all.zng
+zq *.log > all.tzng
 ```
 
 ### Comparisons

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -44,8 +44,8 @@ standard output unless a -o or -d argument is provided, in which case output is
 sent to the indicated file comforming to the type implied by the extension (unless
 -f explicitly indicates the output type).
 
-Supported input formats include zng (.zng), NDJSON (.ndjson), and
-the Zeek log format (.log).  Supported output formats include
+Supported input formats include binary and text zng, NDJSON, and
+the Zeek log format.  Supported output formats include
 all the input formats along with text and tabular formats.
 
 The input file format is inferred from the data.  If multiple files are
@@ -54,7 +54,7 @@ match input types.  If multiple files are concatenated into a stream and
 presented as standard input, the files must all be of the same type as the
 beginning of stream will determine the format.
 
-The output format is zng by default, but can be overridden with -f.
+The output format is text zng by default, but can be overridden with -f.
 
 After the options, the query may be specified as a
 single argument conforming with ZQL syntax; i.e., it should be quoted as

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
@@ -35,7 +35,7 @@ func TestMuxDriver(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("muxed into one writer", func(t *testing.T) {
-		reader := zngio.NewReader(strings.NewReader(input), zctx)
+		reader := tzngio.NewReader(strings.NewReader(input), zctx)
 		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader, nil, nano.MaxSpan), false, nano.MaxSpan, nil)
 		assert.NoError(t, err)
 		c := counter{}
@@ -46,7 +46,7 @@ func TestMuxDriver(t *testing.T) {
 	})
 
 	t.Run("muxed into individual writers", func(t *testing.T) {
-		reader := zngio.NewReader(strings.NewReader(input), zctx)
+		reader := tzngio.NewReader(strings.NewReader(input), zctx)
 		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader, nil, nano.MaxSpan), false, nano.MaxSpan, nil)
 		assert.NoError(t, err)
 		cs := []zbuf.Writer{&counter{}, &counter{}}

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/expr"
-	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
@@ -19,7 +19,7 @@ import (
 // XXX copied from filter_test.go where could we put a single copy of this?
 func parseOneRecord(zngsrc string) (*zng.Record, error) {
 	ior := strings.NewReader(zngsrc)
-	reader := zngio.NewReader(ior, resolver.NewContext())
+	reader := tzngio.NewReader(ior, resolver.NewContext())
 
 	rec, err := reader.Read()
 	if err != nil {

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/filter"
-	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
@@ -61,7 +61,7 @@ func runTest(filt string, record *zng.Record, expectedResult bool) error {
 
 func parseOneRecord(zngsrc string) (*zng.Record, error) {
 	ior := strings.NewReader(zngsrc)
-	reader := zngio.NewReader(ior, resolver.NewContext())
+	reader := tzngio.NewReader(ior, resolver.NewContext())
 
 	rec, err := reader.Read()
 	if err != nil {

--- a/pkg/test/internal.go
+++ b/pkg/test/internal.go
@@ -21,7 +21,7 @@ type Internal struct {
 	Query        string
 	Input        string
 	InputFormat  string // defaults to "auto", like zq
-	OutputFormat string // defaults to "zng", like zq
+	OutputFormat string // defaults to "tzng", like zq
 	Expected     string
 	ExpectedErr  error
 }
@@ -46,7 +46,7 @@ func stringReader(input string, ifmt string, zctx *resolver.Context) (zbuf.Reade
 
 func newEmitter(ofmt string) (*emitter.Bytes, error) {
 	if ofmt == "" {
-		ofmt = "zng"
+		ofmt = "tzng"
 	}
 	// XXX text format options not supported
 	return emitter.NewBytes(&zio.WriterFlags{Format: ofmt})

--- a/proc/groupby_test.go
+++ b/proc/groupby_test.go
@@ -167,7 +167,7 @@ func New(name, input, output, cmd string) test.Internal {
 		Name:         name,
 		Query:        "* | " + cmd,
 		Input:        input,
-		OutputFormat: "zng",
+		OutputFormat: "tzng",
 		Expected:     test.Trim(output),
 	}
 }

--- a/proc/utils.go
+++ b/proc/utils.go
@@ -15,7 +15,7 @@ import (
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
@@ -198,7 +198,7 @@ func (p *ProcTest) Finish() error {
 }
 
 func parse(zctx *resolver.Context, src string) (*zbuf.Array, error) {
-	reader := zngio.NewReader(strings.NewReader(src), zctx)
+	reader := tzngio.NewReader(strings.NewReader(src), zctx)
 	records := make([]*zng.Record, 0)
 	for {
 		rec, err := reader.Read()

--- a/tests/suite/diropt/diropt1.yaml
+++ b/tests/suite/diropt/diropt1.yaml
@@ -1,7 +1,7 @@
-script: zq -f zeek -d out "*" in.zng
+script: zq -f zeek -d out "*" in.tzng
 
 inputs:
-  - name: in.zng
+  - name: in.tzng
     data: |
       #0:record[_path:string,a:string]
       #1:record[_path:string,a:int64]

--- a/tests/suite/diropt/diropt2.yaml
+++ b/tests/suite/diropt/diropt2.yaml
@@ -1,7 +1,7 @@
-script: zq -f zng -d out -o foo- "*" in.zng
+script: zq -f tzng -d out -o foo- "*" in.tzng
 
 inputs:
-  - name: in.zng
+  - name: in.tzng
     data: |
       #0:record[_path:string,a:string]
       #1:record[_path:string,a:int64]
@@ -14,13 +14,13 @@ inputs:
       1:[dns;4;]
 
 outputs:
-  - name: out/foo-conn.zng
+  - name: out/foo-conn.tzng
     data: |
       #0:record[_path:string,a:string]
       0:[conn;foo;]
       0:[conn;hello;]
       0:[conn;world;]
-  - name: out/foo-dns.zng
+  - name: out/foo-dns.tzng
     data: |
       #0:record[_path:string,a:int64]
       0:[dns;1;]

--- a/tests/suite/errors/alias.go
+++ b/tests/suite/errors/alias.go
@@ -17,7 +17,7 @@ const inputRedefineAlias = `
 var RedefineAlias = test.Internal{
 	Name:        "redefine alias",
 	Query:       "*",
-	InputFormat: "zng",
+	InputFormat: "tzng",
 	Input:       test.Trim(inputRedefineAlias),
 	ExpectedErr: resolver.ErrAliasExists,
 }

--- a/tests/suite/errors/combiner.go
+++ b/tests/suite/errors/combiner.go
@@ -6,7 +6,7 @@ import (
 
 var Combiner = test.Shell{
 	Name:   "combiner-error-has-name",
-	Script: `zq -j types.json "*" *.ndjson > http.zng`,
+	Script: `zq -j types.json "*" *.ndjson > http.tzng`,
 	Input: []test.File{
 		test.File{"http.ndjson", test.Trim(http)},
 		test.File{"badpath.ndjson", test.Trim(badpath)},

--- a/tests/suite/errors/dupfields.go
+++ b/tests/suite/errors/dupfields.go
@@ -16,6 +16,6 @@ var DuplicateFields = test.Internal{
 	Name:         "duplicatefields",
 	Query:        "*",
 	Input:        test.Trim(inputDuplicateFields),
-	OutputFormat: "zng",
+	OutputFormat: "tzng",
 	ExpectedErr:  zng.ErrDuplicateFields,
 }

--- a/tests/suite/errors/emptytypelist.go
+++ b/tests/suite/errors/emptytypelist.go
@@ -14,7 +14,7 @@ var EmptyUnionType = test.Internal{
 	Name:        "emptyuniontype",
 	Query:       "*",
 	Input:       test.Trim(inputEmptyUnionType),
-	InputFormat: "zng",
+	InputFormat: "tzng",
 	ExpectedErr: resolver.ErrEmptyTypeList,
 }
 
@@ -27,6 +27,6 @@ var EmptySetType = test.Internal{
 	Name:        "emptysettype",
 	Query:       "*",
 	Input:       test.Trim(inputEmptySetType),
-	InputFormat: "zng",
+	InputFormat: "tzng",
 	ExpectedErr: resolver.ErrEmptyTypeList,
 }

--- a/tests/suite/errors/null.go
+++ b/tests/suite/errors/null.go
@@ -13,7 +13,7 @@ const inputTypeNull = `
 var TypeNull = test.Internal{
 	Name:        "type null",
 	Query:       "*",
-	InputFormat: "zng",
+	InputFormat: "tzng",
 	Input:       test.Trim(inputTypeNull),
 	ExpectedErr: zng.ErrInstantiateNull,
 }

--- a/tests/suite/errors/records.go
+++ b/tests/suite/errors/records.go
@@ -18,7 +18,7 @@ var ErrNotPrimitive = test.Internal{
 	Name:        "container where primitive expected",
 	Query:       "*",
 	Input:       test.Trim(inputErrNotPrimitive),
-	InputFormat: "zng",
+	InputFormat: "tzng",
 	ExpectedErr: zng.ErrNotPrimitive,
 }
 
@@ -41,7 +41,7 @@ var ErrNotContainer = test.Internal{
 	Name:        "primitive where container expected",
 	Query:       "*",
 	Input:       test.Trim(inputErrNotContainer),
-	InputFormat: "zng",
+	InputFormat: "tzng",
 	ExpectedErr: zng.ErrNotContainer,
 }
 
@@ -64,7 +64,7 @@ var ErrExtraField = test.Internal{
 	Name:        "extra field",
 	Query:       "*",
 	Input:       test.Trim(inputErrExtraField),
-	InputFormat: "zng",
+	InputFormat: "tzng",
 	ExpectedErr: zng.ErrExtraField,
 }
 
@@ -77,6 +77,6 @@ var ErrMissingField = test.Internal{
 	Name:        "missing field",
 	Query:       "*",
 	Input:       test.Trim(inputErrMissingField),
-	InputFormat: "zng",
+	InputFormat: "tzng",
 	ExpectedErr: zng.ErrMissingField,
 }

--- a/tests/suite/errors/stoperr.go
+++ b/tests/suite/errors/stoperr.go
@@ -6,29 +6,29 @@ import (
 
 var StopErrStop = test.Shell{
 	Name:   "stop-with-stoperr",
-	Script: `zq  "*" good.zng bad.zng > res.zng`,
+	Script: `zq  "*" good.tzng bad.tzng > res.tzng`,
 	Input: []test.File{
-		test.File{"bad.zng", test.Trim(bad)},
-		test.File{"good.zng", test.Trim(good)},
+		test.File{"bad.tzng", test.Trim(bad)},
+		test.File{"good.tzng", test.Trim(good)},
 	},
 	Expected: []test.File{
-		test.File{"res.zng", ""},
+		test.File{"res.tzng", ""},
 	},
-	ExpectedStderrRE: "bad.zng: format detection error.*",
+	ExpectedStderrRE: "bad.tzng: format detection error.*",
 }
 
 // one input has first bad line (detection fails)
 var StopErrContinue = test.Shell{
 	Name:   "continue-with-stoperr-false",
-	Script: `zq -e=false  "*" good.zng bad.zng > res.zng`,
+	Script: `zq -e=false  "*" good.tzng bad.tzng > res.tzng`,
 	Input: []test.File{
-		test.File{"bad.zng", test.Trim(bad)},
-		test.File{"good.zng", test.Trim(good)},
+		test.File{"bad.tzng", test.Trim(bad)},
+		test.File{"good.tzng", test.Trim(good)},
 	},
 	Expected: []test.File{
-		test.File{"res.zng", test.Trim(good)},
+		test.File{"res.tzng", test.Trim(good)},
 	},
-	ExpectedStderrRE: "bad.zng: format detection error.*",
+	ExpectedStderrRE: "bad.tzng: format detection error.*",
 }
 
 const good = `#0:record[_path:string,ts:time]
@@ -41,15 +41,15 @@ const bad = `#0:record[_path:string,ts:time]
 // one input has first bad line (detection succeeds)
 var StopErrContinueMid = test.Shell{
 	Name:   "continue-with-stoperr-false-mid",
-	Script: `zq -e=false  "*" good.zng bad.zng > res.zng`,
+	Script: `zq -e=false  "*" good.tzng bad.tzng > res.tzng`,
 	Input: []test.File{
-		test.File{"bad.zng", test.Trim(midbad)},
-		test.File{"good.zng", test.Trim(good)},
+		test.File{"bad.tzng", test.Trim(midbad)},
+		test.File{"good.tzng", test.Trim(good)},
 	},
 	Expected: []test.File{
-		test.File{"res.zng", test.Trim(midgood)},
+		test.File{"res.tzng", test.Trim(midgood)},
 	},
-	ExpectedStderrRE: "bad.zng.*: invalid descriptor",
+	ExpectedStderrRE: "bad.tzng.*: invalid descriptor",
 }
 
 const midbad = `#0:record[_path:string,ts:time]

--- a/tests/suite/jsontype/test.go
+++ b/tests/suite/jsontype/test.go
@@ -6,13 +6,13 @@ import (
 
 var Test = test.Shell{
 	Name:   "json-types",
-	Script: `zq -j types.json "*" in.ndjson > http.zng`,
+	Script: `zq -j types.json "*" in.ndjson > http.tzng`,
 	Input: []test.File{
 		test.File{"in.ndjson", test.Trim(input)},
 		test.File{"types.json", test.Trim(types)},
 	},
 	Expected: []test.File{
-		test.File{"http.zng", test.Trim(httpZng)},
+		test.File{"http.tzng", test.Trim(httpTzng)},
 	},
 }
 
@@ -54,19 +54,19 @@ const types = `
   ]
 }`
 
-const httpZng = `
+const httpTzng = `
 #0:record[_path:string,ts:time,uid:bstring,id:record[orig_h:ip]]
 0:[http;1490385563.306076;CXY9a54W2dLZwzPXf1;[10.10.7.65;]]`
 
 var TestInferPath = test.Shell{
 	Name:   "json-types-inferpath",
-	Script: `zq -j types.json "*" *.log > http.zng`,
+	Script: `zq -j types.json "*" *.log > http.tzng`,
 	Input: []test.File{
 		test.File{"http_20190830_08:00:00-09:00:00-0500.log", test.Trim(inputNoPath)},
 		test.File{"types.json", test.Trim(types)},
 	},
 	Expected: []test.File{
-		test.File{"http.zng", test.Trim(httpZng)},
+		test.File{"http.tzng", test.Trim(httpTzng)},
 	},
 }
 
@@ -74,13 +74,13 @@ const inputNoPath = `{"ts":"2017-03-24T19:59:23.306076Z","uid":"CXY9a54W2dLZwzPX
 
 var TestSet = test.Shell{
 	Name:   "json-types-set",
-	Script: `zq -j types.json "*" in.ndjson > http.zng`,
+	Script: `zq -j types.json "*" in.ndjson > http.tzng`,
 	Input: []test.File{
 		test.File{"in.ndjson", test.Trim(inputSet)},
 		test.File{"types.json", test.Trim(typesSet)},
 	},
 	Expected: []test.File{
-		test.File{"http.zng", test.Trim(zngSet)},
+		test.File{"http.tzng", test.Trim(tzngSet)},
 	},
 }
 
@@ -113,19 +113,19 @@ const typesSet = `
   ]
 }`
 
-const zngSet = `
+const tzngSet = `
 #0:record[_path:string,ts:time,uids:set[bstring]]
 0:[sets;1490385563.306076;[a;b;]]`
 
 var TestNoTs = test.Shell{
 	Name:   "json-types-no-ts",
-	Script: `zq -j types.json "*" in.ndjson > out.zng`,
+	Script: `zq -j types.json "*" in.ndjson > out.tzng`,
 	Input: []test.File{
 		test.File{"in.ndjson", test.Trim(inputNoTs)},
 		test.File{"types.json", test.Trim(typesNoTs)},
 	},
 	Expected: []test.File{
-		test.File{"out.zng", test.Trim(zngNoTs)},
+		test.File{"out.tzng", test.Trim(tzngNoTs)},
 	},
 }
 
@@ -154,19 +154,19 @@ const typesNoTs = `
   ]
 }`
 
-const zngNoTs = `
+const tzngNoTs = `
 #0:record[_path:string,name:bstring]
 0:[nots;foo;]`
 
 var TestTs = test.Shell{
 	Name:   "json-types-ts",
-	Script: `zq -j types.json "every 1d count()" in.ndjson > http.zng`,
+	Script: `zq -j types.json "every 1d count()" in.ndjson > http.tzng`,
 	Input: []test.File{
 		test.File{"in.ndjson", test.Trim(inputTs)},
 		test.File{"types.json", test.Trim(typesTs)},
 	},
 	Expected: []test.File{
-		test.File{"http.zng", test.Trim(zngTs)},
+		test.File{"http.tzng", test.Trim(tzngTs)},
 	},
 }
 
@@ -195,6 +195,6 @@ const typesTs = `
   ]
 }`
 
-const zngTs = `
+const tzngTs = `
 #0:record[ts:time,count:uint64]
 0:[1425513600;1;]`

--- a/zbuf/peeker_test.go
+++ b/zbuf/peeker_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-func newTextReader(logs string) *zngio.Reader {
+func newTextReader(logs string) *tzngio.Reader {
 	logs = strings.TrimSpace(logs) + "\n"
-	return zngio.NewReader(strings.NewReader(logs), resolver.NewContext())
+	return tzngio.NewReader(strings.NewReader(logs), resolver.NewContext())
 }
 
 const input = `

--- a/zbuf/syntax_test.go
+++ b/zbuf/syntax_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +30,7 @@ func cleanup(s string) string {
 
 func reader(s string) zbuf.Reader {
 	r := strings.NewReader(cleanup(s))
-	return zngio.NewReader(r, resolver.NewContext())
+	return tzngio.NewReader(r, resolver.NewContext())
 }
 
 func TestZngSyntax(t *testing.T) {

--- a/zio/bzngio/index_test.go
+++ b/zio/bzngio/index_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
-	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/require"
 )
@@ -73,8 +73,8 @@ func TestBzngIndex(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// create a test bzng file
-	reader := zngio.NewReader(strings.NewReader(zngData), resolver.NewContext())
-	fname := filepath.Join(dir, "test.zng")
+	reader := tzngio.NewReader(strings.NewReader(zngData), resolver.NewContext())
+	fname := filepath.Join(dir, "test.tzng")
 	fp, err := os.Create(fname)
 	require.NoError(t, err)
 

--- a/zio/detector/lookup.go
+++ b/zio/detector/lookup.go
@@ -10,9 +10,9 @@ import (
 	"github.com/brimsec/zq/zio/ndjsonio"
 	"github.com/brimsec/zq/zio/tableio"
 	"github.com/brimsec/zq/zio/textio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zio/zeekio"
 	"github.com/brimsec/zq/zio/zjsonio"
-	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 )
@@ -26,7 +26,7 @@ func (*nullWriter) Write(*zng.Record) error {
 func LookupWriter(w io.WriteCloser, wflags *zio.WriterFlags) *zio.Writer {
 	flags := *wflags
 	if flags.Format == "" {
-		flags.Format = "zng"
+		flags.Format = "tzng"
 	}
 	var f zbuf.WriteFlusher
 	switch flags.Format {
@@ -35,7 +35,9 @@ func LookupWriter(w io.WriteCloser, wflags *zio.WriterFlags) *zio.Writer {
 	case "null":
 		f = zbuf.NopFlusher(&nullWriter{})
 	case "zng":
-		f = zbuf.NopFlusher(zngio.NewWriter(w))
+		panic("zng")
+	case "tzng":
+		f = zbuf.NopFlusher(tzngio.NewWriter(w))
 	case "bzng":
 		f = bzngio.NewWriter(w, flags)
 	case "zeek":
@@ -57,8 +59,8 @@ func LookupWriter(w io.WriteCloser, wflags *zio.WriterFlags) *zio.Writer {
 
 func LookupReader(r io.Reader, zctx *resolver.Context, flags *zio.ReaderFlags) (zbuf.Reader, error) {
 	switch flags.Format {
-	case "zng":
-		return zngio.NewReader(r, zctx), nil
+	case "tzng":
+		return tzngio.NewReader(r, zctx), nil
 	case "zeek":
 		return zeekio.NewReader(r, zctx)
 	case "ndjson":

--- a/zio/detector/reader.go
+++ b/zio/detector/reader.go
@@ -7,9 +7,9 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/bzngio"
 	"github.com/brimsec/zq/zio/ndjsonio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zio/zeekio"
 	"github.com/brimsec/zq/zio/zjsonio"
-	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
 )
@@ -18,9 +18,9 @@ func NewReader(r io.Reader, zctx *resolver.Context) (zbuf.Reader, error) {
 	recorder := NewRecorder(r)
 	track := NewTrack(recorder)
 
-	zngErr := match(zngio.NewReader(track, resolver.NewContext()), "tzng")
+	zngErr := match(tzngio.NewReader(track, resolver.NewContext()), "tzng")
 	if zngErr == nil {
-		return zngio.NewReader(recorder, zctx), nil
+		return tzngio.NewReader(recorder, zctx), nil
 	}
 	track.Reset()
 

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/assert"
@@ -52,7 +52,7 @@ func TestNDJSONWriter(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			var out bytes.Buffer
 			w := NewWriter(&out)
-			r := zngio.NewReader(strings.NewReader(c.input), resolver.NewContext())
+			r := tzngio.NewReader(strings.NewReader(c.input), resolver.NewContext())
 			require.NoError(t, zbuf.Copy(zbuf.NopFlusher(w), r))
 			NDJSONEq(t, c.output, out.String())
 		})
@@ -159,43 +159,43 @@ func NDJSONEq(t *testing.T, expected string, actual string) {
 
 func TestNewRawFromJSON(t *testing.T) {
 	type testcase struct {
-		name, zng, json, defaultPath string
+		name, tzng, json, defaultPath string
 	}
 	cases := []testcase{
 		{
 			name: "LongDuration",
-			zng: `#0:record[_path:string,ts:time,span:duration]
+			tzng: `#0:record[_path:string,ts:time,span:duration]
 0:[test;1573860644.637486;0.123456134;]`,
 			json: `{"_path": "test", "ts": "2019-11-15T23:30:44.637486Z", "span": 0.1234561341234234}`,
 		},
 		{
 			name: "TsISO8601",
-			zng: `#0:record[_path:string,b:bool,i:int64,s:set[bool],ts:time,v:array[int64]]
+			tzng: `#0:record[_path:string,b:bool,i:int64,s:set[bool],ts:time,v:array[int64]]
 0:[test;-;-;-;1573860644.637486;-;]`,
 			json: `{"_path": "test", "ts":"2019-11-15T23:30:44.637486Z"}`,
 		},
 		{
 			name: "TsEpoch",
-			zng: `#0:record[_path:string,ts:time]
+			tzng: `#0:record[_path:string,ts:time]
 0:[test;1573860644.637486;]`,
 			json: `{"_path": "test", "ts":1573860644.637486}`,
 		},
 		{
 			name: "TsMillis",
-			zng: `#0:record[_path:string,ts:time]
+			tzng: `#0:record[_path:string,ts:time]
 0:[test;1573860644.637000;]`,
 			json: `{"_path": "test", "ts":1573860644637}`,
 		},
 		{
 			name: "defaultPath",
-			zng: `#0:record[_path:string,ts:time]
+			tzng: `#0:record[_path:string,ts:time]
 0:[inferred;1573860644.637000;]`,
 			json:        `{"ts":1573860644637}`,
 			defaultPath: "inferred",
 		},
 		{
 			name: "defaultPath (unused)",
-			zng: `#0:record[_path:string,ts:time]
+			tzng: `#0:record[_path:string,ts:time]
 0:[test;1573860644.637000;]`,
 			json:        `{"_path": "test", "ts":1573860644637}`,
 			defaultPath: "inferred",
@@ -204,7 +204,7 @@ func TestNewRawFromJSON(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			r := zngio.NewReader(strings.NewReader(c.zng), resolver.NewContext())
+			r := tzngio.NewReader(strings.NewReader(c.tzng), resolver.NewContext())
 			expected, err := r.Read()
 			require.NoError(t, err)
 			typ := expected.Type

--- a/zio/tzngio/parser.go
+++ b/zio/tzngio/parser.go
@@ -1,4 +1,4 @@
-package zngio
+package tzngio
 
 import (
 	"errors"

--- a/zio/tzngio/reader.go
+++ b/zio/tzngio/reader.go
@@ -1,4 +1,4 @@
-package zngio
+package tzngio
 
 import (
 	"bufio"

--- a/zio/tzngio/reader_test.go
+++ b/zio/tzngio/reader_test.go
@@ -1,4 +1,4 @@
-package zngio_test
+package tzngio_test
 
 import (
 	"bytes"
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +24,7 @@ func TestCtrl(t *testing.T) {
 	// this tests reading of control via text zng,
 	// then writing of raw control, and reading back the result
 	in := []byte(strings.TrimSpace(ctrl) + "\n")
-	r := zngio.NewReader(bytes.NewReader(in), resolver.NewContext())
+	r := tzngio.NewReader(bytes.NewReader(in), resolver.NewContext())
 
 	_, body, err := r.ReadPayload()
 	assert.NoError(t, err)
@@ -115,8 +115,8 @@ func (o *output) Close() error { return nil }
 func boomerangErr(t *testing.T, name, logs, errorMsg string, errorArgs ...interface{}) {
 	t.Run(name, func(t *testing.T) {
 		in := []byte(strings.TrimSpace(logs) + "\n")
-		zngSrc := zngio.NewReader(bytes.NewReader(in), resolver.NewContext())
-		zngDst := zbuf.NopFlusher(zngio.NewWriter(&output{}))
+		zngSrc := tzngio.NewReader(bytes.NewReader(in), resolver.NewContext())
+		zngDst := zbuf.NopFlusher(tzngio.NewWriter(&output{}))
 		err := zbuf.Copy(zngDst, zngSrc)
 		assert.Errorf(t, err, errorMsg, errorArgs...)
 	})
@@ -127,8 +127,8 @@ func boomerang(t *testing.T, name, logs string) {
 	t.Run(name, func(t *testing.T) {
 		var out output
 		in := []byte(strings.TrimSpace(logs) + "\n")
-		zngSrc := zngio.NewReader(bytes.NewReader(in), resolver.NewContext())
-		zngDst := zbuf.NopFlusher(zngio.NewWriter(&out))
+		zngSrc := tzngio.NewReader(bytes.NewReader(in), resolver.NewContext())
+		zngDst := zbuf.NopFlusher(tzngio.NewWriter(&out))
 		err := zbuf.Copy(zngDst, zngSrc)
 		require.NoError(t, err)
 		assert.Equal(t, string(in), out.String())

--- a/zio/tzngio/writer.go
+++ b/zio/tzngio/writer.go
@@ -1,4 +1,4 @@
-package zngio
+package tzngio
 
 import (
 	"fmt"

--- a/zio/zeekio/writer_test.go
+++ b/zio/zeekio/writer_test.go
@@ -7,48 +7,48 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zio/zeekio"
-	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/require"
 )
 
 func TestWriter(t *testing.T) {
 	t.Run("replaces-array", func(t *testing.T) {
-		zng := `#1:record[array:array[int64]]
+		tzng := `#1:record[array:array[int64]]
 1:[[1;2;3;]]`
 		zeek := zeekfile(
 			[]string{"array"},
 			[]string{"vector[int]"},
 			[]string{"1,2,3"},
 		)
-		runcase(t, zng, zeek)
+		runcase(t, tzng, zeek)
 	})
 	t.Run("replaces-bstring", func(t *testing.T) {
-		zng := `#1:record[bstring:bstring]
+		tzng := `#1:record[bstring:bstring]
 1:[test;]`
 		zeek := zeekfile(
 			[]string{"bstring"},
 			[]string{"string"},
 			[]string{"test"},
 		)
-		runcase(t, zng, zeek)
+		runcase(t, tzng, zeek)
 	})
 	t.Run("replaces-type-in-containers", func(t *testing.T) {
-		zng := `#1:record[array:array[bstring],set:set[bstring],id:record[bstring:bstring]]
+		tzng := `#1:record[array:array[bstring],set:set[bstring],id:record[bstring:bstring]]
 1:[[test1;test2;test3;][test1;test2;][test4;]]`
 		zeek := zeekfile(
 			[]string{"array", "set", "id.bstring"},
 			[]string{"vector[string]", "set[string]", "string"},
 			[]string{"test1,test2,test3", "test1,test2", "test4"},
 		)
-		runcase(t, zng, zeek)
+		runcase(t, tzng, zeek)
 	})
 }
 
-func runcase(t *testing.T, zng, expected string) {
+func runcase(t *testing.T, tzng, expected string) {
 	out := bytes.NewBuffer(nil)
-	r := zngio.NewReader(strings.NewReader(zng), resolver.NewContext())
+	r := tzngio.NewReader(strings.NewReader(tzng), resolver.NewContext())
 	rec, err := r.Read()
 	require.NoError(t, err)
 	w := zeekio.NewWriter(out, zio.WriterFlags{})

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -14,7 +14,7 @@ type ReaderFlags struct {
 }
 
 func (f *ReaderFlags) SetFlags(fs *flag.FlagSet) {
-	fs.StringVar(&f.Format, "i", "auto", "format of input data [auto,bzng,ndjson,zeek,zjson,zng]")
+	fs.StringVar(&f.Format, "i", "auto", "format of input data [auto,bzng,ndjson,zeek,zjson,tzng]")
 }
 
 // WriterFlags has the union of the flags accepted by all the different
@@ -29,7 +29,7 @@ type WriterFlags struct {
 }
 
 func (f *WriterFlags) SetFlags(fs *flag.FlagSet) {
-	fs.StringVar(&f.Format, "f", "zng", "format for output data [bzng,ndjson,table,text,types,zeek,zjson,zng]")
+	fs.StringVar(&f.Format, "f", "tzng", "format for output data [bzng,ndjson,table,text,types,zeek,zjson,tzng]")
 	fs.BoolVar(&f.ShowTypes, "T", false, "display field types in text output")
 	fs.BoolVar(&f.ShowFields, "F", false, "display field names in text output")
 	fs.BoolVar(&f.EpochDates, "E", false, "display epoch timestamps in text output")
@@ -60,8 +60,8 @@ func (w *Writer) Close() error {
 
 func Extension(format string) string {
 	switch format {
-	case "zng":
-		return ".zng"
+	case "tzng":
+		return ".tzng"
 	case "zeek":
 		return ".log"
 	case "ndjson":

--- a/zio/zio_test.go
+++ b/zio/zio_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,8 +16,8 @@ func assertError(t *testing.T, err error, pattern, what string) {
 	assert.Containsf(t, err.Error(), pattern, "error message for %s is as expected", what)
 }
 
-// Test things related to parsing zng
-func TestZngDescriptors(t *testing.T) {
+// Test things related to parsing tzng
+func TestTzngDescriptors(t *testing.T) {
 	// Step 1 - Test a simple zng descriptor and corresponding value
 	src := "#1:record[s:string,n:int32]\n"
 	src += "1:[foo;5;]\n"
@@ -29,7 +29,7 @@ func TestZngDescriptors(t *testing.T) {
 	// Step 4 - Test that referencing an invalid descriptor is an error.
 	src += "100:[something;somethingelse;]\n"
 
-	r := zngio.NewReader(strings.NewReader(src), resolver.NewContext())
+	r := tzngio.NewReader(strings.NewReader(src), resolver.NewContext())
 
 	// Check Step 1
 	record, err := r.Read()
@@ -76,23 +76,23 @@ func TestZngDescriptors(t *testing.T) {
 	}
 
 	for _, z := range zngs {
-		r := zngio.NewReader(strings.NewReader(z), resolver.NewContext())
+		r := tzngio.NewReader(strings.NewReader(z), resolver.NewContext())
 		_, err = r.Read()
-		assert.Error(t, err, "zng parse error", "invalid zng")
+		assert.Error(t, err, "tzng parse error", "invalid tzng")
 	}
 	// Can't use a descriptor of non-record type
-	r = zngio.NewReader(strings.NewReader("#3:string\n"), resolver.NewContext())
+	r = tzngio.NewReader(strings.NewReader("#3:string\n"), resolver.NewContext())
 	_, err = r.Read()
 	assertError(t, err, "not a record", "descriptor with non-record type")
 
 	// Descriptor with an invalid type is rejected
-	r = zngio.NewReader(strings.NewReader("#4:notatype\n"), resolver.NewContext())
+	r = tzngio.NewReader(strings.NewReader("#4:notatype\n"), resolver.NewContext())
 	_, err = r.Read()
 	assertError(t, err, "unknown type", "descriptor with invalid type")
 
 	// Trying to redefine a descriptor is an error XXX this should be ok
 	d := "#1:record[n:int32]\n"
-	r = zngio.NewReader(strings.NewReader(d+d), resolver.NewContext())
+	r = tzngio.NewReader(strings.NewReader(d+d), resolver.NewContext())
 	_, err = r.Read()
 	assertError(t, err, "descriptor already exists", "redefining //descriptor")
 }

--- a/zng/builder_test.go
+++ b/zng/builder_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/zcode"
-	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +21,7 @@ const builder = `
 2:[7;[3;]]`
 
 func TestBuilder(t *testing.T) {
-	r := zngio.NewReader(strings.NewReader(builder), resolver.NewContext())
+	r := tzngio.NewReader(strings.NewReader(builder), resolver.NewContext())
 	r0, _ := r.Read()
 	r1, _ := r.Read()
 	r2, _ := r.Read()

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -17,7 +17,7 @@ of heterogeneously typed records, e.g., structured logs, where filtering and
 analytics may be applied to a stream in parts without having to fully deserialize
 every value.
 
-ZNG has both a text form simply called "ZNG",
+ZNG has both a text form simply called "TZNG",
 comprised of a sequence of newline-delimited UTF-8 strings,
 as well as a binary form called "BZNG".
 
@@ -34,7 +34,7 @@ binary serialization format that allows "lazy parsing" of fields such that
 only the fields of interest in a stream need to be deserialized and interpreted.
 Unlike Avro, ZNG embeds its schemas in the data stream and thereby admits
 an efficient multiplexing of heterogeneous data types by prepending to each
-data value a simple integer identifier to reference its type.   
+data value a simple integer identifier to reference its type.
 
 ZNG requires no external schema definitions as its type system
 constructs schemas on the fly from within the stream using composable,
@@ -451,7 +451,7 @@ For sets, the concatenation of elements must be normalized so that the
 sequence of bytes encoding each element's tag-counted value is
 lexicographically greater than that of the preceding element.
 
-## 3. ZNG Text Format
+## 3. ZNG Text Format (TZNG)
 
 The ZNG text format is a human-readable form that follows directly from the BZNG
 binary format.  A ZNG file/stream is encoded with UTF-8.

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/brimsec/zq/pkg/test"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/ndjsonio"
-	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zqd"
 	"github.com/brimsec/zq/zqd/api"
 	"github.com/brimsec/zq/zqd/zeek"
@@ -580,7 +580,7 @@ func zngSearch(t *testing.T, client *api.Connection, space, prog string) string 
 	r, err := client.Search(context.Background(), req)
 	require.NoError(t, err)
 	buf := bytes.NewBuffer(nil)
-	w := zbuf.NopFlusher(zngio.NewWriter(buf))
+	w := zbuf.NopFlusher(tzngio.NewWriter(buf))
 	require.NoError(t, zbuf.Copy(w, r))
 	return buf.String()
 }

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -25,7 +25,7 @@
 //
 // Input format is detected automatically and can be anything recognized by
 // "zq -i auto" (including optional gzip compression).  Output format defaults
-// to zng but can be set to anything accepted by "zq -f".
+// to tzng but can be set to anything accepted by "zq -f".
 //
 //    zql: count()
 //
@@ -51,7 +51,7 @@
 // defining the script, e.g.,
 //
 // inputs:
-//    - name: in1.zng
+//    - name: in1.tzng
 //      data: |
 //         #0:record[i:int64]
 //         0:[1;]
@@ -60,15 +60,15 @@
 //         #0:record[i:int64]
 //         0:[2;]
 // script: |
-//    zq -o out.zng in1.zng -
-//    zq -o count.zng "count()" out.zng
+//    zq -o out.tzng in1.tzng -
+//    zq -o count.tzng "count()" out.tzng
 // outputs:
-//    - name: out.zng
+//    - name: out.tzng
 //      data: |
 //         #0:record[i:int64]
 //         0:[1;]
 //         0:[2;]
-//    - name: count.zng
+//    - name: count.tzng
 //      data: |
 //         #0:record[count:uint64]
 //         0:[2;]
@@ -364,7 +364,7 @@ func FromYAMLFile(filename string) (*ZTest, error) {
 		return nil, errors.New("found multiple YAML documents or garbage after first document")
 	}
 	if z.OutputFormat == "" {
-		z.OutputFormat = "zng"
+		z.OutputFormat = "tzng"
 	}
 	if z.ErrorRE != "" {
 		z.errRegex, err = regexp.Compile(z.ErrorRE)


### PR DESCRIPTION
This commit implements the renaming of the ".zng" extension to
".tzng". Along with this, many variable names are changed to avoid
ambiguity and help cement the new "tzng" term.

This is the first half of #544. The second half (renaming bzng->zng) will come in a separate PR.