### PR TITLE
Fix subnet searches

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -115,7 +115,7 @@ func EvalAny(eval Predicate, recursive bool) Filter {
 }
 
 func compileSearch(node *ast.Search) (Filter, error) {
-	if node.Value.Type == "regexp" {
+	if node.Value.Type == "regexp" || node.Value.Type == "net" {
 		match, err := Comparison("=~", node.Value)
 		if err != nil {
 			return nil, err

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -287,6 +287,18 @@ func TestFilters(t *testing.T) {
 		{"wor*", true},
 	})
 
+	// Test searching with subnet syntax
+	record, err = parseOneRecord(`
+#0:record[addr:ip]
+0:[192.168.1.50;]
+`)
+	require.NoError(t, err)
+	runCases(t, record, []testcase{
+		{"192.168.0.0/16", true},
+		{"192.168.1.0/24", true},
+		{"10.0.0.0/8", false},
+	})
+
 	// Test time coercion
 	record, err = parseOneRecord(`
 #0:record[ts:time,ts2:time,ts3:time]


### PR DESCRIPTION
When search was reworked in #597, subnet searches (i.e., a search term
that is just a network such as "192.168.1.0/24") were broken.  Fix them
here and add a test case.
Fixes #806 