### PR TITLE
allow record access methods to work with aliases

### DIFF
--- a/zng/recordval.go
+++ b/zng/recordval.go
@@ -402,7 +402,7 @@ func (r *Record) AccessString(field string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	switch v.Type.(type) {
+	switch AliasedType(v.Type).(type) {
 	case *TypeOfString, *TypeOfBstring:
 		return DecodeString(v.Bytes)
 	default:
@@ -415,7 +415,7 @@ func (r *Record) AccessBool(field string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if _, ok := v.Type.(*TypeOfBool); !ok {
+	if _, ok := AliasedType(v.Type).(*TypeOfBool); !ok {
 		return false, ErrTypeMismatch
 	}
 	return DecodeBool(v.Bytes)
@@ -426,7 +426,7 @@ func (r *Record) AccessInt(field string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	switch v.Type.(type) {
+	switch AliasedType(v.Type).(type) {
 	case *TypeOfByte:
 		b, err := DecodeByte(v.Bytes)
 		return int64(b), err
@@ -453,7 +453,7 @@ func (r *Record) AccessIP(field string) (net.IP, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, ok := v.Type.(*TypeOfIP); !ok {
+	if _, ok := AliasedType(v.Type).(*TypeOfIP); !ok {
 		return nil, ErrTypeMismatch
 	}
 	return DecodeIP(v.Bytes)
@@ -464,7 +464,7 @@ func (r *Record) AccessTime(field string) (nano.Ts, error) {
 	if err != nil {
 		return 0, err
 	}
-	if _, ok := v.Type.(*TypeOfTime); !ok {
+	if _, ok := AliasedType(v.Type).(*TypeOfTime); !ok {
 		return 0, ErrTypeMismatch
 	}
 	return DecodeTime(v.Bytes)

--- a/zng/recordval_test.go
+++ b/zng/recordval_test.go
@@ -1,11 +1,15 @@
 package zng_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRecordTypeCheck(t *testing.T) {
@@ -56,4 +60,23 @@ func TestRecordTypeCheck(t *testing.T) {
 		r.Raw = b.Bytes()
 		assert.NoError(t, r.TypeCheck())
 	})
+}
+
+const in = `
+#zfile=string
+#zbool=bool
+#0:record[foo:zfile,bar:zbool]
+0:[hello;true;]
+`
+
+func TestRecordAccessAlias(t *testing.T) {
+	reader := tzngio.NewReader(strings.NewReader(in), resolver.NewContext())
+	rec, err := reader.Read()
+	require.NoError(t, err)
+	s, err := rec.AccessString("foo")
+	require.NoError(t, err)
+	assert.Equal(t, s, "hello")
+	b, err := rec.AccessBool("bar")
+	require.NoError(t, err)
+	assert.Equal(t, b, true)
 }


### PR DESCRIPTION
The zng.Record.Access* methods required strict type equality to
the accessed fields.  This commit relaxes the constraint to allow
accesses when the underlying aliased types are compatibles.