### PR TITLE
Send scanner stats back in search

### DIFF
--- a/driver/compile.go
+++ b/driver/compile.go
@@ -25,7 +25,7 @@ func Compile(ctx context.Context, program ast.Proc, reader zbuf.Reader, reverse 
 func CompileWarningsCh(ctx context.Context, program ast.Proc, reader zbuf.Reader, reverse bool, span nano.Span, logger *zap.Logger, ch chan string) (*MuxOutput, error) {
 
 	filterAst, program := liftFilter(program)
-	input, err := inputProc(reader, filterAst, span)
+	scanner, err := inputProc(reader, filterAst, span)
 	if err != nil {
 		return nil, err
 	}
@@ -36,11 +36,11 @@ func CompileWarningsCh(ctx context.Context, program ast.Proc, reader zbuf.Reader
 		Reverse:     reverse,
 		Warnings:    ch,
 	}
-	leaves, err := proc.CompileProc(nil, program, pctx, input)
+	leaves, err := proc.CompileProc(nil, program, pctx, scanner)
 	if err != nil {
 		return nil, err
 	}
-	return NewMuxOutput(pctx, leaves), nil
+	return NewMuxOutput(pctx, leaves, scanner), nil
 }
 
 // liftFilter removes the filter at the head of the flowgraph AST, if
@@ -70,7 +70,7 @@ func liftFilter(p ast.Proc) (*ast.FilterProc, ast.Proc) {
 // inputProc takes a Reader, optional Filter AST, and timespan, and
 // constructs an input proc that can be used as the head of a
 // flowgraph.
-func inputProc(reader zbuf.Reader, fltast *ast.FilterProc, span nano.Span) (proc.Proc, error) {
+func inputProc(reader zbuf.Reader, fltast *ast.FilterProc, span nano.Span) (*scanner.Scanner, error) {
 	var f filter.Filter
 	if fltast != nil {
 		var err error

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -25,7 +25,7 @@ func Compile(ctx context.Context, program ast.Proc, reader zbuf.Reader, reverse 
 func CompileWarningsCh(ctx context.Context, program ast.Proc, reader zbuf.Reader, reverse bool, span nano.Span, logger *zap.Logger, ch chan string) (*MuxOutput, error) {
 
 	filterAst, program := liftFilter(program)
-	scanner, err := inputProc(reader, filterAst, span)
+	scanner, err := newScanner(reader, filterAst, span)
 	if err != nil {
 		return nil, err
 	}
@@ -67,10 +67,10 @@ func liftFilter(p ast.Proc) (*ast.FilterProc, ast.Proc) {
 	return nil, p
 }
 
-// inputProc takes a Reader, optional Filter AST, and timespan, and
-// constructs an input proc that can be used as the head of a
+// newScanner takes a Reader, optional Filter AST, and timespan, and
+// constructs a scanner that can be used as the head of a
 // flowgraph.
-func inputProc(reader zbuf.Reader, fltast *ast.FilterProc, span nano.Span) (*scanner.Scanner, error) {
+func newScanner(reader zbuf.Reader, fltast *ast.FilterProc, span nano.Span) (*scanner.Scanner, error) {
 	var f filter.Filter
 	if fltast != nil {
 		var err error

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -13,7 +13,7 @@ import (
 type Driver interface {
 	Warn(msg string) error
 	Write(channelID int, batch zbuf.Batch) error
-	ChannelEnd(channelID int, stats api.ScannerStats) error
+	ChannelEnd(channelID int) error
 	Stats(api.ScannerStats) error
 }
 
@@ -38,9 +38,8 @@ func Run(out *MuxOutput, d Driver, statsTickCh <-chan time.Time) error {
 			}
 		}
 		if chunk.Batch == nil {
-			// One of the flowgraph tails is done.  We send stats and
-			// a done message for each channel that finishes
-			if err := d.ChannelEnd(chunk.ID, out.Stats()); err != nil {
+			// One of the flowgraph tails is done.
+			if err := d.ChannelEnd(chunk.ID); err != nil {
 				return err
 			}
 		} else {
@@ -89,5 +88,5 @@ func (d *CLI) Warn(msg string) error {
 	return nil
 }
 
-func (d *CLI) ChannelEnd(int, api.ScannerStats) error { return nil }
-func (d *CLI) Stats(api.ScannerStats) error           { return nil }
+func (d *CLI) ChannelEnd(int) error         { return nil }
+func (d *CLI) Stats(api.ScannerStats) error { return nil }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -17,7 +17,6 @@ type Scanner struct {
 	filter filter.Filter
 	span   nano.Span
 	stats  struct {
-		currentTs      int64
 		bytesRead      int64
 		bytesMatched   int64
 		recordsRead    int64

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -66,12 +66,10 @@ type SearchStats struct {
 }
 
 type ScannerStats struct {
-	CurrentTs       nano.Ts `json:"current_ts"`
-	BytesRead       int64   `json:"bytes_read"`
-	BytesMatched    int64   `json:"bytes_matched"`
-	RecordsRead     int64   `json:"records_read"`
-	RecordsMatched  int64   `json:"records_matched"`
-	RecordsReceived int64   `json:"records_received"`
+	BytesRead      int64 `json:"bytes_read"`
+	BytesMatched   int64 `json:"bytes_matched"`
+	RecordsRead    int64 `json:"records_read"`
+	RecordsMatched int64 `json:"records_matched"`
 }
 
 type SpaceInfo struct {

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -606,7 +606,7 @@ func TestDeleteDuringPacketPost(t *testing.T) {
 }
 
 // zngSearch runs the provided zql program as a search on the provided
-// space, returning a slice of control messages along with a strong
+// space, returning a slice of control messages along with a string
 // containing the tzng results.
 func zngSearch(t *testing.T, client *api.Connection, space, prog string) ([]interface{}, string) {
 	parsed, err := zql.ParseProc(prog)

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -49,7 +49,7 @@ func TestPacketPostSuccess(t *testing.T) {
 0:[1501770877.501001;]
 0:[1501770877.471635;]
 0:[1501770877.471635;]`
-		_, res := zngSearch(t, p.client, p.space, "cut ts")
+		res := searchTzng(t, p.client, p.space, "cut ts")
 		assert.Equal(t, test.Trim(expected), res)
 	})
 	t.Run("SpaceInfo", func(t *testing.T) {

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -49,7 +49,7 @@ func TestPacketPostSuccess(t *testing.T) {
 0:[1501770877.501001;]
 0:[1501770877.471635;]
 0:[1501770877.471635;]`
-		res := zngSearch(t, p.client, p.space, "cut ts")
+		_, res := zngSearch(t, p.client, p.space, "cut ts")
 		assert.Equal(t, test.Trim(expected), res)
 	})
 	t.Run("SpaceInfo", func(t *testing.T) {

--- a/zqd/ingest/driver.go
+++ b/zqd/ingest/driver.go
@@ -36,6 +36,6 @@ func (d *logdriver) Stats(stats api.ScannerStats) error {
 	return nil
 }
 
-func (d *logdriver) ChannelEnd(cid int, stats api.ScannerStats) error {
-	return d.Stats(stats)
+func (d *logdriver) ChannelEnd(cid int) error {
+	return nil
 }

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -72,6 +72,10 @@ func (s *Search) Run(output Output) error {
 		d.abort(0, err)
 		return err
 	}
+	if err := d.Stats(s.mux.Stats()); err != nil {
+		d.abort(0, err)
+		return err
+	}
 	return d.end(0)
 }
 
@@ -146,10 +150,7 @@ func (d *searchdriver) Stats(stats api.ScannerStats) error {
 	return d.output.SendControl(v)
 }
 
-func (d *searchdriver) ChannelEnd(cid int, stats api.ScannerStats) error {
-	if err := d.Stats(stats); err != nil {
-		return err
-	}
+func (d *searchdriver) ChannelEnd(cid int) error {
 	v := &api.SearchEnd{
 		Type:      "SearchEnd",
 		ChannelID: cid,


### PR DESCRIPTION
This commit tracks scanner stats in scanner.Scanner, and wires things up so that they get sent back in searches (via the existing driver.Driver interface).

closes #555 