### PR TITLE
Cut -c

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -200,7 +200,8 @@ type (
 	// sending each such modified record to its output in the order received.
 	CutProc struct {
 		Node
-		Fields []FieldExpr `json:"fields"`
+		Complement bool        `json:"complement"`
+		Fields     []FieldExpr `json:"fields"`
 	}
 	// A HeadProc node represents a proc that forwards the indicated number
 	// of records then terminates.

--- a/proc/colbuilder.go
+++ b/proc/colbuilder.go
@@ -255,11 +255,3 @@ func (c *ColumnBuilder) TypedColumns(types []zng.Type) []zng.Column {
 	}
 	return stack[0].cols
 }
-
-func (c *ColumnBuilder) FullNames() []string {
-	ret := make([]string, len(c.fields))
-	for i, field := range c.fields {
-		ret[i] = field.fullname
-	}
-	return ret
-}

--- a/proc/cut.go
+++ b/proc/cut.go
@@ -31,7 +31,11 @@ func CompileCutProc(c *Context, parent Proc, node *ast.CutProc) (*Cut, error) {
 	if err != nil {
 		return nil, fmt.Errorf("compiling cut: %w", err)
 	}
-	builder, err := NewColumnBuilder(c.TypeContext, node.Fields)
+	var fields []string
+	for _, field := range node.Fields {
+		fields = append(fields, expr.FieldExprToString(field))
+	}
+	builder, err := NewColumnBuilder(c.TypeContext, fields)
 	if err != nil {
 		return nil, fmt.Errorf("compiling cut: %w", err)
 	}

--- a/proc/cut.go
+++ b/proc/cut.go
@@ -38,6 +38,16 @@ func CompileCutProc(c *Context, parent Proc, node *ast.CutProc) (*Cut, error) {
 	for _, field := range node.Fields {
 		fields = append(fields, expr.FieldExprToString(field))
 	}
+
+	_, err := expr.CompileFieldExprs(node.Fields)
+	if err != nil {
+		return nil, fmt.Errorf("compiling cut: %w", err)
+	}
+	_, err = NewColumnBuilder(c.TypeContext, fields)
+	if err != nil {
+		return nil, fmt.Errorf("compiling cut: %w", err)
+	}
+
 	return &Cut{
 		Base:        Base{Context: c, Parent: parent},
 		complement:  node.Complement,

--- a/proc/cut.go
+++ b/proc/cut.go
@@ -39,13 +39,16 @@ func CompileCutProc(c *Context, parent Proc, node *ast.CutProc) (*Cut, error) {
 		fields = append(fields, expr.FieldExprToString(field))
 	}
 
+	// build these once at compile time for error checking.
 	_, err := expr.CompileFieldExprs(node.Fields)
 	if err != nil {
 		return nil, fmt.Errorf("compiling cut: %w", err)
 	}
-	_, err = NewColumnBuilder(c.TypeContext, fields)
-	if err != nil {
-		return nil, fmt.Errorf("compiling cut: %w", err)
+	if !node.Complement {
+		_, err = NewColumnBuilder(c.TypeContext, fields)
+		if err != nil {
+			return nil, fmt.Errorf("compiling cut: %w", err)
+		}
 	}
 
 	return &Cut{

--- a/proc/cut_test.go
+++ b/proc/cut_test.go
@@ -33,6 +33,13 @@ const fooAndBar = `
 0:[foo3;bar3;]
 `
 
+const fooAndBarAndBlar = `
+#0:record[foo:string,bar:string,blar:string]
+0:[foo1;bar1;blar1;]
+0:[foo2;bar2;blar2;]
+0:[foo3;bar3;blar3;]
+`
+
 func TestCut(t *testing.T) {
 	// test "cut foo" on records that only have field foo
 	proc.TestOneProc(t, fooOnly, fooOnly, "cut foo")
@@ -56,6 +63,21 @@ func TestCut(t *testing.T) {
 
 	// test cut on multiple fields.
 	proc.TestOneProc(t, fooAndBar, fooAndBar, "cut foo,bar")
+}
+
+func TestCutComplement(t *testing.T) {
+	// test "cut foo" on records that only have field foo
+	proc.TestOneProc(t, fooOnly, fooOnly, "cut -c boo")
+
+	// test "cut foo" on records that have fields foo and bar
+	proc.TestOneProc(t, fooAndBar, barOnly, "cut -c foo")
+
+	// test "cut -c foo" on some fields with foo, some without
+	proc.TestOneProc(t, fooOnly+barOnly, barOnly, "cut -c foo")
+	proc.TestOneProc(t, barOnly+fooOnly, barOnly, "cut -c foo")
+
+	// test cut on multiple fields.
+	proc.TestOneProc(t, fooAndBarAndBlar, fooOnly, "cut -c bar,blar")
 }
 
 func ctx() *proc.Context {
@@ -130,6 +152,7 @@ const nestedOut2 = `
 // Test cutting fields inside nested records.
 func TestCutNested(t *testing.T) {
 	proc.TestOneProc(t, nestedIn1, nestedOut1, "cut rec.foo")
+	proc.TestOneProc(t, nestedIn1, nestedOut1, "cut -c rec.bar")
 	proc.TestOneProc(t, nestedIn1, nestedIn1, "cut rec.foo,rec.bar")
 	proc.TestOneProc(t, nestedIn2, nestedOut2, "cut rec1.sub1.foo,rec1.sub2.bar,rec2.foo,foo")
 }

--- a/proc/cut_test.go
+++ b/proc/cut_test.go
@@ -149,10 +149,17 @@ const nestedOut2 = `
 0:[[[foo1.2;][bar2.2;]][foo3.2;]outer2;]
 `
 
+const nestedOut2Complement = `
+#0:record[foo:string,rec2:record[foo:string]]
+0:[outer1;[foo3.1;]]
+0:[outer2;[foo3.2;]]
+`
+
 // Test cutting fields inside nested records.
 func TestCutNested(t *testing.T) {
 	proc.TestOneProc(t, nestedIn1, nestedOut1, "cut rec.foo")
 	proc.TestOneProc(t, nestedIn1, nestedOut1, "cut -c rec.bar")
 	proc.TestOneProc(t, nestedIn1, nestedIn1, "cut rec.foo,rec.bar")
 	proc.TestOneProc(t, nestedIn2, nestedOut2, "cut rec1.sub1.foo,rec1.sub2.bar,rec2.foo,foo")
+	proc.TestOneProc(t, nestedIn2, nestedOut2Complement, "cut -c rec1")
 }

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -65,7 +65,11 @@ func CompileGroupBy(node *ast.GroupByProc, zctx *resolver.Context) (*GroupByPara
 		}
 		reducers = append(reducers, compiled)
 	}
-	builder, err := NewColumnBuilder(zctx, node.Keys)
+	var names []string
+	for _, name := range node.Keys {
+		names = append(names, expr.FieldExprToString(name))
+	}
+	builder, err := NewColumnBuilder(zctx, names)
 	if err != nil {
 		return nil, fmt.Errorf("compiling groupby: %w", err)
 	}

--- a/proc/utils.go
+++ b/proc/utils.go
@@ -285,7 +285,7 @@ func TestOneProcWithBatches(t *testing.T, cmd string, zngs ...string) {
 		r1 := batchout.Index(i)
 		r2 := result.Index(i)
 		// XXX could print something a lot pretter if/when this fails.
-		require.Equalf(t, r2.Raw, r1.Raw, "Expected record %d to match", i)
+		require.Equalf(t, string(r2.Raw), string(r1.Raw), "Expected record %d to match", i)
 	}
 }
 

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -215,9 +215,18 @@ func makeTopProc(fieldsIn, limitIn, flushIn interface{}) *ast.TopProc {
 	return &ast.TopProc{ast.Node{"TopProc"}, limit, fields, flush}
 }
 
-func makeCutProc(fieldsIn interface{}) *ast.CutProc {
+func makeCutProc(argsIn, fieldsIn interface{}) (*ast.CutProc, error) {
+	var complement bool
+	argsArray := argsIn.([]interface{})
+	if len(argsArray) > 1 {
+		return nil, fmt.Errorf("Duplicate argument -c")
+	}
+	if len(argsArray) == 1 {
+		complement = true
+	}
+
 	fields := fieldExprArray(fieldsIn)
-	return &ast.CutProc{ast.Node{"CutProc"}, fields}
+	return &ast.CutProc{ast.Node{"CutProc"}, complement, fields}, nil
 }
 
 func makeHeadProc(countIn interface{}) *ast.HeadProc {

--- a/zql/parser-support.js
+++ b/zql/parser-support.js
@@ -93,7 +93,16 @@ function makeTopProc(fields, limit, flush) {
   return { op: "TopProc", fields, limit, flush};
 }
 
-function makeCutProc(fields) { return { op: "CutProc", fields }; }
+function makeCutProc(args, fields) {
+    let complement = false;
+    if (args.length > 1) {
+      throw new Error(`Duplicate argument -c`);
+    }
+    if (args.length == 1) {
+        complement = true;
+    }
+    return { op: "CutProc", complement, fields };
+}
 function makeHeadProc(count) { return { op: "HeadProc", count }; }
 function makeTailProc(count) { return { op: "TailProc", count }; }
 function makeUniqProc(cflag) { return { op: "TailProc", cflag }; }

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -2703,28 +2703,61 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "cut",
+			name: "cutArg",
 			pos:  position{line: 356, col: 1, offset: 8555},
+			expr: &zeroOrMoreExpr{
+				pos: position{line: 356, col: 10, offset: 8564},
+				expr: &actionExpr{
+					pos: position{line: 356, col: 11, offset: 8565},
+					run: (*parser).calloncutArg2,
+					expr: &seqExpr{
+						pos: position{line: 356, col: 11, offset: 8565},
+						exprs: []interface{}{
+							&ruleRefExpr{
+								pos:  position{line: 356, col: 11, offset: 8565},
+								name: "_",
+							},
+							&litMatcher{
+								pos:        position{line: 356, col: 13, offset: 8567},
+								val:        "-c",
+								ignoreCase: false,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "cut",
+			pos:  position{line: 358, col: 1, offset: 8609},
 			expr: &actionExpr{
-				pos: position{line: 357, col: 5, offset: 8563},
+				pos: position{line: 359, col: 5, offset: 8617},
 				run: (*parser).calloncut1,
 				expr: &seqExpr{
-					pos: position{line: 357, col: 5, offset: 8563},
+					pos: position{line: 359, col: 5, offset: 8617},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 357, col: 5, offset: 8563},
+							pos:        position{line: 359, col: 5, offset: 8617},
 							val:        "cut",
 							ignoreCase: true,
 						},
+						&labeledExpr{
+							pos:   position{line: 359, col: 12, offset: 8624},
+							label: "arg",
+							expr: &ruleRefExpr{
+								pos:  position{line: 359, col: 16, offset: 8628},
+								name: "cutArg",
+							},
+						},
 						&ruleRefExpr{
-							pos:  position{line: 357, col: 12, offset: 8570},
+							pos:  position{line: 359, col: 23, offset: 8635},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 357, col: 14, offset: 8572},
+							pos:   position{line: 359, col: 25, offset: 8637},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 357, col: 19, offset: 8577},
+								pos:  position{line: 359, col: 30, offset: 8642},
 								name: "fieldRefDotOnlyList",
 							},
 						},
@@ -2734,30 +2767,30 @@ var g = &grammar{
 		},
 		{
 			name: "head",
-			pos:  position{line: 358, col: 1, offset: 8631},
+			pos:  position{line: 360, col: 1, offset: 8697},
 			expr: &choiceExpr{
-				pos: position{line: 359, col: 5, offset: 8640},
+				pos: position{line: 361, col: 5, offset: 8706},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 359, col: 5, offset: 8640},
+						pos: position{line: 361, col: 5, offset: 8706},
 						run: (*parser).callonhead2,
 						expr: &seqExpr{
-							pos: position{line: 359, col: 5, offset: 8640},
+							pos: position{line: 361, col: 5, offset: 8706},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 359, col: 5, offset: 8640},
+									pos:        position{line: 361, col: 5, offset: 8706},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 359, col: 13, offset: 8648},
+									pos:  position{line: 361, col: 13, offset: 8714},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 359, col: 15, offset: 8650},
+									pos:   position{line: 361, col: 15, offset: 8716},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 359, col: 21, offset: 8656},
+										pos:  position{line: 361, col: 21, offset: 8722},
 										name: "unsignedInteger",
 									},
 								},
@@ -2765,10 +2798,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 360, col: 5, offset: 8712},
+						pos: position{line: 362, col: 5, offset: 8778},
 						run: (*parser).callonhead8,
 						expr: &litMatcher{
-							pos:        position{line: 360, col: 5, offset: 8712},
+							pos:        position{line: 362, col: 5, offset: 8778},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2778,30 +2811,30 @@ var g = &grammar{
 		},
 		{
 			name: "tail",
-			pos:  position{line: 361, col: 1, offset: 8752},
+			pos:  position{line: 363, col: 1, offset: 8818},
 			expr: &choiceExpr{
-				pos: position{line: 362, col: 5, offset: 8761},
+				pos: position{line: 364, col: 5, offset: 8827},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 362, col: 5, offset: 8761},
+						pos: position{line: 364, col: 5, offset: 8827},
 						run: (*parser).callontail2,
 						expr: &seqExpr{
-							pos: position{line: 362, col: 5, offset: 8761},
+							pos: position{line: 364, col: 5, offset: 8827},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 362, col: 5, offset: 8761},
+									pos:        position{line: 364, col: 5, offset: 8827},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 362, col: 13, offset: 8769},
+									pos:  position{line: 364, col: 13, offset: 8835},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 362, col: 15, offset: 8771},
+									pos:   position{line: 364, col: 15, offset: 8837},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 362, col: 21, offset: 8777},
+										pos:  position{line: 364, col: 21, offset: 8843},
 										name: "unsignedInteger",
 									},
 								},
@@ -2809,10 +2842,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 363, col: 5, offset: 8833},
+						pos: position{line: 365, col: 5, offset: 8899},
 						run: (*parser).callontail8,
 						expr: &litMatcher{
-							pos:        position{line: 363, col: 5, offset: 8833},
+							pos:        position{line: 365, col: 5, offset: 8899},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2822,27 +2855,27 @@ var g = &grammar{
 		},
 		{
 			name: "filter",
-			pos:  position{line: 365, col: 1, offset: 8874},
+			pos:  position{line: 367, col: 1, offset: 8940},
 			expr: &actionExpr{
-				pos: position{line: 366, col: 5, offset: 8885},
+				pos: position{line: 368, col: 5, offset: 8951},
 				run: (*parser).callonfilter1,
 				expr: &seqExpr{
-					pos: position{line: 366, col: 5, offset: 8885},
+					pos: position{line: 368, col: 5, offset: 8951},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 366, col: 5, offset: 8885},
+							pos:        position{line: 368, col: 5, offset: 8951},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 366, col: 15, offset: 8895},
+							pos:  position{line: 368, col: 15, offset: 8961},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 366, col: 17, offset: 8897},
+							pos:   position{line: 368, col: 17, offset: 8963},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 366, col: 22, offset: 8902},
+								pos:  position{line: 368, col: 22, offset: 8968},
 								name: "searchExpr",
 							},
 						},
@@ -2852,27 +2885,27 @@ var g = &grammar{
 		},
 		{
 			name: "uniq",
-			pos:  position{line: 369, col: 1, offset: 8960},
+			pos:  position{line: 371, col: 1, offset: 9026},
 			expr: &choiceExpr{
-				pos: position{line: 370, col: 5, offset: 8969},
+				pos: position{line: 372, col: 5, offset: 9035},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 370, col: 5, offset: 8969},
+						pos: position{line: 372, col: 5, offset: 9035},
 						run: (*parser).callonuniq2,
 						expr: &seqExpr{
-							pos: position{line: 370, col: 5, offset: 8969},
+							pos: position{line: 372, col: 5, offset: 9035},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 370, col: 5, offset: 8969},
+									pos:        position{line: 372, col: 5, offset: 9035},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 370, col: 13, offset: 8977},
+									pos:  position{line: 372, col: 13, offset: 9043},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 370, col: 15, offset: 8979},
+									pos:        position{line: 372, col: 15, offset: 9045},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2880,10 +2913,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 373, col: 5, offset: 9033},
+						pos: position{line: 375, col: 5, offset: 9099},
 						run: (*parser).callonuniq7,
 						expr: &litMatcher{
-							pos:        position{line: 373, col: 5, offset: 9033},
+							pos:        position{line: 375, col: 5, offset: 9099},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2893,48 +2926,48 @@ var g = &grammar{
 		},
 		{
 			name: "put",
-			pos:  position{line: 377, col: 1, offset: 9088},
+			pos:  position{line: 379, col: 1, offset: 9154},
 			expr: &actionExpr{
-				pos: position{line: 378, col: 5, offset: 9096},
+				pos: position{line: 380, col: 5, offset: 9162},
 				run: (*parser).callonput1,
 				expr: &seqExpr{
-					pos: position{line: 378, col: 5, offset: 9096},
+					pos: position{line: 380, col: 5, offset: 9162},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 378, col: 5, offset: 9096},
+							pos:        position{line: 380, col: 5, offset: 9162},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 378, col: 12, offset: 9103},
+							pos:  position{line: 380, col: 12, offset: 9169},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 378, col: 14, offset: 9105},
+							pos:   position{line: 380, col: 14, offset: 9171},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 378, col: 16, offset: 9107},
+								pos:  position{line: 380, col: 16, offset: 9173},
 								name: "fieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 378, col: 26, offset: 9117},
+							pos:  position{line: 380, col: 26, offset: 9183},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 378, col: 29, offset: 9120},
+							pos:        position{line: 380, col: 29, offset: 9186},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 378, col: 33, offset: 9124},
+							pos:  position{line: 380, col: 33, offset: 9190},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 378, col: 36, offset: 9127},
+							pos:   position{line: 380, col: 36, offset: 9193},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 378, col: 38, offset: 9129},
+								pos:  position{line: 380, col: 38, offset: 9195},
 								name: "Expression",
 							},
 						},
@@ -2944,79 +2977,79 @@ var g = &grammar{
 		},
 		{
 			name: "PrimaryExpression",
-			pos:  position{line: 382, col: 1, offset: 9185},
+			pos:  position{line: 384, col: 1, offset: 9251},
 			expr: &choiceExpr{
-				pos: position{line: 383, col: 5, offset: 9207},
+				pos: position{line: 385, col: 5, offset: 9273},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 383, col: 5, offset: 9207},
+						pos:  position{line: 385, col: 5, offset: 9273},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 384, col: 5, offset: 9225},
+						pos:  position{line: 386, col: 5, offset: 9291},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 385, col: 5, offset: 9243},
+						pos:  position{line: 387, col: 5, offset: 9309},
 						name: "PortLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 386, col: 5, offset: 9259},
+						pos:  position{line: 388, col: 5, offset: 9325},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 387, col: 5, offset: 9277},
+						pos:  position{line: 389, col: 5, offset: 9343},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 388, col: 5, offset: 9296},
+						pos:  position{line: 390, col: 5, offset: 9362},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 389, col: 5, offset: 9313},
+						pos:  position{line: 391, col: 5, offset: 9379},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 390, col: 5, offset: 9332},
+						pos:  position{line: 392, col: 5, offset: 9398},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 391, col: 5, offset: 9351},
+						pos:  position{line: 393, col: 5, offset: 9417},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 392, col: 5, offset: 9367},
+						pos:  position{line: 394, col: 5, offset: 9433},
 						name: "FieldReference",
 					},
 					&actionExpr{
-						pos: position{line: 393, col: 5, offset: 9386},
+						pos: position{line: 395, col: 5, offset: 9452},
 						run: (*parser).callonPrimaryExpression12,
 						expr: &seqExpr{
-							pos: position{line: 393, col: 5, offset: 9386},
+							pos: position{line: 395, col: 5, offset: 9452},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 393, col: 5, offset: 9386},
+									pos:        position{line: 395, col: 5, offset: 9452},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 393, col: 9, offset: 9390},
+									pos:  position{line: 395, col: 9, offset: 9456},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 393, col: 12, offset: 9393},
+									pos:   position{line: 395, col: 12, offset: 9459},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 393, col: 17, offset: 9398},
+										pos:  position{line: 395, col: 17, offset: 9464},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 393, col: 28, offset: 9409},
+									pos:  position{line: 395, col: 28, offset: 9475},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 393, col: 31, offset: 9412},
+									pos:        position{line: 395, col: 31, offset: 9478},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3028,15 +3061,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldReference",
-			pos:  position{line: 395, col: 1, offset: 9438},
+			pos:  position{line: 397, col: 1, offset: 9504},
 			expr: &actionExpr{
-				pos: position{line: 396, col: 5, offset: 9457},
+				pos: position{line: 398, col: 5, offset: 9523},
 				run: (*parser).callonFieldReference1,
 				expr: &labeledExpr{
-					pos:   position{line: 396, col: 5, offset: 9457},
+					pos:   position{line: 398, col: 5, offset: 9523},
 					label: "f",
 					expr: &ruleRefExpr{
-						pos:  position{line: 396, col: 7, offset: 9459},
+						pos:  position{line: 398, col: 7, offset: 9525},
 						name: "fieldName",
 					},
 				},
@@ -3044,71 +3077,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expression",
-			pos:  position{line: 406, col: 1, offset: 9708},
+			pos:  position{line: 408, col: 1, offset: 9774},
 			expr: &ruleRefExpr{
-				pos:  position{line: 406, col: 14, offset: 9721},
+				pos:  position{line: 408, col: 14, offset: 9787},
 				name: "ConditionalExpression",
 			},
 		},
 		{
 			name: "ConditionalExpression",
-			pos:  position{line: 408, col: 1, offset: 9744},
+			pos:  position{line: 410, col: 1, offset: 9810},
 			expr: &choiceExpr{
-				pos: position{line: 409, col: 5, offset: 9770},
+				pos: position{line: 411, col: 5, offset: 9836},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 409, col: 5, offset: 9770},
+						pos: position{line: 411, col: 5, offset: 9836},
 						run: (*parser).callonConditionalExpression2,
 						expr: &seqExpr{
-							pos: position{line: 409, col: 5, offset: 9770},
+							pos: position{line: 411, col: 5, offset: 9836},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 409, col: 5, offset: 9770},
+									pos:   position{line: 411, col: 5, offset: 9836},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 409, col: 15, offset: 9780},
+										pos:  position{line: 411, col: 15, offset: 9846},
 										name: "LogicalORExpression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 409, col: 35, offset: 9800},
+									pos:  position{line: 411, col: 35, offset: 9866},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 409, col: 38, offset: 9803},
+									pos:        position{line: 411, col: 38, offset: 9869},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 409, col: 42, offset: 9807},
+									pos:  position{line: 411, col: 42, offset: 9873},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 409, col: 45, offset: 9810},
+									pos:   position{line: 411, col: 45, offset: 9876},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 409, col: 56, offset: 9821},
+										pos:  position{line: 411, col: 56, offset: 9887},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 409, col: 67, offset: 9832},
+									pos:  position{line: 411, col: 67, offset: 9898},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 409, col: 70, offset: 9835},
+									pos:        position{line: 411, col: 70, offset: 9901},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 409, col: 74, offset: 9839},
+									pos:  position{line: 411, col: 74, offset: 9905},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 409, col: 77, offset: 9842},
+									pos:   position{line: 411, col: 77, offset: 9908},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 409, col: 88, offset: 9853},
+										pos:  position{line: 411, col: 88, offset: 9919},
 										name: "Expression",
 									},
 								},
@@ -3116,7 +3149,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 412, col: 5, offset: 9945},
+						pos:  position{line: 414, col: 5, offset: 10011},
 						name: "LogicalORExpression",
 					},
 				},
@@ -3124,43 +3157,43 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalORExpression",
-			pos:  position{line: 414, col: 1, offset: 9966},
+			pos:  position{line: 416, col: 1, offset: 10032},
 			expr: &actionExpr{
-				pos: position{line: 415, col: 5, offset: 9990},
+				pos: position{line: 417, col: 5, offset: 10056},
 				run: (*parser).callonLogicalORExpression1,
 				expr: &seqExpr{
-					pos: position{line: 415, col: 5, offset: 9990},
+					pos: position{line: 417, col: 5, offset: 10056},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 415, col: 5, offset: 9990},
+							pos:   position{line: 417, col: 5, offset: 10056},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 415, col: 11, offset: 9996},
+								pos:  position{line: 417, col: 11, offset: 10062},
 								name: "LogicalANDExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 416, col: 5, offset: 10021},
+							pos:   position{line: 418, col: 5, offset: 10087},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 416, col: 10, offset: 10026},
+								pos: position{line: 418, col: 10, offset: 10092},
 								expr: &seqExpr{
-									pos: position{line: 416, col: 11, offset: 10027},
+									pos: position{line: 418, col: 11, offset: 10093},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 416, col: 11, offset: 10027},
+											pos:  position{line: 418, col: 11, offset: 10093},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 416, col: 14, offset: 10030},
+											pos:  position{line: 418, col: 14, offset: 10096},
 											name: "orToken",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 416, col: 22, offset: 10038},
+											pos:  position{line: 418, col: 22, offset: 10104},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 416, col: 25, offset: 10041},
+											pos:  position{line: 418, col: 25, offset: 10107},
 											name: "LogicalANDExpression",
 										},
 									},
@@ -3173,43 +3206,43 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalANDExpression",
-			pos:  position{line: 420, col: 1, offset: 10126},
+			pos:  position{line: 422, col: 1, offset: 10192},
 			expr: &actionExpr{
-				pos: position{line: 421, col: 5, offset: 10151},
+				pos: position{line: 423, col: 5, offset: 10217},
 				run: (*parser).callonLogicalANDExpression1,
 				expr: &seqExpr{
-					pos: position{line: 421, col: 5, offset: 10151},
+					pos: position{line: 423, col: 5, offset: 10217},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 421, col: 5, offset: 10151},
+							pos:   position{line: 423, col: 5, offset: 10217},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 421, col: 11, offset: 10157},
+								pos:  position{line: 423, col: 11, offset: 10223},
 								name: "EqualityCompareExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 422, col: 5, offset: 10187},
+							pos:   position{line: 424, col: 5, offset: 10253},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 422, col: 10, offset: 10192},
+								pos: position{line: 424, col: 10, offset: 10258},
 								expr: &seqExpr{
-									pos: position{line: 422, col: 11, offset: 10193},
+									pos: position{line: 424, col: 11, offset: 10259},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 422, col: 11, offset: 10193},
+											pos:  position{line: 424, col: 11, offset: 10259},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 422, col: 14, offset: 10196},
+											pos:  position{line: 424, col: 14, offset: 10262},
 											name: "andToken",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 422, col: 23, offset: 10205},
+											pos:  position{line: 424, col: 23, offset: 10271},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 422, col: 26, offset: 10208},
+											pos:  position{line: 424, col: 26, offset: 10274},
 											name: "EqualityCompareExpression",
 										},
 									},
@@ -3222,43 +3255,43 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpression",
-			pos:  position{line: 426, col: 1, offset: 10298},
+			pos:  position{line: 428, col: 1, offset: 10364},
 			expr: &actionExpr{
-				pos: position{line: 427, col: 5, offset: 10328},
+				pos: position{line: 429, col: 5, offset: 10394},
 				run: (*parser).callonEqualityCompareExpression1,
 				expr: &seqExpr{
-					pos: position{line: 427, col: 5, offset: 10328},
+					pos: position{line: 429, col: 5, offset: 10394},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 427, col: 5, offset: 10328},
+							pos:   position{line: 429, col: 5, offset: 10394},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 427, col: 11, offset: 10334},
+								pos:  position{line: 429, col: 11, offset: 10400},
 								name: "RelativeExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 428, col: 5, offset: 10357},
+							pos:   position{line: 430, col: 5, offset: 10423},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 428, col: 10, offset: 10362},
+								pos: position{line: 430, col: 10, offset: 10428},
 								expr: &seqExpr{
-									pos: position{line: 428, col: 11, offset: 10363},
+									pos: position{line: 430, col: 11, offset: 10429},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 11, offset: 10363},
+											pos:  position{line: 430, col: 11, offset: 10429},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 14, offset: 10366},
+											pos:  position{line: 430, col: 14, offset: 10432},
 											name: "EqualityComparator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 33, offset: 10385},
+											pos:  position{line: 430, col: 33, offset: 10451},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 36, offset: 10388},
+											pos:  position{line: 430, col: 36, offset: 10454},
 											name: "RelativeExpression",
 										},
 									},
@@ -3271,25 +3304,25 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 432, col: 1, offset: 10471},
+			pos:  position{line: 434, col: 1, offset: 10537},
 			expr: &actionExpr{
-				pos: position{line: 432, col: 20, offset: 10490},
+				pos: position{line: 434, col: 20, offset: 10556},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 432, col: 21, offset: 10491},
+					pos: position{line: 434, col: 21, offset: 10557},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 432, col: 21, offset: 10491},
+							pos:        position{line: 434, col: 21, offset: 10557},
 							val:        "=~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 432, col: 28, offset: 10498},
+							pos:        position{line: 434, col: 28, offset: 10564},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 432, col: 34, offset: 10504},
+							pos:        position{line: 434, col: 34, offset: 10570},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3299,19 +3332,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 434, col: 1, offset: 10542},
+			pos:  position{line: 436, col: 1, offset: 10608},
 			expr: &choiceExpr{
-				pos: position{line: 435, col: 5, offset: 10565},
+				pos: position{line: 437, col: 5, offset: 10631},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 435, col: 5, offset: 10565},
+						pos:  position{line: 437, col: 5, offset: 10631},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 436, col: 5, offset: 10586},
+						pos: position{line: 438, col: 5, offset: 10652},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 436, col: 5, offset: 10586},
+							pos:        position{line: 438, col: 5, offset: 10652},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3321,43 +3354,43 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpression",
-			pos:  position{line: 438, col: 1, offset: 10623},
+			pos:  position{line: 440, col: 1, offset: 10689},
 			expr: &actionExpr{
-				pos: position{line: 439, col: 5, offset: 10646},
+				pos: position{line: 441, col: 5, offset: 10712},
 				run: (*parser).callonRelativeExpression1,
 				expr: &seqExpr{
-					pos: position{line: 439, col: 5, offset: 10646},
+					pos: position{line: 441, col: 5, offset: 10712},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 439, col: 5, offset: 10646},
+							pos:   position{line: 441, col: 5, offset: 10712},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 439, col: 11, offset: 10652},
+								pos:  position{line: 441, col: 11, offset: 10718},
 								name: "AdditiveExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 5, offset: 10675},
+							pos:   position{line: 442, col: 5, offset: 10741},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 440, col: 10, offset: 10680},
+								pos: position{line: 442, col: 10, offset: 10746},
 								expr: &seqExpr{
-									pos: position{line: 440, col: 11, offset: 10681},
+									pos: position{line: 442, col: 11, offset: 10747},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 11, offset: 10681},
+											pos:  position{line: 442, col: 11, offset: 10747},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 14, offset: 10684},
+											pos:  position{line: 442, col: 14, offset: 10750},
 											name: "RelativeOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 31, offset: 10701},
+											pos:  position{line: 442, col: 31, offset: 10767},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 34, offset: 10704},
+											pos:  position{line: 442, col: 34, offset: 10770},
 											name: "AdditiveExpression",
 										},
 									},
@@ -3370,30 +3403,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 444, col: 1, offset: 10787},
+			pos:  position{line: 446, col: 1, offset: 10853},
 			expr: &actionExpr{
-				pos: position{line: 444, col: 20, offset: 10806},
+				pos: position{line: 446, col: 20, offset: 10872},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 444, col: 21, offset: 10807},
+					pos: position{line: 446, col: 21, offset: 10873},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 444, col: 21, offset: 10807},
+							pos:        position{line: 446, col: 21, offset: 10873},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 28, offset: 10814},
+							pos:        position{line: 446, col: 28, offset: 10880},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 34, offset: 10820},
+							pos:        position{line: 446, col: 34, offset: 10886},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 41, offset: 10827},
+							pos:        position{line: 446, col: 41, offset: 10893},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -3403,43 +3436,43 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpression",
-			pos:  position{line: 446, col: 1, offset: 10864},
+			pos:  position{line: 448, col: 1, offset: 10930},
 			expr: &actionExpr{
-				pos: position{line: 447, col: 5, offset: 10887},
+				pos: position{line: 449, col: 5, offset: 10953},
 				run: (*parser).callonAdditiveExpression1,
 				expr: &seqExpr{
-					pos: position{line: 447, col: 5, offset: 10887},
+					pos: position{line: 449, col: 5, offset: 10953},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 447, col: 5, offset: 10887},
+							pos:   position{line: 449, col: 5, offset: 10953},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 447, col: 11, offset: 10893},
+								pos:  position{line: 449, col: 11, offset: 10959},
 								name: "MultiplicativeExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 448, col: 5, offset: 10922},
+							pos:   position{line: 450, col: 5, offset: 10988},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 448, col: 10, offset: 10927},
+								pos: position{line: 450, col: 10, offset: 10993},
 								expr: &seqExpr{
-									pos: position{line: 448, col: 11, offset: 10928},
+									pos: position{line: 450, col: 11, offset: 10994},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 448, col: 11, offset: 10928},
+											pos:  position{line: 450, col: 11, offset: 10994},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 448, col: 14, offset: 10931},
+											pos:  position{line: 450, col: 14, offset: 10997},
 											name: "AdditiveOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 448, col: 31, offset: 10948},
+											pos:  position{line: 450, col: 31, offset: 11014},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 448, col: 34, offset: 10951},
+											pos:  position{line: 450, col: 34, offset: 11017},
 											name: "MultiplicativeExpression",
 										},
 									},
@@ -3452,20 +3485,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 452, col: 1, offset: 11040},
+			pos:  position{line: 454, col: 1, offset: 11106},
 			expr: &actionExpr{
-				pos: position{line: 452, col: 20, offset: 11059},
+				pos: position{line: 454, col: 20, offset: 11125},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 452, col: 21, offset: 11060},
+					pos: position{line: 454, col: 21, offset: 11126},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 452, col: 21, offset: 11060},
+							pos:        position{line: 454, col: 21, offset: 11126},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 452, col: 27, offset: 11066},
+							pos:        position{line: 454, col: 27, offset: 11132},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3475,50 +3508,50 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpression",
-			pos:  position{line: 454, col: 1, offset: 11103},
+			pos:  position{line: 456, col: 1, offset: 11169},
 			expr: &actionExpr{
-				pos: position{line: 455, col: 5, offset: 11132},
+				pos: position{line: 457, col: 5, offset: 11198},
 				run: (*parser).callonMultiplicativeExpression1,
 				expr: &seqExpr{
-					pos: position{line: 455, col: 5, offset: 11132},
+					pos: position{line: 457, col: 5, offset: 11198},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 455, col: 5, offset: 11132},
+							pos:   position{line: 457, col: 5, offset: 11198},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 455, col: 11, offset: 11138},
+								pos:  position{line: 457, col: 11, offset: 11204},
 								name: "NotExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 456, col: 5, offset: 11156},
+							pos:   position{line: 458, col: 5, offset: 11222},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 456, col: 10, offset: 11161},
+								pos: position{line: 458, col: 10, offset: 11227},
 								expr: &seqExpr{
-									pos: position{line: 456, col: 11, offset: 11162},
+									pos: position{line: 458, col: 11, offset: 11228},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 456, col: 11, offset: 11162},
+											pos:  position{line: 458, col: 11, offset: 11228},
 											name: "__",
 										},
 										&labeledExpr{
-											pos:   position{line: 456, col: 14, offset: 11165},
+											pos:   position{line: 458, col: 14, offset: 11231},
 											label: "op",
 											expr: &ruleRefExpr{
-												pos:  position{line: 456, col: 17, offset: 11168},
+												pos:  position{line: 458, col: 17, offset: 11234},
 												name: "MultiplicativeOperator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 456, col: 40, offset: 11191},
+											pos:  position{line: 458, col: 40, offset: 11257},
 											name: "__",
 										},
 										&labeledExpr{
-											pos:   position{line: 456, col: 43, offset: 11194},
+											pos:   position{line: 458, col: 43, offset: 11260},
 											label: "operand",
 											expr: &ruleRefExpr{
-												pos:  position{line: 456, col: 51, offset: 11202},
+												pos:  position{line: 458, col: 51, offset: 11268},
 												name: "NotExpression",
 											},
 										},
@@ -3532,20 +3565,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 460, col: 1, offset: 11280},
+			pos:  position{line: 462, col: 1, offset: 11346},
 			expr: &actionExpr{
-				pos: position{line: 460, col: 26, offset: 11305},
+				pos: position{line: 462, col: 26, offset: 11371},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 460, col: 27, offset: 11306},
+					pos: position{line: 462, col: 27, offset: 11372},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 460, col: 27, offset: 11306},
+							pos:        position{line: 462, col: 27, offset: 11372},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 460, col: 33, offset: 11312},
+							pos:        position{line: 462, col: 33, offset: 11378},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -3555,30 +3588,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpression",
-			pos:  position{line: 462, col: 1, offset: 11349},
+			pos:  position{line: 464, col: 1, offset: 11415},
 			expr: &choiceExpr{
-				pos: position{line: 463, col: 5, offset: 11367},
+				pos: position{line: 465, col: 5, offset: 11433},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 463, col: 5, offset: 11367},
+						pos: position{line: 465, col: 5, offset: 11433},
 						run: (*parser).callonNotExpression2,
 						expr: &seqExpr{
-							pos: position{line: 463, col: 5, offset: 11367},
+							pos: position{line: 465, col: 5, offset: 11433},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 463, col: 5, offset: 11367},
+									pos:        position{line: 465, col: 5, offset: 11433},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 463, col: 9, offset: 11371},
+									pos:  position{line: 465, col: 9, offset: 11437},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 463, col: 12, offset: 11374},
+									pos:   position{line: 465, col: 12, offset: 11440},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 463, col: 14, offset: 11376},
+										pos:  position{line: 465, col: 14, offset: 11442},
 										name: "NotExpression",
 									},
 								},
@@ -3586,7 +3619,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 466, col: 5, offset: 11444},
+						pos:  position{line: 468, col: 5, offset: 11510},
 						name: "CallExpression",
 					},
 				},
@@ -3594,43 +3627,43 @@ var g = &grammar{
 		},
 		{
 			name: "CallExpression",
-			pos:  position{line: 469, col: 1, offset: 11461},
+			pos:  position{line: 471, col: 1, offset: 11527},
 			expr: &choiceExpr{
-				pos: position{line: 470, col: 5, offset: 11480},
+				pos: position{line: 472, col: 5, offset: 11546},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 470, col: 5, offset: 11480},
+						pos: position{line: 472, col: 5, offset: 11546},
 						run: (*parser).callonCallExpression2,
 						expr: &seqExpr{
-							pos: position{line: 470, col: 5, offset: 11480},
+							pos: position{line: 472, col: 5, offset: 11546},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 470, col: 5, offset: 11480},
+									pos:   position{line: 472, col: 5, offset: 11546},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 470, col: 8, offset: 11483},
+										pos:  position{line: 472, col: 8, offset: 11549},
 										name: "FunctionName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 470, col: 21, offset: 11496},
+									pos:  position{line: 472, col: 21, offset: 11562},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 470, col: 24, offset: 11499},
+									pos:        position{line: 472, col: 24, offset: 11565},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 470, col: 28, offset: 11503},
+									pos:   position{line: 472, col: 28, offset: 11569},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 470, col: 33, offset: 11508},
+										pos:  position{line: 472, col: 33, offset: 11574},
 										name: "ArgumentList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 470, col: 46, offset: 11521},
+									pos:        position{line: 472, col: 46, offset: 11587},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3638,7 +3671,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 473, col: 5, offset: 11584},
+						pos:  position{line: 475, col: 5, offset: 11650},
 						name: "DereferenceExpression",
 					},
 				},
@@ -3646,21 +3679,21 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionName",
-			pos:  position{line: 475, col: 1, offset: 11607},
+			pos:  position{line: 477, col: 1, offset: 11673},
 			expr: &actionExpr{
-				pos: position{line: 476, col: 5, offset: 11624},
+				pos: position{line: 478, col: 5, offset: 11690},
 				run: (*parser).callonFunctionName1,
 				expr: &seqExpr{
-					pos: position{line: 476, col: 5, offset: 11624},
+					pos: position{line: 478, col: 5, offset: 11690},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 476, col: 5, offset: 11624},
+							pos:  position{line: 478, col: 5, offset: 11690},
 							name: "FunctionNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 476, col: 23, offset: 11642},
+							pos: position{line: 478, col: 23, offset: 11708},
 							expr: &ruleRefExpr{
-								pos:  position{line: 476, col: 23, offset: 11642},
+								pos:  position{line: 478, col: 23, offset: 11708},
 								name: "FunctionNameRest",
 							},
 						},
@@ -3670,9 +3703,9 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionNameStart",
-			pos:  position{line: 478, col: 1, offset: 11692},
+			pos:  position{line: 480, col: 1, offset: 11758},
 			expr: &charClassMatcher{
-				pos:        position{line: 478, col: 21, offset: 11712},
+				pos:        position{line: 480, col: 21, offset: 11778},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -3681,16 +3714,16 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionNameRest",
-			pos:  position{line: 479, col: 1, offset: 11721},
+			pos:  position{line: 481, col: 1, offset: 11787},
 			expr: &choiceExpr{
-				pos: position{line: 479, col: 20, offset: 11740},
+				pos: position{line: 481, col: 20, offset: 11806},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 479, col: 20, offset: 11740},
+						pos:  position{line: 481, col: 20, offset: 11806},
 						name: "FunctionNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 479, col: 40, offset: 11760},
+						pos:        position{line: 481, col: 40, offset: 11826},
 						val:        "[.0-9]",
 						chars:      []rune{'.'},
 						ranges:     []rune{'0', '9'},
@@ -3702,53 +3735,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 481, col: 1, offset: 11768},
+			pos:  position{line: 483, col: 1, offset: 11834},
 			expr: &choiceExpr{
-				pos: position{line: 482, col: 5, offset: 11785},
+				pos: position{line: 484, col: 5, offset: 11851},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 482, col: 5, offset: 11785},
+						pos: position{line: 484, col: 5, offset: 11851},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 482, col: 5, offset: 11785},
+							pos: position{line: 484, col: 5, offset: 11851},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 482, col: 5, offset: 11785},
+									pos:   position{line: 484, col: 5, offset: 11851},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 482, col: 11, offset: 11791},
+										pos:  position{line: 484, col: 11, offset: 11857},
 										name: "Expression",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 482, col: 22, offset: 11802},
+									pos:   position{line: 484, col: 22, offset: 11868},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 482, col: 27, offset: 11807},
+										pos: position{line: 484, col: 27, offset: 11873},
 										expr: &actionExpr{
-											pos: position{line: 482, col: 28, offset: 11808},
+											pos: position{line: 484, col: 28, offset: 11874},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 482, col: 28, offset: 11808},
+												pos: position{line: 484, col: 28, offset: 11874},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 482, col: 28, offset: 11808},
+														pos:  position{line: 484, col: 28, offset: 11874},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 482, col: 31, offset: 11811},
+														pos:        position{line: 484, col: 31, offset: 11877},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 482, col: 35, offset: 11815},
+														pos:  position{line: 484, col: 35, offset: 11881},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 482, col: 38, offset: 11818},
+														pos:   position{line: 484, col: 38, offset: 11884},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 482, col: 40, offset: 11820},
+															pos:  position{line: 484, col: 40, offset: 11886},
 															name: "Expression",
 														},
 													},
@@ -3761,10 +3794,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 485, col: 5, offset: 11936},
+						pos: position{line: 487, col: 5, offset: 12002},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 485, col: 5, offset: 11936},
+							pos:  position{line: 487, col: 5, offset: 12002},
 							name: "__",
 						},
 					},
@@ -3773,88 +3806,88 @@ var g = &grammar{
 		},
 		{
 			name: "DereferenceExpression",
-			pos:  position{line: 487, col: 1, offset: 11972},
+			pos:  position{line: 489, col: 1, offset: 12038},
 			expr: &actionExpr{
-				pos: position{line: 488, col: 5, offset: 11998},
+				pos: position{line: 490, col: 5, offset: 12064},
 				run: (*parser).callonDereferenceExpression1,
 				expr: &seqExpr{
-					pos: position{line: 488, col: 5, offset: 11998},
+					pos: position{line: 490, col: 5, offset: 12064},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 488, col: 5, offset: 11998},
+							pos:   position{line: 490, col: 5, offset: 12064},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 488, col: 10, offset: 12003},
+								pos:  position{line: 490, col: 10, offset: 12069},
 								name: "PrimaryExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 489, col: 5, offset: 12025},
+							pos:   position{line: 491, col: 5, offset: 12091},
 							label: "derefs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 489, col: 12, offset: 12032},
+								pos: position{line: 491, col: 12, offset: 12098},
 								expr: &choiceExpr{
-									pos: position{line: 490, col: 9, offset: 12042},
+									pos: position{line: 492, col: 9, offset: 12108},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 490, col: 9, offset: 12042},
+											pos: position{line: 492, col: 9, offset: 12108},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 490, col: 9, offset: 12042},
+													pos:  position{line: 492, col: 9, offset: 12108},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 490, col: 12, offset: 12045},
+													pos:        position{line: 492, col: 12, offset: 12111},
 													val:        "[",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 490, col: 16, offset: 12049},
+													pos:  position{line: 492, col: 16, offset: 12115},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 490, col: 19, offset: 12052},
+													pos:   position{line: 492, col: 19, offset: 12118},
 													label: "index",
 													expr: &ruleRefExpr{
-														pos:  position{line: 490, col: 25, offset: 12058},
+														pos:  position{line: 492, col: 25, offset: 12124},
 														name: "Expression",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 490, col: 36, offset: 12069},
+													pos:  position{line: 492, col: 36, offset: 12135},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 490, col: 39, offset: 12072},
+													pos:        position{line: 492, col: 39, offset: 12138},
 													val:        "]",
 													ignoreCase: false,
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 491, col: 9, offset: 12084},
+											pos: position{line: 493, col: 9, offset: 12150},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 491, col: 9, offset: 12084},
+													pos:  position{line: 493, col: 9, offset: 12150},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 491, col: 12, offset: 12087},
+													pos:        position{line: 493, col: 12, offset: 12153},
 													val:        ".",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 491, col: 16, offset: 12091},
+													pos:  position{line: 493, col: 16, offset: 12157},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 491, col: 20, offset: 12095},
+													pos: position{line: 493, col: 20, offset: 12161},
 													run: (*parser).callonDereferenceExpression20,
 													expr: &labeledExpr{
-														pos:   position{line: 491, col: 20, offset: 12095},
+														pos:   position{line: 493, col: 20, offset: 12161},
 														label: "field",
 														expr: &ruleRefExpr{
-															pos:  position{line: 491, col: 26, offset: 12101},
+															pos:  position{line: 493, col: 26, offset: 12167},
 															name: "fieldName",
 														},
 													},
@@ -3871,54 +3904,54 @@ var g = &grammar{
 		},
 		{
 			name: "duration",
-			pos:  position{line: 496, col: 1, offset: 12236},
+			pos:  position{line: 498, col: 1, offset: 12302},
 			expr: &choiceExpr{
-				pos: position{line: 497, col: 5, offset: 12249},
+				pos: position{line: 499, col: 5, offset: 12315},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 497, col: 5, offset: 12249},
+						pos:  position{line: 499, col: 5, offset: 12315},
 						name: "seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 498, col: 5, offset: 12261},
+						pos:  position{line: 500, col: 5, offset: 12327},
 						name: "minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 499, col: 5, offset: 12273},
+						pos:  position{line: 501, col: 5, offset: 12339},
 						name: "hours",
 					},
 					&seqExpr{
-						pos: position{line: 500, col: 5, offset: 12283},
+						pos: position{line: 502, col: 5, offset: 12349},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 500, col: 5, offset: 12283},
+								pos:  position{line: 502, col: 5, offset: 12349},
 								name: "hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 500, col: 11, offset: 12289},
+								pos:  position{line: 502, col: 11, offset: 12355},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 500, col: 13, offset: 12291},
+								pos:        position{line: 502, col: 13, offset: 12357},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 500, col: 19, offset: 12297},
+								pos:  position{line: 502, col: 19, offset: 12363},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 500, col: 21, offset: 12299},
+								pos:  position{line: 502, col: 21, offset: 12365},
 								name: "minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 501, col: 5, offset: 12311},
+						pos:  position{line: 503, col: 5, offset: 12377},
 						name: "days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 502, col: 5, offset: 12320},
+						pos:  position{line: 504, col: 5, offset: 12386},
 						name: "weeks",
 					},
 				},
@@ -3926,32 +3959,32 @@ var g = &grammar{
 		},
 		{
 			name: "sec_abbrev",
-			pos:  position{line: 504, col: 1, offset: 12327},
+			pos:  position{line: 506, col: 1, offset: 12393},
 			expr: &choiceExpr{
-				pos: position{line: 505, col: 5, offset: 12342},
+				pos: position{line: 507, col: 5, offset: 12408},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 505, col: 5, offset: 12342},
+						pos:        position{line: 507, col: 5, offset: 12408},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 506, col: 5, offset: 12356},
+						pos:        position{line: 508, col: 5, offset: 12422},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 507, col: 5, offset: 12369},
+						pos:        position{line: 509, col: 5, offset: 12435},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 508, col: 5, offset: 12380},
+						pos:        position{line: 510, col: 5, offset: 12446},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 509, col: 5, offset: 12390},
+						pos:        position{line: 511, col: 5, offset: 12456},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -3960,32 +3993,32 @@ var g = &grammar{
 		},
 		{
 			name: "min_abbrev",
-			pos:  position{line: 511, col: 1, offset: 12395},
+			pos:  position{line: 513, col: 1, offset: 12461},
 			expr: &choiceExpr{
-				pos: position{line: 512, col: 5, offset: 12410},
+				pos: position{line: 514, col: 5, offset: 12476},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 512, col: 5, offset: 12410},
+						pos:        position{line: 514, col: 5, offset: 12476},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 513, col: 5, offset: 12424},
+						pos:        position{line: 515, col: 5, offset: 12490},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 514, col: 5, offset: 12437},
+						pos:        position{line: 516, col: 5, offset: 12503},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 515, col: 5, offset: 12448},
+						pos:        position{line: 517, col: 5, offset: 12514},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 516, col: 5, offset: 12458},
+						pos:        position{line: 518, col: 5, offset: 12524},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -3994,32 +4027,32 @@ var g = &grammar{
 		},
 		{
 			name: "hour_abbrev",
-			pos:  position{line: 518, col: 1, offset: 12463},
+			pos:  position{line: 520, col: 1, offset: 12529},
 			expr: &choiceExpr{
-				pos: position{line: 519, col: 5, offset: 12479},
+				pos: position{line: 521, col: 5, offset: 12545},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 519, col: 5, offset: 12479},
+						pos:        position{line: 521, col: 5, offset: 12545},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 520, col: 5, offset: 12491},
+						pos:        position{line: 522, col: 5, offset: 12557},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 521, col: 5, offset: 12501},
+						pos:        position{line: 523, col: 5, offset: 12567},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 522, col: 5, offset: 12510},
+						pos:        position{line: 524, col: 5, offset: 12576},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 523, col: 5, offset: 12518},
+						pos:        position{line: 525, col: 5, offset: 12584},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -4028,22 +4061,22 @@ var g = &grammar{
 		},
 		{
 			name: "day_abbrev",
-			pos:  position{line: 525, col: 1, offset: 12526},
+			pos:  position{line: 527, col: 1, offset: 12592},
 			expr: &choiceExpr{
-				pos: position{line: 525, col: 14, offset: 12539},
+				pos: position{line: 527, col: 14, offset: 12605},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 525, col: 14, offset: 12539},
+						pos:        position{line: 527, col: 14, offset: 12605},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 525, col: 21, offset: 12546},
+						pos:        position{line: 527, col: 21, offset: 12612},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 525, col: 27, offset: 12552},
+						pos:        position{line: 527, col: 27, offset: 12618},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -4052,32 +4085,32 @@ var g = &grammar{
 		},
 		{
 			name: "week_abbrev",
-			pos:  position{line: 526, col: 1, offset: 12556},
+			pos:  position{line: 528, col: 1, offset: 12622},
 			expr: &choiceExpr{
-				pos: position{line: 526, col: 15, offset: 12570},
+				pos: position{line: 528, col: 15, offset: 12636},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 526, col: 15, offset: 12570},
+						pos:        position{line: 528, col: 15, offset: 12636},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 526, col: 23, offset: 12578},
+						pos:        position{line: 528, col: 23, offset: 12644},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 526, col: 30, offset: 12585},
+						pos:        position{line: 528, col: 30, offset: 12651},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 526, col: 36, offset: 12591},
+						pos:        position{line: 528, col: 36, offset: 12657},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 526, col: 41, offset: 12596},
+						pos:        position{line: 528, col: 41, offset: 12662},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -4086,42 +4119,42 @@ var g = &grammar{
 		},
 		{
 			name: "seconds",
-			pos:  position{line: 528, col: 1, offset: 12601},
+			pos:  position{line: 530, col: 1, offset: 12667},
 			expr: &choiceExpr{
-				pos: position{line: 529, col: 5, offset: 12613},
+				pos: position{line: 531, col: 5, offset: 12679},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 529, col: 5, offset: 12613},
+						pos: position{line: 531, col: 5, offset: 12679},
 						run: (*parser).callonseconds2,
 						expr: &litMatcher{
-							pos:        position{line: 529, col: 5, offset: 12613},
+							pos:        position{line: 531, col: 5, offset: 12679},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 530, col: 5, offset: 12658},
+						pos: position{line: 532, col: 5, offset: 12724},
 						run: (*parser).callonseconds4,
 						expr: &seqExpr{
-							pos: position{line: 530, col: 5, offset: 12658},
+							pos: position{line: 532, col: 5, offset: 12724},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 530, col: 5, offset: 12658},
+									pos:   position{line: 532, col: 5, offset: 12724},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 530, col: 9, offset: 12662},
+										pos:  position{line: 532, col: 9, offset: 12728},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 530, col: 16, offset: 12669},
+									pos: position{line: 532, col: 16, offset: 12735},
 									expr: &ruleRefExpr{
-										pos:  position{line: 530, col: 16, offset: 12669},
+										pos:  position{line: 532, col: 16, offset: 12735},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 530, col: 19, offset: 12672},
+									pos:  position{line: 532, col: 19, offset: 12738},
 									name: "sec_abbrev",
 								},
 							},
@@ -4132,42 +4165,42 @@ var g = &grammar{
 		},
 		{
 			name: "minutes",
-			pos:  position{line: 532, col: 1, offset: 12718},
+			pos:  position{line: 534, col: 1, offset: 12784},
 			expr: &choiceExpr{
-				pos: position{line: 533, col: 5, offset: 12730},
+				pos: position{line: 535, col: 5, offset: 12796},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 533, col: 5, offset: 12730},
+						pos: position{line: 535, col: 5, offset: 12796},
 						run: (*parser).callonminutes2,
 						expr: &litMatcher{
-							pos:        position{line: 533, col: 5, offset: 12730},
+							pos:        position{line: 535, col: 5, offset: 12796},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 534, col: 5, offset: 12776},
+						pos: position{line: 536, col: 5, offset: 12842},
 						run: (*parser).callonminutes4,
 						expr: &seqExpr{
-							pos: position{line: 534, col: 5, offset: 12776},
+							pos: position{line: 536, col: 5, offset: 12842},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 534, col: 5, offset: 12776},
+									pos:   position{line: 536, col: 5, offset: 12842},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 534, col: 9, offset: 12780},
+										pos:  position{line: 536, col: 9, offset: 12846},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 534, col: 16, offset: 12787},
+									pos: position{line: 536, col: 16, offset: 12853},
 									expr: &ruleRefExpr{
-										pos:  position{line: 534, col: 16, offset: 12787},
+										pos:  position{line: 536, col: 16, offset: 12853},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 534, col: 19, offset: 12790},
+									pos:  position{line: 536, col: 19, offset: 12856},
 									name: "min_abbrev",
 								},
 							},
@@ -4178,42 +4211,42 @@ var g = &grammar{
 		},
 		{
 			name: "hours",
-			pos:  position{line: 536, col: 1, offset: 12845},
+			pos:  position{line: 538, col: 1, offset: 12911},
 			expr: &choiceExpr{
-				pos: position{line: 537, col: 5, offset: 12855},
+				pos: position{line: 539, col: 5, offset: 12921},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 537, col: 5, offset: 12855},
+						pos: position{line: 539, col: 5, offset: 12921},
 						run: (*parser).callonhours2,
 						expr: &litMatcher{
-							pos:        position{line: 537, col: 5, offset: 12855},
+							pos:        position{line: 539, col: 5, offset: 12921},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 538, col: 5, offset: 12901},
+						pos: position{line: 540, col: 5, offset: 12967},
 						run: (*parser).callonhours4,
 						expr: &seqExpr{
-							pos: position{line: 538, col: 5, offset: 12901},
+							pos: position{line: 540, col: 5, offset: 12967},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 538, col: 5, offset: 12901},
+									pos:   position{line: 540, col: 5, offset: 12967},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 538, col: 9, offset: 12905},
+										pos:  position{line: 540, col: 9, offset: 12971},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 538, col: 16, offset: 12912},
+									pos: position{line: 540, col: 16, offset: 12978},
 									expr: &ruleRefExpr{
-										pos:  position{line: 538, col: 16, offset: 12912},
+										pos:  position{line: 540, col: 16, offset: 12978},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 538, col: 19, offset: 12915},
+									pos:  position{line: 540, col: 19, offset: 12981},
 									name: "hour_abbrev",
 								},
 							},
@@ -4224,42 +4257,42 @@ var g = &grammar{
 		},
 		{
 			name: "days",
-			pos:  position{line: 540, col: 1, offset: 12973},
+			pos:  position{line: 542, col: 1, offset: 13039},
 			expr: &choiceExpr{
-				pos: position{line: 541, col: 5, offset: 12982},
+				pos: position{line: 543, col: 5, offset: 13048},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 541, col: 5, offset: 12982},
+						pos: position{line: 543, col: 5, offset: 13048},
 						run: (*parser).callondays2,
 						expr: &litMatcher{
-							pos:        position{line: 541, col: 5, offset: 12982},
+							pos:        position{line: 543, col: 5, offset: 13048},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 542, col: 5, offset: 13030},
+						pos: position{line: 544, col: 5, offset: 13096},
 						run: (*parser).callondays4,
 						expr: &seqExpr{
-							pos: position{line: 542, col: 5, offset: 13030},
+							pos: position{line: 544, col: 5, offset: 13096},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 542, col: 5, offset: 13030},
+									pos:   position{line: 544, col: 5, offset: 13096},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 542, col: 9, offset: 13034},
+										pos:  position{line: 544, col: 9, offset: 13100},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 542, col: 16, offset: 13041},
+									pos: position{line: 544, col: 16, offset: 13107},
 									expr: &ruleRefExpr{
-										pos:  position{line: 542, col: 16, offset: 13041},
+										pos:  position{line: 544, col: 16, offset: 13107},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 542, col: 19, offset: 13044},
+									pos:  position{line: 544, col: 19, offset: 13110},
 									name: "day_abbrev",
 								},
 							},
@@ -4270,30 +4303,30 @@ var g = &grammar{
 		},
 		{
 			name: "weeks",
-			pos:  position{line: 544, col: 1, offset: 13104},
+			pos:  position{line: 546, col: 1, offset: 13170},
 			expr: &actionExpr{
-				pos: position{line: 545, col: 5, offset: 13114},
+				pos: position{line: 547, col: 5, offset: 13180},
 				run: (*parser).callonweeks1,
 				expr: &seqExpr{
-					pos: position{line: 545, col: 5, offset: 13114},
+					pos: position{line: 547, col: 5, offset: 13180},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 545, col: 5, offset: 13114},
+							pos:   position{line: 547, col: 5, offset: 13180},
 							label: "num",
 							expr: &ruleRefExpr{
-								pos:  position{line: 545, col: 9, offset: 13118},
+								pos:  position{line: 547, col: 9, offset: 13184},
 								name: "number",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 545, col: 16, offset: 13125},
+							pos: position{line: 547, col: 16, offset: 13191},
 							expr: &ruleRefExpr{
-								pos:  position{line: 545, col: 16, offset: 13125},
+								pos:  position{line: 547, col: 16, offset: 13191},
 								name: "_",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 545, col: 19, offset: 13128},
+							pos:  position{line: 547, col: 19, offset: 13194},
 							name: "week_abbrev",
 						},
 					},
@@ -4302,53 +4335,53 @@ var g = &grammar{
 		},
 		{
 			name: "number",
-			pos:  position{line: 547, col: 1, offset: 13191},
+			pos:  position{line: 549, col: 1, offset: 13257},
 			expr: &ruleRefExpr{
-				pos:  position{line: 547, col: 10, offset: 13200},
+				pos:  position{line: 549, col: 10, offset: 13266},
 				name: "unsignedInteger",
 			},
 		},
 		{
 			name: "addr",
-			pos:  position{line: 551, col: 1, offset: 13246},
+			pos:  position{line: 553, col: 1, offset: 13312},
 			expr: &actionExpr{
-				pos: position{line: 552, col: 5, offset: 13255},
+				pos: position{line: 554, col: 5, offset: 13321},
 				run: (*parser).callonaddr1,
 				expr: &labeledExpr{
-					pos:   position{line: 552, col: 5, offset: 13255},
+					pos:   position{line: 554, col: 5, offset: 13321},
 					label: "a",
 					expr: &seqExpr{
-						pos: position{line: 552, col: 8, offset: 13258},
+						pos: position{line: 554, col: 8, offset: 13324},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 552, col: 8, offset: 13258},
+								pos:  position{line: 554, col: 8, offset: 13324},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 552, col: 24, offset: 13274},
+								pos:        position{line: 554, col: 24, offset: 13340},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 552, col: 28, offset: 13278},
+								pos:  position{line: 554, col: 28, offset: 13344},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 552, col: 44, offset: 13294},
+								pos:        position{line: 554, col: 44, offset: 13360},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 552, col: 48, offset: 13298},
+								pos:  position{line: 554, col: 48, offset: 13364},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 552, col: 64, offset: 13314},
+								pos:        position{line: 554, col: 64, offset: 13380},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 552, col: 68, offset: 13318},
+								pos:  position{line: 554, col: 68, offset: 13384},
 								name: "unsignedInteger",
 							},
 						},
@@ -4358,23 +4391,23 @@ var g = &grammar{
 		},
 		{
 			name: "port",
-			pos:  position{line: 554, col: 1, offset: 13367},
+			pos:  position{line: 556, col: 1, offset: 13433},
 			expr: &actionExpr{
-				pos: position{line: 555, col: 5, offset: 13376},
+				pos: position{line: 557, col: 5, offset: 13442},
 				run: (*parser).callonport1,
 				expr: &seqExpr{
-					pos: position{line: 555, col: 5, offset: 13376},
+					pos: position{line: 557, col: 5, offset: 13442},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 555, col: 5, offset: 13376},
+							pos:        position{line: 557, col: 5, offset: 13442},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 555, col: 9, offset: 13380},
+							pos:   position{line: 557, col: 9, offset: 13446},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 555, col: 11, offset: 13382},
+								pos:  position{line: 557, col: 11, offset: 13448},
 								name: "suint",
 							},
 						},
@@ -4384,32 +4417,32 @@ var g = &grammar{
 		},
 		{
 			name: "ip6addr",
-			pos:  position{line: 559, col: 1, offset: 13538},
+			pos:  position{line: 561, col: 1, offset: 13604},
 			expr: &choiceExpr{
-				pos: position{line: 560, col: 5, offset: 13550},
+				pos: position{line: 562, col: 5, offset: 13616},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 560, col: 5, offset: 13550},
+						pos: position{line: 562, col: 5, offset: 13616},
 						run: (*parser).callonip6addr2,
 						expr: &seqExpr{
-							pos: position{line: 560, col: 5, offset: 13550},
+							pos: position{line: 562, col: 5, offset: 13616},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 560, col: 5, offset: 13550},
+									pos:   position{line: 562, col: 5, offset: 13616},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 560, col: 7, offset: 13552},
+										pos: position{line: 562, col: 7, offset: 13618},
 										expr: &ruleRefExpr{
-											pos:  position{line: 560, col: 8, offset: 13553},
+											pos:  position{line: 562, col: 8, offset: 13619},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 560, col: 20, offset: 13565},
+									pos:   position{line: 562, col: 20, offset: 13631},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 560, col: 22, offset: 13567},
+										pos:  position{line: 562, col: 22, offset: 13633},
 										name: "ip6tail",
 									},
 								},
@@ -4417,51 +4450,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 563, col: 5, offset: 13631},
+						pos: position{line: 565, col: 5, offset: 13697},
 						run: (*parser).callonip6addr9,
 						expr: &seqExpr{
-							pos: position{line: 563, col: 5, offset: 13631},
+							pos: position{line: 565, col: 5, offset: 13697},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 563, col: 5, offset: 13631},
+									pos:   position{line: 565, col: 5, offset: 13697},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 563, col: 7, offset: 13633},
+										pos:  position{line: 565, col: 7, offset: 13699},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 563, col: 11, offset: 13637},
+									pos:   position{line: 565, col: 11, offset: 13703},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 563, col: 13, offset: 13639},
+										pos: position{line: 565, col: 13, offset: 13705},
 										expr: &ruleRefExpr{
-											pos:  position{line: 563, col: 14, offset: 13640},
+											pos:  position{line: 565, col: 14, offset: 13706},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 563, col: 25, offset: 13651},
+									pos:        position{line: 565, col: 25, offset: 13717},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 563, col: 30, offset: 13656},
+									pos:   position{line: 565, col: 30, offset: 13722},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 563, col: 32, offset: 13658},
+										pos: position{line: 565, col: 32, offset: 13724},
 										expr: &ruleRefExpr{
-											pos:  position{line: 563, col: 33, offset: 13659},
+											pos:  position{line: 565, col: 33, offset: 13725},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 563, col: 45, offset: 13671},
+									pos:   position{line: 565, col: 45, offset: 13737},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 563, col: 47, offset: 13673},
+										pos:  position{line: 565, col: 47, offset: 13739},
 										name: "ip6tail",
 									},
 								},
@@ -4469,32 +4502,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 566, col: 5, offset: 13772},
+						pos: position{line: 568, col: 5, offset: 13838},
 						run: (*parser).callonip6addr22,
 						expr: &seqExpr{
-							pos: position{line: 566, col: 5, offset: 13772},
+							pos: position{line: 568, col: 5, offset: 13838},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 566, col: 5, offset: 13772},
+									pos:        position{line: 568, col: 5, offset: 13838},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 566, col: 10, offset: 13777},
+									pos:   position{line: 568, col: 10, offset: 13843},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 566, col: 12, offset: 13779},
+										pos: position{line: 568, col: 12, offset: 13845},
 										expr: &ruleRefExpr{
-											pos:  position{line: 566, col: 13, offset: 13780},
+											pos:  position{line: 568, col: 13, offset: 13846},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 566, col: 25, offset: 13792},
+									pos:   position{line: 568, col: 25, offset: 13858},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 566, col: 27, offset: 13794},
+										pos:  position{line: 568, col: 27, offset: 13860},
 										name: "ip6tail",
 									},
 								},
@@ -4502,32 +4535,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 569, col: 5, offset: 13865},
+						pos: position{line: 571, col: 5, offset: 13931},
 						run: (*parser).callonip6addr30,
 						expr: &seqExpr{
-							pos: position{line: 569, col: 5, offset: 13865},
+							pos: position{line: 571, col: 5, offset: 13931},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 569, col: 5, offset: 13865},
+									pos:   position{line: 571, col: 5, offset: 13931},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 569, col: 7, offset: 13867},
+										pos:  position{line: 571, col: 7, offset: 13933},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 569, col: 11, offset: 13871},
+									pos:   position{line: 571, col: 11, offset: 13937},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 569, col: 13, offset: 13873},
+										pos: position{line: 571, col: 13, offset: 13939},
 										expr: &ruleRefExpr{
-											pos:  position{line: 569, col: 14, offset: 13874},
+											pos:  position{line: 571, col: 14, offset: 13940},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 569, col: 25, offset: 13885},
+									pos:        position{line: 571, col: 25, offset: 13951},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -4535,10 +4568,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 572, col: 5, offset: 13953},
+						pos: position{line: 574, col: 5, offset: 14019},
 						run: (*parser).callonip6addr38,
 						expr: &litMatcher{
-							pos:        position{line: 572, col: 5, offset: 13953},
+							pos:        position{line: 574, col: 5, offset: 14019},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -4548,16 +4581,16 @@ var g = &grammar{
 		},
 		{
 			name: "ip6tail",
-			pos:  position{line: 576, col: 1, offset: 13990},
+			pos:  position{line: 578, col: 1, offset: 14056},
 			expr: &choiceExpr{
-				pos: position{line: 577, col: 5, offset: 14002},
+				pos: position{line: 579, col: 5, offset: 14068},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 577, col: 5, offset: 14002},
+						pos:  position{line: 579, col: 5, offset: 14068},
 						name: "addr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 578, col: 5, offset: 14011},
+						pos:  position{line: 580, col: 5, offset: 14077},
 						name: "h16",
 					},
 				},
@@ -4565,23 +4598,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_append",
-			pos:  position{line: 580, col: 1, offset: 14016},
+			pos:  position{line: 582, col: 1, offset: 14082},
 			expr: &actionExpr{
-				pos: position{line: 580, col: 12, offset: 14027},
+				pos: position{line: 582, col: 12, offset: 14093},
 				run: (*parser).callonh_append1,
 				expr: &seqExpr{
-					pos: position{line: 580, col: 12, offset: 14027},
+					pos: position{line: 582, col: 12, offset: 14093},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 580, col: 12, offset: 14027},
+							pos:        position{line: 582, col: 12, offset: 14093},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 580, col: 16, offset: 14031},
+							pos:   position{line: 582, col: 16, offset: 14097},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 580, col: 18, offset: 14033},
+								pos:  position{line: 582, col: 18, offset: 14099},
 								name: "h16",
 							},
 						},
@@ -4591,23 +4624,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_prepend",
-			pos:  position{line: 581, col: 1, offset: 14070},
+			pos:  position{line: 583, col: 1, offset: 14136},
 			expr: &actionExpr{
-				pos: position{line: 581, col: 13, offset: 14082},
+				pos: position{line: 583, col: 13, offset: 14148},
 				run: (*parser).callonh_prepend1,
 				expr: &seqExpr{
-					pos: position{line: 581, col: 13, offset: 14082},
+					pos: position{line: 583, col: 13, offset: 14148},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 581, col: 13, offset: 14082},
+							pos:   position{line: 583, col: 13, offset: 14148},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 581, col: 15, offset: 14084},
+								pos:  position{line: 583, col: 15, offset: 14150},
 								name: "h16",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 581, col: 19, offset: 14088},
+							pos:        position{line: 583, col: 19, offset: 14154},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -4617,43 +4650,43 @@ var g = &grammar{
 		},
 		{
 			name: "sub_addr",
-			pos:  position{line: 583, col: 1, offset: 14126},
+			pos:  position{line: 585, col: 1, offset: 14192},
 			expr: &choiceExpr{
-				pos: position{line: 584, col: 5, offset: 14139},
+				pos: position{line: 586, col: 5, offset: 14205},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 584, col: 5, offset: 14139},
+						pos:  position{line: 586, col: 5, offset: 14205},
 						name: "addr",
 					},
 					&actionExpr{
-						pos: position{line: 585, col: 5, offset: 14148},
+						pos: position{line: 587, col: 5, offset: 14214},
 						run: (*parser).callonsub_addr3,
 						expr: &labeledExpr{
-							pos:   position{line: 585, col: 5, offset: 14148},
+							pos:   position{line: 587, col: 5, offset: 14214},
 							label: "a",
 							expr: &seqExpr{
-								pos: position{line: 585, col: 8, offset: 14151},
+								pos: position{line: 587, col: 8, offset: 14217},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 585, col: 8, offset: 14151},
+										pos:  position{line: 587, col: 8, offset: 14217},
 										name: "unsignedInteger",
 									},
 									&litMatcher{
-										pos:        position{line: 585, col: 24, offset: 14167},
+										pos:        position{line: 587, col: 24, offset: 14233},
 										val:        ".",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 585, col: 28, offset: 14171},
+										pos:  position{line: 587, col: 28, offset: 14237},
 										name: "unsignedInteger",
 									},
 									&litMatcher{
-										pos:        position{line: 585, col: 44, offset: 14187},
+										pos:        position{line: 587, col: 44, offset: 14253},
 										val:        ".",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 585, col: 48, offset: 14191},
+										pos:  position{line: 587, col: 48, offset: 14257},
 										name: "unsignedInteger",
 									},
 								},
@@ -4661,25 +4694,25 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 586, col: 5, offset: 14251},
+						pos: position{line: 588, col: 5, offset: 14317},
 						run: (*parser).callonsub_addr11,
 						expr: &labeledExpr{
-							pos:   position{line: 586, col: 5, offset: 14251},
+							pos:   position{line: 588, col: 5, offset: 14317},
 							label: "a",
 							expr: &seqExpr{
-								pos: position{line: 586, col: 8, offset: 14254},
+								pos: position{line: 588, col: 8, offset: 14320},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 586, col: 8, offset: 14254},
+										pos:  position{line: 588, col: 8, offset: 14320},
 										name: "unsignedInteger",
 									},
 									&litMatcher{
-										pos:        position{line: 586, col: 24, offset: 14270},
+										pos:        position{line: 588, col: 24, offset: 14336},
 										val:        ".",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 586, col: 28, offset: 14274},
+										pos:  position{line: 588, col: 28, offset: 14340},
 										name: "unsignedInteger",
 									},
 								},
@@ -4687,13 +4720,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 587, col: 5, offset: 14336},
+						pos: position{line: 589, col: 5, offset: 14402},
 						run: (*parser).callonsub_addr17,
 						expr: &labeledExpr{
-							pos:   position{line: 587, col: 5, offset: 14336},
+							pos:   position{line: 589, col: 5, offset: 14402},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 587, col: 7, offset: 14338},
+								pos:  position{line: 589, col: 7, offset: 14404},
 								name: "unsignedInteger",
 							},
 						},
@@ -4703,31 +4736,31 @@ var g = &grammar{
 		},
 		{
 			name: "subnet",
-			pos:  position{line: 589, col: 1, offset: 14397},
+			pos:  position{line: 591, col: 1, offset: 14463},
 			expr: &actionExpr{
-				pos: position{line: 590, col: 5, offset: 14408},
+				pos: position{line: 592, col: 5, offset: 14474},
 				run: (*parser).callonsubnet1,
 				expr: &seqExpr{
-					pos: position{line: 590, col: 5, offset: 14408},
+					pos: position{line: 592, col: 5, offset: 14474},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 590, col: 5, offset: 14408},
+							pos:   position{line: 592, col: 5, offset: 14474},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 590, col: 7, offset: 14410},
+								pos:  position{line: 592, col: 7, offset: 14476},
 								name: "sub_addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 590, col: 16, offset: 14419},
+							pos:        position{line: 592, col: 16, offset: 14485},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 590, col: 20, offset: 14423},
+							pos:   position{line: 592, col: 20, offset: 14489},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 590, col: 22, offset: 14425},
+								pos:  position{line: 592, col: 22, offset: 14491},
 								name: "unsignedInteger",
 							},
 						},
@@ -4737,31 +4770,31 @@ var g = &grammar{
 		},
 		{
 			name: "ip6subnet",
-			pos:  position{line: 594, col: 1, offset: 14509},
+			pos:  position{line: 596, col: 1, offset: 14575},
 			expr: &actionExpr{
-				pos: position{line: 595, col: 5, offset: 14523},
+				pos: position{line: 597, col: 5, offset: 14589},
 				run: (*parser).callonip6subnet1,
 				expr: &seqExpr{
-					pos: position{line: 595, col: 5, offset: 14523},
+					pos: position{line: 597, col: 5, offset: 14589},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 595, col: 5, offset: 14523},
+							pos:   position{line: 597, col: 5, offset: 14589},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 595, col: 7, offset: 14525},
+								pos:  position{line: 597, col: 7, offset: 14591},
 								name: "ip6addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 595, col: 15, offset: 14533},
+							pos:        position{line: 597, col: 15, offset: 14599},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 595, col: 19, offset: 14537},
+							pos:   position{line: 597, col: 19, offset: 14603},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 595, col: 21, offset: 14539},
+								pos:  position{line: 597, col: 21, offset: 14605},
 								name: "unsignedInteger",
 							},
 						},
@@ -4771,15 +4804,15 @@ var g = &grammar{
 		},
 		{
 			name: "unsignedInteger",
-			pos:  position{line: 599, col: 1, offset: 14613},
+			pos:  position{line: 601, col: 1, offset: 14679},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 5, offset: 14633},
+				pos: position{line: 602, col: 5, offset: 14699},
 				run: (*parser).callonunsignedInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 600, col: 5, offset: 14633},
+					pos:   position{line: 602, col: 5, offset: 14699},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 600, col: 7, offset: 14635},
+						pos:  position{line: 602, col: 7, offset: 14701},
 						name: "suint",
 					},
 				},
@@ -4787,14 +4820,14 @@ var g = &grammar{
 		},
 		{
 			name: "suint",
-			pos:  position{line: 602, col: 1, offset: 14670},
+			pos:  position{line: 604, col: 1, offset: 14736},
 			expr: &actionExpr{
-				pos: position{line: 603, col: 5, offset: 14680},
+				pos: position{line: 605, col: 5, offset: 14746},
 				run: (*parser).callonsuint1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 603, col: 5, offset: 14680},
+					pos: position{line: 605, col: 5, offset: 14746},
 					expr: &charClassMatcher{
-						pos:        position{line: 603, col: 5, offset: 14680},
+						pos:        position{line: 605, col: 5, offset: 14746},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4805,15 +4838,15 @@ var g = &grammar{
 		},
 		{
 			name: "integer",
-			pos:  position{line: 605, col: 1, offset: 14719},
+			pos:  position{line: 607, col: 1, offset: 14785},
 			expr: &actionExpr{
-				pos: position{line: 606, col: 5, offset: 14731},
+				pos: position{line: 608, col: 5, offset: 14797},
 				run: (*parser).calloninteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 606, col: 5, offset: 14731},
+					pos:   position{line: 608, col: 5, offset: 14797},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 606, col: 7, offset: 14733},
+						pos:  position{line: 608, col: 7, offset: 14799},
 						name: "sinteger",
 					},
 				},
@@ -4821,17 +4854,17 @@ var g = &grammar{
 		},
 		{
 			name: "sinteger",
-			pos:  position{line: 608, col: 1, offset: 14771},
+			pos:  position{line: 610, col: 1, offset: 14837},
 			expr: &actionExpr{
-				pos: position{line: 609, col: 5, offset: 14784},
+				pos: position{line: 611, col: 5, offset: 14850},
 				run: (*parser).callonsinteger1,
 				expr: &seqExpr{
-					pos: position{line: 609, col: 5, offset: 14784},
+					pos: position{line: 611, col: 5, offset: 14850},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 609, col: 5, offset: 14784},
+							pos: position{line: 611, col: 5, offset: 14850},
 							expr: &charClassMatcher{
-								pos:        position{line: 609, col: 5, offset: 14784},
+								pos:        position{line: 611, col: 5, offset: 14850},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -4839,7 +4872,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 609, col: 11, offset: 14790},
+							pos:  position{line: 611, col: 11, offset: 14856},
 							name: "suint",
 						},
 					},
@@ -4848,15 +4881,15 @@ var g = &grammar{
 		},
 		{
 			name: "double",
-			pos:  position{line: 611, col: 1, offset: 14828},
+			pos:  position{line: 613, col: 1, offset: 14894},
 			expr: &actionExpr{
-				pos: position{line: 612, col: 5, offset: 14839},
+				pos: position{line: 614, col: 5, offset: 14905},
 				run: (*parser).callondouble1,
 				expr: &labeledExpr{
-					pos:   position{line: 612, col: 5, offset: 14839},
+					pos:   position{line: 614, col: 5, offset: 14905},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 612, col: 7, offset: 14841},
+						pos:  position{line: 614, col: 7, offset: 14907},
 						name: "sdouble",
 					},
 				},
@@ -4864,47 +4897,47 @@ var g = &grammar{
 		},
 		{
 			name: "sdouble",
-			pos:  position{line: 616, col: 1, offset: 14888},
+			pos:  position{line: 618, col: 1, offset: 14954},
 			expr: &choiceExpr{
-				pos: position{line: 617, col: 5, offset: 14900},
+				pos: position{line: 619, col: 5, offset: 14966},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 617, col: 5, offset: 14900},
+						pos: position{line: 619, col: 5, offset: 14966},
 						run: (*parser).callonsdouble2,
 						expr: &seqExpr{
-							pos: position{line: 617, col: 5, offset: 14900},
+							pos: position{line: 619, col: 5, offset: 14966},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 617, col: 5, offset: 14900},
+									pos: position{line: 619, col: 5, offset: 14966},
 									expr: &litMatcher{
-										pos:        position{line: 617, col: 5, offset: 14900},
+										pos:        position{line: 619, col: 5, offset: 14966},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 617, col: 10, offset: 14905},
+									pos: position{line: 619, col: 10, offset: 14971},
 									expr: &ruleRefExpr{
-										pos:  position{line: 617, col: 10, offset: 14905},
+										pos:  position{line: 619, col: 10, offset: 14971},
 										name: "doubleInteger",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 617, col: 25, offset: 14920},
+									pos:        position{line: 619, col: 25, offset: 14986},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 617, col: 29, offset: 14924},
+									pos: position{line: 619, col: 29, offset: 14990},
 									expr: &ruleRefExpr{
-										pos:  position{line: 617, col: 29, offset: 14924},
+										pos:  position{line: 619, col: 29, offset: 14990},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 617, col: 42, offset: 14937},
+									pos: position{line: 619, col: 42, offset: 15003},
 									expr: &ruleRefExpr{
-										pos:  position{line: 617, col: 42, offset: 14937},
+										pos:  position{line: 619, col: 42, offset: 15003},
 										name: "exponentPart",
 									},
 								},
@@ -4912,35 +4945,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 620, col: 5, offset: 14996},
+						pos: position{line: 622, col: 5, offset: 15062},
 						run: (*parser).callonsdouble13,
 						expr: &seqExpr{
-							pos: position{line: 620, col: 5, offset: 14996},
+							pos: position{line: 622, col: 5, offset: 15062},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 620, col: 5, offset: 14996},
+									pos: position{line: 622, col: 5, offset: 15062},
 									expr: &litMatcher{
-										pos:        position{line: 620, col: 5, offset: 14996},
+										pos:        position{line: 622, col: 5, offset: 15062},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 620, col: 10, offset: 15001},
+									pos:        position{line: 622, col: 10, offset: 15067},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 620, col: 14, offset: 15005},
+									pos: position{line: 622, col: 14, offset: 15071},
 									expr: &ruleRefExpr{
-										pos:  position{line: 620, col: 14, offset: 15005},
+										pos:  position{line: 622, col: 14, offset: 15071},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 620, col: 27, offset: 15018},
+									pos: position{line: 622, col: 27, offset: 15084},
 									expr: &ruleRefExpr{
-										pos:  position{line: 620, col: 27, offset: 15018},
+										pos:  position{line: 622, col: 27, offset: 15084},
 										name: "exponentPart",
 									},
 								},
@@ -4952,29 +4985,29 @@ var g = &grammar{
 		},
 		{
 			name: "doubleInteger",
-			pos:  position{line: 624, col: 1, offset: 15074},
+			pos:  position{line: 626, col: 1, offset: 15140},
 			expr: &choiceExpr{
-				pos: position{line: 625, col: 5, offset: 15092},
+				pos: position{line: 627, col: 5, offset: 15158},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 625, col: 5, offset: 15092},
+						pos:        position{line: 627, col: 5, offset: 15158},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 626, col: 5, offset: 15100},
+						pos: position{line: 628, col: 5, offset: 15166},
 						exprs: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 626, col: 5, offset: 15100},
+								pos:        position{line: 628, col: 5, offset: 15166},
 								val:        "[1-9]",
 								ranges:     []rune{'1', '9'},
 								ignoreCase: false,
 								inverted:   false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 626, col: 11, offset: 15106},
+								pos: position{line: 628, col: 11, offset: 15172},
 								expr: &charClassMatcher{
-									pos:        position{line: 626, col: 11, offset: 15106},
+									pos:        position{line: 628, col: 11, offset: 15172},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -4988,9 +5021,9 @@ var g = &grammar{
 		},
 		{
 			name: "doubleDigit",
-			pos:  position{line: 628, col: 1, offset: 15114},
+			pos:  position{line: 630, col: 1, offset: 15180},
 			expr: &charClassMatcher{
-				pos:        position{line: 628, col: 15, offset: 15128},
+				pos:        position{line: 630, col: 15, offset: 15194},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -4999,17 +5032,17 @@ var g = &grammar{
 		},
 		{
 			name: "exponentPart",
-			pos:  position{line: 630, col: 1, offset: 15135},
+			pos:  position{line: 632, col: 1, offset: 15201},
 			expr: &seqExpr{
-				pos: position{line: 630, col: 16, offset: 15150},
+				pos: position{line: 632, col: 16, offset: 15216},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 630, col: 16, offset: 15150},
+						pos:        position{line: 632, col: 16, offset: 15216},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 630, col: 21, offset: 15155},
+						pos:  position{line: 632, col: 21, offset: 15221},
 						name: "sinteger",
 					},
 				},
@@ -5017,17 +5050,17 @@ var g = &grammar{
 		},
 		{
 			name: "h16",
-			pos:  position{line: 632, col: 1, offset: 15165},
+			pos:  position{line: 634, col: 1, offset: 15231},
 			expr: &actionExpr{
-				pos: position{line: 632, col: 7, offset: 15171},
+				pos: position{line: 634, col: 7, offset: 15237},
 				run: (*parser).callonh161,
 				expr: &labeledExpr{
-					pos:   position{line: 632, col: 7, offset: 15171},
+					pos:   position{line: 634, col: 7, offset: 15237},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 632, col: 13, offset: 15177},
+						pos: position{line: 634, col: 13, offset: 15243},
 						expr: &ruleRefExpr{
-							pos:  position{line: 632, col: 13, offset: 15177},
+							pos:  position{line: 634, col: 13, offset: 15243},
 							name: "hexdigit",
 						},
 					},
@@ -5036,9 +5069,9 @@ var g = &grammar{
 		},
 		{
 			name: "hexdigit",
-			pos:  position{line: 634, col: 1, offset: 15219},
+			pos:  position{line: 636, col: 1, offset: 15285},
 			expr: &charClassMatcher{
-				pos:        position{line: 634, col: 12, offset: 15230},
+				pos:        position{line: 636, col: 12, offset: 15296},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -5047,17 +5080,17 @@ var g = &grammar{
 		},
 		{
 			name: "searchWord",
-			pos:  position{line: 636, col: 1, offset: 15243},
+			pos:  position{line: 638, col: 1, offset: 15309},
 			expr: &actionExpr{
-				pos: position{line: 637, col: 5, offset: 15258},
+				pos: position{line: 639, col: 5, offset: 15324},
 				run: (*parser).callonsearchWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 637, col: 5, offset: 15258},
+					pos:   position{line: 639, col: 5, offset: 15324},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 637, col: 11, offset: 15264},
+						pos: position{line: 639, col: 11, offset: 15330},
 						expr: &ruleRefExpr{
-							pos:  position{line: 637, col: 11, offset: 15264},
+							pos:  position{line: 639, col: 11, offset: 15330},
 							name: "searchWordPart",
 						},
 					},
@@ -5066,33 +5099,33 @@ var g = &grammar{
 		},
 		{
 			name: "searchWordPart",
-			pos:  position{line: 639, col: 1, offset: 15314},
+			pos:  position{line: 641, col: 1, offset: 15380},
 			expr: &choiceExpr{
-				pos: position{line: 640, col: 5, offset: 15333},
+				pos: position{line: 642, col: 5, offset: 15399},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 640, col: 5, offset: 15333},
+						pos: position{line: 642, col: 5, offset: 15399},
 						run: (*parser).callonsearchWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 640, col: 5, offset: 15333},
+							pos: position{line: 642, col: 5, offset: 15399},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 640, col: 5, offset: 15333},
+									pos:        position{line: 642, col: 5, offset: 15399},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 640, col: 10, offset: 15338},
+									pos:   position{line: 642, col: 10, offset: 15404},
 									label: "s",
 									expr: &choiceExpr{
-										pos: position{line: 640, col: 13, offset: 15341},
+										pos: position{line: 642, col: 13, offset: 15407},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 640, col: 13, offset: 15341},
+												pos:  position{line: 642, col: 13, offset: 15407},
 												name: "escapeSequence",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 640, col: 30, offset: 15358},
+												pos:  position{line: 642, col: 30, offset: 15424},
 												name: "searchEscape",
 											},
 										},
@@ -5102,18 +5135,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 641, col: 5, offset: 15395},
+						pos: position{line: 643, col: 5, offset: 15461},
 						run: (*parser).callonsearchWordPart9,
 						expr: &seqExpr{
-							pos: position{line: 641, col: 5, offset: 15395},
+							pos: position{line: 643, col: 5, offset: 15461},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 641, col: 5, offset: 15395},
+									pos: position{line: 643, col: 5, offset: 15461},
 									expr: &choiceExpr{
-										pos: position{line: 641, col: 7, offset: 15397},
+										pos: position{line: 643, col: 7, offset: 15463},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 641, col: 7, offset: 15397},
+												pos:        position{line: 643, col: 7, offset: 15463},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -5121,14 +5154,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 641, col: 42, offset: 15432},
+												pos:  position{line: 643, col: 42, offset: 15498},
 												name: "ws",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 641, col: 46, offset: 15436,
+									line: 643, col: 46, offset: 15502,
 								},
 							},
 						},
@@ -5138,34 +5171,34 @@ var g = &grammar{
 		},
 		{
 			name: "quotedString",
-			pos:  position{line: 643, col: 1, offset: 15470},
+			pos:  position{line: 645, col: 1, offset: 15536},
 			expr: &choiceExpr{
-				pos: position{line: 644, col: 5, offset: 15487},
+				pos: position{line: 646, col: 5, offset: 15553},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 644, col: 5, offset: 15487},
+						pos: position{line: 646, col: 5, offset: 15553},
 						run: (*parser).callonquotedString2,
 						expr: &seqExpr{
-							pos: position{line: 644, col: 5, offset: 15487},
+							pos: position{line: 646, col: 5, offset: 15553},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 644, col: 5, offset: 15487},
+									pos:        position{line: 646, col: 5, offset: 15553},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 644, col: 9, offset: 15491},
+									pos:   position{line: 646, col: 9, offset: 15557},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 644, col: 11, offset: 15493},
+										pos: position{line: 646, col: 11, offset: 15559},
 										expr: &ruleRefExpr{
-											pos:  position{line: 644, col: 11, offset: 15493},
+											pos:  position{line: 646, col: 11, offset: 15559},
 											name: "doubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 644, col: 29, offset: 15511},
+									pos:        position{line: 646, col: 29, offset: 15577},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5173,29 +5206,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 645, col: 5, offset: 15548},
+						pos: position{line: 647, col: 5, offset: 15614},
 						run: (*parser).callonquotedString9,
 						expr: &seqExpr{
-							pos: position{line: 645, col: 5, offset: 15548},
+							pos: position{line: 647, col: 5, offset: 15614},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 645, col: 5, offset: 15548},
+									pos:        position{line: 647, col: 5, offset: 15614},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 645, col: 9, offset: 15552},
+									pos:   position{line: 647, col: 9, offset: 15618},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 645, col: 11, offset: 15554},
+										pos: position{line: 647, col: 11, offset: 15620},
 										expr: &ruleRefExpr{
-											pos:  position{line: 645, col: 11, offset: 15554},
+											pos:  position{line: 647, col: 11, offset: 15620},
 											name: "singleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 645, col: 29, offset: 15572},
+									pos:        position{line: 647, col: 29, offset: 15638},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5207,55 +5240,55 @@ var g = &grammar{
 		},
 		{
 			name: "doubleQuotedChar",
-			pos:  position{line: 647, col: 1, offset: 15606},
+			pos:  position{line: 649, col: 1, offset: 15672},
 			expr: &choiceExpr{
-				pos: position{line: 648, col: 5, offset: 15627},
+				pos: position{line: 650, col: 5, offset: 15693},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 648, col: 5, offset: 15627},
+						pos: position{line: 650, col: 5, offset: 15693},
 						run: (*parser).callondoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 648, col: 5, offset: 15627},
+							pos: position{line: 650, col: 5, offset: 15693},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 648, col: 5, offset: 15627},
+									pos: position{line: 650, col: 5, offset: 15693},
 									expr: &choiceExpr{
-										pos: position{line: 648, col: 7, offset: 15629},
+										pos: position{line: 650, col: 7, offset: 15695},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 648, col: 7, offset: 15629},
+												pos:        position{line: 650, col: 7, offset: 15695},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 648, col: 13, offset: 15635},
+												pos:  position{line: 650, col: 13, offset: 15701},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 648, col: 26, offset: 15648,
+									line: 650, col: 26, offset: 15714,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 649, col: 5, offset: 15685},
+						pos: position{line: 651, col: 5, offset: 15751},
 						run: (*parser).callondoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 649, col: 5, offset: 15685},
+							pos: position{line: 651, col: 5, offset: 15751},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 649, col: 5, offset: 15685},
+									pos:        position{line: 651, col: 5, offset: 15751},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 649, col: 10, offset: 15690},
+									pos:   position{line: 651, col: 10, offset: 15756},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 649, col: 12, offset: 15692},
+										pos:  position{line: 651, col: 12, offset: 15758},
 										name: "escapeSequence",
 									},
 								},
@@ -5267,55 +5300,55 @@ var g = &grammar{
 		},
 		{
 			name: "singleQuotedChar",
-			pos:  position{line: 651, col: 1, offset: 15726},
+			pos:  position{line: 653, col: 1, offset: 15792},
 			expr: &choiceExpr{
-				pos: position{line: 652, col: 5, offset: 15747},
+				pos: position{line: 654, col: 5, offset: 15813},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 652, col: 5, offset: 15747},
+						pos: position{line: 654, col: 5, offset: 15813},
 						run: (*parser).callonsingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 652, col: 5, offset: 15747},
+							pos: position{line: 654, col: 5, offset: 15813},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 652, col: 5, offset: 15747},
+									pos: position{line: 654, col: 5, offset: 15813},
 									expr: &choiceExpr{
-										pos: position{line: 652, col: 7, offset: 15749},
+										pos: position{line: 654, col: 7, offset: 15815},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 652, col: 7, offset: 15749},
+												pos:        position{line: 654, col: 7, offset: 15815},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 652, col: 13, offset: 15755},
+												pos:  position{line: 654, col: 13, offset: 15821},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 652, col: 26, offset: 15768,
+									line: 654, col: 26, offset: 15834,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 653, col: 5, offset: 15805},
+						pos: position{line: 655, col: 5, offset: 15871},
 						run: (*parser).callonsingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 653, col: 5, offset: 15805},
+							pos: position{line: 655, col: 5, offset: 15871},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 653, col: 5, offset: 15805},
+									pos:        position{line: 655, col: 5, offset: 15871},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 653, col: 10, offset: 15810},
+									pos:   position{line: 655, col: 10, offset: 15876},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 653, col: 12, offset: 15812},
+										pos:  position{line: 655, col: 12, offset: 15878},
 										name: "escapeSequence",
 									},
 								},
@@ -5327,38 +5360,38 @@ var g = &grammar{
 		},
 		{
 			name: "escapeSequence",
-			pos:  position{line: 655, col: 1, offset: 15846},
+			pos:  position{line: 657, col: 1, offset: 15912},
 			expr: &choiceExpr{
-				pos: position{line: 656, col: 5, offset: 15865},
+				pos: position{line: 658, col: 5, offset: 15931},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 656, col: 5, offset: 15865},
+						pos: position{line: 658, col: 5, offset: 15931},
 						run: (*parser).callonescapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 656, col: 5, offset: 15865},
+							pos: position{line: 658, col: 5, offset: 15931},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 656, col: 5, offset: 15865},
+									pos:        position{line: 658, col: 5, offset: 15931},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 656, col: 9, offset: 15869},
+									pos:  position{line: 658, col: 9, offset: 15935},
 									name: "hexdigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 656, col: 18, offset: 15878},
+									pos:  position{line: 658, col: 18, offset: 15944},
 									name: "hexdigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 657, col: 5, offset: 15929},
+						pos:  position{line: 659, col: 5, offset: 15995},
 						name: "singleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 658, col: 5, offset: 15950},
+						pos:  position{line: 660, col: 5, offset: 16016},
 						name: "unicodeEscape",
 					},
 				},
@@ -5366,75 +5399,75 @@ var g = &grammar{
 		},
 		{
 			name: "singleCharEscape",
-			pos:  position{line: 660, col: 1, offset: 15965},
+			pos:  position{line: 662, col: 1, offset: 16031},
 			expr: &choiceExpr{
-				pos: position{line: 661, col: 5, offset: 15986},
+				pos: position{line: 663, col: 5, offset: 16052},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 661, col: 5, offset: 15986},
+						pos:        position{line: 663, col: 5, offset: 16052},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 662, col: 5, offset: 15994},
+						pos:        position{line: 664, col: 5, offset: 16060},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 663, col: 5, offset: 16002},
+						pos:        position{line: 665, col: 5, offset: 16068},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 664, col: 5, offset: 16011},
+						pos: position{line: 666, col: 5, offset: 16077},
 						run: (*parser).callonsingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 664, col: 5, offset: 16011},
+							pos:        position{line: 666, col: 5, offset: 16077},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 665, col: 5, offset: 16040},
+						pos: position{line: 667, col: 5, offset: 16106},
 						run: (*parser).callonsingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 665, col: 5, offset: 16040},
+							pos:        position{line: 667, col: 5, offset: 16106},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 666, col: 5, offset: 16069},
+						pos: position{line: 668, col: 5, offset: 16135},
 						run: (*parser).callonsingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 666, col: 5, offset: 16069},
+							pos:        position{line: 668, col: 5, offset: 16135},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 667, col: 5, offset: 16098},
+						pos: position{line: 669, col: 5, offset: 16164},
 						run: (*parser).callonsingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 667, col: 5, offset: 16098},
+							pos:        position{line: 669, col: 5, offset: 16164},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 668, col: 5, offset: 16127},
+						pos: position{line: 670, col: 5, offset: 16193},
 						run: (*parser).callonsingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 668, col: 5, offset: 16127},
+							pos:        position{line: 670, col: 5, offset: 16193},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 669, col: 5, offset: 16156},
+						pos: position{line: 671, col: 5, offset: 16222},
 						run: (*parser).callonsingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 669, col: 5, offset: 16156},
+							pos:        position{line: 671, col: 5, offset: 16222},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5444,24 +5477,24 @@ var g = &grammar{
 		},
 		{
 			name: "searchEscape",
-			pos:  position{line: 671, col: 1, offset: 16182},
+			pos:  position{line: 673, col: 1, offset: 16248},
 			expr: &choiceExpr{
-				pos: position{line: 672, col: 5, offset: 16199},
+				pos: position{line: 674, col: 5, offset: 16265},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 672, col: 5, offset: 16199},
+						pos: position{line: 674, col: 5, offset: 16265},
 						run: (*parser).callonsearchEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 672, col: 5, offset: 16199},
+							pos:        position{line: 674, col: 5, offset: 16265},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 673, col: 5, offset: 16227},
+						pos: position{line: 675, col: 5, offset: 16293},
 						run: (*parser).callonsearchEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 673, col: 5, offset: 16227},
+							pos:        position{line: 675, col: 5, offset: 16293},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -5471,41 +5504,41 @@ var g = &grammar{
 		},
 		{
 			name: "unicodeEscape",
-			pos:  position{line: 675, col: 1, offset: 16254},
+			pos:  position{line: 677, col: 1, offset: 16320},
 			expr: &choiceExpr{
-				pos: position{line: 676, col: 5, offset: 16272},
+				pos: position{line: 678, col: 5, offset: 16338},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 676, col: 5, offset: 16272},
+						pos: position{line: 678, col: 5, offset: 16338},
 						run: (*parser).callonunicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 676, col: 5, offset: 16272},
+							pos: position{line: 678, col: 5, offset: 16338},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 676, col: 5, offset: 16272},
+									pos:        position{line: 678, col: 5, offset: 16338},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 676, col: 9, offset: 16276},
+									pos:   position{line: 678, col: 9, offset: 16342},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 676, col: 16, offset: 16283},
+										pos: position{line: 678, col: 16, offset: 16349},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 676, col: 16, offset: 16283},
+												pos:  position{line: 678, col: 16, offset: 16349},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 676, col: 25, offset: 16292},
+												pos:  position{line: 678, col: 25, offset: 16358},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 676, col: 34, offset: 16301},
+												pos:  position{line: 678, col: 34, offset: 16367},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 676, col: 43, offset: 16310},
+												pos:  position{line: 678, col: 43, offset: 16376},
 												name: "hexdigit",
 											},
 										},
@@ -5515,63 +5548,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 679, col: 5, offset: 16373},
+						pos: position{line: 681, col: 5, offset: 16439},
 						run: (*parser).callonunicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 679, col: 5, offset: 16373},
+							pos: position{line: 681, col: 5, offset: 16439},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 679, col: 5, offset: 16373},
+									pos:        position{line: 681, col: 5, offset: 16439},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 679, col: 9, offset: 16377},
+									pos:        position{line: 681, col: 9, offset: 16443},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 679, col: 13, offset: 16381},
+									pos:   position{line: 681, col: 13, offset: 16447},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 679, col: 20, offset: 16388},
+										pos: position{line: 681, col: 20, offset: 16454},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 679, col: 20, offset: 16388},
+												pos:  position{line: 681, col: 20, offset: 16454},
 												name: "hexdigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 679, col: 29, offset: 16397},
+												pos: position{line: 681, col: 29, offset: 16463},
 												expr: &ruleRefExpr{
-													pos:  position{line: 679, col: 29, offset: 16397},
+													pos:  position{line: 681, col: 29, offset: 16463},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 679, col: 39, offset: 16407},
+												pos: position{line: 681, col: 39, offset: 16473},
 												expr: &ruleRefExpr{
-													pos:  position{line: 679, col: 39, offset: 16407},
+													pos:  position{line: 681, col: 39, offset: 16473},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 679, col: 49, offset: 16417},
+												pos: position{line: 681, col: 49, offset: 16483},
 												expr: &ruleRefExpr{
-													pos:  position{line: 679, col: 49, offset: 16417},
+													pos:  position{line: 681, col: 49, offset: 16483},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 679, col: 59, offset: 16427},
+												pos: position{line: 681, col: 59, offset: 16493},
 												expr: &ruleRefExpr{
-													pos:  position{line: 679, col: 59, offset: 16427},
+													pos:  position{line: 681, col: 59, offset: 16493},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 679, col: 69, offset: 16437},
+												pos: position{line: 681, col: 69, offset: 16503},
 												expr: &ruleRefExpr{
-													pos:  position{line: 679, col: 69, offset: 16437},
+													pos:  position{line: 681, col: 69, offset: 16503},
 													name: "hexdigit",
 												},
 											},
@@ -5579,7 +5612,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 679, col: 80, offset: 16448},
+									pos:        position{line: 681, col: 80, offset: 16514},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5591,28 +5624,28 @@ var g = &grammar{
 		},
 		{
 			name: "reString",
-			pos:  position{line: 683, col: 1, offset: 16502},
+			pos:  position{line: 685, col: 1, offset: 16568},
 			expr: &actionExpr{
-				pos: position{line: 684, col: 5, offset: 16515},
+				pos: position{line: 686, col: 5, offset: 16581},
 				run: (*parser).callonreString1,
 				expr: &seqExpr{
-					pos: position{line: 684, col: 5, offset: 16515},
+					pos: position{line: 686, col: 5, offset: 16581},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 684, col: 5, offset: 16515},
+							pos:        position{line: 686, col: 5, offset: 16581},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 684, col: 9, offset: 16519},
+							pos:   position{line: 686, col: 9, offset: 16585},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 684, col: 11, offset: 16521},
+								pos:  position{line: 686, col: 11, offset: 16587},
 								name: "reBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 684, col: 18, offset: 16528},
+							pos:        position{line: 686, col: 18, offset: 16594},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5622,24 +5655,24 @@ var g = &grammar{
 		},
 		{
 			name: "reBody",
-			pos:  position{line: 686, col: 1, offset: 16551},
+			pos:  position{line: 688, col: 1, offset: 16617},
 			expr: &actionExpr{
-				pos: position{line: 687, col: 5, offset: 16562},
+				pos: position{line: 689, col: 5, offset: 16628},
 				run: (*parser).callonreBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 687, col: 5, offset: 16562},
+					pos: position{line: 689, col: 5, offset: 16628},
 					expr: &choiceExpr{
-						pos: position{line: 687, col: 6, offset: 16563},
+						pos: position{line: 689, col: 6, offset: 16629},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 687, col: 6, offset: 16563},
+								pos:        position{line: 689, col: 6, offset: 16629},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 687, col: 13, offset: 16570},
+								pos:        position{line: 689, col: 13, offset: 16636},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -5650,9 +5683,9 @@ var g = &grammar{
 		},
 		{
 			name: "escapedChar",
-			pos:  position{line: 689, col: 1, offset: 16610},
+			pos:  position{line: 691, col: 1, offset: 16676},
 			expr: &charClassMatcher{
-				pos:        position{line: 690, col: 5, offset: 16626},
+				pos:        position{line: 692, col: 5, offset: 16692},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5662,37 +5695,37 @@ var g = &grammar{
 		},
 		{
 			name: "ws",
-			pos:  position{line: 692, col: 1, offset: 16641},
+			pos:  position{line: 694, col: 1, offset: 16707},
 			expr: &choiceExpr{
-				pos: position{line: 693, col: 5, offset: 16648},
+				pos: position{line: 695, col: 5, offset: 16714},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 693, col: 5, offset: 16648},
+						pos:        position{line: 695, col: 5, offset: 16714},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 694, col: 5, offset: 16657},
+						pos:        position{line: 696, col: 5, offset: 16723},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 695, col: 5, offset: 16666},
+						pos:        position{line: 697, col: 5, offset: 16732},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 696, col: 5, offset: 16675},
+						pos:        position{line: 698, col: 5, offset: 16741},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 697, col: 5, offset: 16683},
+						pos:        position{line: 699, col: 5, offset: 16749},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 698, col: 5, offset: 16696},
+						pos:        position{line: 700, col: 5, offset: 16762},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5702,33 +5735,33 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 700, col: 1, offset: 16706},
+			pos:         position{line: 702, col: 1, offset: 16772},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 700, col: 18, offset: 16723},
+				pos: position{line: 702, col: 18, offset: 16789},
 				expr: &ruleRefExpr{
-					pos:  position{line: 700, col: 18, offset: 16723},
+					pos:  position{line: 702, col: 18, offset: 16789},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 701, col: 1, offset: 16727},
+			pos:  position{line: 703, col: 1, offset: 16793},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 701, col: 6, offset: 16732},
+				pos: position{line: 703, col: 6, offset: 16798},
 				expr: &ruleRefExpr{
-					pos:  position{line: 701, col: 6, offset: 16732},
+					pos:  position{line: 703, col: 6, offset: 16798},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 703, col: 1, offset: 16737},
+			pos:  position{line: 705, col: 1, offset: 16803},
 			expr: &notExpr{
-				pos: position{line: 703, col: 7, offset: 16743},
+				pos: position{line: 705, col: 7, offset: 16809},
 				expr: &anyMatcher{
-					line: 703, col: 8, offset: 16744,
+					line: 705, col: 8, offset: 16810,
 				},
 			},
 		},
@@ -6712,14 +6745,24 @@ func (p *parser) callonprocLimitArg1() (interface{}, error) {
 	return p.cur.onprocLimitArg1(stack["limit"])
 }
 
-func (c *current) oncut1(list interface{}) (interface{}, error) {
-	return makeCutProc(list), nil
+func (c *current) oncutArg2() (interface{}, error) {
+	return makeArg("c", nil), nil
+}
+
+func (p *parser) calloncutArg2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.oncutArg2()
+}
+
+func (c *current) oncut1(arg, list interface{}) (interface{}, error) {
+	return makeCutProc(arg, list)
 }
 
 func (p *parser) calloncut1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.oncut1(stack["list"])
+	return p.cur.oncut1(stack["arg"], stack["list"])
 }
 
 func (c *current) onhead2(count interface{}) (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -430,247 +430,248 @@ function peg$parse(input, options) {
           return makeTopProc(list, limit, flush)
         },
       peg$c166 = function(limit) { return limit },
-      peg$c167 = "cut",
-      peg$c168 = peg$literalExpectation("cut", true),
-      peg$c169 = function(list) { return makeCutProc(list) },
-      peg$c170 = "head",
-      peg$c171 = peg$literalExpectation("head", true),
-      peg$c172 = function(count) { return makeHeadProc(count) },
-      peg$c173 = function() { return makeHeadProc(1) },
-      peg$c174 = "tail",
-      peg$c175 = peg$literalExpectation("tail", true),
-      peg$c176 = function(count) { return makeTailProc(count) },
-      peg$c177 = function() { return makeTailProc(1) },
-      peg$c178 = "filter",
-      peg$c179 = peg$literalExpectation("filter", true),
-      peg$c180 = "uniq",
-      peg$c181 = peg$literalExpectation("uniq", true),
-      peg$c182 = "-c",
-      peg$c183 = peg$literalExpectation("-c", false),
-      peg$c184 = function() {
+      peg$c167 = "-c",
+      peg$c168 = peg$literalExpectation("-c", false),
+      peg$c169 = function() { return makeArg("c", null) },
+      peg$c170 = "cut",
+      peg$c171 = peg$literalExpectation("cut", true),
+      peg$c172 = function(arg, list) {  return makeCutProc(arg, list) },
+      peg$c173 = "head",
+      peg$c174 = peg$literalExpectation("head", true),
+      peg$c175 = function(count) { return makeHeadProc(count) },
+      peg$c176 = function() { return makeHeadProc(1) },
+      peg$c177 = "tail",
+      peg$c178 = peg$literalExpectation("tail", true),
+      peg$c179 = function(count) { return makeTailProc(count) },
+      peg$c180 = function() { return makeTailProc(1) },
+      peg$c181 = "filter",
+      peg$c182 = peg$literalExpectation("filter", true),
+      peg$c183 = "uniq",
+      peg$c184 = peg$literalExpectation("uniq", true),
+      peg$c185 = function() {
             return makeUniqProc(true)
           },
-      peg$c185 = function() {
+      peg$c186 = function() {
             return makeUniqProc(false)
           },
-      peg$c186 = "put",
-      peg$c187 = peg$literalExpectation("put", true),
-      peg$c188 = function(f, e) {
+      peg$c187 = "put",
+      peg$c188 = peg$literalExpectation("put", true),
+      peg$c189 = function(f, e) {
             return makePutProc(f, e)
           },
-      peg$c189 = function(f) {
+      peg$c190 = function(f) {
             return chainFieldCalls(f, [])
           },
-      peg$c190 = "?",
-      peg$c191 = peg$literalExpectation("?", false),
-      peg$c192 = ":",
-      peg$c193 = peg$literalExpectation(":", false),
-      peg$c194 = function(condition, thenClause, elseClause) {
+      peg$c191 = "?",
+      peg$c192 = peg$literalExpectation("?", false),
+      peg$c193 = ":",
+      peg$c194 = peg$literalExpectation(":", false),
+      peg$c195 = function(condition, thenClause, elseClause) {
           return makeConditionalExpr(condition, thenClause, elseClause)
         },
-      peg$c195 = function(first, rest) {
+      peg$c196 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c196 = "=~",
-      peg$c197 = peg$literalExpectation("=~", false),
-      peg$c198 = "!=",
-      peg$c199 = peg$literalExpectation("!=", false),
-      peg$c200 = peg$literalExpectation("in", false),
-      peg$c201 = "<=",
-      peg$c202 = peg$literalExpectation("<=", false),
-      peg$c203 = "<",
-      peg$c204 = peg$literalExpectation("<", false),
-      peg$c205 = ">=",
-      peg$c206 = peg$literalExpectation(">=", false),
-      peg$c207 = ">",
-      peg$c208 = peg$literalExpectation(">", false),
-      peg$c209 = "+",
-      peg$c210 = peg$literalExpectation("+", false),
-      peg$c211 = "/",
-      peg$c212 = peg$literalExpectation("/", false),
-      peg$c213 = function(e) {
+      peg$c197 = "=~",
+      peg$c198 = peg$literalExpectation("=~", false),
+      peg$c199 = "!=",
+      peg$c200 = peg$literalExpectation("!=", false),
+      peg$c201 = peg$literalExpectation("in", false),
+      peg$c202 = "<=",
+      peg$c203 = peg$literalExpectation("<=", false),
+      peg$c204 = "<",
+      peg$c205 = peg$literalExpectation("<", false),
+      peg$c206 = ">=",
+      peg$c207 = peg$literalExpectation(">=", false),
+      peg$c208 = ">",
+      peg$c209 = peg$literalExpectation(">", false),
+      peg$c210 = "+",
+      peg$c211 = peg$literalExpectation("+", false),
+      peg$c212 = "/",
+      peg$c213 = peg$literalExpectation("/", false),
+      peg$c214 = function(e) {
               return makeUnaryExpr("!", e)
           },
-      peg$c214 = function(fn, args) {
+      peg$c215 = function(fn, args) {
               return makeFunctionCall(fn, args)
           },
-      peg$c215 = /^[A-Za-z]/,
-      peg$c216 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
-      peg$c217 = /^[.0-9]/,
-      peg$c218 = peg$classExpectation([".", ["0", "9"]], false, false),
-      peg$c219 = function(first, e) { return e },
-      peg$c220 = function(first, rest) {
+      peg$c216 = /^[A-Za-z]/,
+      peg$c217 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
+      peg$c218 = /^[.0-9]/,
+      peg$c219 = peg$classExpectation([".", ["0", "9"]], false, false),
+      peg$c220 = function(first, e) { return e },
+      peg$c221 = function(first, rest) {
             return [first, ... rest]
         },
-      peg$c221 = function() { return [] },
-      peg$c222 = function(base, field) { return makeLiteral("string", text()) },
-      peg$c223 = function(base, derefs) {
+      peg$c222 = function() { return [] },
+      peg$c223 = function(base, field) { return makeLiteral("string", text()) },
+      peg$c224 = function(base, derefs) {
               return makeBinaryExprChain(base, derefs)
           },
-      peg$c224 = peg$literalExpectation("and", false),
-      peg$c225 = "seconds",
-      peg$c226 = peg$literalExpectation("seconds", false),
-      peg$c227 = "second",
-      peg$c228 = peg$literalExpectation("second", false),
-      peg$c229 = "secs",
-      peg$c230 = peg$literalExpectation("secs", false),
-      peg$c231 = "sec",
-      peg$c232 = peg$literalExpectation("sec", false),
-      peg$c233 = "s",
-      peg$c234 = peg$literalExpectation("s", false),
-      peg$c235 = "minutes",
-      peg$c236 = peg$literalExpectation("minutes", false),
-      peg$c237 = "minute",
-      peg$c238 = peg$literalExpectation("minute", false),
-      peg$c239 = "mins",
-      peg$c240 = peg$literalExpectation("mins", false),
-      peg$c241 = peg$literalExpectation("min", false),
-      peg$c242 = "m",
-      peg$c243 = peg$literalExpectation("m", false),
-      peg$c244 = "hours",
-      peg$c245 = peg$literalExpectation("hours", false),
-      peg$c246 = "hrs",
-      peg$c247 = peg$literalExpectation("hrs", false),
-      peg$c248 = "hr",
-      peg$c249 = peg$literalExpectation("hr", false),
-      peg$c250 = "h",
-      peg$c251 = peg$literalExpectation("h", false),
-      peg$c252 = "hour",
-      peg$c253 = peg$literalExpectation("hour", false),
-      peg$c254 = "days",
-      peg$c255 = peg$literalExpectation("days", false),
-      peg$c256 = "day",
-      peg$c257 = peg$literalExpectation("day", false),
-      peg$c258 = "d",
-      peg$c259 = peg$literalExpectation("d", false),
-      peg$c260 = "weeks",
-      peg$c261 = peg$literalExpectation("weeks", false),
-      peg$c262 = "week",
-      peg$c263 = peg$literalExpectation("week", false),
-      peg$c264 = "wks",
-      peg$c265 = peg$literalExpectation("wks", false),
-      peg$c266 = "wk",
-      peg$c267 = peg$literalExpectation("wk", false),
-      peg$c268 = "w",
-      peg$c269 = peg$literalExpectation("w", false),
-      peg$c270 = function() { return makeDuration(1) },
-      peg$c271 = function(num) { return makeDuration(num) },
-      peg$c272 = function() { return makeDuration(60) },
-      peg$c273 = function(num) { return makeDuration(num*60) },
-      peg$c274 = function() { return makeDuration(3600) },
-      peg$c275 = function(num) { return makeDuration(num*3600) },
-      peg$c276 = function() { return makeDuration(3600*24) },
-      peg$c277 = function(num) { return makeDuration(num*3600*24) },
-      peg$c278 = function(num) { return makeDuration(num*3600*24*7) },
-      peg$c279 = function(a) { return text() },
-      peg$c280 = function(a, b) {
+      peg$c225 = peg$literalExpectation("and", false),
+      peg$c226 = "seconds",
+      peg$c227 = peg$literalExpectation("seconds", false),
+      peg$c228 = "second",
+      peg$c229 = peg$literalExpectation("second", false),
+      peg$c230 = "secs",
+      peg$c231 = peg$literalExpectation("secs", false),
+      peg$c232 = "sec",
+      peg$c233 = peg$literalExpectation("sec", false),
+      peg$c234 = "s",
+      peg$c235 = peg$literalExpectation("s", false),
+      peg$c236 = "minutes",
+      peg$c237 = peg$literalExpectation("minutes", false),
+      peg$c238 = "minute",
+      peg$c239 = peg$literalExpectation("minute", false),
+      peg$c240 = "mins",
+      peg$c241 = peg$literalExpectation("mins", false),
+      peg$c242 = peg$literalExpectation("min", false),
+      peg$c243 = "m",
+      peg$c244 = peg$literalExpectation("m", false),
+      peg$c245 = "hours",
+      peg$c246 = peg$literalExpectation("hours", false),
+      peg$c247 = "hrs",
+      peg$c248 = peg$literalExpectation("hrs", false),
+      peg$c249 = "hr",
+      peg$c250 = peg$literalExpectation("hr", false),
+      peg$c251 = "h",
+      peg$c252 = peg$literalExpectation("h", false),
+      peg$c253 = "hour",
+      peg$c254 = peg$literalExpectation("hour", false),
+      peg$c255 = "days",
+      peg$c256 = peg$literalExpectation("days", false),
+      peg$c257 = "day",
+      peg$c258 = peg$literalExpectation("day", false),
+      peg$c259 = "d",
+      peg$c260 = peg$literalExpectation("d", false),
+      peg$c261 = "weeks",
+      peg$c262 = peg$literalExpectation("weeks", false),
+      peg$c263 = "week",
+      peg$c264 = peg$literalExpectation("week", false),
+      peg$c265 = "wks",
+      peg$c266 = peg$literalExpectation("wks", false),
+      peg$c267 = "wk",
+      peg$c268 = peg$literalExpectation("wk", false),
+      peg$c269 = "w",
+      peg$c270 = peg$literalExpectation("w", false),
+      peg$c271 = function() { return makeDuration(1) },
+      peg$c272 = function(num) { return makeDuration(num) },
+      peg$c273 = function() { return makeDuration(60) },
+      peg$c274 = function(num) { return makeDuration(num*60) },
+      peg$c275 = function() { return makeDuration(3600) },
+      peg$c276 = function(num) { return makeDuration(num*3600) },
+      peg$c277 = function() { return makeDuration(3600*24) },
+      peg$c278 = function(num) { return makeDuration(num*3600*24) },
+      peg$c279 = function(num) { return makeDuration(num*3600*24*7) },
+      peg$c280 = function(a) { return text() },
+      peg$c281 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c281 = "::",
-      peg$c282 = peg$literalExpectation("::", false),
-      peg$c283 = function(a, b, d, e) {
+      peg$c282 = "::",
+      peg$c283 = peg$literalExpectation("::", false),
+      peg$c284 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c284 = function(a, b) {
+      peg$c285 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c285 = function(a, b) {
+      peg$c286 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c286 = function() {
+      peg$c287 = function() {
             return "::"
           },
-      peg$c287 = function(v) { return ":" + v },
-      peg$c288 = function(v) { return v + ":" },
-      peg$c289 = function(a) { return text() + ".0" },
-      peg$c290 = function(a) { return text() + ".0.0" },
-      peg$c291 = function(a) { return text() + ".0.0.0" },
-      peg$c292 = function(a, m) {
+      peg$c288 = function(v) { return ":" + v },
+      peg$c289 = function(v) { return v + ":" },
+      peg$c290 = function(a) { return text() + ".0" },
+      peg$c291 = function(a) { return text() + ".0.0" },
+      peg$c292 = function(a) { return text() + ".0.0.0" },
+      peg$c293 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c293 = function(a, m) {
+      peg$c294 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c294 = function(s) { return parseInt(s) },
-      peg$c295 = /^[+\-]/,
-      peg$c296 = peg$classExpectation(["+", "-"], false, false),
-      peg$c297 = function(s) {
+      peg$c295 = function(s) { return parseInt(s) },
+      peg$c296 = /^[+\-]/,
+      peg$c297 = peg$classExpectation(["+", "-"], false, false),
+      peg$c298 = function(s) {
             return parseFloat(s)
         },
-      peg$c298 = function() {
+      peg$c299 = function() {
             return text()
           },
-      peg$c299 = "0",
-      peg$c300 = peg$literalExpectation("0", false),
-      peg$c301 = /^[1-9]/,
-      peg$c302 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c303 = "e",
-      peg$c304 = peg$literalExpectation("e", true),
-      peg$c305 = function(chars) { return text() },
-      peg$c306 = /^[0-9a-fA-F]/,
-      peg$c307 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c308 = function(chars) { return joinChars(chars) },
-      peg$c309 = "\\",
-      peg$c310 = peg$literalExpectation("\\", false),
-      peg$c311 = /^[\0-\x1F\\(),!><="|';]/,
-      peg$c312 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
-      peg$c313 = peg$anyExpectation(),
-      peg$c314 = "\"",
-      peg$c315 = peg$literalExpectation("\"", false),
-      peg$c316 = function(v) { return joinChars(v) },
-      peg$c317 = "'",
-      peg$c318 = peg$literalExpectation("'", false),
-      peg$c319 = "x",
-      peg$c320 = peg$literalExpectation("x", false),
-      peg$c321 = function() { return "\\" + text() },
-      peg$c322 = "b",
-      peg$c323 = peg$literalExpectation("b", false),
-      peg$c324 = function() { return "\b" },
-      peg$c325 = "f",
-      peg$c326 = peg$literalExpectation("f", false),
-      peg$c327 = function() { return "\f" },
-      peg$c328 = "n",
-      peg$c329 = peg$literalExpectation("n", false),
-      peg$c330 = function() { return "\n" },
-      peg$c331 = "r",
-      peg$c332 = peg$literalExpectation("r", false),
-      peg$c333 = function() { return "\r" },
-      peg$c334 = "t",
-      peg$c335 = peg$literalExpectation("t", false),
-      peg$c336 = function() { return "\t" },
-      peg$c337 = "v",
-      peg$c338 = peg$literalExpectation("v", false),
-      peg$c339 = function() { return "\v" },
-      peg$c340 = function() { return "=" },
-      peg$c341 = function() { return "\\*" },
-      peg$c342 = "u",
-      peg$c343 = peg$literalExpectation("u", false),
-      peg$c344 = function(chars) {
+      peg$c300 = "0",
+      peg$c301 = peg$literalExpectation("0", false),
+      peg$c302 = /^[1-9]/,
+      peg$c303 = peg$classExpectation([["1", "9"]], false, false),
+      peg$c304 = "e",
+      peg$c305 = peg$literalExpectation("e", true),
+      peg$c306 = function(chars) { return text() },
+      peg$c307 = /^[0-9a-fA-F]/,
+      peg$c308 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c309 = function(chars) { return joinChars(chars) },
+      peg$c310 = "\\",
+      peg$c311 = peg$literalExpectation("\\", false),
+      peg$c312 = /^[\0-\x1F\\(),!><="|';]/,
+      peg$c313 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
+      peg$c314 = peg$anyExpectation(),
+      peg$c315 = "\"",
+      peg$c316 = peg$literalExpectation("\"", false),
+      peg$c317 = function(v) { return joinChars(v) },
+      peg$c318 = "'",
+      peg$c319 = peg$literalExpectation("'", false),
+      peg$c320 = "x",
+      peg$c321 = peg$literalExpectation("x", false),
+      peg$c322 = function() { return "\\" + text() },
+      peg$c323 = "b",
+      peg$c324 = peg$literalExpectation("b", false),
+      peg$c325 = function() { return "\b" },
+      peg$c326 = "f",
+      peg$c327 = peg$literalExpectation("f", false),
+      peg$c328 = function() { return "\f" },
+      peg$c329 = "n",
+      peg$c330 = peg$literalExpectation("n", false),
+      peg$c331 = function() { return "\n" },
+      peg$c332 = "r",
+      peg$c333 = peg$literalExpectation("r", false),
+      peg$c334 = function() { return "\r" },
+      peg$c335 = "t",
+      peg$c336 = peg$literalExpectation("t", false),
+      peg$c337 = function() { return "\t" },
+      peg$c338 = "v",
+      peg$c339 = peg$literalExpectation("v", false),
+      peg$c340 = function() { return "\v" },
+      peg$c341 = function() { return "=" },
+      peg$c342 = function() { return "\\*" },
+      peg$c343 = "u",
+      peg$c344 = peg$literalExpectation("u", false),
+      peg$c345 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c345 = "{",
-      peg$c346 = peg$literalExpectation("{", false),
-      peg$c347 = "}",
-      peg$c348 = peg$literalExpectation("}", false),
-      peg$c349 = /^[^\/\\]/,
-      peg$c350 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c351 = "\\/",
-      peg$c352 = peg$literalExpectation("\\/", false),
-      peg$c353 = /^[\0-\x1F\\]/,
-      peg$c354 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c355 = "\t",
-      peg$c356 = peg$literalExpectation("\t", false),
-      peg$c357 = "\x0B",
-      peg$c358 = peg$literalExpectation("\x0B", false),
-      peg$c359 = "\f",
-      peg$c360 = peg$literalExpectation("\f", false),
-      peg$c361 = " ",
-      peg$c362 = peg$literalExpectation(" ", false),
-      peg$c363 = "\xA0",
-      peg$c364 = peg$literalExpectation("\xA0", false),
-      peg$c365 = "\uFEFF",
-      peg$c366 = peg$literalExpectation("\uFEFF", false),
-      peg$c367 = peg$otherExpectation("whitespace"),
+      peg$c346 = "{",
+      peg$c347 = peg$literalExpectation("{", false),
+      peg$c348 = "}",
+      peg$c349 = peg$literalExpectation("}", false),
+      peg$c350 = /^[^\/\\]/,
+      peg$c351 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c352 = "\\/",
+      peg$c353 = peg$literalExpectation("\\/", false),
+      peg$c354 = /^[\0-\x1F\\]/,
+      peg$c355 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c356 = "\t",
+      peg$c357 = peg$literalExpectation("\t", false),
+      peg$c358 = "\x0B",
+      peg$c359 = peg$literalExpectation("\x0B", false),
+      peg$c360 = "\f",
+      peg$c361 = peg$literalExpectation("\f", false),
+      peg$c362 = " ",
+      peg$c363 = peg$literalExpectation(" ", false),
+      peg$c364 = "\xA0",
+      peg$c365 = peg$literalExpectation("\xA0", false),
+      peg$c366 = "\uFEFF",
+      peg$c367 = peg$literalExpectation("\uFEFF", false),
+      peg$c368 = peg$otherExpectation("whitespace"),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -3948,25 +3949,86 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsecut() {
+  function peg$parsecutArg() {
     var s0, s1, s2, s3;
 
+    s0 = [];
+    s1 = peg$currPos;
+    s2 = peg$parse_();
+    if (s2 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c167) {
+        s3 = peg$c167;
+        peg$currPos += 2;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c168); }
+      }
+      if (s3 !== peg$FAILED) {
+        peg$savedPos = s1;
+        s2 = peg$c169();
+        s1 = s2;
+      } else {
+        peg$currPos = s1;
+        s1 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s1;
+      s1 = peg$FAILED;
+    }
+    while (s1 !== peg$FAILED) {
+      s0.push(s1);
+      s1 = peg$currPos;
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c167) {
+          s3 = peg$c167;
+          peg$currPos += 2;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c168); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s1;
+          s2 = peg$c169();
+          s1 = s2;
+        } else {
+          peg$currPos = s1;
+          s1 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s1;
+        s1 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parsecut() {
+    var s0, s1, s2, s3, s4;
+
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c167) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c170) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c168); }
+      if (peg$silentFails === 0) { peg$fail(peg$c171); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
+      s2 = peg$parsecutArg();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parsefieldRefDotOnlyList();
+        s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c169(s3);
-          s0 = s1;
+          s4 = peg$parsefieldRefDotOnlyList();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c172(s2, s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -3987,12 +4049,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c170) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c173) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c171); }
+      if (peg$silentFails === 0) { peg$fail(peg$c174); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4000,7 +4062,7 @@ function peg$parse(input, options) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c172(s3);
+          s1 = peg$c175(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4016,16 +4078,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c170) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c173) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c171); }
+        if (peg$silentFails === 0) { peg$fail(peg$c174); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c173();
+        s1 = peg$c176();
       }
       s0 = s1;
     }
@@ -4037,12 +4099,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c174) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c177) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c175); }
+      if (peg$silentFails === 0) { peg$fail(peg$c178); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4050,7 +4112,7 @@ function peg$parse(input, options) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s3);
+          s1 = peg$c179(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4066,16 +4128,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c174) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c177) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+        if (peg$silentFails === 0) { peg$fail(peg$c178); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c177();
+        s1 = peg$c180();
       }
       s0 = s1;
     }
@@ -4087,12 +4149,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c178) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c181) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c179); }
+      if (peg$silentFails === 0) { peg$fail(peg$c182); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4122,26 +4184,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c180) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c183) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c181); }
+      if (peg$silentFails === 0) { peg$fail(peg$c184); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c182) {
-          s3 = peg$c182;
+        if (input.substr(peg$currPos, 2) === peg$c167) {
+          s3 = peg$c167;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c183); }
+          if (peg$silentFails === 0) { peg$fail(peg$c168); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c184();
+          s1 = peg$c185();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4157,16 +4219,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c180) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c183) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c181); }
+        if (peg$silentFails === 0) { peg$fail(peg$c184); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c185();
+        s1 = peg$c186();
       }
       s0 = s1;
     }
@@ -4178,12 +4240,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c186) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c187) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c187); }
+      if (peg$silentFails === 0) { peg$fail(peg$c188); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4205,7 +4267,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseConditionalExpression();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c188(s3, s7);
+                  s1 = peg$c189(s3, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4329,7 +4391,7 @@ function peg$parse(input, options) {
     s1 = peg$parsefieldName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c189(s1);
+      s1 = peg$c190(s1);
     }
     s0 = s1;
 
@@ -4353,11 +4415,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c190;
+          s3 = peg$c191;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c191); }
+          if (peg$silentFails === 0) { peg$fail(peg$c192); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4367,11 +4429,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c192;
+                  s7 = peg$c193;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c193); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c194); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -4379,7 +4441,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpression();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c194(s1, s5, s9);
+                      s1 = peg$c195(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4490,7 +4552,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c195(s1, s2);
+        s1 = peg$c196(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4570,7 +4632,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c195(s1, s2);
+        s1 = peg$c196(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4650,7 +4712,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c195(s1, s2);
+        s1 = peg$c196(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4668,12 +4730,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c196) {
-      s1 = peg$c196;
+    if (input.substr(peg$currPos, 2) === peg$c197) {
+      s1 = peg$c197;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c197); }
+      if (peg$silentFails === 0) { peg$fail(peg$c198); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 61) {
@@ -4684,12 +4746,12 @@ function peg$parse(input, options) {
         if (peg$silentFails === 0) { peg$fail(peg$c139); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c198) {
-          s1 = peg$c198;
+        if (input.substr(peg$currPos, 2) === peg$c199) {
+          s1 = peg$c199;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c199); }
+          if (peg$silentFails === 0) { peg$fail(peg$c200); }
         }
       }
     }
@@ -4713,7 +4775,7 @@ function peg$parse(input, options) {
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c200); }
+        if (peg$silentFails === 0) { peg$fail(peg$c201); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -4791,7 +4853,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c195(s1, s2);
+        s1 = peg$c196(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4809,36 +4871,36 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c201) {
-      s1 = peg$c201;
+    if (input.substr(peg$currPos, 2) === peg$c202) {
+      s1 = peg$c202;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c202); }
+      if (peg$silentFails === 0) { peg$fail(peg$c203); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c203;
+        s1 = peg$c204;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c204); }
+        if (peg$silentFails === 0) { peg$fail(peg$c205); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c205) {
-          s1 = peg$c205;
+        if (input.substr(peg$currPos, 2) === peg$c206) {
+          s1 = peg$c206;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c206); }
+          if (peg$silentFails === 0) { peg$fail(peg$c207); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c207;
+            s1 = peg$c208;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c208); }
+            if (peg$silentFails === 0) { peg$fail(peg$c209); }
           }
         }
       }
@@ -4918,7 +4980,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c195(s1, s2);
+        s1 = peg$c196(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4937,11 +4999,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c209;
+      s1 = peg$c210;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c210); }
+      if (peg$silentFails === 0) { peg$fail(peg$c211); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
@@ -5027,7 +5089,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c195(s1, s2);
+        s1 = peg$c196(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5054,11 +5116,11 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c211;
+        s1 = peg$c212;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c212); }
+        if (peg$silentFails === 0) { peg$fail(peg$c213); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -5087,7 +5149,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpression();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c213(s3);
+          s1 = peg$c214(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5135,7 +5197,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c214(s1, s4);
+              s1 = peg$c215(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5195,12 +5257,12 @@ function peg$parse(input, options) {
   function peg$parseFunctionNameStart() {
     var s0;
 
-    if (peg$c215.test(input.charAt(peg$currPos))) {
+    if (peg$c216.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c216); }
+      if (peg$silentFails === 0) { peg$fail(peg$c217); }
     }
 
     return s0;
@@ -5211,12 +5273,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseFunctionNameStart();
     if (s0 === peg$FAILED) {
-      if (peg$c217.test(input.charAt(peg$currPos))) {
+      if (peg$c218.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c218); }
+        if (peg$silentFails === 0) { peg$fail(peg$c219); }
       }
     }
 
@@ -5246,7 +5308,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpression();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c219(s1, s7);
+              s4 = peg$c220(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5282,7 +5344,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpression();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c219(s1, s7);
+                s4 = peg$c220(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5303,7 +5365,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c220(s1, s2);
+        s1 = peg$c221(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5318,7 +5380,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c221();
+        s1 = peg$c222();
       }
       s0 = s1;
     }
@@ -5402,7 +5464,7 @@ function peg$parse(input, options) {
               s8 = peg$parsefieldName();
               if (s8 !== peg$FAILED) {
                 peg$savedPos = s7;
-                s8 = peg$c222(s1, s8);
+                s8 = peg$c223(s1, s8);
               }
               s7 = s8;
               if (s7 !== peg$FAILED) {
@@ -5496,7 +5558,7 @@ function peg$parse(input, options) {
                 s8 = peg$parsefieldName();
                 if (s8 !== peg$FAILED) {
                   peg$savedPos = s7;
-                  s8 = peg$c222(s1, s8);
+                  s8 = peg$c223(s1, s8);
                 }
                 s7 = s8;
                 if (s7 !== peg$FAILED) {
@@ -5522,7 +5584,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c223(s1, s2);
+        s1 = peg$c224(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5555,7 +5617,7 @@ function peg$parse(input, options) {
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c224); }
+                if (peg$silentFails === 0) { peg$fail(peg$c225); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -5600,44 +5662,44 @@ function peg$parse(input, options) {
   function peg$parsesec_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c225) {
-      s0 = peg$c225;
+    if (input.substr(peg$currPos, 7) === peg$c226) {
+      s0 = peg$c226;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+      if (peg$silentFails === 0) { peg$fail(peg$c227); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c227) {
-        s0 = peg$c227;
+      if (input.substr(peg$currPos, 6) === peg$c228) {
+        s0 = peg$c228;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c228); }
+        if (peg$silentFails === 0) { peg$fail(peg$c229); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c229) {
-          s0 = peg$c229;
+        if (input.substr(peg$currPos, 4) === peg$c230) {
+          s0 = peg$c230;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c230); }
+          if (peg$silentFails === 0) { peg$fail(peg$c231); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c231) {
-            s0 = peg$c231;
+          if (input.substr(peg$currPos, 3) === peg$c232) {
+            s0 = peg$c232;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c232); }
+            if (peg$silentFails === 0) { peg$fail(peg$c233); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c233;
+              s0 = peg$c234;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c234); }
+              if (peg$silentFails === 0) { peg$fail(peg$c235); }
             }
           }
         }
@@ -5650,28 +5712,28 @@ function peg$parse(input, options) {
   function peg$parsemin_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c235) {
-      s0 = peg$c235;
+    if (input.substr(peg$currPos, 7) === peg$c236) {
+      s0 = peg$c236;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c236); }
+      if (peg$silentFails === 0) { peg$fail(peg$c237); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c237) {
-        s0 = peg$c237;
+      if (input.substr(peg$currPos, 6) === peg$c238) {
+        s0 = peg$c238;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c238); }
+        if (peg$silentFails === 0) { peg$fail(peg$c239); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c239) {
-          s0 = peg$c239;
+        if (input.substr(peg$currPos, 4) === peg$c240) {
+          s0 = peg$c240;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          if (peg$silentFails === 0) { peg$fail(peg$c241); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 3) === peg$c117) {
@@ -5679,15 +5741,15 @@ function peg$parse(input, options) {
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c241); }
+            if (peg$silentFails === 0) { peg$fail(peg$c242); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c242;
+              s0 = peg$c243;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c243); }
+              if (peg$silentFails === 0) { peg$fail(peg$c244); }
             }
           }
         }
@@ -5700,44 +5762,44 @@ function peg$parse(input, options) {
   function peg$parsehour_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c244) {
-      s0 = peg$c244;
+    if (input.substr(peg$currPos, 5) === peg$c245) {
+      s0 = peg$c245;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c245); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c246) {
-        s0 = peg$c246;
+      if (input.substr(peg$currPos, 3) === peg$c247) {
+        s0 = peg$c247;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c247); }
+        if (peg$silentFails === 0) { peg$fail(peg$c248); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c248) {
-          s0 = peg$c248;
+        if (input.substr(peg$currPos, 2) === peg$c249) {
+          s0 = peg$c249;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c249); }
+          if (peg$silentFails === 0) { peg$fail(peg$c250); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c250;
+            s0 = peg$c251;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c251); }
+            if (peg$silentFails === 0) { peg$fail(peg$c252); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c252) {
-              s0 = peg$c252;
+            if (input.substr(peg$currPos, 4) === peg$c253) {
+              s0 = peg$c253;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c253); }
+              if (peg$silentFails === 0) { peg$fail(peg$c254); }
             }
           }
         }
@@ -5750,28 +5812,28 @@ function peg$parse(input, options) {
   function peg$parseday_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c254) {
-      s0 = peg$c254;
+    if (input.substr(peg$currPos, 4) === peg$c255) {
+      s0 = peg$c255;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c255); }
+      if (peg$silentFails === 0) { peg$fail(peg$c256); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c256) {
-        s0 = peg$c256;
+      if (input.substr(peg$currPos, 3) === peg$c257) {
+        s0 = peg$c257;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c257); }
+        if (peg$silentFails === 0) { peg$fail(peg$c258); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c258;
+          s0 = peg$c259;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c259); }
+          if (peg$silentFails === 0) { peg$fail(peg$c260); }
         }
       }
     }
@@ -5782,44 +5844,44 @@ function peg$parse(input, options) {
   function peg$parseweek_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c260) {
-      s0 = peg$c260;
+    if (input.substr(peg$currPos, 5) === peg$c261) {
+      s0 = peg$c261;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c261); }
+      if (peg$silentFails === 0) { peg$fail(peg$c262); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c262) {
-        s0 = peg$c262;
+      if (input.substr(peg$currPos, 4) === peg$c263) {
+        s0 = peg$c263;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c263); }
+        if (peg$silentFails === 0) { peg$fail(peg$c264); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c264) {
-          s0 = peg$c264;
+        if (input.substr(peg$currPos, 3) === peg$c265) {
+          s0 = peg$c265;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c265); }
+          if (peg$silentFails === 0) { peg$fail(peg$c266); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c266) {
-            s0 = peg$c266;
+          if (input.substr(peg$currPos, 2) === peg$c267) {
+            s0 = peg$c267;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c267); }
+            if (peg$silentFails === 0) { peg$fail(peg$c268); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c268;
+              s0 = peg$c269;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c269); }
+              if (peg$silentFails === 0) { peg$fail(peg$c270); }
             }
           }
         }
@@ -5833,16 +5895,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c227) {
-      s1 = peg$c227;
+    if (input.substr(peg$currPos, 6) === peg$c228) {
+      s1 = peg$c228;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c228); }
+      if (peg$silentFails === 0) { peg$fail(peg$c229); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c270();
+      s1 = peg$c271();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5857,7 +5919,7 @@ function peg$parse(input, options) {
           s3 = peg$parsesec_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c271(s1);
+            s1 = peg$c272(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5880,16 +5942,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c237) {
-      s1 = peg$c237;
+    if (input.substr(peg$currPos, 6) === peg$c238) {
+      s1 = peg$c238;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c239); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c272();
+      s1 = peg$c273();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5904,7 +5966,7 @@ function peg$parse(input, options) {
           s3 = peg$parsemin_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c273(s1);
+            s1 = peg$c274(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5927,16 +5989,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c252) {
-      s1 = peg$c252;
+    if (input.substr(peg$currPos, 4) === peg$c253) {
+      s1 = peg$c253;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c254); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c274();
+      s1 = peg$c275();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5951,7 +6013,7 @@ function peg$parse(input, options) {
           s3 = peg$parsehour_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c275(s1);
+            s1 = peg$c276(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5974,16 +6036,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c256) {
-      s1 = peg$c256;
+    if (input.substr(peg$currPos, 3) === peg$c257) {
+      s1 = peg$c257;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c257); }
+      if (peg$silentFails === 0) { peg$fail(peg$c258); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c276();
+      s1 = peg$c277();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5998,7 +6060,7 @@ function peg$parse(input, options) {
           s3 = peg$parseday_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c277(s1);
+            s1 = peg$c278(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6031,7 +6093,7 @@ function peg$parse(input, options) {
         s3 = peg$parseweek_abbrev();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c278(s1);
+          s1 = peg$c279(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6118,7 +6180,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c279(s1);
+      s1 = peg$c280(s1);
     }
     s0 = s1;
 
@@ -6130,11 +6192,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c192;
+      s1 = peg$c193;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c193); }
+      if (peg$silentFails === 0) { peg$fail(peg$c194); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesuint();
@@ -6172,7 +6234,7 @@ function peg$parse(input, options) {
       s2 = peg$parseip6tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c280(s1, s2);
+        s1 = peg$c281(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6193,12 +6255,12 @@ function peg$parse(input, options) {
           s3 = peg$parseh_append();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c281) {
-            s3 = peg$c281;
+          if (input.substr(peg$currPos, 2) === peg$c282) {
+            s3 = peg$c282;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c282); }
+            if (peg$silentFails === 0) { peg$fail(peg$c283); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6211,7 +6273,7 @@ function peg$parse(input, options) {
               s5 = peg$parseip6tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c283(s1, s2, s4, s5);
+                s1 = peg$c284(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6235,12 +6297,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c281) {
-          s1 = peg$c281;
+        if (input.substr(peg$currPos, 2) === peg$c282) {
+          s1 = peg$c282;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c282); }
+          if (peg$silentFails === 0) { peg$fail(peg$c283); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6253,7 +6315,7 @@ function peg$parse(input, options) {
             s3 = peg$parseip6tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c284(s2, s3);
+              s1 = peg$c285(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6278,16 +6340,16 @@ function peg$parse(input, options) {
               s3 = peg$parseh_append();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c281) {
-                s3 = peg$c281;
+              if (input.substr(peg$currPos, 2) === peg$c282) {
+                s3 = peg$c282;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c282); }
+                if (peg$silentFails === 0) { peg$fail(peg$c283); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c285(s1, s2);
+                s1 = peg$c286(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6303,16 +6365,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c281) {
-              s1 = peg$c281;
+            if (input.substr(peg$currPos, 2) === peg$c282) {
+              s1 = peg$c282;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c282); }
+              if (peg$silentFails === 0) { peg$fail(peg$c283); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c286();
+              s1 = peg$c287();
             }
             s0 = s1;
           }
@@ -6339,17 +6401,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c192;
+      s1 = peg$c193;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c193); }
+      if (peg$silentFails === 0) { peg$fail(peg$c194); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseh16();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c287(s2);
+        s1 = peg$c288(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6370,15 +6432,15 @@ function peg$parse(input, options) {
     s1 = peg$parseh16();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c192;
+        s2 = peg$c193;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c193); }
+        if (peg$silentFails === 0) { peg$fail(peg$c194); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c288(s1);
+        s1 = peg$c289(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6445,7 +6507,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c289(s1);
+        s1 = peg$c290(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -6479,7 +6541,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c290(s1);
+          s1 = peg$c291(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -6487,7 +6549,7 @@ function peg$parse(input, options) {
           s1 = peg$parseunsignedInteger();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c291(s1);
+            s1 = peg$c292(s1);
           }
           s0 = s1;
         }
@@ -6504,17 +6566,17 @@ function peg$parse(input, options) {
     s1 = peg$parsesub_addr();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c211;
+        s2 = peg$c212;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c212); }
+        if (peg$silentFails === 0) { peg$fail(peg$c213); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c292(s1, s3);
+          s1 = peg$c293(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6539,17 +6601,17 @@ function peg$parse(input, options) {
     s1 = peg$parseip6addr();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c211;
+        s2 = peg$c212;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c212); }
+        if (peg$silentFails === 0) { peg$fail(peg$c213); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c293(s1, s3);
+          s1 = peg$c294(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6574,7 +6636,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesuint();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c294(s1);
+      s1 = peg$c295(s1);
     }
     s0 = s1;
 
@@ -6623,7 +6685,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesinteger();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c294(s1);
+      s1 = peg$c295(s1);
     }
     s0 = s1;
 
@@ -6634,12 +6696,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c295.test(input.charAt(peg$currPos))) {
+    if (peg$c296.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c296); }
+      if (peg$silentFails === 0) { peg$fail(peg$c297); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -6669,7 +6731,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesdouble();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c297(s1);
+      s1 = peg$c298(s1);
     }
     s0 = s1;
 
@@ -6727,7 +6789,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c298();
+              s1 = peg$c299();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6787,7 +6849,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c298();
+              s1 = peg$c299();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6814,20 +6876,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     if (input.charCodeAt(peg$currPos) === 48) {
-      s0 = peg$c299;
+      s0 = peg$c300;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c300); }
+      if (peg$silentFails === 0) { peg$fail(peg$c301); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$c301.test(input.charAt(peg$currPos))) {
+      if (peg$c302.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c302); }
+        if (peg$silentFails === 0) { peg$fail(peg$c303); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -6882,12 +6944,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c303) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c304) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c304); }
+      if (peg$silentFails === 0) { peg$fail(peg$c305); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesinteger();
@@ -6922,7 +6984,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c305(s1);
+      s1 = peg$c306(s1);
     }
     s0 = s1;
 
@@ -6932,12 +6994,12 @@ function peg$parse(input, options) {
   function peg$parsehexdigit() {
     var s0;
 
-    if (peg$c306.test(input.charAt(peg$currPos))) {
+    if (peg$c307.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c307); }
+      if (peg$silentFails === 0) { peg$fail(peg$c308); }
     }
 
     return s0;
@@ -6959,7 +7021,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c308(s1);
+      s1 = peg$c309(s1);
     }
     s0 = s1;
 
@@ -6971,11 +7033,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c309;
+      s1 = peg$c310;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c310); }
+      if (peg$silentFails === 0) { peg$fail(peg$c311); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseescapeSequence();
@@ -6998,12 +7060,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c311.test(input.charAt(peg$currPos))) {
+      if (peg$c312.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c312); }
+        if (peg$silentFails === 0) { peg$fail(peg$c313); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parsews();
@@ -7021,7 +7083,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c313); }
+          if (peg$silentFails === 0) { peg$fail(peg$c314); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -7045,11 +7107,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c314;
+      s1 = peg$c315;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c315); }
+      if (peg$silentFails === 0) { peg$fail(peg$c316); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -7060,15 +7122,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c314;
+          s3 = peg$c315;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c315); }
+          if (peg$silentFails === 0) { peg$fail(peg$c316); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c316(s2);
+          s1 = peg$c317(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7085,11 +7147,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c317;
+        s1 = peg$c318;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c318); }
+        if (peg$silentFails === 0) { peg$fail(peg$c319); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7100,15 +7162,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c317;
+            s3 = peg$c318;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c318); }
+            if (peg$silentFails === 0) { peg$fail(peg$c319); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c316(s2);
+            s1 = peg$c317(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7134,11 +7196,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c314;
+      s2 = peg$c315;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c315); }
+      if (peg$silentFails === 0) { peg$fail(peg$c316); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -7156,7 +7218,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c313); }
+        if (peg$silentFails === 0) { peg$fail(peg$c314); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -7173,11 +7235,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c309;
+        s1 = peg$c310;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c310); }
+        if (peg$silentFails === 0) { peg$fail(peg$c311); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -7205,11 +7267,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c317;
+      s2 = peg$c318;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c318); }
+      if (peg$silentFails === 0) { peg$fail(peg$c319); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -7227,7 +7289,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c313); }
+        if (peg$silentFails === 0) { peg$fail(peg$c314); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -7244,11 +7306,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c309;
+        s1 = peg$c310;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c310); }
+        if (peg$silentFails === 0) { peg$fail(peg$c311); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -7274,11 +7336,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c319;
+      s1 = peg$c320;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c320); }
+      if (peg$silentFails === 0) { peg$fail(peg$c321); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsehexdigit();
@@ -7286,7 +7348,7 @@ function peg$parse(input, options) {
         s3 = peg$parsehexdigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c321();
+          s1 = peg$c322();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7314,110 +7376,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c317;
+      s0 = peg$c318;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c318); }
+      if (peg$silentFails === 0) { peg$fail(peg$c319); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c314;
+        s0 = peg$c315;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c315); }
+        if (peg$silentFails === 0) { peg$fail(peg$c316); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c309;
+          s0 = peg$c310;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c310); }
+          if (peg$silentFails === 0) { peg$fail(peg$c311); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c322;
+            s1 = peg$c323;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c323); }
+            if (peg$silentFails === 0) { peg$fail(peg$c324); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c324();
+            s1 = peg$c325();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c325;
+              s1 = peg$c326;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c326); }
+              if (peg$silentFails === 0) { peg$fail(peg$c327); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c327();
+              s1 = peg$c328();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c328;
+                s1 = peg$c329;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c329); }
+                if (peg$silentFails === 0) { peg$fail(peg$c330); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c330();
+                s1 = peg$c331();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c331;
+                  s1 = peg$c332;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c332); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c333); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c333();
+                  s1 = peg$c334();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c334;
+                    s1 = peg$c335;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c335); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c336); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c336();
+                    s1 = peg$c337();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c337;
+                      s1 = peg$c338;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c339); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c339();
+                      s1 = peg$c340();
                     }
                     s0 = s1;
                   }
@@ -7445,7 +7507,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c340();
+      s1 = peg$c341();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7459,7 +7521,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c341();
+        s1 = peg$c342();
       }
       s0 = s1;
     }
@@ -7472,11 +7534,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c342;
+      s1 = peg$c343;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c344); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7508,7 +7570,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c344(s2);
+        s1 = peg$c345(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7521,19 +7583,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c342;
+        s1 = peg$c343;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c343); }
+        if (peg$silentFails === 0) { peg$fail(peg$c344); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c345;
+          s2 = peg$c346;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c346); }
+          if (peg$silentFails === 0) { peg$fail(peg$c347); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7592,15 +7654,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c347;
+              s4 = peg$c348;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c348); }
+              if (peg$silentFails === 0) { peg$fail(peg$c349); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c344(s3);
+              s1 = peg$c345(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7628,21 +7690,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c211;
+      s1 = peg$c212;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c212); }
+      if (peg$silentFails === 0) { peg$fail(peg$c213); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsereBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c211;
+          s3 = peg$c212;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c212); }
+          if (peg$silentFails === 0) { peg$fail(peg$c213); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -7669,39 +7731,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c349.test(input.charAt(peg$currPos))) {
+    if (peg$c350.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c350); }
+      if (peg$silentFails === 0) { peg$fail(peg$c351); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c351) {
-        s2 = peg$c351;
+      if (input.substr(peg$currPos, 2) === peg$c352) {
+        s2 = peg$c352;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c352); }
+        if (peg$silentFails === 0) { peg$fail(peg$c353); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c349.test(input.charAt(peg$currPos))) {
+        if (peg$c350.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c350); }
+          if (peg$silentFails === 0) { peg$fail(peg$c351); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c351) {
-            s2 = peg$c351;
+          if (input.substr(peg$currPos, 2) === peg$c352) {
+            s2 = peg$c352;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c352); }
+            if (peg$silentFails === 0) { peg$fail(peg$c353); }
           }
         }
       }
@@ -7720,12 +7782,12 @@ function peg$parse(input, options) {
   function peg$parseescapedChar() {
     var s0;
 
-    if (peg$c353.test(input.charAt(peg$currPos))) {
+    if (peg$c354.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c354); }
+      if (peg$silentFails === 0) { peg$fail(peg$c355); }
     }
 
     return s0;
@@ -7735,51 +7797,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c355;
+      s0 = peg$c356;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c357;
+        s0 = peg$c358;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c358); }
+        if (peg$silentFails === 0) { peg$fail(peg$c359); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c359;
+          s0 = peg$c360;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c360); }
+          if (peg$silentFails === 0) { peg$fail(peg$c361); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c361;
+            s0 = peg$c362;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c362); }
+            if (peg$silentFails === 0) { peg$fail(peg$c363); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c363;
+              s0 = peg$c364;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c364); }
+              if (peg$silentFails === 0) { peg$fail(peg$c365); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c365;
+                s0 = peg$c366;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c366); }
+                if (peg$silentFails === 0) { peg$fail(peg$c367); }
               }
             }
           }
@@ -7807,7 +7869,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
 
     return s0;
@@ -7836,7 +7898,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c313); }
+      if (peg$silentFails === 0) { peg$fail(peg$c314); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {
@@ -7880,6 +7942,8 @@ function peg$parse(input, options) {
   }
 
   function makeSearch(text, value, bareWord) {
+    // bare word searches can be anything (*), globs (anything else
+    // containing glob meta-characters), or just plain strings.
     if (bareWord && value.type == "string") {
       if (text == "*") {
         return makeMatchAll();
@@ -7944,7 +8008,16 @@ function peg$parse(input, options) {
     return { op: "TopProc", fields, limit, flush};
   }
 
-  function makeCutProc(fields) { return { op: "CutProc", fields }; }
+  function makeCutProc(args, fields) {
+      let complement = false;
+      if (args.length > 1) {
+        throw new Error(`Duplicate argument -c`);
+      }
+      if (args.length == 1) {
+          complement = true;
+      }
+      return { op: "CutProc", complement, fields };
+  }
   function makeHeadProc(count) { return { op: "HeadProc", count }; }
   function makeTailProc(count) { return { op: "TailProc", count }; }
   function makeUniqProc(cflag) { return { op: "TailProc", cflag }; }

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -387,8 +387,10 @@ top
 procLimitArg
   = _ "-limit" _ limit:unsignedInteger { RETURN(limit) }
 
+cutArg = (_ "-c" { RETURN(makeArg("c", NULL)) })*
+
 cut
-  = "cut"i _ list:fieldRefDotOnlyList { RETURN(makeCutProc(list)) }
+  = "cut"i arg:cutArg _ list:fieldRefDotOnlyList {  return makeCutProc(arg, list) }
 head
   = "head"i _ count:unsignedInteger { RETURN(makeHeadProc(count)) }
   / "head"i { RETURN(makeHeadProc(1)) }


### PR DESCRIPTION
Add support for the `-c` ("complement") option to cut, where all record fields _not_ in the provided field list are to be passed through.

closes #497 