### PR TITLE
Stdin error filename

### DIFF
--- a/cmd/zar/chop/command.go
+++ b/cmd/zar/chop/command.go
@@ -67,7 +67,7 @@ func (c *Command) Run(args []string) error {
 	}
 	path := args[0]
 	if path == "-" {
-		path = "/dev/stdin"
+		path = detector.StdinPath
 	}
 	zctx := resolver.NewContext()
 	cfg := detector.OpenConfig{

--- a/cmd/zar/chop/command.go
+++ b/cmd/zar/chop/command.go
@@ -66,10 +66,12 @@ func (c *Command) Run(args []string) error {
 		return errors.New("zar chop: exactly one input file must be specified (- for stdin)")
 	}
 	path := args[0]
+	if path == "-" {
+		path = "/dev/stdin"
+	}
 	zctx := resolver.NewContext()
 	cfg := detector.OpenConfig{
-		Format:    c.ReaderFlags.Format,
-		DashStdin: true,
+		Format: c.ReaderFlags.Format,
 		//JSONTypeConfig: c.jsonTypeConfig,
 		//JSONPathRegex:  c.jsonPathRegexp,
 	}

--- a/cmd/zar/zdx/command.go
+++ b/cmd/zar/zdx/command.go
@@ -73,8 +73,7 @@ func (c *Command) Run(args []string) error {
 		path := archive.Localize(zardir, args[:1])
 		zctx := resolver.NewContext()
 		cfg := detector.OpenConfig{
-			Format:    c.ReaderFlags.Format,
-			DashStdin: true, //XXX
+			Format: c.ReaderFlags.Format,
 			//JSONTypeConfig: c.jsonTypeConfig,
 			//JSONPathRegex:  c.jsonPathRegexp,
 		}

--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -190,7 +190,6 @@ func (c *Command) Run(args []string) error {
 func (c *Command) inputReaders(zctx *resolver.Context, paths []string) ([]zbuf.Reader, error) {
 	cfg := detector.OpenConfig{
 		Format:         c.ReaderFlags.Format,
-		DashStdin:      true,
 		JSONTypeConfig: c.jsonTypeConfig,
 		JSONPathRegex:  c.jsonPathRegexp,
 	}

--- a/cmd/zdx/convert/command.go
+++ b/cmd/zdx/convert/command.go
@@ -64,7 +64,7 @@ func (c *Command) Run(args []string) error {
 	}
 	path := args[0]
 	if path == "-" {
-		path = "/dev/stdin"
+		path = detector.StdinPath
 	}
 	zctx := resolver.NewContext()
 	cfg := detector.OpenConfig{

--- a/cmd/zdx/convert/command.go
+++ b/cmd/zdx/convert/command.go
@@ -63,10 +63,12 @@ func (c *Command) Run(args []string) error {
 		return errors.New("must specify a single zng input file containing keys and optional values")
 	}
 	path := args[0]
+	if path == "-" {
+		path = "/dev/stdin"
+	}
 	zctx := resolver.NewContext()
 	cfg := detector.OpenConfig{
-		Format:    c.ReaderFlags.Format,
-		DashStdin: true,
+		Format: c.ReaderFlags.Format,
 		//JSONTypeConfig: c.jsonTypeConfig,
 		//JSONPathRegex:  c.jsonPathRegexp,
 	}

--- a/cmd/zdx/create/command.go
+++ b/cmd/zdx/create/command.go
@@ -66,10 +66,12 @@ func (c *Command) Run(args []string) error {
 		return errors.New("must specify a single zng input file containing the indicated keys")
 	}
 	path := args[0]
+	if path == "-" {
+		path = "/dev/stdin"
+	}
 	zctx := resolver.NewContext()
 	cfg := detector.OpenConfig{
-		Format:    c.ReaderFlags.Format,
-		DashStdin: true,
+		Format: c.ReaderFlags.Format,
 		//JSONTypeConfig: c.jsonTypeConfig,
 		//JSONPathRegex:  c.jsonPathRegexp,
 	}

--- a/cmd/zdx/create/command.go
+++ b/cmd/zdx/create/command.go
@@ -67,7 +67,7 @@ func (c *Command) Run(args []string) error {
 	}
 	path := args[0]
 	if path == "-" {
-		path = "/dev/stdin"
+		path = detector.StdinPath
 	}
 	zctx := resolver.NewContext()
 	cfg := detector.OpenConfig{

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -259,6 +259,9 @@ func (c *Command) inputReaders(paths []string) ([]zbuf.Reader, error) {
 	var readers []zbuf.Reader
 	for _, path := range paths {
 		file, err := detector.OpenFile(c.zctx, path, cfg)
+		if path == "-" {
+			path = "stdin"
+		}
 		if err != nil {
 			err = fmt.Errorf("%s: %w", path, err)
 			if c.stopErr {

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -252,16 +252,15 @@ func (c *Command) errorf(format string, args ...interface{}) {
 func (c *Command) inputReaders(paths []string) ([]zbuf.Reader, error) {
 	cfg := detector.OpenConfig{
 		Format:         c.ReaderFlags.Format,
-		DashStdin:      true,
 		JSONTypeConfig: c.jsonTypeConfig,
 		JSONPathRegex:  c.jsonPathRegexp,
 	}
 	var readers []zbuf.Reader
 	for _, path := range paths {
-		file, err := detector.OpenFile(c.zctx, path, cfg)
 		if path == "-" {
-			path = "stdin"
+			path = "/dev/stdin"
 		}
+		file, err := detector.OpenFile(c.zctx, path, cfg)
 		if err != nil {
 			err = fmt.Errorf("%s: %w", path, err)
 			if c.stopErr {

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -249,15 +249,6 @@ func (c *Command) errorf(format string, args ...interface{}) {
 	_, _ = fmt.Fprintf(os.Stderr, format, args...)
 }
 
-type namedReader struct {
-	zbuf.Reader
-	name string
-}
-
-func (r namedReader) String() string {
-	return r.name
-}
-
 func (c *Command) inputReaders(paths []string) ([]zbuf.Reader, error) {
 	cfg := detector.OpenConfig{
 		Format:         c.ReaderFlags.Format,
@@ -276,8 +267,7 @@ func (c *Command) inputReaders(paths []string) ([]zbuf.Reader, error) {
 			c.errorf("%s\n", err)
 			continue
 		}
-		// wrap in a named reader so the reader implements Stringer
-		readers = append(readers, namedReader{file, path})
+		readers = append(readers, file)
 	}
 	return readers, nil
 }

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -258,7 +258,7 @@ func (c *Command) inputReaders(paths []string) ([]zbuf.Reader, error) {
 	var readers []zbuf.Reader
 	for _, path := range paths {
 		if path == "-" {
-			path = "/dev/stdin"
+			path = detector.StdinPath
 		}
 		file, err := detector.OpenFile(c.zctx, path, cfg)
 		if err != nil {

--- a/tests/suite/errors/stdin-name-auto.yaml
+++ b/tests/suite/errors/stdin-name-auto.yaml
@@ -1,0 +1,13 @@
+script: |
+  zq - < bad.tzng
+
+inputs:
+  - name: bad.tzng
+    data: |
+        #0:record[_path:string]
+        0:[conn;1;]
+
+outputs:
+  - name: stderr
+    regexp: |
+      stdin: format detection error

--- a/tests/suite/errors/stdin-name.yaml
+++ b/tests/suite/errors/stdin-name.yaml
@@ -1,0 +1,13 @@
+script: |
+  zq  -i tzng - < bad.tzng
+
+inputs:
+  - name: bad.tzng
+    data: |
+        #0:record[_path:string]
+        0:[conn;1;]
+
+outputs:
+  - name: stderr
+    regexp: |
+      stdin: .* record with extra field

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -21,7 +21,6 @@ import (
 
 type OpenConfig struct {
 	Format         string
-	DashStdin      bool
 	JSONTypeConfig *ndjsonio.TypeConfig
 	JSONPathRegex  string
 	AwsCfg         *aws.Config
@@ -49,9 +48,8 @@ func OpenFile(zctx *resolver.Context, path string, cfg OpenConfig) (*zbuf.File, 
 	}
 
 	var f *os.File
-	if cfg.DashStdin && path == "-" {
+	if path == "/dev/stdin" {
 		f = os.Stdin
-		path = "stdin"
 	} else {
 		info, err := os.Stat(path)
 		if err != nil {

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -51,6 +51,7 @@ func OpenFile(zctx *resolver.Context, path string, cfg OpenConfig) (*zbuf.File, 
 	var f *os.File
 	if cfg.DashStdin && path == "-" {
 		f = os.Stdin
+		path = "stdin"
 	} else {
 		info, err := os.Stat(path)
 		if err != nil {

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -34,6 +34,8 @@ func IsS3Path(path string) bool {
 	return u.Scheme == "s3"
 }
 
+const StdinPath = "/dev/stdin"
+
 // OpenFile creates and returns zbuf.File for the indicated "path",
 // which can be a local file path, a local directory path, or an S3
 // URL. If the path is neither of these or can't otherwise be opened,
@@ -48,7 +50,7 @@ func OpenFile(zctx *resolver.Context, path string, cfg OpenConfig) (*zbuf.File, 
 	}
 
 	var f *os.File
-	if path == "/dev/stdin" {
+	if path == StdinPath {
 		f = os.Stdin
 	} else {
 		info, err := os.Stat(path)


### PR DESCRIPTION
It's a little odd when zq produces error messages starting with `-:` like:

```
$ cat bad.tzng | zq -t - 
-: format detection error
   [...]
```

This PR fixes things so that those messages now start with `stdin:`, like they would with other file names.

