### PR TITLE
Clone zq-sample-data to depth of 1 in zar README

### DIFF
--- a/cmd/zar/README.md
+++ b/cmd/zar/README.md
@@ -19,7 +19,7 @@ svn checkout https://github.com/brimsec/zq-sample-data/trunk/zng
 ```
 Or, you can clone the whole data repo using git and symlink the zng dir:
 ```
-git clone https://github.com/brimsec/zq-sample-data.git
+git clone --depth=1 https://github.com/brimsec/zq-sample-data.git
 ln -s zq-sample-data/zng
 ```
 


### PR DESCRIPTION
By getting only the most recent commit of the sample data, it'll clone quicker.