### PR TITLE
zar: fix index path logged on stdout

### DIFF
--- a/archive/indexer.go
+++ b/archive/indexer.go
@@ -51,7 +51,7 @@ func run(zardir string, rules []Rule, progress chan<- string) error {
 		}
 		writers = append(writers, w)
 		if progress != nil {
-			progress <- fmt.Sprintf("%s: creating index %s", logPath, rule.Path(logPath))
+			progress <- fmt.Sprintf("%s: creating index %s", logPath, rule.Path(zardir))
 		}
 	}
 	file, err := fs.Open(logPath)


### PR DESCRIPTION
`zar index` was saying 
```
.../logs/20180324/1521912990.158766.zng: creating index .../logs/20180324/1521912990.158766.zng/zdx:field:id.orig_h
```
instead of saying
```
.../logs/20180324/1521912990.158766.zng: creating index .../logs/20180324/1521912990.158766.zng.zar/zdx:field:id.orig_h
```

(missing the ".zar" suffix in the index path)