### PR TITLE
Prevent creating record types with duplicate field names

### DIFF
--- a/proc/colbuilder.go
+++ b/proc/colbuilder.go
@@ -242,7 +242,9 @@ func (c *ColumnBuilder) TypedColumns(types []zng.Type) []zng.Column {
 		current.cols = append(current.cols, zng.NewColumn(field.name, types[i]))
 
 		for j := 0; j < field.containerEnds; j++ {
-			recType := c.zctx.LookupTypeRecord(current.cols)
+			// LookupTypeRecord() fails if there are duplicate
+			// fields but logic above already prevents this case.
+			recType, _ := c.zctx.LookupTypeRecord(current.cols)
 			slen := len(stack)
 			stack = stack[:slen-1]
 			cur := stack[slen-2]

--- a/proc/colbuilder.go
+++ b/proc/colbuilder.go
@@ -242,9 +242,7 @@ func (c *ColumnBuilder) TypedColumns(types []zng.Type) []zng.Column {
 		current.cols = append(current.cols, zng.NewColumn(field.name, types[i]))
 
 		for j := 0; j < field.containerEnds; j++ {
-			// LookupTypeRecord() fails if there are duplicate
-			// fields but logic above already prevents this case.
-			recType, _ := c.zctx.LookupTypeRecord(current.cols)
+			recType := c.zctx.MustLookupTypeRecord(current.cols)
 			slen := len(stack)
 			stack = stack[:slen-1]
 			cur := stack[slen-2]

--- a/proc/cut.go
+++ b/proc/cut.go
@@ -130,7 +130,10 @@ func (c *Cut) complementBuilder(r *zng.Record) (*cutBuilder, error) {
 		return nil, err
 	}
 	cols := builder.TypedColumns(outColTypes)
-	outType := c.TypeContext.LookupTypeRecord(cols)
+	outType, err := c.TypeContext.LookupTypeRecord(cols)
+	if err != nil {
+		return nil, err
+	}
 	return &cutBuilder{resolvers, builder, outType}, nil
 }
 
@@ -178,7 +181,10 @@ func (c *Cut) setBuilder(r *zng.Record) (*cutBuilder, error) {
 		outColTypes = append(outColTypes, val.Type)
 	}
 	cols := builder.TypedColumns(outColTypes)
-	outType := c.TypeContext.LookupTypeRecord(cols)
+	outType, err := c.TypeContext.LookupTypeRecord(cols)
+	if err != nil {
+		return nil, err
+	}
 	return &cutBuilder{resolvers, builder, outType}, nil
 }
 

--- a/proc/put.go
+++ b/proc/put.go
@@ -82,8 +82,13 @@ func (p *Put) put(in *zng.Record) *zng.Record {
 			cols = append(cols, newcolumn)
 		}
 
+		typ, err := p.TypeContext.LookupTypeRecord(cols)
+		if err != nil {
+			p.maybeWarn(err)
+			return in
+		}
 		newinfo := descinfo{
-			outType:   p.TypeContext.LookupTypeRecord(cols),
+			outType:   typ,
 			valType:   val.Type,
 			position:  position,
 			container: val.IsContainer(),

--- a/proc/reducer.go
+++ b/proc/reducer.go
@@ -31,9 +31,12 @@ func NewReducer(c *Context, parent Proc, params ReducerParams) Proc {
 	}
 }
 
-func (r *Reducer) output() *zbuf.Array {
-	rec := r.columns.Result(r.Context.TypeContext)
-	return zbuf.NewArray([]*zng.Record{rec}, nano.NewSpanTs(r.MinTs, r.MaxTs))
+func (r *Reducer) output() (*zbuf.Array, error) {
+	rec, err := r.columns.Result(r.Context.TypeContext)
+	if err != nil {
+		return nil, err
+	}
+	return zbuf.NewArray([]*zng.Record{rec}, nano.NewSpanTs(r.MinTs, r.MaxTs)), nil
 }
 
 func (r *Reducer) Pull() (zbuf.Batch, error) {
@@ -47,7 +50,7 @@ func (r *Reducer) Pull() (zbuf.Batch, error) {
 			return nil, nil
 		}
 		r.n = 0
-		return r.output(), nil
+		return r.output()
 	}
 	for k := 0; k < batch.Length(); k++ {
 		r.consume(batch.Index(k))

--- a/reducer/compile/row.go
+++ b/reducer/compile/row.go
@@ -44,7 +44,7 @@ func (r *Row) Consume(rec *zng.Record) {
 }
 
 // Result creates a new record from the results of the reducers.
-func (r *Row) Result(zctx *resolver.Context) *zng.Record {
+func (r *Row) Result(zctx *resolver.Context) (*zng.Record, error) {
 	n := len(r.Reducers)
 	columns := make([]zng.Column, n)
 	var zv zcode.Bytes
@@ -53,6 +53,9 @@ func (r *Row) Result(zctx *resolver.Context) *zng.Record {
 		columns[k] = zng.NewColumn(r.Defs[k].Target(), val.Type)
 		zv = val.Encode(zv)
 	}
-	typ := zctx.LookupTypeRecord(columns)
-	return zng.NewRecordTs(typ, 0, zv)
+	typ, err := zctx.LookupTypeRecord(columns)
+	if err != nil {
+		return nil, err
+	}
+	return zng.NewRecordTs(typ, 0, zv), nil
 }

--- a/tests/suite/errors/dupfields.yaml
+++ b/tests/suite/errors/dupfields.yaml
@@ -13,4 +13,4 @@ inputs:
 outputs:
   - name: stderr
     regexp: |
-      duplicate fields in record type
+      duplicate field foo

--- a/tests/suite/reducer/duplicate.yaml
+++ b/tests/suite/reducer/duplicate.yaml
@@ -1,0 +1,8 @@
+zql: count(), count()
+
+input: |
+  #0:record[x:int32]
+  0:[1;]
+  0:[2;]
+
+errorRE: duplicate column count

--- a/tests/suite/reducer/duplicate.yaml
+++ b/tests/suite/reducer/duplicate.yaml
@@ -5,4 +5,4 @@ input: |
   0:[1;]
   0:[2;]
 
-errorRE: duplicate column count
+errorRE: duplicate field count

--- a/zdx/mem.go
+++ b/zdx/mem.go
@@ -77,7 +77,8 @@ func (t *MemTable) open() {
 	if t.valType != nil {
 		cols = append(cols, zng.Column{"value", t.valType})
 	}
-	t.builder = zng.NewBuilder(t.zctx.LookupTypeRecord(cols))
+	typ, _ := t.zctx.LookupTypeRecord(cols)
+	t.builder = zng.NewBuilder(typ)
 }
 
 func checkType(which string, before *zng.Type, after zng.Type) error {

--- a/zdx/mem.go
+++ b/zdx/mem.go
@@ -77,7 +77,7 @@ func (t *MemTable) open() {
 	if t.valType != nil {
 		cols = append(cols, zng.Column{"value", t.valType})
 	}
-	typ, _ := t.zctx.LookupTypeRecord(cols)
+	typ := t.zctx.MustLookupTypeRecord(cols)
 	t.builder = zng.NewBuilder(typ)
 }
 

--- a/zdx/writer.go
+++ b/zdx/writer.go
@@ -147,7 +147,7 @@ func (w *Writer) writeIndexRecord(key *zng.Value, offset int64) error {
 			{"key", key.Type},
 			{"value", zng.TypeInt64},
 		}
-		w.recType = resolver.NewContext().LookupTypeRecord(cols)
+		w.recType, _ = resolver.NewContext().LookupTypeRecord(cols)
 		w.builder = zng.NewBuilder(w.recType)
 	}
 	if w.recType.Columns[0].Type != key.Type {

--- a/zdx/writer.go
+++ b/zdx/writer.go
@@ -147,7 +147,7 @@ func (w *Writer) writeIndexRecord(key *zng.Value, offset int64) error {
 			{"key", key.Type},
 			{"value", zng.TypeInt64},
 		}
-		w.recType, _ = resolver.NewContext().LookupTypeRecord(cols)
+		w.recType = resolver.NewContext().MustLookupTypeRecord(cols)
 		w.builder = zng.NewBuilder(w.recType)
 	}
 	if w.recType.Columns[0].Type != key.Type {

--- a/zio/ndjsonio/inferparser.go
+++ b/zio/ndjsonio/inferparser.go
@@ -43,7 +43,10 @@ func (p *inferParser) parseObject(b []byte) (zng.Value, error) {
 	for i, kv := range kvs {
 		columns[i] = zng.NewColumn(string(kv.key), zng.TypeString)
 	}
-	columns, _ = zeekio.Unflatten(p.zctx, columns, false)
+	columns, _, err = zeekio.Unflatten(p.zctx, columns, false)
+	if err != nil {
+		return zng.Value{}, err
+	}
 
 	// Parse the actual values and fill in column types along the way,
 	// taking care to step into nested records as necessary.
@@ -78,7 +81,10 @@ func (p *inferParser) parseObject(b []byte) (zng.Value, error) {
 		}
 	}
 
-	typ := p.zctx.LookupTypeRecord(columns)
+	typ, err := p.zctx.LookupTypeRecord(columns)
+	if err != nil {
+		return zng.Value{}, err
+	}
 	return zng.Value{typ, encodeContainer(vals)}, nil
 }
 

--- a/zio/ndjsonio/reader.go
+++ b/zio/ndjsonio/reader.go
@@ -127,7 +127,10 @@ again:
 	if err != nil {
 		return nil, fmt.Errorf("line %d: %w", r.scanner.Stats.Lines, err)
 	}
-	outType := r.zctx.LookupTypeRecord(zv.Type.(*zng.TypeRecord).Columns)
+	outType, err := r.zctx.LookupTypeRecord(zv.Type.(*zng.TypeRecord).Columns)
+	if err != nil {
+		return nil, err
+	}
 	record, err := zng.NewRecord(outType, zv.Bytes)
 	if err != nil {
 		return nil, err

--- a/zio/zeekio/flatten.go
+++ b/zio/zeekio/flatten.go
@@ -64,7 +64,11 @@ func (f *Flattener) Flatten(r *zng.Record) (*zng.Record, error) {
 	flatType := f.mapper.Map(id)
 	if flatType == nil {
 		cols := FlattenColumns(r.Type.Columns)
-		flatType = f.zctx.LookupTypeRecord(cols)
+		var err error
+		flatType, err = f.zctx.LookupTypeRecord(cols)
+		if err != nil {
+			return nil, err
+		}
 		f.mapper.EnterTypeRecord(id, flatType)
 	}
 	// Since we are mapping the input context to itself we can do a
@@ -78,7 +82,6 @@ func (f *Flattener) Flatten(r *zng.Record) (*zng.Record, error) {
 		return nil, err
 	}
 	return zng.NewRecord(flatType, zv)
-
 }
 
 // FlattenColumns turns nested records into a series of columns of

--- a/zng/builder_test.go
+++ b/zng/builder_test.go
@@ -28,27 +28,32 @@ func TestBuilder(t *testing.T) {
 
 	zctx := resolver.NewContext()
 
-	t0 := zctx.LookupTypeRecord([]zng.Column{
+	t0, err := zctx.LookupTypeRecord([]zng.Column{
 		{"key", zng.TypeIP},
 	})
+	assert.NoError(t, err)
 	b0 := zng.NewBuilder(t0)
 	ip := net.ParseIP("1.2.3.4")
 	rec := b0.Build(zng.EncodeIP(ip))
 	assert.Equal(t, r0.Raw, rec.Raw)
 
-	t1 := zctx.LookupTypeRecord([]zng.Column{
+	t1, err := zctx.LookupTypeRecord([]zng.Column{
 		{"a", zng.TypeInt64},
 		{"b", zng.TypeInt64},
 		{"c", zng.TypeInt64},
 	})
+	assert.NoError(t, err)
 	b1 := zng.NewBuilder(t1)
 	rec = b1.Build(zng.EncodeInt(1), zng.EncodeInt(2), zng.EncodeInt(3))
 	assert.Equal(t, r1.Raw, rec.Raw)
 
-	t2 := zctx.LookupTypeRecord([]zng.Column{
+	subrec, err := zctx.LookupTypeRecord([]zng.Column{{"x", zng.TypeInt64}})
+	assert.NoError(t, err)
+	t2, err := zctx.LookupTypeRecord([]zng.Column{
 		{"a", zng.TypeInt64},
-		{"r", zctx.LookupTypeRecord([]zng.Column{{"x", zng.TypeInt64}})},
+		{"r", subrec},
 	})
+	assert.NoError(t, err)
 	b2 := zng.NewBuilder(t2)
 	// XXX this is where this package needs work
 	// the second column here is a container here and this is where it would

--- a/zng/format_test.go
+++ b/zng/format_test.go
@@ -23,10 +23,11 @@ func TestFormatting(t *testing.T) {
 	bstringVecType := zctx.LookupTypeArray(zng.TypeBstring)
 	setOfVectorsType := zctx.LookupTypeSet(bstringVecType)
 	vecOfVectorsType := zctx.LookupTypeArray(bstringVecType)
-	recType := zctx.LookupTypeRecord([]zng.Column{
+	recType, err := zctx.LookupTypeRecord([]zng.Column{
 		{"b", zng.TypeBstring},
 		{"s", zng.TypeString},
 	})
+	assert.NoError(t, err)
 
 	type Expect struct {
 		fmt      zng.OutFmt

--- a/zng/resolver/context.go
+++ b/zng/resolver/context.go
@@ -226,6 +226,14 @@ func (c *Context) LookupTypeRecord(columns []zng.Column) (*zng.TypeRecord, error
 	return typ, nil
 }
 
+func (c *Context) MustLookupTypeRecord(columns []zng.Column) *zng.TypeRecord {
+	r, err := c.LookupTypeRecord(columns)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
 func (c *Context) LookupTypeSet(inner zng.Type) *zng.TypeSet {
 	key := setKey(inner)
 	c.mu.Lock()

--- a/zng/resolver/context.go
+++ b/zng/resolver/context.go
@@ -209,7 +209,7 @@ func (c *Context) LookupTypeRecord(columns []zng.Column) (*zng.TypeRecord, error
 	for _, col := range columns {
 		_, exists := names[col.Name]
 		if exists {
-			return nil, fmt.Errorf("duplicate column %s", col.Name)
+			return nil, fmt.Errorf("duplicate field %s", col.Name)
 		}
 		names[col.Name] = val
 	}
@@ -457,11 +457,6 @@ func (c *Context) parseRecordTypeBody(in string) (string, zng.Type, error) {
 		rest, col, err := c.parseColumn(in)
 		if err != nil {
 			return "", nil, err
-		}
-		for _, c := range columns {
-			if col.Name == c.Name {
-				return "", nil, zng.ErrDuplicateFields
-			}
 		}
 		columns = append(columns, col)
 		rest, ok = match(rest, ",")

--- a/zng/resolver/context.go
+++ b/zng/resolver/context.go
@@ -202,17 +202,28 @@ func (c *Context) AddType(t zng.Type) zng.Type {
 // and returned.  The closure of types within the columns must all be from
 // this type context.  If you want to use columns from a different type context,
 // use TranslateTypeRecord.
-func (c *Context) LookupTypeRecord(columns []zng.Column) *zng.TypeRecord {
+func (c *Context) LookupTypeRecord(columns []zng.Column) (*zng.TypeRecord, error) {
+	// First check for duplicate columns
+	names := make(map[string]struct{})
+	var val struct{}
+	for _, col := range columns {
+		_, exists := names[col.Name]
+		if exists {
+			return nil, fmt.Errorf("duplicate column %s", col.Name)
+		}
+		names[col.Name] = val
+	}
+
 	key := recordKey(columns)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	id, ok := c.lut[key]
 	if ok {
-		return c.table[id].(*zng.TypeRecord)
+		return c.table[id].(*zng.TypeRecord), nil
 	}
 	typ := zng.NewTypeRecord(-1, columns)
 	c.addTypeWithLock(key, typ)
-	return typ
+	return typ, nil
 }
 
 func (c *Context) LookupTypeSet(inner zng.Type) *zng.TypeSet {
@@ -291,7 +302,10 @@ func (c *Context) AddColumns(r *zng.Record, newCols []zng.Column, vals []zng.Val
 	for _, val := range vals {
 		zv = val.Encode(zv)
 	}
-	typ := c.LookupTypeRecord(outCols)
+	typ, err := c.LookupTypeRecord(outCols)
+	if err != nil {
+		return nil, err
+	}
 	return zng.NewRecord(typ, zv)
 }
 
@@ -448,10 +462,14 @@ func (c *Context) parseRecordTypeBody(in string) (string, zng.Type, error) {
 			continue
 		}
 		rest, ok = match(rest, "]")
-		if ok {
-			return rest, c.LookupTypeRecord(columns), nil
+		if !ok {
+			return "", nil, zng.ErrTypeSyntax
 		}
-		return "", nil, zng.ErrTypeSyntax
+		typ, err := c.LookupTypeRecord(columns)
+		if err != nil {
+			return "", nil, err
+		}
+		return rest, typ, nil
 	}
 }
 
@@ -577,7 +595,12 @@ func (c *Context) TranslateTypeRecord(ext *zng.TypeRecord) *zng.TypeRecord {
 		child := c.TranslateType(col.Type)
 		columns = append(columns, zng.NewColumn(col.Name, child))
 	}
-	return c.LookupTypeRecord(columns)
+
+	// LookupTypeRecord() fails if there are duplicate columns but
+	// since this comes from an already validated record, it should
+	// not fail
+	typ, _ := c.LookupTypeRecord(columns)
+	return typ
 }
 
 func (c *Context) TranslateTypeUnion(ext *zng.TypeUnion) *zng.TypeUnion {

--- a/zng/resolver/context.go
+++ b/zng/resolver/context.go
@@ -207,8 +207,8 @@ func (c *Context) LookupTypeRecord(columns []zng.Column) (*zng.TypeRecord, error
 	names := make(map[string]struct{})
 	var val struct{}
 	for _, col := range columns {
-		_, exists := names[col.Name]
-		if exists {
+		_, ok := names[col.Name]
+		if ok {
 			return nil, fmt.Errorf("duplicate field %s", col.Name)
 		}
 		names[col.Name] = val
@@ -599,11 +599,7 @@ func (c *Context) TranslateTypeRecord(ext *zng.TypeRecord) *zng.TypeRecord {
 		columns = append(columns, zng.NewColumn(col.Name, child))
 	}
 
-	// LookupTypeRecord() fails if there are duplicate columns but
-	// since this comes from an already validated record, it should
-	// not fail
-	typ, _ := c.LookupTypeRecord(columns)
-	return typ
+	return c.MustLookupTypeRecord(columns)
 }
 
 func (c *Context) TranslateTypeUnion(ext *zng.TypeUnion) *zng.TypeUnion {

--- a/zng/resolver/context_test.go
+++ b/zng/resolver/context_test.go
@@ -12,7 +12,8 @@ import (
 
 func TestContextAddColumns(t *testing.T) {
 	ctx := NewContext()
-	d := ctx.LookupTypeRecord([]zng.Column{zng.NewColumn("s1", zng.TypeString)})
+	d, err := ctx.LookupTypeRecord([]zng.Column{zng.NewColumn("s1", zng.TypeString)})
+	require.NoError(t, err)
 	r, err := zbuf.NewRecordZeekStrings(d, "S1")
 	require.NoError(t, err)
 	cols := []zng.Column{zng.NewColumn("ts", zng.TypeTime), zng.NewColumn("s2", zng.TypeString)}
@@ -30,10 +31,11 @@ func TestContextAddColumns(t *testing.T) {
 func TestDuplicates(t *testing.T) {
 	ctx := NewContext()
 	setType := ctx.LookupTypeSet(zng.TypeInt32)
-	typ1 := ctx.LookupTypeRecord([]zng.Column{
+	typ1, err := ctx.LookupTypeRecord([]zng.Column{
 		zng.NewColumn("a", zng.TypeString),
 		zng.NewColumn("b", setType),
 	})
+	require.NoError(t, err)
 	typ2, err := ctx.LookupByName("record[a:string,b:set[int32]]")
 	require.NoError(t, err)
 	assert.EqualValues(t, typ1.ID(), typ2.ID())

--- a/zng/resolver/encoder.go
+++ b/zng/resolver/encoder.go
@@ -96,7 +96,10 @@ func (e *Encoder) encodeTypeRecord(dst []byte, ext *zng.TypeRecord) ([]byte, zng
 		}
 		columns = append(columns, zng.NewColumn(col.Name, child))
 	}
-	typ := e.zctx.LookupTypeRecord(columns)
+	typ, err := e.zctx.LookupTypeRecord(columns)
+	if err != nil {
+		return nil, nil, err
+	}
 	if e.isEncoded(typ.ID()) {
 		return dst, typ, nil
 	}

--- a/zng/value.go
+++ b/zng/value.go
@@ -10,9 +10,8 @@ import (
 )
 
 var (
-	ErrNotNumber       = errors.New("not a number")
-	ErrTypeSyntax      = errors.New("syntax error parsing type string")
-	ErrDuplicateFields = errors.New("duplicate fields in record type")
+	ErrNotNumber  = errors.New("not a number")
+	ErrTypeSyntax = errors.New("syntax error parsing type string")
 )
 
 type Value struct {


### PR DESCRIPTION
The substantive change in LookupTypeRecord() is relatively small,
most of the change here involves adding error handling to previously
infallible code paths.

Closes #652
