### PR TITLE
zqd api renaming: s/Packet/Pcap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test-heavy: build $(SAMPLEDATA)
 	@go test -v -tags=heavy ./tests
 
 test-zeek: bin/$(ZEEKPATH)
-	@ZEEK=$(CURDIR)/bin/$(ZEEKPATH)/zeek go test -v -run=PacketPost -tags=zeek ./zqd
+	@ZEEK=$(CURDIR)/bin/$(ZEEKPATH)/zeek go test -v -run=PcapPost -tags=zeek ./zqd
 
 perf-compare: build $(SAMPLEDATA)
 	scripts/comparison-test.sh

--- a/pcap/index.go
+++ b/pcap/index.go
@@ -104,7 +104,7 @@ func CreateIndex(r io.Reader, size int) (Index, error) {
 		index = append(index, *section)
 	}
 	if len(index) == 0 {
-		return nil, ErrNoPacketsFound
+		return nil, ErrNoPcapsFound
 	}
 	return index, nil
 }

--- a/pcap/search.go
+++ b/pcap/search.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	// ErrNoPacketsFound is an error indicating no packets have been found.
-	ErrNoPacketsFound = zqe.E(zqe.NotFound, "no packets found")
+	// ErrNoPcapsFound is an error indicating no packets have been found.
+	ErrNoPcapsFound = zqe.E(zqe.NotFound, "no packets found")
 )
 
 type PacketFilter func(gopacket.Packet) bool
@@ -163,7 +163,7 @@ func (s *Search) Reader(ctx context.Context, r pcapio.Reader) (*SearchReader, er
 		return nil, err
 	}
 	if len(reader.window) == 0 {
-		return nil, ErrNoPacketsFound
+		return nil, ErrNoPcapsFound
 	}
 	return reader, nil
 }

