### PR TITLE
zapi: Signal based context

### DIFF
--- a/cmd/zapi/cmd/info/info.go
+++ b/cmd/zapi/cmd/info/info.go
@@ -1,7 +1,6 @@
 package info
 
 import (
-	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -42,7 +41,7 @@ func New(parent charm.Command, flags *flag.FlagSet) (charm.Command, error) {
 func (c *Command) Run(args []string) error {
 	client := c.Client()
 	if len(args) > 0 {
-		matches, err := cmd.SpaceGlob(context.TODO(), client, args...)
+		matches, err := cmd.SpaceGlob(c.Context(), client, args...)
 		if err != nil {
 			return err
 		}
@@ -55,7 +54,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	info, err := client.SpaceInfo(context.TODO(), id)
+	info, err := client.SpaceInfo(c.Context(), id)
 	if err != nil {
 		return err
 	}

--- a/cmd/zapi/cmd/signal.go
+++ b/cmd/zapi/cmd/signal.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+)
+
+type signalCtx struct {
+	context.Context
+	sigs   []os.Signal
+	caught os.Signal
+}
+
+func newSignalCtx(ctx context.Context, sigs ...os.Signal) (s *signalCtx) {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, sigs...)
+	childctx, cancel := context.WithCancel(ctx)
+	s = &signalCtx{Context: childctx, sigs: sigs}
+	go func() {
+		select {
+		case sig := <-signals:
+			s.caught = sig
+			cancel()
+			return
+		case <-childctx.Done():
+			return
+		}
+	}()
+	return
+}
+
+func (s *signalCtx) Caught() os.Signal {
+	<-s.Done()
+	return s.caught
+}


### PR DESCRIPTION
For zapi add a context to the root command that cancels when
SIGTERM or SIGINT is recieved. This context should be passed into
any long running tasks launched by the command.

This functionality will come more into play when the longer running
commands such search or post data are shortly introduced.