### PR TITLE
Remove OpenConfig.DashStdin

### DIFF
--- a/cmd/zar/chop/command.go
+++ b/cmd/zar/chop/command.go
@@ -66,10 +66,12 @@ func (c *Command) Run(args []string) error {
 		return errors.New("zar chop: exactly one input file must be specified (- for stdin)")
 	}
 	path := args[0]
+	if path == "-" {
+		path = "/dev/stdin"
+	}
 	zctx := resolver.NewContext()
 	cfg := detector.OpenConfig{
-		Format:    c.ReaderFlags.Format,
-		DashStdin: true,
+		Format: c.ReaderFlags.Format,
 		//JSONTypeConfig: c.jsonTypeConfig,
 		//JSONPathRegex:  c.jsonPathRegexp,
 	}

--- a/cmd/zar/zdx/command.go
+++ b/cmd/zar/zdx/command.go
@@ -73,8 +73,7 @@ func (c *Command) Run(args []string) error {
 		path := archive.Localize(zardir, args[:1])
 		zctx := resolver.NewContext()
 		cfg := detector.OpenConfig{
-			Format:    c.ReaderFlags.Format,
-			DashStdin: true, //XXX
+			Format: c.ReaderFlags.Format,
 			//JSONTypeConfig: c.jsonTypeConfig,
 			//JSONPathRegex:  c.jsonPathRegexp,
 		}

--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -190,7 +190,6 @@ func (c *Command) Run(args []string) error {
 func (c *Command) inputReaders(zctx *resolver.Context, paths []string) ([]zbuf.Reader, error) {
 	cfg := detector.OpenConfig{
 		Format:         c.ReaderFlags.Format,
-		DashStdin:      true,
 		JSONTypeConfig: c.jsonTypeConfig,
 		JSONPathRegex:  c.jsonPathRegexp,
 	}

--- a/cmd/zdx/convert/command.go
+++ b/cmd/zdx/convert/command.go
@@ -63,10 +63,12 @@ func (c *Command) Run(args []string) error {
 		return errors.New("must specify a single zng input file containing keys and optional values")
 	}
 	path := args[0]
+	if path == "-" {
+		path = "/dev/stdin"
+	}
 	zctx := resolver.NewContext()
 	cfg := detector.OpenConfig{
-		Format:    c.ReaderFlags.Format,
-		DashStdin: true,
+		Format: c.ReaderFlags.Format,
 		//JSONTypeConfig: c.jsonTypeConfig,
 		//JSONPathRegex:  c.jsonPathRegexp,
 	}

--- a/cmd/zdx/create/command.go
+++ b/cmd/zdx/create/command.go
@@ -66,10 +66,12 @@ func (c *Command) Run(args []string) error {
 		return errors.New("must specify a single zng input file containing the indicated keys")
 	}
 	path := args[0]
+	if path == "-" {
+		path = "/dev/stdin"
+	}
 	zctx := resolver.NewContext()
 	cfg := detector.OpenConfig{
-		Format:    c.ReaderFlags.Format,
-		DashStdin: true,
+		Format: c.ReaderFlags.Format,
 		//JSONTypeConfig: c.jsonTypeConfig,
 		//JSONPathRegex:  c.jsonPathRegexp,
 	}

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -252,16 +252,15 @@ func (c *Command) errorf(format string, args ...interface{}) {
 func (c *Command) inputReaders(paths []string) ([]zbuf.Reader, error) {
 	cfg := detector.OpenConfig{
 		Format:         c.ReaderFlags.Format,
-		DashStdin:      true,
 		JSONTypeConfig: c.jsonTypeConfig,
 		JSONPathRegex:  c.jsonPathRegexp,
 	}
 	var readers []zbuf.Reader
 	for _, path := range paths {
-		file, err := detector.OpenFile(c.zctx, path, cfg)
 		if path == "-" {
-			path = "stdin"
+			path = "/dev/stdin"
 		}
+		file, err := detector.OpenFile(c.zctx, path, cfg)
 		if err != nil {
 			err = fmt.Errorf("%s: %w", path, err)
 			if c.stopErr {

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -21,7 +21,6 @@ import (
 
 type OpenConfig struct {
 	Format         string
-	DashStdin      bool
 	JSONTypeConfig *ndjsonio.TypeConfig
 	JSONPathRegex  string
 	AwsCfg         *aws.Config
@@ -49,9 +48,8 @@ func OpenFile(zctx *resolver.Context, path string, cfg OpenConfig) (*zbuf.File, 
 	}
 
 	var f *os.File
-	if cfg.DashStdin && path == "-" {
+	if path == "/dev/stdin" {
 		f = os.Stdin
-		path = "stdin"
 	} else {
 		info, err := os.Stat(path)
 		if err != nil {


### PR DESCRIPTION
While working on #777 I noticed that rather than have zbuf be aware of CLI-specific shortcuts, we could just do the `-` to `/dev/stdin` translation in the command handling code and also get rid of the minor clunkiness of setting `path="stdin"` in #777. 