### PR TITLE
Consistent span usage in api

### DIFF
--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -75,13 +75,12 @@ type ScannerStats struct {
 }
 
 type SpaceInfo struct {
-	Name          string   `json:"name"`
-	MinTime       *nano.Ts `json:"min_time,omitempty"`
-	MaxTime       *nano.Ts `json:"max_time,omitempty"`
-	Size          int64    `json:"size" unit:"bytes"`
-	PacketSupport bool     `json:"packet_support"`
-	PacketSize    int64    `json:"packet_size" unit:"bytes"`
-	PacketPath    string   `json:"packet_path"`
+	Name          string     `json:"name"`
+	Span          *nano.Span `json:"span,omitempty"`
+	Size          int64      `json:"size" unit:"bytes"`
+	PacketSupport bool       `json:"packet_support"`
+	PacketSize    int64      `json:"packet_size" unit:"bytes"`
+	PacketPath    string     `json:"packet_path"`
 }
 
 type StatusResponse struct {
@@ -101,14 +100,13 @@ type PacketPostRequest struct {
 }
 
 type PacketPostStatus struct {
-	Type           string   `json:"type"`
-	StartTime      nano.Ts  `json:"start_time"`
-	UpdateTime     nano.Ts  `json:"update_time"`
-	PacketSize     int64    `json:"packet_total_size" unit:"bytes"`
-	PacketReadSize int64    `json:"packet_read_size" unit:"bytes"`
-	SnapshotCount  int      `json:"snapshot_count"`
-	MinTime        *nano.Ts `json:"min_time,omitempty"`
-	MaxTime        *nano.Ts `json:"max_time,omitempty"`
+	Type           string     `json:"type"`
+	StartTime      nano.Ts    `json:"start_time"`
+	UpdateTime     nano.Ts    `json:"update_time"`
+	PacketSize     int64      `json:"packet_total_size" unit:"bytes"`
+	PacketReadSize int64      `json:"packet_read_size" unit:"bytes"`
+	SnapshotCount  int        `json:"snapshot_count"`
+	Span           *nano.Span `json:"span,omitempty"`
 }
 
 type LogPostRequest struct {
@@ -123,10 +121,9 @@ type LogPostWarning struct {
 }
 
 type LogPostStatus struct {
-	Type    string   `json:"type"`
-	MinTime *nano.Ts `json:"min_time,omitempty"`
-	MaxTime *nano.Ts `json:"max_time,omitempty"`
-	Size    int64    `json:"size" unit:"bytes"`
+	Type string     `json:"type"`
+	Span *nano.Span `json:"span,omitempty"`
+	Size int64      `json:"size" unit:"bytes"`
 }
 
 // PacketSearch are the query string args to the packet endpoint when searching

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -258,8 +258,8 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 		case <-ticker.C:
 		}
 
-		var minTs, maxTs *nano.Ts
-		if minTs, maxTs, err = s.GetTimes(); err != nil {
+		var span *nano.Span
+		if span, err = s.Span(); err != nil {
 			break
 		}
 		status := api.PacketPostStatus{
@@ -269,8 +269,7 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 			PacketSize:     proc.PcapSize,
 			PacketReadSize: proc.PcapReadSize(),
 			SnapshotCount:  proc.SnapshotCount(),
-			MinTime:        minTs,
-			MaxTime:        maxTs,
+			Span:           span,
 		}
 		if err := pipe.Send(status); err != nil {
 			logger.Warn("Error sending payload", zap.Error(err))

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -150,10 +150,9 @@ func TestSpaceInfo(t *testing.T) {
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	_ = postSpaceLogs(t, client, sp.Name, nil, false, src)
-	min, max := nano.Ts(1e9), nano.Ts(2e9)
+	span := nano.Span{1e9, 1e9}
 	expected := &api.SpaceInfo{
-		MinTime:       &min,
-		MaxTime:       &max,
+		Span:          &span,
 		Name:          sp.Name,
 		Size:          80,
 		PacketSupport: false,
@@ -324,12 +323,11 @@ func TestPostZngLogs(t *testing.T) {
 
 	payloads := postSpaceLogs(t, client, spaceName, nil, false, strings.Join(src1, "\n"), strings.Join(src2, "\n"))
 	status := payloads[len(payloads)-2].(*api.LogPostStatus)
-	min, max := nano.Ts(1e9), nano.Ts(2e9)
+	span := &nano.Span{1e9, 1e9}
 	require.Equal(t, &api.LogPostStatus{
-		Type:    "LogPostStatus",
-		MinTime: &min,
-		MaxTime: &max,
-		Size:    80,
+		Type: "LogPostStatus",
+		Span: span,
+		Size: 80,
 	}, status)
 
 	taskend := payloads[len(payloads)-1].(*api.TaskEnd)
@@ -342,8 +340,7 @@ func TestPostZngLogs(t *testing.T) {
 	info, err := client.SpaceInfo(context.Background(), spaceName)
 	require.NoError(t, err)
 	require.Equal(t, &api.SpaceInfo{
-		MinTime:       &min,
-		MaxTime:       &max,
+		Span:          span,
 		Name:          spaceName,
 		Size:          80,
 		PacketSupport: false,
@@ -372,12 +369,11 @@ func TestPostZngLogWarning(t *testing.T) {
 	assert.Regexp(t, ": line 3: bad format$", warn2.Warning)
 
 	status := payloads[len(payloads)-2].(*api.LogPostStatus)
-	ts := nano.Ts(1e9)
+	span := &nano.Span{nano.Ts(1e9), 0}
 	expected := &api.LogPostStatus{
-		Type:    "LogPostStatus",
-		MinTime: &ts,
-		MaxTime: &ts,
-		Size:    49,
+		Type: "LogPostStatus",
+		Span: span,
+		Size: 49,
 	}
 	require.Equal(t, expected, status)
 
@@ -428,12 +424,11 @@ func TestPostNDJSONLogs(t *testing.T) {
 		res := zngSearch(t, client, spaceName, "*")
 		require.Equal(t, expected, strings.TrimSpace(res))
 
-		min, max := nano.Ts(1e9), nano.Ts(2e9)
+		span := nano.Span{1e9, 1e9}
 		info, err := client.SpaceInfo(context.Background(), spaceName)
 		require.NoError(t, err)
 		require.Equal(t, &api.SpaceInfo{
-			MinTime:       &min,
-			MaxTime:       &max,
+			Span:          &span,
 			Name:          spaceName,
 			Size:          80,
 			PacketSupport: false,
@@ -487,12 +482,11 @@ func TestPostNDJSONLogWarning(t *testing.T) {
 	assert.Regexp(t, ": line 2: incomplete descriptor", warn2.Warning)
 
 	status := payloads[len(payloads)-2].(*api.LogPostStatus)
-	ts := nano.Ts(1e9)
+	span := nano.Span{1e9, 0}
 	expected := &api.LogPostStatus{
-		Type:    "LogPostStatus",
-		MinTime: &ts,
-		MaxTime: &ts,
-		Size:    25,
+		Type: "LogPostStatus",
+		Span: &span,
+		Size: 25,
 	}
 	require.Equal(t, expected, status)
 

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -150,7 +150,7 @@ func TestSpaceInfo(t *testing.T) {
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	_ = postSpaceLogs(t, client, sp.Name, nil, false, src)
-	span := nano.Span{1e9, 1e9}
+	span := nano.Span{Ts: 1e9, Dur: 1e9 + 1}
 	expected := &api.SpaceInfo{
 		Span:          &span,
 		Name:          sp.Name,
@@ -323,7 +323,7 @@ func TestPostZngLogs(t *testing.T) {
 
 	payloads := postSpaceLogs(t, client, spaceName, nil, false, strings.Join(src1, "\n"), strings.Join(src2, "\n"))
 	status := payloads[len(payloads)-2].(*api.LogPostStatus)
-	span := &nano.Span{1e9, 1e9}
+	span := &nano.Span{Ts: 1e9, Dur: 1e9 + 1}
 	require.Equal(t, &api.LogPostStatus{
 		Type: "LogPostStatus",
 		Span: span,
@@ -369,7 +369,7 @@ func TestPostZngLogWarning(t *testing.T) {
 	assert.Regexp(t, ": line 3: bad format$", warn2.Warning)
 
 	status := payloads[len(payloads)-2].(*api.LogPostStatus)
-	span := &nano.Span{nano.Ts(1e9), 0}
+	span := &nano.Span{Ts: nano.Ts(1e9), Dur: 1}
 	expected := &api.LogPostStatus{
 		Type: "LogPostStatus",
 		Span: span,
@@ -424,7 +424,7 @@ func TestPostNDJSONLogs(t *testing.T) {
 		res := zngSearch(t, client, spaceName, "*")
 		require.Equal(t, expected, strings.TrimSpace(res))
 
-		span := nano.Span{1e9, 1e9}
+		span := nano.Span{Ts: 1e9, Dur: 1e9 + 1}
 		info, err := client.SpaceInfo(context.Background(), spaceName)
 		require.NoError(t, err)
 		require.Equal(t, &api.SpaceInfo{
@@ -482,7 +482,7 @@ func TestPostNDJSONLogWarning(t *testing.T) {
 	assert.Regexp(t, ": line 2: incomplete descriptor", warn2.Warning)
 
 	status := payloads[len(payloads)-2].(*api.LogPostStatus)
-	span := nano.Span{1e9, 0}
+	span := nano.Span{Ts: 1e9, Dur: 1}
 	expected := &api.LogPostStatus{
 		Type: "LogPostStatus",
 		Span: &span,

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -56,8 +56,7 @@ func TestPacketPostSuccess(t *testing.T) {
 		info, err := p.client.SpaceInfo(context.Background(), p.space)
 		assert.NoError(t, err)
 		assert.Equal(t, p.space, info.Name)
-		assert.Equal(t, nano.Unix(1501770877, 471635000), *info.MinTime)
-		assert.Equal(t, nano.Unix(1501770880, 988247000), *info.MaxTime)
+		assert.Equal(t, nano.NewSpanTs(nano.Unix(1501770877, 471635000), nano.Unix(1501770880, 988247000)), *info.Span)
 		// Must use InDelta here because zeek randomly generates uids that
 		// vary in size.
 		assert.InDelta(t, 1437, info.Size, 10)
@@ -80,8 +79,7 @@ func TestPacketPostSuccess(t *testing.T) {
 		assert.Equal(t, status.PacketSize, info.Size())
 		assert.Equal(t, status.PacketReadSize, info.Size())
 		assert.Equal(t, 1, status.SnapshotCount)
-		assert.Equal(t, nano.Unix(1501770877, 471635000), *status.MinTime)
-		assert.Equal(t, nano.Unix(1501770880, 988247000), *status.MaxTime)
+		assert.Equal(t, nano.NewSpanTs(nano.Unix(1501770877, 471635000), nano.Unix(1501770880, 988247000)), *status.Span)
 	})
 	t.Run("TaskEndMessage", func(t *testing.T) {
 		status := p.payloads[len(p.payloads)-1].(*api.TaskEnd)

--- a/zqd/ingest/log.go
+++ b/zqd/ingest/log.go
@@ -125,7 +125,7 @@ func ingestLogs(ctx context.Context, pipe *api.JSONPipe, s *space.Space, req api
 	if tailW.r != nil {
 		min := nano.Min(tailW.r.Ts, headW.r.Ts)
 		max := nano.Max(tailW.r.Ts, headW.r.Ts)
-		if err = s.SetSpan(nano.NewSpanTs(min, max)); err != nil {
+		if err = s.SetSpan(nano.NewSpanTs(min, max+1)); err != nil {
 			return err
 		}
 	}

--- a/zqd/ingest/log.go
+++ b/zqd/ingest/log.go
@@ -123,7 +123,9 @@ func ingestLogs(ctx context.Context, pipe *api.JSONPipe, s *space.Space, req api
 		return err
 	}
 	if tailW.r != nil {
-		if err = s.SetTimes(tailW.r.Ts, headW.r.Ts); err != nil {
+		min := nano.Min(tailW.r.Ts, headW.r.Ts)
+		max := nano.Max(tailW.r.Ts, headW.r.Ts)
+		if err = s.SetSpan(nano.NewSpanTs(min, max)); err != nil {
 			return err
 		}
 	}
@@ -135,10 +137,9 @@ func ingestLogs(ctx context.Context, pipe *api.JSONPipe, s *space.Space, req api
 		return err
 	}
 	status := api.LogPostStatus{
-		Type:    "LogPostStatus",
-		MinTime: info.MinTime,
-		MaxTime: info.MaxTime,
-		Size:    info.Size,
+		Type: "LogPostStatus",
+		Span: info.Span,
+		Size: info.Size,
 	}
 	return pipe.Send(status)
 }

--- a/zqd/ingest/pcap.go
+++ b/zqd/ingest/pcap.go
@@ -112,7 +112,7 @@ func (p *Process) run(ctx context.Context) error {
 		os.Remove(p.space.DataPath(space.PcapIndexFile))
 		os.Remove(p.space.DataPath(space.AllZngFile))
 		p.space.SetPacketPath("")
-		p.space.UnsetTimes()
+		p.space.UnsetSpan()
 	}
 
 	ticker := time.NewTicker(time.Second)

--- a/zqd/ingest/pcap.go
+++ b/zqd/ingest/pcap.go
@@ -176,7 +176,7 @@ func (p *Process) indexPcap() error {
 	f.Close()
 	// grab span from index and use to generate space info min/max time.
 	span := idx.Span()
-	if err = p.space.SetTimes(span.Ts, span.End()); err != nil {
+	if err = p.space.SetSpan(span); err != nil {
 		return err
 	}
 	return os.Rename(tmppath, idxpath)

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -426,11 +426,8 @@ func (i info) Span() nano.Span {
 	return nano.NewSpanTs(i.MinTime, i.MaxTime)
 }
 
-// UnsetTimes nils out the cached time range value for the space.
-// XXX For right now this simply deletes the info file as nothing else is stored
-// there. When we get to brimsec/zq#541 the time range should be represented as
-// as a pointer to a nano.Span.
-func (s *Space) UnsetTimes() error {
+// UnsetSpan nils out the cached time span value for the space.
+func (s *Space) UnsetSpan() error {
 	return os.Remove(s.DataPath(infoFile))
 }
 


### PR DESCRIPTION
Make the api consistent by leveraging nano.Span when expressing time
ranges.

Note: I didn't change the info file to a span. This would require
a migration for older installations. I figure this isn't worth the
effort as at some point we'll probably change the way determine the
time span of a space.

closes #541