### PR TITLE
make -f zng the default for zng output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/yuin/goldmark v1.1.22
 	go.uber.org/multierr v1.3.0
 	go.uber.org/zap v1.12.0
+	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	golang.org/x/text v0.3.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/tests/suite/errors/stoperr2.yaml
+++ b/tests/suite/errors/stoperr2.yaml
@@ -1,6 +1,6 @@
 # one input has first bad line (detection fails)
 script: |
-  zq -e=false  "*" good.tzng bad.tzng > res.tzng
+  zq -t -e=false  "*" good.tzng bad.tzng > res.tzng
 
 inputs:
   - name: good.tzng

--- a/tests/suite/errors/stoperr3.yaml
+++ b/tests/suite/errors/stoperr3.yaml
@@ -1,12 +1,12 @@
 # one input has first bad line (detection succeeds)
 script: |
-  zq -e=false  "*" midgood.tzng midbad.tzng > res.tzng
+  zq -t -e=false  "*" midgood.tzng midbad.tzng > res.tzng
 
 inputs:
   - name: midgood.tzng
     data: |
         #0:record[_path:string,ts:time]
-        0:[conn;1;]    
+        0:[conn;1;]
   - name: midbad.tzng
     data: |
         #0:record[_path:string,ts:time]

--- a/tests/suite/jsontype/test-infer-path.yaml
+++ b/tests/suite/jsontype/test-infer-path.yaml
@@ -1,4 +1,4 @@
-script: zq -j types.json "*" *.log > http.tzng
+script: zq -t -j types.json "*" *.log > http.tzng
 
 inputs:
   - name: http_20190830_08:00:00-09:00:00-0500.log

--- a/tests/suite/jsontype/test-no-ts.yaml
+++ b/tests/suite/jsontype/test-no-ts.yaml
@@ -1,4 +1,4 @@
-script: zq -j types.json "*" in.ndjson > out.tzng
+script: zq -t -j types.json "*" in.ndjson > out.tzng
 
 inputs:
   - name: in.ndjson

--- a/tests/suite/jsontype/test-set.yaml
+++ b/tests/suite/jsontype/test-set.yaml
@@ -1,4 +1,4 @@
-script: zq -j types.json "*" in.ndjson > http.tzng
+script: zq -t -j types.json "*" in.ndjson > http.tzng
 
 inputs:
   - name: in.ndjson

--- a/tests/suite/jsontype/test-ts.yaml
+++ b/tests/suite/jsontype/test-ts.yaml
@@ -1,4 +1,4 @@
-script: zq -j types.json "every 1d count()" in.ndjson > http.tzng
+script: zq -t -j types.json "every 1d count()" in.ndjson > http.tzng
 
 inputs:
   - name: in.ndjson

--- a/tests/suite/jsontype/test.yaml
+++ b/tests/suite/jsontype/test.yaml
@@ -1,4 +1,4 @@
-script: zq -j types.json "*" in.ndjson > http.tzng
+script: zq -t -j types.json "*" in.ndjson > http.tzng
 
 inputs:
   - name: in.ndjson

--- a/tests/suite/trunc/trunc.yaml
+++ b/tests/suite/trunc/trunc.yaml
@@ -1,7 +1,7 @@
 script: |
-  zq -o out.tzng long.tzng
-  zq -o out.tzng short.tzng
-  zq out.tzng
+  zq -t -o out.tzng long.tzng
+  zq -t -o out.tzng short.tzng
+  zq -t out.tzng
 
 inputs:
   - name: short.tzng

--- a/tests/suite/zdx/create.yaml
+++ b/tests/suite/zdx/create.yaml
@@ -1,6 +1,6 @@
 script: |
   zdx create -o index -k a in.zng
-  zq index.bzng
+  zq -t index.bzng
 
 inputs:
   - name: in.zng

--- a/tests/suite/zdx/find.yaml
+++ b/tests/suite/zdx/find.yaml
@@ -1,9 +1,11 @@
 script: |
   zdx create -o index -k v babble.tzng
-  zdx lookup -k 469 index
+  zdx lookup -t -k 469 index
+  echo ===
   # 50 not in index
