### PR TITLE
alert brim on zq merges to master

### DIFF
--- a/.github/workflows/notify-brim-merge.yml
+++ b/.github/workflows/notify-brim-merge.yml
@@ -19,7 +19,7 @@ jobs:
         # https://developer.github.com/v3/activity/events/types/#pullrequestevent
         # Pull request
         # https://developer.github.com/v3/pulls/
-        merged=$(cat $GITHUB_EVENT_PATH | jq '.pull_request.merged')
+        merged=$(jq .pull_request.merged < "${GITHUB_EVENT_PATH}")
         echo "::set-output name=merged::$merged"
       id: vars
     - name: Post PR closed event, if the close was a merge

--- a/.github/workflows/notify-brim-merge.yml
+++ b/.github/workflows/notify-brim-merge.yml
@@ -1,4 +1,4 @@
-name: Notify PR merge
+name: Notify Brim
 
 on:
   pull_request:

--- a/.github/workflows/notify-brim-merge.yml
+++ b/.github/workflows/notify-brim-merge.yml
@@ -3,6 +3,8 @@ name: Notify Brim
 # https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
 on:
   pull_request:
+    branches:
+      - master
     types: closed
 
 jobs:

--- a/.github/workflows/notify-brim-merge.yml
+++ b/.github/workflows/notify-brim-merge.yml
@@ -1,6 +1,8 @@
 name: Notify Brim
 
 # https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
+# Use pull_request because it contains more interesting metadata than a
+# push event.
 on:
   pull_request:
     branches:

--- a/.github/workflows/notify-brim-merge.yml
+++ b/.github/workflows/notify-brim-merge.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
     - name: Populate "merged" variable
       run: |

--- a/.github/workflows/notify-brim-merge.yml
+++ b/.github/workflows/notify-brim-merge.yml
@@ -25,10 +25,10 @@ jobs:
     - name: Post PR closed event, if the close was a merge
       if: steps.vars.outputs.merged == 'true'
       run: |
-        cat $GITHUB_EVENT_PATH
+        jq < "${GITHUB_EVENT_PATH}"
         # Get what we want from the pull request event, craft a
         # repository dispatch event, and send it.
         # https://help.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch
         # https://developer.github.com/v3/repos/#create-a-repository-dispatch-event
-        cat $GITHUB_EVENT_PATH | jq '.pull_request | { "event_type": "zq-pr-merged", "client_payload": {body, "branch": .head.ref, merge_commit_sha, number, title, "url": .html_url, "user": .user.login}}' > payload.json
+        jq '.pull_request | { "event_type": "zq-pr-merged", "client_payload": {body, "branch": .head.ref, merge_commit_sha, number, title, "url": .html_url, "user": .user.login}}' < "${GITHUB_EVENT_PATH}" > payload.json
         curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.v3+json"  -H "Content-Type: application/json" ${{ secrets.MERGE_EVENT_URL }} --data @payload.json

--- a/.github/workflows/notify-brim-merge.yml
+++ b/.github/workflows/notify-brim-merge.yml
@@ -23,16 +23,16 @@ jobs:
         # https://developer.github.com/v3/activity/events/types/#pullrequestevent
         # Pull request
         # https://developer.github.com/v3/pulls/
-        merged=$(jq .pull_request.merged < "${GITHUB_EVENT_PATH}")
+        merged=$(jq .pull_request.merged "${GITHUB_EVENT_PATH}")
         echo "::set-output name=merged::$merged"
       id: vars
     - name: Post PR closed event, if the close was a merge
       if: steps.vars.outputs.merged == 'true'
       run: |
-        jq < "${GITHUB_EVENT_PATH}"
+        jq '.' "${GITHUB_EVENT_PATH}"
         # Get what we want from the pull request event, craft a
         # repository dispatch event, and send it.
         # https://help.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch
         # https://developer.github.com/v3/repos/#create-a-repository-dispatch-event
-        jq '.pull_request | { "event_type": "zq-pr-merged", "client_payload": {body, "branch": .head.ref, merge_commit_sha, number, title, "url": .html_url, "user": .user.login}}' < "${GITHUB_EVENT_PATH}" > payload.json
+        jq '.pull_request | { "event_type": "zq-pr-merged", "client_payload": {body, "branch": .head.ref, merge_commit_sha, number, title, "url": .html_url, "user": .user.login}}' "${GITHUB_EVENT_PATH}" > payload.json
         curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.v3+json"  -H "Content-Type: application/json" https://api.github.com/repos/brimsec/brim/dispatches --data @payload.json

--- a/.github/workflows/notify-brim-merge.yml
+++ b/.github/workflows/notify-brim-merge.yml
@@ -31,4 +31,4 @@ jobs:
         # https://help.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch
         # https://developer.github.com/v3/repos/#create-a-repository-dispatch-event
         jq '.pull_request | { "event_type": "zq-pr-merged", "client_payload": {body, "branch": .head.ref, merge_commit_sha, number, title, "url": .html_url, "user": .user.login}}' < "${GITHUB_EVENT_PATH}" > payload.json
-        curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.v3+json"  -H "Content-Type: application/json" ${{ secrets.MERGE_EVENT_URL }} --data @payload.json
+        curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.v3+json"  -H "Content-Type: application/json" https://api.github.com/repos/brimsec/brim/dispatches --data @payload.json

--- a/.github/workflows/notify-brim-merge.yml
+++ b/.github/workflows/notify-brim-merge.yml
@@ -1,5 +1,6 @@
 name: Notify Brim
 
