### PR TITLE
Page iterator

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
-	"runtime/pprof"
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/driver"
@@ -162,18 +161,6 @@ func isTerminal(f *os.File) bool {
 }
 
 func (c *Command) Run(args []string) error {
-	if true {
-		f, err := os.Create("profile")
-		if err != nil {
-			fmt.Printf("Can't open profile: %s\n", err)
-		} else {
-			err = pprof.StartCPUProfile(f)
-			if err != nil {
-				fmt.Printf("Can't start pfoiler: %s\n", err)
-			}
-			defer pprof.StopCPUProfile()
-		}
-	}
 	if c.showVersion {
 		return c.printVersion()
 	}

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"runtime/pprof"
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/driver"
@@ -161,6 +162,18 @@ func isTerminal(f *os.File) bool {
 }
 
 func (c *Command) Run(args []string) error {
+	if true {
+		f, err := os.Create("profile")
+		if err != nil {
+			fmt.Printf("Can't open profile: %s\n", err)
+		} else {
+			err = pprof.StartCPUProfile(f)
+			if err != nil {
+				fmt.Printf("Can't start pfoiler: %s\n", err)
+			}
+			defer pprof.StopCPUProfile()
+		}
+	}
 	if c.showVersion {
 		return c.printVersion()
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/sys v0.0.0-20200513112337-417ce2331b5c // indirect
 	golang.org/x/text v0.3.2
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/alexbrainman/ps v0.0.0-20171229230509-b3e1b4a15894
+	github.com/apache/thrift v0.0.0-20181112125854-24918abba929
 	github.com/aws/aws-sdk-go v1.30.19
 	github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f
 	github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,7 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cheggaaa/pb v1.0.28 h1:kWGpdAcSp3MxMU9CCHOwz/8V0kCHN4+9yQm2MzWuI98=
 github.com/cheggaaa/pb v1.0.28/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
@@ -265,6 +266,8 @@ github.com/hashicorp/vault/sdk v0.1.13 h1:mOEPeOhT7jl0J4AMl1E705+BcmeRs1VmKNb9F0
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 h1:UDMh68UUwekSh5iP2OMhRRZJiiBccgV7axzUG8vi56c=
+github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf h1:WfD7VjIE6z8dIvMsI4/s+1qr5EL+zoIGev1BQj1eoJ8=
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h1:hyb9oH7vZsitZCiBt0ZvifOrB+qc8PS5IiilCIb87rg=
@@ -657,7 +660,11 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200513112337-417ce2331b5c h1:kISX68E8gSkNYAFRFiDU8rl5RIn1sJYKYb/r2vMLDrU=
+golang.org/x/sys v0.0.0-20200513112337-417ce2331b5c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/zio/parquetio/iterator.go
+++ b/zio/parquetio/iterator.go
@@ -1,0 +1,528 @@
+package parquetio
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/xitongsys/parquet-go/common"
+	"github.com/xitongsys/parquet-go/compress"
+	"github.com/xitongsys/parquet-go/layout"
+	"github.com/xitongsys/parquet-go/parquet"
+	"github.com/xitongsys/parquet-go/reader"
+	"github.com/xitongsys/parquet-go/source"
+)
+
+type valueReader interface {
+	nextBoolean() bool
+	nextInt32() int32
+	nextInt64() int64
+	nextFloat() float64
+	nextDouble() float64
+	nextByteArray() []byte
+}
+
+type columnIterator struct {
+	pr   *reader.ParquetReader
+	name string
+
+	maxRL int32
+	maxDL int32
+
+	rowGroup int
+
+	groupRead    int
+	groupTotal   int
+	thriftReader *thrift.TBufferedTransport
+	colMetadata  *parquet.ColumnMetaData
+
+	pageRead  int
+	pageTotal int
+
+	rlReader  *hybridReader
+	dlReader  *hybridReader
+	valReader valueReader
+
+	// only used for PageType_DICTIONARY_PAGE
+	byteArrayDict [][]byte
+	// XXX need other types
+}
+
+func newColumnIterator(pr *reader.ParquetReader, name string, maxRL, maxDL int32) *columnIterator {
+	return &columnIterator{
+		pr:    pr,
+		name:  name,
+		maxRL: maxRL,
+		maxDL: maxDL,
+	}
+}
+
+func (i *columnIterator) clearDictionaries() {
+	i.byteArrayDict = nil
+	// XXX other types
+}
+
+func (i *columnIterator) loadOnePage() (*parquet.PageHeader, []byte, error) {
+	if i.groupRead == i.groupTotal {
+		if i.rowGroup >= len(i.pr.Footer.RowGroups) {
+			return nil, nil, io.EOF
+		}
+		rg := i.pr.Footer.RowGroups[i.rowGroup]
+		i.rowGroup++
+
+		i.groupRead = 0
+		i.groupTotal = int(rg.NumRows)
+
+		var col *parquet.ColumnChunk
+		for _, c := range rg.Columns {
+			if c.MetaData.PathInSchema[0] == i.name {
+				col = c
+				break
+			}
+		}
+		if col == nil {
+			panic("cannot find column")
+		}
+
+		if col.FilePath != nil {
+			panic("ColumnChunk refers to external file")
+		}
+
+		i.colMetadata = col.MetaData
+		offset := i.colMetadata.DataPageOffset
+		if i.colMetadata.DictionaryPageOffset != nil {
+			offset = *i.colMetadata.DictionaryPageOffset
+		}
+		size := i.colMetadata.TotalCompressedSize
+
+		// XXX
+		i.thriftReader = source.ConvertToThriftReader(i.pr.PFile, offset, size)
+
+		i.clearDictionaries()
+	}
+
+	header, err := layout.ReadPageHeader(i.thriftReader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// fmt.Printf("header type %s\n", header.GetType())
+	// XXX assert on page type
+
+	compressedLen := header.GetCompressedPageSize()
+
+	raw := make([]byte, compressedLen)
+	_, err = i.thriftReader.Read(raw)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	page, err := compress.Uncompress(raw, i.colMetadata.GetCodec())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return header, page, nil
+}
+
+func (i *columnIterator) ensureDataPage() {
+	if i.pageRead < i.pageTotal {
+		return
+	}
+
+	// XXX update groupTotal
+
+	for {
+		header, page, err := i.loadOnePage()
+		if err != nil {
+			panic(err)
+		}
+
+		switch header.GetType() {
+		case parquet.PageType_DICTIONARY_PAGE:
+			i.loadDictionaryPage(header, page)
+
+		case parquet.PageType_DATA_PAGE:
+			i.initializeDataPage(header, page)
+			return
+
+		default:
+			panic(fmt.Sprintf("unhandled page type %s", header.GetType()))
+		}
+	}
+}
+
+func (i *columnIterator) loadDictionaryPage(header *parquet.PageHeader, buf []byte) {
+	n := int(header.DictionaryPageHeader.GetNumValues())
+	switch i.colMetadata.GetType() {
+	case parquet.Type_BYTE_ARRAY:
+		i.byteArrayDict = make([][]byte, n)
+		r := plainReader{buf}
+		for j := 0; j < n; j++ {
+			i.byteArrayDict[j] = r.nextByteArray()
+		}
+
+	default:
+		//fmt.Printf("skipping dictionary page for type %s\n", i.colMetadata.GetType())
+	}
+}
+
+func (i *columnIterator) initializeDataPage(header *parquet.PageHeader, buf []byte) {
+	i.pageRead = 0
+	i.pageTotal = int(header.DataPageHeader.GetNumValues())
+
+	if i.maxRL > 0 {
+		width := int(common.BitNum(uint64(i.maxRL)))
+		hbuf, n, err := grabLenDenotedBuf(buf)
+		if err != nil {
+			panic(err)
+		}
+		buf = buf[n:]
+		i.rlReader = newHybridReader(hbuf, width)
+	} else {
+		i.rlReader = nil
+	}
+
+	if i.maxDL > 0 {
+		width := int(common.BitNum(uint64(i.maxDL)))
+		hbuf, n, err := grabLenDenotedBuf(buf)
+		if err != nil {
+			panic(err)
+		}
+		buf = buf[n:]
+		i.dlReader = newHybridReader(hbuf, width)
+	} else {
+		i.dlReader = nil
+	}
+
+	enc := header.DataPageHeader.GetEncoding()
+	switch enc {
+	case parquet.Encoding_PLAIN:
+		//fmt.Printf("instantiate plainReader for %s\n", i.name)
+		i.valReader = &plainReader{buf}
+	case parquet.Encoding_PLAIN_DICTIONARY:
+		switch i.colMetadata.GetType() {
+		case parquet.Type_BYTE_ARRAY:
+			i.valReader = newDictionaryByteArrayReader(buf, i.byteArrayDict)
+		default:
+			//fmt.Printf("skipping dictionary page of type %s\n", i.colMetadata.GetType())
+			i.valReader = &nullReader{}
+		}
+	default:
+		//fmt.Printf("skipping data page with encoding %s\n", enc)
+		i.valReader = &nullReader{}
+	}
+}
+
+func (i *columnIterator) peekDL() int32 {
+	i.ensureDataPage()
+	if i.dlReader == nil {
+		return 0
+	}
+	return int32(i.dlReader.peekInt64())
+}
+
+// advance counter, grab rl and dl
+func (i *columnIterator) commonNext() (int32, int32) {
+	i.ensureDataPage()
+	i.pageRead++
+
+	var rl, dl int32
+	if i.rlReader != nil {
+		rl = int32(i.rlReader.nextInt64())
+	}
+	if i.dlReader != nil {
+		dl = int32(i.dlReader.nextInt64())
+	}
+
+	if rl == i.maxRL {
+		i.groupRead++
+	}
+
+	return rl, dl
+}
+
+func (i *columnIterator) nextBoolean() (bool, int32, int32) {
+	rl, dl := i.commonNext()
+	var v bool
+	if dl == i.maxDL {
+		v = i.valReader.nextBoolean()
+	}
+	return v, rl, dl
+}
+
+func (i *columnIterator) nextInt32() (int32, int32, int32) {
+	rl, dl := i.commonNext()
+	var v int32
+	if dl == i.maxDL {
+		v = i.valReader.nextInt32()
+	}
+	return v, rl, dl
+}
+
+func (i *columnIterator) nextInt64() (int64, int32, int32) {
+	rl, dl := i.commonNext()
+	var v int64
+	if dl == i.maxDL {
+		v = i.valReader.nextInt64()
+	}
+	return v, rl, dl
+}
+
+func (i *columnIterator) nextFloat() (float64, int32, int32) {
+	rl, dl := i.commonNext()
+	var v float64
+	if dl == i.maxDL {
+		v = i.valReader.nextFloat()
+	}
+	return v, rl, dl
+}
+
+func (i *columnIterator) nextDouble() (float64, int32, int32) {
+	rl, dl := i.commonNext()
+	var v float64
+	if dl == i.maxDL {
+		v = i.valReader.nextDouble()
+	}
+	return v, rl, dl
+}
+
+func (i *columnIterator) nextByteArray() ([]byte, int32, int32) {
+	rl, dl := i.commonNext()
+	var v []byte
+	if dl == i.maxDL {
+		v = i.valReader.nextByteArray()
+	}
+	return v, rl, dl
+}
+
+func grabLenDenotedBuf(buf []byte) ([]byte, int, error) {
+	if len(buf) < 4 {
+		return nil, 0, fmt.Errorf("buffer is too short (%d)", len(buf))
+	}
+	ln := binary.LittleEndian.Uint32(buf[:4])
+	total := int(4 + ln)
+	if len(buf) < total {
+		return nil, 0, fmt.Errorf("buffer is too short (%d, need %d)", len(buf), total)
+	}
+	return buf[4:total], total, nil
+}
+
+type hybridReader struct {
+	buf   []byte
+	width int
+	vals  []int64
+}
+
+func newHybridReader(buf []byte, width int) *hybridReader {
+	return &hybridReader{buf, width, nil}
+}
+
+func makeMask(bits int) uint64 {
+	return uint64(1<<bits) - 1
+}
+
+func (r *hybridReader) fillVals() {
+	if len(r.vals) > 0 {
+		return
+	}
+	hdr, n := binary.Uvarint(r.buf)
+	if n == 0 {
+		panic("could not decode varint")
+	}
+	r.buf = r.buf[n:]
+	if hdr&1 == 0 {
+		// RLE encoded
+		raw := []byte{0, 0, 0, 0}
+		bytes := (r.width + 7) / 8
+		for i := 0; i < bytes; i++ {
+			raw[i] = r.buf[i]
+		}
+		val := int32(binary.LittleEndian.Uint32(raw))
+		r.buf = r.buf[bytes:]
+
+		n := int(hdr >> 1)
+		//fmt.Printf("decode rle %d x %d\n", val, n)
+		if cap(r.vals) >= n {
+			r.vals = r.vals[:n]
+		} else {
+			r.vals = make([]int64, n, n)
+		}
+		for i := 0; i < n; i++ {
+			r.vals[i] = int64(val)
+		}
+	} else {
+		// bit packed
+		groups := int(hdr >> 1)
+		//fmt.Printf("decode packed %d*8 %d-bit values\n", groups, r.width)
+		n := groups * 8
+		if cap(r.vals) >= n {
+			r.vals = r.vals[:n]
+		} else {
+			r.vals = make([]int64, n, n)
+		}
+
+		mask := makeMask(r.width)
+		var iv uint64
+		havebits := 0
+
+		if len(r.buf) < (groups * r.width) {
+			panic(fmt.Sprintf("need %d bytes for packed but have %d", groups*r.width, len(r.buf)))
+		}
+		bi := 0
+		for i := 0; i < n; i++ {
+			for havebits < r.width {
+				iv = (iv << 8) | uint64(r.buf[bi])
+				havebits += 8
+				bi++
+			}
+			r.vals[i] = int64(iv & mask)
+			iv >>= r.width
+			havebits -= r.width
+		}
+		r.buf = r.buf[r.width*groups:]
+	}
+}
+
+func (r *hybridReader) peekInt64() int64 {
+	r.fillVals()
+	return r.vals[0]
+}
+
+func (r *hybridReader) nextInt64() int64 {
+	r.fillVals()
+	ret := r.vals[0]
+	r.vals = r.vals[1:]
+	return ret
+}
+
+type nullReader struct {
+}
+
+func (r *nullReader) nextBoolean() bool {
+	return false
+}
+
+func (r *nullReader) nextInt32() int32 {
+	return 0
+}
+
+func (r *nullReader) nextInt64() int64 {
+	return 0
+}
+
+func (r *nullReader) nextFloat() float64 {
+	return 0
+}
+
+func (r *nullReader) nextDouble() float64 {
+	return 0
+}
+
+func (r *nullReader) nextByteArray() []byte {
+	return nil
+}
+
+// Handle Parquet PLAIN encoding type
+type plainReader struct {
+	buf []byte
+}
+
+func (r *plainReader) nextBoolean() bool {
+	// panic("implement plain boolean reader")
+	return false
+}
+
+func (r *plainReader) nextInt32() int32 {
+	if len(r.buf) < 4 {
+		panic("underflow in PLAIN INT32")
+	}
+
+	ret := binary.LittleEndian.Uint32(r.buf[:4])
+	r.buf = r.buf[4:]
+	return int32(ret)
+}
+
+func (r *plainReader) nextInt64() int64 {
+	if len(r.buf) < 8 {
+		panic("underflow in PLAIN INT64")
+	}
+
+	ret := binary.LittleEndian.Uint64(r.buf[:8])
+	r.buf = r.buf[8:]
+	return int64(ret)
+}
+
+func (r *plainReader) nextFloat() float64 {
+	if len(r.buf) < 4 {
+		panic("underflow in PLAIN FLOAT")
+	}
+	v := binary.LittleEndian.Uint32(r.buf[:4])
+	r.buf = r.buf[4:]
+	return float64(math.Float32frombits(v))
+}
+
+func (r *plainReader) nextDouble() float64 {
+	if len(r.buf) < 8 {
+		panic("underflow in PLAIN DOUBLE")
+	}
+	v := binary.LittleEndian.Uint64(r.buf[:8])
+	r.buf = r.buf[8:]
+	return math.Float64frombits(v)
+}
+
+func (r *plainReader) nextByteArray() []byte {
+	if len(r.buf) < 4 {
+		panic("underflow in PLAIN BYTE_ARRAY")
+	}
+	ln := binary.LittleEndian.Uint32(r.buf[:4])
+	total := int(4 + ln)
+	if len(r.buf) < total {
+		panic("underflow in PLAIN BYTE_ARRAY")
+	}
+	ret := r.buf[4:total]
+	r.buf = r.buf[total:]
+	return ret
+}
+
+// Handle Parquet PLAIN_DICTIONARY encoding type
+type dictionaryByteArrayReader struct {
+	dict        [][]byte
+	indexReader *hybridReader
+}
+
+func newDictionaryByteArrayReader(buf []byte, dict [][]byte) *dictionaryByteArrayReader {
+	width := int(buf[0])
+	reader := newHybridReader(buf[1:], width)
+	return &dictionaryByteArrayReader{dict, reader}
+}
+
+func (r *dictionaryByteArrayReader) nextBoolean() bool {
+	panic("cannot read BOOLEAN from BYTE_ARRAY dictionary reader")
+}
+
+func (r *dictionaryByteArrayReader) nextInt32() int32 {
+	panic("cannot read INT32 from BYTE_ARRAY dictionary reader")
+}
+
+func (r *dictionaryByteArrayReader) nextInt64() int64 {
+	panic("cannot read INT64 from BYTE_ARRAY dictionary reader")
+}
+
+func (r *dictionaryByteArrayReader) nextFloat() float64 {
+	panic("cannot read FLOAT from BYTE_ARRAY dictionary reader")
+}
+
+func (r *dictionaryByteArrayReader) nextDouble() float64 {
+	panic("cannot read DOUBLE from BYTE_ARRAY dictionary reader")
+}
+
+func (r *dictionaryByteArrayReader) nextByteArray() []byte {
+	i := int(r.indexReader.nextInt64())
+	if i > len(r.dict) {
+		panic(fmt.Sprintf("dictionary index too large (%d>%d)", i, len(r.dict)))
+	}
+	return r.dict[i]
+}

--- a/zio/parquetio/iterator.go
+++ b/zio/parquetio/iterator.go
@@ -374,7 +374,7 @@ func (r *hybridReader) fillVals() {
 		bi := 0
 		for i := 0; i < n; i++ {
 			for havebits < r.width {
-				iv = (iv << 8) | uint64(r.buf[bi])
+				iv |= uint64(r.buf[bi]) << havebits
 				havebits += 8
 				bi++
 			}

--- a/zio/parquetio/reader.go
+++ b/zio/parquetio/reader.go
@@ -484,7 +484,11 @@ func (c *listColumn) append(builder *zcode.Builder) error {
 
 	builder.BeginContainer()
 	for {
-		builder.AppendPrimitive(encodeZng(v, c.innerType))
+		if v == nil {
+			builder.AppendPrimitive(nil)
+		} else {
+			builder.AppendPrimitive(encodeZng(v, c.innerType))
+		}
 		if rl == c.maxRepetition {
 			break
 		}

--- a/zio/parquetio/reader.go
+++ b/zio/parquetio/reader.go
@@ -69,7 +69,7 @@ func lookupPrimitiveType(typ *parquet.Type, cType *parquet.ConvertedType) (Handl
 		// XXX case parquet.ConvertedType_INTERVAL:
 
 		default:
-			return HandledType(-1), false
+			return -1, false
 		}
 
 		// XXX handle logical types
@@ -90,10 +90,10 @@ func lookupPrimitiveType(typ *parquet.Type, cType *parquet.ConvertedType) (Handl
 		case parquet.Type_INT96:
 			return int96, true
 		default:
-			return HandledType(-1), false
+			return -1, false
 		}
 	} else {
-		return HandledType(-1), false
+		return -1, false
 	}
 }
 

--- a/zio/parquetio/reader.go
+++ b/zio/parquetio/reader.go
@@ -471,7 +471,7 @@ func appendItem(builder *zcode.Builder, typ HandledType, iter *columnIterator, m
 		//case timestampMilliseconds, timestampMicroseconds, timestampNanoseconds:
 		// XXX
 	default:
-		return false, fmt.Errorf("unhandled type %s", typ)
+		return false, fmt.Errorf("unhandled type %d", typ)
 	}
 	return (rl == maxRep), nil
 }

--- a/zio/parquetio/reader.go
+++ b/zio/parquetio/reader.go
@@ -508,8 +508,7 @@ func (r *Reader) Read() (*zng.Record, error) {
 
 	r.builder.Reset()
 	for _, c := range r.columns {
-		err := c.append(r.builder)
-		if err != nil {
+		if err := c.append(r.builder); err != nil {
 			return nil, err
 		}
 	}

--- a/zio/parquetio/reader.go
+++ b/zio/parquetio/reader.go
@@ -494,7 +494,7 @@ func (c *listColumn) append(builder *zcode.Builder) error {
 	v, rl, dl := c.readNext()
 
 	if c.maxDefinition > dl {
-		builder.AppendPrimitive(nil)
+		builder.AppendContainer(nil)
 		return nil
 	}
 


### PR DESCRIPTION
This is definitely a first cut but the desire on Slack was to create a PR for it now.  I have not had a chance to clean this up, some specific things that need cleaning are:
- error handling is sloppy and inconsistent, it many cases we just panic when encountering some parquet feature or variant that is not yet handled
- various bits of duplicated code
- little attention has been given to comments, names of functions/variables, ordering of functions in the source filed, etc.
- the wide reader interfaces that have methods for every parquet primitive type make for very verbose code.  @mccanne 's suggestion for this is to push the zng encoding all the way into the iterators which would also improve performance.

I think the last item would be best done in a separate follow-up.  As for the rest, I'm aware of all the cleanup that needs to happen, a review with detailed comments about those issues is probably not a good use of anybody's time at this stage...
