### PR TITLE
report detailed pcap errors

### DIFF
--- a/cmd/pcap/ts/command.go
+++ b/cmd/pcap/ts/command.go
@@ -79,9 +79,9 @@ func (c *Command) Run(args []string) error {
 			break
 		}
 		if typ == pcapio.TypePacket {
-			pkt, ts, _ := reader.Packet(block)
-			if pkt == nil {
-				return pcapio.ErrCorruptPcap
+			_, ts, _, err := reader.Packet(block)
+			if err != nil {
+				return err
 			}
 			fmt.Fprintln(out, ts.StringFloat())
 		}

--- a/pcap/index.go
+++ b/pcap/index.go
@@ -43,7 +43,7 @@ type Section struct {
 func CreateIndex(r io.Reader, size int) (Index, error) {
 	reader, err := pcapio.NewReader(r)
 	if err != nil {
-		return nil, errInvalidPcap(err)
+		return nil, err
 	}
 	var offsets []ranger.Point
 	var index Index
@@ -55,7 +55,7 @@ func CreateIndex(r io.Reader, size int) (Index, error) {
 			if err == io.EOF {
 				break
 			}
-			return nil, errInvalidPcap(err)
+			return nil, err
 		}
 		if block == nil {
 			break
@@ -64,7 +64,7 @@ func CreateIndex(r io.Reader, size int) (Index, error) {
 		default:
 			if section == nil {
 				err = errors.New("missing section header")
-				return nil, errInvalidPcap(err)
+				return nil, pcapio.NewErrInvalidPcap(err)
 			}
 			slice := slicer.Slice{
 				Offset: off,
@@ -75,7 +75,7 @@ func CreateIndex(r io.Reader, size int) (Index, error) {
 		case pcapio.TypePacket:
 			pkt, ts, _, err := reader.Packet(block)
 			if pkt == nil {
-				return nil, errInvalidPcap(err)
+				return nil, err
 			}
 			y := uint64(ts)
 			offsets = append(offsets, ranger.Point{X: off, Y: y})
@@ -84,7 +84,7 @@ func CreateIndex(r io.Reader, size int) (Index, error) {
 			// end previous section and start a new one
 			if section == nil && offsets != nil {
 				err = errors.New("missing section header")
-				return nil, errInvalidPcap(err)
+				return nil, pcapio.NewErrInvalidPcap(err)
 			}
 			if section != nil && offsets != nil {
 				section.Index = ranger.NewEnvelope(offsets, size)

--- a/pcap/index.go
+++ b/pcap/index.go
@@ -63,7 +63,7 @@ func CreateIndex(r io.Reader, size int) (Index, error) {
 		switch typ {
 		default:
 			if section == nil {
-				err = errors.New("missing section header")
+				err := errors.New("missing section header")
 				return nil, pcapio.NewErrInvalidPcap(err)
 			}
 			slice := slicer.Slice{

--- a/pcap/index.go
+++ b/pcap/index.go
@@ -83,7 +83,7 @@ func CreateIndex(r io.Reader, size int) (Index, error) {
 		case pcapio.TypeSection:
 			// end previous section and start a new one
 			if section == nil && offsets != nil {
-				err = errors.New("missing section header")
+				err := errors.New("missing section header")
 				return nil, pcapio.NewErrInvalidPcap(err)
 			}
 			if section != nil && offsets != nil {

--- a/pcap/index_test.go
+++ b/pcap/index_test.go
@@ -6,14 +6,15 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/pcap"
+	"github.com/brimsec/zq/pcap/pcapio"
 	"github.com/stretchr/testify/require"
 )
 
 func TestInvalidIndex(t *testing.T) {
-	r := strings.NewReader("this is not a valid pcap")
+	r := strings.NewReader("this is not a valid pcap.")
 	_, err := pcap.CreateIndex(r, 0)
 	require.Error(t, err)
-	var e *pcap.ErrInvalidPcap
+	var e *pcapio.ErrInvalidPcap
 	if !errors.Is(err, e) {
 		require.FailNow(t, "error is not of type pcap.ErrInvalidPcap", err)
 	}

--- a/pcap/index_test.go
+++ b/pcap/index_test.go
@@ -1,0 +1,20 @@
+package pcap_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/brimsec/zq/pcap"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidIndex(t *testing.T) {
+	r := strings.NewReader("this is not a valid pcap")
+	_, err := pcap.CreateIndex(r, 0)
+	require.Error(t, err)
+	var e *pcap.ErrInvalidPcap
+	if !errors.Is(err, e) {
+		require.FailNow(t, "error is not of type pcap.ErrInvalidPcap", err)
+	}
+}

--- a/pcap/pcapio/error.go
+++ b/pcap/pcapio/error.go
@@ -7,11 +7,6 @@ import (
 	"github.com/brimsec/zq/zqe"
 )
 
-type detectorErr struct {
-	pcap   error
-	ngpcap error
-}
-
 type ErrInvalidPcap struct {
 	err error
 }

--- a/pcap/pcapio/error.go
+++ b/pcap/pcapio/error.go
@@ -1,0 +1,43 @@
+package pcapio
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/brimsec/zq/zqe"
+)
+
+type detectorErr struct {
+	pcap   error
+	ngpcap error
+}
+
+type ErrInvalidPcap struct {
+	err error
+}
+
+func NewErrInvalidPcap(err error) error {
+	e := &ErrInvalidPcap{err: err}
+	return zqe.E(zqe.Invalid, e)
+}
+
+func errInvalid(text string) error {
+	return NewErrInvalidPcap(errors.New(text))
+}
+
+func errInvalidf(format string, a ...interface{}) error {
+	return NewErrInvalidPcap(fmt.Errorf(format, a...))
+}
+
+func (e *ErrInvalidPcap) Is(target error) bool {
+	_, ok := target.(*ErrInvalidPcap)
+	return ok
+}
+
+func (e *ErrInvalidPcap) Unwrap() error {
+	return e.err
+}
+
+func (e *ErrInvalidPcap) Error() string {
+	return "invalid pcap: " + e.err.Error()
+}

--- a/pcap/pcapio/error.go
+++ b/pcap/pcapio/error.go
@@ -1,7 +1,6 @@
 package pcapio
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/brimsec/zq/zqe"
@@ -14,10 +13,6 @@ type ErrInvalidPcap struct {
 func NewErrInvalidPcap(err error) error {
 	e := &ErrInvalidPcap{err: err}
 	return zqe.E(zqe.Invalid, e)
-}
-
-func errInvalid(text string) error {
-	return NewErrInvalidPcap(errors.New(text))
 }
 
 func errInvalidf(format string, a ...interface{}) error {

--- a/pcap/pcapio/ngread.go
+++ b/pcap/pcapio/ngread.go
@@ -14,7 +14,6 @@ package pcapio
 
 import (
 	"encoding/binary"
-	"fmt"
 	"io"
 	"time"
 
@@ -152,7 +151,6 @@ func (r *NgReader) readBlock() (ngBlockType, []byte, error) {
 		// avoid infinite loop for bad input
 		return 0, nil, errInvalidf("pcap-ng block too small: %d bytes", length)
 	}
-	fmt.Println("length", length)
 	b, err := r.Reader.Read(int(length))
 	if err != nil {
 		return 0, nil, err

--- a/pcap/pcapio/ngread.go
+++ b/pcap/pcapio/ngread.go
@@ -14,7 +14,6 @@ package pcapio
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -41,13 +40,25 @@ func NewNgReader(r io.Reader) (*NgReader, error) {
 	ret := &NgReader{
 		Reader: peeker.NewReader(r, 32*1024, 1024*1024),
 	}
+	hdr, err := ret.Peek(12)
+	if err != nil {
+		return nil, err
+	}
+	// ensure first block is correct
+	typ := ngBlockType(ret.getUint32(hdr[:4]))
+	//pcapng _must_ start with a section header
+	if typ != ngBlockTypeSectionHeader {
+		return nil, errInvalidf("first block type not a section header: %d", typ)
+	}
+	if err := ret.parseSectionMagic(hdr[8:12]); err != nil {
+		return nil, err
+	}
 	typ, block, err := ret.readBlock()
 	if err != nil {
 		return nil, err
 	}
-	//pcapng _must_ start with a section header
 	if typ != ngBlockTypeSectionHeader {
-		return nil, fmt.Errorf("Unknown magic %x", typ)
+		return nil, errInvalidf("Unknown magic %x", typ)
 	}
 	ret.first = block
 	return ret, nil
@@ -55,16 +66,16 @@ func NewNgReader(r io.Reader) (*NgReader, error) {
 
 func (r *NgReader) parsePacket(block []byte) ([]byte, int, error) {
 	if len(block) < PacketBlockHeaderLen {
-		return nil, 0, errors.New("packet buffer length less then minimum packet size")
+		return nil, 0, errInvalid("packet buffer length less then minimum packet size")
 	}
 	ifno := int(r.getUint32(block[8:12]))
 	if ifno >= len(r.ifaces) {
-		return nil, 0, fmt.Errorf("packet references unknown interface no: %d", ifno)
+		return nil, 0, errInvalidf("packet references unknown interface no: %d", ifno)
 	}
 	caplen := int(r.getUint32(block[20:24]))
 	packet := block[PacketBlockHeaderLen:]
 	if len(packet) < caplen {
-		return nil, 0, errors.New("invalid capture length")
+		return nil, 0, errInvalid("invalid capture length")
 	}
 	return packet[:caplen], ifno, nil
 }
@@ -139,17 +150,18 @@ func (r *NgReader) readBlock() (ngBlockType, []byte, error) {
 	length := r.getUint32(hdr[4:8])
 	if length < 20 {
 		// avoid infinite loop for bad input
-		return 0, nil, fmt.Errorf("pcap-ng block too small: %d bytes", length)
+		return 0, nil, errInvalidf("pcap-ng block too small: %d bytes", length)
 	}
+	fmt.Println("length", length)
 	b, err := r.Reader.Read(int(length))
 	if err != nil {
 		return 0, nil, err
 	}
 	if uint32(len(b)) < length {
-		return 0, nil, errors.New("truncated pcap-ng block")
+		return 0, nil, errInvalid("truncated pcap-ng block")
 	}
 	if r.getUint32(b[length-4:length]) != uint32(length) {
-		return 0, nil, errors.New("pcap-ng trailer length mismatch")
+		return 0, nil, errInvalid("pcap-ng trailer length mismatch")
 	}
 	return typ, b, err
 }
@@ -160,7 +172,7 @@ func (r *NgReader) parseSectionMagic(b []byte) error {
 	} else if binary.LittleEndian.Uint32(b) == ngByteOrderMagic {
 		r.bigEndian = false
 	} else {
-		return errors.New("Wrong byte order value in Section Header")
+		return errInvalid("Wrong byte order value in Section Header")
 	}
 	r.ifaces = r.ifaces[:0]
 	return nil
@@ -177,7 +189,7 @@ func (r *NgReader) readOption(b []byte) (ngOptionCode, []byte, int, error) {
 	length := r.getUint16(b[2:4])
 	b = b[4:]
 	if int(length) > len(b) {
-		return 0, nil, 0, errors.New("bad option length")
+		return 0, nil, 0, errInvalid("bad option length")
 	}
 	// Determine padding. The option value field is always padded up to 32 bits.
 	padding := length % 4
@@ -191,7 +203,7 @@ func (r *NgReader) readOption(b []byte) (ngOptionCode, []byte, int, error) {
 // calculation, and adds the interface details to the current list.
 func (r *NgReader) parseInterfaceDescriptor(b []byte) error {
 	if len(b) < 20 {
-		return errors.New("bad interface descriptor block")
+		return errInvalid("bad interface descriptor block")
 	}
 	var intf NgInterface
 	intf.LinkType = layers.LinkType(r.getUint16(b[8:10]))
@@ -218,12 +230,12 @@ func (r *NgReader) parseInterfaceDescriptor(b []byte) error {
 			intf.OS = string(body)
 		case ngOptionCodeInterfaceTimestampOffset:
 			if len(body) != 8 {
-				return errors.New("bad option value: ngOptionCodeInterfaceTimestampOffset")
+				return errInvalid("bad option value: ngOptionCodeInterfaceTimestampOffset")
 			}
 			intf.TimestampOffset = r.getUint64(body[:8])
 		case ngOptionCodeInterfaceTimestampResolution:
 			if len(body) != 1 {
-				return errors.New("bad option value: ngOptionCodeInterfaceTimestampResolution")
+				return errInvalid("bad option value: ngOptionCodeInterfaceTimestampResolution")
 			}
 			intf.TimestampResolution = NgResolution(body[0])
 		}
@@ -284,7 +296,7 @@ func (r *NgReader) Read() ([]byte, BlockType, error) {
 			}
 			return block, TypePacket, nil
 		case ngBlockTypeSimplePacket:
-			return nil, 0, errors.New("pcap-ng simple packets not supported")
+			return nil, 0, errInvalid("pcap-ng simple packets not supported")
 		case ngBlockTypeInterfaceDescriptor:
 			err := r.parseInterfaceDescriptor(block)
 			return block, TypeInterface, err
@@ -293,7 +305,7 @@ func (r *NgReader) Read() ([]byte, BlockType, error) {
 		case ngBlockTypeSectionHeader:
 			return block, TypeSection, err
 		case ngBlockTypePacket:
-			return nil, 0, errors.New("pcap-ng deprecated type packet not supported")
+			return nil, 0, errInvalid("pcap-ng deprecated type packet not supported")
 		}
 	}
 	return nil, 0, nil

--- a/pcap/pcapio/ngread.go
+++ b/pcap/pcapio/ngread.go
@@ -58,7 +58,7 @@ func NewNgReader(r io.Reader) (*NgReader, error) {
 		return nil, err
 	}
 	if typ != ngBlockTypeSectionHeader {
-		return nil, errInvalidf("Unknown magic %x", typ)
+		return nil, errInvalidf("unknown magic %x", typ)
 	}
 	ret.first = block
 	return ret, nil

--- a/pcap/pcapio/ngread.go
+++ b/pcap/pcapio/ngread.go
@@ -66,7 +66,7 @@ func NewNgReader(r io.Reader) (*NgReader, error) {
 
 func (r *NgReader) parsePacket(block []byte) ([]byte, int, error) {
 	if len(block) < PacketBlockHeaderLen {
-		return nil, 0, errInvalid("packet buffer length less then minimum packet size")
+		return nil, 0, errInvalid("packet buffer length less than minimum packet size")
 	}
 	ifno := int(r.getUint32(block[8:12]))
 	if ifno >= len(r.ifaces) {

--- a/pcap/pcapio/pcapng.go
+++ b/pcap/pcapio/pcapng.go
@@ -13,19 +13,12 @@
 package pcapio
 
 import (
-	"errors"
 	"math"
 	"time"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 )
-
-// ErrNgVersionMismatch gets returned for unknown pcapng section versions. This can only happen if ReaderOptions.SkipUnknownVersion == false
-var ErrNgVersionMismatch = errors.New("Unknown pcapng Version in Section Header")
-
-// ErrNgLinkTypeMismatch gets returned if the link type of an interface is not the same as the link type from the first interface. This can only happen if ReaderOptions.ErrorOnMismatchingLinkType == true && ReaderOptions.WantMixedLinkType == false
-var ErrNgLinkTypeMismatch = errors.New("Link type of current interface is different from first one")
 
 const (
 	ngByteOrderMagic = 0x1A2B3C4D

--- a/pcap/pcapio/read.go
+++ b/pcap/pcapio/read.go
@@ -85,11 +85,11 @@ func NewPcapReader(r io.Reader) (*PcapReader, error) {
 
 func (r *PcapReader) Packet(block []byte) ([]byte, nano.Ts, layers.LinkType, error) {
 	if len(block) <= packetHeaderLen {
-		return nil, 0, 0, errInvalid("packet buffer length less than minimum packet size")
+		return nil, 0, 0, errInvalidf("packet buffer length less than minimum packet size")
 	}
 	caplen := int(r.byteOrder.Uint32(block[8:12]))
 	if caplen+packetHeaderLen > len(block) {
-		return nil, 0, 0, errInvalid("invalid capture length")
+		return nil, 0, 0, errInvalidf("invalid capture length")
 	}
 	ts := r.TsFromHeader(block)
 	pkt := block[packetHeaderLen:]
@@ -116,13 +116,13 @@ func (r *PcapReader) readHeader() error {
 		r.byteOrder = binary.BigEndian
 		r.nanoSecsFactor = 1000
 	} else {
-		return errInvalidf("Unknown magic %x", magic)
+		return errInvalidf("unknown magic %x", magic)
 	}
 	if r.versionMajor = r.byteOrder.Uint16(hdr[4:6]); r.versionMajor != versionMajor {
-		return errInvalidf("Unknown major version %d", r.versionMajor)
+		return errInvalidf("unknown major version %d", r.versionMajor)
 	}
 	if r.versionMinor = r.byteOrder.Uint16(hdr[6:8]); r.versionMinor != versionMinor {
-		return fmt.Errorf("Unknown minor version %d", r.versionMinor)
+		return errInvalidf("unknown minor version %d", r.versionMinor)
 	}
 	// ignore timezone 8:12 and sigfigs 12:16
 	r.snaplen = r.byteOrder.Uint32(hdr[16:20])

--- a/pcap/pcapio/read.go
+++ b/pcap/pcapio/read.go
@@ -85,7 +85,7 @@ func NewPcapReader(r io.Reader) (*PcapReader, error) {
 
 func (r *PcapReader) Packet(block []byte) ([]byte, nano.Ts, layers.LinkType, error) {
 	if len(block) <= packetHeaderLen {
-		return nil, 0, 0, errInvalid("packet buffer length less then minimum packet size")
+		return nil, 0, 0, errInvalid("packet buffer length less than minimum packet size")
 	}
 	caplen := int(r.byteOrder.Uint32(block[8:12]))
 	if caplen+packetHeaderLen > len(block) {

--- a/pcap/pcapio/reader.go
+++ b/pcap/pcapio/reader.go
@@ -48,7 +48,7 @@ func NewReader(r io.Reader) (Reader, error) {
 	var pcaperr, ngerr *ErrInvalidPcap
 	if errors.As(err1, &pcaperr) && errors.As(err2, &ngerr) {
 		err1 = fmt.Errorf("pcap: %w", pcaperr.err)
-		err2 = fmt.Errorf("ngpcap: %w", ngerr.err)
+		err2 = fmt.Errorf("pcapng: %w", ngerr.err)
 		err := multierr.Combine(err1, err2)
 		return nil, NewErrInvalidPcap(err)
 	}

--- a/pcap/pcapio/reader.go
+++ b/pcap/pcapio/reader.go
@@ -1,6 +1,8 @@
 package pcapio
 
 import (
+	"errors"
+	"fmt"
 	"io"
 
 	"github.com/brimsec/zq/pkg/nano"
@@ -42,6 +44,13 @@ func NewReader(r io.Reader) (Reader, error) {
 	_, err2 := NewNgReader(track)
 	if err2 == nil {
 		return NewNgReader(recorder)
+	}
+	var pcaperr, ngerr *ErrInvalidPcap
+	if errors.As(err1, &pcaperr) && errors.As(err2, &ngerr) {
+		err1 = fmt.Errorf("pcap: %w", pcaperr.err)
+		err2 = fmt.Errorf("ngpcap: %w", ngerr.err)
+		err := multierr.Combine(err1, err2)
+		return nil, NewErrInvalidPcap(err)
 	}
 	return nil, multierr.Combine(err1, err2)
 }

--- a/pcap/search.go
+++ b/pcap/search.go
@@ -19,28 +19,6 @@ var (
 	ErrNoPcapsFound = zqe.E(zqe.NotFound, "no packets found")
 )
 
-type ErrInvalidPcap struct {
-	err error
-}
-
-func errInvalidPcap(err error) error {
-	e := &ErrInvalidPcap{err: err}
-	return zqe.E(zqe.Invalid, e)
-}
-
-func (e *ErrInvalidPcap) Is(target error) bool {
-	_, ok := target.(*ErrInvalidPcap)
-	return ok
-}
-
-func (e *ErrInvalidPcap) Unwrap() error {
-	return e.err
-}
-
-func (e *ErrInvalidPcap) Error() string {
-	return "invalid pcap: " + e.err.Error()
-}
-
 type PacketFilter func(gopacket.Packet) bool
 
 // Search describes the parameters for a packet search over a pcap file.
@@ -216,7 +194,7 @@ func (s *SearchReader) fill(ctx context.Context) error {
 			if err == io.EOF {
 				break
 			}
-			return errInvalidPcap(err)
+			return err
 		}
 		if block == nil {
 			break
@@ -236,7 +214,7 @@ func (s *SearchReader) fill(ctx context.Context) error {
 		default:
 			pktBuf, ts, linkType, err := s.reader.Packet(block)
 			if pktBuf == nil {
-				return errInvalidPcap(err)
+				return err
 			}
 			if !s.span.ContainsClosed(ts) {
 				continue

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -152,7 +152,7 @@ func TestPcapPostInvalidPcap(t *testing.T) {
 			t.Fatalf("expected error to be for type *api.ErrorResponse, got %T", p.err)
 		}
 		assert.Equal(t, http.StatusBadRequest, reserr.StatusCode())
-		require.Regexp(t, "invalid pcap: pcap: Unknown magic 73696874; ngpcap: first block type not a section header: 1936287860", reserr.Err.Error())
+		require.Regexp(t, "invalid pcap: pcap: unknown magic 73696874; pcapng: first block type not a section header: 1936287860", reserr.Err.Error())
 	})
 	t.Run("EmptySpaceInfo", func(t *testing.T) {
 		info, err := p.client.SpaceInfo(context.Background(), p.space.ID)

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -152,8 +152,7 @@ func TestPcapPostInvalidPcap(t *testing.T) {
 			t.Fatalf("expected error to be for type *api.ErrorResponse, got %T", p.err)
 		}
 		assert.Equal(t, http.StatusBadRequest, reserr.StatusCode())
-		// XXX Better error message here.
-		require.Regexp(t, "bad pcap file", reserr.Err.Error())
+		require.Regexp(t, "invalid pcap: Unknown magic 73696874; truncated input", reserr.Err.Error())
 	})
 	t.Run("EmptySpaceInfo", func(t *testing.T) {
 		info, err := p.client.SpaceInfo(context.Background(), p.space.ID)

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -152,7 +152,7 @@ func TestPcapPostInvalidPcap(t *testing.T) {
 			t.Fatalf("expected error to be for type *api.ErrorResponse, got %T", p.err)
 		}
 		assert.Equal(t, http.StatusBadRequest, reserr.StatusCode())
-		require.Regexp(t, "invalid pcap: Unknown magic 73696874; truncated input", reserr.Err.Error())
+		require.Regexp(t, "invalid pcap: pcap: Unknown magic 73696874; ngpcap: first block type not a section header: 1936287860", reserr.Err.Error())
 	})
 	t.Run("EmptySpaceInfo", func(t *testing.T) {
 		info, err := p.client.SpaceInfo(context.Background(), p.space.ID)


### PR DESCRIPTION
Previously package pcap was hiding detailed pcap error information
by returning a generic ErrCorruptPcap error.

This pr restructure the way package pcap reports errors. package pcapio
now returns unwrapped errors with specifics as to why a pcap function
failed.

package pcap wraps errors returned from pcapio with ErrInvalidPcap.
As a result the detailed error reporting is preserved.

closes #490