--- a/pcap/slicer.go
+++ b/pcap/slicer.go
@@ -25,7 +25,7 @@ func GenerateSlices(index Index, span nano.Span) ([]slicer.Slice, error) {
 	var slices []slicer.Slice
 	for _, section := range index {
 		pslice, err := FindPacketSlice(section.Index, span)
-		if err == ErrNoPacketsFound {
+		if err == ErrNoPcapsFound {
 			continue
 		}
 		if err != nil {
@@ -41,12 +41,12 @@ func GenerateSlices(index Index, span nano.Span) ([]slicer.Slice, error) {
 
 func FindPacketSlice(e ranger.Envelope, span nano.Span) (slicer.Slice, error) {
 	if len(e) == 0 {
-		return slicer.Slice{}, ErrNoPacketsFound
+		return slicer.Slice{}, ErrNoPcapsFound
 	}
 	d := e.FindSmallestDomain(ranger.Range{uint64(span.Ts), uint64(span.End())})
 	gap := d.X1 - d.X0
 	if gap == 0 {
-		return slicer.Slice{}, ErrNoPacketsFound
+		return slicer.Slice{}, ErrNoPcapsFound
 	}
 	return slicer.Slice{d.X0, d.X1 - d.X0}, nil
 }

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -73,12 +73,12 @@ type ScannerStats struct {
 }
 
 type SpaceInfo struct {
-	Name          string     `json:"name"`
-	Span          *nano.Span `json:"span,omitempty"`
-	Size          int64      `json:"size" unit:"bytes"`
-	PacketSupport bool       `json:"packet_support"`
-	PacketSize    int64      `json:"packet_size" unit:"bytes"`
-	PacketPath    string     `json:"packet_path"`
+	Name        string     `json:"name"`
+	Span        *nano.Span `json:"span,omitempty"`
+	Size        int64      `json:"size" unit:"bytes"`
+	PcapSupport bool       `json:"pcap_support"`
+	PcapSize    int64      `json:"pcap_size" unit:"bytes"`
+	PcapPath    string     `json:"pcap_path"`
 }
 
 type StatusResponse struct {
@@ -93,18 +93,18 @@ type SpacePostRequest struct {
 
 type SpacePostResponse SpacePostRequest
 
-type PacketPostRequest struct {
+type PcapPostRequest struct {
 	Path string `json:"path"`
 }
 
-type PacketPostStatus struct {
-	Type           string     `json:"type"`
-	StartTime      nano.Ts    `json:"start_time"`
-	UpdateTime     nano.Ts    `json:"update_time"`
-	PacketSize     int64      `json:"packet_total_size" unit:"bytes"`
-	PacketReadSize int64      `json:"packet_read_size" unit:"bytes"`
-	SnapshotCount  int        `json:"snapshot_count"`
-	Span           *nano.Span `json:"span,omitempty"`
+type PcapPostStatus struct {
+	Type          string     `json:"type"`
+	StartTime     nano.Ts    `json:"start_time"`
+	UpdateTime    nano.Ts    `json:"update_time"`
+	PcapSize      int64      `json:"pcap_total_size" unit:"bytes"`
+	PcapReadSize  int64      `json:"pcap_read_size" unit:"bytes"`
+	SnapshotCount int        `json:"snapshot_count"`
+	Span          *nano.Span `json:"span,omitempty"`
 }
 
 type LogPostRequest struct {
@@ -124,9 +124,9 @@ type LogPostStatus struct {
 	LogReadSize  int64  `json:"log_read_size" unit:"bytes"`
 }
 
-// PacketSearch are the query string args to the packet endpoint when searching
+// PcapSearch are the query string args to the packet endpoint when searching
 // for packets within a connection 5-tuple.
-type PacketSearch struct {
+type PcapSearch struct {
 	Span    nano.Span
 	Proto   string `validate:"required"`
 	SrcHost net.IP `validate:"required"`
@@ -136,7 +136,7 @@ type PacketSearch struct {
 }
 
 // ToQuery transforms a packet search into a url.Values.
-func (ps *PacketSearch) ToQuery() url.Values {
+func (ps *PcapSearch) ToQuery() url.Values {
 	tssec, tsns := ps.Span.Ts.Split()
 	dursec := int(ps.Span.Dur / 1000000000)
 	durns := int(int64(ps.Span.Dur) - int64(dursec)*1000000000)
@@ -158,7 +158,7 @@ func (ps *PacketSearch) ToQuery() url.Values {
 }
 
 // FromQuery parses a query string and populates the receiver's values.
-func (ps *PacketSearch) FromQuery(v url.Values) error {
+func (ps *PcapSearch) FromQuery(v url.Values) error {
 	var err error
 	var tsSec, tsNs, durSec, durNs int64
 	if tsSec, err = strconv.ParseInt(v.Get("ts_sec"), 10, 64); err != nil {

--- a/zqd/api/connection.go
+++ b/zqd/api/connection.go
@@ -195,11 +195,11 @@ func (c *Connection) Search(ctx context.Context, search SearchRequest) (Search, 
 	return NewZngSearch(r), nil
 }
 
-func (c *Connection) PacketPost(ctx context.Context, space string, payload PacketPostRequest) (*Stream, error) {
+func (c *Connection) PcapPost(ctx context.Context, space string, payload PcapPostRequest) (*Stream, error) {
 	req := c.Request(ctx).
 		SetBody(payload)
 	req.Method = http.MethodPost
-	req.URL = path.Join("/space", url.PathEscape(space), "packet")
+	req.URL = path.Join("/space", url.PathEscape(space), "pcap")
 	r, err := c.stream(req)
 	if err != nil {
 		return nil, err
@@ -208,11 +208,11 @@ func (c *Connection) PacketPost(ctx context.Context, space string, payload Packe
 	return NewStream(jsonpipe), nil
 }
 
-func (c *Connection) PcapSearch(ctx context.Context, space string, payload PacketSearch) (*PcapReadCloser, error) {
+func (c *Connection) PcapSearch(ctx context.Context, space string, payload PcapSearch) (*PcapReadCloser, error) {
 	req := c.Request(ctx).
 		SetQueryParamsFromValues(payload.ToQuery())
 	req.Method = http.MethodGet
-	req.URL = path.Join("/space", url.PathEscape(space), "packet")
+	req.URL = path.Join("/space", url.PathEscape(space), "pcap")
 	r, err := c.stream(req)
 	if err != nil {
 		if r, ok := err.(*ErrorResponse); ok && r.StatusCode() == http.StatusNotFound {

--- a/zqd/api/unpack.go
+++ b/zqd/api/unpack.go
@@ -30,8 +30,8 @@ func unpack(b []byte) (interface{}, error) {
 		out = &SearchStats{}
 	case "SearchEnd":
 		out = &SearchEnd{}
-	case "PacketPostStatus":
-		out = &PacketPostStatus{}
+	case "PcapPostStatus":
+		out = &PcapPostStatus{}
 	case "LogPostStatus":
 		out = &LogPostStatus{}
 	case "LogPostWarning":

--- a/zqd/handler.go
+++ b/zqd/handler.go
@@ -2,6 +2,7 @@ package zqd
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -40,6 +41,12 @@ func NewHandler(core *Core, logger *zap.Logger) http.Handler {
 	})
 	h.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok"))
+	})
+	// XXX This can be removed once a new release has been cut and added to
+	// brim.
+	h.HandleFunc("/space/{space}/packet", func(w http.ResponseWriter, r *http.Request) {
+		name := mux.Vars(r)["space"]
+		http.Redirect(w, r, fmt.Sprintf("/space/%s/pcap", name), http.StatusPermanentRedirect)
 	})
 	return h
 }

--- a/zqd/handler.go
+++ b/zqd/handler.go
@@ -30,8 +30,8 @@ func NewHandler(core *Core, logger *zap.Logger) http.Handler {
 	h.Handle("/space", handleSpacePost).Methods("POST")
 	h.Handle("/space/{space}", handleSpaceGet).Methods("GET")
 	h.Handle("/space/{space}", handleSpaceDelete).Methods("DELETE")
-	h.Handle("/space/{space}/packet", handlePacketSearch).Methods("GET")
-	h.Handle("/space/{space}/packet", handlePacketPost).Methods("POST")
+	h.Handle("/space/{space}/pcap", handlePcapSearch).Methods("GET")
+	h.Handle("/space/{space}/pcap", handlePcapPost).Methods("POST")
 	h.Handle("/space/{space}/log", handleLogPost).Methods("POST")
 	h.Handle("/search", handleSearch).Methods("POST")
 	h.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -118,7 +118,7 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func handlePacketSearch(c *Core, w http.ResponseWriter, r *http.Request) {
+func handlePcapSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	s := extractSpace(c, w, r)
 	if s == nil {
 		return
@@ -131,13 +131,13 @@ func handlePacketSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 	defer cancel()
 
-	var req api.PacketSearch
+	var req api.PcapSearch
 	if err := req.FromQuery(r.URL.Query()); err != nil {
 		respondError(c, w, r, zqe.E(zqe.Invalid, err))
 		return
 	}
 	reader, err := s.PcapSearch(ctx, req)
-	if err == pcap.ErrNoPacketsFound {
+	if err == pcap.ErrNoPcapsFound {
 		respondError(c, w, r, zqe.E(zqe.NotFound, err))
 		return
 	}
@@ -212,7 +212,7 @@ func handleSpaceDelete(c *Core, w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
+func handlePcapPost(c *Core, w http.ResponseWriter, r *http.Request) {
 	if !c.HasZeek() {
 		respondError(c, w, r, zqe.E(zqe.Invalid, "packet post not supported: zeek not found"))
 		return
@@ -231,7 +231,7 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 	defer cancel()
 
-	var req api.PacketPostRequest
+	var req api.PcapPostRequest
 	if !request(c, w, r, &req) {
 		return
 	}
@@ -265,14 +265,14 @@ func handlePacketPost(c *Core, w http.ResponseWriter, r *http.Request) {
 		if span, err = s.Span(); err != nil {
 			break
 		}
-		status := api.PacketPostStatus{
-			Type:           "PacketPostStatus",
-			StartTime:      proc.StartTime,
-			UpdateTime:     nano.Now(),
-			PacketSize:     proc.PcapSize,
-			PacketReadSize: proc.PcapReadSize(),
-			SnapshotCount:  proc.SnapshotCount(),
-			Span:           span,
+		status := api.PcapPostStatus{
+			Type:          "PcapPostStatus",
+			StartTime:     proc.StartTime,
+			UpdateTime:    nano.Now(),
+			PcapSize:      proc.PcapSize,
+			PcapReadSize:  proc.PcapReadSize(),
+			SnapshotCount: proc.SnapshotCount(),
+			Span:          span,
 		}
 		if err := pipe.Send(status); err != nil {
 			logger.Warn("Error sending payload", zap.Error(err))

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -198,10 +198,10 @@ func TestSpaceInfo(t *testing.T) {
 	_ = postSpaceLogs(t, client, sp.Name, nil, false, src)
 	span := nano.Span{Ts: 1e9, Dur: 1e9 + 1}
 	expected := &api.SpaceInfo{
-		Span:          &span,
-		Name:          sp.Name,
-		Size:          80,
-		PacketSupport: false,
+		Span:        &span,
+		Name:        sp.Name,
+		Size:        80,
+		PcapSupport: false,
 	}
 	info, err := client.SpaceInfo(ctx, sp.Name)
 	require.NoError(t, err)
@@ -217,9 +217,9 @@ func TestSpaceInfoNoData(t *testing.T) {
 	info, err := client.SpaceInfo(ctx, sp.Name)
 	require.NoError(t, err)
 	expected := &api.SpaceInfo{
-		Name:          sp.Name,
-		Size:          0,
-		PacketSupport: false,
+		Name:        sp.Name,
+		Size:        0,
+		PcapSupport: false,
 	}
 	require.Equal(t, expected, info)
 }
@@ -401,10 +401,10 @@ func TestPostZngLogs(t *testing.T) {
 	info, err := client.SpaceInfo(context.Background(), spaceName)
 	require.NoError(t, err)
 	require.Equal(t, &api.SpaceInfo{
-		Span:          span,
-		Name:          spaceName,
-		Size:          80,
-		PacketSupport: false,
+		Span:        span,
+		Name:        spaceName,
+		Size:        80,
+		PcapSupport: false,
 	}, info)
 }
 
@@ -488,10 +488,10 @@ func TestPostNDJSONLogs(t *testing.T) {
 		info, err := client.SpaceInfo(context.Background(), spaceName)
 		require.NoError(t, err)
 		require.Equal(t, &api.SpaceInfo{
-			Span:          &span,
-			Name:          spaceName,
-			Size:          80,
-			PacketSupport: false,
+			Span:        &span,
+			Name:        spaceName,
+			Size:        80,
+			PcapSupport: false,
 		}, info)
 	}
 	t.Run("plain", func(t *testing.T) {
@@ -572,11 +572,11 @@ func TestPostLogStopErr(t *testing.T) {
 	assert.Regexp(t, ": format detection error.*", last.Error.Message)
 }
 
-func TestDeleteDuringPacketPost(t *testing.T) {
+func TestDeleteDuringPcapPost(t *testing.T) {
 	c, client, done := newCore(t)
 	defer done()
 
-	spaceName := "deleteDuringPacketPost"
+	spaceName := "deleteDuringPcapPost"
 	pcapfile := "./testdata/valid.pcap"
 
 	_, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: spaceName})
@@ -590,11 +590,11 @@ func TestDeleteDuringPacketPost(t *testing.T) {
 	c.ZeekLauncher = testZeekLauncher(nil, waitFn)
 
 	var wg sync.WaitGroup
-	packetPostErr := make(chan error)
+	pcapPostErr := make(chan error)
 
 	wg.Add(1)
 	doPost := func() error {
-		stream, err := client.PacketPost(context.Background(), spaceName, api.PacketPostRequest{pcapfile})
+		stream, err := client.PcapPost(context.Background(), spaceName, api.PcapPostRequest{pcapfile})
 		if err != nil {
 			return err
 		}
@@ -619,14 +619,14 @@ func TestDeleteDuringPacketPost(t *testing.T) {
 		return *taskEnd.Error
 	}
 	go func() {
-		packetPostErr <- doPost()
+		pcapPostErr <- doPost()
 	}()
 
 	wg.Wait()
 	err = client.SpaceDelete(context.Background(), spaceName)
 	require.NoError(t, err)
 
-	require.Error(t, <-packetPostErr, "context canceled")
+	require.Error(t, <-pcapPostErr, "context canceled")
 }
 
 // search runs the provided zql program as a search on the provided

--- a/zqd/ingest/pcap.go
+++ b/zqd/ingest/pcap.go
@@ -77,7 +77,7 @@ func Pcap(ctx context.Context, s *space.Space, pcap string, zlauncher zeek.Launc
 		os.Remove(p.space.DataPath(space.PcapIndexFile))
 		return nil, err
 	}
-	if err = p.space.SetPacketPath(p.pcapPath); err != nil {
+	if err = p.space.SetPcapPath(p.pcapPath); err != nil {
 		os.Remove(p.space.DataPath(space.PcapIndexFile))
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (p *Process) run(ctx context.Context) error {
 		os.RemoveAll(p.logdir)
 		os.Remove(p.space.DataPath(space.PcapIndexFile))
 		os.Remove(p.space.DataPath(space.AllZngFile))
-		p.space.SetPacketPath("")
+		p.space.SetPcapPath("")
 		p.space.UnsetSpan()
 	}
 


### PR DESCRIPTION
Based on the decision to refer to packet captures as pcaps, replace
the parts of the zqd api that incorrectly refer to packets with pcaps.

closes #562