### PR TITLE
add zar mkdirs/rmdirs

### DIFF
--- a/archive/finder.go
+++ b/archive/finder.go
@@ -39,7 +39,7 @@ func Search(zardir string, rule Rule, pattern string, skipMissing bool) (bool, e
 			// No index for this rule.  Skip it if the skip boolean
 			// says it's ok.  Otherwise, we return ErrNotExist since
 			// the client was looking for something that wasn't indexed,
-			// and they probabl want to know.  T
+			// and they would probably want to know.
 			err = nil
 		} else {
 			err = fmt.Errorf("%s: %w", finder.Path(), err)

--- a/archive/walk.go
+++ b/archive/walk.go
@@ -1,0 +1,90 @@
+package archive
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type Visitor func(zardir string) error
+
+func IsZarDir(path string) bool {
+	return filepath.Ext(path) == zarExt
+}
+
+func ZarDirToLog(path string) string {
+	return strings.TrimRight(path, zarExt)
+}
+
+func LogToZarDir(path string) string {
+	return path + zarExt
+}
+
+// Walk descends a directory hierarchy looking for zar directories and
+// invokes the visitor on each log file with a zar dir, providing the path
+// of the log file and path of the zar dir.
+func Walk(dir string, visit Visitor) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("%q: %v", path, err)
+		}
+		if info.IsDir() && IsZarDir(path) {
+			if err := visit(path); err != nil {
+				return err
+			}
+			return filepath.SkipDir
+		}
+		// descend...
+		return nil
+	})
+}
+
+// MkDirs descends a directory hierarchy looking for file paths that match
+// the provided regular expression and creates a zar directory for each
+// such file path.
+func MkDirs(dir string, re *regexp.Regexp) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("%q: %v", path, err)
+		}
+		if info.IsDir() {
+			if IsZarDir(path) {
+				// don't create zar dirs inside of existing
+				// zar dirs
+				return filepath.SkipDir
+			}
+			// descend...
+			return nil
+		}
+		if re.Match([]byte(path)) {
+			zardir := LogToZarDir(path)
+			if err := os.Mkdir(zardir, 0700); err != nil {
+				if os.IsExist(err) {
+					err = nil
+				}
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// RmDirs descends a directory hierarchy looking for zar dirs and remove
+// each such directory and all of its contents.
+func RmDirs(dir string) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("%q: %v", path, err)
+		}
+		if info.IsDir() && IsZarDir(path) {
+			if err := os.RemoveAll(path); err != nil {
+				return err
+			}
+			return filepath.SkipDir
+		}
+		// descend...
+		return nil
+	})
+}

--- a/cmd/zar/find/command.go
+++ b/cmd/zar/find/command.go
@@ -40,12 +40,14 @@ func init() {
 
 type Command struct {
 	*root.Command
-	dir string
+	dir         string
+	skipMissing bool
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	f.StringVar(&c.dir, "d", ".", "directory to descend")
+	f.BoolVar(&c.skipMissing, "Q", false, "skip errors caused by missing index files ")
 	return c, nil
 }
 
@@ -72,7 +74,7 @@ func (c *Command) Run(args []string) error {
 		}
 		wg.Done()
 	}()
-	err = archive.Find(c.dir, rule, pattern, hits)
+	err = archive.Find(c.dir, rule, pattern, hits, c.skipMissing)
 	close(hits)
 	wg.Wait()
 	return err

--- a/cmd/zar/index/command.go
+++ b/cmd/zar/index/command.go
@@ -17,8 +17,9 @@ var Index = &charm.Spec{
 	Short: "create index files for zng files",
 	Long: `
 zar index descends the directory argument starting at dir and looks
-for zng files.  Each zng file fund is indexed according to the one or
-more indexing rules provided.
+for files with zar directories.  Each such file found is indexed according
+to the one or more indexing rules provided, and the resulting indexes
+are written to that file's zar directoryr.
 
 A pattern is either a field name or a ":" followed by a zng type name.
 For example, to index the all fields of type port and the field id.orig_h,
@@ -26,10 +27,7 @@ you would run
 
 	zar index -d /path/to/logs id.orig_h :port
 
-Each pattern results a separate zdx index file for each zng file found.  The zdx
-files for a given zng file are written to a sub-directory of the directory
-containing that file, where the name of the sub-directory is a concatenation
-of the zng file name and the suffix ".zar".
+Each pattern results a separate zdx index file for each log file found.
 `,
 	New: New,
 }

