### PR TITLE
Npm installable zq

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
-dist/
+dist/*
+!dist/.gitignore
 tests/test-root
 zq-sample-data
 zql/deps/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 bin/
-dist/*
-!dist/.gitignore
+dist/
 tests/test-root
 zq-sample-data
 zql/deps/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export GO111MODULE=on
 
-VERSION = $(shell git describe --tags --dirty)
+VERSION = $(shell git describe --tags --dirty --always)
 LDFLAGS = -s -X main.version=$(VERSION)
 ZEEKTAG = v3.0.2-brim1
 ZEEKPATH = zeek-$(ZEEKTAG)

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ create-release-assets:
 test-ci: fmt tidy vet test-unit test-system test-zeek test-heavy
 
 clean:
-	@rm -rf dist
+	@rm -rf dist/*
 
 .PHONY: fmt tidy vet test-unit test-system test-heavy sampledata test-ci
 .PHONY: perf-compare build install create-release-assets clean

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 export GO111MODULE=on
 
+# If VERSION or LDFLAGS change, please also change
+# npm/build.
 VERSION = $(shell git describe --tags --dirty --always)
 LDFLAGS = -s -X main.version=$(VERSION)
 ZEEKTAG = v3.0.2-brim1
@@ -49,6 +51,7 @@ test-zeek: bin/$(ZEEKPATH)
 perf-compare: build $(SAMPLEDATA)
 	scripts/comparison-test.sh
 
+# If the build recipe changes, please also change npm/build.
 build:
 	@mkdir -p dist
 	@go build -ldflags='$(LDFLAGS)' -o dist ./cmd/...

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ create-release-assets:
 test-ci: fmt tidy vet test-unit test-system test-zeek test-heavy
 
 clean:
-	@rm -rf dist/*
+	@rm -rf dist
 
 .PHONY: fmt tidy vet test-unit test-system test-heavy sampledata test-ci
 .PHONY: perf-compare build install create-release-assets clean

--- a/npm/build/index.js
+++ b/npm/build/index.js
@@ -1,0 +1,39 @@
+// Mimic the build recipe in Makefile. Written in node so it works on
+// Windows and *nix when trying to npm install zq.
+const child_process = require("child_process")
+const fs = require("fs")
+
+const getVersion = () => {
+  const GIT_COMMAND = "git describe --tags --dirty --always"
+  let cmdOut = "prepack-unknown"
+  try {
+    cmdOut = child_process.execSync(GIT_COMMAND, {stdio: "pipe"})
+  } catch (e) {
+    console.log(`unable to run "${GIT_COMMAND}": ${e.toString().trim()}`)
+  }
+  return cmdOut.toString().trim()
+}
+
+const getLdflags = (version) => `-s -X main.version=${version}`
+
+const getBuildCommand = (options) =>
+  // Double-quotes work both in Windows and *nix shells
+  `go build -ldflags="${options.ldflags}" -o dist ./cmd/...`
+
+const mkdir_p = (path) => {
+  if (!fs.existsSync(path)) {
+    fs.mkdirSync(path)
+  }
+}
+
+const build = () => {
+  let version = getVersion()
+  let ldflags = getLdflags(version)
+  let buildCommand = getBuildCommand({ldflags: ldflags})
+  mkdir_p("dist")
+  console.log(buildCommand)
+  // Just let any failure here bubble up.
+  child_process.execSync(buildCommand)
+}
+
+build()

--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "zq"
+  "name": "zq",
+  "version": "0.13.0-dev"
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,14 @@
 {
   "name": "zq",
-  "version": "0.13.0-dev"
+  "version": "0.13.0-dev",
+  "scripts": {
+      "prepack": "go build -o dist ./cmd/..."
+  },
+  "files": [
+      "dist/**",
+      "**/*.js"
+  ],
+  "directories": {
+      "bin": "dist"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zq",
   "version": "0.13.0-dev",
   "scripts": {
-      "prepack": "go build -o dist ./cmd/..."
+      "prepack": "node npm/build"
   },
   "files": [
       "dist/**",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zq",
-  "version": "0.13.0-dev",
+  "version": "0.12.0-dev",
   "scripts": {
       "prepack": "node npm/build"
   },


### PR DESCRIPTION
Here is one approach for being able to have Brim point to arbitrary zq commit hashes. When you `npm install github:brimsec/zq#hash`, this will clone zq.git, run scripts.prepack, and put dist/ and zq's javascript files into node_modules/zq. Everything from dist/ also goes into node_modules/.bin so that npx zq and similar usage is possible. Brim's scripts/download-zdeps will copy zq and zqd from node_modules/zq/dist into zdeps.

Companion Brim-side PR: https://github.com/brimsec/brim/pull/730

There are a lot of words in the ordered list below. This is one of those changes where a lot happens under the hood even though the diff line count is small, and I want to show that earlier realizations or conditions inform later design choices. Not having managed a Node project before, I might have missed some NPM capability. Please let me know if something is obviously wrong.

1. Local development changes or CI changes to Brim's package.json to modify zq SHOULD be performed via `npm install github:brimsec/zq#commitish`. Other methods of changing package.json are not as nearly attractive. This choice has consequences, as you'll see below.
1. We do not want to produce and track zq binary artifacts after all zq.git CI runs. This means anything that wants to npm install Brim MUST be able to build zq, so anything that wants to npm install Brim MUST also have Go. This means CI and Brim developers MUST have Go. Because release packaging includes zq/zqd, users of release artifacts either MAY or MAY NOT have Go.
1. To be able to `npm install github:brimsec/zq#commitish`, zq's package.json MUST contain a version.
1. A npm-installed zq -version MUST contain a commit hash of zq.
1. A commit hash of zq MUST be derived from a clone of zq, not an export. The .git directory must exist. Without this, 4 is violated.
1. npm install of a Github project first clones the repository and then copies stuff from that clone directory into node_modules, with optional intermediate steps along the way. When npm installing a Github project, it is not possible to carry over that project's clone's .git directory into node_modules. [npm-packlist](https://github.com/npm/npm-packlist/blob/master/index.js#L111) explicitly filters the .git directory, even if you try to unignore it in .npmignore. Note this violates 5 above.
1. This means zq's package.json MUST build zq from its pre-npm packed git clone *before* being installed into node_modules.
1. zq's version derivation mechanism is git describe --tags --dirty.
1. When a Github project in package.json has an arbitrary hash that is also pointed to by a ref in the source repository (e.g., Brim's package.json specifies zq as brimsec/zq#d4cba020b77b16957aba25ecd41da44ad5028c9b, and zq.git's refs/heads/master points to d4cba020b77b16957aba25ecd41da44ad5028c9b), [pacote](https://github.com/npm/pacote/blob/v9.5.11/lib/util/git.js#L147) performs a shallow clone of the project as part of the npm install. In those cases, git describe --tags --dirty will fail, because there are no tags fetched. This violates 8 above. Changing this to git describe --tags --dirty --always will produce a short hash if the clone is shallow.  In cases where pacote has to perform a full clone, git describe --tags --dirty --always will produce identical output to git describe --tags --dirty.
1. You might notice that the version in zq's package.json is largely arbitrary and never gets surfaced. It only satisfies brim-side `npm install zq` but serves no other purpose.
1. ~The instructions for building zq should be in zq.git, but one problem here is that Makefile is the source of truth, and make isn't available on Windows. TODO: zq's package.json's scripts.prepack should call something that can set VERSION and LDFLAGS that works on Windows as well as UNIX-based platforms. zq's Makefile should use the same thing. How to make that platform- and tool-independent is still TBD. Note that without VERSION, zq produced from npm install has a version of "unknown".~ While this is a valid concern, I think it's also "perfect as enemy of the good". I have implemented the build recipe in a parallel node script. More elaboration is below.
1. ~dist is kept around for now as a persistent, empty directory, because it makes the prepack script Just Work for demonstration purposes. When 10 above is working, this can probably go away.~ Obsolete after 2494187
1. Because zq's scripts.prepack is responsible for building zq (as it should be), when Brim wants to npm install zq#v1.2.3 (something that looks like a semver/release, not a ash), npm will clone zq#v1.2.3, build zq, put the built assets into node_modules/zq as usual. But then scripts/download-zdeps will download the zq v1.2.3 release assets from Github anyway. I'm not sure how to make npm install of zq in brim behave differently in this case. This is getting into some nastiness: trying to use npm to deal with a Go project. This also comes all the way back to the beginning, in that the choice to use npm install of a Go project is a little awkward. **Update after 7fa865c:** I have left this behavior as written. I think it's convenient to have zq's dist in node_modles/zq/dist. If folks don't want that confusion for tagged releases, that's something we should talk about.

Fixes #677 #678 #679 