### PR TITLE
Rename bzng to zng

### DIFF
--- a/archive/finder.go
+++ b/archive/finder.go
@@ -25,7 +25,7 @@ func Find(dir string, pattern []byte) ([]string, error) {
 			// descend...
 			return nil
 		}
-		if filepath.Ext(name) == ".bzng" {
+		if filepath.Ext(name) == ".zng" {
 			hit, err := SearchFile(path, pattern)
 			if err != nil {
 				fmt.Printf("%s\n", err)

--- a/archive/indexer.go
+++ b/archive/indexer.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zdx"
-	"github.com/brimsec/zq/zio/bzngio"
+	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 )
@@ -37,7 +37,7 @@ func CreateIndexes(dir string) error {
 			// descend...
 			return nil
 		}
-		if filepath.Ext(name) == ".bzng" {
+		if filepath.Ext(name) == ".zng" {
 			err = IndexLogFile(path)
 			if err != nil {
 				fmt.Printf("%s: %s\n", path, err)
@@ -70,7 +70,7 @@ func IndexLogFile(path string) error {
 	defer file.Close()
 	// XXX should be able to index any kind of logs... find should take
 	// a regexp to match files and then use auto-detect or -i for input format
-	reader := bzngio.NewReader(file, resolver.NewContext())
+	reader := zngio.NewReader(file, resolver.NewContext())
 	table, err := indexTypeIP(reader)
 	if err != nil {
 		return err

--- a/cmd/zar/chop/command.go
+++ b/cmd/zar/chop/command.go
@@ -13,7 +13,7 @@ import (
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
-	"github.com/brimsec/zq/zio/bzngio"
+	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/mccanne/charm"
 )
@@ -21,7 +21,7 @@ import (
 var Chop = &charm.Spec{
 	Name:  "chop",
 	Usage: "chop [options] file",
-	Short: "chop bzng files into pieces",
+	Short: "chop zng files into pieces",
 	Long: `
 	TBD
 `,
@@ -65,7 +65,7 @@ func (c *Command) Run(args []string) error {
 		}
 		defer file.Close()
 	}
-	r := bzngio.NewReader(bufio.NewReader(file), resolver.NewContext())
+	r := zngio.NewReader(bufio.NewReader(file), resolver.NewContext())
 	var w *bufwriter.Writer
 	var zw zbuf.Writer
 	var n int
@@ -86,7 +86,7 @@ func (c *Command) Run(args []string) error {
 			if err := os.MkdirAll(dir, 0755); err != nil {
 				return err
 			}
-			path := filepath.Join(dir, ts.StringFloat()+".bzng")
+			path := filepath.Join(dir, ts.StringFloat()+".zng")
 			//XXX for now just truncate any existing file.
 			// a future PR will do a split/merge.
 			out, err := os.OpenFile(path, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0644)
@@ -95,7 +95,7 @@ func (c *Command) Run(args []string) error {
 			}
 			fmt.Printf("writing %s\n", path)
 			w = bufwriter.New(out)
-			zw = bzngio.NewWriter(w, zio.WriterFlags{})
+			zw = zngio.NewWriter(w, zio.WriterFlags{})
 		}
 		if err := zw.Write(rec); err != nil {
 			return err

--- a/cmd/zar/find/command.go
+++ b/cmd/zar/find/command.go
@@ -16,7 +16,7 @@ var Find = &charm.Spec{
 	Usage: "find [-d dir] <ip>",
 	Short: "look through zar index files and displays matches",
 	Long: `
-"zar find" descends the directory given by the argument looking for bzng files that have
+"zar find" descends the directory given by the argument looking for zng files that have
 a corresponding zar index and if that index contains the <ip> argument,
 then the path of the zng file is printed.
 The current version supports only IP address, but this will soon change.

--- a/cmd/zar/index/command.go
+++ b/cmd/zar/index/command.go
@@ -12,12 +12,12 @@ import (
 var Index = &charm.Spec{
 	Name:  "index",
 	Usage: "index dir",
-	Short: "creates index files for bzng files",
+	Short: "creates index files for zng files",
 	Long: `
-zar find descends the directory argument looking for bzng files and creates an index
-file for IP addresses for each bzng file encountered.  An index is written to
-a sub-directory of the directory containing each encountered bzng file, where the
-name of the sub-directory is a concatenation of the bzng file name and the suffix
+zar find descends the directory argument looking for zng files and creates an index
+file for IP addresses for each zng file encountered.  An index is written to
+a sub-directory of the directory containing each encountered zng file, where the
+name of the sub-directory is a concatenation of the zng file name and the suffix
 ".zar".
 The current version supports only IP address, but this will soon change.
 `,

--- a/performance/README.md
+++ b/performance/README.md
@@ -9,9 +9,9 @@ As there are many results to sift through, here's a few key summary take-aways:
 
 * If all you care about is cutting field values by column, `zeek-cut` does still perform the best. (Alas, that's all `zeek-cut` can do. :smiley:)
 
-* The numerous input/output formats in `zq` are helpful for fitting into your legacy pipelines. However, BZNG performs the best of all `zq`-compatible formats, due to its binary/optimized nature. If you have logs in a non-BZNG format and expect to query them many times, a one-time pass through `zq` to convert them to BZNG format will save you significant time.
+* The numerous input/output formats in `zq` are helpful for fitting into your legacy pipelines. However, ZNG performs the best of all `zq`-compatible formats, due to its binary/optimized nature. If you have logs in a non-ZNG format and expect to query them many times, a one-time pass through `zq` to convert them to ZNG format will save you significant time.
 
-* Particularly when working in BZNG format & when simple analytics (counting, grouping) are in play, `zq` can significantly outperform `jq`. That said, `zq` does not (yet) include the full set of mathematical/other operations available in `jq`. If there's glaring functional omisssions that are limiting your use of `zq`, we welcome [contributions](../README.md#contributing).
+* Particularly when working in ZNG format & when simple analytics (counting, grouping) are in play, `zq` can significantly outperform `jq`. That said, `zq` does not (yet) include the full set of mathematical/other operations available in `jq`. If there's glaring functional omisssions that are limiting your use of `zq`, we welcome [contributions](../README.md#contributing).
 
 # Results
 
@@ -20,20 +20,20 @@ As there are many results to sift through, here's a few key summary take-aways:
 |**<br>Tool**|**<br>Arguments**|**Input<br>Format**|**Output<br>Format**|**<br>Real**|**<br>User**|**<br>Sys**|
 |:----------:|:---------------:|:-----------------:|:------------------:|-----------:|-----------:|----------:|
 |`zq`|`*`|zeek|zeek|15.53|31.54|1.16|
-|`zq`|`*`|zeek|bzng|6.16|8.18|0.44|
-|`zq`|`*`|zeek|zng|10.36|20.23|0.63|
+|`zq`|`*`|zeek|zng|6.16|8.18|0.44|
+|`zq`|`*`|zeek|tzng|10.36|20.23|0.63|
 |`zq`|`*`|zeek|ndjson|67.83|93.00|4.13|
-|`zq`|`*`|bzng|zeek|14.56|20.83|0.55|
-|`zq`|`*`|bzng|bzng|3.23|3.80|0.35|
-|`zq`|`*`|bzng|zng|10.33|13.96|0.44|
-|`zq`|`*`|bzng|ndjson|63.03|71.85|1.05|
-|`zq`|`*`|zng|zeek|15.43|33.72|1.09|
-|`zq`|`*`|zng|bzng|8.09|10.06|0.53|
-|`zq`|`*`|zng|zng|10.20|21.66|0.46|
-|`zq`|`*`|zng|ndjson|67.35|94.67|3.91|
+|`zq`|`*`|zng|zeek|14.56|20.83|0.55|
+|`zq`|`*`|zng|zng|3.23|3.80|0.35|
+|`zq`|`*`|zng|tzng|10.33|13.96|0.44|
+|`zq`|`*`|zng|ndjson|63.03|71.85|1.05|
+|`zq`|`*`|tzng|zeek|15.43|33.72|1.09|
+|`zq`|`*`|tzng|zng|8.09|10.06|0.53|
+|`zq`|`*`|tzng|tzng|10.20|21.66|0.46|
+|`zq`|`*`|tzng|ndjson|67.35|94.67|3.91|
 |`zq`|`*`|ndjson|zeek|56.26|96.27|4.34|
-|`zq`|`*`|ndjson|bzng|52.16|70.37|3.41|
-|`zq`|`*`|ndjson|zng|54.33|87.20|3.70|
+|`zq`|`*`|ndjson|zng|52.16|70.37|3.41|
+|`zq`|`*`|ndjson|tzng|54.33|87.20|3.70|
 |`zq`|`*`|ndjson|ndjson|72.23|161.66|5.48|
 |`zeek-cut`||zeek|zeek-cut|1.40|1.30|0.07|
 |`jq`|`-c "."`|ndjson|ndjson|40.27|5.01|0.84|
@@ -43,20 +43,20 @@ As there are many results to sift through, here's a few key summary take-aways:
 |**<br>Tool**|**<br>Arguments**|**Input<br>Format**|**Output<br>Format**|**<br>Real**|**<br>User**|**<br>Sys**|
 |:----------:|:---------------:|:-----------------:|:------------------:|-----------:|-----------:|----------:|
 |`zq`|`cut ts`|zeek|zeek|6.70|10.46|0.55|
-|`zq`|`cut ts`|zeek|bzng|6.45|8.29|0.46|
-|`zq`|`cut ts`|zeek|zng|6.63|10.02|0.49|
+|`zq`|`cut ts`|zeek|zng|6.45|8.29|0.46|
+|`zq`|`cut ts`|zeek|tzng|6.63|10.02|0.49|
 |`zq`|`cut ts`|zeek|ndjson|7.68|16.89|0.55|
-|`zq`|`cut ts`|bzng|zeek|3.76|5.94|0.20|
-|`zq`|`cut ts`|bzng|bzng|3.72|4.50|0.32|
-|`zq`|`cut ts`|bzng|zng|3.73|5.71|0.19|
-|`zq`|`cut ts`|bzng|ndjson|6.61|10.85|0.34|
-|`zq`|`cut ts`|zng|zeek|8.80|12.80|0.57|
-|`zq`|`cut ts`|zng|bzng|8.47|10.51|0.50|
-|`zq`|`cut ts`|zng|zng|8.74|12.35|0.43|
-|`zq`|`cut ts`|zng|ndjson|9.64|19.15|0.58|
+|`zq`|`cut ts`|zng|zeek|3.76|5.94|0.20|
+|`zq`|`cut ts`|zng|zng|3.72|4.50|0.32|
+|`zq`|`cut ts`|zng|tzng|3.73|5.71|0.19|
+|`zq`|`cut ts`|zng|ndjson|6.61|10.85|0.34|
+|`zq`|`cut ts`|tzng|zeek|8.80|12.80|0.57|
+|`zq`|`cut ts`|tzng|zng|8.47|10.51|0.50|
+|`zq`|`cut ts`|tzng|tzng|8.74|12.35|0.43|
+|`zq`|`cut ts`|tzng|ndjson|9.64|19.15|0.58|
 |`zq`|`cut ts`|ndjson|zeek|52.62|72.58|3.43|
-|`zq`|`cut ts`|ndjson|bzng|52.15|70.09|3.46|
-|`zq`|`cut ts`|ndjson|zng|52.46|71.97|3.51|
+|`zq`|`cut ts`|ndjson|zng|52.15|70.09|3.46|
+|`zq`|`cut ts`|ndjson|tzng|52.46|71.97|3.51|
 |`zq`|`cut ts`|ndjson|ndjson|53.59|80.07|3.82|
 |`zeek-cut`|`ts`|zeek|zeek-cut|1.33|1.23|0.09|
 |`jq`|`-c ". \| { ts }"`|ndjson|ndjson|22.52|3.80|0.61|
@@ -66,20 +66,20 @@ As there are many results to sift through, here's a few key summary take-aways:
 |**<br>Tool**|**<br>Arguments**|**Input<br>Format**|**Output<br>Format**|**<br>Real**|**<br>User**|**<br>Sys**|
 |:----------:|:---------------:|:-----------------:|:------------------:|-----------:|-----------:|----------:|
 |`zq`|`count()`|zeek|zeek|5.55|5.98|0.18|
-|`zq`|`count()`|zeek|bzng|5.60|6.03|0.20|
-|`zq`|`count()`|zeek|zng|5.65|6.09|0.22|
+|`zq`|`count()`|zeek|zng|5.60|6.03|0.20|
+|`zq`|`count()`|zeek|tzng|5.65|6.09|0.22|
 |`zq`|`count()`|zeek|ndjson|5.54|5.93|0.23|
-|`zq`|`count()`|bzng|zeek|2.99|3.03|0.02|
-|`zq`|`count()`|bzng|bzng|2.97|2.98|0.04|
-|`zq`|`count()`|bzng|zng|2.97|2.99|0.04|
-|`zq`|`count()`|bzng|ndjson|2.98|2.96|0.07|
-|`zq`|`count()`|zng|zeek|7.89|8.52|0.21|
-|`zq`|`count()`|zng|bzng|7.86|8.30|0.30|
-|`zq`|`count()`|zng|zng|7.84|8.28|0.29|
-|`zq`|`count()`|zng|ndjson|7.81|8.31|0.23|
+|`zq`|`count()`|zng|zeek|2.99|3.03|0.02|
+|`zq`|`count()`|zng|zng|2.97|2.98|0.04|
+|`zq`|`count()`|zng|tzng|2.97|2.99|0.04|
+|`zq`|`count()`|zng|ndjson|2.98|2.96|0.07|
+|`zq`|`count()`|tzng|zeek|7.89|8.52|0.21|
+|`zq`|`count()`|tzng|zng|7.86|8.30|0.30|
+|`zq`|`count()`|tzng|tzng|7.84|8.28|0.29|
+|`zq`|`count()`|tzng|ndjson|7.81|8.31|0.23|
 |`zq`|`count()`|ndjson|zeek|50.80|59.57|2.37|
-|`zq`|`count()`|ndjson|bzng|50.39|59.20|2.54|
-|`zq`|`count()`|ndjson|zng|50.14|58.85|2.26|
+|`zq`|`count()`|ndjson|zng|50.39|59.20|2.54|
+|`zq`|`count()`|ndjson|tzng|50.14|58.85|2.26|
 |`zq`|`count()`|ndjson|ndjson|50.31|58.81|2.50|
 |`jq`|`-c -s ". \| length"`|ndjson|ndjson|21.88|3.84|0.55|
 
@@ -88,20 +88,20 @@ As there are many results to sift through, here's a few key summary take-aways:
 |**<br>Tool**|**<br>Arguments**|**Input<br>Format**|**Output<br>Format**|**<br>Real**|**<br>User**|**<br>Sys**|
 |:----------:|:---------------:|:-----------------:|:------------------:|-----------:|-----------:|----------:|
 |`zq`|`count() by id.orig_h`|zeek|zeek|5.93|6.44|0.20|
-|`zq`|`count() by id.orig_h`|zeek|bzng|5.96|6.57|0.15|
-|`zq`|`count() by id.orig_h`|zeek|zng|6.02|6.57|0.22|
+|`zq`|`count() by id.orig_h`|zeek|zng|5.96|6.57|0.15|
+|`zq`|`count() by id.orig_h`|zeek|tzng|6.02|6.57|0.22|
 |`zq`|`count() by id.orig_h`|zeek|ndjson|5.90|6.40|0.22|
-|`zq`|`count() by id.orig_h`|bzng|zeek|3.33|3.36|0.03|
-|`zq`|`count() by id.orig_h`|bzng|bzng|3.31|3.34|0.04|
-|`zq`|`count() by id.orig_h`|bzng|zng|3.35|3.37|0.04|
-|`zq`|`count() by id.orig_h`|bzng|ndjson|3.32|3.37|0.02|
-|`zq`|`count() by id.orig_h`|zng|zeek|8.08|8.54|0.35|
-|`zq`|`count() by id.orig_h`|zng|bzng|8.11|8.76|0.22|
-|`zq`|`count() by id.orig_h`|zng|zng|8.06|8.63|0.23|
-|`zq`|`count() by id.orig_h`|zng|ndjson|8.01|8.63|0.18|
+|`zq`|`count() by id.orig_h`|zng|zeek|3.33|3.36|0.03|
+|`zq`|`count() by id.orig_h`|zng|zng|3.31|3.34|0.04|
+|`zq`|`count() by id.orig_h`|zng|tzng|3.35|3.37|0.04|
+|`zq`|`count() by id.orig_h`|zng|ndjson|3.32|3.37|0.02|
+|`zq`|`count() by id.orig_h`|tzng|zeek|8.08|8.54|0.35|
+|`zq`|`count() by id.orig_h`|tzng|zng|8.11|8.76|0.22|
+|`zq`|`count() by id.orig_h`|tzng|tzng|8.06|8.63|0.23|
+|`zq`|`count() by id.orig_h`|tzng|ndjson|8.01|8.63|0.18|
 |`zq`|`count() by id.orig_h`|ndjson|zeek|50.75|61.33|2.66|
-|`zq`|`count() by id.orig_h`|ndjson|bzng|50.71|61.54|2.49|
-|`zq`|`count() by id.orig_h`|ndjson|zng|50.51|61.20|2.68|
+|`zq`|`count() by id.orig_h`|ndjson|zng|50.71|61.54|2.49|
+|`zq`|`count() by id.orig_h`|ndjson|tzng|50.51|61.20|2.68|
 |`zq`|`count() by id.orig_h`|ndjson|ndjson|50.85|61.67|2.54|
 |`jq`|`-c -s "group_by(."id.orig_h")[] \| length as $l \| .[0] \| .count = $l \| {count,"id.orig_h"}"`|ndjson|ndjson|21.06|3.75|0.51|
 
@@ -110,20 +110,20 @@ As there are many results to sift through, here's a few key summary take-aways:
 |**<br>Tool**|**<br>Arguments**|**Input<br>Format**|**Output<br>Format**|**<br>Real**|**<br>User**|**<br>Sys**|
 |:----------:|:---------------:|:-----------------:|:------------------:|-----------:|-----------:|----------:|
 |`zq`|`id.resp_h=52.85.83.116`|zeek|zeek|5.86|6.32|0.19|
-|`zq`|`id.resp_h=52.85.83.116`|zeek|bzng|5.83|6.20|0.22|
-|`zq`|`id.resp_h=52.85.83.116`|zeek|zng|5.73|6.13|0.19|
+|`zq`|`id.resp_h=52.85.83.116`|zeek|zng|5.83|6.20|0.22|
+|`zq`|`id.resp_h=52.85.83.116`|zeek|tzng|5.73|6.13|0.19|
 |`zq`|`id.resp_h=52.85.83.116`|zeek|ndjson|5.68|6.14|0.12|
-|`zq`|`id.resp_h=52.85.83.116`|bzng|zeek|2.99|2.99|0.02|
-|`zq`|`id.resp_h=52.85.83.116`|bzng|bzng|2.99|2.97|0.03|
-|`zq`|`id.resp_h=52.85.83.116`|bzng|zng|2.96|2.95|0.03|
-|`zq`|`id.resp_h=52.85.83.116`|bzng|ndjson|2.97|2.94|0.04|
-|`zq`|`id.resp_h=52.85.83.116`|zng|zeek|7.70|8.10|0.28|
-|`zq`|`id.resp_h=52.85.83.116`|zng|bzng|7.75|8.28|0.21|
-|`zq`|`id.resp_h=52.85.83.116`|zng|zng|7.84|8.35|0.23|
-|`zq`|`id.resp_h=52.85.83.116`|zng|ndjson|7.77|8.23|0.23|
+|`zq`|`id.resp_h=52.85.83.116`|zng|zeek|2.99|2.99|0.02|
+|`zq`|`id.resp_h=52.85.83.116`|zng|zng|2.99|2.97|0.03|
+|`zq`|`id.resp_h=52.85.83.116`|zng|tzng|2.96|2.95|0.03|
+|`zq`|`id.resp_h=52.85.83.116`|zng|ndjson|2.97|2.94|0.04|
+|`zq`|`id.resp_h=52.85.83.116`|tzng|zeek|7.70|8.10|0.28|
+|`zq`|`id.resp_h=52.85.83.116`|tzng|zng|7.75|8.28|0.21|
+|`zq`|`id.resp_h=52.85.83.116`|tzng|tzng|7.84|8.35|0.23|
+|`zq`|`id.resp_h=52.85.83.116`|tzng|ndjson|7.77|8.23|0.23|
 |`zq`|`id.resp_h=52.85.83.116`|ndjson|zeek|50.08|58.62|2.33|
-|`zq`|`id.resp_h=52.85.83.116`|ndjson|bzng|50.29|58.95|2.53|
-|`zq`|`id.resp_h=52.85.83.116`|ndjson|zng|50.43|58.98|2.47|
+|`zq`|`id.resp_h=52.85.83.116`|ndjson|zng|50.29|58.95|2.53|
+|`zq`|`id.resp_h=52.85.83.116`|ndjson|tzng|50.43|58.98|2.47|
 |`zq`|`id.resp_h=52.85.83.116`|ndjson|ndjson|50.28|58.87|2.55|
 |`jq`|`-c ". \| select(.["id.resp_h"]=="52.85.83.116")"`|ndjson|ndjson|19.56|3.66|0.52|
 

--- a/scripts/comparison-test.sh
+++ b/scripts/comparison-test.sh
@@ -82,8 +82,8 @@ do
     echo -e "### $DESC\n" | tee "$MD"
     echo "|**<br>Tool**|**<br>Arguments**|**Input<br>Format**|**Output<br>Format**|**<br>Real**|**<br>User**|**<br>Sys**|" | tee -a "$MD"
     echo "|:----------:|:---------------:|:-----------------:|:------------------:|-----------:|-----------:|----------:|" | tee -a "$MD"
-    for INPUT in zeek bzng zng ndjson ; do
-      for OUTPUT in zeek bzng zng ndjson ; do
+    for INPUT in zeek zng tzng ndjson ; do
+      for OUTPUT in zeek zng tzng ndjson ; do
         echo -n "|\`zq\`|\`$zql\`|$INPUT|$OUTPUT|" | tee -a "$MD"
         ALL_TIMES=$( ($TIME zq -i "$INPUT" -f "$OUTPUT" "$zql" $DATA/$INPUT/* > /dev/null) 2>&1)
         echo "$ALL_TIMES" | tr '\n' ' ' | awk '{ print $2 "|" $4 "|" $6 "|" }' | tee -a "$MD"

--- a/tests/formats/autodetect/bzng2.yaml
+++ b/tests/formats/autodetect/bzng2.yaml
@@ -4,7 +4,7 @@ input: |
   #0:record[_path:string,ts:time,uid:string,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port],version:string,cipher:string,curve:string,server_name:string,resumed:bool,last_alert:string,next_protocol:string,established:bool,cert_chain_fuids:array[string],client_cert_chain_fuids:array[string],subject:string,issuer:string,client_subject:string,client_issuer:string,validation_status:string]
   0:[ssl;1490385563.053424;CfEBop2hbfJYpjG5Hd;[10.10.7.90;51913;54.230.87.24;443;]TLSv12;TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256;-;choices.truste.com;T;-;http/1.1;T;-;-;-;-;-;-;-;]
 
-output-format: bzng
+output-format: zng
 
 output: !!binary |
   gAQGb3JpZ19oDQZvcmlnX3AOBnJlc3BfaA0GcmVzcF9wDoEJgBMFX3BhdGgJAnRzEAN1aW

--- a/tests/formats/zng/streams-1.yaml
+++ b/tests/formats/zng/streams-1.yaml
@@ -1,4 +1,4 @@
-# Test frame markers inserted into a bzng frame (including testing
+# Test frame markers inserted into a zng frame (including testing
 # that type definitions are repeated as needed).
 
 zql: '*'
@@ -8,7 +8,7 @@ input: |
   0:[a;10;1;]
   0:[xyz;20;1.5;]
 
-output-format: bzng
+output-format: zng
 
 output-flags: -b 1
 

--- a/tests/formats/zng/streams-2.yaml
+++ b/tests/formats/zng/streams-2.yaml
@@ -1,4 +1,4 @@
-# Test that type ids are not re-used across bzng streams.
+# Test that type ids are not re-used across zng streams.
 
 zql: '*'
 
@@ -9,7 +9,7 @@ input: |
   1:[1;]
   1:[2;]
 
-output-format: bzng
+output-format: zng
 
 output-flags: -b 2
 

--- a/tests/formats/zng/type-reset.yaml
+++ b/tests/formats/zng/type-reset.yaml
@@ -3,7 +3,7 @@ zql: '*'
 input: !!binary |
   gAEDa2V5DRcFCgAAAAAXESIAAAAAAAAAAAAAAAAAAAAAhYABA2tleQ0XBQoBJz0WhQ==
 
-output-format: bzng
+output-format: zng
 
 output-flags: -b 2
 

--- a/tests/formats/zng/write.yaml
+++ b/tests/formats/zng/write.yaml
@@ -5,7 +5,7 @@ input: |
   0:[a;10;1;]
   0:[xyz;20;1.5;]
 
-output-format: bzng
+output-format: zng
 
 outputHex: |
   # define a record with 3 columns

--- a/tests/suite/ndjson/test.go
+++ b/tests/suite/ndjson/test.go
@@ -6,7 +6,7 @@ import (
 
 var Exec = test.Exec{
 	Name:     "ndjson",
-	Command:  `zq -f bzng - | zq -i bzng -f ndjson -`,
+	Command:  `zq -f zng - | zq -i zng -f ndjson -`,
 	Input:    test.Trim(input),
 	Expected: test.Trim(expected),
 }

--- a/zio/detector/lookup.go
+++ b/zio/detector/lookup.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
-	"github.com/brimsec/zq/zio/bzngio"
 	"github.com/brimsec/zq/zio/ndjsonio"
 	"github.com/brimsec/zq/zio/tableio"
 	"github.com/brimsec/zq/zio/textio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zio/zeekio"
 	"github.com/brimsec/zq/zio/zjsonio"
+	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 )
@@ -34,12 +34,10 @@ func LookupWriter(w io.WriteCloser, wflags *zio.WriterFlags) *zio.Writer {
 		return nil
 	case "null":
 		f = zbuf.NopFlusher(&nullWriter{})
-	case "zng":
-		panic("zng")
 	case "tzng":
 		f = zbuf.NopFlusher(tzngio.NewWriter(w))
-	case "bzng":
-		f = bzngio.NewWriter(w, flags)
+	case "zng":
+		f = zngio.NewWriter(w, flags)
 	case "zeek":
 		f = zbuf.NopFlusher(zeekio.NewWriter(w, flags))
 	case "ndjson":
@@ -67,8 +65,8 @@ func LookupReader(r io.Reader, zctx *resolver.Context, format string) (zbuf.Read
 		return ndjsonio.NewReader(r, zctx)
 	case "zjson":
 		return zjsonio.NewReader(r, zctx), nil
-	case "bzng":
-		return bzngio.NewReader(r, zctx), nil
+	case "zng":
+		return zngio.NewReader(r, zctx), nil
 	}
 	return nil, fmt.Errorf("no such reader type: \"%s\"", format)
 }

--- a/zio/detector/reader.go
+++ b/zio/detector/reader.go
@@ -5,11 +5,11 @@ import (
 	"io"
 
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio/bzngio"
 	"github.com/brimsec/zq/zio/ndjsonio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zio/zeekio"
 	"github.com/brimsec/zq/zio/zjsonio"
+	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
 )
@@ -18,8 +18,8 @@ func NewReader(r io.Reader, zctx *resolver.Context) (zbuf.Reader, error) {
 	recorder := NewRecorder(r)
 	track := NewTrack(recorder)
 
-	zngErr := match(tzngio.NewReader(track, resolver.NewContext()), "tzng")
-	if zngErr == nil {
+	tzngErr := match(tzngio.NewReader(track, resolver.NewContext()), "tzng")
+	if tzngErr == nil {
 		return tzngio.NewReader(recorder, zctx), nil
 	}
 	track.Reset()
@@ -52,11 +52,11 @@ func NewReader(r io.Reader, zctx *resolver.Context) (zbuf.Reader, error) {
 	}
 	track.Reset()
 
-	bzngErr := match(bzngio.NewReader(track, resolver.NewContext()), "zng")
-	if bzngErr == nil {
-		return bzngio.NewReader(recorder, zctx), nil
+	zngErr := match(zngio.NewReader(track, resolver.NewContext()), "zng")
+	if zngErr == nil {
+		return zngio.NewReader(recorder, zctx), nil
 	}
-	return nil, joinErrs([]error{zngErr, zeekErr, ndjsonErr, zjsonErr, bzngErr})
+	return nil, joinErrs([]error{tzngErr, zeekErr, ndjsonErr, zjsonErr, zngErr})
 }
 
 func joinErrs(errs []error) error {

--- a/zio/tzngio/parser.go
+++ b/zio/tzngio/parser.go
@@ -102,7 +102,7 @@ func zngParseField(builder *zcode.Builder, typ zng.Type, b []byte) ([]byte, erro
 	}
 	if utyp, ok := realType.(*zng.TypeUnion); ok {
 		var childType zng.Type
-		childType, index, b, err = utyp.SplitZng(b)
+		childType, index, b, err = utyp.SplitTzng(b)
 		if err != nil {
 			return nil, err
 		}

--- a/zio/tzngio/writer.go
+++ b/zio/tzngio/writer.go
@@ -11,7 +11,7 @@ import (
 
 type Writer struct {
 	io.Writer
-	// tracker keeps track of a mapping from internal BZNG type IDs for each
+	// tracker keeps track of a mapping from internal ZNG type IDs for each
 	// new record encountered (i.e., which triggers a typedef) so that we
 	// generate the output in canonical form whereby the typedefs in the
 	// stream are numbered sequentially from 0.
@@ -80,7 +80,7 @@ func (w *Writer) write(s string) error {
 
 func (w *Writer) writeUnion(parent zng.Value) error {
 	utyp := zng.AliasedType(parent.Type).(*zng.TypeUnion)
-	inner, index, v, err := utyp.SplitBzng(parent.Bytes)
+	inner, index, v, err := utyp.SplitZng(parent.Bytes)
 	if err != nil {
 		return err
 	}

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -14,7 +14,7 @@ type ReaderFlags struct {
 }
 
 func (f *ReaderFlags) SetFlags(fs *flag.FlagSet) {
-	fs.StringVar(&f.Format, "i", "auto", "format of input data [auto,bzng,ndjson,zeek,zjson,tzng]")
+	fs.StringVar(&f.Format, "i", "auto", "format of input data [auto,zng,ndjson,zeek,zjson,tzng]")
 }
 
 // WriterFlags has the union of the flags accepted by all the different
@@ -29,12 +29,12 @@ type WriterFlags struct {
 }
 
 func (f *WriterFlags) SetFlags(fs *flag.FlagSet) {
-	fs.StringVar(&f.Format, "f", "tzng", "format for output data [bzng,ndjson,table,text,types,zeek,zjson,tzng]")
+	fs.StringVar(&f.Format, "f", "tzng", "format for output data [zng,ndjson,table,text,types,zeek,zjson,tzng]")
 	fs.BoolVar(&f.ShowTypes, "T", false, "display field types in text output")
 	fs.BoolVar(&f.ShowFields, "F", false, "display field names in text output")
 	fs.BoolVar(&f.EpochDates, "E", false, "display epoch timestamps in text output")
 	fs.BoolVar(&f.UTF8, "U", false, "display zeek strings as UTF-8")
-	fs.IntVar(&f.StreamRecordsMax, "b", 0, "limit for number of records in each BZNG stream(0 for no limit)")
+	fs.IntVar(&f.StreamRecordsMax, "b", 0, "limit for number of records in each ZNG stream(0 for no limit)")
 }
 
 type Writer struct {
@@ -72,8 +72,8 @@ func Extension(format string) string {
 		return ".txt"
 	case "table":
 		return ".tbl"
-	case "bzng":
-		return ".bzng"
+	case "zng":
+		return ".zng"
 	default:
 		return ""
 	}

--- a/zio/zjsonio/stream.go
+++ b/zio/zjsonio/stream.go
@@ -51,7 +51,7 @@ func encodeUnion(typ *zng.TypeUnion, v []byte) (interface{}, error) {
 	if v == nil {
 		return nil, nil
 	}
-	inner, index, v, err := typ.SplitBzng(v)
+	inner, index, v, err := typ.SplitZng(v)
 	if err != nil {
 		return nil, err
 	}

--- a/zio/zngio/index.go
+++ b/zio/zngio/index.go
@@ -1,4 +1,4 @@
-package bzngio
+package zngio
 
 import (
 	"errors"
@@ -106,9 +106,9 @@ func (i *indexReader) readOne() (*zng.Record, error) {
 	return rec, nil
 }
 
-// rangeReader is a wrapper around bzngio.Reader that uses an in-memory
+// rangeReader is a wrapper around zngio.Reader that uses an in-memory
 // index to reduce the I/O needed to get matching records when reading a
-// large bzng file that includes sub-streams and a nano.Span that refers
+// large zng file that includes sub-streams and a nano.Span that refers
 // to a smaller time range within the file.
 type rangeReader struct {
 	Reader

--- a/zio/zngio/index_test.go
+++ b/zio/zngio/index_test.go
@@ -1,4 +1,4 @@
-package bzngio
+package zngio
 
 import (
 	"io/ioutil"
@@ -66,13 +66,13 @@ func checkReader(t *testing.T, r zbuf.Reader, checkReads bool) {
 	}
 }
 
-func TestBzngIndex(t *testing.T) {
+func TestZngIndex(t *testing.T) {
 	// get a scratch directory
 	dir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	// create a test bzng file
+	// create a test zng file
 	reader := tzngio.NewReader(strings.NewReader(zngData), resolver.NewContext())
 	fname := filepath.Join(dir, "test.tzng")
 	fp, err := os.Create(fname)
@@ -95,7 +95,7 @@ func TestBzngIndex(t *testing.T) {
 	index := NewTimeIndex()
 
 	// Create a time span that hits parts of different streams
-	// from within the bzng file.
+	// from within the zng file.
 	start, err := nano.ParseTs(startTime)
 	require.NoError(t, err)
 	end, err := nano.ParseTs(endTime)

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -1,4 +1,4 @@
-package bzngio
+package zngio
 
 import (
 	"encoding/binary"

--- a/zio/zngio/seeker.go
+++ b/zio/zngio/seeker.go
@@ -1,4 +1,4 @@
-package bzngio
+package zngio
 
 import (
 	"io"

--- a/zio/zngio/types.go
+++ b/zio/zngio/types.go
@@ -1,15 +1,15 @@
-// Package bzngio provides an API for reading and writing zng values and
+// Package zngio provides an API for reading and writing zng values and
 // directives in binary zng format.  The Reader and Writer types implement the
 // the zbuf.Reader and zbuf.Writer interfaces.  Since these methods
-// read and write only zbuf.Records, but the bzng format includes additional
+// read and write only zbuf.Records, but the zng format includes additional
 // functionality, other methods are available to read/write zng comments
 // and include virtual channel numbers in the stream.  Virtual channels
 // provide a way to indicate which output of a flowgraph a result came from
-// when a flowgraph computes multiple output channels.  The bzng values in
+// when a flowgraph computes multiple output channels.  The zng values in
 // this zng value are "machine format" as prescirbed by the ZNG spec.
 // The vanilla zbuf.Reader and zbuf.Writer implementations ignore application-specific
 // payloads (e.g., channel encodings).
-package bzngio
+package zngio
 
 import (
 	"fmt"

--- a/zio/zngio/types_test.go
+++ b/zio/zngio/types_test.go
@@ -1,10 +1,10 @@
-package bzngio_test
+package zngio_test
 
 import (
 	"bytes"
 	"testing"
 
-	"github.com/brimsec/zq/zio/bzngio"
+	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,7 +17,7 @@ func TestContextSerialization(t *testing.T) {
 	b, _ := ctx.Serialize()
 	reader := bytes.NewReader(b)
 	newCtx := resolver.NewContext()
-	err := bzngio.ReadTypeContext(reader, newCtx)
+	err := zngio.ReadTypeContext(reader, newCtx)
 	require.NoError(t, err)
 	r1, err := ctx.LookupByName("record[a:int32,b:int32]")
 	require.NoError(t, err)

--- a/zio/zngio/writer.go
+++ b/zio/zngio/writer.go
@@ -1,4 +1,4 @@
-package bzngio
+package zngio
 
 import (
 	"io"

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -19,7 +19,7 @@ every value.
 
 ZNG has both a text form simply called "TZNG",
 comprised of a sequence of newline-delimited UTF-8 strings,
-as well as a binary form called "BZNG".
+as well as a binary form called "ZNG".
 
 ZNG is richly typed and thinner on the wire than JSON.
 Like [newline-delimited JSON (NDJSON)](http://ndjson.org/),
@@ -110,13 +110,13 @@ Note that the value encoding need not refer to the field names and types as that
 completely captured by the type ID.  Values merely encode the value
 information consistent with the referenced type ID.
 
-## 2. ZNG Binary Format (BZNG)
+## 2. ZNG Binary Format (ZNG)
 
-The BZNG binary format is based on machine-readable data types with an
+The ZNG binary format is based on machine-readable data types with an
 encoding methodology inspired by Avro and
 [Protocol Buffers](https://developers.google.com/protocol-buffers).
 
-A BZNG stream comprises a sequence of interleaved control messages and value messages
+A ZNG stream comprises a sequence of interleaved control messages and value messages
 that are serialized into a stream of bytes.
 
 Each message is prefixed with a single-byte header code.  The upper bit of
@@ -126,7 +126,7 @@ or a value message (0).
 ### 2.1 Control Messages
 
 The lower 7 bits of a control header byte define the control code.
-Control codes 0 through 5 are reserved for BZNG:
+Control codes 0 through 5 are reserved for ZNG:
 
 | Code | Message Type      |
 |------|-------------------|
@@ -199,7 +199,7 @@ the type encoding.  This creates a binding between the implied type ID
 (i.e., 23 plus the count of all previous typedefs in the stream) and the new
 type definition.
 
-The type ID is encoded as a `uvarint`, an encoding used throughout the BZNG format.
+The type ID is encoded as a `uvarint`, an encoding used throughout the ZNG format.
 
 > Inspired by Protocol Buffers,
 > a `uvarint` is an unsigned, variable-length integer encoded as a sequence of
@@ -290,10 +290,10 @@ The `<ntypes>` and the type IDs are all encoded as `uvarint`.
 A type alias defines a new type ID that binds a new type name
 to a previously existing type ID.  This is useful for systems like Zeek,
 where there are customary type names that are well-known to users of the
-Zeek system and are easily mapped onto a BZNG type having a different name.
+Zeek system and are easily mapped onto a ZNG type having a different name.
 By encoding the aliases in the format, there is no need to configure mapping
 information across different systems using the format, as the type aliases
-are communicated to the consumer of a BZNG stream.
+are communicated to the consumer of a ZNG stream.
 
 A type alias is encoded as follows:
 ```
@@ -309,14 +309,14 @@ followed by that many bytes of UTF-8 string.
 
 ### 2.1.2 End-of-stream Markers
 
-A BZNG stream must be terminated by an end-of-stream marker.
-A new BZNG stream may begin immediately after an end-of-stream marker.
+A ZNG stream must be terminated by an end-of-stream marker.
+A new ZNG stream may begin immediately after an end-of-stream marker.
 Each such stream has its own, independent type context.
 
-In this way, the concatenation of BZNG streams (or BZNG files containing
-BZNG streams) results in a valid BZNG data sequence.
+In this way, the concatenation of ZNG streams (or ZNG files containing
+ZNG streams) results in a valid ZNG data sequence.
 
-For example, a large BZNG file can be arranged into multiple, smaller streams
+For example, a large ZNG file can be arranged into multiple, smaller streams
 to facilitate random access at stream boundaries.
 This benefit comes at the cost of some additional overhead --
 the space consumed by stream boundary markers and repeated type definitions.
@@ -343,7 +343,7 @@ previously defined type, the appropriate typedef control code must
 be re-emitted
 (and note that the typedef may now be assigned a different ID).
 
-### 2.2 BZNG Value Messages
+### 2.2 ZNG Value Messages
 
 Following a header byte with bit 7 zero is a `typed value`
 with a `uvarint7` encoding its length.
@@ -453,7 +453,7 @@ lexicographically greater than that of the preceding element.
 
 ## 3. ZNG Text Format (TZNG)
 
-The ZNG text format is a human-readable form that follows directly from the BZNG
+The ZNG text format is a human-readable form that follows directly from the ZNG
 binary format.  A ZNG file/stream is encoded with UTF-8.
 All subsequent references to characters and strings in this section refer to
 the Unicode code points that result when the stream is decoded.
@@ -513,7 +513,7 @@ is any UTF-8 string with escaped newlines.
 
 ### Type Grammar
 
-Given the above textual definitions and the underlying BZNG specification, a
+Given the above textual definitions and the underlying ZNG specification, a
 grammar describing the textual type encodings is:
 ```
 <stype> := bool | byte | int16 | uint16 | int32 | uint32 | int64 | uint64 | float64
@@ -696,7 +696,7 @@ record(a:"hello",b:"world")
 string("this is a semicolon: ;")
 ```
 Note that the tag integers occupy their own numeric space indepedent of
-any underlying BZNG type IDs.
+any underlying ZNG type IDs.
 
 The semicolon terminator is important.  Consider this ZNG depicting
 sets of strings:

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -17,7 +17,7 @@ of heterogeneously typed records, e.g., structured logs, where filtering and
 analytics may be applied to a stream in parts without having to fully deserialize
 every value.
 
-ZNG has both a text form simply called "TZNG",
+ZNG has both a text form called "TZNG",
 comprised of a sequence of newline-delimited UTF-8 strings,
 as well as a binary form called "ZNG".
 

--- a/zng/docs/zng-over-http.md
+++ b/zng/docs/zng-over-http.md
@@ -57,8 +57,8 @@ generates responses and simply operates normally.
 Since a Zeek log is fully interchangeable with the ZNG format, Zeek files can be
 easily posted to a service like this using, e.g.,
 ```
-zq -f bzng cong.log > conn.bzng
-curl -X POST "http://localhost:8080/logs" --data-binary @conn.bzng
+zq -f zng cong.log > conn.zng
+curl -X POST "http://localhost:8080/logs" --data-binary @conn.zng
 ```
 
 ## Reference Implementations

--- a/zng/resolver/context.go
+++ b/zng/resolver/context.go
@@ -557,7 +557,7 @@ func (c *Context) TranslateType(ext zng.Type) zng.Type {
 	switch ext := ext.(type) {
 	default:
 		//XXX
-		panic(fmt.Sprintf("bzng cannot translate type: %s", ext))
+		panic(fmt.Sprintf("zng cannot translate type: %s", ext))
 	case *zng.TypeRecord:
 		return c.TranslateTypeRecord(ext)
 	case *zng.TypeSet:

--- a/zng/resolver/encoder.go
+++ b/zng/resolver/encoder.go
@@ -71,7 +71,7 @@ func (e *Encoder) encodeType(dst []byte, ext zng.Type) ([]byte, zng.Type, error)
 	switch ext := ext.(type) {
 	default:
 		//XXX
-		panic(fmt.Sprintf("bzng cannot encode type: %s", ext))
+		panic(fmt.Sprintf("zng cannot encode type: %s", ext))
 	case *zng.TypeRecord:
 		return e.encodeTypeRecord(dst, ext)
 	case *zng.TypeSet:
@@ -188,7 +188,7 @@ func serializeTypes(dst []byte, types []zng.Type) []byte {
 	for _, typ := range types {
 		switch typ := typ.(type) {
 		default:
-			panic(fmt.Sprintf("bzng cannot serialize type: %s", typ))
+			panic(fmt.Sprintf("zng cannot serialize type: %s", typ))
 		case *zng.TypeRecord:
 			dst = serializeTypeRecord(dst, typ.Columns)
 		case *zng.TypeSet:

--- a/zng/set.go
+++ b/zng/set.go
@@ -100,7 +100,7 @@ func (t *TypeSet) Marshal(zv zcode.Bytes) (interface{}, error) {
 }
 
 // NormalizeSet interprets zv as a set body and returns an equivalent set body
-// that is normalized according to the BZNG specification (i.e., each element's
+// that is normalized according to the ZNG specification (i.e., each element's
 // tag-counted value is lexicographically greater than that of the preceding
 // element).
 func NormalizeSet(zv zcode.Bytes) zcode.Bytes {

--- a/zng/union.go
+++ b/zng/union.go
@@ -45,10 +45,10 @@ func (t *TypeUnion) Parse(in []byte) (zcode.Bytes, error) {
 	panic("TypeUnion.Parse shouldn't be called")
 }
 
-// SplitBzng takes a bzng encoding of a value of the receiver's union type and
+// SplitZng takes a zng encoding of a value of the receiver's union type and
 // returns the concrete type of the value, its index into the union
 // type, and the value encoding.
-func (t *TypeUnion) SplitBzng(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) {
+func (t *TypeUnion) SplitZng(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) {
 	it := zcode.Iter(zv)
 	v, container, err := it.Next()
 	if err != nil {
@@ -72,10 +72,10 @@ func (t *TypeUnion) SplitBzng(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) 
 	return inner, int64(index), v, nil
 }
 
-// SplitZng takes a zng encoding of a value of the receiver's type and returns the
+// SplitTzng takes a tzng encoding of a value of the receiver's type and returns the
 // concrete type of the value, its index into the union type, and the value
 // encoding.
-func (t *TypeUnion) SplitZng(in []byte) (Type, int, []byte, error) {
+func (t *TypeUnion) SplitTzng(in []byte) (Type, int, []byte, error) {
 	c := bytes.Index(in, []byte{':'})
 	if c < 0 {
 		return nil, -1, nil, ErrBadValue
@@ -92,7 +92,7 @@ func (t *TypeUnion) SplitZng(in []byte) (Type, int, []byte, error) {
 }
 
 func (t *TypeUnion) StringOf(zv zcode.Bytes, ofmt OutFmt, _ bool) string {
-	typ, index, iv, err := t.SplitBzng(zv)
+	typ, index, iv, err := t.SplitZng(zv)
 	if err != nil {
 		// this follows set and record StringOfs. Like there, XXX.
 		return "ERR"
@@ -103,7 +103,7 @@ func (t *TypeUnion) StringOf(zv zcode.Bytes, ofmt OutFmt, _ bool) string {
 }
 
 func (t *TypeUnion) Marshal(zv zcode.Bytes) (interface{}, error) {
-	inner, _, zv, err := t.SplitBzng(zv)
+	inner, _, zv, err := t.SplitZng(zv)
 	if err != nil {
 		return nil, err
 	}

--- a/zng/value.go
+++ b/zng/value.go
@@ -86,7 +86,7 @@ func (v Value) String() string {
 	return v.Format(OutFormatDebug)
 }
 
-// Encode appends the BZNG representation of this value to the passed in
+// Encode appends the ZNG representation of this value to the passed in
 // argument and returns the resulting zcode.Bytes (which may or may not
 // be the same underlying buffer, as with append(), depending on its capacity)
 func (v Value) Encode(dst zcode.Bytes) zcode.Bytes {

--- a/zqd/api/connection.go
+++ b/zqd/api/connection.go
@@ -185,14 +185,14 @@ func (c *Connection) SpaceDelete(ctx context.Context, spaceName string) (err err
 func (c *Connection) Search(ctx context.Context, search SearchRequest) (Search, error) {
 	req := c.Request(ctx).
 		SetBody(search).
-		SetQueryParam("format", "bzng")
+		SetQueryParam("format", "zng")
 	req.Method = http.MethodPost
 	req.URL = "/search"
 	r, err := c.stream(req)
 	if err != nil {
 		return nil, err
 	}
-	return NewBzngSearch(r), nil
+	return NewZngSearch(r), nil
 }
 
 func (c *Connection) PacketPost(ctx context.Context, space string, payload PacketPostRequest) (*Stream, error) {

--- a/zqd/api/zng.go
+++ b/zqd/api/zng.go
@@ -4,30 +4,30 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/brimsec/zq/zio/bzngio"
+	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-type BzngSearch struct {
-	reader *bzngio.Reader
+type ZngSearch struct {
+	reader *zngio.Reader
 	onctrl func(interface{})
 }
 
-func NewBzngSearch(body io.Reader) *BzngSearch {
-	return &BzngSearch{
-		reader: bzngio.NewReader(body, resolver.NewContext()),
+func NewZngSearch(body io.Reader) *ZngSearch {
+	return &ZngSearch{
+		reader: zngio.NewReader(body, resolver.NewContext()),
 	}
 }
 
 // SetOnCtrl registers a callback function that will be fired when a control
 // payload is found in the search stream. Not safe for concurrent use, this
 // should be set before the first read is called.
-func (r *BzngSearch) SetOnCtrl(cb func(interface{})) {
+func (r *ZngSearch) SetOnCtrl(cb func(interface{})) {
 	r.onctrl = cb
 }
 
-func (r *BzngSearch) Read() (*zng.Record, error) {
+func (r *ZngSearch) Read() (*zng.Record, error) {
 	for {
 		rec, b, err := r.reader.ReadPayload()
 		if err != nil || b == nil {

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -101,9 +101,9 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	case "zjson", "json":
 		// XXX Should write appropriate ndjson content header.
 		out = search.NewJSONOutput(w, search.DefaultMTU)
-	case "bzng":
-		// XXX Should write appropriate bzng content header.
-		out = search.NewBzngOutput(w)
+	case "zng":
+		// XXX Should write appropriate zng content header.
+		out = search.NewZngOutput(w)
 	default:
 		respondError(c, w, r, zqe.E(zqe.Invalid, "unsupported format: %s", format))
 		return

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -1,5 +1,5 @@
 // Package search provides an implementation for launching zq searches and performing
-// analytics on bzng files stored in the server's root directory.
+// analytics on zng files stored in the server's root directory.
 package search
 
 import (

--- a/zqd/search/zng.go
+++ b/zqd/search/zng.go
@@ -6,36 +6,36 @@ import (
 
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
-	"github.com/brimsec/zq/zio/bzngio"
+	"github.com/brimsec/zq/zio/zngio"
 )
 
-// BzngOutput writes bzng encodings directly to the client via
+// ZngOutput writes zng encodings directly to the client via
 // binary data sent over http chunked encoding interleaved with json
 // protocol messages sent as zng comment payloads.  The simplicity of
 // this is a thing of beauty.
 // Also, it implements the Output interface.
-type BzngOutput struct {
+type ZngOutput struct {
 	response http.ResponseWriter
-	writer   *bzngio.Writer
+	writer   *zngio.Writer
 }
 
-func NewBzngOutput(response http.ResponseWriter) *BzngOutput {
-	o := &BzngOutput{
+func NewZngOutput(response http.ResponseWriter) *ZngOutput {
+	o := &ZngOutput{
 		response: response,
-		writer:   bzngio.NewWriter(response, zio.WriterFlags{}),
+		writer:   zngio.NewWriter(response, zio.WriterFlags{}),
 	}
 	return o
 }
 
-func (r *BzngOutput) flush() {
+func (r *ZngOutput) flush() {
 	r.response.(http.Flusher).Flush()
 }
 
-func (r *BzngOutput) Collect() interface{} {
+func (r *ZngOutput) Collect() interface{} {
 	return "TBD" //XXX
 }
 
-func (r *BzngOutput) SendBatch(cid int, batch zbuf.Batch) error {
+func (r *ZngOutput) SendBatch(cid int, batch zbuf.Batch) error {
 	for _, rec := range batch.Records() {
 		// XXX need to send channel id as control payload
 		if err := r.writer.Write(rec); err != nil {
@@ -47,11 +47,11 @@ func (r *BzngOutput) SendBatch(cid int, batch zbuf.Batch) error {
 	return nil
 }
 
-func (r *BzngOutput) End(ctrl interface{}) error {
+func (r *ZngOutput) End(ctrl interface{}) error {
 	return r.SendControl(ctrl)
 }
 
-func (r *BzngOutput) SendControl(ctrl interface{}) error {
+func (r *ZngOutput) SendControl(ctrl interface{}) error {
 	msg, err := json.Marshal(ctrl)
 	if err != nil {
 		//XXX need a better json error message

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -15,14 +15,14 @@ import (
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio/bzngio"
+	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqd/api"
 	"github.com/brimsec/zq/zqe"
 )
 
 const (
-	AllBzngFile   = "all.bzng"
+	AllZngFile    = "all.zng"
 	configFile    = "config.json"
 	infoFile      = "info.json"
 	PcapIndexFile = "packets.idx.json"
@@ -170,7 +170,7 @@ func (c *SearchReadCloser) Close() error {
 
 // LogSize returns the size in bytes of the logs in space.
 func (s Space) LogSize() (int64, error) {
-	return sizeof(s.DataPath(AllBzngFile))
+	return sizeof(s.DataPath(AllZngFile))
 }
 
 // PacketSize returns the size in bytes of the packet capture in the space.
@@ -196,15 +196,15 @@ func (s Space) DataPath(elem ...string) string {
 func (s Space) OpenZng(span nano.Span) (zbuf.ReadCloser, error) {
 	zctx := resolver.NewContext()
 
-	f, err := os.Open(s.DataPath(AllBzngFile))
+	f, err := os.Open(s.DataPath(AllZngFile))
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
-		r := bzngio.NewReader(strings.NewReader(""), zctx)
+		r := zngio.NewReader(strings.NewReader(""), zctx)
 		return zbuf.NopReadCloser(r), nil
 	} else {
-		r := bzngio.NewReader(f, zctx)
+		r := zngio.NewReader(f, zctx)
 		return zbuf.NewReadCloser(r, f), nil
 	}
 }

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -201,12 +201,22 @@ func (s Space) OpenZng(span nano.Span) (zbuf.ReadCloser, error) {
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
-		r := zngio.NewReader(strings.NewReader(""), zctx)
-		return zbuf.NopReadCloser(r), nil
 	} else {
 		r := zngio.NewReader(f, zctx)
 		return zbuf.NewReadCloser(r, f), nil
 	}
+
+	bzngFile := strings.TrimSuffix(AllZngFile, filepath.Ext(AllZngFile)) + ".bzng"
+	f, err = os.Open(s.DataPath(bzngFile))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		r := zngio.NewReader(strings.NewReader(""), zctx)
+		return zbuf.NopReadCloser(r), nil
+	}
+	r := zngio.NewReader(f, zctx)
+	return zbuf.NewReadCloser(r, f), nil
 }
 
 func (s Space) OpenFile(file string) (*os.File, error) {


### PR DESCRIPTION
Closes #544 

The second commit changes Space.OpenZng() to check "all.bzng" if "all.zng" is not found. I've checked that it works manually but can add a temporary test to handlers_test.go if folks think that is warranted.