### PR TITLE
Revise casting from int to time

### DIFF
--- a/expr/expr.go
+++ b/expr/expr.go
@@ -1070,7 +1070,7 @@ func compileCast(node ast.CastExpression) (NativeEvaluator, error) {
 			if !ok {
 				return zngnative.Value{}, ErrBadCast
 			}
-			return zngnative.Value{zng.TypeTime, i}, nil
+			return zngnative.Value{zng.TypeTime, i * 1_000_000_000}, nil
 		}, nil
 	default:
 		return nil, fmt.Errorf("cast to %s not implemeneted", node.Type)

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -685,6 +685,6 @@ func TestCasts(t *testing.T) {
 	// Test casts to time
 	ts := zng.Value{zng.TypeTime, zng.EncodeTime(nano.Ts(1589126400_000_000_000))}
 	testSuccessful(t, "1589126400.0 :time", record, ts)
-	testSuccessful(t, "1589126400000000000 :time", record, ts)
+	testSuccessful(t, "1589126400 :time", record, ts)
 	testError(t, `"1234" :time`, record, expr.ErrBadCast, "cannot cast string to time")
 }


### PR DESCRIPTION
The first iteration of casts interpreted an integer as nanoseconds when
casting it to time.  But this is inconsistent with the handling of
number-time releationships everywhere else in zng/zql.  Revise to handle
integers as seconds.