### PR TITLE
zngio: don't swallow errors when reading

### DIFF
--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -95,8 +95,11 @@ func (r *Reader) LastSOS() int64 {
 func (r *Reader) ReadPayload() (*zng.Record, []byte, error) {
 again:
 	b, err := r.read(1)
-	if err == io.EOF || len(b) == 0 {
+	if err == io.EOF || err == peeker.ErrTruncated {
 		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
 	}
 	code := b[0]
 	if code&0x80 != 0 {

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -96,6 +96,7 @@ func (r *Reader) ReadPayload() (*zng.Record, []byte, error) {
 again:
 	b, err := r.read(1)
 	if err != nil {
+		// Having tried to read a single byte above, ErrTruncated means io.EOF.
 		if err == io.EOF || err == peeker.ErrTruncated {
 			return nil, nil, nil
 		}

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -95,10 +95,10 @@ func (r *Reader) LastSOS() int64 {
 func (r *Reader) ReadPayload() (*zng.Record, []byte, error) {
 again:
 	b, err := r.read(1)
-	if err == io.EOF || err == peeker.ErrTruncated {
-		return nil, nil, nil
-	}
 	if err != nil {
+		if err == io.EOF || err == peeker.ErrTruncated {
+			return nil, nil, nil
+		}
 		return nil, nil, err
 	}
 	code := b[0]


### PR DESCRIPTION
The zngio.Reader was not returning errors from the underlying io.Reader. This PR fixes that.

