### PR TITLE
Generic Spill to Disk SortReader

### DIFF
--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -16,6 +16,7 @@ import (
 	"github.com/brimsec/zq/cmd/zar/root"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
@@ -168,7 +169,7 @@ func (c *Command) Run(args []string) error {
 				readers[i] = zbuf.NewWarningReader(r, wch)
 			}
 		}
-		reader := zbuf.NewCombiner(readers)
+		reader := zbuf.NewCombiner(readers, expr.SortTsAscending)
 		defer reader.Close()
 		writer, err := c.openOutput(zardir, c.outputFile)
 		if err != nil {

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -16,6 +16,7 @@ import (
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/zbuf"
@@ -241,7 +242,7 @@ func (c *Command) Run(args []string) error {
 			readers[i] = zbuf.NewWarningReader(r, wch)
 		}
 	}
-	reader := zbuf.NewCombiner(readers)
+	reader := zbuf.NewCombiner(readers, expr.SortTsAscending)
 	defer reader.Close()
 
 	writer, err := c.openOutput()

--- a/expr/sort.go
+++ b/expr/sort.go
@@ -8,6 +8,11 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
+var (
+	SortTsAscending  = sortTsFn(false)
+	SortTsDescending = sortTsFn(true)
+)
+
 type SortFn func(a *zng.Record, b *zng.Record) int
 type KeyCompareFn func(*zng.Record) int
 
@@ -359,5 +364,22 @@ func LookupSorter(typ zng.Type) comparefn {
 			}
 			return bytes.Compare(va.To16(), vb.To16())
 		}
+	}
+}
+
+func sortTsFn(desc bool) SortFn {
+	return func(a, b *zng.Record) int {
+		var i int
+		if a.Ts == b.Ts {
+			i = 0
+		} else if a.Ts < b.Ts {
+			i = -1
+		} else {
+			i = 1
+		}
+		if desc {
+			i = i * -1
+		}
+		return i
 	}
 }

--- a/zbuf/batch.go
+++ b/zbuf/batch.go
@@ -48,3 +48,52 @@ func ReadBatch(zr Reader, n int) (Batch, error) {
 	}
 	return NewArray(recs, nano.NewSpanTs(minTs, maxTs)), nil
 }
+
+func ReadBatchSize(zr Reader, n int64) (Batch, error) {
+	minTs, maxTs := nano.MaxTs, nano.MinTs
+	var size int64
+	recs := make([]*zng.Record, 0, n)
+	for size < n {
+		rec, err := zr.Read()
+		if err != nil {
+			return nil, err
+		}
+		if rec == nil {
+			break
+		}
+		if rec.Ts < minTs {
+			minTs = rec.Ts
+		}
+		if rec.Ts > maxTs {
+			maxTs = rec.Ts
+		}
+		// Copy the underlying buffer (if volatile) because call to next
+		// reader.Next() may overwrite said buffer.
+		rec.CopyBody()
+		recs = append(recs, rec)
+		size += int64(len(rec.Raw))
+	}
+	if len(recs) == 0 {
+		return nil, nil
+	}
+	return NewArray(recs, nano.NewSpanTs(minTs, maxTs)), nil
+
+}
+
+type batchReader struct {
+	batch Batch
+	n     int
+}
+
+func NewBatchReader(batch Batch) Reader {
+	return &batchReader{batch: batch}
+}
+
+func (b *batchReader) Read() (*zng.Record, error) {
+	if b.n >= b.batch.Length() {
+		return nil, nil
+	}
+	rec := b.batch.Index(b.n)
+	b.n++
+	return rec, nil
+}

--- a/zbuf/combiner.go
+++ b/zbuf/combiner.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/zng"
 )
 
@@ -11,13 +12,15 @@ type Combiner struct {
 	readers []Reader
 	hol     []*zng.Record
 	done    []bool
+	sortFn  expr.SortFn
 }
 
-func NewCombiner(readers []Reader) *Combiner {
+func NewCombiner(readers []Reader, sortFn expr.SortFn) *Combiner {
 	return &Combiner{
 		readers: readers,
 		hol:     make([]*zng.Record, len(readers)),
 		done:    make([]bool, len(readers)),
+		sortFn:  sortFn,
 	}
 }
 
@@ -38,7 +41,7 @@ func (c *Combiner) Read() (*zng.Record, error) {
 			}
 			c.hol[k] = tup
 		}
-		if idx == -1 || c.hol[k].Ts < c.hol[idx].Ts {
+		if idx == -1 || c.sortFn(c.hol[k], c.hol[idx]) == -1 {
 			idx = k
 		}
 	}

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/ndjsonio"
@@ -166,5 +167,5 @@ func OpenFiles(zctx *resolver.Context, paths ...string) (*zbuf.Combiner, error) 
 		}
 		readers = append(readers, reader)
 	}
