### PR TITLE
Simplify zar zq

### DIFF
--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -34,9 +34,9 @@ var Zq = &charm.Spec{
 	Long: `
 "zar zq" descends the directory given by the -R option (or ZAR_ROOT env) looking for
 logs with zar directories and for each such directory found, it runs
-the zq logic relative to that directory.  The file names here are relative to that
-directory and the special name "_" refers to the actual log file
-in the parent of the zar directory.
+the zq logic relative to that directory and emits the results in zng format.
+The file names here are relative to that directory and the special name "_" refers
+to the actual log file in the parent of the zar directory.
 
 If the root directory is not specified by either the ZAR_ROOT environemnt
 variable or the -R option, then the current directory is assumed.
@@ -58,7 +58,6 @@ type Command struct {
 	stopErr        bool
 	quiet          bool
 	ReaderFlags    zio.ReaderFlags
-	WriterFlags    zio.WriterFlags
 }
 
 func fileExists(path string) bool {
@@ -80,9 +79,6 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	f.StringVar(&c.jsonTypePath, "j", "", "path to json types file")
 	f.StringVar(&c.jsonPathRegexp, "pathregexp", c.jsonPathRegexp, "regexp for extracting _path from json log name (when -inferpath=true)")
 	f.BoolVar(&c.stopErr, "e", true, "stop upon input errors")
-
-	// Flags added for writers are -f, -T, -F, -E, -U, and -b
-	c.WriterFlags.SetFlags(f)
 
 	// Flags added for readers are -i XXX json
 	c.ReaderFlags.SetFlags(f)
@@ -224,7 +220,8 @@ func (c *Command) openOutput(zardir, filename string) (zbuf.WriteCloser, error) 
 	if path != "" {
 		path = filepath.Join(zardir, filename)
 	}
-	w, err := emitter.NewFile(path, &c.WriterFlags)
+	flags := zio.WriterFlags{Format: "zng"}
+	w, err := emitter.NewFile(path, &flags)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -2,14 +2,11 @@ package zq
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 
 	"github.com/brimsec/zq/archive"
 	"github.com/brimsec/zq/ast"
@@ -20,7 +17,6 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
-	"github.com/brimsec/zq/zio/ndjsonio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
 	"github.com/mccanne/charm"
@@ -50,14 +46,10 @@ func init() {
 
 type Command struct {
 	*root.Command
-	root           string
-	jsonTypePath   string
-	jsonPathRegexp string
-	jsonTypeConfig *ndjsonio.TypeConfig
-	outputFile     string
-	stopErr        bool
-	quiet          bool
-	ReaderFlags    zio.ReaderFlags
+	root       string
+	outputFile string
+	stopErr    bool
+	quiet      bool
 }
 
 func fileExists(path string) bool {
@@ -76,30 +68,9 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
 	f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
 	f.StringVar(&c.outputFile, "o", "", "write data to output file")
-	f.StringVar(&c.jsonTypePath, "j", "", "path to json types file")
-	f.StringVar(&c.jsonPathRegexp, "pathregexp", c.jsonPathRegexp, "regexp for extracting _path from json log name (when -inferpath=true)")
 	f.BoolVar(&c.stopErr, "e", true, "stop upon input errors")
 
-	// Flags added for readers are -i XXX json
-	c.ReaderFlags.SetFlags(f)
-
 	return c, nil
-}
-
-func (c *Command) loadJsonTypes() (*ndjsonio.TypeConfig, error) {
-	data, err := ioutil.ReadFile(c.jsonTypePath)
-	if err != nil {
-		return nil, err
-	}
-	var tc ndjsonio.TypeConfig
-	err = json.Unmarshal(data, &tc)
-	if err != nil {
-		return nil, fmt.Errorf("%s: unmarshaling error: %s", c.jsonTypePath, err)
-	}
-	if err = tc.Validate(); err != nil {
-		return nil, fmt.Errorf("%s: %s", c.jsonTypePath, err)
-	}
-	return &tc, nil
 }
 
 //XXX lots here copied from zq command... we should refactor into a tools package
@@ -114,16 +85,6 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 
-	if _, err := regexp.Compile(c.jsonPathRegexp); err != nil {
-		return err
-	}
-	if c.jsonTypePath != "" {
-		tc, err := c.loadJsonTypes()
-		if err != nil {
-			return err
-		}
-		c.jsonTypeConfig = tc
-	}
 	if len(args) == 0 {
 		return errors.New("zar zq needs input arguments")
 	}
@@ -186,9 +147,7 @@ func (c *Command) Run(args []string) error {
 
 func (c *Command) inputReaders(zctx *resolver.Context, paths []string) ([]zbuf.Reader, error) {
 	cfg := detector.OpenConfig{
-		Format:         c.ReaderFlags.Format,
-		JSONTypeConfig: c.jsonTypeConfig,
-		JSONPathRegex:  c.jsonPathRegexp,
+		Format: "zng",
 	}
 	var readers []zbuf.Reader
 	for _, path := range paths {

--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -179,8 +179,7 @@ func (c *Command) openOutput(zardir, filename string) (zbuf.WriteCloser, error) 
 	if path != "" {
 		path = filepath.Join(zardir, filename)
 	}
-	flags := zio.WriterFlags{Format: "zng"}
-	w, err := emitter.NewFile(path, &flags)
+	w, err := emitter.NewFile(path, &zio.WriterFlags{Format: "zng"})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR has two simplifying changes to `zar zq`. The change itself is straightforward but has implications on zar in two ways:

- The first commit removes the `-f` flag, such that `zar zq` always emits zng. This is the way it is used throughout the README, and for other formats, one can pipe `zar zq` into `zq`, as in the README.  (And as it says, "we love pipes"!). This closes #759.

- The second commit removes all input reader flags. Given that zar archive contents are stored in zng, there's no need for json-related flags.  This closes #757.