### PR TITLE
Add options to ParquetReader

### DIFF
--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -134,7 +134,7 @@ func OpenParquet(zctx *resolver.Context, path string, cfg OpenConfig) (*zbuf.Fil
 		return nil, err
 	}
 
-	r, err := parquetio.NewReader(pf, zctx)
+	r, err := parquetio.NewReader(pf, zctx, parquetio.ReaderOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/zio/parquetio/reader.go
+++ b/zio/parquetio/reader.go
@@ -126,8 +126,8 @@ func simpleParquetTypeToZngType(typ HandledType) zng.Type {
 }
 
 type ReaderOpts struct {
-	columns                []string
-	ignoreUnhandledColumns bool
+	Columns                []string
+	IgnoreUnhandledColumns bool
 }
 
 type Reader struct {
@@ -179,10 +179,10 @@ type column interface {
 }
 
 func (o *ReaderOpts) wantColumn(name string) bool {
-	if len(o.columns) == 0 {
+	if len(o.Columns) == 0 {
 		return true
 	}
-	for _, cname := range o.columns {
+	for _, cname := range o.Columns {
 		if name == cname {
 			return true
 		}
@@ -212,7 +212,7 @@ func buildColumns(pr *reader.ParquetReader, opts ReaderOpts) ([]column, error) {
 		}
 
 		if col == nil {
-			if opts.ignoreUnhandledColumns {
+			if opts.IgnoreUnhandledColumns {
 				continue
 			}
 			return nil, fmt.Errorf("cannot handle column %s", col.getName())


### PR DESCRIPTION
The column handling can now be customized -- columns with unknown structure
that the reader cannot handle can either be a fatal error (the default) or
ignored.  Also, a specific list of column names can be passed in in which
case the reader will not do the I/O and decoding work for other columns.
None of these options are yet wired up to zq command line arguments.