### PR TITLE
Serialize zero spans as a json null

### DIFF
--- a/pkg/nano/span_test.go
+++ b/pkg/nano/span_test.go
@@ -1,11 +1,42 @@
 package nano_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestSpanJSON(t *testing.T) {
+	type teststruct struct {
+		Span nano.Span `json:"span"`
+	}
+	t.Run("MarshalZero", func(t *testing.T) {
+		data, err := json.Marshal(teststruct{})
+		assert.NoError(t, err)
+		assert.Equal(t, `{"span":null}`, string(data))
+	})
+	t.Run("UnmarshalZero", func(t *testing.T) {
+		test := teststruct{nano.Span{Ts: 0, Dur: 1}}
+		err := json.Unmarshal([]byte(`{"span":null}`), &test)
+		assert.NoError(t, err)
+		assert.Equal(t, nano.Span{}, test.Span)
+	})
+	t.Run("Marshal", func(t *testing.T) {
+		test := teststruct{nano.Span{Ts: 0, Dur: 1}}
+		data, err := json.Marshal(test)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"span":{"ts":{"sec":0,"ns":0},"dur":{"sec":0,"ns":1}}}`, string(data))
+	})
+	t.Run("Unmarshal", func(t *testing.T) {
+		input := `{"span":{"ts":{"sec":0,"ns":0},"dur":{"sec":0,"ns":1}}}`
+		test := teststruct{nano.Span{Ts: 0, Dur: 10000}}
+		err := json.Unmarshal([]byte(input), &test)
+		assert.NoError(t, err)
+		assert.Equal(t, nano.Span{Dur: 1}, test.Span)
+	})
+}
 
 func TestSubSpan(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
A span with Dur == 0 is an impossible time span- why not use this
as the nil value of span?

Change json serialization of `nano.Span`s so that if span.Dur == 0
the span gets a null value in json. Like was json null values set a
span in a struct to `nano.Span{0, 0}`.