### PR TITLE
zql: add Time.trunc()

### DIFF
--- a/expr/functions.go
+++ b/expr/functions.go
@@ -55,6 +55,7 @@ var allFns = map[string]struct {
 	"Time.fromMilliseconds": {1, 1, timeFromMsec},
 	"Time.fromMicroseconds": {1, 1, timeFromUsec},
 	"Time.fromNanoseconds":  {1, 1, timeFromNsec},
+	"Time.trunc":            {2, 2, timeTrunc},
 }
 
 func err(fn string, err error) (zngnative.Value, error) {
@@ -447,4 +448,17 @@ func timeFromNsec(args []zngnative.Value) (zngnative.Value, error) {
 		return err("Time.fromNanoseconds", ErrBadArgument)
 	}
 	return zngnative.Value{zng.TypeTime, ns}, nil
+}
+
+func timeTrunc(args []zngnative.Value) (zngnative.Value, error) {
+	ts, ok := zngnative.CoerceNativeToTime(args[0])
+	if !ok {
+		return err("Time.trunc", ErrBadArgument)
+	}
+	dur, ok := zngnative.CoerceNativeToInt(args[1])
+	if !ok {
+		return err("Time.trunc", ErrBadArgument)
+	}
+	dur = dur * 1_000_000_000
+	return zngnative.Value{zng.TypeTime, int64(ts.Trunc(dur))}, nil
 }

--- a/expr/functions_test.go
+++ b/expr/functions_test.go
@@ -245,6 +245,7 @@ func TestTime(t *testing.T) {
 	testSuccessful(t, exp, nil, zval)
 	exp = fmt.Sprintf("Time.fromNanoseconds(%d)", nsec)
 	testSuccessful(t, exp, nil, zval)
+	testSuccessful(t, "Time.trunc(1590506867.967, 1)", nil, zng.Value{zng.TypeTime, zng.EncodeTime(nano.Ts(1590506867 * 1_000_000_000))})
 
 	testError(t, "Time.fromISO()", nil, expr.ErrTooFewArgs, "Time.fromISO() with no args")
 	testError(t, `Time.fromISO("abc", "def")`, nil, expr.ErrTooManyArgs, "Time.fromISO() with too many args")


### PR DESCRIPTION
This PR adds a new zql function `Time.trunc(t, s)` that truncates the time `t` to the nearest multiple of `s` below it using `nano.Ts.Trunc()`.

Part of #828 