### PR TITLE
Fix race on pcap post endoint test

### DIFF
--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -74,7 +74,8 @@ func TestPacketPostSuccess(t *testing.T) {
 	t.Run("StatusMessage", func(t *testing.T) {
 		info, err := os.Stat(p.pcapfile)
 		require.NoError(t, err)
-		status := p.payloads[1].(*api.PacketPostStatus)
+		plen := len(p.payloads)
+		status := p.payloads[plen-2].(*api.PacketPostStatus)
 		assert.Equal(t, status.Type, "PacketPostStatus")
 		assert.Equal(t, status.PacketSize, info.Size())
 		assert.Equal(t, status.PacketReadSize, info.Size())


### PR DESCRIPTION
As observed here: https://github.com/brimsec/zq/pull/472/checks?check_run_id=539670834

If the endpoint happens to return more than one status message
this can result in the test failing based off of incomplete numbers.
Fix test to take the the last StatusMessage.

closes #524