### PR TITLE
zar index: add -i flag to select input file

### DIFF
--- a/archive/indexer.go
+++ b/archive/indexer.go
@@ -30,10 +30,11 @@ func fieldZdxName(fieldname string) string {
 	return "zdx:field:" + fieldname
 }
 
-func IndexDirTree(ark *Archive, rules []Rule, progress chan<- string) error {
+func IndexDirTree(ark *Archive, rules []Rule, path string, progress chan<- string) error {
 	nerr := 0
 	return Walk(ark, func(zardir string) error {
-		if err := run(zardir, rules, progress); err != nil {
+		logPath := Localize(zardir, path)
+		if err := run(zardir, rules, logPath, progress); err != nil {
 			if progress != nil {
 				progress <- fmt.Sprintf("%s: %s\n", zardir, err)
 			}
@@ -47,9 +48,8 @@ func IndexDirTree(ark *Archive, rules []Rule, progress chan<- string) error {
 	})
 }
 
-func runOne(zardir string, rule Rule, progress chan<- string) error {
-	logPath := ZarDirToLog(zardir)
-	file, err := fs.Open(logPath)
+func runOne(zardir string, rule Rule, inputPath string, progress chan<- string) error {
+	file, err := fs.Open(inputPath)
 	if err != nil {
 		return err
 	}
@@ -66,14 +66,14 @@ func runOne(zardir string, rule Rule, progress chan<- string) error {
 		return err
 	}
 	if progress != nil {
-		progress <- fmt.Sprintf("%s: creating index %s", logPath, rule.Path(zardir))
+		progress <- fmt.Sprintf("%s: creating index %s", inputPath, rule.Path(zardir))
 	}
 	return driver.Run(out, fgi, nil)
 }
 
-func run(zardir string, rules []Rule, progress chan<- string) error {
+func run(zardir string, rules []Rule, logPath string, progress chan<- string) error {
 	for _, rule := range rules {
-		err := runOne(zardir, rule, progress)
+		err := runOne(zardir, rule, logPath, progress)
 		if err != nil {
 			return err
 		}

--- a/archive/walk.go
+++ b/archive/walk.go
@@ -18,22 +18,15 @@ func LogToZarDir(path string) string {
 	return path + zarExt
 }
 
-// Localize maps the provided slice of relative pathnames into
-// absolute path names relative to the given zardir and returns
-// the new pathnames as a slice.  The special name "_" is mapped
-// to the path of the log file that corresponds to this zardir.
-func Localize(zardir string, filenames []string) []string {
-	var out []string
-	for _, filename := range filenames {
-		var s string
-		if filename == "_" {
-			s = ZarDirToLog(zardir)
-		} else {
-			s = filepath.Join(zardir, filename)
-		}
-		out = append(out, s)
+// Localize maps the provided relative path name into absolute path
+// names relative to the given zardir and returns the result.  The
+// special name "_" is mapped to the path of the log file that
+// corresponds to this zardir.
+func Localize(zardir string, pathname string) string {
+	if pathname == "_" {
+		return ZarDirToLog(zardir)
 	}
-	return out
+	return filepath.Join(zardir, pathname)
 }
 
 // Walk traverses the archive invoking the visitor on the zar dir corresponding

--- a/cmd/zar/README.md
+++ b/cmd/zar/README.md
@@ -408,7 +408,7 @@ where each index includes a count of the occurrences.
 zar zq -o forward.zng "id.orig_h != null | put from=id.orig_h,to=id.resp_h | count() by from,to" _
 zar zq -o reverse.zng "id.orig_h != null | put from=id.resp_h,to=id.orig_h | count() by from,to" _
 zar zq -o directed-pairs.zng "sum(count) as count by from,to" forward.zng reverse.zng
-zar zdx -o graph -k from,to directed-pairs.zng
+zar index -i directed-pairs.zng -o graph  -k from,to -z "*"
 ```
 > (Note: there is a small change we can make to zql to do this with one `zar zq`
 > command... coming soon.)

--- a/cmd/zar/index/command.go
+++ b/cmd/zar/index/command.go
@@ -50,6 +50,7 @@ type Command struct {
 	*root.Command
 	root       string
 	quiet      bool
+	inputFile  string
 	outputFile string
 	framesize  int
 	keys       string
@@ -61,6 +62,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
 	f.StringVar(&c.keys, "k", "key", "one or more comma-separated key fields")
 	f.IntVar(&c.framesize, "f", 32*1024, "minimum frame size used in zdx file")
+	f.StringVar(&c.inputFile, "i", "_", "input file relative to each zar directory ('_' means archive log file in the parent of the zar directory)")
 	f.StringVar(&c.outputFile, "o", "zdx", "output index name (for custom indexes)")
 	f.BoolVar(&c.quiet, "q", false, "don't print progress on stdout")
 	f.StringVar(&c.zql, "z", "", "zql for custom indexes")
@@ -108,7 +110,7 @@ func (c *Command) Run(args []string) error {
 			wg.Done()
 		}()
 	}
-	err = archive.IndexDirTree(ark, rules, progress)
+	err = archive.IndexDirTree(ark, rules, c.inputFile, progress)
 	if progress != nil {
 		close(progress)
 		wg.Wait()

--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -94,8 +94,8 @@ func (c *Command) Run(args []string) error {
 		inputs := args
 		var query ast.Proc
 		var err error
-		first := archive.Localize(zardir, inputs[:1])
-		if first[0] != "" && fileExists(first[0]) {
+		first := archive.Localize(zardir, inputs[0])
+		if first != "" && fileExists(first) {
 			query, err = zql.ParseProc("*")
 			if err != nil {
 				return err
@@ -107,7 +107,10 @@ func (c *Command) Run(args []string) error {
 			}
 			inputs = inputs[1:]
 		}
-		localPaths := archive.Localize(zardir, inputs)
+		var localPaths []string
+		for _, input := range inputs {
+			localPaths = append(localPaths, archive.Localize(zardir, input))
+		}
 		readers, err := c.inputReaders(resolver.NewContext(), localPaths)
 		if err != nil {
 			return err

--- a/tests/suite/zar/index-custom-input.yaml
+++ b/tests/suite/zar/index-custom-input.yaml
@@ -1,0 +1,18 @@
+# test a simple indexing scenario with the use of the -i flag
+script: |
+  mkdir logs
+  zar import -R ./logs babble.tzng
+  zar zq -q -o sums.zng -R ./logs "sum(v) by s" _
+  zar index -i sums.zng -q -R ./logs -o index -z "put key=s | sort key"
+  zq -t logs/20200422/1587518620.0622373.zng.zar/index.1.zng
+
+inputs:
+  - name: babble.tzng
+    source: ../zdx/babble.tzng
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[key:string,_btree_child:int64]
+      0:[Algedi-pigeonman;0;]
+      0:[protistic-haystack;32795;]


### PR DESCRIPTION
This PR adds the `-i` option to `zar index`, allowing it to operate over other files than the usual archive log file. 

With this change, the one remaining `zar zdx` example in the demo can be moved to `zar index` (which landed while #816 was ongoing).