--- a/cmd/zar/ls/command.go
+++ b/cmd/zar/ls/command.go
@@ -1,0 +1,54 @@
+package ls
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/brimsec/zq/archive"
+	"github.com/brimsec/zq/cmd/zar/root"
+	"github.com/mccanne/charm"
+)
+
+var Ls = &charm.Spec{
+	Name:  "ls",
+	Usage: "ls [-d <dir>]",
+	Short: "list the zar directories in an archive",
+	Long: `
+"zar ls" descends the directory given by the -d option and prints out
+the path of each zar directory.  TBD: In the future, this command could
+display a detailed summary of the context each zar directory.
+`,
+	New: New,
+}
+
+func init() {
+	root.Zar.Add(Ls)
+}
+
+type Command struct {
+	*root.Command
+	dir     string
+	pattern string
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	if len(args) == 0 {
+		return errors.New("zar ls: no directory specified")
+	}
+	for _, dir := range args {
+		err := archive.Walk(dir, func(zardir string) error {
+			fmt.Println(zardir)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/zar/ls/command.go
+++ b/cmd/zar/ls/command.go
@@ -12,11 +12,12 @@ import (
 
 var Ls = &charm.Spec{
 	Name:  "ls",
-	Usage: "ls [-d <dir>]",
+	Usage: "ls dir [dir ...]",
 	Short: "list the zar directories in an archive",
 	Long: `
-"zar ls" descends the directory given by the -d option and prints out
-the path of each zar directory.  TBD: In the future, this command could
+"zar ls" descends the one or more directories specified and prints out
+the path of each zar directory contained with those top-level directories.
+TBD: In the future, this command could
 display a detailed summary of the context each zar directory.
 `,
 	New: New,
@@ -28,8 +29,6 @@ func init() {
 
 type Command struct {
 	*root.Command
-	dir     string
-	pattern string
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {

--- a/cmd/zar/main.go
+++ b/cmd/zar/main.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/brimsec/zq/cmd/zar/chop"
 	_ "github.com/brimsec/zq/cmd/zar/find"
 	_ "github.com/brimsec/zq/cmd/zar/index"
+	_ "github.com/brimsec/zq/cmd/zar/ls"
 	_ "github.com/brimsec/zq/cmd/zar/mkdirs"
 	_ "github.com/brimsec/zq/cmd/zar/rmdirs"
 	"github.com/brimsec/zq/cmd/zar/root"

--- a/cmd/zar/main.go
+++ b/cmd/zar/main.go
@@ -7,6 +7,8 @@ import (
 	_ "github.com/brimsec/zq/cmd/zar/chop"
 	_ "github.com/brimsec/zq/cmd/zar/find"
 	_ "github.com/brimsec/zq/cmd/zar/index"
+	_ "github.com/brimsec/zq/cmd/zar/mkdirs"
+	_ "github.com/brimsec/zq/cmd/zar/rmdirs"
 	"github.com/brimsec/zq/cmd/zar/root"
 )
 

--- a/cmd/zar/mkdirs/command.go
+++ b/cmd/zar/mkdirs/command.go
@@ -1,0 +1,59 @@
+package mkdirs
+
+import (
+	"errors"
+	"flag"
+	"regexp"
+
+	"github.com/brimsec/zq/archive"
+	"github.com/brimsec/zq/cmd/zar/root"
+	"github.com/brimsec/zq/reglob"
+	"github.com/mccanne/charm"
+)
+
+var MkDirs = &charm.Spec{
+	Name:  "mkdirs",
+	Usage: "mkdirs [-d <dir>] [glob]",
+	Short: "walk a directory tree and create zar directories",
+	Long: `
+"zar mkdirs" descends the directory given by the -d option looking for
+log files that match the glob-style expression.  If the glob is not provided,
+"*.zng" is used as a default.  For each matched file,
+mkdirs creates a zar directory if it does not already exist.  This conveniently
+separates the problem of identifying the log files that should have zar
+directories from the commands that operate on the content of the directories.
+The zar directory's path name is comprised of the file path concatenated
+with the extension ".zar".
+`,
+	New: New,
+}
+
+func init() {
+	root.Zar.Add(MkDirs)
+}
+
+type Command struct {
+	*root.Command
+	dir string
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	f.StringVar(&c.dir, "d", ".", "directory to descend")
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	if len(args) > 1 {
+		return errors.New("zar mkdirs: too many arguments")
+	}
+	pattern := "*.zng"
+	if len(args) == 1 {
+		pattern = args[0]
+	}
+	re, err := regexp.Compile(reglob.Reglob(pattern))
+	if err != nil {
+		return err
+	}
+	return archive.MkDirs(c.dir, re)
+}

--- a/cmd/zar/rmdirs/command.go
+++ b/cmd/zar/rmdirs/command.go
@@ -11,7 +11,7 @@ import (
 
 var RmDirs = &charm.Spec{
 	Name:  "rmdirs",
-	Usage: "rmdirs [-d <dir>]",
+	Usage: "rmdirs <dir>",
 	Short: "walk a directory tree and remove zar directories",
 	Long: `
 "zar rmdirs" descends the directory given by the -d option looking for

--- a/cmd/zar/rmdirs/command.go
+++ b/cmd/zar/rmdirs/command.go
@@ -28,19 +28,16 @@ func init() {
 
 type Command struct {
 	*root.Command
-	dir     string
-	pattern string
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
-	f.StringVar(&c.dir, "d", ".", "directory to descend")
 	return c, nil
 }
 
 func (c *Command) Run(args []string) error {
-	if len(args) != 0 {
-		return errors.New("zar mkdirs: unknown arguments on command line")
+	if len(args) != 1 {
+		return errors.New("zar rmdirs: must specified top-level directory to walk and delete")
 	}
-	return archive.RmDirs(c.dir)
+	return archive.RmDirs(args[0])
 }

--- a/cmd/zar/rmdirs/command.go
+++ b/cmd/zar/rmdirs/command.go
@@ -1,0 +1,46 @@
+package rmdirs
+
+import (
+	"errors"
+	"flag"
+
+	"github.com/brimsec/zq/archive"
+	"github.com/brimsec/zq/cmd/zar/root"
+	"github.com/mccanne/charm"
+)
+
+var RmDirs = &charm.Spec{
+	Name:  "rmdirs",
+	Usage: "rmdirs [-d <dir>]",
+	Short: "walk a directory tree and remove zar directories",
+	Long: `
+"zar rmdirs" descends the directory given by the -d option looking for
+zar directories and removes them along with their contents.  WARNING:
+this is no prompting for the files and directories that will be removed
+so use carefully.
+`,
+	New: New,
+}
+
+func init() {
+	root.Zar.Add(RmDirs)
+}
+
+type Command struct {
+	*root.Command
+	dir     string
+	pattern string
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	f.StringVar(&c.dir, "d", ".", "directory to descend")
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	if len(args) != 0 {
+		return errors.New("zar mkdirs: unknown arguments on command line")
+	}
+	return archive.RmDirs(c.dir)
+}

--- a/tests/suite/zar/basic.yaml
+++ b/tests/suite/zar/basic.yaml
@@ -1,7 +1,7 @@
 script: |
   mkdir logs
   zar chop -q -b 2500 -d ./logs babble.tzng
-  zar mkdirs -d ./logs
+  zar mkdirs ./logs
   zar index -q -d ./logs v
   zar find -d ./logs v=106
   echo ===

--- a/tests/suite/zar/basic.yaml
+++ b/tests/suite/zar/basic.yaml
@@ -1,6 +1,7 @@
 script: |
   mkdir logs
   zar chop -q -b 2500 -d ./logs babble.tzng
+  zar mkdirs -d ./logs
   zar index -q -d ./logs v
   zar find -d ./logs v=106
   echo ===

--- a/tests/suite/zar/dirs.yaml
+++ b/tests/suite/zar/dirs.yaml
@@ -1,0 +1,34 @@
+script: |
+  mkdir logs
+  echo -n > logs/f1.zng
+  echo -n > logs/f2.zng
+  echo -n > logs/f3.ndjson
+  zar mkdirs -d logs "*.zng"
+  find logs
+  echo ===
+  zar rmdirs -d logs
+  find logs
+  echo ===
+  zar mkdirs -d logs "*.ndjson"
+  find logs
+
+outputs:
+  - name: stdout
+    data: |
+      logs
+      logs/f1.zng
+      logs/f2.zng
+      logs/f3.ndjson
+      logs/f2.zng.zar
+      logs/f1.zng.zar
+      ===
+      logs
+      logs/f1.zng
+      logs/f2.zng
+      logs/f3.ndjson
+      ===
+      logs
+      logs/f3.ndjson.zar
+      logs/f1.zng
+      logs/f2.zng
+      logs/f3.ndjson

--- a/tests/suite/zar/dirs.yaml
+++ b/tests/suite/zar/dirs.yaml
@@ -4,23 +4,23 @@ script: |
   echo -n > logs/f2.zng
   echo -n > logs/f3.ndjson
   zar mkdirs -d logs "*.zng"
-  find logs
+  find logs | sort
   echo ===
   zar rmdirs -d logs
-  find logs
+  find logs | sort
   echo ===
   zar mkdirs -d logs "*.ndjson"
-  find logs
+  find logs | sort
 
 outputs:
   - name: stdout
     data: |
       logs
       logs/f1.zng
-      logs/f2.zng
-      logs/f3.ndjson
-      logs/f2.zng.zar
       logs/f1.zng.zar
+      logs/f2.zng
+      logs/f2.zng.zar
+      logs/f3.ndjson
       ===
       logs
       logs/f1.zng
@@ -28,7 +28,7 @@ outputs:
       logs/f3.ndjson
       ===
       logs
+      logs/f1.zng
+      logs/f2.zng
+      logs/f3.ndjson
       logs/f3.ndjson.zar
-      logs/f1.zng
-      logs/f2.zng
-      logs/f3.ndjson

--- a/tests/suite/zar/dirs.yaml
+++ b/tests/suite/zar/dirs.yaml
@@ -3,13 +3,13 @@ script: |
   echo -n > logs/f1.zng
   echo -n > logs/f2.zng
   echo -n > logs/f3.ndjson
-  zar mkdirs -d logs "*.zng"
+  zar mkdirs -p "*.zng" logs
   find logs | sort
   echo ===
-  zar rmdirs -d logs
+  zar rmdirs logs
   find logs | sort
   echo ===
-  zar mkdirs -d logs "*.ndjson"
+  zar mkdirs -p "*.ndjson" logs
   find logs | sort
 
 outputs:

--- a/ztest/shell.go
+++ b/ztest/shell.go
@@ -14,7 +14,7 @@ func RunShell(dir *Dir, bindir, script string, stdin io.Reader) (string, string,
 	} else {
 		cmd = exec.Command("bash", "-c", script)
 	}
-	cmd.Env = []string{"PATH=" + bindir}
+	cmd.Env = []string{"PATH=/bin:/usr/bin:" + bindir}
 	cmd.Dir = dir.Path()
 	cmd.Stdin = stdin
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
This commit makes the creation of zar directories in an archive
explicit and adds the command "zar mkdirs" to create directories
and "zar rmdirs" to remove them.

We also added /bin and /usr/bin to the PATH in ztest script commands
so ls, find, etc now work.