### PR TITLE
allow zar find to stream hits as zng

### DIFF
--- a/archive/rule.go
+++ b/archive/rule.go
@@ -88,3 +88,26 @@ func (f *FieldRule) NewFinder(dir string) *zdx.Finder {
 	zdxPath := filepath.Join(dir, fieldZdxName(f.field))
 	return zdx.NewFinder(zdxPath)
 }
+
+// StaticRule provides a means XXX to generate Indexers and Finders for a field-specific
+// rules.  Each FieldRule is configured with a field name and the new methods
+// create Indexers and Finders that operate on this field.
+type StaticRule struct {
+	indexName string
+}
+
+func NewStaticRule(name string) (*StaticRule, error) {
+	return &StaticRule{
+		indexName: name,
+	}, nil
+}
+
+func (s *StaticRule) NewIndexer(dir string) (Indexer, error) {
+	//XXX shouldn't be called
+	return nil, nil
+}
+
+func (s *StaticRule) NewFinder(dir string) *zdx.Finder {
+	zdxPath := filepath.Join(dir, s.indexName)
+	return zdx.NewFinder(zdxPath)
+}

--- a/cmd/zar/find/command.go
+++ b/cmd/zar/find/command.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/brimsec/zq/archive"
 	"github.com/brimsec/zq/cmd/zar/root"
+	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zng"
 	"github.com/mccanne/charm"
 )
 
@@ -46,12 +49,21 @@ type Command struct {
 	*root.Command
 	root        string
 	skipMissing bool
+	indexFile   string
+	outputFile  string
+	WriterFlags zio.WriterFlags
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
 	f.BoolVar(&c.skipMissing, "Q", false, "skip errors caused by missing index files ")
+	f.StringVar(&c.indexFile, "x", "", "name of zdx index in the zar dirs")
+	f.StringVar(&c.outputFile, "o", "", "write data to output file")
+
+	// Flags added for writers are -f, -T, -F, -E, -U, and -b
+	c.WriterFlags.SetFlags(f)
+
 	return c, nil
 }
 
@@ -59,31 +71,74 @@ func (c *Command) Run(args []string) error {
 	if len(args) != 1 {
 		return errors.New("zar find: exactly one search pattern must be provided")
 	}
-	v := strings.Split(args[0], "=")
-	if len(v) != 2 {
-		return errors.New("zar find: syntax error: " + args[0])
-	}
-	fieldOrType := v[0]
-	pattern := v[1]
-	rule, err := archive.NewRule(fieldOrType)
-	if err != nil {
-		return errors.New("zar find: error parsing pattern: " + err.Error())
-	}
-	hits := make(chan string)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		for hit := range hits {
-			fmt.Println(hit)
+	var pattern string
+	var rule archive.Rule
+	zngOutput := false
+	if c.outputFile != "" {
+		if c.indexFile == "" {
+			return errors.New("zar find: must specify -x with -o")
 		}
-		wg.Done()
-	}()
+		zngOutput = true
+		//XXX hack fo now.  fix later.r
+		rule, _ = archive.NewStaticRule(c.indexFile)
+		pattern = args[0]
+	} else {
+		v := strings.Split(args[0], "=")
+		if len(v) != 2 {
+			return errors.New("zar find: syntax error: " + args[0])
+		}
+		fieldOrType := v[0]
+		pattern = v[1]
+		var err error
+		rule, err = archive.NewRule(fieldOrType)
+		if err != nil {
+			return errors.New("zar find: error parsing pattern: " + err.Error())
+		}
+	}
+	//XXX allow "-" to trigger zng but changed back for emitter API
+	if c.outputFile == "-" {
+		c.outputFile = ""
+	}
 	rootDir := c.root
 	if rootDir == "" {
 		rootDir = "."
 	}
-	err = archive.Find(rootDir, rule, pattern, hits, c.skipMissing)
-	close(hits)
+	var err error
+	var searchErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	if zngOutput {
+		writer, err := emitter.NewFile(c.outputFile, &c.WriterFlags)
+		if err != nil {
+			return err
+		}
+		defer writer.Close()
+		hits := make(chan *zng.Record)
+		go func() {
+			for hit := range hits {
+				if err := writer.Write(hit); err != nil {
+					searchErr = err
+					break
+				}
+			}
+			wg.Done()
+		}()
+		err = archive.FindZng(rootDir, rule, pattern, hits, c.skipMissing)
+		close(hits)
+	} else {
+		hits := make(chan string)
+		go func() {
+			for hit := range hits {
+				fmt.Println(hit)
+			}
+			wg.Done()
+		}()
+		err = archive.Find(rootDir, rule, pattern, hits, c.skipMissing)
+		close(hits)
+	}
 	wg.Wait()
+	if err == nil {
+		err = searchErr
+	}
 	return err
 }

--- a/tests/suite/zar/findzng.yaml
+++ b/tests/suite/zar/findzng.yaml
@@ -1,0 +1,20 @@
+
+script: |
+  mkdir logs
+  zar chop -q -b 2500 -R ./logs babble.tzng
+  zar mkdirs ./logs
+  # make an index by hand for each log containing a sum
+  zar zq -R ./logs -o tmp.zng "sum(v) by s | put key=s | sort key" _
+  # turn each custom key file into a b-tere index
+  zar zdx -R ./logs -f 500 -o index tmp.zng
+  zar find -R ./logs -o - -x index amphitheatral-televox | zq -t -
+
+inputs:
+  - name: babble.tzng
+    source: ../zdx/babble.tzng
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[s:string,sum:int64,key:string]
+      0:[amphitheatral-televox;251;amphitheatral-televox;]


### PR DESCRIPTION
This commit changes zar find so if you specify an output file
or ("-o -" for stdout) zar find will output zng instead of a list
of log paths, where hte zng file is comprised of a stream zng.Records
where each record corresponds to the records with the matched key
for the hit from each index file.

For now, this is kind of hacked together for prototyping and demo
purposes.  We will clean it up soon a forthcoming PR.