### PR TITLE
Use json typing info during format detection

### DIFF
--- a/pkg/test/internal.go
+++ b/pkg/test/internal.go
@@ -32,7 +32,7 @@ func Trim(s string) string {
 
 func stringReader(input string, ifmt string, zctx *resolver.Context) (zbuf.Reader, error) {
 	if ifmt == "" {
-		return detector.NewReader(strings.NewReader(input), zctx)
+		return detector.NewReader(strings.NewReader(input), zctx, "", detector.OpenConfig{})
 	}
 	zr, err := detector.LookupReader(strings.NewReader(input), zctx, ifmt)
 	if err != nil {

--- a/pkg/test/internal.go
+++ b/pkg/test/internal.go
@@ -32,7 +32,7 @@ func Trim(s string) string {
 
 func stringReader(input string, ifmt string, zctx *resolver.Context) (zbuf.Reader, error) {
 	if ifmt == "" {
-		return detector.NewReader(strings.NewReader(input), zctx, "", detector.OpenConfig{})
+		return detector.NewReader(strings.NewReader(input), zctx)
 	}
 	zr, err := detector.LookupReader(strings.NewReader(input), zctx, ifmt)
 	if err != nil {

--- a/pkg/test/internal.go
+++ b/pkg/test/internal.go
@@ -3,6 +3,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/brimsec/zq/driver"
@@ -31,17 +32,12 @@ func Trim(s string) string {
 }
 
 func stringReader(input string, ifmt string, zctx *resolver.Context) (zbuf.Reader, error) {
-	if ifmt == "" {
-		return detector.NewReader(strings.NewReader(input), zctx)
+	cfg := detector.OpenConfig{
+		Format: ifmt,
 	}
-	zr, err := detector.LookupReader(strings.NewReader(input), zctx, ifmt)
-	if err != nil {
-		return nil, err
-	}
-	if zr == nil {
-		return nil, fmt.Errorf("unknown input format %s", ifmt)
-	}
-	return zr, nil
+	rc := ioutil.NopCloser(strings.NewReader(input))
+
+	return detector.OpenFromNamedReadCloser(zctx, rc, "test", cfg)
 }
 
 func newEmitter(ofmt string) (*emitter.Bytes, error) {

--- a/tests/suite/jsontype/nesting.yaml
+++ b/tests/suite/jsontype/nesting.yaml
@@ -1,4 +1,4 @@
-script: zq -i ndjson -j types.json -t "*" in.ndjson
+script: zq -j types.json -t "*" in.ndjson
 
 inputs:
   - name: in.ndjson

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -129,7 +129,7 @@ func OpenFromNamedReadCloser(zctx *resolver.Context, rc io.ReadCloser, path stri
 	r := GzipReader(rc)
 	var zr zbuf.Reader
 	if cfg.Format == "" || cfg.Format == "auto" {
-		zr, err = NewReader(r, zctx, path, cfg)
+		zr, err = NewReaderWithConfig(r, zctx, path, cfg)
 	} else {
 		zr, err = LookupReader(r, zctx, cfg.Format)
 	}

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -129,7 +129,7 @@ func OpenFromNamedReadCloser(zctx *resolver.Context, rc io.ReadCloser, path stri
 	r := GzipReader(rc)
 	var zr zbuf.Reader
 	if cfg.Format == "" || cfg.Format == "auto" {
-		zr, err = NewReader(r, zctx)
+		zr, err = NewReader(r, zctx, path, cfg)
 	} else {
 		zr, err = LookupReader(r, zctx, cfg.Format)
 	}

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/url"
 	"os"
-	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -131,16 +130,10 @@ func OpenFromNamedReadCloser(zctx *resolver.Context, rc io.ReadCloser, path stri
 	if cfg.Format == "" || cfg.Format == "auto" {
 		zr, err = NewReaderWithConfig(r, zctx, path, cfg)
 	} else {
-		zr, err = LookupReader(r, zctx, cfg.Format)
+		zr, err = lookupReader(r, zctx, path, cfg)
 	}
 	if err != nil {
 		return nil, err
-	}
-
-	if jr, ok := zr.(*ndjsonio.Reader); ok && cfg.JSONTypeConfig != nil {
-		if err = jsonConfig(cfg, jr, path); err != nil {
-			return nil, err
-		}
 	}
 
 	return zbuf.NewFile(zr, rc, path), nil
@@ -156,14 +149,4 @@ func OpenFiles(zctx *resolver.Context, paths ...string) (*zbuf.Combiner, error) 
 		readers = append(readers, reader)
 	}
 	return zbuf.NewCombiner(readers), nil
-}
-
-func jsonConfig(cfg OpenConfig, jr *ndjsonio.Reader, filename string) error {
-	var path string
-	re := regexp.MustCompile(cfg.JSONPathRegex)
-	match := re.FindStringSubmatch(filename)
-	if len(match) == 2 {
-		path = match[1]
-	}
-	return jr.ConfigureTypes(*cfg.JSONTypeConfig, path)
 }

--- a/zio/detector/lookup.go
+++ b/zio/detector/lookup.go
@@ -55,18 +55,18 @@ func LookupWriter(w io.WriteCloser, wflags *zio.WriterFlags) *zio.Writer {
 	}
 }
 
-func LookupReader(r io.Reader, zctx *resolver.Context, format string) (zbuf.Reader, error) {
-	switch format {
+func lookupReader(r io.Reader, zctx *resolver.Context, path string, cfg OpenConfig) (zbuf.Reader, error) {
+	switch cfg.Format {
 	case "tzng":
 		return tzngio.NewReader(r, zctx), nil
 	case "zeek":
 		return zeekio.NewReader(r, zctx)
 	case "ndjson":
-		return ndjsonio.NewReader(r, zctx)
+		return ndjsonio.NewReader(r, zctx, cfg.JSONTypeConfig, cfg.JSONPathRegex, path)
 	case "zjson":
 		return zjsonio.NewReader(r, zctx), nil
 	case "zng":
 		return zngio.NewReader(r, zctx), nil
 	}
-	return nil, fmt.Errorf("no such reader type: \"%s\"", format)
+	return nil, fmt.Errorf("no such reader type: \"%s\"", cfg.Format)
 }

--- a/zio/detector/reader.go
+++ b/zio/detector/reader.go
@@ -47,7 +47,7 @@ func NewReaderWithConfig(r io.Reader, zctx *resolver.Context, path string, cfg O
 		return nil, err
 	}
 	if cfg.JSONTypeConfig != nil {
-		if err = jsonConfig(cfg, nr, path); err != nil {
+		if err := jsonConfig(cfg, nr, path); err != nil {
 			return nil, err
 		}
 	}

--- a/zio/detector/reader.go
+++ b/zio/detector/reader.go
@@ -14,7 +14,7 @@ import (
 	"github.com/brimsec/zq/zqe"
 )
 
-func NewReader(r io.Reader, zctx *resolver.Context) (zbuf.Reader, error) {
+func NewReader(r io.Reader, zctx *resolver.Context, path string, cfg OpenConfig) (zbuf.Reader, error) {
 	recorder := NewRecorder(r)
 	track := NewTrack(recorder)
 
@@ -45,6 +45,11 @@ func NewReader(r io.Reader, zctx *resolver.Context) (zbuf.Reader, error) {
 	nr, err := ndjsonio.NewReader(track, resolver.NewContext())
 	if err != nil {
 		return nil, err
+	}
+	if cfg.JSONTypeConfig != nil {
+		if err = jsonConfig(cfg, nr, path); err != nil {
+			return nil, err
+		}
 	}
 	ndjsonErr := match(nr, "ndjson")
 	if ndjsonErr == nil {

--- a/zio/detector/reader.go
+++ b/zio/detector/reader.go
@@ -14,7 +14,7 @@ import (
 	"github.com/brimsec/zq/zqe"
 )
 
-func NewReader(r io.Reader, zctx *resolver.Context, path string, cfg OpenConfig) (zbuf.Reader, error) {
+func NewReaderWithConfig(r io.Reader, zctx *resolver.Context, path string, cfg OpenConfig) (zbuf.Reader, error) {
 	recorder := NewRecorder(r)
 	track := NewTrack(recorder)
 
@@ -62,6 +62,10 @@ func NewReader(r io.Reader, zctx *resolver.Context, path string, cfg OpenConfig)
 		return zngio.NewReader(recorder, zctx), nil
 	}
 	return nil, joinErrs([]error{tzngErr, zeekErr, ndjsonErr, zjsonErr, zngErr})
+}
+
+func NewReader(r io.Reader, zctx *resolver.Context) (zbuf.Reader, error) {
+	return NewReaderWithConfig(r, zctx, "", OpenConfig{})
 }
 
 func joinErrs(errs []error) error {

--- a/zio/detector/reader.go
+++ b/zio/detector/reader.go
@@ -42,18 +42,13 @@ func NewReaderWithConfig(r io.Reader, zctx *resolver.Context, path string, cfg O
 	track.Reset()
 
 	// ndjson must come after zjson since zjson is a subset of ndjson
-	nr, err := ndjsonio.NewReader(track, resolver.NewContext())
+	nr, err := ndjsonio.NewReader(track, resolver.NewContext(), cfg.JSONTypeConfig, cfg.JSONPathRegex, path)
 	if err != nil {
 		return nil, err
 	}
-	if cfg.JSONTypeConfig != nil {
-		if err := jsonConfig(cfg, nr, path); err != nil {
-			return nil, err
-		}
-	}
 	ndjsonErr := match(nr, "ndjson")
 	if ndjsonErr == nil {
-		return ndjsonio.NewReader(recorder, zctx)
+		return ndjsonio.NewReader(recorder, zctx, cfg.JSONTypeConfig, cfg.JSONPathRegex, path)
 	}
 	track.Reset()
 

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -127,7 +127,7 @@ func TestNDJSON(t *testing.T) {
 func runtestcase(t *testing.T, input, output string) {
 	var out bytes.Buffer
 	w := NewWriter(&out)
-	r, err := NewReader(strings.NewReader(input), resolver.NewContext())
+	r, err := NewReader(strings.NewReader(input), resolver.NewContext(), nil, "", "")
 	require.NoError(t, err)
 	require.NoError(t, zbuf.Copy(zbuf.NopFlusher(w), r))
 	NDJSONEq(t, output, out.String())
@@ -332,10 +332,9 @@ func TestNDJSONTypeErrors(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			var out bytes.Buffer
 			w := NewWriter(&out)
-			r, err := NewReader(strings.NewReader(c.input), resolver.NewContext())
+			r, err := NewReader(strings.NewReader(c.input), resolver.NewContext(), nil, "", "")
 			require.NoError(t, err)
-
-			err = r.ConfigureTypes(typeConfig, c.defaultPath)
+			err = r.configureTypes(typeConfig, c.defaultPath)
 			require.NoError(t, err)
 
 			err = zbuf.Copy(zbuf.NopFlusher(w), r)

--- a/zio/ndjsonio/reader.go
+++ b/zio/ndjsonio/reader.go
@@ -50,7 +50,10 @@ func NewReader(reader io.Reader, zctx *resolver.Context, tc *TypeConfig, JSONPat
 	}
 	if tc != nil {
 		var path string
-		re := regexp.MustCompile(JSONPathRegex)
+		re, err := regexp.Compile(JSONPathRegex)
+		if err != nil {
+			return nil, err
+		}
 		match := re.FindStringSubmatch(filepath)
 		if len(match) == 2 {
 			path = match[1]

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -574,14 +574,14 @@ func TestPostNDJSONLogWarning(t *testing.T) {
 	payloads := postSpaceLogs(t, client, spaceName, &tc, false, src1, src2)
 	warn1 := payloads[1].(*api.LogPostWarning)
 	warn2 := payloads[2].(*api.LogPostWarning)
-	assert.Regexp(t, ": line 1: descriptor not found$", warn1.Warning)
+	assert.Regexp(t, ": line 1: descriptor not found", warn1.Warning)
 	assert.Regexp(t, ": line 2: incomplete descriptor", warn2.Warning)
 
 	status := payloads[len(payloads)-2].(*api.LogPostStatus)
 	expected := &api.LogPostStatus{
 		Type:         "LogPostStatus",
-		LogTotalSize: 134,
-		LogReadSize:  134,
+		LogTotalSize: 71,
+		LogReadSize:  71,
 	}
 	require.Equal(t, expected, status)
 

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -619,7 +619,7 @@ func runzq(bindir, ZQL, outputFormat, outputFlags string, inputs ...string) (out
 func loadInputs(inputs []string, zctx *resolver.Context) (*zbuf.Combiner, error) {
 	var readers []zbuf.Reader
 	for _, input := range inputs {
-		zr, err := detector.NewReader(detector.GzipReader(strings.NewReader(input)), zctx)
+		zr, err := detector.NewReader(detector.GzipReader(strings.NewReader(input)), zctx, "", detector.OpenConfig{})
 		if err != nil {
 			return nil, err
 		}

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -619,7 +619,7 @@ func runzq(bindir, ZQL, outputFormat, outputFlags string, inputs ...string) (out
 func loadInputs(inputs []string, zctx *resolver.Context) (*zbuf.Combiner, error) {
 	var readers []zbuf.Reader
 	for _, input := range inputs {
-		zr, err := detector.NewReader(detector.GzipReader(strings.NewReader(input)), zctx, "", detector.OpenConfig{})
+		zr, err := detector.NewReader(detector.GzipReader(strings.NewReader(input)), zctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Previously, the throwaway ndjsonio reader used during detection was not configured any with json typing info that may have been provided (via the zqd API or zq -j).

This meant that format detection ndjsonio did not fully reflect actual reader behavior. 

This commit fixes that. It also removes an egregious manifestation of #747, which is that even post #748 , reading a typed json file with nesting would crash, because detection was not passing the typing scheme to the ndjsonio reader, and so that reader was using inference, which ran into #747.

Now type detection works with nested ndjson, as the change to nesting.yaml shows. #747 remains unfixed of course but is less visible pending a complete fix.


