### PR TITLE
Have scanner listen and stop on context.Cancel

### DIFF
--- a/driver/compile.go
+++ b/driver/compile.go
@@ -25,7 +25,7 @@ func Compile(ctx context.Context, program ast.Proc, reader zbuf.Reader, reverse 
 func CompileWarningsCh(ctx context.Context, program ast.Proc, reader zbuf.Reader, reverse bool, span nano.Span, logger *zap.Logger, ch chan string) (*MuxOutput, error) {
 
 	filterAst, program := liftFilter(program)
-	scanner, err := newScanner(reader, filterAst, span)
+	scanner, err := newScanner(ctx, reader, filterAst, span)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func liftFilter(p ast.Proc) (*ast.FilterProc, ast.Proc) {
 // newScanner takes a Reader, optional Filter AST, and timespan, and
 // constructs a scanner that can be used as the head of a
 // flowgraph.
-func newScanner(reader zbuf.Reader, fltast *ast.FilterProc, span nano.Span) (*scanner.Scanner, error) {
+func newScanner(ctx context.Context, reader zbuf.Reader, fltast *ast.FilterProc, span nano.Span) (*scanner.Scanner, error) {
 	var f filter.Filter
 	if fltast != nil {
 		var err error
@@ -78,5 +78,5 @@ func newScanner(reader zbuf.Reader, fltast *ast.FilterProc, span nano.Span) (*sc
 			return nil, err
 		}
 	}
-	return scanner.NewScanner(reader, f, span), nil
+	return scanner.NewScanner(ctx, reader, f, span), nil
 }

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
@@ -35,7 +34,7 @@ func TestMuxDriver(t *testing.T) {
 
 	t.Run("muxed into one writer", func(t *testing.T) {
 		reader := tzngio.NewReader(strings.NewReader(input), zctx)
-		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader, nil, nano.MaxSpan), false, nano.MaxSpan, nil)
+		flowgraph, err := Compile(context.Background(), query, reader, false, nano.MaxSpan, nil)
 		assert.NoError(t, err)
 		c := counter{}
 		d := NewCLI(&c)
@@ -46,7 +45,7 @@ func TestMuxDriver(t *testing.T) {
 
 	t.Run("muxed into individual writers", func(t *testing.T) {
 		reader := tzngio.NewReader(strings.NewReader(input), zctx)
-		flowgraph, err := Compile(context.Background(), query, scanner.NewScanner(reader, nil, nano.MaxSpan), false, nano.MaxSpan, nil)
+		flowgraph, err := Compile(context.Background(), query, reader, false, nano.MaxSpan, nil)
 		assert.NoError(t, err)
 		cs := []zbuf.Writer{&counter{}, &counter{}}
 		d := NewCLI(cs...)

--- a/proc/split.go
+++ b/proc/split.go
@@ -108,14 +108,12 @@ func (s *SplitChannel) Pull() (zbuf.Batch, error) {
 	if s.ch == nil {
 		return nil, nil
 	}
-	// Send SplitProc a request, then read the result.  If context is
-	// canceled, we send a nil request to let SplitProc know we're done,
-	// which will cause it to exit when it sees that all of us SplitChannels
-	// are gone.  We don't want both SplitProc and SplitChannel listening
-	// on context canceled as that could lead to deadlock.
+	// Send SplitProc a request, then read the result. On EOS we send a nil
+	// request to let SplitProc know we're done, which will cause it to exit
+	// when it sees that all of us SplitChannels are gone.
 	s.request <- s.ch
 	result := <-s.ch
-	if result.Batch == nil && result.Err == nil {
+	if EOS(result.Batch, result.Err) {
 		s.Done()
 	}
 	return result.Batch, result.Err

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -53,7 +53,10 @@ func (s *Scanner) Stats() api.ScannerStats {
 
 // Read implements zbuf.Reader.Read.
 func (s *Scanner) Read() (*zng.Record, error) {
-	for s.ctx.Err() == nil {
+	for {
+		if err := s.ctx.Err(); err != nil {
+			return nil, err
+		}
 		rec, err := s.reader.Read()
 		if err != nil || rec == nil {
 			return nil, err
@@ -71,7 +74,6 @@ func (s *Scanner) Read() (*zng.Record, error) {
 		rec.CopyBody()
 		return rec, nil
 	}
-	return nil, nil
 }
 
 // Done is required to implement proc.Proc interface. Ignore for now.


### PR DESCRIPTION
The lack of context listening to the cancel signal was causing a
a long running ingest handler to not exit when the context of the
request was cancelled. Add context.Err check to scanner which in
turn emits EOS and lets the the flowgraph elegantly cease operations.

Also there was a deadlock occurring in the split proc it recieves an
EOS and the split proc has receieved no data.
The was occurring because the child SplitChannel procs were themselves
listening for context.Done() and exiting before the SplitProc could
tell them itself and the parent SplitProc was then deadlocked trying to
push an EOS to children that were not listening. Tell the SplitChannel to calm
down and trust the process.

closes #707