### PR TITLE
Translate "\r\n" line endings to "\n" in skim.Scanner

### DIFF
--- a/pkg/skim/skim_test.go
+++ b/pkg/skim/skim_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/pkg/skim"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,4 +71,15 @@ func TestSkimNoNewLine(t *testing.T) {
 		t.Fatal(err)
 	}
 	require.Equal(t, []byte(nil), line)
+}
+
+func TestSkimCarriageReturn(t *testing.T) {
+	data := []byte("line1\n\r\nline2\r\n\r\n\rline3\rline3\nline4\r")
+	buf := make([]byte, ReadSize)
+	scanner := skim.NewScanner(bytes.NewReader(data), buf, MaxLineSize)
+	for _, s := range []string{"line1\n", "line2\n", "\rline3\rline3\n", "line4\r"} {
+		line, err := scanner.ScanLine()
+		require.NoError(t, err)
+		assert.Equal(t, s, string(line))
+	}
 }

--- a/zio/zeekio/reader_test.go
+++ b/zio/zeekio/reader_test.go
@@ -1,0 +1,39 @@
+package zeekio
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReaderCRLF(t *testing.T) {
+	input := `
+#separator \x09
+#set_separator	,
+#empty_field	(empty)
+#unset_field	-
+#path	a
+#fields	ts	i
+#types	time	int
+10.000000	1
+`
+	input = strings.ReplaceAll(input, "\n", "\r\n")
+	r, err := NewReader(strings.NewReader(input), resolver.NewContext())
+	require.NoError(t, err)
+	rec, err := r.Read()
+	require.NoError(t, err)
+	ts, err := rec.AccessTime("ts")
+	require.NoError(t, err)
+	assert.Exactly(t, 10*nano.Ts(time.Second), ts)
+	d, err := rec.AccessInt("i")
+	require.NoError(t, err)
+	assert.Exactly(t, int64(1), d)
+	rec, err = r.Read()
+	require.NoError(t, err)
+	assert.Nil(t, rec)
+}


### PR DESCRIPTION
This is motivated by the "\r\n" line endings in the logs currently generated by MinGW Zeek. That behavior might change, but this is probably a good idea regardless.