### PR TITLE
Move scanner.Combiner/Mapper to package zbuf

### DIFF
--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -17,7 +17,6 @@ import (
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
@@ -168,7 +167,7 @@ func (c *Command) Run(args []string) error {
 				readers[i] = zbuf.NewWarningReader(r, wch)
 			}
 		}
-		reader := scanner.NewCombiner(readers)
+		reader := zbuf.NewCombiner(readers)
 		defer reader.Close()
 		writer, err := c.openOutput(zardir, c.outputFile)
 		if err != nil {

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -15,7 +15,6 @@ import (
 	"github.com/brimsec/zq/emitter"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/proc"
-	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
@@ -230,7 +229,7 @@ func (c *Command) Run(args []string) error {
 			readers[i] = zbuf.NewWarningReader(r, wch)
 		}
 	}
-	reader := scanner.NewCombiner(readers)
+	reader := zbuf.NewCombiner(readers)
 	defer reader.Close()
 
 	writer, err := c.openOutput()

--- a/zbuf/combiner.go
+++ b/zbuf/combiner.go
@@ -1,39 +1,24 @@
-package scanner
+package zbuf
 
 import (
 	"fmt"
 	"io"
 
-	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zng/resolver"
 )
 
 type Combiner struct {
-	readers []zbuf.Reader
+	readers []Reader
 	hol     []*zng.Record
 	done    []bool
 }
 
-func NewCombiner(readers []zbuf.Reader) *Combiner {
+func NewCombiner(readers []Reader) *Combiner {
 	return &Combiner{
 		readers: readers,
 		hol:     make([]*zng.Record, len(readers)),
 		done:    make([]bool, len(readers)),
 	}
-}
-
-func OpenFiles(zctx *resolver.Context, paths ...string) (*Combiner, error) {
-	var readers []zbuf.Reader
-	for _, path := range paths {
-		reader, err := detector.OpenFile(zctx, path, detector.OpenConfig{})
-		if err != nil {
-			return nil, err
-		}
-		readers = append(readers, reader)
-	}
-	return NewCombiner(readers), nil
 }
 
 func (c *Combiner) Read() (*zng.Record, error) {
@@ -65,14 +50,14 @@ func (c *Combiner) Read() (*zng.Record, error) {
 	return tup, nil
 }
 
-func (c *Combiner) closeReader(r zbuf.Reader) error {
+func (c *Combiner) closeReader(r Reader) error {
 	if closer, ok := r.(io.Closer); ok {
 		return closer.Close()
 	}
 	return nil
 }
 
-// Close closes underlying zbuf.Readers implementing the io.Closer
+// Close closes underlying Readers implementing the io.Closer
 // interface if they haven't already been closed.
 func (c *Combiner) Close() error {
 	var err error

--- a/zbuf/mapper.go
+++ b/zbuf/mapper.go
@@ -1,17 +1,16 @@
-package scanner
+package zbuf
 
 import (
-	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 )
 
 type Mapper struct {
-	zbuf.Reader
+	Reader
 	mapper *resolver.Mapper
 }
 
-func NewMapper(reader zbuf.Reader, zctx *resolver.Context) *Mapper {
+func NewMapper(reader Reader, zctx *resolver.Context) *Mapper {
 	return &Mapper{
 		Reader: reader,
 		mapper: resolver.NewMapper(zctx),

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -57,6 +57,18 @@ func OpenFile(zctx *resolver.Context, path string, cfg OpenConfig) (*zbuf.File, 
 	return zbuf.NewFile(zr, f), nil
 }
 
+func OpenFiles(zctx *resolver.Context, paths ...string) (*zbuf.Combiner, error) {
+	var readers []zbuf.Reader
+	for _, path := range paths {
+		reader, err := OpenFile(zctx, path, OpenConfig{})
+		if err != nil {
+			return nil, err
+		}
+		readers = append(readers, reader)
+	}
+	return zbuf.NewCombiner(readers), nil
+}
+
 func jsonConfig(cfg OpenConfig, jr *ndjsonio.Reader, filename string) error {
 	var path string
 	re := regexp.MustCompile(cfg.JSONPathRegex)

--- a/zng/resolver/context_test.go
+++ b/zng/resolver/context_test.go
@@ -1,4 +1,4 @@
-package resolver
+package resolver_test
 
 import (
 	"testing"
@@ -6,12 +6,13 @@ import (
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestContextAddColumns(t *testing.T) {
-	ctx := NewContext()
+	ctx := resolver.NewContext()
 	d, err := ctx.LookupTypeRecord([]zng.Column{zng.NewColumn("s1", zng.TypeString)})
 	require.NoError(t, err)
 	r, err := zbuf.NewRecordZeekStrings(d, "S1")
@@ -29,7 +30,7 @@ func TestContextAddColumns(t *testing.T) {
 }
 
 func TestDuplicates(t *testing.T) {
-	ctx := NewContext()
+	ctx := resolver.NewContext()
 	setType := ctx.LookupTypeSet(zng.TypeInt32)
 	typ1, err := ctx.LookupTypeRecord([]zng.Column{
 		zng.NewColumn("a", zng.TypeString),

--- a/zqd/ingest/log.go
+++ b/zqd/ingest/log.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
@@ -151,13 +150,13 @@ func compileLogIngest(ctx context.Context, s *space.Space, rs []zbuf.Reader, pro
 		return nil, err
 	}
 	if stopErr {
-		r := scanner.NewCombiner(rs)
+		r := zbuf.NewCombiner(rs)
 		return driver.Compile(ctx, p, r, false, nano.MaxSpan, zap.NewNop())
 	}
 	wch := make(chan string, 5)
 	for i, r := range rs {
 		rs[i] = zbuf.NewWarningReader(r, wch)
 	}
-	r := scanner.NewCombiner(rs)
+	r := zbuf.NewCombiner(rs)
 	return driver.CompileWarningsCh(ctx, p, r, false, nano.MaxSpan, zap.NewNop(), wch)
 }

--- a/zqd/ingest/pcap.go
+++ b/zqd/ingest/pcap.go
@@ -14,9 +14,9 @@ import (
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pcap"
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqd/search"
@@ -227,7 +227,7 @@ func (p *Process) createSnapshot(ctx context.Context) error {
 		return nil
 	}
 	// convert logs into sorted zng
-	zr, err := scanner.OpenFiles(resolver.NewContext(), files...)
+	zr, err := detector.OpenFiles(resolver.NewContext(), files...)
 	if err != nil {
 		return err
 	}

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -11,7 +11,6 @@ import (
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqd/api"
@@ -56,7 +55,7 @@ func NewSearch(ctx context.Context, s *space.Space, req api.SearchRequest) (*Sea
 		return nil, err
 	}
 	zctx := resolver.NewContext()
-	mapper := scanner.NewMapper(zngReader, zctx)
+	mapper := zbuf.NewMapper(zngReader, zctx)
 	mux, err := launch(ctx, query, mapper, zctx)
 	if err != nil {
 		zngReader.Close()

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -130,7 +130,6 @@ import (
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
@@ -617,7 +616,7 @@ func runzq(bindir, ZQL, outputFormat, outputFlags string, inputs ...string) (out
 	return string(outbuf.Bytes()), string(errbuf.Bytes()), nil
 }
 
-func loadInputs(inputs []string, zctx *resolver.Context) (*scanner.Combiner, error) {
+func loadInputs(inputs []string, zctx *resolver.Context) (*zbuf.Combiner, error) {
 	var readers []zbuf.Reader
 	for _, input := range inputs {
 		zr, err := detector.NewReader(detector.GzipReader(strings.NewReader(input)), zctx)
@@ -626,7 +625,7 @@ func loadInputs(inputs []string, zctx *resolver.Context) (*scanner.Combiner, err
 		}
 		readers = append(readers, zr)
 	}
-	return scanner.NewCombiner(readers), nil
+	return zbuf.NewCombiner(readers), nil
 }
 
 func tmpInputFiles(inputs []string) (string, []string, error) {


### PR DESCRIPTION
The purpose of package scanner is to provide a proc interface
for a zbuf.Reader source. scanner.Combiner/Mapper do not fit
within the package. Move them to the growing library of truly useful
generic zng stream operators in zbuf.