### PR TITLE
allow baselayer zdx index to have arbitrary values

### DIFF
--- a/tests/suite/zdx/flexkey.yaml
+++ b/tests/suite/zdx/flexkey.yaml
@@ -1,0 +1,26 @@
+script: |
+  zq -o tmp.zng "sum(v) by s | put key=s | sort key"  babble.tzng
+  # -x says input keys already sorted and don't create new base records
+  zdx create -o index -x tmp.zng
+  # 50 not in index
+  zq -t index.1.zng
+  echo ===
+  zdx lookup -t -k wailer-strick index
+  echo ===
+  zdx lookup -t -k Anatinacea-bestrew index
+
+inputs:
+  - name: babble.tzng
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[key:string,value:int64]
+      0:[Algedi-pigeonman;0;]
+      0:[protohydrogen-plesiomorphism;32770;]
+      ===
+      #0:record[s:string,sum:int64,key:string]
+      0:[wailer-strick;149;wailer-strick;]
+      ===
+      #0:record[s:string,sum:int64,key:string]
+      0:[Anatinacea-bestrew;339;Anatinacea-bestrew;]

--- a/zdx/writer.go
+++ b/zdx/writer.go
@@ -107,8 +107,8 @@ func (w *Writer) Write(rec *zng.Record) error {
 	// Remember the first key of a new frame. This happens at beginning
 	// of stream or when we end the current frame immediately above.
 	if w.frameKey == nil {
-		key := rec.Value(0)
-		if key.Type == nil {
+		key, err := rec.ValueByField("key")
+		if err != nil {
 			return ErrCorruptFile
 		}
 		// Copy the key value from the stream so we can write it to the


### PR DESCRIPTION
This commit allows the base-layer zdx index to have arbitray
structure, requiring only that there is a field called "key"
and that the records are sorted by the key.  When we change
the zdx file format to be embodied in a single zng file, we
will relax this requirement, allowing the key to be any field,
and will put the key field's name in the header of the zng
index file.  This will be in a future PR.

This change allows us to put interesting information inside indexes,
e.g., analytics aggregations, so that computation can be carried
across index files by piping the output of a zar search into
a zq command that can aggregate or otherwise process the
information stored in the row-slices of the index.