### PR TITLE
spawn zeek on windows with new hidden subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 tests/test-root
 zq-sample-data
 zql/deps/
+.idea

--- a/cmd/zqd/main.go
+++ b/cmd/zqd/main.go
@@ -6,6 +6,7 @@ import (
 
 	_ "github.com/brimsec/zq/cmd/zqd/listen"
 	root "github.com/brimsec/zq/cmd/zqd/root"
+	_ "github.com/brimsec/zq/cmd/zqd/winexec"
 	"github.com/brimsec/zq/zqd"
 )
 

--- a/cmd/zqd/winexec/command.go
+++ b/cmd/zqd/winexec/command.go
@@ -1,0 +1,35 @@
+package winexec
+
+import (
+	"flag"
+
+	"github.com/brimsec/zq/cmd/zqd/root"
+	"github.com/mccanne/charm"
+)
+
+func init() {
+	root.Zqd.Add(spec)
+}
+
+var spec = &charm.Spec{
+	Hidden: true,
+	Name:   "winexec",
+	Usage:  "winexec <command> <command-options...>",
+	Short:  "exec helper for windows",
+	Long: `
+Executes the given command and arguments, terminating all spawned processes on exit.
+`,
+	New: newWindowsExecutor,
+}
+
+func newWindowsExecutor(_ charm.Command, _ *flag.FlagSet) (charm.Command, error) {
+	c := &windowsExecutor{}
+	return c, nil
+}
+
+type windowsExecutor struct {
+}
+
+func (w *windowsExecutor) Run(args []string) error {
+	return winexec(args)
+}

--- a/cmd/zqd/winexec/command.go
+++ b/cmd/zqd/winexec/command.go
@@ -15,16 +15,15 @@ var spec = &charm.Spec{
 	Hidden: true,
 	Name:   "winexec",
 	Usage:  "winexec <command> <command-options...>",
-	Short:  "exec helper for windows",
+	Short:  "exec helper for Windows",
 	Long: `
-Executes the given command and arguments, terminating all spawned processes on exit.
+Executes the given command, terminating all spawned processes on exit.
 `,
 	New: newWindowsExecutor,
 }
 
 func newWindowsExecutor(_ charm.Command, _ *flag.FlagSet) (charm.Command, error) {
-	c := &windowsExecutor{}
-	return c, nil
+	return &windowsExecutor{}, nil
 }
 
 type windowsExecutor struct {

--- a/cmd/zqd/winexec/exec.go
+++ b/cmd/zqd/winexec/exec.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package winexec
+
+import "fmt"
+
+func winexec(_ []string) error {
+	return fmt.Errorf("winexec only for windows platforms")
+}

--- a/cmd/zqd/winexec/exec.go
+++ b/cmd/zqd/winexec/exec.go
@@ -2,8 +2,8 @@
 
 package winexec
 
-import "fmt"
+import "errors"
 
 func winexec(_ []string) error {
-	return fmt.Errorf("winexec only for windows platforms")
+	return errors.New("winexec is only available on Windows")
 }

--- a/cmd/zqd/winexec/exec_windows.go
+++ b/cmd/zqd/winexec/exec_windows.go
@@ -1,7 +1,7 @@
 package winexec
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"os/exec"
 	"unsafe"
@@ -28,8 +28,7 @@ func ensureSpawnedProcessTermination() error {
 
 	// We add ourselves so that any process we launch will automatically be
 	// added to the job.
-	err = jo.AddCurrentProcess()
-	if err != nil {
+	if err := jo.AddCurrentProcess(); err != nil {
 		return err
 	}
 
@@ -52,11 +51,10 @@ func ensureSpawnedProcessTermination() error {
 
 func winexec(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("expected command to execute")
+		return errors.New("expected command to execute")
 	}
 
-	err := ensureSpawnedProcessTermination()
-	if err != nil {
+	if err := ensureSpawnedProcessTermination(); err != nil {
 		return err
 	}
 

--- a/cmd/zqd/winexec/exec_windows.go
+++ b/cmd/zqd/winexec/exec_windows.go
@@ -1,0 +1,68 @@
+package winexec
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"unsafe"
+
+	"github.com/alexbrainman/ps"
+	"github.com/alexbrainman/ps/winapi"
+)
+
+// ensureSpawnedProcessTermination ensures that when this Go process terminates, the
+// launched process will also be terminated. It does so via the Windows
+// job objects api:
+// https://docs.microsoft.com/en-us/windows/win32/procthread/job-objects
+//
+// See this Go issue for discussion about the challenge of process management
+// on Windows, and the mention of the ps & winapi package used here:
+// https://github.com/golang/go/issues/17608
+func ensureSpawnedProcessTermination() error {
+	// Create an unnamed job object; no name is necessary since no other
+	// process needs to find or interact with it.
+	jo, err := ps.CreateJobObject("")
+	if err != nil {
+		return err
+	}
+
+	// We add ourselves so that any process we launch will automatically be
+	// added to the job.
+	err = jo.AddCurrentProcess()
+	if err != nil {
+		return err
+	}
+
+	// We set the "kill on job close" option for the job, so that when the
+	// last handle to the job is closed, all of the processes in the job
+	// will be terminated.
+	// This process is the only one with a handle to the job object, and we
+	// intentionally leave it open. Like other handles, it will be closed
+	// automatically when this process terminates. When that occurs, the
+	// 'kill on job close' option will trigger the termination of any
+	// spawned processes.
+	limitInfo := winapi.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: winapi.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: winapi.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	return winapi.SetInformationJobObject(jo.Handle, winapi.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&limitInfo)), uint32(unsafe.Sizeof(limitInfo)))
+}
+
+func winexec(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("expected command to execute")
+	}
+
+	err := ensureSpawnedProcessTermination()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/brimsec/zq
 go 1.13
 
 require (
+	github.com/alexbrainman/ps v0.0.0-20171229230509-b3e1b4a15894
 	github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f
 	github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e
 	github.com/go-resty/resty/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/alexbrainman/ps v0.0.0-20171229230509-b3e1b4a15894 h1:A6LgNoQeWttVPnIRYzKsbex/HePFxYT9ygCZvgVJDU0=
+github.com/alexbrainman/ps v0.0.0-20171229230509-b3e1b4a15894/go.mod h1:Wgrp3f69GNEJz6CdHKtBqKAWdmYTd1K9IlOV+uuv4Uw=
 github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f h1:y06x6vGnFYfXUoVMbrcP1Uzpj4JG01eB5vRps9G8agM=
 github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f/go.mod h1:2stgcRjl6QmW+gU2h5E7BQXg4HU0gzxKWDuT5HviN9s=
 github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e h1:oJCXMss/3rg5F6Poy9wG3JQusc58Mzk5B9Z6wSnssNE=


### PR DESCRIPTION
This adds a hidden zqd subcommand "winexec", that executes a command
using the same job object based spawned process termination we are
already using in the windows zeek-launcher utility. Use this subcommand
when we launch zeek on windows. This is a first step to treating zeek as
more of a black box from inside zqd, so that users can run their own
zeek setup.