### PR TITLE
Add space PUT endpoint

### DIFF
--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -95,6 +95,10 @@ type SpacePostRequest struct {
 	DataPath string `json:"data_path"`
 }
 
+type SpacePutRequest struct {
+	Name string `json:"name"`
+}
+
 type PcapPostRequest struct {
 	Path string `json:"path"`
 }

--- a/zqd/api/connection.go
+++ b/zqd/api/connection.go
@@ -166,6 +166,13 @@ func (c *Connection) SpacePost(ctx context.Context, req SpacePostRequest) (*Spac
 	return resp.Result().(*SpaceInfo), nil
 }
 
+func (c *Connection) SpacePut(ctx context.Context, id SpaceID, req SpacePutRequest) error {
+	_, err := c.Request(ctx).
+		SetBody(req).
+		Put(path.Join("/space", string(id)))
+	return err
+}
+
 func (c *Connection) SpaceList(ctx context.Context) ([]SpaceInfo, error) {
 	var res []SpaceInfo
 	_, err := c.Request(ctx).

--- a/zqd/handler.go
+++ b/zqd/handler.go
@@ -30,6 +30,7 @@ func NewHandler(core *Core, logger *zap.Logger) http.Handler {
 	h.Handle("/space", handleSpaceList).Methods("GET")
 	h.Handle("/space", handleSpacePost).Methods("POST")
 	h.Handle("/space/{space}", handleSpaceGet).Methods("GET")
+	h.Handle("/space/{space}", handleSpacePut).Methods("PUT")
 	h.Handle("/space/{space}", handleSpaceDelete).Methods("DELETE")
 	h.Handle("/space/{space}/pcap", handlePcapSearch).Methods("GET")
 	h.Handle("/space/{space}/pcap", handlePcapPost).Methods("POST")

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -205,6 +205,28 @@ func handleSpacePost(c *Core, w http.ResponseWriter, r *http.Request) {
 	respond(c, w, r, http.StatusOK, info)
 }
 
+func handleSpacePut(c *Core, w http.ResponseWriter, r *http.Request) {
+	s := extractSpace(c, w, r)
+	if s == nil {
+		return
+	}
+	_, cancel, err := s.StartSpaceOp(r.Context())
+	if err != nil {
+		respondError(c, w, r, err)
+		return
+	}
+	defer cancel()
+	var req api.SpacePutRequest
+	if !request(c, w, r, &req) {
+		return
+	}
+	if err := s.Update(req); err != nil {
+		respondError(c, w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func handleSpaceDelete(c *Core, w http.ResponseWriter, r *http.Request) {
 	v := mux.Vars(r)
 	id, ok := v["space"]

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -257,6 +257,19 @@ func TestSpacePostDataPath(t *testing.T) {
 	assert.Equal(t, datapath, sp.DataPath)
 }
 
+func TestSpacePut(t *testing.T) {
+	ctx := context.Background()
+	_, client, done := newCore(t)
+	defer done()
+	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
+	require.NoError(t, err)
+	err = client.SpacePut(ctx, sp.ID, api.SpacePutRequest{Name: "new_name"})
+	require.NoError(t, err)
+	info, err := client.SpaceInfo(ctx, sp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "new_name", info.Name)
+}
+
 func TestSpaceDelete(t *testing.T) {
 	ctx := context.Background()
 	_, client, done := newCore(t)

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -105,6 +105,15 @@ func (s *Space) ID() api.SpaceID {
 	return api.SpaceID(filepath.Base(s.path))
 }
 
+func (s *Space) Update(req api.SpacePutRequest) error {
+	if req.Name == "" {
+		return zqe.E(zqe.Invalid, "cannot set name to an empty string")
+	}
+	// XXX This is not thread safe. Will fix in upcoming pr.
+	s.conf.Name = req.Name
+	return s.conf.save(s.path)
+}
+
 func (s *Space) Info() (api.SpaceInfo, error) {
 	logsize, err := s.LogSize()
 	if err != nil {


### PR DESCRIPTION
For endpoint only allows users to update the name of the space. As
with other space accessors this method is not thread safe. This
will be fixed soon, but I wanted to get the feature in to allow
brim devs to fully implement space name change functionality in the
interim.