### PR TITLE
include stack trace on panic errors

### DIFF
--- a/driver/mux.go
+++ b/driver/mux.go
@@ -2,7 +2,6 @@ package driver
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zqd/api"
+	"github.com/brimsec/zq/zqe"
 )
 
 type MuxResult struct {
@@ -43,7 +43,7 @@ func (m *Mux) safeGet() (b zbuf.Batch, err error) {
 		if r == nil {
 			return
 		}
-		err = fmt.Errorf("panic: %+v", r)
+		err = zqe.RecoverError(r)
 	}()
 	b, err = m.Get()
 	return

--- a/zqd/middleware.go
+++ b/zqd/middleware.go
@@ -2,12 +2,12 @@ package zqd
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strconv"
 	"sync/atomic"
 	"time"
 
+	"github.com/brimsec/zq/zqe"
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
 )
@@ -76,9 +76,9 @@ func panicCatchMiddleware(logger *zap.Logger) mux.MiddlewareFunc {
 				if r == nil {
 					return
 				}
-				rstr := fmt.Sprint(r)
-				logger.DPanic("Panic", zap.String("error", rstr))
-				http.Error(w, rstr, http.StatusInternalServerError)
+				err := zqe.RecoverError(r)
+				logger.DPanic("panic", zap.Error(err))
+				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}()
 
 			next.ServeHTTP(w, r)

--- a/zqd/middleware.go
+++ b/zqd/middleware.go
@@ -2,6 +2,7 @@ package zqd
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 	"sync/atomic"
@@ -76,8 +77,8 @@ func panicCatchMiddleware(logger *zap.Logger) mux.MiddlewareFunc {
 				if r == nil {
 					return
 				}
+				logger.DPanic("Panic", zap.String("error", fmt.Sprint(r)))
 				err := zqe.RecoverError(r)
-				logger.DPanic("panic", zap.Error(err))
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}()
 

--- a/zqe/error.go
+++ b/zqe/error.go
@@ -5,6 +5,7 @@ package zqe
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
 	"strings"
 )
 
@@ -117,4 +118,8 @@ func E(args ...interface{}) error {
 	}
 
 	return e
+}
+
+func RecoverError(r interface{}) error {
+	return E("panic: %+v\n%s\n", r, string(debug.Stack()))
 }


### PR DESCRIPTION
With this change, if a panic occurs either inside one of the mux goroutines, or inside the chain of an api handler, we will:
* log the panic message and stack trace to the zq-core.log file
* send the error message back to Brim, which will display the error & stack trace in the "yellow error" field, where it can be copied, pasted, and reported.

