### PR TITLE
add zng.Builder.Parse()

### DIFF
--- a/zng/builder.go
+++ b/zng/builder.go
@@ -55,13 +55,15 @@ func (b *Builder) Build(zvs ...zcode.Bytes) *Record {
 	return &b.rec
 }
 
-// Parse creates a record from the zng string representation of each leaf field
+// Parse creates a record from the a text representation of each leaf value
 // in the DFS traversal of the record type.  If there aren't enough inputs values
 // to occupy every leaf value, then those values are left unset, in which case
 // a valid record is returned along with ErrIncomplete.
-// XXX This currently does not work for embedded sets, unions, and so forth.
-// We need to define a record value syntax and do proper recusive descent
-// parsing here.
+// XXX We do not yet have a complete specification of the literal syntax of
+// zng values (e.g., as defined in zql) but once we have clarity, we will
+// update this routine with proper recursive-descent parsing of the syntax,
+// or we will use the peg parser to generate an AST for the literal and
+// take that AST as input here.
 func (b *Builder) Parse(vals ...string) (*Record, error) {
 	b.Reset()
 	out, err := b.parseRecord(b.Type, vals)
@@ -151,7 +153,9 @@ func (b *Builder) parseArray(typ *TypeArray, in string) error {
 	}
 	//XXX for now just use simple comma rule, which means comman
 	// cannot be embedded in a set value here.  we need a recursive
-	// descent parser like the type parser to d this correctly
+	// descent parser like the type parser to d this correctly or
+	// change all this to built from an AST literal object parsed
+	// by the zql parser.
 	for _, val := range strings.Split(in, ",") {
 		switch v := inner.(type) {
 		case *TypeRecord:

--- a/zng/builder_test.go
+++ b/zng/builder_test.go
@@ -18,13 +18,15 @@ const builder = `
 #2:record[a:int64,r:record[x:int64]]
 0:[1.2.3.4;]
 1:[1;2;3;]
-2:[7;[3;]]`
+2:[7;[3;]]
+2:[7;-;]`
 
 func TestBuilder(t *testing.T) {
 	r := tzngio.NewReader(strings.NewReader(builder), resolver.NewContext())
 	r0, _ := r.Read()
 	r1, _ := r.Read()
 	r2, _ := r.Read()
+	r3, _ := r.Read()
 
 	zctx := resolver.NewContext()
 
@@ -67,4 +69,12 @@ func TestBuilder(t *testing.T) {
 	rb.AppendPrimitive(zng.EncodeInt(3))
 	rec = b2.Build(zng.EncodeInt(7), rb.Bytes())
 	assert.Equal(t, r2.Raw, rec.Raw)
+
+	rec, err = b2.Parse("7", "3")
+	assert.NoError(t, err)
+	assert.Equal(t, r2.Raw, rec.Raw)
+
+	rec, err = b2.Parse("7")
+	assert.Equal(t, err, zng.ErrIncomplete)
+	assert.Equal(t, r3.Raw, rec.Raw)
 }


### PR DESCRIPTION
This commit adds a Parse method to the zng builder so that records
can be built from a DFS traversal of the string representation of
the leaf values.  A future PR will define a syntax for record values
and do a proper recursive descent here, but for now, this will be
used by the upcoming zar/zdx PR for multi-value keys.