### PR TITLE
improve error message for bad zeekrunner

### DIFF
--- a/zqd/zeek/zeek.go
+++ b/zqd/zeek/zeek.go
@@ -76,6 +76,10 @@ func (p *process) wrapError(err error) error {
 		stderr = strings.TrimSpace(stderr)
 		return fmt.Errorf("zeek exited with status %d: %s", exitErr.ExitCode(), stderr)
 	}
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		return fmt.Errorf("error executing zeek runner: %s: %v", pathErr.Path, pathErr.Err)
+	}
 	return err
 }
 


### PR DESCRIPTION
Improve the error message when there's a problem executing the zeek runner.

Fixes #767 


<img width="597" alt="Screen Shot 2020-05-14 at 21 26 50" src="https://user-images.githubusercontent.com/704945/82011491-fd8e2c00-9629-11ea-94d8-8efb9ae59306.png">
<img width="607" alt="Screen Shot 2020-05-14 at 21 27 48" src="https://user-images.githubusercontent.com/704945/82011498-0252e000-962a-11ea-8817-d8e208176b3f.png">
