### PR TITLE
use -R and ZAR_ROOT instead of -d for zar root directories

### DIFF
--- a/cmd/zar/index/command.go
+++ b/cmd/zar/index/command.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/brimsec/zq/archive"
@@ -13,21 +14,24 @@ import (
 
 var Index = &charm.Spec{
 	Name:  "index",
-	Usage: "index -d dir pattern [ pattern ...]",
+	Usage: "index [-R dir] pattern [ pattern ...]",
 	Short: "create index files for zng files",
 	Long: `
 zar index descends the directory argument starting at dir and looks
 for files with zar directories.  Each such file found is indexed according
 to the one or more indexing rules provided, and the resulting indexes
-are written to that file's zar directoryr.
+are written to that file's zar directory.
 
 A pattern is either a field name or a ":" followed by a zng type name.
 For example, to index the all fields of type port and the field id.orig_h,
 you would run
 
-	zar index -d /path/to/logs id.orig_h :port
+	zar index -R /path/to/logs id.orig_h :port
 
 Each pattern results a separate zdx index file for each log file found.
+
+The root directory must be specified either by the ZAR_ROOT environemnt
+variable or the -R option.
 `,
 	New: New,
 }
@@ -38,13 +42,13 @@ func init() {
 
 type Command struct {
 	*root.Command
-	dir   string
+	root  string
 	quiet bool
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
-	f.StringVar(&c.dir, "d", "", "directory to descend")
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
 	f.BoolVar(&c.quiet, "q", false, "don't print progress on stdout")
 	return c, nil
 }
@@ -53,8 +57,8 @@ func (c *Command) Run(args []string) error {
 	if len(args) == 0 {
 		return errors.New("zar index: one or more indexing patterns must be specified")
 	}
-	if c.dir == "" {
-		return errors.New("zar index: a directory must be specified with -d")
+	if c.root == "" {
+		return errors.New("zar index: a directory must be specified with -R or ZAR_ROOT")
 	}
 	var rules []archive.Rule
 	for _, pattern := range args {
@@ -76,7 +80,7 @@ func (c *Command) Run(args []string) error {
 			wg.Done()
 		}()
 	}
-	err := archive.IndexDirTree(c.dir, rules, progress)
+	err := archive.IndexDirTree(c.root, rules, progress)
 	if progress != nil {
 		close(progress)
 		wg.Wait()

--- a/cmd/zar/rmdirs/command.go
+++ b/cmd/zar/rmdirs/command.go
@@ -14,7 +14,7 @@ var RmDirs = &charm.Spec{
 	Usage: "rmdirs <dir>",
 	Short: "walk a directory tree and remove zar directories",
 	Long: `
-"zar rmdirs" descends the directory given by the -d option looking for
+"zar rmdirs" descends the provided directory looking for
 zar directories and removes them along with their contents.  WARNING:
 this is no prompting for the files and directories that will be removed
 so use carefully.

--- a/tests/suite/zar/basic.yaml
+++ b/tests/suite/zar/basic.yaml
@@ -1,11 +1,11 @@
 script: |
   mkdir logs
-  zar chop -q -b 2500 -d ./logs babble.tzng
+  zar chop -q -b 2500 -R ./logs babble.tzng
   zar mkdirs ./logs
-  zar index -q -d ./logs v
-  zar find -d ./logs v=106
+  zar index -q -R ./logs v
+  zar find -R ./logs v=106
   echo ===
-  zar find -d ./logs v=10600
+  zar find -R ./logs v=10600
   echo ===
 
 inputs:


### PR DESCRIPTION
This commit changes the -d argument for the zar commands to -R 
to avoid confusion with zq's -d argument.  It also allows setting of 
ZAR_ROOT env to ease typing when running lots of different zar 
commands on the same root.
