### PR TITLE
add type null to LookupTypeById() in zng module

### DIFF
--- a/tests/formats/zng/null-reducer.yaml
+++ b/tests/formats/zng/null-reducer.yaml
@@ -1,0 +1,14 @@
+script: |
+  zq "sum(a) by v" in.tzng | zq -t -
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[v:int64]
+      0:[10;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[v:int64,sum:null]
+      0:[10;-;]

--- a/zng/type.go
+++ b/zng/type.go
@@ -198,6 +198,8 @@ func LookupPrimitiveById(id int) Type {
 		return TypeTime
 	case IdDuration:
 		return TypeDuration
+	case IdNull:
+		return TypeNull
 	}
 	return nil
 }


### PR DESCRIPTION
Type null was missing from LookupTypeById().  This was found when
running reducers on missing fields resulting in a group-by output
that had a null-typed column.  A test was added for this case.