### PR TITLE
add "zar zq"

### DIFF
--- a/archive/walk.go
+++ b/archive/walk.go
@@ -15,11 +15,29 @@ func IsZarDir(path string) bool {
 }
 
 func ZarDirToLog(path string) string {
-	return strings.TrimRight(path, zarExt)
+	return strings.TrimSuffix(path, zarExt)
 }
 
 func LogToZarDir(path string) string {
 	return path + zarExt
+}
+
+// Localize maps the provided slice of relative pathnames into
+// absolute path names relative to the given zardir and returns
+// the new pathnames as a slice.  The special name "_" is mapped
+// to the path of the log file that corresponds to this zardir.
+func Localize(zardir string, filenames []string) []string {
+	var out []string
+	for _, filename := range filenames {
+		var s string
+		if filename == "_" {
+			s = ZarDirToLog(zardir)
+		} else {
+			s = filepath.Join(zardir, filename)
+		}
+		out = append(out, s)
+	}
+	return out
 }
 
 // Walk descends a directory hierarchy looking for zar directories and

--- a/cmd/zar/find/command.go
+++ b/cmd/zar/find/command.go
@@ -1,4 +1,4 @@
-package index
+package find
 
 import (
 	"errors"

--- a/cmd/zar/main.go
+++ b/cmd/zar/main.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/brimsec/zq/cmd/zar/mkdirs"
 	_ "github.com/brimsec/zq/cmd/zar/rmdirs"
 	"github.com/brimsec/zq/cmd/zar/root"
+	_ "github.com/brimsec/zq/cmd/zar/zq"
 )
 
 // Version is set via the Go linker.