-  zdx lookup -k 50 index
-  zdx lookup -k 30 index
+  zdx lookup -t -k 50 index
+  echo ===
+  zdx lookup -t -k 30 index
 
 inputs:
   - name: babble.tzng
@@ -13,5 +15,7 @@ outputs:
     data: |
       #0:record[key:int64]
       0:[469;]
+      ===
+      ===
       #0:record[key:int64]
       0:[30;]

--- a/tests/suite/zdx/tsindex.yaml
+++ b/tests/suite/zdx/tsindex.yaml
@@ -1,14 +1,14 @@
 script: |
   # index ts every 10 records
-  zq -f zng -b 10 babble.tzng | zdx create -S -o index -k ts -
+  zq -b 10 babble.tzng | zdx create -S -o index -k ts -
   # exact lookup for this particular ts
-  zdx lookup -k 1587512531.06754599 index
+  zdx lookup -t -k 1587512531.06754599 index
   echo ===
   # exact lookup for an absent ts
-  zdx lookup -k 1587512531.06754600 index
+  zdx lookup -t -k 1587512531.06754600 index
   echo ===
   # closest lookup for the absent ts
-  zdx lookup -c -k 1587512531.06754600 index
+  zdx lookup -c -t -k 1587512531.06754600 index
 
 inputs:
   - name: babble.tzng

--- a/tests/suite/ztest/stdio.yaml
+++ b/tests/suite/ztest/stdio.yaml
@@ -1,4 +1,4 @@
-script: zq -
+script: zq -t -
 
 inputs:
   - name: stdin

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -29,7 +29,7 @@ type WriterFlags struct {
 }
 
 func (f *WriterFlags) SetFlags(fs *flag.FlagSet) {
-	fs.StringVar(&f.Format, "f", "tzng", "format for output data [zng,ndjson,table,text,types,zeek,zjson,tzng]")
+	fs.StringVar(&f.Format, "f", "zng", "format for output data [zng,ndjson,table,text,types,zeek,zjson,tzng]")
 	fs.BoolVar(&f.ShowTypes, "T", false, "display field types in text output")
 	fs.BoolVar(&f.ShowFields, "F", false, "display field names in text output")
 	fs.BoolVar(&f.EpochDates, "E", false, "display epoch timestamps in text output")

--- a/zql/docs/search-syntax/README.md
+++ b/zql/docs/search-syntax/README.md
@@ -24,7 +24,7 @@ The simplest possible ZQL search is a match against all events. This search is e
 
 #### Example:
 ```zq-command
-zq '*' conn.log.gz
+zq -t '*' conn.log.gz
 ```
 
 #### Output:
@@ -44,7 +44,7 @@ To start a ZQL pipeline with this default search, you can similarly leave out th
 
 #### Example #1:
 ```zq-command
-zq 'cut server_tree_name' ntlm.log.gz # Shorthand for: zq '* | cut server_tree_name' ntlm.log.gz
+zq -t 'cut server_tree_name' ntlm.log.gz # Shorthand for: zq '* | cut server_tree_name' ntlm.log.gz
 ```
 
 #### Output:
@@ -58,7 +58,7 @@ zq 'cut server_tree_name' ntlm.log.gz # Shorthand for: zq '* | cut server_tree_n
 
 #### Example #2:
 ```zq-command
-zq 'count() by _path' *.log.gz  # Shorthand for: zq '* | count() by _path' *.log.gz
+zq -t 'count() by _path' *.log.gz  # Shorthand for: zq '* | count() by _path' *.log.gz
 ```
 
 #### Output:
@@ -288,7 +288,7 @@ In addition to testing for equality via `=`, other common comparison operators `
 
 For example, the following search finds connections that have transferred many bytes.
 
-#### Example: 
+#### Example:
 ```zq-command
 zq -f table 'orig_bytes > 1000000' *.log.gz
 ```


### PR DESCRIPTION
This commit makes (binary) zng the default for zq and zdx lookup.
It also adds a check to see if binary data is being written to
a terminal and exists with an error. -B overrides this check and
-t was added as a shortcut for "-f tzng" to save typing when
you want the text output.

There is code replicated between the two commands.   We should 
refactor this so there is a common package ("tools" or "zq") used 
across all the related zq tools to do common arg parsing, zng 
file reader/writer setup, schema-map config set, and so forth.
