### PR TITLE
driver.Run(): take a <-chan time.Time rather than a time.Duration

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -239,7 +239,7 @@ func (c *Command) Run(args []string) error {
 	if !c.quiet {
 		d.SetWarningsWriter(os.Stderr)
 	}
-	return driver.Run(mux, d, 0)
+	return driver.Run(mux, d, nil)
 }
 
 func (c *Command) errorf(format string, args ...interface{}) {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -17,16 +17,11 @@ type Driver interface {
 	Stats(api.ScannerStats) error
 }
 
-func Run(out *MuxOutput, d Driver, statsInterval time.Duration) error {
+func Run(out *MuxOutput, d Driver, statsTicker <-chan time.Time) error {
 	//stats are zero at this point.
 	var stats api.ScannerStats
-	if statsInterval == 0 {
-		statsInterval = time.Second * 10
-	}
-	ticker := time.NewTicker(statsInterval)
-	defer ticker.Stop()
 	for !out.Complete() {
-		chunk := out.Pull(ticker.C)
+		chunk := out.Pull(statsTicker)
 		if chunk.Err != nil {
 			if chunk.Err == ErrTimeout {
 				/* not yet

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/scanner"
@@ -40,7 +39,7 @@ func TestMuxDriver(t *testing.T) {
 		assert.NoError(t, err)
 		c := counter{}
 		d := NewCLI(&c)
-		err = Run(flowgraph, d, time.Second)
+		err = Run(flowgraph, d, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, c.n)
 	})
@@ -51,7 +50,7 @@ func TestMuxDriver(t *testing.T) {
 		assert.NoError(t, err)
 		cs := []zbuf.Writer{&counter{}, &counter{}}
 		d := NewCLI(cs...)
-		err = Run(flowgraph, d, time.Second)
+		err = Run(flowgraph, d, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, cs[0].(*counter).n)
 		assert.Equal(t, 1, cs[1].(*counter).n)

--- a/driver/mux.go
+++ b/driver/mux.go
@@ -94,18 +94,15 @@ func (m *MuxOutput) Pull(timeout <-chan time.Time) MuxResult {
 		return MuxResult{proc.Result{}, -1, ""}
 	}
 	var result MuxResult
-	if timeout == nil {
-		result = <-m.in
-	} else {
-		select {
-		case <-timeout:
-			return MuxResult{proc.Result{nil, ErrTimeout}, 0, ""}
-		case result = <-m.in:
-			// empty
-		case warning := <-m.ctx.Warnings:
-			return MuxResult{proc.Result{}, 0, warning}
-		}
+	select {
+	case <-timeout:
+		return MuxResult{proc.Result{nil, ErrTimeout}, 0, ""}
+	case result = <-m.in:
+		// empty
+	case warning := <-m.ctx.Warnings:
+		return MuxResult{proc.Result{}, 0, warning}
 	}
+
 	if proc.EOS(result.Batch, result.Err) {
 		m.runners--
 	}

--- a/pkg/test/internal.go
+++ b/pkg/test/internal.go
@@ -70,7 +70,7 @@ func (i *Internal) Run() (string, error) {
 		return "", err
 	}
 	d := driver.NewCLI(output)
-	if err := driver.Run(mux, d, 0); err != nil {
+	if err := driver.Run(mux, d, nil); err != nil {
 		return "", err
 	}
 	return string(output.Bytes()), nil

--- a/zqd/ingest/log.go
+++ b/zqd/ingest/log.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/nano"
@@ -113,7 +114,10 @@ func ingestLogs(ctx context.Context, pipe *api.JSONPipe, s *space.Space, req api
 		startTime: nano.Now(),
 		writers:   []zbuf.Writer{zw, &headW, &tailW},
 	}
-	err = driver.Run(mux, d, search.StatsInterval)
+
+	statsTicker := time.NewTicker(search.StatsInterval)
+	defer statsTicker.Stop()
+	err = driver.Run(mux, d, statsTicker.C)
 	if err != nil {
 		zngfile.Close()
 		os.Remove(zngfile.Name())

--- a/zqd/ingest/pcap.go
+++ b/zqd/ingest/pcap.go
@@ -277,7 +277,9 @@ func (p *Process) ingestLogs(ctx context.Context, w zbuf.Writer, r zbuf.Reader, 
 		startTime: nano.Now(),
 		writers:   []zbuf.Writer{w},
 	}
-	return driver.Run(mux, d, search.StatsInterval)
+	statsTicker := time.NewTicker(search.StatsInterval)
+	defer statsTicker.Stop()
+	return driver.Run(mux, d, statsTicker.C)
 }
 
 func (p *Process) Write(b []byte) (int, error) {

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -66,7 +66,9 @@ func (s *Search) Run(output Output) error {
 		startTime: nano.Now(),
 	}
 	d.start(0)
-	if err := driver.Run(s.mux, d, StatsInterval); err != nil {
+	statsTicker := time.NewTicker(StatsInterval)
+	defer statsTicker.Stop()
+	if err := driver.Run(s.mux, d, statsTicker.C); err != nil {
 		d.abort(0, err)
 		return err
 	}

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -607,7 +607,7 @@ func runzq(bindir, ZQL, outputFormat, outputFlags string, inputs ...string) (out
 	}
 	d := driver.NewCLI(zw)
 	d.SetWarningsWriter(&errbuf)
-	err = driver.Run(muxOutput, d, 0)
+	err = driver.Run(muxOutput, d, nil)
 	if err2 := zw.Flush(); err == nil {
 		err = err2
 	}


### PR DESCRIPTION
Following @nwt and @mattnibs suggestion in https://github.com/brimsec/zq/pull/549#pullrequestreview-391636896

closes #554 