-	return zbuf.NewCombiner(readers), nil
+	return zbuf.NewCombiner(readers, expr.SortTsAscending), nil
 }

--- a/zio/detector/s3_test.go
+++ b/zio/detector/s3_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/tzngio"
@@ -114,7 +115,7 @@ func TestS3Minio(t *testing.T) {
 		require.NoError(t, err)
 		defer f2.Close()
 
-		c := zbuf.NewCombiner([]zbuf.Reader{f1, f2})
+		c := zbuf.NewCombiner([]zbuf.Reader{f1, f2}, expr.SortTsAscending)
 
 		w := tzngio.NewWriter(&out)
 		err = zbuf.Copy(zbuf.NopFlusher(w), c)

--- a/zio/transform/sort.go
+++ b/zio/transform/sort.go
@@ -1,0 +1,155 @@
+package transform
+
+import (
+	"bufio"
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+var SortMemMaxBytes int64 = 128 * 1024 * 1024
+
+type SortReader struct {
+	peeker  *zbuf.Peeker
+	maxSize int64
+	baseDir string
+	tmpDir  string
+	sortFn  expr.SortFn
+	ctx     context.Context
+
+	once        sync.Once
+	ch          chan result
+	records     []*zng.Record
+	currentSize int64
+}
+
+func NewSortReader(ctx context.Context, r zbuf.Reader, maxSize int64, sortFn expr.SortFn, dir string) *SortReader {
+	if maxSize == 0 {
+		maxSize = SortMemMaxBytes
+	}
+	return &SortReader{
+		ctx:     ctx,
+		peeker:  zbuf.NewPeeker(r),
+		maxSize: maxSize,
+		baseDir: dir,
+		sortFn:  sortFn,
+		ch:      make(chan result),
+	}
+}
+
+type result struct {
+	record *zng.Record
+	err    error
+}
+
+func (s *SortReader) run() {
+	var err error
+	var batch zbuf.Batch
+	defer s.cleanup()
+	for s.ctx.Err() == nil {
+		batch, err = zbuf.ReadBatchSize(s.peeker, s.maxSize)
+		if err != nil {
+			s.ch <- result{nil, err}
+		}
+		records := batch.Records()
+		expr.SortStable(records, s.sortFn)
+		batch = zbuf.NewArray(records, batch.Span())
+		// if we are at EOF break loop and finish
+		if rec, _ := s.peeker.Peek(); rec == nil {
+			break
+		}
+		if err = s.flushBatch(batch); err != nil {
+			s.ch <- result{nil, err}
+			return
+		}
+	}
+	s.finish(batch)
+}
+
+func (s *SortReader) flushBatch(batch zbuf.Batch) error {
+	s.createTmpDir()
+	f, err := ioutil.TempFile(s.tmpDir, ".tmp-*.zng")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	r := zbuf.NewBatchReader(batch)
+	bw := bufio.NewWriter(f)
+	w := zngio.NewWriter(bw, zio.WriterFlags{})
+	if err := zbuf.CopyWithContext(s.ctx, w, r); err != nil {
+		return err
+	}
+	return bw.Flush()
+}
+
+func (s *SortReader) finish(batch zbuf.Batch) error {
+	br := zbuf.NewBatchReader(batch)
+	if s.tmpDir == "" {
+		s.send(br)
+		return nil
+	}
+	zctx := resolver.NewContext()
+	readers := []zbuf.Reader{br}
+	files, err := filepath.Glob(filepath.Join(s.tmpDir, "*.zng"))
+	if err != nil {
+		return err
+	}
+	for _, name := range files {
+		f, err := os.Open(name)
+		if err != nil {
+			return err
+		}
+		zr := zbuf.NewPeeker(zngio.NewReader(bufio.NewReader(f), zctx))
+		readers = append(readers, zr)
+	}
+	combiner := zbuf.NewCombiner(readers, s.sortFn)
+	s.send(combiner)
+	return combiner.Close()
+}
+
+func (s *SortReader) send(r zbuf.Reader) {
+	for s.ctx.Err() == nil {
+		rec, err := r.Read()
+		// XXX may need ctx interrupt here?
+		s.ch <- result{rec, err}
+		if rec == nil || err != nil {
+			break
+		}
+	}
+}
+
+func (s *SortReader) cleanup() error {
+	if s.tmpDir != "" {
+		tmp := s.tmpDir
+		s.tmpDir = ""
+		return os.RemoveAll(tmp)
+	}
+	return nil
+}
+
+func (s *SortReader) createTmpDir() error {
+	var err error
+	if s.tmpDir == "" {
+		s.tmpDir, err = ioutil.TempDir(s.baseDir, "SortReader")
+	}
+	return err
+}
+
+func (s *SortReader) Read() (*zng.Record, error) {
+	s.once.Do(func() { go s.run() })
+	select {
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	case res := <-s.ch:
+		return res.record, res.err
+	}
+}

--- a/zio/transform/sort_test.go
+++ b/zio/transform/sort_test.go
@@ -1,0 +1,83 @@
+package transform_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/pkg/test"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/transform"
+	"github.com/brimsec/zq/zio/tzngio"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAscending(t *testing.T) {
+	const input = `
+#0:record[ts:time,value:int32]
+0:[6;1;]
+0:[5;2;]
+0:[4;3;]
+0:[3;4;]
+0:[2;5;]
+0:[1;6;]`
+
+	const expected = `
+#0:record[ts:time,value:int32]
+0:[1;6;]
+0:[2;5;]
+0:[3;4;]
+0:[4;3;]
+0:[5;2;]
+0:[6;1;]`
+	t.Run("InMemory", func(t *testing.T) {
+		r := tzngio.NewReader(strings.NewReader(input), resolver.NewContext())
+		sr := transform.NewSortReader(context.Background(), r, 0, expr.SortTsAscending, "")
+		runTest(t, sr, expected)
+	})
+	t.Run("SpillToDisk", func(t *testing.T) {
+		r := tzngio.NewReader(strings.NewReader(input), resolver.NewContext())
+		sr := transform.NewSortReader(context.Background(), r, 1, expr.SortTsAscending, "")
+		runTest(t, sr, expected)
+	})
+}
+
+func TestDescending(t *testing.T) {
+	const input = `
+#0:record[ts:time,value:int32]
+0:[1;1;]
+0:[2;2;]
+0:[3;3;]
+0:[4;4;]
+0:[5;5;]
+0:[6;6;]
+`
+	const expected = `
+#0:record[ts:time,value:int32]
+0:[6;6;]
+0:[5;5;]
+0:[4;4;]
+0:[3;3;]
+0:[2;2;]
+0:[1;1;]`
+	t.Run("InMemory", func(t *testing.T) {
+		r := tzngio.NewReader(strings.NewReader(input), resolver.NewContext())
+		sr := transform.NewSortReader(context.Background(), r, 0, expr.SortTsDescending, "")
+		runTest(t, sr, expected)
+	})
+	t.Run("SpillToDisk", func(t *testing.T) {
+		r := tzngio.NewReader(strings.NewReader(input), resolver.NewContext())
+		sr := transform.NewSortReader(context.Background(), r, 1, expr.SortTsDescending, "")
+		runTest(t, sr, expected)
+	})
+}
+
+func runTest(t *testing.T, sr *transform.SortReader, expected string) {
+	buf := bytes.NewBuffer(nil)
+	err := zbuf.Copy(zbuf.NopFlusher(tzngio.NewWriter(buf)), sr)
+	require.NoError(t, err)
+	require.Equal(t, test.Trim(expected), buf.String())
+}

--- a/zqd/ingest/log.go
+++ b/zqd/ingest/log.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/detector"
@@ -130,7 +131,7 @@ func (p *LogOp) start(ctx context.Context, store *storage.ZngStorage) {
 	for _, warning := range p.warnings {
 		p.warningCh <- warning
 	}
-	r := zbuf.NewCombiner(p.readers)
+	r := zbuf.NewCombiner(p.readers, expr.SortTsDescending)
 	p.err = store.Rewrite(ctx, r)
 	if err := p.closeFiles(); err != nil && p.err != nil {
 		p.err = err

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -129,6 +129,7 @@ import (
 
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
@@ -625,7 +626,7 @@ func loadInputs(inputs []string, zctx *resolver.Context) (*zbuf.Combiner, error)
 		}
 		readers = append(readers, zr)
 	}
-	return zbuf.NewCombiner(readers), nil
+	return zbuf.NewCombiner(readers, expr.SortTsAscending), nil
 }
 
 func tmpInputFiles(inputs []string) (string, []string, error) {


### PR DESCRIPTION
An implementation of a generic disk spill sort reader than could be
used as a basis for the sort and group by proc.

Add package zio/transform for placement zio readers that transform.

Also:
- Adjust zbuf.Combiner so it takes an expr.SortFn as an arugment and
can there for be used anywhere where streams need to be merged in a
sorted fashion.