--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -1,0 +1,238 @@
+package zq
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/brimsec/zq/archive"
+	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/cmd/zar/root"
+	"github.com/brimsec/zq/driver"
+	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/scanner"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/detector"
+	"github.com/brimsec/zq/zio/ndjsonio"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zql"
+	"github.com/mccanne/charm"
+	"go.uber.org/zap"
+)
+
+var Zq = &charm.Spec{
+	Name:  "zq",
+	Usage: "zq [-R dir] [options]",
+	Short: "walk an archive and run zq logic",
+	Long: `
+"zar zq" descends the directory given by the -R option (or ZAR_ROOT env) looking for
+logs with zar directories and for each such directory found, it runs
+the zq logic relative to that directory.  The file names here are relative to that
+directory and the special name "_" refers to the actual log file
+in the parent of the zar directory.
+
+If the root directory is not specified by either the ZAR_ROOT environemnt
+variable or the -R option, then the current directory is assumed.
+`,
+	New: New,
+}
+
+func init() {
+	root.Zar.Add(Zq)
+}
+
+type Command struct {
+	*root.Command
+	root           string
+	jsonTypePath   string
+	jsonPathRegexp string
+	jsonTypeConfig *ndjsonio.TypeConfig
+	outputFile     string
+	stopErr        bool
+	quiet          bool
+	ReaderFlags    zio.ReaderFlags
+	WriterFlags    zio.WriterFlags
+}
+
+func fileExists(path string) bool {
+	if path == "-" {
+		return true
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
+	// XXX f.StringVar(&c.dir, "d", "", "directory for output data files")
+	f.StringVar(&c.outputFile, "o", "", "write data to output file")
+	f.StringVar(&c.jsonTypePath, "j", "", "path to json types file")
+	f.StringVar(&c.jsonPathRegexp, "pathregexp", c.jsonPathRegexp, "regexp for extracting _path from json log name (when -inferpath=true)")
+	// XXX f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
+	f.BoolVar(&c.stopErr, "e", true, "stop upon input errors")
+
+	// Flags added for writers are -f, -T, -F, -E, -U, and -b
+	c.WriterFlags.SetFlags(f)
+
+	// Flags added for readers are -i XXX json
+	c.ReaderFlags.SetFlags(f)
+
+	return c, nil
+}
+
+func (c *Command) loadJsonTypes() (*ndjsonio.TypeConfig, error) {
+	data, err := ioutil.ReadFile(c.jsonTypePath)
+	if err != nil {
+		return nil, err
+	}
+	var tc ndjsonio.TypeConfig
+	err = json.Unmarshal(data, &tc)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unmarshaling error: %s", c.jsonTypePath, err)
+	}
+	if err = tc.Validate(); err != nil {
+		return nil, fmt.Errorf("%s: %s", c.jsonTypePath, err)
+	}
+	return &tc, nil
+}
+
+//XXX lots here copied from zq command... we should refactor into a tools package
+func (c *Command) Run(args []string) error {
+	//XXX
+	if c.outputFile == "-" {
+		c.outputFile = ""
+	}
+
+	if _, err := regexp.Compile(c.jsonPathRegexp); err != nil {
+		return err
+	}
+	if c.jsonTypePath != "" {
+		tc, err := c.loadJsonTypes()
+		if err != nil {
+			return err
+		}
+		c.jsonTypeConfig = tc
+	}
+	if len(args) == 0 {
+		return errors.New("zar zq needs input arguments")
+	}
+	rootPath := c.root
+	if rootPath == "" {
+		rootPath = "."
+	}
+	// XXX this is parallelizable except for writing to stdout when
+	// concatenating results
+	return archive.Walk(rootPath, func(zardir string) error {
+		inputs := args
+		var query ast.Proc
+		var err error
+		first := archive.Localize(zardir, inputs[:1])
+		if first[0] != "" && fileExists(first[0]) {
+			query, err = zql.ParseProc("*")
+			if err != nil {
+				return err
+			}
+		} else {
+			query, err = zql.ParseProc(inputs[0])
+			if err != nil {
+				return err
+			}
+			inputs = inputs[1:]
+		}
+		localPaths := archive.Localize(zardir, inputs)
+		readers, err := c.inputReaders(resolver.NewContext(), localPaths)
+		if err != nil {
+			return err
+		}
+		if len(readers) == 0 {
+			// XXX silently skip if no file found
+			return nil
+		}
+		wch := make(chan string, 5)
+		if !c.stopErr {
+			for i, r := range readers {
+				readers[i] = zbuf.NewWarningReader(r, wch)
+			}
+		}
+		reader := scanner.NewCombiner(readers)
+		defer reader.Close()
+		writer, err := c.openOutput(zardir, c.outputFile)
+		if err != nil {
+			return err
+		}
+		defer writer.Close()
+		// XXX we shouldn't need zap here, nano?  etc
+		mux, err := driver.CompileWarningsCh(context.Background(), query, reader, false, nano.MaxSpan, zap.NewNop(), wch)
+		if err != nil {
+			return err
+		}
+		d := driver.NewCLI(writer)
+		if !c.quiet {
+			d.SetWarningsWriter(os.Stderr)
+		}
+		return driver.Run(mux, d, nil)
+	})
+}
+
+func (c *Command) inputReaders(zctx *resolver.Context, paths []string) ([]zbuf.Reader, error) {
+	cfg := detector.OpenConfig{
+		Format:         c.ReaderFlags.Format,
+		DashStdin:      true,
+		JSONTypeConfig: c.jsonTypeConfig,
+		JSONPathRegex:  c.jsonPathRegexp,
+	}
+	var readers []zbuf.Reader
+	for _, path := range paths {
+		file, err := detector.OpenFile(zctx, path, cfg)
+		if err != nil {
+			// XXX for zar zq siliently conotinue if file doesn't exist
+			if os.IsNotExist(err) {
+				continue
+			}
+			err = fmt.Errorf("%s: %w", path, err)
+			if c.stopErr {
+				return nil, err
+			}
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			continue
+		}
+		// wrap in a named reader so the reader implements Stringer
+		readers = append(readers, namedReader{file, path})
+	}
+	return readers, nil
+}
+
+func (c *Command) openOutput(zardir, filename string) (zbuf.WriteCloser, error) {
+	path := filename
+	// prepend path if not stdout
+	if path != "" {
+		path = filepath.Join(zardir, filename)
+	}
+	w, err := emitter.NewFile(path, &c.WriterFlags)
+	if err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+type namedReader struct {
+	zbuf.Reader
+	name string
+}
+
+func (r namedReader) String() string {
+	return r.name
+}

--- a/tests/suite/zar/zq.yaml
+++ b/tests/suite/zar/zq.yaml
@@ -1,0 +1,26 @@
+script: |
+  mkdir logs
+  zar chop -q -b 2500 -R ./logs babble.tzng
+  zar mkdirs ./logs
+  zar zq -R ./logs "count()" _ | zq -t "sum(count)" -
+  echo ===
+  zar zq -R ./logs -o count.zng "count()" _
+  zar zq -R ./logs count.zng | zq -t "sum(count)" -
+  echo ===
+  zq -t logs/20200421/1587511070.06294938.zng.zar/count.zng
+
+inputs:
+  - name: babble.tzng
+    source: ../zdx/babble.tzng
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[sum:uint64]
+      0:[1000;]
+      ===
+      #0:record[sum:uint64]
+      0:[1000;]
+      ===
+      #0:record[count:uint64]
+      0:[78;]


### PR DESCRIPTION
This command adds support for the "zq" sub-command of zar, which
lets you run zq-style commands over the log files in a zar archive.
In this case, the file "_" is the log file in question and any
files referred to live within the zar directory associated with
the log.  The zq command is run for each log file found.