### PR TITLE
zqd search endpoint: only allow backwards searches

### DIFF
--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -78,7 +78,7 @@ func TestSearchEmptySpace(t *testing.T) {
 	require.Equal(t, "", res)
 }
 
-func TestSearchInvalidRequest(t *testing.T) {
+func TestSearchError(t *testing.T) {
 	src := `
 #0:record[_path:string,ts:time,uid:bstring]
 0:[conn;1521911723.205187;CBrzd94qfowOqJwCHa;]
@@ -94,16 +94,30 @@ func TestSearchInvalidRequest(t *testing.T) {
 	require.NoError(t, err)
 	proc, err := json.Marshal(parsed)
 	require.NoError(t, err)
-	req := api.SearchRequest{
-		Space: "test",
-		Proc:  proc,
-		Span:  nano.MaxSpan,
-		Dir:   2,
-	}
-	_, err = client.Search(context.Background(), req)
-	require.Error(t, err)
-	errResp := err.(*api.ErrorResponse)
-	require.IsType(t, &api.Error{}, errResp.Err)
+	t.Run("InvalidDir", func(t *testing.T) {
+		req := api.SearchRequest{
+			Space: "test",
+			Proc:  proc,
+			Span:  nano.MaxSpan,
+			Dir:   2,
+		}
+		_, err = client.Search(context.Background(), req)
+		require.Error(t, err)
+		errResp := err.(*api.ErrorResponse)
+		require.IsType(t, &api.Error{}, errResp.Err)
+	})
+	t.Run("ForwardSearchUnsupported", func(t *testing.T) {
+		req := api.SearchRequest{
+			Space: "test",
+			Proc:  proc,
+			Span:  nano.MaxSpan,
+			Dir:   1,
+		}
+		_, err = client.Search(context.Background(), req)
+		require.Error(t, err)
+		errResp := err.(*api.ErrorResponse)
+		require.IsType(t, &api.Error{}, errResp.Err)
+	})
 }
 
 func TestSpaceList(t *testing.T) {

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -104,7 +105,8 @@ func TestSearchError(t *testing.T) {
 		_, err = client.Search(context.Background(), req)
 		require.Error(t, err)
 		errResp := err.(*api.ErrorResponse)
-		require.IsType(t, &api.Error{}, errResp.Err)
+		assert.Equal(t, http.StatusBadRequest, errResp.StatusCode())
+		assert.IsType(t, &api.Error{}, errResp.Err)
 	})
 	t.Run("ForwardSearchUnsupported", func(t *testing.T) {
 		req := api.SearchRequest{
@@ -116,7 +118,8 @@ func TestSearchError(t *testing.T) {
 		_, err = client.Search(context.Background(), req)
 		require.Error(t, err)
 		errResp := err.(*api.ErrorResponse)
-		require.IsType(t, &api.Error{}, errResp.Err)
+		assert.Equal(t, http.StatusBadRequest, errResp.StatusCode())
+		assert.IsType(t, &api.Error{}, errResp.Err)
 	})
 }
 

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -41,7 +41,7 @@ func NewSearch(ctx context.Context, s *space.Space, req api.SearchRequest) (*Sea
 	// XXX zqd only supports backwards searches, remove once this has been
 	// fixed.
 	if req.Dir == 1 {
-		return nil, zqe.E("forward facing searches not supported", zqe.Invalid)
+		return nil, zqe.E(zqe.Invalid, "forward facing searches not supported")
 	}
 	if req.Dir != -1 {
 		return nil, zqe.E("time direction must be 1 or -1", zqe.Invalid)

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -16,6 +16,7 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqd/api"
 	"github.com/brimsec/zq/zqd/space"
+	"github.com/brimsec/zq/zqe"
 	"go.uber.org/zap"
 )
 
@@ -37,9 +38,13 @@ func NewSearch(ctx context.Context, s *space.Space, req api.SearchRequest) (*Sea
 	if req.Span.Dur < 0 {
 		return nil, errors.New("time span must have non-negative duration")
 	}
-	// XXX allow either direction even through we do forward only right now
-	if req.Dir != 1 && req.Dir != -1 {
-		return nil, errors.New("time direction must be 1 or -1")
+	// XXX zqd only supports backwards searches, remove once this has been
+	// fixed.
+	if req.Dir == 1 {
+		return nil, zqe.E("forward facing searches not supported", zqe.Invalid)
+	}
+	if req.Dir != -1 {
+		return nil, zqe.E("time direction must be 1 or -1", zqe.Invalid)
 	}
 	query, err := UnpackQuery(req)
 	if err != nil {

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -44,7 +44,7 @@ func NewSearch(ctx context.Context, s *space.Space, req api.SearchRequest) (*Sea
 		return nil, zqe.E(zqe.Invalid, "forward facing searches not supported")
 	}
 	if req.Dir != -1 {
-		return nil, zqe.E("time direction must be 1 or -1", zqe.Invalid)
+		return nil, zqe.E(zqe.Invalid, "time direction must be 1 or -1")
 	}
 	query, err := UnpackQuery(req)
 	if err != nil {

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -41,7 +41,7 @@ func NewSearch(ctx context.Context, s *space.Space, req api.SearchRequest) (*Sea
 	// XXX zqd only supports backwards searches, remove once this has been
 	// fixed.
 	if req.Dir == 1 {
-		return nil, zqe.E(zqe.Invalid, "forward facing searches not supported")
+		return nil, zqe.E(zqe.Invalid, "forward searches not yet supported")
 	}
 	if req.Dir != -1 {
 		return nil, zqe.E(zqe.Invalid, "time direction must be 1 or -1")


### PR DESCRIPTION
Also, use zqe when returning errors for invalid dir values.

closes #503