### PR TITLE
zqd: Ensure posted space name is unique

### DIFF
--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -237,6 +237,21 @@ func TestSpacePostNameOnly(t *testing.T) {
 	require.Equal(t, expected, sp)
 }
 
+func TestSpacePostDuplicateName(t *testing.T) {
+	ctx := context.Background()
+	c, client, done := newCore(t)
+	defer done()
+	expected := &api.SpacePostResponse{
+		Name:    "test_01",
+		DataDir: filepath.Join(c.Root, "test_01"),
+	}
+	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
+	require.NoError(t, err)
+	sp, err = client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
+	require.NoError(t, err)
+	require.Equal(t, expected, sp)
+}
+
 func TestSpacePostDataDir(t *testing.T) {
 	ctx := context.Background()
 	tmp := createTempDir(t)

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -120,7 +120,6 @@ func (m *Manager) Create(name, dataPath string) (*api.SpacePostResponse, error) 
 	}
 
 	if _, exists := m.spaces[name]; exists {
-		m.mapLock.Unlock()
 		m.logger.Error("created duplicate space name", zap.String("name", name))
 		return nil, errors.New("created duplicate space name (this should not happen)")
 	}

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -119,6 +119,12 @@ func (m *Manager) Create(name, dataPath string) (*api.SpacePostResponse, error) 
 		return nil, err
 	}
 
+	if _, exists := m.spaces[name]; exists {
+		m.mapLock.Unlock()
+		m.logger.Error("created duplicate space name", zap.String("name", name))
+		return nil, errors.New("created duplicate space name (this should not happen)")
+	}
+
 	m.spaces[name] = newSpace(path, c)
 	return &api.SpacePostResponse{
 		Name:    name,

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -93,12 +93,6 @@ func NewManager(root string, logger *zap.Logger) *Manager {
 
 func (m *Manager) Create(name, dataPath string) (*api.SpacePostResponse, error) {
 	m.mapLock.Lock()
-	_, exists := m.spaces[name]
-	if exists {
-		m.mapLock.Unlock()
-		return nil, ErrSpaceExists
-	}
-
 	defer m.mapLock.Unlock()
 
 	if name == "" && dataPath == "" {

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -106,19 +106,14 @@ func (m *Manager) Create(name, dataPath string) (*api.SpacePostResponse, error) 
 	}
 	var path string
 	if name == "" {
-		var err error
-		if path, err = fs.UniqueDir(m.rootPath, filepath.Base(dataPath)); err != nil {
-			return nil, err
-		}
-		name = filepath.Base(path)
-	} else {
-		path = filepath.Join(m.rootPath, name)
-		if err := os.Mkdir(path, 0700); err != nil {
-			if os.IsExist(err) {
-				return nil, ErrSpaceExists
-			}
-			return nil, err
-		}
+		name = filepath.Base(dataPath)
+	}
+	path, err := fs.UniqueDir(m.rootPath, name)
+	if err != nil {
+		return nil, err
+	}
+	name = filepath.Base(path)
+	if dataPath == "" {
 		dataPath = path
 	}
 	c := config{


### PR DESCRIPTION
Previously we were returning an error if a user tried to create
a space with name that already existed. Allow a duplicate name to
be posted and use fs.UniqueDir to make the name unique.