### PR TITLE
add "zar zdx" command

### DIFF
--- a/cmd/zar/main.go
+++ b/cmd/zar/main.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/brimsec/zq/cmd/zar/mkdirs"
 	_ "github.com/brimsec/zq/cmd/zar/rmdirs"
 	"github.com/brimsec/zq/cmd/zar/root"
+	_ "github.com/brimsec/zq/cmd/zar/zdx"
 	_ "github.com/brimsec/zq/cmd/zar/zq"
 )
 

--- a/cmd/zar/zdx/command.go
+++ b/cmd/zar/zdx/command.go
@@ -1,0 +1,120 @@
+package cmdzdx
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/brimsec/zq/archive"
+	"github.com/brimsec/zq/cmd/zar/root"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zdx"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/detector"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/mccanne/charm"
+)
+
+var Zdx = &charm.Spec{
+	Name:  "zdx",
+	Usage: "zdx [-R dir] [options] file",
+	Short: "walk an archive and create zdx indexes for the named file",
+	Long: `
+"zar zdx" descends the directory given by the -R option (or ZAR_ROOT env) looking for
+logs with zar directories and for each such directory found, it runs
+zdx on the file provided relative to each zar directory.
+The input file must have a field called "key" where all the records in the
+file are sorted by that key in increasing value according to the zng type
+of the key.
+If the root directory is not specified by either the ZAR_ROOT environemnt
+variable or the -R option, then the current directory is assumed.
+`,
+	New: New,
+}
+
+func init() {
+	root.Zar.Add(Zdx)
+}
+
+type Command struct {
+	*root.Command
+	root        string
+	framesize   int
+	outputFile  string
+	quiet       bool
+	ReaderFlags zio.ReaderFlags
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.IntVar(&c.framesize, "f", 32*1024, "minimum frame size used in zdx file")
+	f.StringVar(&c.outputFile, "o", "zdx", "output zdx bundle name")
+	f.BoolVar(&c.quiet, "q", false, "do not print any warnings to stderr")
+
+	c.ReaderFlags.SetFlags(f)
+
+	return c, nil
+}
+
+//XXX lots here copied from zq command... we should refactor into a tools package
+func (c *Command) Run(args []string) error {
+	if len(args) != 1 {
+		return errors.New("zar zdx takes exactly one input file name")
+	}
+	rootPath := c.root
+	if rootPath == "" {
+		rootPath = "."
+	}
+	// XXX this is parallelizable except for writing to stdout when
+	// concatenating results
+	return archive.Walk(rootPath, func(zardir string) error {
+		path := archive.Localize(zardir, args[:1])
+		zctx := resolver.NewContext()
+		cfg := detector.OpenConfig{
+			Format:    c.ReaderFlags.Format,
+			DashStdin: true, //XXX
+			//JSONTypeConfig: c.jsonTypeConfig,
+			//JSONPathRegex:  c.jsonPathRegexp,
+		}
+		file, err := detector.OpenFile(zctx, path[0], cfg)
+		if err != nil {
+			if os.IsNotExist(err) {
+				if !c.quiet {
+					fmt.Fprintln(os.Stderr, err.Error())
+				}
+				err = nil
+			}
+			return err
+		}
+
+		//XXX should have a single-file Localizer
+		outputPath := archive.Localize(zardir, []string{c.outputFile})
+		writer, err := zdx.NewWriter(outputPath[0], c.framesize)
+		if err != nil {
+			return err
+		}
+		close := true
+		defer func() {
+			if close {
+				writer.Close()
+			}
+		}()
+		reader := zbuf.Reader(file)
+		// XXX we can add this later... for now, "zar index" handles
+		// this is the code path here demos the creation of indexes
+		// with abritray aggrates in the fields of each base record
+		//if !c.inputReady {
+		//	reader, err = c.buildTable(zctx, file)
+		//	if err != nil {
+		//		return err
+		//	}
+		//}
+		if err := zbuf.Copy(writer, reader); err != nil {
+			return err
+		}
+		close = false
+		return writer.Close()
+	})
+}

--- a/tests/suite/zar/zdx.yaml
+++ b/tests/suite/zar/zdx.yaml
@@ -1,0 +1,42 @@
+script: |
+  mkdir logs
+  zar chop -q -b 2500 -R ./logs babble.tzng
+  zar mkdirs ./logs
+  # make an index by hand for each log containing a sum
+  zar zq -R ./logs -o tmp.zng "sum(v) by s | put key=s | sort key" _
+  # turn each custom key file into a b-tere index
+  zar zdx -R ./logs -f 500 -o index tmp.zng
+  ls logs/*/*/index.1.zng | sort
+  echo ===
+  zq -t logs/20200421/1587513208.06466306.zng.zar/index.1.zng
+
+inputs:
+  - name: babble.tzng
+    source: ../zdx/babble.tzng
+
+outputs:
+  - name: stdout
+    data: |
+      logs/20200421/1587508830.06852324.zng.zar/index.1.zng
+      logs/20200421/1587509666.06371639.zng.zar/index.1.zng
+      logs/20200421/1587510340.06376481.zng.zar/index.1.zng
+      logs/20200421/1587511070.06294938.zng.zar/index.1.zng
+      logs/20200421/1587511703.06774599.zng.zar/index.1.zng
+      logs/20200421/1587512398.0689091.zng.zar/index.1.zng
+      logs/20200421/1587513208.06466306.zng.zar/index.1.zng
+      logs/20200422/1587513965.0662909.zng.zar/index.1.zng
+      logs/20200422/1587514781.06104719.zng.zar/index.1.zng
+      logs/20200422/1587515638.06653301.zng.zar/index.1.zng
+      logs/20200422/1587516408.06648763.zng.zar/index.1.zng
+      logs/20200422/1587517144.06969796.zng.zar/index.1.zng
+      logs/20200422/1587517919.0642989.zng.zar/index.1.zng
+      ===
+      #0:record[key:string,value:int64]
+      0:[Auriga-teat;0;]
+      0:[amphitheatral-televox;520;]
+      0:[coulee-fraze;1021;]
+      0:[immanency-sarcastical;1566;]
+      0:[operculum-junctional;2097;]
+      0:[regulate-monopodium;2630;]
+      0:[stinkstone-canonize;3130;]
+      0:[willowbiter-Greekish;3638;]

--- a/zdx/writer.go
+++ b/zdx/writer.go
@@ -49,6 +49,9 @@ type Writer struct {
 // provide keys in increasing lexicographic order.  Duplicate keys are not
 // allowed but will not be detected.  Close() must be called when done writing.
 func NewWriter(path string, framesize int) (*Writer, error) {
+	if framesize == 0 {
+		return nil, errors.New("zdx framesize cannot be zero")
+	}
 	return newWriter(path, framesize, 0)
 }
 


### PR DESCRIPTION
This commit adds a zdx subcommand to zar, which lets you walk an
archive and run zdx on a given named zng file, which must be
a zng file with sorted keys.