### PR TITLE
fix crash when index file is present but empty

### DIFF
--- a/archive/finder.go
+++ b/archive/finder.go
@@ -63,6 +63,11 @@ func Search(path string, rule Rule, pattern string) (bool, error) {
 		}
 		return false, err
 	}
+	defer finder.Close()
+	if keyType == nil {
+		// This happens when an index exists but is empty.
+		return false, nil
+	}
 	keyBytes, err := keyType.Parse([]byte(pattern))
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", finder.Path(), err)

--- a/cmd/zdx/lookup/command.go
+++ b/cmd/zdx/lookup/command.go
@@ -74,10 +74,10 @@ func (c *LookupCommand) Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	defer finder.Close()
 	if keyType == nil {
 		return fmt.Errorf("%s: index is empty", path)
 	}
-	defer finder.Close()
 	// XXX Parse doesn't work yet for record values, but everything else
 	// is ready to go to use records and index keys
 	key, err := keyType.Parse([]byte(c.key))

--- a/tests/suite/zdx/empty.yaml
+++ b/tests/suite/zdx/empty.yaml
@@ -1,0 +1,8 @@
+script: |
+  echo "" > empty.zng
+  zdx lookup -t -k none empty
+
+outputs:
+  - name: stderr
+    regexp: |
+      empty: index is empty

--- a/tests/suite/zdx/empty.yaml
+++ b/tests/suite/zdx/empty.yaml
@@ -1,5 +1,5 @@
 script: |
-  echo "" > empty.zng
+  echo -n "" > empty.zng
   zdx lookup -t -k none empty
 
 outputs:

--- a/zdx/zdx_test.go
+++ b/zdx/zdx_test.go
@@ -108,6 +108,8 @@ func TestSearch(t *testing.T) {
 	if !bytes.Equal(value, value2) {
 		t.Error("key lookup failed")
 	}
+	err = finder.Close()
+	require.NoError(t, err)
 }
 
 func TestZdx(t *testing.T) {


### PR DESCRIPTION
This commit fixes a bug where the keyType returned by finder.Open()
is nil. This happens when an index exists but has nothing in it.
The fix is to return a false match in this case.

We also noticed the finder wasn't being closed here leaving
potentially many files opened during a traversal.  We added
logic to close the temporary finder used in each search.

Resolves #649
