### PR TITLE
add "test" target to Makefile for easy isolated test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ test-unit:
 test-system: build
 	@ZTEST_BINDIR=$(CURDIR)/dist go test -v ./tests
 
+test: build
+	@ZTEST_BINDIR=$(CURDIR)/dist go test -v -tags=system ./tests -run $(TEST) -args PATH=$(shell pwd)/dist
+
 test-heavy: build $(SAMPLEDATA)
 	@go test -v -tags=heavy ./tests
 

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,8 @@ LDFLAGS = -s -X main.version=$(VERSION)
 ZEEKTAG = v3.0.2-brim1
 ZEEKPATH = zeek-$(ZEEKTAG)
 
-# By putting this optional target first, conditiional on the TEST env var,
-# you can run just one test using by simiply typing "make TEST=go-test-path",
-# e.g., "make TEST=TestZTest/suite/cut/cut"
+# This enables a shortcut to run a single test from the ./tests suite, e.g.:
+# make TEST=TestZTest/suite/cut/cut
 ifneq "$(TEST)" ""
 test-one: test-run
 endif

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,13 @@ LDFLAGS = -s -X main.version=$(VERSION)
 ZEEKTAG = v3.0.2-brim1
 ZEEKPATH = zeek-$(ZEEKTAG)
 
+# By putting this optional target first, conditiional on the TEST env var,
+# you can run just one test using by simiply typing "make TEST=go-test-path",
+# e.g., "make TEST=TestZTest/suite/cut/cut"
+ifneq "$(TEST)" ""
+test-one: test-run
+endif
+
 vet:
 	@go vet -copylocks ./...
 
@@ -42,8 +49,8 @@ test-unit:
 test-system: build
 	@ZTEST_BINDIR=$(CURDIR)/dist go test -v ./tests
 
-test: build
-	@ZTEST_BINDIR=$(CURDIR)/dist go test -v -tags=system ./tests -run $(TEST) -args PATH=$(shell pwd)/dist
+test-run: build
+	@ZTEST_BINDIR=$(CURDIR)/dist go test -v ./tests -run $(TEST)
 
 test-heavy: build $(SAMPLEDATA)
 	@go test -v -tags=heavy ./tests


### PR DESCRIPTION
This change to the Makefile makes it much easier to run isolated
tests that fail by cutting and pasting the go test path that
you want to run and assinging to a var called TEST on the make
command line, e.g.,

	make test TEST=TestZTest/formats/zng/streams-3