+# https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
 on:
   pull_request:
     types: closed
@@ -10,6 +11,14 @@ jobs:
     steps:
     - name: Populate "merged" variable
       run: |
+        # GITHUB_EVENT_PATH
+        # https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
+        # The path of the file with the complete webhook event payload. For example, /github/workflow/event.json
+        #
+        # Pull request event
+        # https://developer.github.com/v3/activity/events/types/#pullrequestevent
+        # Pull request
+        # https://developer.github.com/v3/pulls/
         merged=$(cat $GITHUB_EVENT_PATH | jq '.pull_request.merged')
         echo "::set-output name=merged::$merged"
       id: vars
@@ -17,5 +26,9 @@ jobs:
       if: steps.vars.outputs.merged == 'true'
       run: |
         cat $GITHUB_EVENT_PATH
+        # Get what we want from the pull request event, craft a
+        # repository dispatch event, and send it.
+        # https://help.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch
+        # https://developer.github.com/v3/repos/#create-a-repository-dispatch-event
         cat $GITHUB_EVENT_PATH | jq '.pull_request | { "event_type": "zq-pr-merged", "client_payload": {body, "branch": .head.ref, merge_commit_sha, number, title, "url": .html_url, "user": .user.login}}' > payload.json
         curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.v3+json"  -H "Content-Type: application/json" ${{ secrets.MERGE_EVENT_URL }} --data @payload.json

--- a/.github/workflows/notify-brim-merge.yml
+++ b/.github/workflows/notify-brim-merge.yml
@@ -12,11 +12,9 @@ jobs:
       run: |
         merged=$(cat $GITHUB_EVENT_PATH | jq '.pull_request.merged')
         echo "::set-output name=merged::$merged"
-        nopost=$(cat $GITHUB_EVENT_PATH | jq '[.pull_request.labels[] | select(.name=="no-post-action") ]| length')
-        echo "::set-output name=nopost::$nopost"
       id: vars
     - name: Post PR closed event, if the close was a merge
-      if: steps.vars.outputs.merged == 'true' && steps.vars.outputs.nopost != '1'
+      if: steps.vars.outputs.merged == 'true'
       run: |
         cat $GITHUB_EVENT_PATH
         cat $GITHUB_EVENT_PATH | jq '.pull_request | { "event_type": "zq-pr-merged", "client_payload": {body, "branch": .head.ref, merge_commit_sha, number, title, "url": .html_url, "user": .user.login}}' > payload.json

--- a/.github/workflows/notify-brim-merge.yml
+++ b/.github/workflows/notify-brim-merge.yml
@@ -18,4 +18,4 @@ jobs:
       run: |
         cat $GITHUB_EVENT_PATH
         cat $GITHUB_EVENT_PATH | jq '.pull_request | { "event_type": "zq-pr-merged", "client_payload": {body, "branch": .head.ref, merge_commit_sha, number, title, "url": .html_url, "user": .user.login}}' > payload.json
-        curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" ${{ secrets.MERGE_EVENT_URL }} --data @payload.json
+        curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.v3+json"  -H "Content-Type: application/json" ${{ secrets.MERGE_EVENT_URL }} --data @payload.json

--- a/.github/workflows/notify-brim-merge.yml
+++ b/.github/workflows/notify-brim-merge.yml
@@ -1,0 +1,23 @@
+name: Notify PR merge
+
+on:
+  pull_request:
+    types: closed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Populate "merged" variable
+      run: |
+        merged=$(cat $GITHUB_EVENT_PATH | jq '.pull_request.merged')
+        echo "::set-output name=merged::$merged"
+        nopost=$(cat $GITHUB_EVENT_PATH | jq '[.pull_request.labels[] | select(.name=="no-post-action") ]| length')
+        echo "::set-output name=nopost::$nopost"
+      id: vars
+    - name: Post PR closed event, if the close was a merge
+      if: steps.vars.outputs.merged == 'true' && steps.vars.outputs.nopost != '1'
+      run: |
+        cat $GITHUB_EVENT_PATH
+        cat $GITHUB_EVENT_PATH | jq '.pull_request | { "event_type": "zq-pr-merged", "client_payload": {body, "branch": .head.ref, merge_commit_sha, number, title, "url": .html_url, "user": .user.login}}' > payload.json
+        curl -XPOST -u "${{ secrets.PAT_USERNAME }}:${{ secrets.PAT_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json"  -H "Content-Type: application/json" ${{ secrets.MERGE_EVENT_URL }} --data @payload.json


### PR DESCRIPTION
This is one part of fixing https://github.com/brimsec/brim/issues/734 . It's based on previous work of @henridf so big thanks goes to him.

On this side, we need to send a repository_dispatch event to the Github API route for brimsec/brim. We do that by triggering a workflow when a pull request is closed. The event that this worfklow receives is written in $GITHUB_EVENT_PATH. We can inspect that, get interesting fields from it using `jq`, and then craft and send the repository_dispatch event.

I tested this by merging two PRs into a dummy branch. Linked below are the PRs and their associated zq and brim workflow runs.

1. https://github.com/brimsec/zq/pull/738
   - zq event: https://github.com/brimsec/zq/actions/runs/98584159
   - brim event: https://github.com/brimsec/brim/actions/runs/98584231
1. https://github.com/brimsec/zq/pull/739
   - zq event: https://github.com/brimsec/zq/actions/runs/98595909
   - brim event: none; this PR was closed. The zq event above chose not to dispatch to Brim.

More work is needed Brim-side to handle the dispatch. Right now it simply shows that the receiving event is well-formed.

