### PR TITLE
open output files with truncation

### DIFF
--- a/cmd/pcap/cut/command.go
+++ b/cmd/pcap/cut/command.go
@@ -124,7 +124,7 @@ func (c *Command) Run(args []string) error {
 
 	out := io.Writer(os.Stdout)
 	if c.outputFile != "-" {
-		f, err := os.OpenFile(c.outputFile, os.O_RDWR|os.O_CREATE, 0644)
+		f, err := os.OpenFile(c.outputFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return err
 		}

--- a/cmd/pcap/slice/command.go
+++ b/cmd/pcap/slice/command.go
@@ -141,7 +141,7 @@ func (c *Command) Run(args []string) error {
 	}
 	out := io.Writer(os.Stdout)
 	if c.outputFile != "-" {
-		f, err := os.OpenFile(c.outputFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+		f, err := os.OpenFile(c.outputFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return err
 		}

--- a/cmd/pcap/ts/command.go
+++ b/cmd/pcap/ts/command.go
@@ -60,7 +60,7 @@ func (c *Command) Run(args []string) error {
 	out := os.Stdout
 	if c.outputFile != "-" {
 		var err error
-		out, err = os.OpenFile(c.outputFile, os.O_RDWR|os.O_CREATE, 0644)
+		out, err = os.OpenFile(c.outputFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return err
 		}

--- a/emitter/file.go
+++ b/emitter/file.go
@@ -25,7 +25,7 @@ func NewFile(path string, flags *zio.WriterFlags) (*zio.Writer, error) {
 		f = &noClose{os.Stdout}
 	} else {
 		var err error
-		flags := os.O_WRONLY | os.O_CREATE
+		flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
 		file, err := os.OpenFile(path, flags, 0600)
 		if err != nil {
 			return nil, err

--- a/emitter/types.go
+++ b/emitter/types.go
@@ -23,7 +23,7 @@ func NewTypeLogger(path string, verbose bool) (*TypeLogger, error) {
 		f = &noClose{os.Stdout}
 	} else {
 		var err error
-		flags := os.O_WRONLY | os.O_CREATE
+		flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
 		file, err := os.OpenFile(path, flags, 0600)
 		if err != nil {
 			return nil, err

--- a/tests/suite/trunc/trunc.yaml
+++ b/tests/suite/trunc/trunc.yaml
@@ -1,0 +1,21 @@
+script: |
+  zq -o out.tzng long.tzng
+  zq -o out.tzng short.tzng
+  zq out.tzng
+
+inputs:
+  - name: short.tzng
+    data: |
+      #0:record[a:string]
+      0:[hello;]
+  - name: long.tzng
+    data: |
+      #0:record[a:string]
+      0:[hello;]
+      0:[there;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[a:string]
+      0:[hello;]


### PR DESCRIPTION
This PR fixes a bug where the zng.Writer output files
were opened without truncation.  This would cause corrupt
files to be created when overlaying new but shorter output
on an existing file.
