### PR TITLE
Lenient parsing of json numbers

### DIFF
--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -200,6 +200,20 @@ func TestNewRawFromJSON(t *testing.T) {
 			json:        `{"_path": "test", "ts":1573860644637}`,
 			defaultPath: "inferred",
 		},
+		{
+			name: "uint64 in scientific notation",
+			tzng: `#0:record[_path:string,datetime:uint64]
+0:[test;1521835103;]`,
+			json:        `{"_path": "test", "datetime":1.521835103E9}`,
+			defaultPath: "inferred",
+		},
+		{
+			name: "int64 in scientific notation",
+			tzng: `#0:record[_path:string,datetime:int64]
+0:[test;-1521835103;]`,
+			json:        `{"_path": "test", "datetime":-1.521835103E9}`,
+			defaultPath: "inferred",
+		},
 	}
 
 	for _, c := range cases {

--- a/zio/ndjsonio/typeparser.go
+++ b/zio/ndjsonio/typeparser.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
+	"github.com/brimsec/zq/pkg/byteconv"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zio/zeekio"
@@ -304,49 +304,49 @@ func parseSimpleType(value []byte, typ zng.Type) ([]byte, error) {
 	case zng.TypeDuration:
 		// cannot use nano.Parse because javascript floats values can have
 		// greater precision than 1e-9.
-		f, err := strconv.ParseFloat(string(value), 10)
+		f, err := byteconv.ParseFloat64(value)
 		if err != nil {
 			return nil, err
 		}
 		return zng.EncodeInt(int64(f * 1e9)), nil
 	case zng.TypeUint64:
-		f, err := strconv.ParseFloat(string(value), 10)
+		f, err := byteconv.ParseFloat64(value)
 		if err != nil {
 			return nil, err
 		}
 		return zng.EncodeUint(uint64(f)), nil
 	case zng.TypeInt64:
-		f, err := strconv.ParseFloat(string(value), 10)
+		f, err := byteconv.ParseFloat64(value)
 		if err != nil {
 			return nil, err
 		}
 		return zng.EncodeInt(int64(f)), nil
 	case zng.TypeUint32:
-		f, err := strconv.ParseFloat(string(value), 10)
+		f, err := byteconv.ParseFloat64(value)
 		if err != nil {
 			return nil, err
 		}
 		return zng.EncodeUint(uint64(uint32(f))), nil
 	case zng.TypeInt32:
-		f, err := strconv.ParseFloat(string(value), 10)
+		f, err := byteconv.ParseFloat64(value)
 		if err != nil {
 			return nil, err
 		}
 		return zng.EncodeInt(int64(int32(f))), nil
 	case zng.TypeUint16:
-		f, err := strconv.ParseFloat(string(value), 10)
+		f, err := byteconv.ParseFloat64(value)
 		if err != nil {
 			return nil, err
 		}
 		return zng.EncodeUint(uint64(uint16(f))), nil
 	case zng.TypeInt16:
-		f, err := strconv.ParseFloat(string(value), 10)
+		f, err := byteconv.ParseFloat64(value)
 		if err != nil {
 			return nil, err
 		}
 		return zng.EncodeInt(int64(int16(f))), nil
 	case zng.TypeByte:
-		f, err := strconv.ParseFloat(string(value), 10)
+		f, err := byteconv.ParseFloat64(value)
 		if err != nil {
 			return nil, err
 		}

--- a/zio/ndjsonio/typeparser.go
+++ b/zio/ndjsonio/typeparser.go
@@ -309,6 +309,48 @@ func parseSimpleType(value []byte, typ zng.Type) ([]byte, error) {
 			return nil, err
 		}
 		return zng.EncodeInt(int64(f * 1e9)), nil
+	case zng.TypeUint64:
+		f, err := strconv.ParseFloat(string(value), 10)
+		if err != nil {
+			return nil, err
+		}
+		return zng.EncodeUint(uint64(f)), nil
+	case zng.TypeInt64:
+		f, err := strconv.ParseFloat(string(value), 10)
+		if err != nil {
+			return nil, err
+		}
+		return zng.EncodeInt(int64(f)), nil
+	case zng.TypeUint32:
+		f, err := strconv.ParseFloat(string(value), 10)
+		if err != nil {
+			return nil, err
+		}
+		return zng.EncodeUint(uint64(uint32(f))), nil
+	case zng.TypeInt32:
+		f, err := strconv.ParseFloat(string(value), 10)
+		if err != nil {
+			return nil, err
+		}
+		return zng.EncodeInt(int64(int32(f))), nil
+	case zng.TypeUint16:
+		f, err := strconv.ParseFloat(string(value), 10)
+		if err != nil {
+			return nil, err
+		}
+		return zng.EncodeUint(uint64(uint16(f))), nil
+	case zng.TypeInt16:
+		f, err := strconv.ParseFloat(string(value), 10)
+		if err != nil {
+			return nil, err
+		}
+		return zng.EncodeInt(int64(int16(f))), nil
+	case zng.TypeByte:
+		f, err := strconv.ParseFloat(string(value), 10)
+		if err != nil {
+			return nil, err
+		}
+		return zng.EncodeUint(uint64(uint8(f))), nil
 	default:
 		b, err := typ.Parse(value)
 		if err != nil {


### PR DESCRIPTION
Json has a single numeric type, so we should be a bit more lenient when parsing numbers into the multitude of zng numeric types.

closes #766 
