### PR TITLE
Robustify FieldExpr

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -31,6 +31,7 @@ type BooleanExpr interface {
 
 // FieldExpr is the interface implemented by expressions that reference fields.
 type FieldExpr interface {
+	fieldExprNode()
 }
 
 type Expression interface {
@@ -129,6 +130,9 @@ type (
 		Param string    `json:"param"`
 	}
 )
+
+func (*FieldRead) fieldExprNode() {}
+func (*FieldCall) fieldExprNode() {}
 
 type UnaryExpression struct {
 	Node


### PR DESCRIPTION
ast.FieldExpr was defined as interface{} which means that any go
value is a value FieldExpr.  Make this a little more type safe by
adding any empty method.