### PR TITLE
Remove special case time-binning support from groupby proc

### DIFF
--- a/archive/rule.go
+++ b/archive/rule.go
@@ -65,6 +65,11 @@ const framesize = 32 * 1024 * 2
 
 const keyName = "key"
 
+var keyAst = ast.Assignment{
+	Target: "key",
+	Expr:   &ast.FieldRead{Field: "key"},
+}
+
 // NewFieldRule creates an indexing rule that will index all fields of
 // the type passed in as argument.
 func NewTypeRule(typeName string) (*Rule, error) {
@@ -79,7 +84,7 @@ func NewTypeRule(typeName string) (*Rule, error) {
 				typeName: typeName,
 			},
 			&ast.GroupByProc{
-				Keys: []string{keyName},
+				Keys: []ast.Assignment{keyAst},
 			},
 			&ast.SortProc{},
 		},
@@ -97,7 +102,7 @@ func NewFieldRule(fieldName string) (*Rule, error) {
 				out:   keyName,
 			},
 			&ast.GroupByProc{
-				Keys: []string{keyName},
+				Keys: []ast.Assignment{keyAst},
 			},
 			&ast.SortProc{},
 		},

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -176,6 +176,7 @@ func (*FunctionCall) exprNode()          {}
 func (*CastExpression) exprNode()        {}
 func (*Literal) exprNode()               {}
 func (*FieldRead) exprNode()             {}
+func (*FieldCall) exprNode()             {}
 
 // ----------------------------------------------------------------------------
 // Procs
@@ -264,10 +265,10 @@ type (
 	// be aggregated over. When absent, the runtime defaults to an appropriate value.
 	GroupByProc struct {
 		Node
-		Duration Duration  `json:"duration"`
-		Limit    int       `json:"limit,omitempty"`
-		Keys     []string  `json:"keys"`
-		Reducers []Reducer `json:"reducers"`
+		Duration Duration     `json:"duration"`
+		Limit    int          `json:"limit,omitempty"`
+		Keys     []Assignment `json:"keys"`
+		Reducers []Reducer    `json:"reducers"`
 	}
 	// TopProc is similar to proc.SortProc with a few key differences:
 	// - It only sorts in descending order.

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -283,11 +283,11 @@ type (
 
 	PutProc struct {
 		Node
-		Clauses []PutClause `json:"clauses"`
+		Clauses []Assignment `json:"clauses"`
 	}
 )
 
-type PutClause struct {
+type Assignment struct {
 	Target string     `json:"target"`
 	Expr   Expression `json:"expression"`
 }

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -263,12 +263,15 @@ type (
 	// large time ranges are processed and streamed efficiently.
 	// The limit parameter specifies the number of different groups that can
 	// be aggregated over. When absent, the runtime defaults to an appropriate value.
+	//
+	// xxx comment sorted
 	GroupByProc struct {
 		Node
 		Duration Duration     `json:"duration"`
 		Limit    int          `json:"limit,omitempty"`
 		Keys     []Assignment `json:"keys"`
 		Reducers []Reducer    `json:"reducers"`
+		Sorted   int          `json:"sorted"`
 	}
 	// TopProc is similar to proc.SortProc with a few key differences:
 	// - It only sorts in descending order.

--- a/ast/unpack.go
+++ b/ast/unpack.go
@@ -87,17 +87,17 @@ func unpackProc(custom Unpacker, node joe.JSON) (Proc, error) {
 			return nil, errors.New("PutProc clauses must be an array")
 		}
 		n := clausesNode.Len()
-		clauses := make([]PutClause, n)
+		clauses := make([]Assignment, n)
 		for k := 0; k < n; k++ {
 			exprNode := clausesNode.Index(k).Get("expression")
 			if exprNode == joe.Undefined {
-				return nil, errors.New("PutClause missing expression")
+				return nil, errors.New("Assignment missing expression")
 			}
 			expr, err := unpackExpression(exprNode)
 			if err != nil {
 				return nil, err
 			}
-			clauses[k] = PutClause{Expr: expr}
+			clauses[k] = Assignment{Expr: expr}
 		}
 		return &PutProc{Clauses: clauses}, nil
 	case "UniqProc":

--- a/expr/functions.go
+++ b/expr/functions.go
@@ -55,6 +55,7 @@ var allFns = map[string]struct {
 	"Time.fromMilliseconds": {1, 1, timeFromMsec},
 	"Time.fromMicroseconds": {1, 1, timeFromUsec},
 	"Time.fromNanoseconds":  {1, 1, timeFromNsec},
+	"Time.trunc":            {2, 2, timeTrunc},
 }
 
 func err(fn string, err error) (zngnative.Value, error) {
@@ -447,4 +448,17 @@ func timeFromNsec(args []zngnative.Value) (zngnative.Value, error) {
 		return err("Time.fromNanoseconds", ErrBadArgument)
 	}
 	return zngnative.Value{zng.TypeTime, ns}, nil
+}
+
+func timeTrunc(args []zngnative.Value) (zngnative.Value, error) {
+	ts, ok := zngnative.CoerceNativeToTime(args[0])
+	if !ok {
+		return err("Time.trunc", ErrBadArgument)
+	}
+	dur, ok := zngnative.CoerceNativeToInt(args[1])
+	if !ok {
+		return err("Time.trunc", ErrBadArgument)
+	}
+	dur = dur * 1_000_000_000
+	return zngnative.Value{zng.TypeTime, int64(ts.Trunc(dur))}, nil
 }

--- a/expr/functions_test.go
+++ b/expr/functions_test.go
@@ -245,6 +245,7 @@ func TestTime(t *testing.T) {
 	testSuccessful(t, exp, nil, zval)
 	exp = fmt.Sprintf("Time.fromNanoseconds(%d)", nsec)
 	testSuccessful(t, exp, nil, zval)
+	testSuccessful(t, "Time.trunc(1590506867.967, 1)", nil, zng.Value{zng.TypeTime, zng.EncodeTime(nano.Ts(1590506867 * 1_000_000_000))})
 
 	testError(t, "Time.fromISO()", nil, expr.ErrTooFewArgs, "Time.fromISO() with no args")
 	testError(t, `Time.fromISO("abc", "def")`, nil, expr.ErrTooManyArgs, "Time.fromISO() with too many args")

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mccanne/joe v0.0.0-20181124064909-25770742c256
 	github.com/minio/minio v0.0.0-20200506004754-8eb99d3a877f
 	github.com/peterh/liner v1.1.0
+	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/segmentio/ksuid v1.0.2
 	github.com/stretchr/testify v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/mccanne/joe v0.0.0-20181124064909-25770742c256
 	github.com/minio/minio v0.0.0-20200506004754-8eb99d3a877f
 	github.com/peterh/liner v1.1.0
-	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/segmentio/ksuid v1.0.2
 	github.com/stretchr/testify v1.5.1

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -2,6 +2,7 @@ package proc
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -15,7 +16,6 @@ import (
 	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"time"
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/expr"
@@ -26,7 +25,6 @@ type GroupByKey struct {
 }
 
 type GroupByParams struct {
-	duration ast.Duration
 	limit    int
 	keys     []GroupByKey
 	reducers []compile.CompiledReducer
@@ -63,7 +61,6 @@ func CompileGroupBy(node *ast.GroupByProc, zctx *resolver.Context) (*GroupByPara
 			},
 		}
 		astKeys = append([]ast.Assignment{everyKey}, astKeys...)
-		node.Duration.Seconds = 0
 	}
 
 	for _, astKey := range astKeys {
@@ -90,7 +87,6 @@ func CompileGroupBy(node *ast.GroupByProc, zctx *resolver.Context) (*GroupByPara
 		return nil, fmt.Errorf("compiling groupby: %w", err)
 	}
 	return &GroupByParams{
-		duration: node.Duration,
 		limit:    node.Limit,
 		keys:     keys,
 		reducers: reducers,
@@ -115,9 +111,7 @@ func compileKeyExpr(ex ast.Expression) (expr.ExpressionEvaluator, error) {
 // GroupBy computes aggregations using a GroupByAggregator.
 type GroupBy struct {
 	Base
-	timeBinned bool
-	interval   time.Duration
-	agg        *GroupByAggregator
+	agg *GroupByAggregator
 }
 
 // A keyRow holds information about the key column types that result
@@ -151,47 +145,34 @@ type GroupByAggregator struct {
 	keys        []GroupByKey
 	reducerDefs []compile.CompiledReducer
 	builder     *ColumnBuilder
-	// For a regular group-by, tables has one entry with key 0.  For a
-	// time-binned group-by, tables has one entry per bin and is keyed by
-	// bin timestamp (so that a bin with span [ts, ts+timeBinDuration) has
-	// key ts).
-	tables          map[nano.Ts]map[string]*GroupByRow
-	TimeBinDuration int64 // Zero means regular group-by (no time binning).
-	reverse         bool
-	logger          *zap.Logger
-	limit           int
+	table       map[string]*GroupByRow
+	reverse     bool
+	logger      *zap.Logger
+	limit       int
 }
 
 type GroupByRow struct {
 	keycols  []zng.Column
 	keyvals  zcode.Bytes
-	ts       nano.Ts
 	reducers compile.Row
 }
 
 func NewGroupByAggregator(c *Context, params GroupByParams) *GroupByAggregator {
-	//XXX we should change this AST format... left over from Looky
-	// convert second to nano second
-	dur := int64(params.duration.Seconds) * 1000000000
-	if dur < 0 {
-		panic("dur cannot be negative")
-	}
 	limit := params.limit
 	if limit == 0 {
 		limit = defaultGroupByLimit
 	}
 	return &GroupByAggregator{
-		keys:            params.keys,
-		zctx:            c.TypeContext,
-		kctx:            resolver.NewContext(),
-		reducerDefs:     params.reducers,
-		builder:         params.builder,
-		keyRows:         make(map[int]keyRow),
-		tables:          make(map[nano.Ts]map[string]*GroupByRow),
-		TimeBinDuration: dur,
-		reverse:         c.Reverse,
-		logger:          c.Logger,
-		limit:           limit,
+		keys:        params.keys,
+		zctx:        c.TypeContext,
+		kctx:        resolver.NewContext(),
+		reducerDefs: params.reducers,
+		builder:     params.builder,
+		keyRows:     make(map[int]keyRow),
+		table:       make(map[string]*GroupByRow),
+		reverse:     c.Reverse,
+		logger:      c.Logger,
+		limit:       limit,
 	}
 }
 
@@ -199,11 +180,9 @@ func NewGroupBy(c *Context, parent Proc, params GroupByParams) *GroupBy {
 	// XXX in a subsequent PR we will isolate ast params and pass in
 	// ast.GroupByParams
 	agg := NewGroupByAggregator(c, params)
-	timeBinned := params.duration.Seconds > 0
 	return &GroupBy{
-		Base:       Base{Context: c, Parent: parent},
-		timeBinned: timeBinned,
-		agg:        agg,
+		Base: Base{Context: c, Parent: parent},
+		agg:  agg,
 	}
 }
 
@@ -213,7 +192,7 @@ func (g *GroupBy) Pull() (zbuf.Batch, error) {
 		return nil, err
 	}
 	if batch == nil {
-		return g.agg.Results(true, g.MinTs, g.MaxTs)
+		return g.agg.Results(g.MinTs, g.MaxTs)
 	}
 	for k := 0; k < batch.Length(); k++ {
 		err := g.agg.Consume(batch.Index(k))
@@ -223,26 +202,16 @@ func (g *GroupBy) Pull() (zbuf.Batch, error) {
 		}
 	}
 	batch.Unref()
-	if g.timeBinned {
-		f, err := g.agg.Results(false, g.MinTs, g.MaxTs)
-		if err != nil {
-			return nil, err
-		}
-		if f != nil {
-			return f, nil
-		}
-	}
 	return zbuf.NewArray([]*zng.Record{}, batch.Span()), nil
 }
 
-func (g *GroupByAggregator) createGroupByRow(keyCols []zng.Column, ts nano.Ts, vals zcode.Bytes) *GroupByRow {
+func (g *GroupByAggregator) createGroupByRow(keyCols []zng.Column, vals zcode.Bytes) *GroupByRow {
 	// Make a deep copy so the caller can reuse the underlying arrays.
 	v := make(zcode.Bytes, len(vals))
 	copy(v, vals)
 	return &GroupByRow{
 		keycols:  keyCols,
 		keyvals:  v,
-		ts:       ts,
 		reducers: compile.Row{Defs: g.reducerDefs},
 	}
 }
@@ -332,63 +301,27 @@ func (g *GroupByAggregator) Consume(r *zng.Record) error {
 	keyBytes = append(keyBytes, zv...)
 	g.cacheKey = keyBytes
 
-	var ts nano.Ts
-	if g.TimeBinDuration > 0 {
-		ts = r.Ts.Trunc(g.TimeBinDuration)
-	}
-	table, ok := g.tables[ts]
+	row, ok := g.table[string(keyBytes)]
 	if !ok {
-		table = make(map[string]*GroupByRow)
-		g.tables[ts] = table
-	}
-	row, ok := table[string(keyBytes)]
-	if !ok {
-		if len(table) >= g.limit {
+		if len(g.table) >= g.limit {
 			return errTooBig(g.limit)
 		}
-		row = g.createGroupByRow(keyRow.columns, ts, keyBytes[4:])
-		table[string(keyBytes)] = row
+		row = g.createGroupByRow(keyRow.columns, keyBytes[4:])
+		g.table[string(keyBytes)] = row
 	}
 	row.reducers.Consume(r)
 	return nil
 }
 
-// Results returns a batch of aggregation result records.
-// If this is a time-binned aggregation, this can be called multiple
-// times; all completed time bins at the time of the invocation are
-// returned. A final call with eof=true should be made to get the
-// final (possibly incomplete) time bin.
-// If this is not a time-binned aggregation, a single call (with
-// eof=true) should be made after all records have been Consumed()'d.
-func (g *GroupByAggregator) Results(eof bool, minTs nano.Ts, maxTs nano.Ts) (zbuf.Batch, error) {
-	var bins []nano.Ts
-	for b := range g.tables {
-		bins = append(bins, b)
+// Results returns a zbuf.Batch with all aggregation result
+// records. It should be called once after all records have been
+// Consumed()'d.
+func (g *GroupByAggregator) Results(minTs nano.Ts, maxTs nano.Ts) (zbuf.Batch, error) {
+	recs, err := g.records()
+	if err != nil {
+		return nil, err
 	}
-	if g.reverse {
-		sort.Slice(bins, func(i, j int) bool { return bins[i] > bins[j] })
-	} else {
-		sort.Slice(bins, func(i, j int) bool { return bins[i] < bins[j] })
-	}
-	var recs []*zng.Record
-	for _, b := range bins {
-		if g.TimeBinDuration > 0 && !eof {
-			// We're not yet at EOF, so for a reverse search, we haven't
-			// seen all of g.minTs's bin and should skip it.
-			// Similarly, for a forward search, we haven't seen all
-			// of g.maxTs's bin and should skip it.
-			if g.reverse && b == minTs.Trunc(g.TimeBinDuration) ||
-				!g.reverse && b == maxTs.Trunc(g.TimeBinDuration) {
-				continue
-			}
-		}
-		newRecs, err := g.recordsForTable(g.tables[b])
-		if err != nil {
-			return nil, err
-		}
-		recs = append(recs, newRecs...)
-		delete(g.tables, b)
-	}
+	g.table = nil
 	if len(recs) == 0 {
 		// Don't propagate empty batches.
 		return nil, nil
@@ -397,26 +330,23 @@ func (g *GroupByAggregator) Results(eof bool, minTs nano.Ts, maxTs nano.Ts) (zbu
 	if g.reverse {
 		first, last = last, first
 	}
-	span := nano.NewSpanTs(first.Ts, last.Ts.Add(g.TimeBinDuration))
+	span := nano.NewSpanTs(first.Ts, last.Ts)
 	return zbuf.NewArray(recs, span), nil
 }
 
-// recordsForTable returns a slice of records with one record per table entry
-// in a deterministic but undefined order.
-func (g *GroupByAggregator) recordsForTable(table map[string]*GroupByRow) ([]*zng.Record, error) {
+// records returns a slice of all records from the groupby table in a
+// deterministic but undefined order.
+func (g *GroupByAggregator) records() ([]*zng.Record, error) {
 	var keys []string
-	for k := range table {
+	for k := range g.table {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
 	var recs []*zng.Record
 	for _, k := range keys {
-		row := table[k]
+		row := g.table[k]
 		var zv zcode.Bytes
-		if g.TimeBinDuration > 0 {
-			zv = zcode.AppendPrimitive(zv, zng.EncodeTime(row.ts))
-		}
 		zv = append(zv, row.keyvals...)
 		for _, red := range row.reducers.Reducers {
 			// a reducer value is never a container
@@ -430,7 +360,10 @@ func (g *GroupByAggregator) recordsForTable(table map[string]*GroupByRow) ([]*zn
 		if err != nil {
 			return nil, err
 		}
-		r := zng.NewRecordTs(typ, row.ts, zv)
+		r, err := zng.NewRecord(typ, zv)
+		if err != nil {
+			return nil, err
+		}
 		recs = append(recs, r)
 	}
 	return recs, nil
@@ -442,15 +375,9 @@ func (g *GroupByAggregator) lookupRowType(row *GroupByRow) (*zng.TypeRecord, err
 	// descriptor since it is rare for there to be multiple descriptors
 	// or for it change from row to row.
 	n := len(g.keys) + len(g.reducerDefs)
-	if g.TimeBinDuration > 0 {
-		n++
-	}
 	cols := make([]zng.Column, 0, n)
-
-	if g.TimeBinDuration > 0 {
-		cols = append(cols, zng.NewColumn("ts", zng.TypeTime))
-	}
 	types := make([]zng.Type, len(row.keycols))
+
 	for k, col := range row.keycols {
 		types[k] = col.Type
 	}

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -49,6 +49,12 @@ func CompileGroupBy(node *ast.GroupByProc, zctx *resolver.Context) (*GroupByPara
 	keys := make([]GroupByKey, 0)
 	astKeys := node.Keys
 	var targetNames []string
+
+	if node.Sorted != 0 && node.Duration.Seconds == 0 && len(astKeys) > 0 {
+		if _, ok := astKeys[0].Expr.(ast.FieldExpr); !ok {
+			return nil, fmt.Errorf("compiling groupby: cannot use -sorted in conjunction with a computed primary key")
+		}
+	}
 	if node.Duration.Seconds > 0 {
 		everyKey := ast.Assignment{
 			Target: "ts",

--- a/proc/groupby_test.go
+++ b/proc/groupby_test.go
@@ -31,8 +31,9 @@ const groupMultiOut = `
 `
 
 const unsetIn = `
-0:[-;-;3;]
-0:[-;-;4;]
+#1:record[key1:string,key2:string,n:int32]
+1:[-;-;3;]
+1:[-;-;4;]
 `
 
 const groupSingleOut_unsetOut = `
@@ -92,6 +93,11 @@ const nestedKeyOut = `
 0:[[1;]2;]
 0:[[2;]1;]
 `
+const nestedKeyAssignedOut = `
+#0:record[newkey:int32,count:uint64]
+0:[1;2;]
+0:[2;1;]
+`
 
 const nullIn = `
 #0:record[key:string,val:int64]
@@ -143,6 +149,16 @@ const aliasOut = `
 1:[127.0.0.1;1;]
 `
 
+const computedKeyIn = `
+#0:record[s:string,i:uint64,j:uint64]
+0:[foo;2;2;]
+0:[FOO;2;2;]
+`
+const computedKeyOut = `
+#0:record[s:string,ij:uint64,count:uint64]
+0:[foo;4;2;]
+`
+
 //XXX this should go in a shared package
 type suite []test.Internal
 
@@ -177,9 +193,11 @@ func tests() suite {
 
 	// Test a simple groupby
 	s.add(New("simple", in, groupSingleOut, "count() by key1"))
+	s.add(New("simple", in, groupSingleOut, "count() by key1=key1"))
 
 	// Test that unset key values work correctly
 	s.add(New("unset-keys", in+unsetIn, groupSingleOut_unsetOut, "count() by key1"))
+	s.add(New("unset-keys-at-start", unsetIn+in, groupSingleOut_unsetOut, "count() by key1"))
 
 	// Test grouping by multiple fields
 	s.add(New("multiple-fields", in, groupMultiOut, "count() by key1,key2"))
@@ -209,8 +227,14 @@ func tests() suite {
 	s.add(New("mixed-inputs", mixedIn, mixedOut, "first(f), last(f) by key"))
 
 	s.add(New("aliases", aliasIn, aliasOut, "count() by host"))
-	// XXX add coverage of time batching (every ..)
 
+	// Tests with assignments and computed keys
+	s.add(New("unset-keys-computed", in+unsetIn, groupSingleOut_unsetOut, "count() by key1=String.toLower(String.toUpper(key1))"))
+	s.add(New("unset-keys-assign", in+unsetIn, strings.ReplaceAll(groupSingleOut_unsetOut, "key1", "newkey"), "count() by newkey=key1"))
+	s.add(New("unset-keys-at-start-assign", unsetIn+in, strings.ReplaceAll(groupSingleOut_unsetOut, "key1", "newkey"), "count() by newkey=key1"))
+	s.add(New("multiple-fields-assign", in, strings.ReplaceAll(groupMultiOut, "key2", "newkey"), "count() by key1,newkey=key2"))
+	s.add(New("key-in-record-assign", nestedKeyIn, nestedKeyAssignedOut, "count() by newkey=rec.i"))
+	s.add(New("computed-key", computedKeyIn, computedKeyOut, "count() by s=String.toLower(s), ij=i+j"))
 	return s
 }
 

--- a/proc/utils.go
+++ b/proc/utils.go
@@ -197,7 +197,7 @@ func (p *ProcTest) Finish() error {
 	}
 }
 
-func parse(zctx *resolver.Context, src string) (*zbuf.Array, error) {
+func ParseTestZng(zctx *resolver.Context, src string) (*zbuf.Array, error) {
 	reader := tzngio.NewReader(strings.NewReader(src), zctx)
 	records := make([]*zng.Record, 0)
 	for {
@@ -220,9 +220,9 @@ func parse(zctx *resolver.Context, src string) (*zbuf.Array, error) {
 // given warning(s) are emitted.
 func TestOneProcWithWarnings(t *testing.T, zngin, zngout string, warnings []string, cmd string) {
 	zctx := resolver.NewContext()
-	recsin, err := parse(zctx, zngin)
+	recsin, err := ParseTestZng(zctx, zngin)
 	require.NoError(t, err)
-	recsout, err := parse(zctx, zngout)
+	recsout, err := ParseTestZng(zctx, zngout)
 	require.NoError(t, err)
 
 	test, err := NewProcTestFromSource(cmd, zctx, []zbuf.Batch{recsin})
@@ -265,7 +265,7 @@ func TestOneProcWithBatches(t *testing.T, cmd string, zngs ...string) {
 	resolver := resolver.NewContext()
 	var batches []zbuf.Batch
 	for _, s := range zngs {
-		b, err := parse(resolver, s)
+		b, err := ParseTestZng(resolver, s)
 		require.NoError(t, err, s)
 		batches = append(batches, b)
 	}
@@ -294,9 +294,9 @@ func TestOneProcWithBatches(t *testing.T, cmd string, zngs ...string) {
 // output records must all be present, but they may appear in any order.
 func TestOneProcUnsorted(t *testing.T, zngin, zngout string, cmd string) {
 	resolver := resolver.NewContext()
-	recsin, err := parse(resolver, zngin)
+	recsin, err := ParseTestZng(resolver, zngin)
 	require.NoError(t, err)
-	recsout, err := parse(resolver, zngout)
+	recsout, err := ParseTestZng(resolver, zngout)
 	require.NoError(t, err)
 
 	test, err := NewProcTestFromSource(cmd, resolver, []zbuf.Batch{recsin})

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -261,14 +261,14 @@ func makeFilterProc(expr interface{}) *ast.FilterProc {
 	return &ast.FilterProc{ast.Node{"FilterProc"}, expr.(ast.BooleanExpr)}
 }
 
-func makePutClause(target, expr interface{}) ast.PutClause {
-	return ast.PutClause{target.(string), expr.(ast.Expression)}
+func makeAssignment(target, expr interface{}) ast.Assignment {
+	return ast.Assignment{target.(string), expr.(ast.Expression)}
 }
 
 func makePutProc(first, rest interface{}) *ast.PutProc {
-	clauses := []ast.PutClause{first.(ast.PutClause)}
+	clauses := []ast.Assignment{first.(ast.Assignment)}
 	for _, c := range rest.([]interface{}) {
-		clauses = append(clauses, c.(ast.PutClause))
+		clauses = append(clauses, c.(ast.Assignment))
 	}
 	return &ast.PutProc{ast.Node{"PutProc"}, clauses}
 }

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -321,12 +321,15 @@ func makeGroupByKeys(first, rest interface{}) []ast.Assignment {
 	return keys
 }
 
-func makeGroupByProc(durationIn, limitIn, keysIn, reducersIn interface{}) *ast.GroupByProc {
+func makeGroupByProc(durationIn, sortedIn, limitIn, keysIn, reducersIn interface{}) *ast.GroupByProc {
 	var duration ast.Duration
 	if durationIn != nil {
 		duration = *(durationIn.(*ast.Duration))
 	}
-
+	var sorted int
+	if sortedIn != nil {
+		sorted = sortedIn.(int)
+	}
 	var limit int
 	if limitIn != nil {
 		limit = limitIn.(int)
@@ -347,6 +350,7 @@ func makeGroupByProc(durationIn, limitIn, keysIn, reducersIn interface{}) *ast.G
 		Limit:    limit,
 		Keys:     keys,
 		Reducers: reducers,
+		Sorted:   sorted,
 	}
 }
 

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -307,6 +307,20 @@ func makeReducerProc(reducers interface{}) *ast.ReducerProc {
 	}
 }
 
+func makeGroupByKey(textIn, valIn interface{}) ast.Assignment {
+	text := textIn.(string)
+	val := valIn.(ast.Expression)
+	return ast.Assignment{text, val}
+}
+
+func makeGroupByKeys(first, rest interface{}) []ast.Assignment {
+	keys := []ast.Assignment{first.(ast.Assignment)}
+	for _, k := range rest.([]interface{}) {
+		keys = append(keys, k.(ast.Assignment))
+	}
+	return keys
+}
+
 func makeGroupByProc(durationIn, limitIn, keysIn, reducersIn interface{}) *ast.GroupByProc {
 	var duration ast.Duration
 	if durationIn != nil {
@@ -318,7 +332,13 @@ func makeGroupByProc(durationIn, limitIn, keysIn, reducersIn interface{}) *ast.G
 		limit = limitIn.(int)
 	}
 
-	keys := stringArray(keysIn)
+	var keys []ast.Assignment
+	switch keysSlice := keysIn.(type) {
+	case []interface{}:
+		keys = []ast.Assignment{}
+	case []ast.Assignment:
+		keys = keysSlice
+	}
 	reducers := reducersArray(reducersIn)
 
 	return &ast.GroupByProc{

--- a/zql/parser-support.js
+++ b/zql/parser-support.js
@@ -136,9 +136,9 @@ function makeGroupByKeys(first, rest) {
   return [first, ...rest];
 }
 
-function makeGroupByProc(duration, limit, keys, reducers) {
+function makeGroupByProc(duration, sorted, limit, keys, reducers) {
   if (limit === null) { limit = undefined; }
-  return { op: "GroupByProc", keys, reducers, duration, limit };
+    return { op: "GroupByProc", keys, reducers, duration, limit , sorted};
 }
 
 function makeUnaryExpr(operator, operand) {

--- a/zql/parser-support.js
+++ b/zql/parser-support.js
@@ -107,7 +107,7 @@ function makeTailProc(count) { return { op: "TailProc", count }; }
 function makeUniqProc(cflag) { return { op: "TailProc", cflag }; }
 function makeFilterProc(filter) { return { op: "FilterProc", filter }; }
 
-function makePutClause(target, expression) { return { target, expression }; }
+function makeAssignment(target, expression) { return { target, expression }; }
 function makePutProc(first, rest) {
   return { op: "PutProc", clauses: [first, ...rest] };
 }

--- a/zql/parser-support.js
+++ b/zql/parser-support.js
@@ -128,6 +128,14 @@ function makeReducerProc(reducers) {
   return { op: "ReducerProc", reducers };
 }
 
+function makeGroupByKey(target, expression) {
+    return { op: "Assignment", target, expression };
+}
+
+function makeGroupByKeys(first, rest) {
+  return [first, ...rest];
+}
+
 function makeGroupByProc(duration, limit, keys, reducers) {
   if (limit === null) { limit = undefined; }
   return { op: "GroupByProc", keys, reducers, duration, limit };

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -1258,29 +1258,91 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "groupBy",
+			name: "groupByKeys",
 			pos:  position{line: 184, col: 1, offset: 4183},
 			expr: &actionExpr{
-				pos: position{line: 185, col: 5, offset: 4195},
-				run: (*parser).callongroupBy1,
+				pos: position{line: 185, col: 5, offset: 4199},
+				run: (*parser).callongroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 185, col: 5, offset: 4195},
+					pos: position{line: 185, col: 5, offset: 4199},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 185, col: 5, offset: 4195},
+							pos:        position{line: 185, col: 5, offset: 4199},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 185, col: 11, offset: 4201},
+							pos:  position{line: 185, col: 11, offset: 4205},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 185, col: 13, offset: 4203},
-							label: "list",
+							pos:   position{line: 185, col: 13, offset: 4207},
+							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 185, col: 18, offset: 4208},
-								name: "fieldRefDotOnlyList",
+								pos:  position{line: 185, col: 19, offset: 4213},
+								name: "groupByKey",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 185, col: 30, offset: 4224},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 185, col: 35, offset: 4229},
+								expr: &actionExpr{
+									pos: position{line: 185, col: 36, offset: 4230},
+									run: (*parser).callongroupByKeys9,
+									expr: &seqExpr{
+										pos: position{line: 185, col: 36, offset: 4230},
+										exprs: []interface{}{
+											&ruleRefExpr{
+												pos:  position{line: 185, col: 36, offset: 4230},
+												name: "__",
+											},
+											&litMatcher{
+												pos:        position{line: 185, col: 39, offset: 4233},
+												val:        ",",
+												ignoreCase: false,
+											},
+											&ruleRefExpr{
+												pos:  position{line: 185, col: 43, offset: 4237},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 185, col: 46, offset: 4240},
+												label: "cl",
+												expr: &ruleRefExpr{
+													pos:  position{line: 185, col: 49, offset: 4243},
+													name: "groupByKey",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "groupByKey",
+			pos:  position{line: 190, col: 1, offset: 4332},
+			expr: &choiceExpr{
+				pos: position{line: 191, col: 5, offset: 4347},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 191, col: 5, offset: 4347},
+						name: "Assignment",
+					},
+					&actionExpr{
+						pos: position{line: 192, col: 5, offset: 4362},
+						run: (*parser).callongroupByKey3,
+						expr: &labeledExpr{
+							pos:   position{line: 192, col: 5, offset: 4362},
+							label: "field",
+							expr: &ruleRefExpr{
+								pos:  position{line: 192, col: 11, offset: 4368},
+								name: "fieldExpr",
 							},
 						},
 					},
@@ -1289,27 +1351,27 @@ var g = &grammar{
 		},
 		{
 			name: "everyDur",
-			pos:  position{line: 187, col: 1, offset: 4250},
+			pos:  position{line: 195, col: 1, offset: 4434},
 			expr: &actionExpr{
-				pos: position{line: 188, col: 5, offset: 4263},
+				pos: position{line: 196, col: 5, offset: 4447},
 				run: (*parser).calloneveryDur1,
 				expr: &seqExpr{
-					pos: position{line: 188, col: 5, offset: 4263},
+					pos: position{line: 196, col: 5, offset: 4447},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 188, col: 5, offset: 4263},
+							pos:        position{line: 196, col: 5, offset: 4447},
 							val:        "every",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 188, col: 14, offset: 4272},
+							pos:  position{line: 196, col: 14, offset: 4456},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 188, col: 16, offset: 4274},
+							pos:   position{line: 196, col: 16, offset: 4458},
 							label: "dur",
 							expr: &ruleRefExpr{
-								pos:  position{line: 188, col: 20, offset: 4278},
+								pos:  position{line: 196, col: 20, offset: 4462},
 								name: "duration",
 							},
 						},
@@ -1319,16 +1381,16 @@ var g = &grammar{
 		},
 		{
 			name: "equalityToken",
-			pos:  position{line: 190, col: 1, offset: 4308},
+			pos:  position{line: 198, col: 1, offset: 4492},
 			expr: &choiceExpr{
-				pos: position{line: 191, col: 5, offset: 4326},
+				pos: position{line: 199, col: 5, offset: 4510},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 191, col: 5, offset: 4326},
+						pos:  position{line: 199, col: 5, offset: 4510},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 191, col: 24, offset: 4345},
+						pos:  position{line: 199, col: 24, offset: 4529},
 						name: "RelativeOperator",
 					},
 				},
@@ -1336,12 +1398,12 @@ var g = &grammar{
 		},
 		{
 			name: "andToken",
-			pos:  position{line: 193, col: 1, offset: 4363},
+			pos:  position{line: 201, col: 1, offset: 4547},
 			expr: &actionExpr{
-				pos: position{line: 193, col: 12, offset: 4374},
+				pos: position{line: 201, col: 12, offset: 4558},
 				run: (*parser).callonandToken1,
 				expr: &litMatcher{
-					pos:        position{line: 193, col: 12, offset: 4374},
+					pos:        position{line: 201, col: 12, offset: 4558},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -1349,12 +1411,12 @@ var g = &grammar{
 		},
 		{
 			name: "orToken",
-			pos:  position{line: 194, col: 1, offset: 4412},
+			pos:  position{line: 202, col: 1, offset: 4596},
 			expr: &actionExpr{
-				pos: position{line: 194, col: 11, offset: 4422},
+				pos: position{line: 202, col: 11, offset: 4606},
 				run: (*parser).callonorToken1,
 				expr: &litMatcher{
-					pos:        position{line: 194, col: 11, offset: 4422},
+					pos:        position{line: 202, col: 11, offset: 4606},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -1362,12 +1424,12 @@ var g = &grammar{
 		},
 		{
 			name: "inToken",
-			pos:  position{line: 195, col: 1, offset: 4459},
+			pos:  position{line: 203, col: 1, offset: 4643},
 			expr: &actionExpr{
-				pos: position{line: 195, col: 11, offset: 4469},
+				pos: position{line: 203, col: 11, offset: 4653},
 				run: (*parser).calloninToken1,
 				expr: &litMatcher{
-					pos:        position{line: 195, col: 11, offset: 4469},
+					pos:        position{line: 203, col: 11, offset: 4653},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -1375,12 +1437,12 @@ var g = &grammar{
 		},
 		{
 			name: "notToken",
-			pos:  position{line: 196, col: 1, offset: 4506},
+			pos:  position{line: 204, col: 1, offset: 4690},
 			expr: &actionExpr{
-				pos: position{line: 196, col: 12, offset: 4517},
+				pos: position{line: 204, col: 12, offset: 4701},
 				run: (*parser).callonnotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 196, col: 12, offset: 4517},
+					pos:        position{line: 204, col: 12, offset: 4701},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -1388,21 +1450,21 @@ var g = &grammar{
 		},
 		{
 			name: "fieldName",
-			pos:  position{line: 198, col: 1, offset: 4556},
+			pos:  position{line: 206, col: 1, offset: 4740},
 			expr: &actionExpr{
-				pos: position{line: 198, col: 13, offset: 4568},
+				pos: position{line: 206, col: 13, offset: 4752},
 				run: (*parser).callonfieldName1,
 				expr: &seqExpr{
-					pos: position{line: 198, col: 13, offset: 4568},
+					pos: position{line: 206, col: 13, offset: 4752},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 198, col: 13, offset: 4568},
+							pos:  position{line: 206, col: 13, offset: 4752},
 							name: "fieldNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 198, col: 28, offset: 4583},
+							pos: position{line: 206, col: 28, offset: 4767},
 							expr: &ruleRefExpr{
-								pos:  position{line: 198, col: 28, offset: 4583},
+								pos:  position{line: 206, col: 28, offset: 4767},
 								name: "fieldNameRest",
 							},
 						},
@@ -1412,9 +1474,9 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameStart",
-			pos:  position{line: 200, col: 1, offset: 4630},
+			pos:  position{line: 208, col: 1, offset: 4814},
 			expr: &charClassMatcher{
-				pos:        position{line: 200, col: 18, offset: 4647},
+				pos:        position{line: 208, col: 18, offset: 4831},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -1424,16 +1486,16 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameRest",
-			pos:  position{line: 201, col: 1, offset: 4658},
+			pos:  position{line: 209, col: 1, offset: 4842},
 			expr: &choiceExpr{
-				pos: position{line: 201, col: 17, offset: 4674},
+				pos: position{line: 209, col: 17, offset: 4858},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 201, col: 17, offset: 4674},
+						pos:  position{line: 209, col: 17, offset: 4858},
 						name: "fieldNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 201, col: 34, offset: 4691},
+						pos:        position{line: 209, col: 34, offset: 4875},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -1444,45 +1506,45 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReference",
-			pos:  position{line: 203, col: 1, offset: 4698},
+			pos:  position{line: 211, col: 1, offset: 4882},
 			expr: &actionExpr{
-				pos: position{line: 204, col: 4, offset: 4716},
+				pos: position{line: 212, col: 4, offset: 4900},
 				run: (*parser).callonfieldReference1,
 				expr: &seqExpr{
-					pos: position{line: 204, col: 4, offset: 4716},
+					pos: position{line: 212, col: 4, offset: 4900},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 204, col: 4, offset: 4716},
+							pos:   position{line: 212, col: 4, offset: 4900},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 204, col: 9, offset: 4721},
+								pos:  position{line: 212, col: 9, offset: 4905},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 204, col: 19, offset: 4731},
+							pos:   position{line: 212, col: 19, offset: 4915},
 							label: "derefs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 204, col: 26, offset: 4738},
+								pos: position{line: 212, col: 26, offset: 4922},
 								expr: &choiceExpr{
-									pos: position{line: 205, col: 8, offset: 4747},
+									pos: position{line: 213, col: 8, offset: 4931},
 									alternatives: []interface{}{
 										&actionExpr{
-											pos: position{line: 205, col: 8, offset: 4747},
+											pos: position{line: 213, col: 8, offset: 4931},
 											run: (*parser).callonfieldReference8,
 											expr: &seqExpr{
-												pos: position{line: 205, col: 8, offset: 4747},
+												pos: position{line: 213, col: 8, offset: 4931},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 205, col: 8, offset: 4747},
+														pos:        position{line: 213, col: 8, offset: 4931},
 														val:        ".",
 														ignoreCase: false,
 													},
 													&labeledExpr{
-														pos:   position{line: 205, col: 12, offset: 4751},
+														pos:   position{line: 213, col: 12, offset: 4935},
 														label: "field",
 														expr: &ruleRefExpr{
-															pos:  position{line: 205, col: 18, offset: 4757},
+															pos:  position{line: 213, col: 18, offset: 4941},
 															name: "fieldName",
 														},
 													},
@@ -1490,26 +1552,26 @@ var g = &grammar{
 											},
 										},
 										&actionExpr{
-											pos: position{line: 206, col: 8, offset: 4838},
+											pos: position{line: 214, col: 8, offset: 5022},
 											run: (*parser).callonfieldReference13,
 											expr: &seqExpr{
-												pos: position{line: 206, col: 8, offset: 4838},
+												pos: position{line: 214, col: 8, offset: 5022},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 206, col: 8, offset: 4838},
+														pos:        position{line: 214, col: 8, offset: 5022},
 														val:        "[",
 														ignoreCase: false,
 													},
 													&labeledExpr{
-														pos:   position{line: 206, col: 12, offset: 4842},
+														pos:   position{line: 214, col: 12, offset: 5026},
 														label: "index",
 														expr: &ruleRefExpr{
-															pos:  position{line: 206, col: 18, offset: 4848},
+															pos:  position{line: 214, col: 18, offset: 5032},
 															name: "suint",
 														},
 													},
 													&litMatcher{
-														pos:        position{line: 206, col: 24, offset: 4854},
+														pos:        position{line: 214, col: 24, offset: 5038},
 														val:        "]",
 														ignoreCase: false,
 													},
@@ -1526,60 +1588,60 @@ var g = &grammar{
 		},
 		{
 			name: "fieldExpr",
-			pos:  position{line: 211, col: 1, offset: 4970},
+			pos:  position{line: 219, col: 1, offset: 5154},
 			expr: &choiceExpr{
-				pos: position{line: 212, col: 5, offset: 4984},
+				pos: position{line: 220, col: 5, offset: 5168},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 212, col: 5, offset: 4984},
+						pos: position{line: 220, col: 5, offset: 5168},
 						run: (*parser).callonfieldExpr2,
 						expr: &seqExpr{
-							pos: position{line: 212, col: 5, offset: 4984},
+							pos: position{line: 220, col: 5, offset: 5168},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 212, col: 5, offset: 4984},
+									pos:   position{line: 220, col: 5, offset: 5168},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 212, col: 8, offset: 4987},
+										pos:  position{line: 220, col: 8, offset: 5171},
 										name: "fieldOp",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 212, col: 16, offset: 4995},
+									pos: position{line: 220, col: 16, offset: 5179},
 									expr: &ruleRefExpr{
-										pos:  position{line: 212, col: 16, offset: 4995},
+										pos:  position{line: 220, col: 16, offset: 5179},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 212, col: 19, offset: 4998},
+									pos:        position{line: 220, col: 19, offset: 5182},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 212, col: 23, offset: 5002},
+									pos: position{line: 220, col: 23, offset: 5186},
 									expr: &ruleRefExpr{
-										pos:  position{line: 212, col: 23, offset: 5002},
+										pos:  position{line: 220, col: 23, offset: 5186},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 212, col: 26, offset: 5005},
+									pos:   position{line: 220, col: 26, offset: 5189},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 212, col: 32, offset: 5011},
+										pos:  position{line: 220, col: 32, offset: 5195},
 										name: "fieldReference",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 212, col: 47, offset: 5026},
+									pos: position{line: 220, col: 47, offset: 5210},
 									expr: &ruleRefExpr{
-										pos:  position{line: 212, col: 47, offset: 5026},
+										pos:  position{line: 220, col: 47, offset: 5210},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 212, col: 50, offset: 5029},
+									pos:        position{line: 220, col: 50, offset: 5213},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1587,7 +1649,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 215, col: 5, offset: 5093},
+						pos:  position{line: 223, col: 5, offset: 5277},
 						name: "fieldReference",
 					},
 				},
@@ -1595,12 +1657,12 @@ var g = &grammar{
 		},
 		{
 			name: "fieldOp",
-			pos:  position{line: 217, col: 1, offset: 5109},
+			pos:  position{line: 225, col: 1, offset: 5293},
 			expr: &actionExpr{
-				pos: position{line: 218, col: 5, offset: 5121},
+				pos: position{line: 226, col: 5, offset: 5305},
 				run: (*parser).callonfieldOp1,
 				expr: &litMatcher{
-					pos:        position{line: 218, col: 5, offset: 5121},
+					pos:        position{line: 226, col: 5, offset: 5305},
 					val:        "len",
 					ignoreCase: true,
 				},
@@ -1608,50 +1670,50 @@ var g = &grammar{
 		},
 		{
 			name: "fieldExprList",
-			pos:  position{line: 220, col: 1, offset: 5151},
+			pos:  position{line: 228, col: 1, offset: 5335},
 			expr: &actionExpr{
-				pos: position{line: 221, col: 5, offset: 5169},
+				pos: position{line: 229, col: 5, offset: 5353},
 				run: (*parser).callonfieldExprList1,
 				expr: &seqExpr{
-					pos: position{line: 221, col: 5, offset: 5169},
+					pos: position{line: 229, col: 5, offset: 5353},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 221, col: 5, offset: 5169},
+							pos:   position{line: 229, col: 5, offset: 5353},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 221, col: 11, offset: 5175},
+								pos:  position{line: 229, col: 11, offset: 5359},
 								name: "fieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 221, col: 21, offset: 5185},
+							pos:   position{line: 229, col: 21, offset: 5369},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 221, col: 26, offset: 5190},
+								pos: position{line: 229, col: 26, offset: 5374},
 								expr: &seqExpr{
-									pos: position{line: 221, col: 27, offset: 5191},
+									pos: position{line: 229, col: 27, offset: 5375},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 221, col: 27, offset: 5191},
+											pos: position{line: 229, col: 27, offset: 5375},
 											expr: &ruleRefExpr{
-												pos:  position{line: 221, col: 27, offset: 5191},
+												pos:  position{line: 229, col: 27, offset: 5375},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 221, col: 30, offset: 5194},
+											pos:        position{line: 229, col: 30, offset: 5378},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 221, col: 34, offset: 5198},
+											pos: position{line: 229, col: 34, offset: 5382},
 											expr: &ruleRefExpr{
-												pos:  position{line: 221, col: 34, offset: 5198},
+												pos:  position{line: 229, col: 34, offset: 5382},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 221, col: 37, offset: 5201},
+											pos:  position{line: 229, col: 37, offset: 5385},
 											name: "fieldExpr",
 										},
 									},
@@ -1664,39 +1726,39 @@ var g = &grammar{
 		},
 		{
 			name: "fieldRefDotOnly",
-			pos:  position{line: 231, col: 1, offset: 5396},
+			pos:  position{line: 239, col: 1, offset: 5580},
 			expr: &actionExpr{
-				pos: position{line: 232, col: 5, offset: 5416},
+				pos: position{line: 240, col: 5, offset: 5600},
 				run: (*parser).callonfieldRefDotOnly1,
 				expr: &seqExpr{
-					pos: position{line: 232, col: 5, offset: 5416},
+					pos: position{line: 240, col: 5, offset: 5600},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 232, col: 5, offset: 5416},
+							pos:   position{line: 240, col: 5, offset: 5600},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 232, col: 10, offset: 5421},
+								pos:  position{line: 240, col: 10, offset: 5605},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 232, col: 20, offset: 5431},
+							pos:   position{line: 240, col: 20, offset: 5615},
 							label: "refs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 232, col: 25, offset: 5436},
+								pos: position{line: 240, col: 25, offset: 5620},
 								expr: &seqExpr{
-									pos: position{line: 232, col: 26, offset: 5437},
+									pos: position{line: 240, col: 26, offset: 5621},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 232, col: 26, offset: 5437},
+											pos:        position{line: 240, col: 26, offset: 5621},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&labeledExpr{
-											pos:   position{line: 232, col: 30, offset: 5441},
+											pos:   position{line: 240, col: 30, offset: 5625},
 											label: "field",
 											expr: &ruleRefExpr{
-												pos:  position{line: 232, col: 36, offset: 5447},
+												pos:  position{line: 240, col: 36, offset: 5631},
 												name: "fieldName",
 											},
 										},
@@ -1710,56 +1772,56 @@ var g = &grammar{
 		},
 		{
 			name: "fieldRefDotOnlyList",
-			pos:  position{line: 234, col: 1, offset: 5491},
+			pos:  position{line: 242, col: 1, offset: 5675},
 			expr: &actionExpr{
-				pos: position{line: 235, col: 5, offset: 5515},
+				pos: position{line: 243, col: 5, offset: 5699},
 				run: (*parser).callonfieldRefDotOnlyList1,
 				expr: &seqExpr{
-					pos: position{line: 235, col: 5, offset: 5515},
+					pos: position{line: 243, col: 5, offset: 5699},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 235, col: 5, offset: 5515},
+							pos:   position{line: 243, col: 5, offset: 5699},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 235, col: 11, offset: 5521},
+								pos:  position{line: 243, col: 11, offset: 5705},
 								name: "fieldRefDotOnly",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 235, col: 27, offset: 5537},
+							pos:   position{line: 243, col: 27, offset: 5721},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 235, col: 32, offset: 5542},
+								pos: position{line: 243, col: 32, offset: 5726},
 								expr: &actionExpr{
-									pos: position{line: 235, col: 33, offset: 5543},
+									pos: position{line: 243, col: 33, offset: 5727},
 									run: (*parser).callonfieldRefDotOnlyList7,
 									expr: &seqExpr{
-										pos: position{line: 235, col: 33, offset: 5543},
+										pos: position{line: 243, col: 33, offset: 5727},
 										exprs: []interface{}{
 											&zeroOrOneExpr{
-												pos: position{line: 235, col: 33, offset: 5543},
+												pos: position{line: 243, col: 33, offset: 5727},
 												expr: &ruleRefExpr{
-													pos:  position{line: 235, col: 33, offset: 5543},
+													pos:  position{line: 243, col: 33, offset: 5727},
 													name: "_",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 235, col: 36, offset: 5546},
+												pos:        position{line: 243, col: 36, offset: 5730},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 235, col: 40, offset: 5550},
+												pos: position{line: 243, col: 40, offset: 5734},
 												expr: &ruleRefExpr{
-													pos:  position{line: 235, col: 40, offset: 5550},
+													pos:  position{line: 243, col: 40, offset: 5734},
 													name: "_",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 235, col: 43, offset: 5553},
+												pos:   position{line: 243, col: 43, offset: 5737},
 												label: "ref",
 												expr: &ruleRefExpr{
-													pos:  position{line: 235, col: 47, offset: 5557},
+													pos:  position{line: 243, col: 47, offset: 5741},
 													name: "fieldRefDotOnly",
 												},
 											},
@@ -1774,50 +1836,50 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameList",
-			pos:  position{line: 243, col: 1, offset: 5737},
+			pos:  position{line: 251, col: 1, offset: 5921},
 			expr: &actionExpr{
-				pos: position{line: 244, col: 5, offset: 5755},
+				pos: position{line: 252, col: 5, offset: 5939},
 				run: (*parser).callonfieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 244, col: 5, offset: 5755},
+					pos: position{line: 252, col: 5, offset: 5939},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 244, col: 5, offset: 5755},
+							pos:   position{line: 252, col: 5, offset: 5939},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 244, col: 11, offset: 5761},
+								pos:  position{line: 252, col: 11, offset: 5945},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 244, col: 21, offset: 5771},
+							pos:   position{line: 252, col: 21, offset: 5955},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 244, col: 26, offset: 5776},
+								pos: position{line: 252, col: 26, offset: 5960},
 								expr: &seqExpr{
-									pos: position{line: 244, col: 27, offset: 5777},
+									pos: position{line: 252, col: 27, offset: 5961},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 244, col: 27, offset: 5777},
+											pos: position{line: 252, col: 27, offset: 5961},
 											expr: &ruleRefExpr{
-												pos:  position{line: 244, col: 27, offset: 5777},
+												pos:  position{line: 252, col: 27, offset: 5961},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 244, col: 30, offset: 5780},
+											pos:        position{line: 252, col: 30, offset: 5964},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 244, col: 34, offset: 5784},
+											pos: position{line: 252, col: 34, offset: 5968},
 											expr: &ruleRefExpr{
-												pos:  position{line: 244, col: 34, offset: 5784},
+												pos:  position{line: 252, col: 34, offset: 5968},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 244, col: 37, offset: 5787},
+											pos:  position{line: 252, col: 37, offset: 5971},
 											name: "fieldName",
 										},
 									},
@@ -1830,12 +1892,12 @@ var g = &grammar{
 		},
 		{
 			name: "countOp",
-			pos:  position{line: 252, col: 1, offset: 5980},
+			pos:  position{line: 260, col: 1, offset: 6164},
 			expr: &actionExpr{
-				pos: position{line: 253, col: 5, offset: 5992},
+				pos: position{line: 261, col: 5, offset: 6176},
 				run: (*parser).calloncountOp1,
 				expr: &litMatcher{
-					pos:        position{line: 253, col: 5, offset: 5992},
+					pos:        position{line: 261, col: 5, offset: 6176},
 					val:        "count",
 					ignoreCase: true,
 				},
@@ -1843,105 +1905,105 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReducerOp",
-			pos:  position{line: 255, col: 1, offset: 6026},
+			pos:  position{line: 263, col: 1, offset: 6210},
 			expr: &choiceExpr{
-				pos: position{line: 256, col: 5, offset: 6045},
+				pos: position{line: 264, col: 5, offset: 6229},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 256, col: 5, offset: 6045},
+						pos: position{line: 264, col: 5, offset: 6229},
 						run: (*parser).callonfieldReducerOp2,
 						expr: &litMatcher{
-							pos:        position{line: 256, col: 5, offset: 6045},
+							pos:        position{line: 264, col: 5, offset: 6229},
 							val:        "sum",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 257, col: 5, offset: 6079},
+						pos: position{line: 265, col: 5, offset: 6263},
 						run: (*parser).callonfieldReducerOp4,
 						expr: &litMatcher{
-							pos:        position{line: 257, col: 5, offset: 6079},
+							pos:        position{line: 265, col: 5, offset: 6263},
 							val:        "avg",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 258, col: 5, offset: 6113},
+						pos: position{line: 266, col: 5, offset: 6297},
 						run: (*parser).callonfieldReducerOp6,
 						expr: &litMatcher{
-							pos:        position{line: 258, col: 5, offset: 6113},
+							pos:        position{line: 266, col: 5, offset: 6297},
 							val:        "stdev",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 259, col: 5, offset: 6150},
+						pos: position{line: 267, col: 5, offset: 6334},
 						run: (*parser).callonfieldReducerOp8,
 						expr: &litMatcher{
-							pos:        position{line: 259, col: 5, offset: 6150},
+							pos:        position{line: 267, col: 5, offset: 6334},
 							val:        "sd",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 260, col: 5, offset: 6186},
+						pos: position{line: 268, col: 5, offset: 6370},
 						run: (*parser).callonfieldReducerOp10,
 						expr: &litMatcher{
-							pos:        position{line: 260, col: 5, offset: 6186},
+							pos:        position{line: 268, col: 5, offset: 6370},
 							val:        "var",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 261, col: 5, offset: 6220},
+						pos: position{line: 269, col: 5, offset: 6404},
 						run: (*parser).callonfieldReducerOp12,
 						expr: &litMatcher{
-							pos:        position{line: 261, col: 5, offset: 6220},
+							pos:        position{line: 269, col: 5, offset: 6404},
 							val:        "entropy",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 262, col: 5, offset: 6261},
+						pos: position{line: 270, col: 5, offset: 6445},
 						run: (*parser).callonfieldReducerOp14,
 						expr: &litMatcher{
-							pos:        position{line: 262, col: 5, offset: 6261},
+							pos:        position{line: 270, col: 5, offset: 6445},
 							val:        "min",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 263, col: 5, offset: 6295},
+						pos: position{line: 271, col: 5, offset: 6479},
 						run: (*parser).callonfieldReducerOp16,
 						expr: &litMatcher{
-							pos:        position{line: 263, col: 5, offset: 6295},
+							pos:        position{line: 271, col: 5, offset: 6479},
 							val:        "max",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 264, col: 5, offset: 6329},
+						pos: position{line: 272, col: 5, offset: 6513},
 						run: (*parser).callonfieldReducerOp18,
 						expr: &litMatcher{
-							pos:        position{line: 264, col: 5, offset: 6329},
+							pos:        position{line: 272, col: 5, offset: 6513},
 							val:        "first",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 265, col: 5, offset: 6367},
+						pos: position{line: 273, col: 5, offset: 6551},
 						run: (*parser).callonfieldReducerOp20,
 						expr: &litMatcher{
-							pos:        position{line: 265, col: 5, offset: 6367},
+							pos:        position{line: 273, col: 5, offset: 6551},
 							val:        "last",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 266, col: 5, offset: 6403},
+						pos: position{line: 274, col: 5, offset: 6587},
 						run: (*parser).callonfieldReducerOp22,
 						expr: &litMatcher{
-							pos:        position{line: 266, col: 5, offset: 6403},
+							pos:        position{line: 274, col: 5, offset: 6587},
 							val:        "countdistinct",
 							ignoreCase: true,
 						},
@@ -1951,32 +2013,32 @@ var g = &grammar{
 		},
 		{
 			name: "paddedFieldExpr",
-			pos:  position{line: 268, col: 1, offset: 6453},
+			pos:  position{line: 276, col: 1, offset: 6637},
 			expr: &actionExpr{
-				pos: position{line: 268, col: 19, offset: 6471},
+				pos: position{line: 276, col: 19, offset: 6655},
 				run: (*parser).callonpaddedFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 268, col: 19, offset: 6471},
+					pos: position{line: 276, col: 19, offset: 6655},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 268, col: 19, offset: 6471},
+							pos: position{line: 276, col: 19, offset: 6655},
 							expr: &ruleRefExpr{
-								pos:  position{line: 268, col: 19, offset: 6471},
+								pos:  position{line: 276, col: 19, offset: 6655},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 268, col: 22, offset: 6474},
+							pos:   position{line: 276, col: 22, offset: 6658},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 268, col: 28, offset: 6480},
+								pos:  position{line: 276, col: 28, offset: 6664},
 								name: "fieldExpr",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 268, col: 38, offset: 6490},
+							pos: position{line: 276, col: 38, offset: 6674},
 							expr: &ruleRefExpr{
-								pos:  position{line: 268, col: 38, offset: 6490},
+								pos:  position{line: 276, col: 38, offset: 6674},
 								name: "_",
 							},
 						},
@@ -1986,53 +2048,53 @@ var g = &grammar{
 		},
 		{
 			name: "countReducer",
-			pos:  position{line: 270, col: 1, offset: 6516},
+			pos:  position{line: 278, col: 1, offset: 6700},
 			expr: &actionExpr{
-				pos: position{line: 271, col: 5, offset: 6533},
+				pos: position{line: 279, col: 5, offset: 6717},
 				run: (*parser).calloncountReducer1,
 				expr: &seqExpr{
-					pos: position{line: 271, col: 5, offset: 6533},
+					pos: position{line: 279, col: 5, offset: 6717},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 271, col: 5, offset: 6533},
+							pos:   position{line: 279, col: 5, offset: 6717},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 271, col: 8, offset: 6536},
+								pos:  position{line: 279, col: 8, offset: 6720},
 								name: "countOp",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 271, col: 16, offset: 6544},
+							pos: position{line: 279, col: 16, offset: 6728},
 							expr: &ruleRefExpr{
-								pos:  position{line: 271, col: 16, offset: 6544},
+								pos:  position{line: 279, col: 16, offset: 6728},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 271, col: 19, offset: 6547},
+							pos:        position{line: 279, col: 19, offset: 6731},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 271, col: 23, offset: 6551},
+							pos:   position{line: 279, col: 23, offset: 6735},
 							label: "field",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 271, col: 29, offset: 6557},
+								pos: position{line: 279, col: 29, offset: 6741},
 								expr: &ruleRefExpr{
-									pos:  position{line: 271, col: 29, offset: 6557},
+									pos:  position{line: 279, col: 29, offset: 6741},
 									name: "paddedFieldExpr",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 271, col: 47, offset: 6575},
+							pos: position{line: 279, col: 47, offset: 6759},
 							expr: &ruleRefExpr{
-								pos:  position{line: 271, col: 47, offset: 6575},
+								pos:  position{line: 279, col: 47, offset: 6759},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 271, col: 50, offset: 6578},
+							pos:        position{line: 279, col: 50, offset: 6762},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2042,57 +2104,57 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReducer",
-			pos:  position{line: 275, col: 1, offset: 6637},
+			pos:  position{line: 283, col: 1, offset: 6821},
 			expr: &actionExpr{
-				pos: position{line: 276, col: 5, offset: 6654},
+				pos: position{line: 284, col: 5, offset: 6838},
 				run: (*parser).callonfieldReducer1,
 				expr: &seqExpr{
-					pos: position{line: 276, col: 5, offset: 6654},
+					pos: position{line: 284, col: 5, offset: 6838},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 276, col: 5, offset: 6654},
+							pos:   position{line: 284, col: 5, offset: 6838},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 8, offset: 6657},
+								pos:  position{line: 284, col: 8, offset: 6841},
 								name: "fieldReducerOp",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 276, col: 23, offset: 6672},
+							pos: position{line: 284, col: 23, offset: 6856},
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 23, offset: 6672},
+								pos:  position{line: 284, col: 23, offset: 6856},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 276, col: 26, offset: 6675},
+							pos:        position{line: 284, col: 26, offset: 6859},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 276, col: 30, offset: 6679},
+							pos: position{line: 284, col: 30, offset: 6863},
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 30, offset: 6679},
+								pos:  position{line: 284, col: 30, offset: 6863},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 276, col: 33, offset: 6682},
+							pos:   position{line: 284, col: 33, offset: 6866},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 39, offset: 6688},
+								pos:  position{line: 284, col: 39, offset: 6872},
 								name: "fieldExpr",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 276, col: 50, offset: 6699},
+							pos: position{line: 284, col: 50, offset: 6883},
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 50, offset: 6699},
+								pos:  position{line: 284, col: 50, offset: 6883},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 276, col: 53, offset: 6702},
+							pos:        position{line: 284, col: 53, offset: 6886},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2102,27 +2164,27 @@ var g = &grammar{
 		},
 		{
 			name: "reducerProc",
-			pos:  position{line: 280, col: 1, offset: 6769},
+			pos:  position{line: 288, col: 1, offset: 6953},
 			expr: &actionExpr{
-				pos: position{line: 281, col: 5, offset: 6785},
+				pos: position{line: 289, col: 5, offset: 6969},
 				run: (*parser).callonreducerProc1,
 				expr: &seqExpr{
-					pos: position{line: 281, col: 5, offset: 6785},
+					pos: position{line: 289, col: 5, offset: 6969},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 281, col: 5, offset: 6785},
+							pos:   position{line: 289, col: 5, offset: 6969},
 							label: "every",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 281, col: 11, offset: 6791},
+								pos: position{line: 289, col: 11, offset: 6975},
 								expr: &seqExpr{
-									pos: position{line: 281, col: 12, offset: 6792},
+									pos: position{line: 289, col: 12, offset: 6976},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 12, offset: 6792},
+											pos:  position{line: 289, col: 12, offset: 6976},
 											name: "everyDur",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 21, offset: 6801},
+											pos:  position{line: 289, col: 21, offset: 6985},
 											name: "_",
 										},
 									},
@@ -2130,40 +2192,40 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 25, offset: 6805},
+							pos:   position{line: 289, col: 25, offset: 6989},
 							label: "reducers",
 							expr: &ruleRefExpr{
-								pos:  position{line: 281, col: 34, offset: 6814},
+								pos:  position{line: 289, col: 34, offset: 6998},
 								name: "reducerList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 46, offset: 6826},
+							pos:   position{line: 289, col: 46, offset: 7010},
 							label: "keys",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 281, col: 51, offset: 6831},
+								pos: position{line: 289, col: 51, offset: 7015},
 								expr: &seqExpr{
-									pos: position{line: 281, col: 52, offset: 6832},
+									pos: position{line: 289, col: 52, offset: 7016},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 52, offset: 6832},
+											pos:  position{line: 289, col: 52, offset: 7016},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 281, col: 54, offset: 6834},
-											name: "groupBy",
+											pos:  position{line: 289, col: 54, offset: 7018},
+											name: "groupByKeys",
 										},
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 281, col: 64, offset: 6844},
+							pos:   position{line: 289, col: 68, offset: 7032},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 281, col: 70, offset: 6850},
+								pos: position{line: 289, col: 74, offset: 7038},
 								expr: &ruleRefExpr{
-									pos:  position{line: 281, col: 70, offset: 6850},
+									pos:  position{line: 289, col: 74, offset: 7038},
 									name: "procLimitArg",
 								},
 							},
@@ -2174,27 +2236,27 @@ var g = &grammar{
 		},
 		{
 			name: "asClause",
-			pos:  position{line: 299, col: 1, offset: 7207},
+			pos:  position{line: 307, col: 1, offset: 7395},
 			expr: &actionExpr{
-				pos: position{line: 300, col: 5, offset: 7220},
+				pos: position{line: 308, col: 5, offset: 7408},
 				run: (*parser).callonasClause1,
 				expr: &seqExpr{
-					pos: position{line: 300, col: 5, offset: 7220},
+					pos: position{line: 308, col: 5, offset: 7408},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 300, col: 5, offset: 7220},
+							pos:        position{line: 308, col: 5, offset: 7408},
 							val:        "as",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 300, col: 11, offset: 7226},
+							pos:  position{line: 308, col: 11, offset: 7414},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 300, col: 13, offset: 7228},
+							pos:   position{line: 308, col: 13, offset: 7416},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 300, col: 15, offset: 7230},
+								pos:  position{line: 308, col: 15, offset: 7418},
 								name: "fieldName",
 							},
 						},
@@ -2204,48 +2266,48 @@ var g = &grammar{
 		},
 		{
 			name: "reducerExpr",
-			pos:  position{line: 302, col: 1, offset: 7259},
+			pos:  position{line: 310, col: 1, offset: 7447},
 			expr: &choiceExpr{
-				pos: position{line: 303, col: 5, offset: 7275},
+				pos: position{line: 311, col: 5, offset: 7463},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 303, col: 5, offset: 7275},
+						pos: position{line: 311, col: 5, offset: 7463},
 						run: (*parser).callonreducerExpr2,
 						expr: &seqExpr{
-							pos: position{line: 303, col: 5, offset: 7275},
+							pos: position{line: 311, col: 5, offset: 7463},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 303, col: 5, offset: 7275},
+									pos:   position{line: 311, col: 5, offset: 7463},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 303, col: 11, offset: 7281},
+										pos:  position{line: 311, col: 11, offset: 7469},
 										name: "fieldExpr",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 303, col: 21, offset: 7291},
+									pos: position{line: 311, col: 21, offset: 7479},
 									expr: &ruleRefExpr{
-										pos:  position{line: 303, col: 21, offset: 7291},
+										pos:  position{line: 311, col: 21, offset: 7479},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 303, col: 24, offset: 7294},
+									pos:        position{line: 311, col: 24, offset: 7482},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 303, col: 28, offset: 7298},
+									pos: position{line: 311, col: 28, offset: 7486},
 									expr: &ruleRefExpr{
-										pos:  position{line: 303, col: 28, offset: 7298},
+										pos:  position{line: 311, col: 28, offset: 7486},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 303, col: 31, offset: 7301},
+									pos:   position{line: 311, col: 31, offset: 7489},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 303, col: 33, offset: 7303},
+										pos:  position{line: 311, col: 33, offset: 7491},
 										name: "reducer",
 									},
 								},
@@ -2253,28 +2315,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 306, col: 5, offset: 7366},
+						pos: position{line: 314, col: 5, offset: 7554},
 						run: (*parser).callonreducerExpr13,
 						expr: &seqExpr{
-							pos: position{line: 306, col: 5, offset: 7366},
+							pos: position{line: 314, col: 5, offset: 7554},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 306, col: 5, offset: 7366},
+									pos:   position{line: 314, col: 5, offset: 7554},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 306, col: 7, offset: 7368},
+										pos:  position{line: 314, col: 7, offset: 7556},
 										name: "reducer",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 306, col: 15, offset: 7376},
+									pos:  position{line: 314, col: 15, offset: 7564},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 306, col: 17, offset: 7378},
+									pos:   position{line: 314, col: 17, offset: 7566},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 306, col: 23, offset: 7384},
+										pos:  position{line: 314, col: 23, offset: 7572},
 										name: "asClause",
 									},
 								},
@@ -2282,7 +2344,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 309, col: 5, offset: 7448},
+						pos:  position{line: 317, col: 5, offset: 7636},
 						name: "reducer",
 					},
 				},
@@ -2290,16 +2352,16 @@ var g = &grammar{
 		},
 		{
 			name: "reducer",
-			pos:  position{line: 311, col: 1, offset: 7457},
+			pos:  position{line: 319, col: 1, offset: 7645},
 			expr: &choiceExpr{
-				pos: position{line: 312, col: 5, offset: 7469},
+				pos: position{line: 320, col: 5, offset: 7657},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 312, col: 5, offset: 7469},
+						pos:  position{line: 320, col: 5, offset: 7657},
 						name: "countReducer",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 313, col: 5, offset: 7486},
+						pos:  position{line: 321, col: 5, offset: 7674},
 						name: "fieldReducer",
 					},
 				},
@@ -2307,50 +2369,50 @@ var g = &grammar{
 		},
 		{
 			name: "reducerList",
-			pos:  position{line: 315, col: 1, offset: 7500},
+			pos:  position{line: 323, col: 1, offset: 7688},
 			expr: &actionExpr{
-				pos: position{line: 316, col: 5, offset: 7516},
+				pos: position{line: 324, col: 5, offset: 7704},
 				run: (*parser).callonreducerList1,
 				expr: &seqExpr{
-					pos: position{line: 316, col: 5, offset: 7516},
+					pos: position{line: 324, col: 5, offset: 7704},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 316, col: 5, offset: 7516},
+							pos:   position{line: 324, col: 5, offset: 7704},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 316, col: 11, offset: 7522},
+								pos:  position{line: 324, col: 11, offset: 7710},
 								name: "reducerExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 316, col: 23, offset: 7534},
+							pos:   position{line: 324, col: 23, offset: 7722},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 316, col: 28, offset: 7539},
+								pos: position{line: 324, col: 28, offset: 7727},
 								expr: &seqExpr{
-									pos: position{line: 316, col: 29, offset: 7540},
+									pos: position{line: 324, col: 29, offset: 7728},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 316, col: 29, offset: 7540},
+											pos: position{line: 324, col: 29, offset: 7728},
 											expr: &ruleRefExpr{
-												pos:  position{line: 316, col: 29, offset: 7540},
+												pos:  position{line: 324, col: 29, offset: 7728},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 316, col: 32, offset: 7543},
+											pos:        position{line: 324, col: 32, offset: 7731},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 316, col: 36, offset: 7547},
+											pos: position{line: 324, col: 36, offset: 7735},
 											expr: &ruleRefExpr{
-												pos:  position{line: 316, col: 36, offset: 7547},
+												pos:  position{line: 324, col: 36, offset: 7735},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 316, col: 39, offset: 7550},
+											pos:  position{line: 324, col: 39, offset: 7738},
 											name: "reducerExpr",
 										},
 									},
@@ -2363,40 +2425,40 @@ var g = &grammar{
 		},
 		{
 			name: "simpleProc",
-			pos:  position{line: 324, col: 1, offset: 7747},
+			pos:  position{line: 332, col: 1, offset: 7935},
 			expr: &choiceExpr{
-				pos: position{line: 325, col: 5, offset: 7762},
+				pos: position{line: 333, col: 5, offset: 7950},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 325, col: 5, offset: 7762},
+						pos:  position{line: 333, col: 5, offset: 7950},
 						name: "sort",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 326, col: 5, offset: 7771},
+						pos:  position{line: 334, col: 5, offset: 7959},
 						name: "top",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 327, col: 5, offset: 7779},
+						pos:  position{line: 335, col: 5, offset: 7967},
 						name: "cut",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 328, col: 5, offset: 7787},
+						pos:  position{line: 336, col: 5, offset: 7975},
 						name: "head",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 329, col: 5, offset: 7796},
+						pos:  position{line: 337, col: 5, offset: 7984},
 						name: "tail",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 330, col: 5, offset: 7805},
+						pos:  position{line: 338, col: 5, offset: 7993},
 						name: "filter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 331, col: 5, offset: 7816},
+						pos:  position{line: 339, col: 5, offset: 8004},
 						name: "uniq",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 332, col: 5, offset: 7825},
+						pos:  position{line: 340, col: 5, offset: 8013},
 						name: "put",
 					},
 				},
@@ -2404,46 +2466,46 @@ var g = &grammar{
 		},
 		{
 			name: "sort",
-			pos:  position{line: 334, col: 1, offset: 7830},
+			pos:  position{line: 342, col: 1, offset: 8018},
 			expr: &actionExpr{
-				pos: position{line: 335, col: 5, offset: 7839},
+				pos: position{line: 343, col: 5, offset: 8027},
 				run: (*parser).callonsort1,
 				expr: &seqExpr{
-					pos: position{line: 335, col: 5, offset: 7839},
+					pos: position{line: 343, col: 5, offset: 8027},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 335, col: 5, offset: 7839},
+							pos:        position{line: 343, col: 5, offset: 8027},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 335, col: 13, offset: 7847},
+							pos:   position{line: 343, col: 13, offset: 8035},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 335, col: 18, offset: 7852},
+								pos:  position{line: 343, col: 18, offset: 8040},
 								name: "sortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 335, col: 27, offset: 7861},
+							pos:   position{line: 343, col: 27, offset: 8049},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 335, col: 32, offset: 7866},
+								pos: position{line: 343, col: 32, offset: 8054},
 								expr: &actionExpr{
-									pos: position{line: 335, col: 33, offset: 7867},
+									pos: position{line: 343, col: 33, offset: 8055},
 									run: (*parser).callonsort8,
 									expr: &seqExpr{
-										pos: position{line: 335, col: 33, offset: 7867},
+										pos: position{line: 343, col: 33, offset: 8055},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 335, col: 33, offset: 7867},
+												pos:  position{line: 343, col: 33, offset: 8055},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 335, col: 35, offset: 7869},
+												pos:   position{line: 343, col: 35, offset: 8057},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 335, col: 37, offset: 7871},
+													pos:  position{line: 343, col: 37, offset: 8059},
 													name: "fieldExprList",
 												},
 											},
@@ -2458,24 +2520,24 @@ var g = &grammar{
 		},
 		{
 			name: "sortArgs",
-			pos:  position{line: 339, col: 1, offset: 7948},
+			pos:  position{line: 347, col: 1, offset: 8136},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 339, col: 12, offset: 7959},
+				pos: position{line: 347, col: 12, offset: 8147},
 				expr: &actionExpr{
-					pos: position{line: 339, col: 13, offset: 7960},
+					pos: position{line: 347, col: 13, offset: 8148},
 					run: (*parser).callonsortArgs2,
 					expr: &seqExpr{
-						pos: position{line: 339, col: 13, offset: 7960},
+						pos: position{line: 347, col: 13, offset: 8148},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 339, col: 13, offset: 7960},
+								pos:  position{line: 347, col: 13, offset: 8148},
 								name: "_",
 							},
 							&labeledExpr{
-								pos:   position{line: 339, col: 15, offset: 7962},
+								pos:   position{line: 347, col: 15, offset: 8150},
 								label: "a",
 								expr: &ruleRefExpr{
-									pos:  position{line: 339, col: 17, offset: 7964},
+									pos:  position{line: 347, col: 17, offset: 8152},
 									name: "sortArg",
 								},
 							},
@@ -2486,50 +2548,50 @@ var g = &grammar{
 		},
 		{
 			name: "sortArg",
-			pos:  position{line: 341, col: 1, offset: 7993},
+			pos:  position{line: 349, col: 1, offset: 8181},
 			expr: &choiceExpr{
-				pos: position{line: 342, col: 5, offset: 8005},
+				pos: position{line: 350, col: 5, offset: 8193},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 342, col: 5, offset: 8005},
+						pos: position{line: 350, col: 5, offset: 8193},
 						run: (*parser).callonsortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 342, col: 5, offset: 8005},
+							pos:        position{line: 350, col: 5, offset: 8193},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 343, col: 5, offset: 8048},
+						pos: position{line: 351, col: 5, offset: 8236},
 						run: (*parser).callonsortArg4,
 						expr: &seqExpr{
-							pos: position{line: 343, col: 5, offset: 8048},
+							pos: position{line: 351, col: 5, offset: 8236},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 343, col: 5, offset: 8048},
+									pos:        position{line: 351, col: 5, offset: 8236},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 343, col: 14, offset: 8057},
+									pos:  position{line: 351, col: 14, offset: 8245},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 343, col: 16, offset: 8059},
+									pos:   position{line: 351, col: 16, offset: 8247},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 343, col: 23, offset: 8066},
+										pos: position{line: 351, col: 23, offset: 8254},
 										run: (*parser).callonsortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 343, col: 24, offset: 8067},
+											pos: position{line: 351, col: 24, offset: 8255},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 343, col: 24, offset: 8067},
+													pos:        position{line: 351, col: 24, offset: 8255},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 343, col: 34, offset: 8077},
+													pos:        position{line: 351, col: 34, offset: 8265},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2545,38 +2607,38 @@ var g = &grammar{
 		},
 		{
 			name: "top",
-			pos:  position{line: 345, col: 1, offset: 8159},
+			pos:  position{line: 353, col: 1, offset: 8347},
 			expr: &actionExpr{
-				pos: position{line: 346, col: 5, offset: 8167},
+				pos: position{line: 354, col: 5, offset: 8355},
 				run: (*parser).callontop1,
 				expr: &seqExpr{
-					pos: position{line: 346, col: 5, offset: 8167},
+					pos: position{line: 354, col: 5, offset: 8355},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 346, col: 5, offset: 8167},
+							pos:        position{line: 354, col: 5, offset: 8355},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 346, col: 12, offset: 8174},
+							pos:   position{line: 354, col: 12, offset: 8362},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 346, col: 18, offset: 8180},
+								pos: position{line: 354, col: 18, offset: 8368},
 								expr: &actionExpr{
-									pos: position{line: 346, col: 19, offset: 8181},
+									pos: position{line: 354, col: 19, offset: 8369},
 									run: (*parser).callontop6,
 									expr: &seqExpr{
-										pos: position{line: 346, col: 19, offset: 8181},
+										pos: position{line: 354, col: 19, offset: 8369},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 346, col: 19, offset: 8181},
+												pos:  position{line: 354, col: 19, offset: 8369},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 346, col: 21, offset: 8183},
+												pos:   position{line: 354, col: 21, offset: 8371},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 346, col: 23, offset: 8185},
+													pos:  position{line: 354, col: 23, offset: 8373},
 													name: "unsignedInteger",
 												},
 											},
@@ -2586,19 +2648,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 346, col: 58, offset: 8220},
+							pos:   position{line: 354, col: 58, offset: 8408},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 346, col: 64, offset: 8226},
+								pos: position{line: 354, col: 64, offset: 8414},
 								expr: &seqExpr{
-									pos: position{line: 346, col: 65, offset: 8227},
+									pos: position{line: 354, col: 65, offset: 8415},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 346, col: 65, offset: 8227},
+											pos:  position{line: 354, col: 65, offset: 8415},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 346, col: 67, offset: 8229},
+											pos:        position{line: 354, col: 67, offset: 8417},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2607,25 +2669,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 346, col: 78, offset: 8240},
+							pos:   position{line: 354, col: 78, offset: 8428},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 346, col: 83, offset: 8245},
+								pos: position{line: 354, col: 83, offset: 8433},
 								expr: &actionExpr{
-									pos: position{line: 346, col: 84, offset: 8246},
+									pos: position{line: 354, col: 84, offset: 8434},
 									run: (*parser).callontop18,
 									expr: &seqExpr{
-										pos: position{line: 346, col: 84, offset: 8246},
+										pos: position{line: 354, col: 84, offset: 8434},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 346, col: 84, offset: 8246},
+												pos:  position{line: 354, col: 84, offset: 8434},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 346, col: 86, offset: 8248},
+												pos:   position{line: 354, col: 86, offset: 8436},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 346, col: 88, offset: 8250},
+													pos:  position{line: 354, col: 88, offset: 8438},
 													name: "fieldExprList",
 												},
 											},
@@ -2640,31 +2702,31 @@ var g = &grammar{
 		},
 		{
 			name: "procLimitArg",
-			pos:  position{line: 350, col: 1, offset: 8339},
+			pos:  position{line: 358, col: 1, offset: 8527},
 			expr: &actionExpr{
-				pos: position{line: 351, col: 5, offset: 8356},
+				pos: position{line: 359, col: 5, offset: 8544},
 				run: (*parser).callonprocLimitArg1,
 				expr: &seqExpr{
-					pos: position{line: 351, col: 5, offset: 8356},
+					pos: position{line: 359, col: 5, offset: 8544},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 351, col: 5, offset: 8356},
+							pos:  position{line: 359, col: 5, offset: 8544},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 351, col: 7, offset: 8358},
+							pos:        position{line: 359, col: 7, offset: 8546},
 							val:        "-limit",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 351, col: 16, offset: 8367},
+							pos:  position{line: 359, col: 16, offset: 8555},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 351, col: 18, offset: 8369},
+							pos:   position{line: 359, col: 18, offset: 8557},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 351, col: 24, offset: 8375},
+								pos:  position{line: 359, col: 24, offset: 8563},
 								name: "unsignedInteger",
 							},
 						},
@@ -2674,21 +2736,21 @@ var g = &grammar{
 		},
 		{
 			name: "cutArg",
-			pos:  position{line: 353, col: 1, offset: 8414},
+			pos:  position{line: 361, col: 1, offset: 8602},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 353, col: 10, offset: 8423},
+				pos: position{line: 361, col: 10, offset: 8611},
 				expr: &actionExpr{
-					pos: position{line: 353, col: 11, offset: 8424},
+					pos: position{line: 361, col: 11, offset: 8612},
 					run: (*parser).calloncutArg2,
 					expr: &seqExpr{
-						pos: position{line: 353, col: 11, offset: 8424},
+						pos: position{line: 361, col: 11, offset: 8612},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 353, col: 11, offset: 8424},
+								pos:  position{line: 361, col: 11, offset: 8612},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 353, col: 13, offset: 8426},
+								pos:        position{line: 361, col: 13, offset: 8614},
 								val:        "-c",
 								ignoreCase: false,
 							},
@@ -2699,35 +2761,35 @@ var g = &grammar{
 		},
 		{
 			name: "cut",
-			pos:  position{line: 355, col: 1, offset: 8468},
+			pos:  position{line: 363, col: 1, offset: 8656},
 			expr: &actionExpr{
-				pos: position{line: 356, col: 5, offset: 8476},
+				pos: position{line: 364, col: 5, offset: 8664},
 				run: (*parser).calloncut1,
 				expr: &seqExpr{
-					pos: position{line: 356, col: 5, offset: 8476},
+					pos: position{line: 364, col: 5, offset: 8664},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 356, col: 5, offset: 8476},
+							pos:        position{line: 364, col: 5, offset: 8664},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 356, col: 12, offset: 8483},
+							pos:   position{line: 364, col: 12, offset: 8671},
 							label: "arg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 356, col: 16, offset: 8487},
+								pos:  position{line: 364, col: 16, offset: 8675},
 								name: "cutArg",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 356, col: 23, offset: 8494},
+							pos:  position{line: 364, col: 23, offset: 8682},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 356, col: 25, offset: 8496},
+							pos:   position{line: 364, col: 25, offset: 8684},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 356, col: 30, offset: 8501},
+								pos:  position{line: 364, col: 30, offset: 8689},
 								name: "fieldRefDotOnlyList",
 							},
 						},
@@ -2737,30 +2799,30 @@ var g = &grammar{
 		},
 		{
 			name: "head",
-			pos:  position{line: 357, col: 1, offset: 8556},
+			pos:  position{line: 365, col: 1, offset: 8744},
 			expr: &choiceExpr{
-				pos: position{line: 358, col: 5, offset: 8565},
+				pos: position{line: 366, col: 5, offset: 8753},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 358, col: 5, offset: 8565},
+						pos: position{line: 366, col: 5, offset: 8753},
 						run: (*parser).callonhead2,
 						expr: &seqExpr{
-							pos: position{line: 358, col: 5, offset: 8565},
+							pos: position{line: 366, col: 5, offset: 8753},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 358, col: 5, offset: 8565},
+									pos:        position{line: 366, col: 5, offset: 8753},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 358, col: 13, offset: 8573},
+									pos:  position{line: 366, col: 13, offset: 8761},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 358, col: 15, offset: 8575},
+									pos:   position{line: 366, col: 15, offset: 8763},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 358, col: 21, offset: 8581},
+										pos:  position{line: 366, col: 21, offset: 8769},
 										name: "unsignedInteger",
 									},
 								},
@@ -2768,10 +2830,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 359, col: 5, offset: 8637},
+						pos: position{line: 367, col: 5, offset: 8825},
 						run: (*parser).callonhead8,
 						expr: &litMatcher{
-							pos:        position{line: 359, col: 5, offset: 8637},
+							pos:        position{line: 367, col: 5, offset: 8825},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2781,30 +2843,30 @@ var g = &grammar{
 		},
 		{
 			name: "tail",
-			pos:  position{line: 360, col: 1, offset: 8677},
+			pos:  position{line: 368, col: 1, offset: 8865},
 			expr: &choiceExpr{
-				pos: position{line: 361, col: 5, offset: 8686},
+				pos: position{line: 369, col: 5, offset: 8874},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 361, col: 5, offset: 8686},
+						pos: position{line: 369, col: 5, offset: 8874},
 						run: (*parser).callontail2,
 						expr: &seqExpr{
-							pos: position{line: 361, col: 5, offset: 8686},
+							pos: position{line: 369, col: 5, offset: 8874},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 361, col: 5, offset: 8686},
+									pos:        position{line: 369, col: 5, offset: 8874},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 361, col: 13, offset: 8694},
+									pos:  position{line: 369, col: 13, offset: 8882},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 361, col: 15, offset: 8696},
+									pos:   position{line: 369, col: 15, offset: 8884},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 361, col: 21, offset: 8702},
+										pos:  position{line: 369, col: 21, offset: 8890},
 										name: "unsignedInteger",
 									},
 								},
@@ -2812,10 +2874,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 362, col: 5, offset: 8758},
+						pos: position{line: 370, col: 5, offset: 8946},
 						run: (*parser).callontail8,
 						expr: &litMatcher{
-							pos:        position{line: 362, col: 5, offset: 8758},
+							pos:        position{line: 370, col: 5, offset: 8946},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2825,27 +2887,27 @@ var g = &grammar{
 		},
 		{
 			name: "filter",
-			pos:  position{line: 364, col: 1, offset: 8799},
+			pos:  position{line: 372, col: 1, offset: 8987},
 			expr: &actionExpr{
-				pos: position{line: 365, col: 5, offset: 8810},
+				pos: position{line: 373, col: 5, offset: 8998},
 				run: (*parser).callonfilter1,
 				expr: &seqExpr{
-					pos: position{line: 365, col: 5, offset: 8810},
+					pos: position{line: 373, col: 5, offset: 8998},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 365, col: 5, offset: 8810},
+							pos:        position{line: 373, col: 5, offset: 8998},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 365, col: 15, offset: 8820},
+							pos:  position{line: 373, col: 15, offset: 9008},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 365, col: 17, offset: 8822},
+							pos:   position{line: 373, col: 17, offset: 9010},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 365, col: 22, offset: 8827},
+								pos:  position{line: 373, col: 22, offset: 9015},
 								name: "searchExpr",
 							},
 						},
@@ -2855,27 +2917,27 @@ var g = &grammar{
 		},
 		{
 			name: "uniq",
-			pos:  position{line: 368, col: 1, offset: 8885},
+			pos:  position{line: 376, col: 1, offset: 9073},
 			expr: &choiceExpr{
-				pos: position{line: 369, col: 5, offset: 8894},
+				pos: position{line: 377, col: 5, offset: 9082},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 369, col: 5, offset: 8894},
+						pos: position{line: 377, col: 5, offset: 9082},
 						run: (*parser).callonuniq2,
 						expr: &seqExpr{
-							pos: position{line: 369, col: 5, offset: 8894},
+							pos: position{line: 377, col: 5, offset: 9082},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 369, col: 5, offset: 8894},
+									pos:        position{line: 377, col: 5, offset: 9082},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 369, col: 13, offset: 8902},
+									pos:  position{line: 377, col: 13, offset: 9090},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 369, col: 15, offset: 8904},
+									pos:        position{line: 377, col: 15, offset: 9092},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2883,10 +2945,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 372, col: 5, offset: 8958},
+						pos: position{line: 380, col: 5, offset: 9146},
 						run: (*parser).callonuniq7,
 						expr: &litMatcher{
-							pos:        position{line: 372, col: 5, offset: 8958},
+							pos:        position{line: 380, col: 5, offset: 9146},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2896,60 +2958,60 @@ var g = &grammar{
 		},
 		{
 			name: "put",
-			pos:  position{line: 376, col: 1, offset: 9013},
+			pos:  position{line: 384, col: 1, offset: 9201},
 			expr: &actionExpr{
-				pos: position{line: 377, col: 5, offset: 9021},
+				pos: position{line: 385, col: 5, offset: 9209},
 				run: (*parser).callonput1,
 				expr: &seqExpr{
-					pos: position{line: 377, col: 5, offset: 9021},
+					pos: position{line: 385, col: 5, offset: 9209},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 377, col: 5, offset: 9021},
+							pos:        position{line: 385, col: 5, offset: 9209},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 377, col: 12, offset: 9028},
+							pos:  position{line: 385, col: 12, offset: 9216},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 377, col: 14, offset: 9030},
+							pos:   position{line: 385, col: 14, offset: 9218},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 377, col: 20, offset: 9036},
-								name: "PutClause",
+								pos:  position{line: 385, col: 20, offset: 9224},
+								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 377, col: 30, offset: 9046},
+							pos:   position{line: 385, col: 31, offset: 9235},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 377, col: 35, offset: 9051},
+								pos: position{line: 385, col: 36, offset: 9240},
 								expr: &actionExpr{
-									pos: position{line: 377, col: 36, offset: 9052},
+									pos: position{line: 385, col: 37, offset: 9241},
 									run: (*parser).callonput9,
 									expr: &seqExpr{
-										pos: position{line: 377, col: 36, offset: 9052},
+										pos: position{line: 385, col: 37, offset: 9241},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 377, col: 36, offset: 9052},
+												pos:  position{line: 385, col: 37, offset: 9241},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 377, col: 39, offset: 9055},
+												pos:        position{line: 385, col: 40, offset: 9244},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 377, col: 43, offset: 9059},
+												pos:  position{line: 385, col: 44, offset: 9248},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 377, col: 46, offset: 9062},
+												pos:   position{line: 385, col: 47, offset: 9251},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 377, col: 49, offset: 9065},
-													name: "PutClause",
+													pos:  position{line: 385, col: 50, offset: 9254},
+													name: "Assignment",
 												},
 											},
 										},
@@ -2962,40 +3024,40 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "PutClause",
-			pos:  position{line: 381, col: 1, offset: 9148},
+			name: "Assignment",
+			pos:  position{line: 389, col: 1, offset: 9338},
 			expr: &actionExpr{
-				pos: position{line: 382, col: 5, offset: 9162},
-				run: (*parser).callonPutClause1,
+				pos: position{line: 390, col: 5, offset: 9353},
+				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 382, col: 5, offset: 9162},
+					pos: position{line: 390, col: 5, offset: 9353},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 382, col: 5, offset: 9162},
+							pos:   position{line: 390, col: 5, offset: 9353},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 382, col: 7, offset: 9164},
+								pos:  position{line: 390, col: 7, offset: 9355},
 								name: "fieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 382, col: 17, offset: 9174},
+							pos:  position{line: 390, col: 17, offset: 9365},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 382, col: 20, offset: 9177},
+							pos:        position{line: 390, col: 20, offset: 9368},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 382, col: 24, offset: 9181},
+							pos:  position{line: 390, col: 24, offset: 9372},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 382, col: 27, offset: 9184},
+							pos:   position{line: 390, col: 27, offset: 9375},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 382, col: 29, offset: 9186},
+								pos:  position{line: 390, col: 29, offset: 9377},
 								name: "Expression",
 							},
 						},
@@ -3005,79 +3067,79 @@ var g = &grammar{
 		},
 		{
 			name: "PrimaryExpression",
-			pos:  position{line: 386, col: 1, offset: 9244},
+			pos:  position{line: 394, col: 1, offset: 9436},
 			expr: &choiceExpr{
-				pos: position{line: 387, col: 5, offset: 9266},
+				pos: position{line: 395, col: 5, offset: 9458},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 387, col: 5, offset: 9266},
+						pos:  position{line: 395, col: 5, offset: 9458},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 388, col: 5, offset: 9284},
+						pos:  position{line: 396, col: 5, offset: 9476},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 389, col: 5, offset: 9302},
+						pos:  position{line: 397, col: 5, offset: 9494},
 						name: "PortLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 390, col: 5, offset: 9318},
+						pos:  position{line: 398, col: 5, offset: 9510},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 391, col: 5, offset: 9336},
+						pos:  position{line: 399, col: 5, offset: 9528},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 392, col: 5, offset: 9355},
+						pos:  position{line: 400, col: 5, offset: 9547},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 393, col: 5, offset: 9372},
+						pos:  position{line: 401, col: 5, offset: 9564},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 394, col: 5, offset: 9391},
+						pos:  position{line: 402, col: 5, offset: 9583},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 395, col: 5, offset: 9410},
+						pos:  position{line: 403, col: 5, offset: 9602},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 396, col: 5, offset: 9426},
+						pos:  position{line: 404, col: 5, offset: 9618},
 						name: "FieldReference",
 					},
 					&actionExpr{
-						pos: position{line: 397, col: 5, offset: 9445},
+						pos: position{line: 405, col: 5, offset: 9637},
 						run: (*parser).callonPrimaryExpression12,
 						expr: &seqExpr{
-							pos: position{line: 397, col: 5, offset: 9445},
+							pos: position{line: 405, col: 5, offset: 9637},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 397, col: 5, offset: 9445},
+									pos:        position{line: 405, col: 5, offset: 9637},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 397, col: 9, offset: 9449},
+									pos:  position{line: 405, col: 9, offset: 9641},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 397, col: 12, offset: 9452},
+									pos:   position{line: 405, col: 12, offset: 9644},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 397, col: 17, offset: 9457},
+										pos:  position{line: 405, col: 17, offset: 9649},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 397, col: 28, offset: 9468},
+									pos:  position{line: 405, col: 28, offset: 9660},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 397, col: 31, offset: 9471},
+									pos:        position{line: 405, col: 31, offset: 9663},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3089,15 +3151,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldReference",
-			pos:  position{line: 399, col: 1, offset: 9497},
+			pos:  position{line: 407, col: 1, offset: 9689},
 			expr: &actionExpr{
-				pos: position{line: 400, col: 5, offset: 9516},
+				pos: position{line: 408, col: 5, offset: 9708},
 				run: (*parser).callonFieldReference1,
 				expr: &labeledExpr{
-					pos:   position{line: 400, col: 5, offset: 9516},
+					pos:   position{line: 408, col: 5, offset: 9708},
 					label: "f",
 					expr: &ruleRefExpr{
-						pos:  position{line: 400, col: 7, offset: 9518},
+						pos:  position{line: 408, col: 7, offset: 9710},
 						name: "fieldName",
 					},
 				},
@@ -3105,71 +3167,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expression",
-			pos:  position{line: 410, col: 1, offset: 9767},
+			pos:  position{line: 418, col: 1, offset: 9959},
 			expr: &ruleRefExpr{
-				pos:  position{line: 410, col: 14, offset: 9780},
+				pos:  position{line: 418, col: 14, offset: 9972},
 				name: "ConditionalExpression",
 			},
 		},
 		{
 			name: "ConditionalExpression",
-			pos:  position{line: 412, col: 1, offset: 9803},
+			pos:  position{line: 420, col: 1, offset: 9995},
 			expr: &choiceExpr{
-				pos: position{line: 413, col: 5, offset: 9829},
+				pos: position{line: 421, col: 5, offset: 10021},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 413, col: 5, offset: 9829},
+						pos: position{line: 421, col: 5, offset: 10021},
 						run: (*parser).callonConditionalExpression2,
 						expr: &seqExpr{
-							pos: position{line: 413, col: 5, offset: 9829},
+							pos: position{line: 421, col: 5, offset: 10021},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 413, col: 5, offset: 9829},
+									pos:   position{line: 421, col: 5, offset: 10021},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 413, col: 15, offset: 9839},
+										pos:  position{line: 421, col: 15, offset: 10031},
 										name: "LogicalORExpression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 413, col: 35, offset: 9859},
+									pos:  position{line: 421, col: 35, offset: 10051},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 413, col: 38, offset: 9862},
+									pos:        position{line: 421, col: 38, offset: 10054},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 413, col: 42, offset: 9866},
+									pos:  position{line: 421, col: 42, offset: 10058},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 413, col: 45, offset: 9869},
+									pos:   position{line: 421, col: 45, offset: 10061},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 413, col: 56, offset: 9880},
+										pos:  position{line: 421, col: 56, offset: 10072},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 413, col: 67, offset: 9891},
+									pos:  position{line: 421, col: 67, offset: 10083},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 413, col: 70, offset: 9894},
+									pos:        position{line: 421, col: 70, offset: 10086},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 413, col: 74, offset: 9898},
+									pos:  position{line: 421, col: 74, offset: 10090},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 413, col: 77, offset: 9901},
+									pos:   position{line: 421, col: 77, offset: 10093},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 413, col: 88, offset: 9912},
+										pos:  position{line: 421, col: 88, offset: 10104},
 										name: "Expression",
 									},
 								},
@@ -3177,7 +3239,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 416, col: 5, offset: 10004},
+						pos:  position{line: 424, col: 5, offset: 10196},
 						name: "LogicalORExpression",
 					},
 				},
@@ -3185,43 +3247,43 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalORExpression",
-			pos:  position{line: 418, col: 1, offset: 10025},
+			pos:  position{line: 426, col: 1, offset: 10217},
 			expr: &actionExpr{
-				pos: position{line: 419, col: 5, offset: 10049},
+				pos: position{line: 427, col: 5, offset: 10241},
 				run: (*parser).callonLogicalORExpression1,
 				expr: &seqExpr{
-					pos: position{line: 419, col: 5, offset: 10049},
+					pos: position{line: 427, col: 5, offset: 10241},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 419, col: 5, offset: 10049},
+							pos:   position{line: 427, col: 5, offset: 10241},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 419, col: 11, offset: 10055},
+								pos:  position{line: 427, col: 11, offset: 10247},
 								name: "LogicalANDExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 420, col: 5, offset: 10080},
+							pos:   position{line: 428, col: 5, offset: 10272},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 420, col: 10, offset: 10085},
+								pos: position{line: 428, col: 10, offset: 10277},
 								expr: &seqExpr{
-									pos: position{line: 420, col: 11, offset: 10086},
+									pos: position{line: 428, col: 11, offset: 10278},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 420, col: 11, offset: 10086},
+											pos:  position{line: 428, col: 11, offset: 10278},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 420, col: 14, offset: 10089},
+											pos:  position{line: 428, col: 14, offset: 10281},
 											name: "orToken",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 420, col: 22, offset: 10097},
+											pos:  position{line: 428, col: 22, offset: 10289},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 420, col: 25, offset: 10100},
+											pos:  position{line: 428, col: 25, offset: 10292},
 											name: "LogicalANDExpression",
 										},
 									},
@@ -3234,43 +3296,43 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalANDExpression",
-			pos:  position{line: 424, col: 1, offset: 10185},
+			pos:  position{line: 432, col: 1, offset: 10377},
 			expr: &actionExpr{
-				pos: position{line: 425, col: 5, offset: 10210},
+				pos: position{line: 433, col: 5, offset: 10402},
 				run: (*parser).callonLogicalANDExpression1,
 				expr: &seqExpr{
-					pos: position{line: 425, col: 5, offset: 10210},
+					pos: position{line: 433, col: 5, offset: 10402},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 425, col: 5, offset: 10210},
+							pos:   position{line: 433, col: 5, offset: 10402},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 425, col: 11, offset: 10216},
+								pos:  position{line: 433, col: 11, offset: 10408},
 								name: "EqualityCompareExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 426, col: 5, offset: 10246},
+							pos:   position{line: 434, col: 5, offset: 10438},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 426, col: 10, offset: 10251},
+								pos: position{line: 434, col: 10, offset: 10443},
 								expr: &seqExpr{
-									pos: position{line: 426, col: 11, offset: 10252},
+									pos: position{line: 434, col: 11, offset: 10444},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 426, col: 11, offset: 10252},
+											pos:  position{line: 434, col: 11, offset: 10444},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 426, col: 14, offset: 10255},
+											pos:  position{line: 434, col: 14, offset: 10447},
 											name: "andToken",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 426, col: 23, offset: 10264},
+											pos:  position{line: 434, col: 23, offset: 10456},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 426, col: 26, offset: 10267},
+											pos:  position{line: 434, col: 26, offset: 10459},
 											name: "EqualityCompareExpression",
 										},
 									},
@@ -3283,43 +3345,43 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpression",
-			pos:  position{line: 430, col: 1, offset: 10357},
+			pos:  position{line: 438, col: 1, offset: 10549},
 			expr: &actionExpr{
-				pos: position{line: 431, col: 5, offset: 10387},
+				pos: position{line: 439, col: 5, offset: 10579},
 				run: (*parser).callonEqualityCompareExpression1,
 				expr: &seqExpr{
-					pos: position{line: 431, col: 5, offset: 10387},
+					pos: position{line: 439, col: 5, offset: 10579},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 431, col: 5, offset: 10387},
+							pos:   position{line: 439, col: 5, offset: 10579},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 431, col: 11, offset: 10393},
+								pos:  position{line: 439, col: 11, offset: 10585},
 								name: "RelativeExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 432, col: 5, offset: 10416},
+							pos:   position{line: 440, col: 5, offset: 10608},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 432, col: 10, offset: 10421},
+								pos: position{line: 440, col: 10, offset: 10613},
 								expr: &seqExpr{
-									pos: position{line: 432, col: 11, offset: 10422},
+									pos: position{line: 440, col: 11, offset: 10614},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 432, col: 11, offset: 10422},
+											pos:  position{line: 440, col: 11, offset: 10614},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 432, col: 14, offset: 10425},
+											pos:  position{line: 440, col: 14, offset: 10617},
 											name: "EqualityComparator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 432, col: 33, offset: 10444},
+											pos:  position{line: 440, col: 33, offset: 10636},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 432, col: 36, offset: 10447},
+											pos:  position{line: 440, col: 36, offset: 10639},
 											name: "RelativeExpression",
 										},
 									},
@@ -3332,30 +3394,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 436, col: 1, offset: 10530},
+			pos:  position{line: 444, col: 1, offset: 10722},
 			expr: &actionExpr{
-				pos: position{line: 436, col: 20, offset: 10549},
+				pos: position{line: 444, col: 20, offset: 10741},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 436, col: 21, offset: 10550},
+					pos: position{line: 444, col: 21, offset: 10742},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 436, col: 21, offset: 10550},
+							pos:        position{line: 444, col: 21, offset: 10742},
 							val:        "=~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 436, col: 28, offset: 10557},
+							pos:        position{line: 444, col: 28, offset: 10749},
 							val:        "!~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 436, col: 35, offset: 10564},
+							pos:        position{line: 444, col: 35, offset: 10756},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 436, col: 41, offset: 10570},
+							pos:        position{line: 444, col: 41, offset: 10762},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3365,19 +3427,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 438, col: 1, offset: 10608},
+			pos:  position{line: 446, col: 1, offset: 10800},
 			expr: &choiceExpr{
-				pos: position{line: 439, col: 5, offset: 10631},
+				pos: position{line: 447, col: 5, offset: 10823},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 439, col: 5, offset: 10631},
+						pos:  position{line: 447, col: 5, offset: 10823},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 440, col: 5, offset: 10652},
+						pos: position{line: 448, col: 5, offset: 10844},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 440, col: 5, offset: 10652},
+							pos:        position{line: 448, col: 5, offset: 10844},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3387,43 +3449,43 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpression",
-			pos:  position{line: 442, col: 1, offset: 10689},
+			pos:  position{line: 450, col: 1, offset: 10881},
 			expr: &actionExpr{
-				pos: position{line: 443, col: 5, offset: 10712},
+				pos: position{line: 451, col: 5, offset: 10904},
 				run: (*parser).callonRelativeExpression1,
 				expr: &seqExpr{
-					pos: position{line: 443, col: 5, offset: 10712},
+					pos: position{line: 451, col: 5, offset: 10904},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 443, col: 5, offset: 10712},
+							pos:   position{line: 451, col: 5, offset: 10904},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 443, col: 11, offset: 10718},
+								pos:  position{line: 451, col: 11, offset: 10910},
 								name: "AdditiveExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 444, col: 5, offset: 10741},
+							pos:   position{line: 452, col: 5, offset: 10933},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 444, col: 10, offset: 10746},
+								pos: position{line: 452, col: 10, offset: 10938},
 								expr: &seqExpr{
-									pos: position{line: 444, col: 11, offset: 10747},
+									pos: position{line: 452, col: 11, offset: 10939},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 444, col: 11, offset: 10747},
+											pos:  position{line: 452, col: 11, offset: 10939},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 444, col: 14, offset: 10750},
+											pos:  position{line: 452, col: 14, offset: 10942},
 											name: "RelativeOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 444, col: 31, offset: 10767},
+											pos:  position{line: 452, col: 31, offset: 10959},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 444, col: 34, offset: 10770},
+											pos:  position{line: 452, col: 34, offset: 10962},
 											name: "AdditiveExpression",
 										},
 									},
@@ -3436,30 +3498,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 448, col: 1, offset: 10853},
+			pos:  position{line: 456, col: 1, offset: 11045},
 			expr: &actionExpr{
-				pos: position{line: 448, col: 20, offset: 10872},
+				pos: position{line: 456, col: 20, offset: 11064},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 448, col: 21, offset: 10873},
+					pos: position{line: 456, col: 21, offset: 11065},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 448, col: 21, offset: 10873},
+							pos:        position{line: 456, col: 21, offset: 11065},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 448, col: 28, offset: 10880},
+							pos:        position{line: 456, col: 28, offset: 11072},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 448, col: 34, offset: 10886},
+							pos:        position{line: 456, col: 34, offset: 11078},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 448, col: 41, offset: 10893},
+							pos:        position{line: 456, col: 41, offset: 11085},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -3469,43 +3531,43 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpression",
-			pos:  position{line: 450, col: 1, offset: 10930},
+			pos:  position{line: 458, col: 1, offset: 11122},
 			expr: &actionExpr{
-				pos: position{line: 451, col: 5, offset: 10953},
+				pos: position{line: 459, col: 5, offset: 11145},
 				run: (*parser).callonAdditiveExpression1,
 				expr: &seqExpr{
-					pos: position{line: 451, col: 5, offset: 10953},
+					pos: position{line: 459, col: 5, offset: 11145},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 451, col: 5, offset: 10953},
+							pos:   position{line: 459, col: 5, offset: 11145},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 451, col: 11, offset: 10959},
+								pos:  position{line: 459, col: 11, offset: 11151},
 								name: "MultiplicativeExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 452, col: 5, offset: 10988},
+							pos:   position{line: 460, col: 5, offset: 11180},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 452, col: 10, offset: 10993},
+								pos: position{line: 460, col: 10, offset: 11185},
 								expr: &seqExpr{
-									pos: position{line: 452, col: 11, offset: 10994},
+									pos: position{line: 460, col: 11, offset: 11186},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 11, offset: 10994},
+											pos:  position{line: 460, col: 11, offset: 11186},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 14, offset: 10997},
+											pos:  position{line: 460, col: 14, offset: 11189},
 											name: "AdditiveOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 31, offset: 11014},
+											pos:  position{line: 460, col: 31, offset: 11206},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 34, offset: 11017},
+											pos:  position{line: 460, col: 34, offset: 11209},
 											name: "MultiplicativeExpression",
 										},
 									},
@@ -3518,20 +3580,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 456, col: 1, offset: 11106},
+			pos:  position{line: 464, col: 1, offset: 11298},
 			expr: &actionExpr{
-				pos: position{line: 456, col: 20, offset: 11125},
+				pos: position{line: 464, col: 20, offset: 11317},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 456, col: 21, offset: 11126},
+					pos: position{line: 464, col: 21, offset: 11318},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 456, col: 21, offset: 11126},
+							pos:        position{line: 464, col: 21, offset: 11318},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 27, offset: 11132},
+							pos:        position{line: 464, col: 27, offset: 11324},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3541,50 +3603,50 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpression",
-			pos:  position{line: 458, col: 1, offset: 11169},
+			pos:  position{line: 466, col: 1, offset: 11361},
 			expr: &actionExpr{
-				pos: position{line: 459, col: 5, offset: 11198},
+				pos: position{line: 467, col: 5, offset: 11390},
 				run: (*parser).callonMultiplicativeExpression1,
 				expr: &seqExpr{
-					pos: position{line: 459, col: 5, offset: 11198},
+					pos: position{line: 467, col: 5, offset: 11390},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 459, col: 5, offset: 11198},
+							pos:   position{line: 467, col: 5, offset: 11390},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 459, col: 11, offset: 11204},
+								pos:  position{line: 467, col: 11, offset: 11396},
 								name: "NotExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 460, col: 5, offset: 11222},
+							pos:   position{line: 468, col: 5, offset: 11414},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 460, col: 10, offset: 11227},
+								pos: position{line: 468, col: 10, offset: 11419},
 								expr: &seqExpr{
-									pos: position{line: 460, col: 11, offset: 11228},
+									pos: position{line: 468, col: 11, offset: 11420},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 11, offset: 11228},
+											pos:  position{line: 468, col: 11, offset: 11420},
 											name: "__",
 										},
 										&labeledExpr{
-											pos:   position{line: 460, col: 14, offset: 11231},
+											pos:   position{line: 468, col: 14, offset: 11423},
 											label: "op",
 											expr: &ruleRefExpr{
-												pos:  position{line: 460, col: 17, offset: 11234},
+												pos:  position{line: 468, col: 17, offset: 11426},
 												name: "MultiplicativeOperator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 40, offset: 11257},
+											pos:  position{line: 468, col: 40, offset: 11449},
 											name: "__",
 										},
 										&labeledExpr{
-											pos:   position{line: 460, col: 43, offset: 11260},
+											pos:   position{line: 468, col: 43, offset: 11452},
 											label: "operand",
 											expr: &ruleRefExpr{
-												pos:  position{line: 460, col: 51, offset: 11268},
+												pos:  position{line: 468, col: 51, offset: 11460},
 												name: "NotExpression",
 											},
 										},
@@ -3598,20 +3660,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 464, col: 1, offset: 11346},
+			pos:  position{line: 472, col: 1, offset: 11538},
 			expr: &actionExpr{
-				pos: position{line: 464, col: 26, offset: 11371},
+				pos: position{line: 472, col: 26, offset: 11563},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 464, col: 27, offset: 11372},
+					pos: position{line: 472, col: 27, offset: 11564},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 464, col: 27, offset: 11372},
+							pos:        position{line: 472, col: 27, offset: 11564},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 464, col: 33, offset: 11378},
+							pos:        position{line: 472, col: 33, offset: 11570},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -3621,30 +3683,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpression",
-			pos:  position{line: 466, col: 1, offset: 11415},
+			pos:  position{line: 474, col: 1, offset: 11607},
 			expr: &choiceExpr{
-				pos: position{line: 467, col: 5, offset: 11433},
+				pos: position{line: 475, col: 5, offset: 11625},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 467, col: 5, offset: 11433},
+						pos: position{line: 475, col: 5, offset: 11625},
 						run: (*parser).callonNotExpression2,
 						expr: &seqExpr{
-							pos: position{line: 467, col: 5, offset: 11433},
+							pos: position{line: 475, col: 5, offset: 11625},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 467, col: 5, offset: 11433},
+									pos:        position{line: 475, col: 5, offset: 11625},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 467, col: 9, offset: 11437},
+									pos:  position{line: 475, col: 9, offset: 11629},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 467, col: 12, offset: 11440},
+									pos:   position{line: 475, col: 12, offset: 11632},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 467, col: 14, offset: 11442},
+										pos:  position{line: 475, col: 14, offset: 11634},
 										name: "NotExpression",
 									},
 								},
@@ -3652,7 +3714,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 470, col: 5, offset: 11510},
+						pos:  position{line: 478, col: 5, offset: 11702},
 						name: "CastExpression",
 					},
 				},
@@ -3660,50 +3722,50 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpression",
-			pos:  position{line: 472, col: 1, offset: 11526},
+			pos:  position{line: 480, col: 1, offset: 11718},
 			expr: &actionExpr{
-				pos: position{line: 473, col: 5, offset: 11545},
+				pos: position{line: 481, col: 5, offset: 11737},
 				run: (*parser).callonCastExpression1,
 				expr: &seqExpr{
-					pos: position{line: 473, col: 5, offset: 11545},
+					pos: position{line: 481, col: 5, offset: 11737},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 473, col: 5, offset: 11545},
+							pos:   position{line: 481, col: 5, offset: 11737},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 473, col: 7, offset: 11547},
+								pos:  position{line: 481, col: 7, offset: 11739},
 								name: "CallExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 473, col: 22, offset: 11562},
+							pos:   position{line: 481, col: 22, offset: 11754},
 							label: "t",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 473, col: 24, offset: 11564},
+								pos: position{line: 481, col: 24, offset: 11756},
 								expr: &actionExpr{
-									pos: position{line: 473, col: 25, offset: 11565},
+									pos: position{line: 481, col: 25, offset: 11757},
 									run: (*parser).callonCastExpression7,
 									expr: &seqExpr{
-										pos: position{line: 473, col: 25, offset: 11565},
+										pos: position{line: 481, col: 25, offset: 11757},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 473, col: 25, offset: 11565},
+												pos:  position{line: 481, col: 25, offset: 11757},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 473, col: 28, offset: 11568},
+												pos:        position{line: 481, col: 28, offset: 11760},
 												val:        ":",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 473, col: 32, offset: 11572},
+												pos:  position{line: 481, col: 32, offset: 11764},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 473, col: 35, offset: 11575},
+												pos:   position{line: 481, col: 35, offset: 11767},
 												label: "ct",
 												expr: &ruleRefExpr{
-													pos:  position{line: 473, col: 38, offset: 11578},
+													pos:  position{line: 481, col: 38, offset: 11770},
 													name: "ZngType",
 												},
 											},
@@ -3718,82 +3780,82 @@ var g = &grammar{
 		},
 		{
 			name: "ZngType",
-			pos:  position{line: 481, col: 1, offset: 11714},
+			pos:  position{line: 489, col: 1, offset: 11906},
 			expr: &choiceExpr{
-				pos: position{line: 482, col: 4, offset: 11725},
+				pos: position{line: 490, col: 4, offset: 11917},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 482, col: 4, offset: 11725},
+						pos:        position{line: 490, col: 4, offset: 11917},
 						val:        "bool",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 482, col: 13, offset: 11734},
+						pos:        position{line: 490, col: 13, offset: 11926},
 						val:        "byte",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 482, col: 22, offset: 11743},
+						pos:        position{line: 490, col: 22, offset: 11935},
 						val:        "int16",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 482, col: 32, offset: 11753},
+						pos:        position{line: 490, col: 32, offset: 11945},
 						val:        "uint16",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 482, col: 43, offset: 11764},
+						pos:        position{line: 490, col: 43, offset: 11956},
 						val:        "int32",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 482, col: 53, offset: 11774},
+						pos:        position{line: 490, col: 53, offset: 11966},
 						val:        "uint32",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 483, col: 4, offset: 11786},
+						pos:        position{line: 491, col: 4, offset: 11978},
 						val:        "int64",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 483, col: 14, offset: 11796},
+						pos:        position{line: 491, col: 14, offset: 11988},
 						val:        "uint64",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 483, col: 25, offset: 11807},
+						pos:        position{line: 491, col: 25, offset: 11999},
 						val:        "float64",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 483, col: 37, offset: 11819},
+						pos:        position{line: 491, col: 37, offset: 12011},
 						val:        "string",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 483, col: 48, offset: 11830},
+						pos:        position{line: 491, col: 48, offset: 12022},
 						val:        "bstring",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 484, col: 4, offset: 11843},
+						pos:        position{line: 492, col: 4, offset: 12035},
 						val:        "ip",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 484, col: 11, offset: 11850},
+						pos:        position{line: 492, col: 11, offset: 12042},
 						val:        "net",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 484, col: 19, offset: 11858},
+						pos:        position{line: 492, col: 19, offset: 12050},
 						val:        "time",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 484, col: 28, offset: 11867},
+						pos:        position{line: 492, col: 28, offset: 12059},
 						val:        "duration",
 						ignoreCase: false,
 					},
@@ -3802,43 +3864,43 @@ var g = &grammar{
 		},
 		{
 			name: "CallExpression",
-			pos:  position{line: 486, col: 1, offset: 11879},
+			pos:  position{line: 494, col: 1, offset: 12071},
 			expr: &choiceExpr{
-				pos: position{line: 487, col: 5, offset: 11898},
+				pos: position{line: 495, col: 5, offset: 12090},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 487, col: 5, offset: 11898},
+						pos: position{line: 495, col: 5, offset: 12090},
 						run: (*parser).callonCallExpression2,
 						expr: &seqExpr{
-							pos: position{line: 487, col: 5, offset: 11898},
+							pos: position{line: 495, col: 5, offset: 12090},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 487, col: 5, offset: 11898},
+									pos:   position{line: 495, col: 5, offset: 12090},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 487, col: 8, offset: 11901},
+										pos:  position{line: 495, col: 8, offset: 12093},
 										name: "FunctionName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 487, col: 21, offset: 11914},
+									pos:  position{line: 495, col: 21, offset: 12106},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 487, col: 24, offset: 11917},
+									pos:        position{line: 495, col: 24, offset: 12109},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 487, col: 28, offset: 11921},
+									pos:   position{line: 495, col: 28, offset: 12113},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 487, col: 33, offset: 11926},
+										pos:  position{line: 495, col: 33, offset: 12118},
 										name: "ArgumentList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 487, col: 46, offset: 11939},
+									pos:        position{line: 495, col: 46, offset: 12131},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3846,7 +3908,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 490, col: 5, offset: 12002},
+						pos:  position{line: 498, col: 5, offset: 12194},
 						name: "DereferenceExpression",
 					},
 				},
@@ -3854,21 +3916,21 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionName",
-			pos:  position{line: 492, col: 1, offset: 12025},
+			pos:  position{line: 500, col: 1, offset: 12217},
 			expr: &actionExpr{
-				pos: position{line: 493, col: 5, offset: 12042},
+				pos: position{line: 501, col: 5, offset: 12234},
 				run: (*parser).callonFunctionName1,
 				expr: &seqExpr{
-					pos: position{line: 493, col: 5, offset: 12042},
+					pos: position{line: 501, col: 5, offset: 12234},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 493, col: 5, offset: 12042},
+							pos:  position{line: 501, col: 5, offset: 12234},
 							name: "FunctionNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 493, col: 23, offset: 12060},
+							pos: position{line: 501, col: 23, offset: 12252},
 							expr: &ruleRefExpr{
-								pos:  position{line: 493, col: 23, offset: 12060},
+								pos:  position{line: 501, col: 23, offset: 12252},
 								name: "FunctionNameRest",
 							},
 						},
@@ -3878,9 +3940,9 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionNameStart",
-			pos:  position{line: 495, col: 1, offset: 12110},
+			pos:  position{line: 503, col: 1, offset: 12302},
 			expr: &charClassMatcher{
-				pos:        position{line: 495, col: 21, offset: 12130},
+				pos:        position{line: 503, col: 21, offset: 12322},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -3889,16 +3951,16 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionNameRest",
-			pos:  position{line: 496, col: 1, offset: 12139},
+			pos:  position{line: 504, col: 1, offset: 12331},
 			expr: &choiceExpr{
-				pos: position{line: 496, col: 20, offset: 12158},
+				pos: position{line: 504, col: 20, offset: 12350},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 496, col: 20, offset: 12158},
+						pos:  position{line: 504, col: 20, offset: 12350},
 						name: "FunctionNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 496, col: 40, offset: 12178},
+						pos:        position{line: 504, col: 40, offset: 12370},
 						val:        "[.0-9]",
 						chars:      []rune{'.'},
 						ranges:     []rune{'0', '9'},
@@ -3910,53 +3972,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 498, col: 1, offset: 12186},
+			pos:  position{line: 506, col: 1, offset: 12378},
 			expr: &choiceExpr{
-				pos: position{line: 499, col: 5, offset: 12203},
+				pos: position{line: 507, col: 5, offset: 12395},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 499, col: 5, offset: 12203},
+						pos: position{line: 507, col: 5, offset: 12395},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 499, col: 5, offset: 12203},
+							pos: position{line: 507, col: 5, offset: 12395},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 499, col: 5, offset: 12203},
+									pos:   position{line: 507, col: 5, offset: 12395},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 499, col: 11, offset: 12209},
+										pos:  position{line: 507, col: 11, offset: 12401},
 										name: "Expression",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 499, col: 22, offset: 12220},
+									pos:   position{line: 507, col: 22, offset: 12412},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 499, col: 27, offset: 12225},
+										pos: position{line: 507, col: 27, offset: 12417},
 										expr: &actionExpr{
-											pos: position{line: 499, col: 28, offset: 12226},
+											pos: position{line: 507, col: 28, offset: 12418},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 499, col: 28, offset: 12226},
+												pos: position{line: 507, col: 28, offset: 12418},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 499, col: 28, offset: 12226},
+														pos:  position{line: 507, col: 28, offset: 12418},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 499, col: 31, offset: 12229},
+														pos:        position{line: 507, col: 31, offset: 12421},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 499, col: 35, offset: 12233},
+														pos:  position{line: 507, col: 35, offset: 12425},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 499, col: 38, offset: 12236},
+														pos:   position{line: 507, col: 38, offset: 12428},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 499, col: 40, offset: 12238},
+															pos:  position{line: 507, col: 40, offset: 12430},
 															name: "Expression",
 														},
 													},
@@ -3969,10 +4031,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 502, col: 5, offset: 12354},
+						pos: position{line: 510, col: 5, offset: 12546},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 502, col: 5, offset: 12354},
+							pos:  position{line: 510, col: 5, offset: 12546},
 							name: "__",
 						},
 					},
@@ -3981,88 +4043,88 @@ var g = &grammar{
 		},
 		{
 			name: "DereferenceExpression",
-			pos:  position{line: 504, col: 1, offset: 12390},
+			pos:  position{line: 512, col: 1, offset: 12582},
 			expr: &actionExpr{
-				pos: position{line: 505, col: 5, offset: 12416},
+				pos: position{line: 513, col: 5, offset: 12608},
 				run: (*parser).callonDereferenceExpression1,
 				expr: &seqExpr{
-					pos: position{line: 505, col: 5, offset: 12416},
+					pos: position{line: 513, col: 5, offset: 12608},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 505, col: 5, offset: 12416},
+							pos:   position{line: 513, col: 5, offset: 12608},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 505, col: 10, offset: 12421},
+								pos:  position{line: 513, col: 10, offset: 12613},
 								name: "PrimaryExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 506, col: 5, offset: 12443},
+							pos:   position{line: 514, col: 5, offset: 12635},
 							label: "derefs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 506, col: 12, offset: 12450},
+								pos: position{line: 514, col: 12, offset: 12642},
 								expr: &choiceExpr{
-									pos: position{line: 507, col: 9, offset: 12460},
+									pos: position{line: 515, col: 9, offset: 12652},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 507, col: 9, offset: 12460},
+											pos: position{line: 515, col: 9, offset: 12652},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 507, col: 9, offset: 12460},
+													pos:  position{line: 515, col: 9, offset: 12652},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 507, col: 12, offset: 12463},
+													pos:        position{line: 515, col: 12, offset: 12655},
 													val:        "[",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 507, col: 16, offset: 12467},
+													pos:  position{line: 515, col: 16, offset: 12659},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 507, col: 19, offset: 12470},
+													pos:   position{line: 515, col: 19, offset: 12662},
 													label: "index",
 													expr: &ruleRefExpr{
-														pos:  position{line: 507, col: 25, offset: 12476},
+														pos:  position{line: 515, col: 25, offset: 12668},
 														name: "Expression",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 507, col: 36, offset: 12487},
+													pos:  position{line: 515, col: 36, offset: 12679},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 507, col: 39, offset: 12490},
+													pos:        position{line: 515, col: 39, offset: 12682},
 													val:        "]",
 													ignoreCase: false,
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 508, col: 9, offset: 12502},
+											pos: position{line: 516, col: 9, offset: 12694},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 508, col: 9, offset: 12502},
+													pos:  position{line: 516, col: 9, offset: 12694},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 508, col: 12, offset: 12505},
+													pos:        position{line: 516, col: 12, offset: 12697},
 													val:        ".",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 508, col: 16, offset: 12509},
+													pos:  position{line: 516, col: 16, offset: 12701},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 508, col: 20, offset: 12513},
+													pos: position{line: 516, col: 20, offset: 12705},
 													run: (*parser).callonDereferenceExpression20,
 													expr: &labeledExpr{
-														pos:   position{line: 508, col: 20, offset: 12513},
+														pos:   position{line: 516, col: 20, offset: 12705},
 														label: "field",
 														expr: &ruleRefExpr{
-															pos:  position{line: 508, col: 26, offset: 12519},
+															pos:  position{line: 516, col: 26, offset: 12711},
 															name: "fieldName",
 														},
 													},
@@ -4079,54 +4141,54 @@ var g = &grammar{
 		},
 		{
 			name: "duration",
-			pos:  position{line: 513, col: 1, offset: 12654},
+			pos:  position{line: 521, col: 1, offset: 12846},
 			expr: &choiceExpr{
-				pos: position{line: 514, col: 5, offset: 12667},
+				pos: position{line: 522, col: 5, offset: 12859},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 514, col: 5, offset: 12667},
+						pos:  position{line: 522, col: 5, offset: 12859},
 						name: "seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 515, col: 5, offset: 12679},
+						pos:  position{line: 523, col: 5, offset: 12871},
 						name: "minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 516, col: 5, offset: 12691},
+						pos:  position{line: 524, col: 5, offset: 12883},
 						name: "hours",
 					},
 					&seqExpr{
-						pos: position{line: 517, col: 5, offset: 12701},
+						pos: position{line: 525, col: 5, offset: 12893},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 517, col: 5, offset: 12701},
+								pos:  position{line: 525, col: 5, offset: 12893},
 								name: "hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 517, col: 11, offset: 12707},
+								pos:  position{line: 525, col: 11, offset: 12899},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 517, col: 13, offset: 12709},
+								pos:        position{line: 525, col: 13, offset: 12901},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 517, col: 19, offset: 12715},
+								pos:  position{line: 525, col: 19, offset: 12907},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 517, col: 21, offset: 12717},
+								pos:  position{line: 525, col: 21, offset: 12909},
 								name: "minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 518, col: 5, offset: 12729},
+						pos:  position{line: 526, col: 5, offset: 12921},
 						name: "days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 519, col: 5, offset: 12738},
+						pos:  position{line: 527, col: 5, offset: 12930},
 						name: "weeks",
 					},
 				},
@@ -4134,32 +4196,32 @@ var g = &grammar{
 		},
 		{
 			name: "sec_abbrev",
-			pos:  position{line: 521, col: 1, offset: 12745},
+			pos:  position{line: 529, col: 1, offset: 12937},
 			expr: &choiceExpr{
-				pos: position{line: 522, col: 5, offset: 12760},
+				pos: position{line: 530, col: 5, offset: 12952},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 522, col: 5, offset: 12760},
+						pos:        position{line: 530, col: 5, offset: 12952},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 523, col: 5, offset: 12774},
+						pos:        position{line: 531, col: 5, offset: 12966},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 524, col: 5, offset: 12787},
+						pos:        position{line: 532, col: 5, offset: 12979},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 525, col: 5, offset: 12798},
+						pos:        position{line: 533, col: 5, offset: 12990},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 526, col: 5, offset: 12808},
+						pos:        position{line: 534, col: 5, offset: 13000},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -4168,32 +4230,32 @@ var g = &grammar{
 		},
 		{
 			name: "min_abbrev",
-			pos:  position{line: 528, col: 1, offset: 12813},
+			pos:  position{line: 536, col: 1, offset: 13005},
 			expr: &choiceExpr{
-				pos: position{line: 529, col: 5, offset: 12828},
+				pos: position{line: 537, col: 5, offset: 13020},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 529, col: 5, offset: 12828},
+						pos:        position{line: 537, col: 5, offset: 13020},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 530, col: 5, offset: 12842},
+						pos:        position{line: 538, col: 5, offset: 13034},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 531, col: 5, offset: 12855},
+						pos:        position{line: 539, col: 5, offset: 13047},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 532, col: 5, offset: 12866},
+						pos:        position{line: 540, col: 5, offset: 13058},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 533, col: 5, offset: 12876},
+						pos:        position{line: 541, col: 5, offset: 13068},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -4202,32 +4264,32 @@ var g = &grammar{
 		},
 		{
 			name: "hour_abbrev",
-			pos:  position{line: 535, col: 1, offset: 12881},
+			pos:  position{line: 543, col: 1, offset: 13073},
 			expr: &choiceExpr{
-				pos: position{line: 536, col: 5, offset: 12897},
+				pos: position{line: 544, col: 5, offset: 13089},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 536, col: 5, offset: 12897},
+						pos:        position{line: 544, col: 5, offset: 13089},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 537, col: 5, offset: 12909},
+						pos:        position{line: 545, col: 5, offset: 13101},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 538, col: 5, offset: 12919},
+						pos:        position{line: 546, col: 5, offset: 13111},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 539, col: 5, offset: 12928},
+						pos:        position{line: 547, col: 5, offset: 13120},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 540, col: 5, offset: 12936},
+						pos:        position{line: 548, col: 5, offset: 13128},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -4236,22 +4298,22 @@ var g = &grammar{
 		},
 		{
 			name: "day_abbrev",
-			pos:  position{line: 542, col: 1, offset: 12944},
+			pos:  position{line: 550, col: 1, offset: 13136},
 			expr: &choiceExpr{
-				pos: position{line: 542, col: 14, offset: 12957},
+				pos: position{line: 550, col: 14, offset: 13149},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 542, col: 14, offset: 12957},
+						pos:        position{line: 550, col: 14, offset: 13149},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 542, col: 21, offset: 12964},
+						pos:        position{line: 550, col: 21, offset: 13156},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 542, col: 27, offset: 12970},
+						pos:        position{line: 550, col: 27, offset: 13162},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -4260,32 +4322,32 @@ var g = &grammar{
 		},
 		{
 			name: "week_abbrev",
-			pos:  position{line: 543, col: 1, offset: 12974},
+			pos:  position{line: 551, col: 1, offset: 13166},
 			expr: &choiceExpr{
-				pos: position{line: 543, col: 15, offset: 12988},
+				pos: position{line: 551, col: 15, offset: 13180},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 543, col: 15, offset: 12988},
+						pos:        position{line: 551, col: 15, offset: 13180},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 543, col: 23, offset: 12996},
+						pos:        position{line: 551, col: 23, offset: 13188},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 543, col: 30, offset: 13003},
+						pos:        position{line: 551, col: 30, offset: 13195},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 543, col: 36, offset: 13009},
+						pos:        position{line: 551, col: 36, offset: 13201},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 543, col: 41, offset: 13014},
+						pos:        position{line: 551, col: 41, offset: 13206},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -4294,42 +4356,42 @@ var g = &grammar{
 		},
 		{
 			name: "seconds",
-			pos:  position{line: 545, col: 1, offset: 13019},
+			pos:  position{line: 553, col: 1, offset: 13211},
 			expr: &choiceExpr{
-				pos: position{line: 546, col: 5, offset: 13031},
+				pos: position{line: 554, col: 5, offset: 13223},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 546, col: 5, offset: 13031},
+						pos: position{line: 554, col: 5, offset: 13223},
 						run: (*parser).callonseconds2,
 						expr: &litMatcher{
-							pos:        position{line: 546, col: 5, offset: 13031},
+							pos:        position{line: 554, col: 5, offset: 13223},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 547, col: 5, offset: 13076},
+						pos: position{line: 555, col: 5, offset: 13268},
 						run: (*parser).callonseconds4,
 						expr: &seqExpr{
-							pos: position{line: 547, col: 5, offset: 13076},
+							pos: position{line: 555, col: 5, offset: 13268},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 547, col: 5, offset: 13076},
+									pos:   position{line: 555, col: 5, offset: 13268},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 547, col: 9, offset: 13080},
+										pos:  position{line: 555, col: 9, offset: 13272},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 547, col: 16, offset: 13087},
+									pos: position{line: 555, col: 16, offset: 13279},
 									expr: &ruleRefExpr{
-										pos:  position{line: 547, col: 16, offset: 13087},
+										pos:  position{line: 555, col: 16, offset: 13279},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 547, col: 19, offset: 13090},
+									pos:  position{line: 555, col: 19, offset: 13282},
 									name: "sec_abbrev",
 								},
 							},
@@ -4340,42 +4402,42 @@ var g = &grammar{
 		},
 		{
 			name: "minutes",
-			pos:  position{line: 549, col: 1, offset: 13136},
+			pos:  position{line: 557, col: 1, offset: 13328},
 			expr: &choiceExpr{
-				pos: position{line: 550, col: 5, offset: 13148},
+				pos: position{line: 558, col: 5, offset: 13340},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 550, col: 5, offset: 13148},
+						pos: position{line: 558, col: 5, offset: 13340},
 						run: (*parser).callonminutes2,
 						expr: &litMatcher{
-							pos:        position{line: 550, col: 5, offset: 13148},
+							pos:        position{line: 558, col: 5, offset: 13340},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 551, col: 5, offset: 13194},
+						pos: position{line: 559, col: 5, offset: 13386},
 						run: (*parser).callonminutes4,
 						expr: &seqExpr{
-							pos: position{line: 551, col: 5, offset: 13194},
+							pos: position{line: 559, col: 5, offset: 13386},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 551, col: 5, offset: 13194},
+									pos:   position{line: 559, col: 5, offset: 13386},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 551, col: 9, offset: 13198},
+										pos:  position{line: 559, col: 9, offset: 13390},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 551, col: 16, offset: 13205},
+									pos: position{line: 559, col: 16, offset: 13397},
 									expr: &ruleRefExpr{
-										pos:  position{line: 551, col: 16, offset: 13205},
+										pos:  position{line: 559, col: 16, offset: 13397},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 551, col: 19, offset: 13208},
+									pos:  position{line: 559, col: 19, offset: 13400},
 									name: "min_abbrev",
 								},
 							},
@@ -4386,42 +4448,42 @@ var g = &grammar{
 		},
 		{
 			name: "hours",
-			pos:  position{line: 553, col: 1, offset: 13263},
+			pos:  position{line: 561, col: 1, offset: 13455},
 			expr: &choiceExpr{
-				pos: position{line: 554, col: 5, offset: 13273},
+				pos: position{line: 562, col: 5, offset: 13465},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 554, col: 5, offset: 13273},
+						pos: position{line: 562, col: 5, offset: 13465},
 						run: (*parser).callonhours2,
 						expr: &litMatcher{
-							pos:        position{line: 554, col: 5, offset: 13273},
+							pos:        position{line: 562, col: 5, offset: 13465},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 555, col: 5, offset: 13319},
+						pos: position{line: 563, col: 5, offset: 13511},
 						run: (*parser).callonhours4,
 						expr: &seqExpr{
-							pos: position{line: 555, col: 5, offset: 13319},
+							pos: position{line: 563, col: 5, offset: 13511},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 555, col: 5, offset: 13319},
+									pos:   position{line: 563, col: 5, offset: 13511},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 555, col: 9, offset: 13323},
+										pos:  position{line: 563, col: 9, offset: 13515},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 555, col: 16, offset: 13330},
+									pos: position{line: 563, col: 16, offset: 13522},
 									expr: &ruleRefExpr{
-										pos:  position{line: 555, col: 16, offset: 13330},
+										pos:  position{line: 563, col: 16, offset: 13522},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 555, col: 19, offset: 13333},
+									pos:  position{line: 563, col: 19, offset: 13525},
 									name: "hour_abbrev",
 								},
 							},
@@ -4432,42 +4494,42 @@ var g = &grammar{
 		},
 		{
 			name: "days",
-			pos:  position{line: 557, col: 1, offset: 13391},
+			pos:  position{line: 565, col: 1, offset: 13583},
 			expr: &choiceExpr{
-				pos: position{line: 558, col: 5, offset: 13400},
+				pos: position{line: 566, col: 5, offset: 13592},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 558, col: 5, offset: 13400},
+						pos: position{line: 566, col: 5, offset: 13592},
 						run: (*parser).callondays2,
 						expr: &litMatcher{
-							pos:        position{line: 558, col: 5, offset: 13400},
+							pos:        position{line: 566, col: 5, offset: 13592},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 559, col: 5, offset: 13448},
+						pos: position{line: 567, col: 5, offset: 13640},
 						run: (*parser).callondays4,
 						expr: &seqExpr{
-							pos: position{line: 559, col: 5, offset: 13448},
+							pos: position{line: 567, col: 5, offset: 13640},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 559, col: 5, offset: 13448},
+									pos:   position{line: 567, col: 5, offset: 13640},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 559, col: 9, offset: 13452},
+										pos:  position{line: 567, col: 9, offset: 13644},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 559, col: 16, offset: 13459},
+									pos: position{line: 567, col: 16, offset: 13651},
 									expr: &ruleRefExpr{
-										pos:  position{line: 559, col: 16, offset: 13459},
+										pos:  position{line: 567, col: 16, offset: 13651},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 559, col: 19, offset: 13462},
+									pos:  position{line: 567, col: 19, offset: 13654},
 									name: "day_abbrev",
 								},
 							},
@@ -4478,30 +4540,30 @@ var g = &grammar{
 		},
 		{
 			name: "weeks",
-			pos:  position{line: 561, col: 1, offset: 13522},
+			pos:  position{line: 569, col: 1, offset: 13714},
 			expr: &actionExpr{
-				pos: position{line: 562, col: 5, offset: 13532},
+				pos: position{line: 570, col: 5, offset: 13724},
 				run: (*parser).callonweeks1,
 				expr: &seqExpr{
-					pos: position{line: 562, col: 5, offset: 13532},
+					pos: position{line: 570, col: 5, offset: 13724},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 562, col: 5, offset: 13532},
+							pos:   position{line: 570, col: 5, offset: 13724},
 							label: "num",
 							expr: &ruleRefExpr{
-								pos:  position{line: 562, col: 9, offset: 13536},
+								pos:  position{line: 570, col: 9, offset: 13728},
 								name: "number",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 562, col: 16, offset: 13543},
+							pos: position{line: 570, col: 16, offset: 13735},
 							expr: &ruleRefExpr{
-								pos:  position{line: 562, col: 16, offset: 13543},
+								pos:  position{line: 570, col: 16, offset: 13735},
 								name: "_",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 562, col: 19, offset: 13546},
+							pos:  position{line: 570, col: 19, offset: 13738},
 							name: "week_abbrev",
 						},
 					},
@@ -4510,53 +4572,53 @@ var g = &grammar{
 		},
 		{
 			name: "number",
-			pos:  position{line: 564, col: 1, offset: 13609},
+			pos:  position{line: 572, col: 1, offset: 13801},
 			expr: &ruleRefExpr{
-				pos:  position{line: 564, col: 10, offset: 13618},
+				pos:  position{line: 572, col: 10, offset: 13810},
 				name: "unsignedInteger",
 			},
 		},
 		{
 			name: "addr",
-			pos:  position{line: 568, col: 1, offset: 13664},
+			pos:  position{line: 576, col: 1, offset: 13856},
 			expr: &actionExpr{
-				pos: position{line: 569, col: 5, offset: 13673},
+				pos: position{line: 577, col: 5, offset: 13865},
 				run: (*parser).callonaddr1,
 				expr: &labeledExpr{
-					pos:   position{line: 569, col: 5, offset: 13673},
+					pos:   position{line: 577, col: 5, offset: 13865},
 					label: "a",
 					expr: &seqExpr{
-						pos: position{line: 569, col: 8, offset: 13676},
+						pos: position{line: 577, col: 8, offset: 13868},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 569, col: 8, offset: 13676},
+								pos:  position{line: 577, col: 8, offset: 13868},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 569, col: 24, offset: 13692},
+								pos:        position{line: 577, col: 24, offset: 13884},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 569, col: 28, offset: 13696},
+								pos:  position{line: 577, col: 28, offset: 13888},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 569, col: 44, offset: 13712},
+								pos:        position{line: 577, col: 44, offset: 13904},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 569, col: 48, offset: 13716},
+								pos:  position{line: 577, col: 48, offset: 13908},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 569, col: 64, offset: 13732},
+								pos:        position{line: 577, col: 64, offset: 13924},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 569, col: 68, offset: 13736},
+								pos:  position{line: 577, col: 68, offset: 13928},
 								name: "unsignedInteger",
 							},
 						},
@@ -4566,23 +4628,23 @@ var g = &grammar{
 		},
 		{
 			name: "port",
-			pos:  position{line: 571, col: 1, offset: 13785},
+			pos:  position{line: 579, col: 1, offset: 13977},
 			expr: &actionExpr{
-				pos: position{line: 572, col: 5, offset: 13794},
+				pos: position{line: 580, col: 5, offset: 13986},
 				run: (*parser).callonport1,
 				expr: &seqExpr{
-					pos: position{line: 572, col: 5, offset: 13794},
+					pos: position{line: 580, col: 5, offset: 13986},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 572, col: 5, offset: 13794},
+							pos:        position{line: 580, col: 5, offset: 13986},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 572, col: 9, offset: 13798},
+							pos:   position{line: 580, col: 9, offset: 13990},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 572, col: 11, offset: 13800},
+								pos:  position{line: 580, col: 11, offset: 13992},
 								name: "suint",
 							},
 						},
@@ -4592,32 +4654,32 @@ var g = &grammar{
 		},
 		{
 			name: "ip6addr",
-			pos:  position{line: 576, col: 1, offset: 13956},
+			pos:  position{line: 584, col: 1, offset: 14148},
 			expr: &choiceExpr{
-				pos: position{line: 577, col: 5, offset: 13968},
+				pos: position{line: 585, col: 5, offset: 14160},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 577, col: 5, offset: 13968},
+						pos: position{line: 585, col: 5, offset: 14160},
 						run: (*parser).callonip6addr2,
 						expr: &seqExpr{
-							pos: position{line: 577, col: 5, offset: 13968},
+							pos: position{line: 585, col: 5, offset: 14160},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 577, col: 5, offset: 13968},
+									pos:   position{line: 585, col: 5, offset: 14160},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 577, col: 7, offset: 13970},
+										pos: position{line: 585, col: 7, offset: 14162},
 										expr: &ruleRefExpr{
-											pos:  position{line: 577, col: 8, offset: 13971},
+											pos:  position{line: 585, col: 8, offset: 14163},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 577, col: 20, offset: 13983},
+									pos:   position{line: 585, col: 20, offset: 14175},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 577, col: 22, offset: 13985},
+										pos:  position{line: 585, col: 22, offset: 14177},
 										name: "ip6tail",
 									},
 								},
@@ -4625,51 +4687,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 580, col: 5, offset: 14049},
+						pos: position{line: 588, col: 5, offset: 14241},
 						run: (*parser).callonip6addr9,
 						expr: &seqExpr{
-							pos: position{line: 580, col: 5, offset: 14049},
+							pos: position{line: 588, col: 5, offset: 14241},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 580, col: 5, offset: 14049},
+									pos:   position{line: 588, col: 5, offset: 14241},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 580, col: 7, offset: 14051},
+										pos:  position{line: 588, col: 7, offset: 14243},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 580, col: 11, offset: 14055},
+									pos:   position{line: 588, col: 11, offset: 14247},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 580, col: 13, offset: 14057},
+										pos: position{line: 588, col: 13, offset: 14249},
 										expr: &ruleRefExpr{
-											pos:  position{line: 580, col: 14, offset: 14058},
+											pos:  position{line: 588, col: 14, offset: 14250},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 580, col: 25, offset: 14069},
+									pos:        position{line: 588, col: 25, offset: 14261},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 580, col: 30, offset: 14074},
+									pos:   position{line: 588, col: 30, offset: 14266},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 580, col: 32, offset: 14076},
+										pos: position{line: 588, col: 32, offset: 14268},
 										expr: &ruleRefExpr{
-											pos:  position{line: 580, col: 33, offset: 14077},
+											pos:  position{line: 588, col: 33, offset: 14269},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 580, col: 45, offset: 14089},
+									pos:   position{line: 588, col: 45, offset: 14281},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 580, col: 47, offset: 14091},
+										pos:  position{line: 588, col: 47, offset: 14283},
 										name: "ip6tail",
 									},
 								},
@@ -4677,32 +4739,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 583, col: 5, offset: 14190},
+						pos: position{line: 591, col: 5, offset: 14382},
 						run: (*parser).callonip6addr22,
 						expr: &seqExpr{
-							pos: position{line: 583, col: 5, offset: 14190},
+							pos: position{line: 591, col: 5, offset: 14382},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 583, col: 5, offset: 14190},
+									pos:        position{line: 591, col: 5, offset: 14382},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 583, col: 10, offset: 14195},
+									pos:   position{line: 591, col: 10, offset: 14387},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 583, col: 12, offset: 14197},
+										pos: position{line: 591, col: 12, offset: 14389},
 										expr: &ruleRefExpr{
-											pos:  position{line: 583, col: 13, offset: 14198},
+											pos:  position{line: 591, col: 13, offset: 14390},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 583, col: 25, offset: 14210},
+									pos:   position{line: 591, col: 25, offset: 14402},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 583, col: 27, offset: 14212},
+										pos:  position{line: 591, col: 27, offset: 14404},
 										name: "ip6tail",
 									},
 								},
@@ -4710,32 +4772,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 586, col: 5, offset: 14283},
+						pos: position{line: 594, col: 5, offset: 14475},
 						run: (*parser).callonip6addr30,
 						expr: &seqExpr{
-							pos: position{line: 586, col: 5, offset: 14283},
+							pos: position{line: 594, col: 5, offset: 14475},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 586, col: 5, offset: 14283},
+									pos:   position{line: 594, col: 5, offset: 14475},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 586, col: 7, offset: 14285},
+										pos:  position{line: 594, col: 7, offset: 14477},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 586, col: 11, offset: 14289},
+									pos:   position{line: 594, col: 11, offset: 14481},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 586, col: 13, offset: 14291},
+										pos: position{line: 594, col: 13, offset: 14483},
 										expr: &ruleRefExpr{
-											pos:  position{line: 586, col: 14, offset: 14292},
+											pos:  position{line: 594, col: 14, offset: 14484},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 586, col: 25, offset: 14303},
+									pos:        position{line: 594, col: 25, offset: 14495},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -4743,10 +4805,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 589, col: 5, offset: 14371},
+						pos: position{line: 597, col: 5, offset: 14563},
 						run: (*parser).callonip6addr38,
 						expr: &litMatcher{
-							pos:        position{line: 589, col: 5, offset: 14371},
+							pos:        position{line: 597, col: 5, offset: 14563},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -4756,16 +4818,16 @@ var g = &grammar{
 		},
 		{
 			name: "ip6tail",
-			pos:  position{line: 593, col: 1, offset: 14408},
+			pos:  position{line: 601, col: 1, offset: 14600},
 			expr: &choiceExpr{
-				pos: position{line: 594, col: 5, offset: 14420},
+				pos: position{line: 602, col: 5, offset: 14612},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 594, col: 5, offset: 14420},
+						pos:  position{line: 602, col: 5, offset: 14612},
 						name: "addr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 595, col: 5, offset: 14429},
+						pos:  position{line: 603, col: 5, offset: 14621},
 						name: "h16",
 					},
 				},
@@ -4773,23 +4835,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_append",
-			pos:  position{line: 597, col: 1, offset: 14434},
+			pos:  position{line: 605, col: 1, offset: 14626},
 			expr: &actionExpr{
-				pos: position{line: 597, col: 12, offset: 14445},
+				pos: position{line: 605, col: 12, offset: 14637},
 				run: (*parser).callonh_append1,
 				expr: &seqExpr{
-					pos: position{line: 597, col: 12, offset: 14445},
+					pos: position{line: 605, col: 12, offset: 14637},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 597, col: 12, offset: 14445},
+							pos:        position{line: 605, col: 12, offset: 14637},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 597, col: 16, offset: 14449},
+							pos:   position{line: 605, col: 16, offset: 14641},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 597, col: 18, offset: 14451},
+								pos:  position{line: 605, col: 18, offset: 14643},
 								name: "h16",
 							},
 						},
@@ -4799,23 +4861,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_prepend",
-			pos:  position{line: 598, col: 1, offset: 14488},
+			pos:  position{line: 606, col: 1, offset: 14680},
 			expr: &actionExpr{
-				pos: position{line: 598, col: 13, offset: 14500},
+				pos: position{line: 606, col: 13, offset: 14692},
 				run: (*parser).callonh_prepend1,
 				expr: &seqExpr{
-					pos: position{line: 598, col: 13, offset: 14500},
+					pos: position{line: 606, col: 13, offset: 14692},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 598, col: 13, offset: 14500},
+							pos:   position{line: 606, col: 13, offset: 14692},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 598, col: 15, offset: 14502},
+								pos:  position{line: 606, col: 15, offset: 14694},
 								name: "h16",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 598, col: 19, offset: 14506},
+							pos:        position{line: 606, col: 19, offset: 14698},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -4825,31 +4887,31 @@ var g = &grammar{
 		},
 		{
 			name: "subnet",
-			pos:  position{line: 600, col: 1, offset: 14544},
+			pos:  position{line: 608, col: 1, offset: 14736},
 			expr: &actionExpr{
-				pos: position{line: 601, col: 5, offset: 14555},
+				pos: position{line: 609, col: 5, offset: 14747},
 				run: (*parser).callonsubnet1,
 				expr: &seqExpr{
-					pos: position{line: 601, col: 5, offset: 14555},
+					pos: position{line: 609, col: 5, offset: 14747},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 601, col: 5, offset: 14555},
+							pos:   position{line: 609, col: 5, offset: 14747},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 601, col: 7, offset: 14557},
+								pos:  position{line: 609, col: 7, offset: 14749},
 								name: "addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 601, col: 12, offset: 14562},
+							pos:        position{line: 609, col: 12, offset: 14754},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 601, col: 16, offset: 14566},
+							pos:   position{line: 609, col: 16, offset: 14758},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 601, col: 18, offset: 14568},
+								pos:  position{line: 609, col: 18, offset: 14760},
 								name: "unsignedInteger",
 							},
 						},
@@ -4859,31 +4921,31 @@ var g = &grammar{
 		},
 		{
 			name: "ip6subnet",
-			pos:  position{line: 605, col: 1, offset: 14652},
+			pos:  position{line: 613, col: 1, offset: 14844},
 			expr: &actionExpr{
-				pos: position{line: 606, col: 5, offset: 14666},
+				pos: position{line: 614, col: 5, offset: 14858},
 				run: (*parser).callonip6subnet1,
 				expr: &seqExpr{
-					pos: position{line: 606, col: 5, offset: 14666},
+					pos: position{line: 614, col: 5, offset: 14858},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 606, col: 5, offset: 14666},
+							pos:   position{line: 614, col: 5, offset: 14858},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 606, col: 7, offset: 14668},
+								pos:  position{line: 614, col: 7, offset: 14860},
 								name: "ip6addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 606, col: 15, offset: 14676},
+							pos:        position{line: 614, col: 15, offset: 14868},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 606, col: 19, offset: 14680},
+							pos:   position{line: 614, col: 19, offset: 14872},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 606, col: 21, offset: 14682},
+								pos:  position{line: 614, col: 21, offset: 14874},
 								name: "unsignedInteger",
 							},
 						},
@@ -4893,15 +4955,15 @@ var g = &grammar{
 		},
 		{
 			name: "unsignedInteger",
-			pos:  position{line: 610, col: 1, offset: 14756},
+			pos:  position{line: 618, col: 1, offset: 14948},
 			expr: &actionExpr{
-				pos: position{line: 611, col: 5, offset: 14776},
+				pos: position{line: 619, col: 5, offset: 14968},
 				run: (*parser).callonunsignedInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 611, col: 5, offset: 14776},
+					pos:   position{line: 619, col: 5, offset: 14968},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 611, col: 7, offset: 14778},
+						pos:  position{line: 619, col: 7, offset: 14970},
 						name: "suint",
 					},
 				},
@@ -4909,14 +4971,14 @@ var g = &grammar{
 		},
 		{
 			name: "suint",
-			pos:  position{line: 613, col: 1, offset: 14813},
+			pos:  position{line: 621, col: 1, offset: 15005},
 			expr: &actionExpr{
-				pos: position{line: 614, col: 5, offset: 14823},
+				pos: position{line: 622, col: 5, offset: 15015},
 				run: (*parser).callonsuint1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 614, col: 5, offset: 14823},
+					pos: position{line: 622, col: 5, offset: 15015},
 					expr: &charClassMatcher{
-						pos:        position{line: 614, col: 5, offset: 14823},
+						pos:        position{line: 622, col: 5, offset: 15015},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4927,15 +4989,15 @@ var g = &grammar{
 		},
 		{
 			name: "integer",
-			pos:  position{line: 616, col: 1, offset: 14862},
+			pos:  position{line: 624, col: 1, offset: 15054},
 			expr: &actionExpr{
-				pos: position{line: 617, col: 5, offset: 14874},
+				pos: position{line: 625, col: 5, offset: 15066},
 				run: (*parser).calloninteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 617, col: 5, offset: 14874},
+					pos:   position{line: 625, col: 5, offset: 15066},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 617, col: 7, offset: 14876},
+						pos:  position{line: 625, col: 7, offset: 15068},
 						name: "sinteger",
 					},
 				},
@@ -4943,17 +5005,17 @@ var g = &grammar{
 		},
 		{
 			name: "sinteger",
-			pos:  position{line: 619, col: 1, offset: 14914},
+			pos:  position{line: 627, col: 1, offset: 15106},
 			expr: &actionExpr{
-				pos: position{line: 620, col: 5, offset: 14927},
+				pos: position{line: 628, col: 5, offset: 15119},
 				run: (*parser).callonsinteger1,
 				expr: &seqExpr{
-					pos: position{line: 620, col: 5, offset: 14927},
+					pos: position{line: 628, col: 5, offset: 15119},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 620, col: 5, offset: 14927},
+							pos: position{line: 628, col: 5, offset: 15119},
 							expr: &charClassMatcher{
-								pos:        position{line: 620, col: 5, offset: 14927},
+								pos:        position{line: 628, col: 5, offset: 15119},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -4961,7 +5023,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 620, col: 11, offset: 14933},
+							pos:  position{line: 628, col: 11, offset: 15125},
 							name: "suint",
 						},
 					},
@@ -4970,15 +5032,15 @@ var g = &grammar{
 		},
 		{
 			name: "double",
-			pos:  position{line: 622, col: 1, offset: 14971},
+			pos:  position{line: 630, col: 1, offset: 15163},
 			expr: &actionExpr{
-				pos: position{line: 623, col: 5, offset: 14982},
+				pos: position{line: 631, col: 5, offset: 15174},
 				run: (*parser).callondouble1,
 				expr: &labeledExpr{
-					pos:   position{line: 623, col: 5, offset: 14982},
+					pos:   position{line: 631, col: 5, offset: 15174},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 623, col: 7, offset: 14984},
+						pos:  position{line: 631, col: 7, offset: 15176},
 						name: "sdouble",
 					},
 				},
@@ -4986,47 +5048,47 @@ var g = &grammar{
 		},
 		{
 			name: "sdouble",
-			pos:  position{line: 627, col: 1, offset: 15031},
+			pos:  position{line: 635, col: 1, offset: 15223},
 			expr: &choiceExpr{
-				pos: position{line: 628, col: 5, offset: 15043},
+				pos: position{line: 636, col: 5, offset: 15235},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 628, col: 5, offset: 15043},
+						pos: position{line: 636, col: 5, offset: 15235},
 						run: (*parser).callonsdouble2,
 						expr: &seqExpr{
-							pos: position{line: 628, col: 5, offset: 15043},
+							pos: position{line: 636, col: 5, offset: 15235},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 628, col: 5, offset: 15043},
+									pos: position{line: 636, col: 5, offset: 15235},
 									expr: &litMatcher{
-										pos:        position{line: 628, col: 5, offset: 15043},
+										pos:        position{line: 636, col: 5, offset: 15235},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 628, col: 10, offset: 15048},
+									pos: position{line: 636, col: 10, offset: 15240},
 									expr: &ruleRefExpr{
-										pos:  position{line: 628, col: 10, offset: 15048},
+										pos:  position{line: 636, col: 10, offset: 15240},
 										name: "doubleInteger",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 628, col: 25, offset: 15063},
+									pos:        position{line: 636, col: 25, offset: 15255},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 628, col: 29, offset: 15067},
+									pos: position{line: 636, col: 29, offset: 15259},
 									expr: &ruleRefExpr{
-										pos:  position{line: 628, col: 29, offset: 15067},
+										pos:  position{line: 636, col: 29, offset: 15259},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 628, col: 42, offset: 15080},
+									pos: position{line: 636, col: 42, offset: 15272},
 									expr: &ruleRefExpr{
-										pos:  position{line: 628, col: 42, offset: 15080},
+										pos:  position{line: 636, col: 42, offset: 15272},
 										name: "exponentPart",
 									},
 								},
@@ -5034,35 +5096,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 631, col: 5, offset: 15139},
+						pos: position{line: 639, col: 5, offset: 15331},
 						run: (*parser).callonsdouble13,
 						expr: &seqExpr{
-							pos: position{line: 631, col: 5, offset: 15139},
+							pos: position{line: 639, col: 5, offset: 15331},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 631, col: 5, offset: 15139},
+									pos: position{line: 639, col: 5, offset: 15331},
 									expr: &litMatcher{
-										pos:        position{line: 631, col: 5, offset: 15139},
+										pos:        position{line: 639, col: 5, offset: 15331},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 631, col: 10, offset: 15144},
+									pos:        position{line: 639, col: 10, offset: 15336},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 631, col: 14, offset: 15148},
+									pos: position{line: 639, col: 14, offset: 15340},
 									expr: &ruleRefExpr{
-										pos:  position{line: 631, col: 14, offset: 15148},
+										pos:  position{line: 639, col: 14, offset: 15340},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 631, col: 27, offset: 15161},
+									pos: position{line: 639, col: 27, offset: 15353},
 									expr: &ruleRefExpr{
-										pos:  position{line: 631, col: 27, offset: 15161},
+										pos:  position{line: 639, col: 27, offset: 15353},
 										name: "exponentPart",
 									},
 								},
@@ -5074,29 +5136,29 @@ var g = &grammar{
 		},
 		{
 			name: "doubleInteger",
-			pos:  position{line: 635, col: 1, offset: 15217},
+			pos:  position{line: 643, col: 1, offset: 15409},
 			expr: &choiceExpr{
-				pos: position{line: 636, col: 5, offset: 15235},
+				pos: position{line: 644, col: 5, offset: 15427},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 636, col: 5, offset: 15235},
+						pos:        position{line: 644, col: 5, offset: 15427},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 637, col: 5, offset: 15243},
+						pos: position{line: 645, col: 5, offset: 15435},
 						exprs: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 637, col: 5, offset: 15243},
+								pos:        position{line: 645, col: 5, offset: 15435},
 								val:        "[1-9]",
 								ranges:     []rune{'1', '9'},
 								ignoreCase: false,
 								inverted:   false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 637, col: 11, offset: 15249},
+								pos: position{line: 645, col: 11, offset: 15441},
 								expr: &charClassMatcher{
-									pos:        position{line: 637, col: 11, offset: 15249},
+									pos:        position{line: 645, col: 11, offset: 15441},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -5110,9 +5172,9 @@ var g = &grammar{
 		},
 		{
 			name: "doubleDigit",
-			pos:  position{line: 639, col: 1, offset: 15257},
+			pos:  position{line: 647, col: 1, offset: 15449},
 			expr: &charClassMatcher{
-				pos:        position{line: 639, col: 15, offset: 15271},
+				pos:        position{line: 647, col: 15, offset: 15463},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -5121,17 +5183,17 @@ var g = &grammar{
 		},
 		{
 			name: "exponentPart",
-			pos:  position{line: 641, col: 1, offset: 15278},
+			pos:  position{line: 649, col: 1, offset: 15470},
 			expr: &seqExpr{
-				pos: position{line: 641, col: 16, offset: 15293},
+				pos: position{line: 649, col: 16, offset: 15485},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 641, col: 16, offset: 15293},
+						pos:        position{line: 649, col: 16, offset: 15485},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 641, col: 21, offset: 15298},
+						pos:  position{line: 649, col: 21, offset: 15490},
 						name: "sinteger",
 					},
 				},
@@ -5139,17 +5201,17 @@ var g = &grammar{
 		},
 		{
 			name: "h16",
-			pos:  position{line: 643, col: 1, offset: 15308},
+			pos:  position{line: 651, col: 1, offset: 15500},
 			expr: &actionExpr{
-				pos: position{line: 643, col: 7, offset: 15314},
+				pos: position{line: 651, col: 7, offset: 15506},
 				run: (*parser).callonh161,
 				expr: &labeledExpr{
-					pos:   position{line: 643, col: 7, offset: 15314},
+					pos:   position{line: 651, col: 7, offset: 15506},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 643, col: 13, offset: 15320},
+						pos: position{line: 651, col: 13, offset: 15512},
 						expr: &ruleRefExpr{
-							pos:  position{line: 643, col: 13, offset: 15320},
+							pos:  position{line: 651, col: 13, offset: 15512},
 							name: "hexdigit",
 						},
 					},
@@ -5158,9 +5220,9 @@ var g = &grammar{
 		},
 		{
 			name: "hexdigit",
-			pos:  position{line: 645, col: 1, offset: 15362},
+			pos:  position{line: 653, col: 1, offset: 15554},
 			expr: &charClassMatcher{
-				pos:        position{line: 645, col: 12, offset: 15373},
+				pos:        position{line: 653, col: 12, offset: 15565},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -5169,17 +5231,17 @@ var g = &grammar{
 		},
 		{
 			name: "searchWord",
-			pos:  position{line: 647, col: 1, offset: 15386},
+			pos:  position{line: 655, col: 1, offset: 15578},
 			expr: &actionExpr{
-				pos: position{line: 648, col: 5, offset: 15401},
+				pos: position{line: 656, col: 5, offset: 15593},
 				run: (*parser).callonsearchWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 648, col: 5, offset: 15401},
+					pos:   position{line: 656, col: 5, offset: 15593},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 648, col: 11, offset: 15407},
+						pos: position{line: 656, col: 11, offset: 15599},
 						expr: &ruleRefExpr{
-							pos:  position{line: 648, col: 11, offset: 15407},
+							pos:  position{line: 656, col: 11, offset: 15599},
 							name: "searchWordPart",
 						},
 					},
@@ -5188,33 +5250,33 @@ var g = &grammar{
 		},
 		{
 			name: "searchWordPart",
-			pos:  position{line: 650, col: 1, offset: 15457},
+			pos:  position{line: 658, col: 1, offset: 15649},
 			expr: &choiceExpr{
-				pos: position{line: 651, col: 5, offset: 15476},
+				pos: position{line: 659, col: 5, offset: 15668},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 651, col: 5, offset: 15476},
+						pos: position{line: 659, col: 5, offset: 15668},
 						run: (*parser).callonsearchWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 651, col: 5, offset: 15476},
+							pos: position{line: 659, col: 5, offset: 15668},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 651, col: 5, offset: 15476},
+									pos:        position{line: 659, col: 5, offset: 15668},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 651, col: 10, offset: 15481},
+									pos:   position{line: 659, col: 10, offset: 15673},
 									label: "s",
 									expr: &choiceExpr{
-										pos: position{line: 651, col: 13, offset: 15484},
+										pos: position{line: 659, col: 13, offset: 15676},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 651, col: 13, offset: 15484},
+												pos:  position{line: 659, col: 13, offset: 15676},
 												name: "escapeSequence",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 651, col: 30, offset: 15501},
+												pos:  position{line: 659, col: 30, offset: 15693},
 												name: "searchEscape",
 											},
 										},
@@ -5224,18 +5286,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 652, col: 5, offset: 15538},
+						pos: position{line: 660, col: 5, offset: 15730},
 						run: (*parser).callonsearchWordPart9,
 						expr: &seqExpr{
-							pos: position{line: 652, col: 5, offset: 15538},
+							pos: position{line: 660, col: 5, offset: 15730},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 652, col: 5, offset: 15538},
+									pos: position{line: 660, col: 5, offset: 15730},
 									expr: &choiceExpr{
-										pos: position{line: 652, col: 7, offset: 15540},
+										pos: position{line: 660, col: 7, offset: 15732},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 652, col: 7, offset: 15540},
+												pos:        position{line: 660, col: 7, offset: 15732},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -5243,14 +5305,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 652, col: 42, offset: 15575},
+												pos:  position{line: 660, col: 42, offset: 15767},
 												name: "ws",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 652, col: 46, offset: 15579,
+									line: 660, col: 46, offset: 15771,
 								},
 							},
 						},
@@ -5260,34 +5322,34 @@ var g = &grammar{
 		},
 		{
 			name: "quotedString",
-			pos:  position{line: 654, col: 1, offset: 15613},
+			pos:  position{line: 662, col: 1, offset: 15805},
 			expr: &choiceExpr{
-				pos: position{line: 655, col: 5, offset: 15630},
+				pos: position{line: 663, col: 5, offset: 15822},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 655, col: 5, offset: 15630},
+						pos: position{line: 663, col: 5, offset: 15822},
 						run: (*parser).callonquotedString2,
 						expr: &seqExpr{
-							pos: position{line: 655, col: 5, offset: 15630},
+							pos: position{line: 663, col: 5, offset: 15822},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 655, col: 5, offset: 15630},
+									pos:        position{line: 663, col: 5, offset: 15822},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 655, col: 9, offset: 15634},
+									pos:   position{line: 663, col: 9, offset: 15826},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 655, col: 11, offset: 15636},
+										pos: position{line: 663, col: 11, offset: 15828},
 										expr: &ruleRefExpr{
-											pos:  position{line: 655, col: 11, offset: 15636},
+											pos:  position{line: 663, col: 11, offset: 15828},
 											name: "doubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 655, col: 29, offset: 15654},
+									pos:        position{line: 663, col: 29, offset: 15846},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5295,29 +5357,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 656, col: 5, offset: 15691},
+						pos: position{line: 664, col: 5, offset: 15883},
 						run: (*parser).callonquotedString9,
 						expr: &seqExpr{
-							pos: position{line: 656, col: 5, offset: 15691},
+							pos: position{line: 664, col: 5, offset: 15883},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 656, col: 5, offset: 15691},
+									pos:        position{line: 664, col: 5, offset: 15883},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 656, col: 9, offset: 15695},
+									pos:   position{line: 664, col: 9, offset: 15887},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 656, col: 11, offset: 15697},
+										pos: position{line: 664, col: 11, offset: 15889},
 										expr: &ruleRefExpr{
-											pos:  position{line: 656, col: 11, offset: 15697},
+											pos:  position{line: 664, col: 11, offset: 15889},
 											name: "singleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 656, col: 29, offset: 15715},
+									pos:        position{line: 664, col: 29, offset: 15907},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5329,55 +5391,55 @@ var g = &grammar{
 		},
 		{
 			name: "doubleQuotedChar",
-			pos:  position{line: 658, col: 1, offset: 15749},
+			pos:  position{line: 666, col: 1, offset: 15941},
 			expr: &choiceExpr{
-				pos: position{line: 659, col: 5, offset: 15770},
+				pos: position{line: 667, col: 5, offset: 15962},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 15770},
+						pos: position{line: 667, col: 5, offset: 15962},
 						run: (*parser).callondoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 15770},
+							pos: position{line: 667, col: 5, offset: 15962},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 659, col: 5, offset: 15770},
+									pos: position{line: 667, col: 5, offset: 15962},
 									expr: &choiceExpr{
-										pos: position{line: 659, col: 7, offset: 15772},
+										pos: position{line: 667, col: 7, offset: 15964},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 659, col: 7, offset: 15772},
+												pos:        position{line: 667, col: 7, offset: 15964},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 659, col: 13, offset: 15778},
+												pos:  position{line: 667, col: 13, offset: 15970},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 659, col: 26, offset: 15791,
+									line: 667, col: 26, offset: 15983,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 660, col: 5, offset: 15828},
+						pos: position{line: 668, col: 5, offset: 16020},
 						run: (*parser).callondoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 660, col: 5, offset: 15828},
+							pos: position{line: 668, col: 5, offset: 16020},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 660, col: 5, offset: 15828},
+									pos:        position{line: 668, col: 5, offset: 16020},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 660, col: 10, offset: 15833},
+									pos:   position{line: 668, col: 10, offset: 16025},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 660, col: 12, offset: 15835},
+										pos:  position{line: 668, col: 12, offset: 16027},
 										name: "escapeSequence",
 									},
 								},
@@ -5389,55 +5451,55 @@ var g = &grammar{
 		},
 		{
 			name: "singleQuotedChar",
-			pos:  position{line: 662, col: 1, offset: 15869},
+			pos:  position{line: 670, col: 1, offset: 16061},
 			expr: &choiceExpr{
-				pos: position{line: 663, col: 5, offset: 15890},
+				pos: position{line: 671, col: 5, offset: 16082},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 663, col: 5, offset: 15890},
+						pos: position{line: 671, col: 5, offset: 16082},
 						run: (*parser).callonsingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 663, col: 5, offset: 15890},
+							pos: position{line: 671, col: 5, offset: 16082},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 663, col: 5, offset: 15890},
+									pos: position{line: 671, col: 5, offset: 16082},
 									expr: &choiceExpr{
-										pos: position{line: 663, col: 7, offset: 15892},
+										pos: position{line: 671, col: 7, offset: 16084},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 663, col: 7, offset: 15892},
+												pos:        position{line: 671, col: 7, offset: 16084},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 663, col: 13, offset: 15898},
+												pos:  position{line: 671, col: 13, offset: 16090},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 663, col: 26, offset: 15911,
+									line: 671, col: 26, offset: 16103,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 664, col: 5, offset: 15948},
+						pos: position{line: 672, col: 5, offset: 16140},
 						run: (*parser).callonsingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 664, col: 5, offset: 15948},
+							pos: position{line: 672, col: 5, offset: 16140},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 664, col: 5, offset: 15948},
+									pos:        position{line: 672, col: 5, offset: 16140},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 664, col: 10, offset: 15953},
+									pos:   position{line: 672, col: 10, offset: 16145},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 664, col: 12, offset: 15955},
+										pos:  position{line: 672, col: 12, offset: 16147},
 										name: "escapeSequence",
 									},
 								},
@@ -5449,38 +5511,38 @@ var g = &grammar{
 		},
 		{
 			name: "escapeSequence",
-			pos:  position{line: 666, col: 1, offset: 15989},
+			pos:  position{line: 674, col: 1, offset: 16181},
 			expr: &choiceExpr{
-				pos: position{line: 667, col: 5, offset: 16008},
+				pos: position{line: 675, col: 5, offset: 16200},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 667, col: 5, offset: 16008},
+						pos: position{line: 675, col: 5, offset: 16200},
 						run: (*parser).callonescapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 667, col: 5, offset: 16008},
+							pos: position{line: 675, col: 5, offset: 16200},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 667, col: 5, offset: 16008},
+									pos:        position{line: 675, col: 5, offset: 16200},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 667, col: 9, offset: 16012},
+									pos:  position{line: 675, col: 9, offset: 16204},
 									name: "hexdigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 667, col: 18, offset: 16021},
+									pos:  position{line: 675, col: 18, offset: 16213},
 									name: "hexdigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 668, col: 5, offset: 16072},
+						pos:  position{line: 676, col: 5, offset: 16264},
 						name: "singleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 669, col: 5, offset: 16093},
+						pos:  position{line: 677, col: 5, offset: 16285},
 						name: "unicodeEscape",
 					},
 				},
@@ -5488,75 +5550,75 @@ var g = &grammar{
 		},
 		{
 			name: "singleCharEscape",
-			pos:  position{line: 671, col: 1, offset: 16108},
+			pos:  position{line: 679, col: 1, offset: 16300},
 			expr: &choiceExpr{
-				pos: position{line: 672, col: 5, offset: 16129},
+				pos: position{line: 680, col: 5, offset: 16321},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 672, col: 5, offset: 16129},
+						pos:        position{line: 680, col: 5, offset: 16321},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 673, col: 5, offset: 16137},
+						pos:        position{line: 681, col: 5, offset: 16329},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 674, col: 5, offset: 16145},
+						pos:        position{line: 682, col: 5, offset: 16337},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 675, col: 5, offset: 16154},
+						pos: position{line: 683, col: 5, offset: 16346},
 						run: (*parser).callonsingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 675, col: 5, offset: 16154},
+							pos:        position{line: 683, col: 5, offset: 16346},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 676, col: 5, offset: 16183},
+						pos: position{line: 684, col: 5, offset: 16375},
 						run: (*parser).callonsingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 676, col: 5, offset: 16183},
+							pos:        position{line: 684, col: 5, offset: 16375},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 677, col: 5, offset: 16212},
+						pos: position{line: 685, col: 5, offset: 16404},
 						run: (*parser).callonsingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 677, col: 5, offset: 16212},
+							pos:        position{line: 685, col: 5, offset: 16404},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 678, col: 5, offset: 16241},
+						pos: position{line: 686, col: 5, offset: 16433},
 						run: (*parser).callonsingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 678, col: 5, offset: 16241},
+							pos:        position{line: 686, col: 5, offset: 16433},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 679, col: 5, offset: 16270},
+						pos: position{line: 687, col: 5, offset: 16462},
 						run: (*parser).callonsingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 679, col: 5, offset: 16270},
+							pos:        position{line: 687, col: 5, offset: 16462},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 680, col: 5, offset: 16299},
+						pos: position{line: 688, col: 5, offset: 16491},
 						run: (*parser).callonsingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 680, col: 5, offset: 16299},
+							pos:        position{line: 688, col: 5, offset: 16491},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5566,24 +5628,24 @@ var g = &grammar{
 		},
 		{
 			name: "searchEscape",
-			pos:  position{line: 682, col: 1, offset: 16325},
+			pos:  position{line: 690, col: 1, offset: 16517},
 			expr: &choiceExpr{
-				pos: position{line: 683, col: 5, offset: 16342},
+				pos: position{line: 691, col: 5, offset: 16534},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 683, col: 5, offset: 16342},
+						pos: position{line: 691, col: 5, offset: 16534},
 						run: (*parser).callonsearchEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 683, col: 5, offset: 16342},
+							pos:        position{line: 691, col: 5, offset: 16534},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 684, col: 5, offset: 16370},
+						pos: position{line: 692, col: 5, offset: 16562},
 						run: (*parser).callonsearchEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 684, col: 5, offset: 16370},
+							pos:        position{line: 692, col: 5, offset: 16562},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -5593,41 +5655,41 @@ var g = &grammar{
 		},
 		{
 			name: "unicodeEscape",
-			pos:  position{line: 686, col: 1, offset: 16397},
+			pos:  position{line: 694, col: 1, offset: 16589},
 			expr: &choiceExpr{
-				pos: position{line: 687, col: 5, offset: 16415},
+				pos: position{line: 695, col: 5, offset: 16607},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 687, col: 5, offset: 16415},
+						pos: position{line: 695, col: 5, offset: 16607},
 						run: (*parser).callonunicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 687, col: 5, offset: 16415},
+							pos: position{line: 695, col: 5, offset: 16607},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 687, col: 5, offset: 16415},
+									pos:        position{line: 695, col: 5, offset: 16607},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 687, col: 9, offset: 16419},
+									pos:   position{line: 695, col: 9, offset: 16611},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 687, col: 16, offset: 16426},
+										pos: position{line: 695, col: 16, offset: 16618},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 687, col: 16, offset: 16426},
+												pos:  position{line: 695, col: 16, offset: 16618},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 687, col: 25, offset: 16435},
+												pos:  position{line: 695, col: 25, offset: 16627},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 687, col: 34, offset: 16444},
+												pos:  position{line: 695, col: 34, offset: 16636},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 687, col: 43, offset: 16453},
+												pos:  position{line: 695, col: 43, offset: 16645},
 												name: "hexdigit",
 											},
 										},
@@ -5637,63 +5699,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 690, col: 5, offset: 16516},
+						pos: position{line: 698, col: 5, offset: 16708},
 						run: (*parser).callonunicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 690, col: 5, offset: 16516},
+							pos: position{line: 698, col: 5, offset: 16708},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 690, col: 5, offset: 16516},
+									pos:        position{line: 698, col: 5, offset: 16708},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 690, col: 9, offset: 16520},
+									pos:        position{line: 698, col: 9, offset: 16712},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 690, col: 13, offset: 16524},
+									pos:   position{line: 698, col: 13, offset: 16716},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 690, col: 20, offset: 16531},
+										pos: position{line: 698, col: 20, offset: 16723},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 690, col: 20, offset: 16531},
+												pos:  position{line: 698, col: 20, offset: 16723},
 												name: "hexdigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 690, col: 29, offset: 16540},
+												pos: position{line: 698, col: 29, offset: 16732},
 												expr: &ruleRefExpr{
-													pos:  position{line: 690, col: 29, offset: 16540},
+													pos:  position{line: 698, col: 29, offset: 16732},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 690, col: 39, offset: 16550},
+												pos: position{line: 698, col: 39, offset: 16742},
 												expr: &ruleRefExpr{
-													pos:  position{line: 690, col: 39, offset: 16550},
+													pos:  position{line: 698, col: 39, offset: 16742},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 690, col: 49, offset: 16560},
+												pos: position{line: 698, col: 49, offset: 16752},
 												expr: &ruleRefExpr{
-													pos:  position{line: 690, col: 49, offset: 16560},
+													pos:  position{line: 698, col: 49, offset: 16752},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 690, col: 59, offset: 16570},
+												pos: position{line: 698, col: 59, offset: 16762},
 												expr: &ruleRefExpr{
-													pos:  position{line: 690, col: 59, offset: 16570},
+													pos:  position{line: 698, col: 59, offset: 16762},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 690, col: 69, offset: 16580},
+												pos: position{line: 698, col: 69, offset: 16772},
 												expr: &ruleRefExpr{
-													pos:  position{line: 690, col: 69, offset: 16580},
+													pos:  position{line: 698, col: 69, offset: 16772},
 													name: "hexdigit",
 												},
 											},
@@ -5701,7 +5763,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 690, col: 80, offset: 16591},
+									pos:        position{line: 698, col: 80, offset: 16783},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5713,28 +5775,28 @@ var g = &grammar{
 		},
 		{
 			name: "reString",
-			pos:  position{line: 694, col: 1, offset: 16645},
+			pos:  position{line: 702, col: 1, offset: 16837},
 			expr: &actionExpr{
-				pos: position{line: 695, col: 5, offset: 16658},
+				pos: position{line: 703, col: 5, offset: 16850},
 				run: (*parser).callonreString1,
 				expr: &seqExpr{
-					pos: position{line: 695, col: 5, offset: 16658},
+					pos: position{line: 703, col: 5, offset: 16850},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 695, col: 5, offset: 16658},
+							pos:        position{line: 703, col: 5, offset: 16850},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 695, col: 9, offset: 16662},
+							pos:   position{line: 703, col: 9, offset: 16854},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 695, col: 11, offset: 16664},
+								pos:  position{line: 703, col: 11, offset: 16856},
 								name: "reBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 695, col: 18, offset: 16671},
+							pos:        position{line: 703, col: 18, offset: 16863},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5744,24 +5806,24 @@ var g = &grammar{
 		},
 		{
 			name: "reBody",
-			pos:  position{line: 697, col: 1, offset: 16694},
+			pos:  position{line: 705, col: 1, offset: 16886},
 			expr: &actionExpr{
-				pos: position{line: 698, col: 5, offset: 16705},
+				pos: position{line: 706, col: 5, offset: 16897},
 				run: (*parser).callonreBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 698, col: 5, offset: 16705},
+					pos: position{line: 706, col: 5, offset: 16897},
 					expr: &choiceExpr{
-						pos: position{line: 698, col: 6, offset: 16706},
+						pos: position{line: 706, col: 6, offset: 16898},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 698, col: 6, offset: 16706},
+								pos:        position{line: 706, col: 6, offset: 16898},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 698, col: 13, offset: 16713},
+								pos:        position{line: 706, col: 13, offset: 16905},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -5772,9 +5834,9 @@ var g = &grammar{
 		},
 		{
 			name: "escapedChar",
-			pos:  position{line: 700, col: 1, offset: 16753},
+			pos:  position{line: 708, col: 1, offset: 16945},
 			expr: &charClassMatcher{
-				pos:        position{line: 701, col: 5, offset: 16769},
+				pos:        position{line: 709, col: 5, offset: 16961},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5784,37 +5846,37 @@ var g = &grammar{
 		},
 		{
 			name: "ws",
-			pos:  position{line: 703, col: 1, offset: 16784},
+			pos:  position{line: 711, col: 1, offset: 16976},
 			expr: &choiceExpr{
-				pos: position{line: 704, col: 5, offset: 16791},
+				pos: position{line: 712, col: 5, offset: 16983},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 704, col: 5, offset: 16791},
+						pos:        position{line: 712, col: 5, offset: 16983},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 705, col: 5, offset: 16800},
+						pos:        position{line: 713, col: 5, offset: 16992},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 706, col: 5, offset: 16809},
+						pos:        position{line: 714, col: 5, offset: 17001},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 707, col: 5, offset: 16818},
+						pos:        position{line: 715, col: 5, offset: 17010},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 708, col: 5, offset: 16826},
+						pos:        position{line: 716, col: 5, offset: 17018},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 709, col: 5, offset: 16839},
+						pos:        position{line: 717, col: 5, offset: 17031},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5824,33 +5886,33 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 711, col: 1, offset: 16849},
+			pos:         position{line: 719, col: 1, offset: 17041},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 711, col: 18, offset: 16866},
+				pos: position{line: 719, col: 18, offset: 17058},
 				expr: &ruleRefExpr{
-					pos:  position{line: 711, col: 18, offset: 16866},
+					pos:  position{line: 719, col: 18, offset: 17058},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 712, col: 1, offset: 16870},
+			pos:  position{line: 720, col: 1, offset: 17062},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 712, col: 6, offset: 16875},
+				pos: position{line: 720, col: 6, offset: 17067},
 				expr: &ruleRefExpr{
-					pos:  position{line: 712, col: 6, offset: 16875},
+					pos:  position{line: 720, col: 6, offset: 17067},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 714, col: 1, offset: 16880},
+			pos:  position{line: 722, col: 1, offset: 17072},
 			expr: &notExpr{
-				pos: position{line: 714, col: 7, offset: 16886},
+				pos: position{line: 722, col: 7, offset: 17078},
 				expr: &anyMatcher{
-					line: 714, col: 8, offset: 16887,
+					line: 722, col: 8, offset: 17079,
 				},
 			},
 		},
@@ -6298,14 +6360,35 @@ func (p *parser) callonproc4() (interface{}, error) {
 	return p.cur.onproc4(stack["proc"])
 }
 
-func (c *current) ongroupBy1(list interface{}) (interface{}, error) {
-	return list, nil
+func (c *current) ongroupByKeys9(cl interface{}) (interface{}, error) {
+	return cl, nil
 }
 
-func (p *parser) callongroupBy1() (interface{}, error) {
+func (p *parser) callongroupByKeys9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.ongroupBy1(stack["list"])
+	return p.cur.ongroupByKeys9(stack["cl"])
+}
+
+func (c *current) ongroupByKeys1(first, rest interface{}) (interface{}, error) {
+	return makeGroupByKeys(first, rest), nil
+
+}
+
+func (p *parser) callongroupByKeys1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.ongroupByKeys1(stack["first"], stack["rest"])
+}
+
+func (c *current) ongroupByKey3(field interface{}) (interface{}, error) {
+	return makeGroupByKey(string(c.text), field), nil
+}
+
+func (p *parser) callongroupByKey3() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.ongroupByKey3(stack["field"])
 }
 
 func (c *current) oneveryDur1(dur interface{}) (interface{}, error) {
@@ -6927,15 +7010,15 @@ func (p *parser) callonput1() (interface{}, error) {
 	return p.cur.onput1(stack["first"], stack["rest"])
 }
 
-func (c *current) onPutClause1(f, e interface{}) (interface{}, error) {
-	return makePutClause(f, e), nil
+func (c *current) onAssignment1(f, e interface{}) (interface{}, error) {
+	return makeAssignment(f, e), nil
 
 }
 
-func (p *parser) callonPutClause1() (interface{}, error) {
+func (p *parser) callonAssignment1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onPutClause1(stack["f"], stack["e"])
+	return p.cur.onAssignment1(stack["f"], stack["e"])
 }
 
 func (c *current) onPrimaryExpression12(expr interface{}) (interface{}, error) {

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -1380,17 +1380,51 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "equalityToken",
+			name: "groupBySorted",
 			pos:  position{line: 198, col: 1, offset: 4492},
-			expr: &choiceExpr{
+			expr: &actionExpr{
 				pos: position{line: 199, col: 5, offset: 4510},
+				run: (*parser).callongroupBySorted1,
+				expr: &seqExpr{
+					pos: position{line: 199, col: 5, offset: 4510},
+					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 199, col: 5, offset: 4510},
+							name: "_",
+						},
+						&litMatcher{
+							pos:        position{line: 199, col: 7, offset: 4512},
+							val:        "-sorted",
+							ignoreCase: true,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 199, col: 18, offset: 4523},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 199, col: 20, offset: 4525},
+							label: "dir",
+							expr: &ruleRefExpr{
+								pos:  position{line: 199, col: 24, offset: 4529},
+								name: "sinteger",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "equalityToken",
+			pos:  position{line: 201, col: 1, offset: 4569},
+			expr: &choiceExpr{
+				pos: position{line: 202, col: 5, offset: 4587},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 199, col: 5, offset: 4510},
+						pos:  position{line: 202, col: 5, offset: 4587},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 199, col: 24, offset: 4529},
+						pos:  position{line: 202, col: 24, offset: 4606},
 						name: "RelativeOperator",
 					},
 				},
@@ -1398,12 +1432,12 @@ var g = &grammar{
 		},
 		{
 			name: "andToken",
-			pos:  position{line: 201, col: 1, offset: 4547},
+			pos:  position{line: 204, col: 1, offset: 4624},
 			expr: &actionExpr{
-				pos: position{line: 201, col: 12, offset: 4558},
+				pos: position{line: 204, col: 12, offset: 4635},
 				run: (*parser).callonandToken1,
 				expr: &litMatcher{
-					pos:        position{line: 201, col: 12, offset: 4558},
+					pos:        position{line: 204, col: 12, offset: 4635},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -1411,12 +1445,12 @@ var g = &grammar{
 		},
 		{
 			name: "orToken",
-			pos:  position{line: 202, col: 1, offset: 4596},
+			pos:  position{line: 205, col: 1, offset: 4673},
 			expr: &actionExpr{
-				pos: position{line: 202, col: 11, offset: 4606},
+				pos: position{line: 205, col: 11, offset: 4683},
 				run: (*parser).callonorToken1,
 				expr: &litMatcher{
-					pos:        position{line: 202, col: 11, offset: 4606},
+					pos:        position{line: 205, col: 11, offset: 4683},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -1424,12 +1458,12 @@ var g = &grammar{
 		},
 		{
 			name: "inToken",
-			pos:  position{line: 203, col: 1, offset: 4643},
+			pos:  position{line: 206, col: 1, offset: 4720},
 			expr: &actionExpr{
-				pos: position{line: 203, col: 11, offset: 4653},
+				pos: position{line: 206, col: 11, offset: 4730},
 				run: (*parser).calloninToken1,
 				expr: &litMatcher{
-					pos:        position{line: 203, col: 11, offset: 4653},
+					pos:        position{line: 206, col: 11, offset: 4730},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -1437,12 +1471,12 @@ var g = &grammar{
 		},
 		{
 			name: "notToken",
-			pos:  position{line: 204, col: 1, offset: 4690},
+			pos:  position{line: 207, col: 1, offset: 4767},
 			expr: &actionExpr{
-				pos: position{line: 204, col: 12, offset: 4701},
+				pos: position{line: 207, col: 12, offset: 4778},
 				run: (*parser).callonnotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 204, col: 12, offset: 4701},
+					pos:        position{line: 207, col: 12, offset: 4778},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -1450,21 +1484,21 @@ var g = &grammar{
 		},
 		{
 			name: "fieldName",
-			pos:  position{line: 206, col: 1, offset: 4740},
+			pos:  position{line: 209, col: 1, offset: 4817},
 			expr: &actionExpr{
-				pos: position{line: 206, col: 13, offset: 4752},
+				pos: position{line: 209, col: 13, offset: 4829},
 				run: (*parser).callonfieldName1,
 				expr: &seqExpr{
-					pos: position{line: 206, col: 13, offset: 4752},
+					pos: position{line: 209, col: 13, offset: 4829},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 206, col: 13, offset: 4752},
+							pos:  position{line: 209, col: 13, offset: 4829},
 							name: "fieldNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 206, col: 28, offset: 4767},
+							pos: position{line: 209, col: 28, offset: 4844},
 							expr: &ruleRefExpr{
-								pos:  position{line: 206, col: 28, offset: 4767},
+								pos:  position{line: 209, col: 28, offset: 4844},
 								name: "fieldNameRest",
 							},
 						},
@@ -1474,9 +1508,9 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameStart",
-			pos:  position{line: 208, col: 1, offset: 4814},
+			pos:  position{line: 211, col: 1, offset: 4891},
 			expr: &charClassMatcher{
-				pos:        position{line: 208, col: 18, offset: 4831},
+				pos:        position{line: 211, col: 18, offset: 4908},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -1486,16 +1520,16 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameRest",
-			pos:  position{line: 209, col: 1, offset: 4842},
+			pos:  position{line: 212, col: 1, offset: 4919},
 			expr: &choiceExpr{
-				pos: position{line: 209, col: 17, offset: 4858},
+				pos: position{line: 212, col: 17, offset: 4935},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 209, col: 17, offset: 4858},
+						pos:  position{line: 212, col: 17, offset: 4935},
 						name: "fieldNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 209, col: 34, offset: 4875},
+						pos:        position{line: 212, col: 34, offset: 4952},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -1506,45 +1540,45 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReference",
-			pos:  position{line: 211, col: 1, offset: 4882},
+			pos:  position{line: 214, col: 1, offset: 4959},
 			expr: &actionExpr{
-				pos: position{line: 212, col: 4, offset: 4900},
+				pos: position{line: 215, col: 4, offset: 4977},
 				run: (*parser).callonfieldReference1,
 				expr: &seqExpr{
-					pos: position{line: 212, col: 4, offset: 4900},
+					pos: position{line: 215, col: 4, offset: 4977},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 212, col: 4, offset: 4900},
+							pos:   position{line: 215, col: 4, offset: 4977},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 212, col: 9, offset: 4905},
+								pos:  position{line: 215, col: 9, offset: 4982},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 212, col: 19, offset: 4915},
+							pos:   position{line: 215, col: 19, offset: 4992},
 							label: "derefs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 212, col: 26, offset: 4922},
+								pos: position{line: 215, col: 26, offset: 4999},
 								expr: &choiceExpr{
-									pos: position{line: 213, col: 8, offset: 4931},
+									pos: position{line: 216, col: 8, offset: 5008},
 									alternatives: []interface{}{
 										&actionExpr{
-											pos: position{line: 213, col: 8, offset: 4931},
+											pos: position{line: 216, col: 8, offset: 5008},
 											run: (*parser).callonfieldReference8,
 											expr: &seqExpr{
-												pos: position{line: 213, col: 8, offset: 4931},
+												pos: position{line: 216, col: 8, offset: 5008},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 213, col: 8, offset: 4931},
+														pos:        position{line: 216, col: 8, offset: 5008},
 														val:        ".",
 														ignoreCase: false,
 													},
 													&labeledExpr{
-														pos:   position{line: 213, col: 12, offset: 4935},
+														pos:   position{line: 216, col: 12, offset: 5012},
 														label: "field",
 														expr: &ruleRefExpr{
-															pos:  position{line: 213, col: 18, offset: 4941},
+															pos:  position{line: 216, col: 18, offset: 5018},
 															name: "fieldName",
 														},
 													},
@@ -1552,26 +1586,26 @@ var g = &grammar{
 											},
 										},
 										&actionExpr{
-											pos: position{line: 214, col: 8, offset: 5022},
+											pos: position{line: 217, col: 8, offset: 5099},
 											run: (*parser).callonfieldReference13,
 											expr: &seqExpr{
-												pos: position{line: 214, col: 8, offset: 5022},
+												pos: position{line: 217, col: 8, offset: 5099},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 214, col: 8, offset: 5022},
+														pos:        position{line: 217, col: 8, offset: 5099},
 														val:        "[",
 														ignoreCase: false,
 													},
 													&labeledExpr{
-														pos:   position{line: 214, col: 12, offset: 5026},
+														pos:   position{line: 217, col: 12, offset: 5103},
 														label: "index",
 														expr: &ruleRefExpr{
-															pos:  position{line: 214, col: 18, offset: 5032},
+															pos:  position{line: 217, col: 18, offset: 5109},
 															name: "suint",
 														},
 													},
 													&litMatcher{
-														pos:        position{line: 214, col: 24, offset: 5038},
+														pos:        position{line: 217, col: 24, offset: 5115},
 														val:        "]",
 														ignoreCase: false,
 													},
@@ -1588,60 +1622,60 @@ var g = &grammar{
 		},
 		{
 			name: "fieldExpr",
-			pos:  position{line: 219, col: 1, offset: 5154},
+			pos:  position{line: 222, col: 1, offset: 5231},
 			expr: &choiceExpr{
-				pos: position{line: 220, col: 5, offset: 5168},
+				pos: position{line: 223, col: 5, offset: 5245},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 220, col: 5, offset: 5168},
+						pos: position{line: 223, col: 5, offset: 5245},
 						run: (*parser).callonfieldExpr2,
 						expr: &seqExpr{
-							pos: position{line: 220, col: 5, offset: 5168},
+							pos: position{line: 223, col: 5, offset: 5245},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 220, col: 5, offset: 5168},
+									pos:   position{line: 223, col: 5, offset: 5245},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 8, offset: 5171},
+										pos:  position{line: 223, col: 8, offset: 5248},
 										name: "fieldOp",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 220, col: 16, offset: 5179},
+									pos: position{line: 223, col: 16, offset: 5256},
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 16, offset: 5179},
+										pos:  position{line: 223, col: 16, offset: 5256},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 220, col: 19, offset: 5182},
+									pos:        position{line: 223, col: 19, offset: 5259},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 220, col: 23, offset: 5186},
+									pos: position{line: 223, col: 23, offset: 5263},
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 23, offset: 5186},
+										pos:  position{line: 223, col: 23, offset: 5263},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 220, col: 26, offset: 5189},
+									pos:   position{line: 223, col: 26, offset: 5266},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 32, offset: 5195},
+										pos:  position{line: 223, col: 32, offset: 5272},
 										name: "fieldReference",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 220, col: 47, offset: 5210},
+									pos: position{line: 223, col: 47, offset: 5287},
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 47, offset: 5210},
+										pos:  position{line: 223, col: 47, offset: 5287},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 220, col: 50, offset: 5213},
+									pos:        position{line: 223, col: 50, offset: 5290},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1649,7 +1683,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 223, col: 5, offset: 5277},
+						pos:  position{line: 226, col: 5, offset: 5354},
 						name: "fieldReference",
 					},
 				},
@@ -1657,12 +1691,12 @@ var g = &grammar{
 		},
 		{
 			name: "fieldOp",
-			pos:  position{line: 225, col: 1, offset: 5293},
+			pos:  position{line: 228, col: 1, offset: 5370},
 			expr: &actionExpr{
-				pos: position{line: 226, col: 5, offset: 5305},
+				pos: position{line: 229, col: 5, offset: 5382},
 				run: (*parser).callonfieldOp1,
 				expr: &litMatcher{
-					pos:        position{line: 226, col: 5, offset: 5305},
+					pos:        position{line: 229, col: 5, offset: 5382},
 					val:        "len",
 					ignoreCase: true,
 				},
@@ -1670,50 +1704,50 @@ var g = &grammar{
 		},
 		{
 			name: "fieldExprList",
-			pos:  position{line: 228, col: 1, offset: 5335},
+			pos:  position{line: 231, col: 1, offset: 5412},
 			expr: &actionExpr{
-				pos: position{line: 229, col: 5, offset: 5353},
+				pos: position{line: 232, col: 5, offset: 5430},
 				run: (*parser).callonfieldExprList1,
 				expr: &seqExpr{
-					pos: position{line: 229, col: 5, offset: 5353},
+					pos: position{line: 232, col: 5, offset: 5430},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 229, col: 5, offset: 5353},
+							pos:   position{line: 232, col: 5, offset: 5430},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 229, col: 11, offset: 5359},
+								pos:  position{line: 232, col: 11, offset: 5436},
 								name: "fieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 229, col: 21, offset: 5369},
+							pos:   position{line: 232, col: 21, offset: 5446},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 229, col: 26, offset: 5374},
+								pos: position{line: 232, col: 26, offset: 5451},
 								expr: &seqExpr{
-									pos: position{line: 229, col: 27, offset: 5375},
+									pos: position{line: 232, col: 27, offset: 5452},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 229, col: 27, offset: 5375},
+											pos: position{line: 232, col: 27, offset: 5452},
 											expr: &ruleRefExpr{
-												pos:  position{line: 229, col: 27, offset: 5375},
+												pos:  position{line: 232, col: 27, offset: 5452},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 229, col: 30, offset: 5378},
+											pos:        position{line: 232, col: 30, offset: 5455},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 229, col: 34, offset: 5382},
+											pos: position{line: 232, col: 34, offset: 5459},
 											expr: &ruleRefExpr{
-												pos:  position{line: 229, col: 34, offset: 5382},
+												pos:  position{line: 232, col: 34, offset: 5459},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 229, col: 37, offset: 5385},
+											pos:  position{line: 232, col: 37, offset: 5462},
 											name: "fieldExpr",
 										},
 									},
@@ -1726,39 +1760,39 @@ var g = &grammar{
 		},
 		{
 			name: "fieldRefDotOnly",
-			pos:  position{line: 239, col: 1, offset: 5580},
+			pos:  position{line: 242, col: 1, offset: 5657},
 			expr: &actionExpr{
-				pos: position{line: 240, col: 5, offset: 5600},
+				pos: position{line: 243, col: 5, offset: 5677},
 				run: (*parser).callonfieldRefDotOnly1,
 				expr: &seqExpr{
-					pos: position{line: 240, col: 5, offset: 5600},
+					pos: position{line: 243, col: 5, offset: 5677},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 240, col: 5, offset: 5600},
+							pos:   position{line: 243, col: 5, offset: 5677},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 240, col: 10, offset: 5605},
+								pos:  position{line: 243, col: 10, offset: 5682},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 240, col: 20, offset: 5615},
+							pos:   position{line: 243, col: 20, offset: 5692},
 							label: "refs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 240, col: 25, offset: 5620},
+								pos: position{line: 243, col: 25, offset: 5697},
 								expr: &seqExpr{
-									pos: position{line: 240, col: 26, offset: 5621},
+									pos: position{line: 243, col: 26, offset: 5698},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 240, col: 26, offset: 5621},
+											pos:        position{line: 243, col: 26, offset: 5698},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&labeledExpr{
-											pos:   position{line: 240, col: 30, offset: 5625},
+											pos:   position{line: 243, col: 30, offset: 5702},
 											label: "field",
 											expr: &ruleRefExpr{
-												pos:  position{line: 240, col: 36, offset: 5631},
+												pos:  position{line: 243, col: 36, offset: 5708},
 												name: "fieldName",
 											},
 										},
@@ -1772,56 +1806,56 @@ var g = &grammar{
 		},
 		{
 			name: "fieldRefDotOnlyList",
-			pos:  position{line: 242, col: 1, offset: 5675},
+			pos:  position{line: 245, col: 1, offset: 5752},
 			expr: &actionExpr{
-				pos: position{line: 243, col: 5, offset: 5699},
+				pos: position{line: 246, col: 5, offset: 5776},
 				run: (*parser).callonfieldRefDotOnlyList1,
 				expr: &seqExpr{
-					pos: position{line: 243, col: 5, offset: 5699},
+					pos: position{line: 246, col: 5, offset: 5776},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 243, col: 5, offset: 5699},
+							pos:   position{line: 246, col: 5, offset: 5776},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 243, col: 11, offset: 5705},
+								pos:  position{line: 246, col: 11, offset: 5782},
 								name: "fieldRefDotOnly",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 243, col: 27, offset: 5721},
+							pos:   position{line: 246, col: 27, offset: 5798},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 243, col: 32, offset: 5726},
+								pos: position{line: 246, col: 32, offset: 5803},
 								expr: &actionExpr{
-									pos: position{line: 243, col: 33, offset: 5727},
+									pos: position{line: 246, col: 33, offset: 5804},
 									run: (*parser).callonfieldRefDotOnlyList7,
 									expr: &seqExpr{
-										pos: position{line: 243, col: 33, offset: 5727},
+										pos: position{line: 246, col: 33, offset: 5804},
 										exprs: []interface{}{
 											&zeroOrOneExpr{
-												pos: position{line: 243, col: 33, offset: 5727},
+												pos: position{line: 246, col: 33, offset: 5804},
 												expr: &ruleRefExpr{
-													pos:  position{line: 243, col: 33, offset: 5727},
+													pos:  position{line: 246, col: 33, offset: 5804},
 													name: "_",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 243, col: 36, offset: 5730},
+												pos:        position{line: 246, col: 36, offset: 5807},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 243, col: 40, offset: 5734},
+												pos: position{line: 246, col: 40, offset: 5811},
 												expr: &ruleRefExpr{
-													pos:  position{line: 243, col: 40, offset: 5734},
+													pos:  position{line: 246, col: 40, offset: 5811},
 													name: "_",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 243, col: 43, offset: 5737},
+												pos:   position{line: 246, col: 43, offset: 5814},
 												label: "ref",
 												expr: &ruleRefExpr{
-													pos:  position{line: 243, col: 47, offset: 5741},
+													pos:  position{line: 246, col: 47, offset: 5818},
 													name: "fieldRefDotOnly",
 												},
 											},
@@ -1836,50 +1870,50 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameList",
-			pos:  position{line: 251, col: 1, offset: 5921},
+			pos:  position{line: 254, col: 1, offset: 5998},
 			expr: &actionExpr{
-				pos: position{line: 252, col: 5, offset: 5939},
+				pos: position{line: 255, col: 5, offset: 6016},
 				run: (*parser).callonfieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 252, col: 5, offset: 5939},
+					pos: position{line: 255, col: 5, offset: 6016},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 252, col: 5, offset: 5939},
+							pos:   position{line: 255, col: 5, offset: 6016},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 252, col: 11, offset: 5945},
+								pos:  position{line: 255, col: 11, offset: 6022},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 252, col: 21, offset: 5955},
+							pos:   position{line: 255, col: 21, offset: 6032},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 252, col: 26, offset: 5960},
+								pos: position{line: 255, col: 26, offset: 6037},
 								expr: &seqExpr{
-									pos: position{line: 252, col: 27, offset: 5961},
+									pos: position{line: 255, col: 27, offset: 6038},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 252, col: 27, offset: 5961},
+											pos: position{line: 255, col: 27, offset: 6038},
 											expr: &ruleRefExpr{
-												pos:  position{line: 252, col: 27, offset: 5961},
+												pos:  position{line: 255, col: 27, offset: 6038},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 252, col: 30, offset: 5964},
+											pos:        position{line: 255, col: 30, offset: 6041},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 252, col: 34, offset: 5968},
+											pos: position{line: 255, col: 34, offset: 6045},
 											expr: &ruleRefExpr{
-												pos:  position{line: 252, col: 34, offset: 5968},
+												pos:  position{line: 255, col: 34, offset: 6045},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 252, col: 37, offset: 5971},
+											pos:  position{line: 255, col: 37, offset: 6048},
 											name: "fieldName",
 										},
 									},
@@ -1892,12 +1926,12 @@ var g = &grammar{
 		},
 		{
 			name: "countOp",
-			pos:  position{line: 260, col: 1, offset: 6164},
+			pos:  position{line: 263, col: 1, offset: 6241},
 			expr: &actionExpr{
-				pos: position{line: 261, col: 5, offset: 6176},
+				pos: position{line: 264, col: 5, offset: 6253},
 				run: (*parser).calloncountOp1,
 				expr: &litMatcher{
-					pos:        position{line: 261, col: 5, offset: 6176},
+					pos:        position{line: 264, col: 5, offset: 6253},
 					val:        "count",
 					ignoreCase: true,
 				},
@@ -1905,105 +1939,105 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReducerOp",
-			pos:  position{line: 263, col: 1, offset: 6210},
+			pos:  position{line: 266, col: 1, offset: 6287},
 			expr: &choiceExpr{
-				pos: position{line: 264, col: 5, offset: 6229},
+				pos: position{line: 267, col: 5, offset: 6306},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 264, col: 5, offset: 6229},
+						pos: position{line: 267, col: 5, offset: 6306},
 						run: (*parser).callonfieldReducerOp2,
 						expr: &litMatcher{
-							pos:        position{line: 264, col: 5, offset: 6229},
+							pos:        position{line: 267, col: 5, offset: 6306},
 							val:        "sum",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 265, col: 5, offset: 6263},
+						pos: position{line: 268, col: 5, offset: 6340},
 						run: (*parser).callonfieldReducerOp4,
 						expr: &litMatcher{
-							pos:        position{line: 265, col: 5, offset: 6263},
+							pos:        position{line: 268, col: 5, offset: 6340},
 							val:        "avg",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 266, col: 5, offset: 6297},
+						pos: position{line: 269, col: 5, offset: 6374},
 						run: (*parser).callonfieldReducerOp6,
 						expr: &litMatcher{
-							pos:        position{line: 266, col: 5, offset: 6297},
+							pos:        position{line: 269, col: 5, offset: 6374},
 							val:        "stdev",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 267, col: 5, offset: 6334},
+						pos: position{line: 270, col: 5, offset: 6411},
 						run: (*parser).callonfieldReducerOp8,
 						expr: &litMatcher{
-							pos:        position{line: 267, col: 5, offset: 6334},
+							pos:        position{line: 270, col: 5, offset: 6411},
 							val:        "sd",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 268, col: 5, offset: 6370},
+						pos: position{line: 271, col: 5, offset: 6447},
 						run: (*parser).callonfieldReducerOp10,
 						expr: &litMatcher{
-							pos:        position{line: 268, col: 5, offset: 6370},
+							pos:        position{line: 271, col: 5, offset: 6447},
 							val:        "var",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 269, col: 5, offset: 6404},
+						pos: position{line: 272, col: 5, offset: 6481},
 						run: (*parser).callonfieldReducerOp12,
 						expr: &litMatcher{
-							pos:        position{line: 269, col: 5, offset: 6404},
+							pos:        position{line: 272, col: 5, offset: 6481},
 							val:        "entropy",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 270, col: 5, offset: 6445},
+						pos: position{line: 273, col: 5, offset: 6522},
 						run: (*parser).callonfieldReducerOp14,
 						expr: &litMatcher{
-							pos:        position{line: 270, col: 5, offset: 6445},
+							pos:        position{line: 273, col: 5, offset: 6522},
 							val:        "min",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 271, col: 5, offset: 6479},
+						pos: position{line: 274, col: 5, offset: 6556},
 						run: (*parser).callonfieldReducerOp16,
 						expr: &litMatcher{
-							pos:        position{line: 271, col: 5, offset: 6479},
+							pos:        position{line: 274, col: 5, offset: 6556},
 							val:        "max",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 272, col: 5, offset: 6513},
+						pos: position{line: 275, col: 5, offset: 6590},
 						run: (*parser).callonfieldReducerOp18,
 						expr: &litMatcher{
-							pos:        position{line: 272, col: 5, offset: 6513},
+							pos:        position{line: 275, col: 5, offset: 6590},
 							val:        "first",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 273, col: 5, offset: 6551},
+						pos: position{line: 276, col: 5, offset: 6628},
 						run: (*parser).callonfieldReducerOp20,
 						expr: &litMatcher{
-							pos:        position{line: 273, col: 5, offset: 6551},
+							pos:        position{line: 276, col: 5, offset: 6628},
 							val:        "last",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 274, col: 5, offset: 6587},
+						pos: position{line: 277, col: 5, offset: 6664},
 						run: (*parser).callonfieldReducerOp22,
 						expr: &litMatcher{
-							pos:        position{line: 274, col: 5, offset: 6587},
+							pos:        position{line: 277, col: 5, offset: 6664},
 							val:        "countdistinct",
 							ignoreCase: true,
 						},
@@ -2013,32 +2047,32 @@ var g = &grammar{
 		},
 		{
 			name: "paddedFieldExpr",
-			pos:  position{line: 276, col: 1, offset: 6637},
+			pos:  position{line: 279, col: 1, offset: 6714},
 			expr: &actionExpr{
-				pos: position{line: 276, col: 19, offset: 6655},
+				pos: position{line: 279, col: 19, offset: 6732},
 				run: (*parser).callonpaddedFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 276, col: 19, offset: 6655},
+					pos: position{line: 279, col: 19, offset: 6732},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 276, col: 19, offset: 6655},
+							pos: position{line: 279, col: 19, offset: 6732},
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 19, offset: 6655},
+								pos:  position{line: 279, col: 19, offset: 6732},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 276, col: 22, offset: 6658},
+							pos:   position{line: 279, col: 22, offset: 6735},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 28, offset: 6664},
+								pos:  position{line: 279, col: 28, offset: 6741},
 								name: "fieldExpr",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 276, col: 38, offset: 6674},
+							pos: position{line: 279, col: 38, offset: 6751},
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 38, offset: 6674},
+								pos:  position{line: 279, col: 38, offset: 6751},
 								name: "_",
 							},
 						},
@@ -2048,53 +2082,53 @@ var g = &grammar{
 		},
 		{
 			name: "countReducer",
-			pos:  position{line: 278, col: 1, offset: 6700},
+			pos:  position{line: 281, col: 1, offset: 6777},
 			expr: &actionExpr{
-				pos: position{line: 279, col: 5, offset: 6717},
+				pos: position{line: 282, col: 5, offset: 6794},
 				run: (*parser).calloncountReducer1,
 				expr: &seqExpr{
-					pos: position{line: 279, col: 5, offset: 6717},
+					pos: position{line: 282, col: 5, offset: 6794},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 279, col: 5, offset: 6717},
+							pos:   position{line: 282, col: 5, offset: 6794},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 8, offset: 6720},
+								pos:  position{line: 282, col: 8, offset: 6797},
 								name: "countOp",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 279, col: 16, offset: 6728},
+							pos: position{line: 282, col: 16, offset: 6805},
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 16, offset: 6728},
+								pos:  position{line: 282, col: 16, offset: 6805},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 279, col: 19, offset: 6731},
+							pos:        position{line: 282, col: 19, offset: 6808},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 279, col: 23, offset: 6735},
+							pos:   position{line: 282, col: 23, offset: 6812},
 							label: "field",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 279, col: 29, offset: 6741},
+								pos: position{line: 282, col: 29, offset: 6818},
 								expr: &ruleRefExpr{
-									pos:  position{line: 279, col: 29, offset: 6741},
+									pos:  position{line: 282, col: 29, offset: 6818},
 									name: "paddedFieldExpr",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 279, col: 47, offset: 6759},
+							pos: position{line: 282, col: 47, offset: 6836},
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 47, offset: 6759},
+								pos:  position{line: 282, col: 47, offset: 6836},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 279, col: 50, offset: 6762},
+							pos:        position{line: 282, col: 50, offset: 6839},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2104,57 +2138,57 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReducer",
-			pos:  position{line: 283, col: 1, offset: 6821},
+			pos:  position{line: 286, col: 1, offset: 6898},
 			expr: &actionExpr{
-				pos: position{line: 284, col: 5, offset: 6838},
+				pos: position{line: 287, col: 5, offset: 6915},
 				run: (*parser).callonfieldReducer1,
 				expr: &seqExpr{
-					pos: position{line: 284, col: 5, offset: 6838},
+					pos: position{line: 287, col: 5, offset: 6915},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 284, col: 5, offset: 6838},
+							pos:   position{line: 287, col: 5, offset: 6915},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 8, offset: 6841},
+								pos:  position{line: 287, col: 8, offset: 6918},
 								name: "fieldReducerOp",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 284, col: 23, offset: 6856},
+							pos: position{line: 287, col: 23, offset: 6933},
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 23, offset: 6856},
+								pos:  position{line: 287, col: 23, offset: 6933},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 284, col: 26, offset: 6859},
+							pos:        position{line: 287, col: 26, offset: 6936},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 284, col: 30, offset: 6863},
+							pos: position{line: 287, col: 30, offset: 6940},
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 30, offset: 6863},
+								pos:  position{line: 287, col: 30, offset: 6940},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 284, col: 33, offset: 6866},
+							pos:   position{line: 287, col: 33, offset: 6943},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 39, offset: 6872},
+								pos:  position{line: 287, col: 39, offset: 6949},
 								name: "fieldExpr",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 284, col: 50, offset: 6883},
+							pos: position{line: 287, col: 50, offset: 6960},
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 50, offset: 6883},
+								pos:  position{line: 287, col: 50, offset: 6960},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 284, col: 53, offset: 6886},
+							pos:        position{line: 287, col: 53, offset: 6963},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2164,27 +2198,27 @@ var g = &grammar{
 		},
 		{
 			name: "reducerProc",
-			pos:  position{line: 288, col: 1, offset: 6953},
+			pos:  position{line: 291, col: 1, offset: 7030},
 			expr: &actionExpr{
-				pos: position{line: 289, col: 5, offset: 6969},
+				pos: position{line: 292, col: 5, offset: 7046},
 				run: (*parser).callonreducerProc1,
 				expr: &seqExpr{
-					pos: position{line: 289, col: 5, offset: 6969},
+					pos: position{line: 292, col: 5, offset: 7046},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 289, col: 5, offset: 6969},
+							pos:   position{line: 292, col: 5, offset: 7046},
 							label: "every",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 289, col: 11, offset: 6975},
+								pos: position{line: 292, col: 11, offset: 7052},
 								expr: &seqExpr{
-									pos: position{line: 289, col: 12, offset: 6976},
+									pos: position{line: 292, col: 12, offset: 7053},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 289, col: 12, offset: 6976},
+											pos:  position{line: 292, col: 12, offset: 7053},
 											name: "everyDur",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 289, col: 21, offset: 6985},
+											pos:  position{line: 292, col: 21, offset: 7062},
 											name: "_",
 										},
 									},
@@ -2192,27 +2226,27 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 289, col: 25, offset: 6989},
+							pos:   position{line: 292, col: 25, offset: 7066},
 							label: "reducers",
 							expr: &ruleRefExpr{
-								pos:  position{line: 289, col: 34, offset: 6998},
+								pos:  position{line: 292, col: 34, offset: 7075},
 								name: "reducerList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 289, col: 46, offset: 7010},
+							pos:   position{line: 292, col: 46, offset: 7087},
 							label: "keys",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 289, col: 51, offset: 7015},
+								pos: position{line: 292, col: 51, offset: 7092},
 								expr: &seqExpr{
-									pos: position{line: 289, col: 52, offset: 7016},
+									pos: position{line: 292, col: 52, offset: 7093},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 289, col: 52, offset: 7016},
+											pos:  position{line: 292, col: 52, offset: 7093},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 289, col: 54, offset: 7018},
+											pos:  position{line: 292, col: 54, offset: 7095},
 											name: "groupByKeys",
 										},
 									},
@@ -2220,12 +2254,23 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 289, col: 68, offset: 7032},
+							pos:   position{line: 292, col: 68, offset: 7109},
+							label: "sorted",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 292, col: 75, offset: 7116},
+								expr: &ruleRefExpr{
+									pos:  position{line: 292, col: 75, offset: 7116},
+									name: "groupBySorted",
+								},
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 292, col: 90, offset: 7131},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 289, col: 74, offset: 7038},
+								pos: position{line: 292, col: 96, offset: 7137},
 								expr: &ruleRefExpr{
-									pos:  position{line: 289, col: 74, offset: 7038},
+									pos:  position{line: 292, col: 96, offset: 7137},
 									name: "procLimitArg",
 								},
 							},
@@ -2236,27 +2281,27 @@ var g = &grammar{
 		},
 		{
 			name: "asClause",
-			pos:  position{line: 307, col: 1, offset: 7395},
+			pos:  position{line: 310, col: 1, offset: 7502},
 			expr: &actionExpr{
-				pos: position{line: 308, col: 5, offset: 7408},
+				pos: position{line: 311, col: 5, offset: 7515},
 				run: (*parser).callonasClause1,
 				expr: &seqExpr{
-					pos: position{line: 308, col: 5, offset: 7408},
+					pos: position{line: 311, col: 5, offset: 7515},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 308, col: 5, offset: 7408},
+							pos:        position{line: 311, col: 5, offset: 7515},
 							val:        "as",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 308, col: 11, offset: 7414},
+							pos:  position{line: 311, col: 11, offset: 7521},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 308, col: 13, offset: 7416},
+							pos:   position{line: 311, col: 13, offset: 7523},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 308, col: 15, offset: 7418},
+								pos:  position{line: 311, col: 15, offset: 7525},
 								name: "fieldName",
 							},
 						},
@@ -2266,48 +2311,48 @@ var g = &grammar{
 		},
 		{
 			name: "reducerExpr",
-			pos:  position{line: 310, col: 1, offset: 7447},
+			pos:  position{line: 313, col: 1, offset: 7554},
 			expr: &choiceExpr{
-				pos: position{line: 311, col: 5, offset: 7463},
+				pos: position{line: 314, col: 5, offset: 7570},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 311, col: 5, offset: 7463},
+						pos: position{line: 314, col: 5, offset: 7570},
 						run: (*parser).callonreducerExpr2,
 						expr: &seqExpr{
-							pos: position{line: 311, col: 5, offset: 7463},
+							pos: position{line: 314, col: 5, offset: 7570},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 311, col: 5, offset: 7463},
+									pos:   position{line: 314, col: 5, offset: 7570},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 311, col: 11, offset: 7469},
+										pos:  position{line: 314, col: 11, offset: 7576},
 										name: "fieldExpr",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 311, col: 21, offset: 7479},
+									pos: position{line: 314, col: 21, offset: 7586},
 									expr: &ruleRefExpr{
-										pos:  position{line: 311, col: 21, offset: 7479},
+										pos:  position{line: 314, col: 21, offset: 7586},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 311, col: 24, offset: 7482},
+									pos:        position{line: 314, col: 24, offset: 7589},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 311, col: 28, offset: 7486},
+									pos: position{line: 314, col: 28, offset: 7593},
 									expr: &ruleRefExpr{
-										pos:  position{line: 311, col: 28, offset: 7486},
+										pos:  position{line: 314, col: 28, offset: 7593},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 311, col: 31, offset: 7489},
+									pos:   position{line: 314, col: 31, offset: 7596},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 311, col: 33, offset: 7491},
+										pos:  position{line: 314, col: 33, offset: 7598},
 										name: "reducer",
 									},
 								},
@@ -2315,28 +2360,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 314, col: 5, offset: 7554},
+						pos: position{line: 317, col: 5, offset: 7661},
 						run: (*parser).callonreducerExpr13,
 						expr: &seqExpr{
-							pos: position{line: 314, col: 5, offset: 7554},
+							pos: position{line: 317, col: 5, offset: 7661},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 314, col: 5, offset: 7554},
+									pos:   position{line: 317, col: 5, offset: 7661},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 314, col: 7, offset: 7556},
+										pos:  position{line: 317, col: 7, offset: 7663},
 										name: "reducer",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 314, col: 15, offset: 7564},
+									pos:  position{line: 317, col: 15, offset: 7671},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 314, col: 17, offset: 7566},
+									pos:   position{line: 317, col: 17, offset: 7673},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 314, col: 23, offset: 7572},
+										pos:  position{line: 317, col: 23, offset: 7679},
 										name: "asClause",
 									},
 								},
@@ -2344,7 +2389,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 5, offset: 7636},
+						pos:  position{line: 320, col: 5, offset: 7743},
 						name: "reducer",
 					},
 				},
@@ -2352,16 +2397,16 @@ var g = &grammar{
 		},
 		{
 			name: "reducer",
-			pos:  position{line: 319, col: 1, offset: 7645},
+			pos:  position{line: 322, col: 1, offset: 7752},
 			expr: &choiceExpr{
-				pos: position{line: 320, col: 5, offset: 7657},
+				pos: position{line: 323, col: 5, offset: 7764},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 5, offset: 7657},
+						pos:  position{line: 323, col: 5, offset: 7764},
 						name: "countReducer",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 321, col: 5, offset: 7674},
+						pos:  position{line: 324, col: 5, offset: 7781},
 						name: "fieldReducer",
 					},
 				},
@@ -2369,50 +2414,50 @@ var g = &grammar{
 		},
 		{
 			name: "reducerList",
-			pos:  position{line: 323, col: 1, offset: 7688},
+			pos:  position{line: 326, col: 1, offset: 7795},
 			expr: &actionExpr{
-				pos: position{line: 324, col: 5, offset: 7704},
+				pos: position{line: 327, col: 5, offset: 7811},
 				run: (*parser).callonreducerList1,
 				expr: &seqExpr{
-					pos: position{line: 324, col: 5, offset: 7704},
+					pos: position{line: 327, col: 5, offset: 7811},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 324, col: 5, offset: 7704},
+							pos:   position{line: 327, col: 5, offset: 7811},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 324, col: 11, offset: 7710},
+								pos:  position{line: 327, col: 11, offset: 7817},
 								name: "reducerExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 324, col: 23, offset: 7722},
+							pos:   position{line: 327, col: 23, offset: 7829},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 324, col: 28, offset: 7727},
+								pos: position{line: 327, col: 28, offset: 7834},
 								expr: &seqExpr{
-									pos: position{line: 324, col: 29, offset: 7728},
+									pos: position{line: 327, col: 29, offset: 7835},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 324, col: 29, offset: 7728},
+											pos: position{line: 327, col: 29, offset: 7835},
 											expr: &ruleRefExpr{
-												pos:  position{line: 324, col: 29, offset: 7728},
+												pos:  position{line: 327, col: 29, offset: 7835},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 324, col: 32, offset: 7731},
+											pos:        position{line: 327, col: 32, offset: 7838},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 324, col: 36, offset: 7735},
+											pos: position{line: 327, col: 36, offset: 7842},
 											expr: &ruleRefExpr{
-												pos:  position{line: 324, col: 36, offset: 7735},
+												pos:  position{line: 327, col: 36, offset: 7842},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 324, col: 39, offset: 7738},
+											pos:  position{line: 327, col: 39, offset: 7845},
 											name: "reducerExpr",
 										},
 									},
@@ -2425,40 +2470,40 @@ var g = &grammar{
 		},
 		{
 			name: "simpleProc",
-			pos:  position{line: 332, col: 1, offset: 7935},
+			pos:  position{line: 335, col: 1, offset: 8042},
 			expr: &choiceExpr{
-				pos: position{line: 333, col: 5, offset: 7950},
+				pos: position{line: 336, col: 5, offset: 8057},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 333, col: 5, offset: 7950},
+						pos:  position{line: 336, col: 5, offset: 8057},
 						name: "sort",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 334, col: 5, offset: 7959},
+						pos:  position{line: 337, col: 5, offset: 8066},
 						name: "top",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 335, col: 5, offset: 7967},
+						pos:  position{line: 338, col: 5, offset: 8074},
 						name: "cut",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 336, col: 5, offset: 7975},
+						pos:  position{line: 339, col: 5, offset: 8082},
 						name: "head",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 337, col: 5, offset: 7984},
+						pos:  position{line: 340, col: 5, offset: 8091},
 						name: "tail",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 338, col: 5, offset: 7993},
+						pos:  position{line: 341, col: 5, offset: 8100},
 						name: "filter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 339, col: 5, offset: 8004},
+						pos:  position{line: 342, col: 5, offset: 8111},
 						name: "uniq",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 340, col: 5, offset: 8013},
+						pos:  position{line: 343, col: 5, offset: 8120},
 						name: "put",
 					},
 				},
@@ -2466,46 +2511,46 @@ var g = &grammar{
 		},
 		{
 			name: "sort",
-			pos:  position{line: 342, col: 1, offset: 8018},
+			pos:  position{line: 345, col: 1, offset: 8125},
 			expr: &actionExpr{
-				pos: position{line: 343, col: 5, offset: 8027},
+				pos: position{line: 346, col: 5, offset: 8134},
 				run: (*parser).callonsort1,
 				expr: &seqExpr{
-					pos: position{line: 343, col: 5, offset: 8027},
+					pos: position{line: 346, col: 5, offset: 8134},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 343, col: 5, offset: 8027},
+							pos:        position{line: 346, col: 5, offset: 8134},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 343, col: 13, offset: 8035},
+							pos:   position{line: 346, col: 13, offset: 8142},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 343, col: 18, offset: 8040},
+								pos:  position{line: 346, col: 18, offset: 8147},
 								name: "sortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 343, col: 27, offset: 8049},
+							pos:   position{line: 346, col: 27, offset: 8156},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 343, col: 32, offset: 8054},
+								pos: position{line: 346, col: 32, offset: 8161},
 								expr: &actionExpr{
-									pos: position{line: 343, col: 33, offset: 8055},
+									pos: position{line: 346, col: 33, offset: 8162},
 									run: (*parser).callonsort8,
 									expr: &seqExpr{
-										pos: position{line: 343, col: 33, offset: 8055},
+										pos: position{line: 346, col: 33, offset: 8162},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 343, col: 33, offset: 8055},
+												pos:  position{line: 346, col: 33, offset: 8162},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 343, col: 35, offset: 8057},
+												pos:   position{line: 346, col: 35, offset: 8164},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 343, col: 37, offset: 8059},
+													pos:  position{line: 346, col: 37, offset: 8166},
 													name: "fieldExprList",
 												},
 											},
@@ -2520,24 +2565,24 @@ var g = &grammar{
 		},
 		{
 			name: "sortArgs",
-			pos:  position{line: 347, col: 1, offset: 8136},
+			pos:  position{line: 350, col: 1, offset: 8243},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 347, col: 12, offset: 8147},
+				pos: position{line: 350, col: 12, offset: 8254},
 				expr: &actionExpr{
-					pos: position{line: 347, col: 13, offset: 8148},
+					pos: position{line: 350, col: 13, offset: 8255},
 					run: (*parser).callonsortArgs2,
 					expr: &seqExpr{
-						pos: position{line: 347, col: 13, offset: 8148},
+						pos: position{line: 350, col: 13, offset: 8255},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 347, col: 13, offset: 8148},
+								pos:  position{line: 350, col: 13, offset: 8255},
 								name: "_",
 							},
 							&labeledExpr{
-								pos:   position{line: 347, col: 15, offset: 8150},
+								pos:   position{line: 350, col: 15, offset: 8257},
 								label: "a",
 								expr: &ruleRefExpr{
-									pos:  position{line: 347, col: 17, offset: 8152},
+									pos:  position{line: 350, col: 17, offset: 8259},
 									name: "sortArg",
 								},
 							},
@@ -2548,50 +2593,50 @@ var g = &grammar{
 		},
 		{
 			name: "sortArg",
-			pos:  position{line: 349, col: 1, offset: 8181},
+			pos:  position{line: 352, col: 1, offset: 8288},
 			expr: &choiceExpr{
-				pos: position{line: 350, col: 5, offset: 8193},
+				pos: position{line: 353, col: 5, offset: 8300},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 350, col: 5, offset: 8193},
+						pos: position{line: 353, col: 5, offset: 8300},
 						run: (*parser).callonsortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 350, col: 5, offset: 8193},
+							pos:        position{line: 353, col: 5, offset: 8300},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 351, col: 5, offset: 8236},
+						pos: position{line: 354, col: 5, offset: 8343},
 						run: (*parser).callonsortArg4,
 						expr: &seqExpr{
-							pos: position{line: 351, col: 5, offset: 8236},
+							pos: position{line: 354, col: 5, offset: 8343},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 351, col: 5, offset: 8236},
+									pos:        position{line: 354, col: 5, offset: 8343},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 14, offset: 8245},
+									pos:  position{line: 354, col: 14, offset: 8352},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 351, col: 16, offset: 8247},
+									pos:   position{line: 354, col: 16, offset: 8354},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 351, col: 23, offset: 8254},
+										pos: position{line: 354, col: 23, offset: 8361},
 										run: (*parser).callonsortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 351, col: 24, offset: 8255},
+											pos: position{line: 354, col: 24, offset: 8362},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 351, col: 24, offset: 8255},
+													pos:        position{line: 354, col: 24, offset: 8362},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 351, col: 34, offset: 8265},
+													pos:        position{line: 354, col: 34, offset: 8372},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2607,38 +2652,38 @@ var g = &grammar{
 		},
 		{
 			name: "top",
-			pos:  position{line: 353, col: 1, offset: 8347},
+			pos:  position{line: 356, col: 1, offset: 8454},
 			expr: &actionExpr{
-				pos: position{line: 354, col: 5, offset: 8355},
+				pos: position{line: 357, col: 5, offset: 8462},
 				run: (*parser).callontop1,
 				expr: &seqExpr{
-					pos: position{line: 354, col: 5, offset: 8355},
+					pos: position{line: 357, col: 5, offset: 8462},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 354, col: 5, offset: 8355},
+							pos:        position{line: 357, col: 5, offset: 8462},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 12, offset: 8362},
+							pos:   position{line: 357, col: 12, offset: 8469},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 354, col: 18, offset: 8368},
+								pos: position{line: 357, col: 18, offset: 8475},
 								expr: &actionExpr{
-									pos: position{line: 354, col: 19, offset: 8369},
+									pos: position{line: 357, col: 19, offset: 8476},
 									run: (*parser).callontop6,
 									expr: &seqExpr{
-										pos: position{line: 354, col: 19, offset: 8369},
+										pos: position{line: 357, col: 19, offset: 8476},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 354, col: 19, offset: 8369},
+												pos:  position{line: 357, col: 19, offset: 8476},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 354, col: 21, offset: 8371},
+												pos:   position{line: 357, col: 21, offset: 8478},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 354, col: 23, offset: 8373},
+													pos:  position{line: 357, col: 23, offset: 8480},
 													name: "unsignedInteger",
 												},
 											},
@@ -2648,19 +2693,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 58, offset: 8408},
+							pos:   position{line: 357, col: 58, offset: 8515},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 354, col: 64, offset: 8414},
+								pos: position{line: 357, col: 64, offset: 8521},
 								expr: &seqExpr{
-									pos: position{line: 354, col: 65, offset: 8415},
+									pos: position{line: 357, col: 65, offset: 8522},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 354, col: 65, offset: 8415},
+											pos:  position{line: 357, col: 65, offset: 8522},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 354, col: 67, offset: 8417},
+											pos:        position{line: 357, col: 67, offset: 8524},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2669,25 +2714,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 78, offset: 8428},
+							pos:   position{line: 357, col: 78, offset: 8535},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 354, col: 83, offset: 8433},
+								pos: position{line: 357, col: 83, offset: 8540},
 								expr: &actionExpr{
-									pos: position{line: 354, col: 84, offset: 8434},
+									pos: position{line: 357, col: 84, offset: 8541},
 									run: (*parser).callontop18,
 									expr: &seqExpr{
-										pos: position{line: 354, col: 84, offset: 8434},
+										pos: position{line: 357, col: 84, offset: 8541},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 354, col: 84, offset: 8434},
+												pos:  position{line: 357, col: 84, offset: 8541},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 354, col: 86, offset: 8436},
+												pos:   position{line: 357, col: 86, offset: 8543},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 354, col: 88, offset: 8438},
+													pos:  position{line: 357, col: 88, offset: 8545},
 													name: "fieldExprList",
 												},
 											},
@@ -2702,31 +2747,31 @@ var g = &grammar{
 		},
 		{
 			name: "procLimitArg",
-			pos:  position{line: 358, col: 1, offset: 8527},
+			pos:  position{line: 361, col: 1, offset: 8634},
 			expr: &actionExpr{
-				pos: position{line: 359, col: 5, offset: 8544},
+				pos: position{line: 362, col: 5, offset: 8651},
 				run: (*parser).callonprocLimitArg1,
 				expr: &seqExpr{
-					pos: position{line: 359, col: 5, offset: 8544},
+					pos: position{line: 362, col: 5, offset: 8651},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 359, col: 5, offset: 8544},
+							pos:  position{line: 362, col: 5, offset: 8651},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 359, col: 7, offset: 8546},
+							pos:        position{line: 362, col: 7, offset: 8653},
 							val:        "-limit",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 359, col: 16, offset: 8555},
+							pos:  position{line: 362, col: 16, offset: 8662},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 359, col: 18, offset: 8557},
+							pos:   position{line: 362, col: 18, offset: 8664},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 359, col: 24, offset: 8563},
+								pos:  position{line: 362, col: 24, offset: 8670},
 								name: "unsignedInteger",
 							},
 						},
@@ -2736,21 +2781,21 @@ var g = &grammar{
 		},
 		{
 			name: "cutArg",
-			pos:  position{line: 361, col: 1, offset: 8602},
+			pos:  position{line: 364, col: 1, offset: 8709},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 361, col: 10, offset: 8611},
+				pos: position{line: 364, col: 10, offset: 8718},
 				expr: &actionExpr{
-					pos: position{line: 361, col: 11, offset: 8612},
+					pos: position{line: 364, col: 11, offset: 8719},
 					run: (*parser).calloncutArg2,
 					expr: &seqExpr{
-						pos: position{line: 361, col: 11, offset: 8612},
+						pos: position{line: 364, col: 11, offset: 8719},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 361, col: 11, offset: 8612},
+								pos:  position{line: 364, col: 11, offset: 8719},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 361, col: 13, offset: 8614},
+								pos:        position{line: 364, col: 13, offset: 8721},
 								val:        "-c",
 								ignoreCase: false,
 							},
@@ -2761,35 +2806,35 @@ var g = &grammar{
 		},
 		{
 			name: "cut",
-			pos:  position{line: 363, col: 1, offset: 8656},
+			pos:  position{line: 366, col: 1, offset: 8763},
 			expr: &actionExpr{
-				pos: position{line: 364, col: 5, offset: 8664},
+				pos: position{line: 367, col: 5, offset: 8771},
 				run: (*parser).calloncut1,
 				expr: &seqExpr{
-					pos: position{line: 364, col: 5, offset: 8664},
+					pos: position{line: 367, col: 5, offset: 8771},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 364, col: 5, offset: 8664},
+							pos:        position{line: 367, col: 5, offset: 8771},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 364, col: 12, offset: 8671},
+							pos:   position{line: 367, col: 12, offset: 8778},
 							label: "arg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 364, col: 16, offset: 8675},
+								pos:  position{line: 367, col: 16, offset: 8782},
 								name: "cutArg",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 364, col: 23, offset: 8682},
+							pos:  position{line: 367, col: 23, offset: 8789},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 364, col: 25, offset: 8684},
+							pos:   position{line: 367, col: 25, offset: 8791},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 364, col: 30, offset: 8689},
+								pos:  position{line: 367, col: 30, offset: 8796},
 								name: "fieldRefDotOnlyList",
 							},
 						},
@@ -2799,30 +2844,30 @@ var g = &grammar{
 		},
 		{
 			name: "head",
-			pos:  position{line: 365, col: 1, offset: 8744},
+			pos:  position{line: 368, col: 1, offset: 8851},
 			expr: &choiceExpr{
-				pos: position{line: 366, col: 5, offset: 8753},
+				pos: position{line: 369, col: 5, offset: 8860},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 366, col: 5, offset: 8753},
+						pos: position{line: 369, col: 5, offset: 8860},
 						run: (*parser).callonhead2,
 						expr: &seqExpr{
-							pos: position{line: 366, col: 5, offset: 8753},
+							pos: position{line: 369, col: 5, offset: 8860},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 366, col: 5, offset: 8753},
+									pos:        position{line: 369, col: 5, offset: 8860},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 366, col: 13, offset: 8761},
+									pos:  position{line: 369, col: 13, offset: 8868},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 366, col: 15, offset: 8763},
+									pos:   position{line: 369, col: 15, offset: 8870},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 366, col: 21, offset: 8769},
+										pos:  position{line: 369, col: 21, offset: 8876},
 										name: "unsignedInteger",
 									},
 								},
@@ -2830,10 +2875,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 367, col: 5, offset: 8825},
+						pos: position{line: 370, col: 5, offset: 8932},
 						run: (*parser).callonhead8,
 						expr: &litMatcher{
-							pos:        position{line: 367, col: 5, offset: 8825},
+							pos:        position{line: 370, col: 5, offset: 8932},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2843,30 +2888,30 @@ var g = &grammar{
 		},
 		{
 			name: "tail",
-			pos:  position{line: 368, col: 1, offset: 8865},
+			pos:  position{line: 371, col: 1, offset: 8972},
 			expr: &choiceExpr{
-				pos: position{line: 369, col: 5, offset: 8874},
+				pos: position{line: 372, col: 5, offset: 8981},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 369, col: 5, offset: 8874},
+						pos: position{line: 372, col: 5, offset: 8981},
 						run: (*parser).callontail2,
 						expr: &seqExpr{
-							pos: position{line: 369, col: 5, offset: 8874},
+							pos: position{line: 372, col: 5, offset: 8981},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 369, col: 5, offset: 8874},
+									pos:        position{line: 372, col: 5, offset: 8981},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 369, col: 13, offset: 8882},
+									pos:  position{line: 372, col: 13, offset: 8989},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 369, col: 15, offset: 8884},
+									pos:   position{line: 372, col: 15, offset: 8991},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 369, col: 21, offset: 8890},
+										pos:  position{line: 372, col: 21, offset: 8997},
 										name: "unsignedInteger",
 									},
 								},
@@ -2874,10 +2919,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 370, col: 5, offset: 8946},
+						pos: position{line: 373, col: 5, offset: 9053},
 						run: (*parser).callontail8,
 						expr: &litMatcher{
-							pos:        position{line: 370, col: 5, offset: 8946},
+							pos:        position{line: 373, col: 5, offset: 9053},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2887,27 +2932,27 @@ var g = &grammar{
 		},
 		{
 			name: "filter",
-			pos:  position{line: 372, col: 1, offset: 8987},
+			pos:  position{line: 375, col: 1, offset: 9094},
 			expr: &actionExpr{
-				pos: position{line: 373, col: 5, offset: 8998},
+				pos: position{line: 376, col: 5, offset: 9105},
 				run: (*parser).callonfilter1,
 				expr: &seqExpr{
-					pos: position{line: 373, col: 5, offset: 8998},
+					pos: position{line: 376, col: 5, offset: 9105},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 373, col: 5, offset: 8998},
+							pos:        position{line: 376, col: 5, offset: 9105},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 373, col: 15, offset: 9008},
+							pos:  position{line: 376, col: 15, offset: 9115},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 373, col: 17, offset: 9010},
+							pos:   position{line: 376, col: 17, offset: 9117},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 373, col: 22, offset: 9015},
+								pos:  position{line: 376, col: 22, offset: 9122},
 								name: "searchExpr",
 							},
 						},
@@ -2917,27 +2962,27 @@ var g = &grammar{
 		},
 		{
 			name: "uniq",
-			pos:  position{line: 376, col: 1, offset: 9073},
+			pos:  position{line: 379, col: 1, offset: 9180},
 			expr: &choiceExpr{
-				pos: position{line: 377, col: 5, offset: 9082},
+				pos: position{line: 380, col: 5, offset: 9189},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 377, col: 5, offset: 9082},
+						pos: position{line: 380, col: 5, offset: 9189},
 						run: (*parser).callonuniq2,
 						expr: &seqExpr{
-							pos: position{line: 377, col: 5, offset: 9082},
+							pos: position{line: 380, col: 5, offset: 9189},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 377, col: 5, offset: 9082},
+									pos:        position{line: 380, col: 5, offset: 9189},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 377, col: 13, offset: 9090},
+									pos:  position{line: 380, col: 13, offset: 9197},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 377, col: 15, offset: 9092},
+									pos:        position{line: 380, col: 15, offset: 9199},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2945,10 +2990,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 380, col: 5, offset: 9146},
+						pos: position{line: 383, col: 5, offset: 9253},
 						run: (*parser).callonuniq7,
 						expr: &litMatcher{
-							pos:        position{line: 380, col: 5, offset: 9146},
+							pos:        position{line: 383, col: 5, offset: 9253},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2958,59 +3003,59 @@ var g = &grammar{
 		},
 		{
 			name: "put",
-			pos:  position{line: 384, col: 1, offset: 9201},
+			pos:  position{line: 387, col: 1, offset: 9308},
 			expr: &actionExpr{
-				pos: position{line: 385, col: 5, offset: 9209},
+				pos: position{line: 388, col: 5, offset: 9316},
 				run: (*parser).callonput1,
 				expr: &seqExpr{
-					pos: position{line: 385, col: 5, offset: 9209},
+					pos: position{line: 388, col: 5, offset: 9316},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 385, col: 5, offset: 9209},
+							pos:        position{line: 388, col: 5, offset: 9316},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 385, col: 12, offset: 9216},
+							pos:  position{line: 388, col: 12, offset: 9323},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 385, col: 14, offset: 9218},
+							pos:   position{line: 388, col: 14, offset: 9325},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 385, col: 20, offset: 9224},
+								pos:  position{line: 388, col: 20, offset: 9331},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 385, col: 31, offset: 9235},
+							pos:   position{line: 388, col: 31, offset: 9342},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 385, col: 36, offset: 9240},
+								pos: position{line: 388, col: 36, offset: 9347},
 								expr: &actionExpr{
-									pos: position{line: 385, col: 37, offset: 9241},
+									pos: position{line: 388, col: 37, offset: 9348},
 									run: (*parser).callonput9,
 									expr: &seqExpr{
-										pos: position{line: 385, col: 37, offset: 9241},
+										pos: position{line: 388, col: 37, offset: 9348},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 385, col: 37, offset: 9241},
+												pos:  position{line: 388, col: 37, offset: 9348},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 385, col: 40, offset: 9244},
+												pos:        position{line: 388, col: 40, offset: 9351},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 385, col: 44, offset: 9248},
+												pos:  position{line: 388, col: 44, offset: 9355},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 385, col: 47, offset: 9251},
+												pos:   position{line: 388, col: 47, offset: 9358},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 385, col: 50, offset: 9254},
+													pos:  position{line: 388, col: 50, offset: 9361},
 													name: "Assignment",
 												},
 											},
@@ -3025,39 +3070,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 389, col: 1, offset: 9338},
+			pos:  position{line: 392, col: 1, offset: 9445},
 			expr: &actionExpr{
-				pos: position{line: 390, col: 5, offset: 9353},
+				pos: position{line: 393, col: 5, offset: 9460},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 390, col: 5, offset: 9353},
+					pos: position{line: 393, col: 5, offset: 9460},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 390, col: 5, offset: 9353},
+							pos:   position{line: 393, col: 5, offset: 9460},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 390, col: 7, offset: 9355},
+								pos:  position{line: 393, col: 7, offset: 9462},
 								name: "fieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 390, col: 17, offset: 9365},
+							pos:  position{line: 393, col: 17, offset: 9472},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 390, col: 20, offset: 9368},
+							pos:        position{line: 393, col: 20, offset: 9475},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 390, col: 24, offset: 9372},
+							pos:  position{line: 393, col: 24, offset: 9479},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 390, col: 27, offset: 9375},
+							pos:   position{line: 393, col: 27, offset: 9482},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 390, col: 29, offset: 9377},
+								pos:  position{line: 393, col: 29, offset: 9484},
 								name: "Expression",
 							},
 						},
@@ -3067,79 +3112,79 @@ var g = &grammar{
 		},
 		{
 			name: "PrimaryExpression",
-			pos:  position{line: 394, col: 1, offset: 9436},
+			pos:  position{line: 397, col: 1, offset: 9543},
 			expr: &choiceExpr{
-				pos: position{line: 395, col: 5, offset: 9458},
+				pos: position{line: 398, col: 5, offset: 9565},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 395, col: 5, offset: 9458},
+						pos:  position{line: 398, col: 5, offset: 9565},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 396, col: 5, offset: 9476},
+						pos:  position{line: 399, col: 5, offset: 9583},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 397, col: 5, offset: 9494},
+						pos:  position{line: 400, col: 5, offset: 9601},
 						name: "PortLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 398, col: 5, offset: 9510},
+						pos:  position{line: 401, col: 5, offset: 9617},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 399, col: 5, offset: 9528},
+						pos:  position{line: 402, col: 5, offset: 9635},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 400, col: 5, offset: 9547},
+						pos:  position{line: 403, col: 5, offset: 9654},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 401, col: 5, offset: 9564},
+						pos:  position{line: 404, col: 5, offset: 9671},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 402, col: 5, offset: 9583},
+						pos:  position{line: 405, col: 5, offset: 9690},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 403, col: 5, offset: 9602},
+						pos:  position{line: 406, col: 5, offset: 9709},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 404, col: 5, offset: 9618},
+						pos:  position{line: 407, col: 5, offset: 9725},
 						name: "FieldReference",
 					},
 					&actionExpr{
-						pos: position{line: 405, col: 5, offset: 9637},
+						pos: position{line: 408, col: 5, offset: 9744},
 						run: (*parser).callonPrimaryExpression12,
 						expr: &seqExpr{
-							pos: position{line: 405, col: 5, offset: 9637},
+							pos: position{line: 408, col: 5, offset: 9744},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 405, col: 5, offset: 9637},
+									pos:        position{line: 408, col: 5, offset: 9744},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 405, col: 9, offset: 9641},
+									pos:  position{line: 408, col: 9, offset: 9748},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 405, col: 12, offset: 9644},
+									pos:   position{line: 408, col: 12, offset: 9751},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 405, col: 17, offset: 9649},
+										pos:  position{line: 408, col: 17, offset: 9756},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 405, col: 28, offset: 9660},
+									pos:  position{line: 408, col: 28, offset: 9767},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 405, col: 31, offset: 9663},
+									pos:        position{line: 408, col: 31, offset: 9770},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3151,15 +3196,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldReference",
-			pos:  position{line: 407, col: 1, offset: 9689},
+			pos:  position{line: 410, col: 1, offset: 9796},
 			expr: &actionExpr{
-				pos: position{line: 408, col: 5, offset: 9708},
+				pos: position{line: 411, col: 5, offset: 9815},
 				run: (*parser).callonFieldReference1,
 				expr: &labeledExpr{
-					pos:   position{line: 408, col: 5, offset: 9708},
+					pos:   position{line: 411, col: 5, offset: 9815},
 					label: "f",
 					expr: &ruleRefExpr{
-						pos:  position{line: 408, col: 7, offset: 9710},
+						pos:  position{line: 411, col: 7, offset: 9817},
 						name: "fieldName",
 					},
 				},
@@ -3167,71 +3212,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expression",
-			pos:  position{line: 418, col: 1, offset: 9959},
+			pos:  position{line: 421, col: 1, offset: 10066},
 			expr: &ruleRefExpr{
-				pos:  position{line: 418, col: 14, offset: 9972},
+				pos:  position{line: 421, col: 14, offset: 10079},
 				name: "ConditionalExpression",
 			},
 		},
 		{
 			name: "ConditionalExpression",
-			pos:  position{line: 420, col: 1, offset: 9995},
+			pos:  position{line: 423, col: 1, offset: 10102},
 			expr: &choiceExpr{
-				pos: position{line: 421, col: 5, offset: 10021},
+				pos: position{line: 424, col: 5, offset: 10128},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 421, col: 5, offset: 10021},
+						pos: position{line: 424, col: 5, offset: 10128},
 						run: (*parser).callonConditionalExpression2,
 						expr: &seqExpr{
-							pos: position{line: 421, col: 5, offset: 10021},
+							pos: position{line: 424, col: 5, offset: 10128},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 421, col: 5, offset: 10021},
+									pos:   position{line: 424, col: 5, offset: 10128},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 421, col: 15, offset: 10031},
+										pos:  position{line: 424, col: 15, offset: 10138},
 										name: "LogicalORExpression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 421, col: 35, offset: 10051},
+									pos:  position{line: 424, col: 35, offset: 10158},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 421, col: 38, offset: 10054},
+									pos:        position{line: 424, col: 38, offset: 10161},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 421, col: 42, offset: 10058},
+									pos:  position{line: 424, col: 42, offset: 10165},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 421, col: 45, offset: 10061},
+									pos:   position{line: 424, col: 45, offset: 10168},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 421, col: 56, offset: 10072},
+										pos:  position{line: 424, col: 56, offset: 10179},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 421, col: 67, offset: 10083},
+									pos:  position{line: 424, col: 67, offset: 10190},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 421, col: 70, offset: 10086},
+									pos:        position{line: 424, col: 70, offset: 10193},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 421, col: 74, offset: 10090},
+									pos:  position{line: 424, col: 74, offset: 10197},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 421, col: 77, offset: 10093},
+									pos:   position{line: 424, col: 77, offset: 10200},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 421, col: 88, offset: 10104},
+										pos:  position{line: 424, col: 88, offset: 10211},
 										name: "Expression",
 									},
 								},
@@ -3239,7 +3284,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 424, col: 5, offset: 10196},
+						pos:  position{line: 427, col: 5, offset: 10303},
 						name: "LogicalORExpression",
 					},
 				},
@@ -3247,43 +3292,43 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalORExpression",
-			pos:  position{line: 426, col: 1, offset: 10217},
+			pos:  position{line: 429, col: 1, offset: 10324},
 			expr: &actionExpr{
-				pos: position{line: 427, col: 5, offset: 10241},
+				pos: position{line: 430, col: 5, offset: 10348},
 				run: (*parser).callonLogicalORExpression1,
 				expr: &seqExpr{
-					pos: position{line: 427, col: 5, offset: 10241},
+					pos: position{line: 430, col: 5, offset: 10348},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 427, col: 5, offset: 10241},
+							pos:   position{line: 430, col: 5, offset: 10348},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 427, col: 11, offset: 10247},
+								pos:  position{line: 430, col: 11, offset: 10354},
 								name: "LogicalANDExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 428, col: 5, offset: 10272},
+							pos:   position{line: 431, col: 5, offset: 10379},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 428, col: 10, offset: 10277},
+								pos: position{line: 431, col: 10, offset: 10384},
 								expr: &seqExpr{
-									pos: position{line: 428, col: 11, offset: 10278},
+									pos: position{line: 431, col: 11, offset: 10385},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 11, offset: 10278},
+											pos:  position{line: 431, col: 11, offset: 10385},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 14, offset: 10281},
+											pos:  position{line: 431, col: 14, offset: 10388},
 											name: "orToken",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 22, offset: 10289},
+											pos:  position{line: 431, col: 22, offset: 10396},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 25, offset: 10292},
+											pos:  position{line: 431, col: 25, offset: 10399},
 											name: "LogicalANDExpression",
 										},
 									},
@@ -3296,43 +3341,43 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalANDExpression",
-			pos:  position{line: 432, col: 1, offset: 10377},
+			pos:  position{line: 435, col: 1, offset: 10484},
 			expr: &actionExpr{
-				pos: position{line: 433, col: 5, offset: 10402},
+				pos: position{line: 436, col: 5, offset: 10509},
 				run: (*parser).callonLogicalANDExpression1,
 				expr: &seqExpr{
-					pos: position{line: 433, col: 5, offset: 10402},
+					pos: position{line: 436, col: 5, offset: 10509},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 433, col: 5, offset: 10402},
+							pos:   position{line: 436, col: 5, offset: 10509},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 433, col: 11, offset: 10408},
+								pos:  position{line: 436, col: 11, offset: 10515},
 								name: "EqualityCompareExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 434, col: 5, offset: 10438},
+							pos:   position{line: 437, col: 5, offset: 10545},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 434, col: 10, offset: 10443},
+								pos: position{line: 437, col: 10, offset: 10550},
 								expr: &seqExpr{
-									pos: position{line: 434, col: 11, offset: 10444},
+									pos: position{line: 437, col: 11, offset: 10551},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 434, col: 11, offset: 10444},
+											pos:  position{line: 437, col: 11, offset: 10551},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 434, col: 14, offset: 10447},
+											pos:  position{line: 437, col: 14, offset: 10554},
 											name: "andToken",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 434, col: 23, offset: 10456},
+											pos:  position{line: 437, col: 23, offset: 10563},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 434, col: 26, offset: 10459},
+											pos:  position{line: 437, col: 26, offset: 10566},
 											name: "EqualityCompareExpression",
 										},
 									},
@@ -3345,43 +3390,43 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpression",
-			pos:  position{line: 438, col: 1, offset: 10549},
+			pos:  position{line: 441, col: 1, offset: 10656},
 			expr: &actionExpr{
-				pos: position{line: 439, col: 5, offset: 10579},
+				pos: position{line: 442, col: 5, offset: 10686},
 				run: (*parser).callonEqualityCompareExpression1,
 				expr: &seqExpr{
-					pos: position{line: 439, col: 5, offset: 10579},
+					pos: position{line: 442, col: 5, offset: 10686},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 439, col: 5, offset: 10579},
+							pos:   position{line: 442, col: 5, offset: 10686},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 439, col: 11, offset: 10585},
+								pos:  position{line: 442, col: 11, offset: 10692},
 								name: "RelativeExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 5, offset: 10608},
+							pos:   position{line: 443, col: 5, offset: 10715},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 440, col: 10, offset: 10613},
+								pos: position{line: 443, col: 10, offset: 10720},
 								expr: &seqExpr{
-									pos: position{line: 440, col: 11, offset: 10614},
+									pos: position{line: 443, col: 11, offset: 10721},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 11, offset: 10614},
+											pos:  position{line: 443, col: 11, offset: 10721},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 14, offset: 10617},
+											pos:  position{line: 443, col: 14, offset: 10724},
 											name: "EqualityComparator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 33, offset: 10636},
+											pos:  position{line: 443, col: 33, offset: 10743},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 36, offset: 10639},
+											pos:  position{line: 443, col: 36, offset: 10746},
 											name: "RelativeExpression",
 										},
 									},
@@ -3394,30 +3439,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 444, col: 1, offset: 10722},
+			pos:  position{line: 447, col: 1, offset: 10829},
 			expr: &actionExpr{
-				pos: position{line: 444, col: 20, offset: 10741},
+				pos: position{line: 447, col: 20, offset: 10848},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 444, col: 21, offset: 10742},
+					pos: position{line: 447, col: 21, offset: 10849},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 444, col: 21, offset: 10742},
+							pos:        position{line: 447, col: 21, offset: 10849},
 							val:        "=~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 28, offset: 10749},
+							pos:        position{line: 447, col: 28, offset: 10856},
 							val:        "!~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 35, offset: 10756},
+							pos:        position{line: 447, col: 35, offset: 10863},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 41, offset: 10762},
+							pos:        position{line: 447, col: 41, offset: 10869},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3427,19 +3472,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 446, col: 1, offset: 10800},
+			pos:  position{line: 449, col: 1, offset: 10907},
 			expr: &choiceExpr{
-				pos: position{line: 447, col: 5, offset: 10823},
+				pos: position{line: 450, col: 5, offset: 10930},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 447, col: 5, offset: 10823},
+						pos:  position{line: 450, col: 5, offset: 10930},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 448, col: 5, offset: 10844},
+						pos: position{line: 451, col: 5, offset: 10951},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 448, col: 5, offset: 10844},
+							pos:        position{line: 451, col: 5, offset: 10951},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3449,43 +3494,43 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpression",
-			pos:  position{line: 450, col: 1, offset: 10881},
+			pos:  position{line: 453, col: 1, offset: 10988},
 			expr: &actionExpr{
-				pos: position{line: 451, col: 5, offset: 10904},
+				pos: position{line: 454, col: 5, offset: 11011},
 				run: (*parser).callonRelativeExpression1,
 				expr: &seqExpr{
-					pos: position{line: 451, col: 5, offset: 10904},
+					pos: position{line: 454, col: 5, offset: 11011},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 451, col: 5, offset: 10904},
+							pos:   position{line: 454, col: 5, offset: 11011},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 451, col: 11, offset: 10910},
+								pos:  position{line: 454, col: 11, offset: 11017},
 								name: "AdditiveExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 452, col: 5, offset: 10933},
+							pos:   position{line: 455, col: 5, offset: 11040},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 452, col: 10, offset: 10938},
+								pos: position{line: 455, col: 10, offset: 11045},
 								expr: &seqExpr{
-									pos: position{line: 452, col: 11, offset: 10939},
+									pos: position{line: 455, col: 11, offset: 11046},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 11, offset: 10939},
+											pos:  position{line: 455, col: 11, offset: 11046},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 14, offset: 10942},
+											pos:  position{line: 455, col: 14, offset: 11049},
 											name: "RelativeOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 31, offset: 10959},
+											pos:  position{line: 455, col: 31, offset: 11066},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 34, offset: 10962},
+											pos:  position{line: 455, col: 34, offset: 11069},
 											name: "AdditiveExpression",
 										},
 									},
@@ -3498,30 +3543,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 456, col: 1, offset: 11045},
+			pos:  position{line: 459, col: 1, offset: 11152},
 			expr: &actionExpr{
-				pos: position{line: 456, col: 20, offset: 11064},
+				pos: position{line: 459, col: 20, offset: 11171},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 456, col: 21, offset: 11065},
+					pos: position{line: 459, col: 21, offset: 11172},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 456, col: 21, offset: 11065},
+							pos:        position{line: 459, col: 21, offset: 11172},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 28, offset: 11072},
+							pos:        position{line: 459, col: 28, offset: 11179},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 34, offset: 11078},
+							pos:        position{line: 459, col: 34, offset: 11185},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 41, offset: 11085},
+							pos:        position{line: 459, col: 41, offset: 11192},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -3531,43 +3576,43 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpression",
-			pos:  position{line: 458, col: 1, offset: 11122},
+			pos:  position{line: 461, col: 1, offset: 11229},
 			expr: &actionExpr{
-				pos: position{line: 459, col: 5, offset: 11145},
+				pos: position{line: 462, col: 5, offset: 11252},
 				run: (*parser).callonAdditiveExpression1,
 				expr: &seqExpr{
-					pos: position{line: 459, col: 5, offset: 11145},
+					pos: position{line: 462, col: 5, offset: 11252},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 459, col: 5, offset: 11145},
+							pos:   position{line: 462, col: 5, offset: 11252},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 459, col: 11, offset: 11151},
+								pos:  position{line: 462, col: 11, offset: 11258},
 								name: "MultiplicativeExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 460, col: 5, offset: 11180},
+							pos:   position{line: 463, col: 5, offset: 11287},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 460, col: 10, offset: 11185},
+								pos: position{line: 463, col: 10, offset: 11292},
 								expr: &seqExpr{
-									pos: position{line: 460, col: 11, offset: 11186},
+									pos: position{line: 463, col: 11, offset: 11293},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 11, offset: 11186},
+											pos:  position{line: 463, col: 11, offset: 11293},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 14, offset: 11189},
+											pos:  position{line: 463, col: 14, offset: 11296},
 											name: "AdditiveOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 31, offset: 11206},
+											pos:  position{line: 463, col: 31, offset: 11313},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 34, offset: 11209},
+											pos:  position{line: 463, col: 34, offset: 11316},
 											name: "MultiplicativeExpression",
 										},
 									},
@@ -3580,20 +3625,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 464, col: 1, offset: 11298},
+			pos:  position{line: 467, col: 1, offset: 11405},
 			expr: &actionExpr{
-				pos: position{line: 464, col: 20, offset: 11317},
+				pos: position{line: 467, col: 20, offset: 11424},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 464, col: 21, offset: 11318},
+					pos: position{line: 467, col: 21, offset: 11425},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 464, col: 21, offset: 11318},
+							pos:        position{line: 467, col: 21, offset: 11425},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 464, col: 27, offset: 11324},
+							pos:        position{line: 467, col: 27, offset: 11431},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3603,50 +3648,50 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpression",
-			pos:  position{line: 466, col: 1, offset: 11361},
+			pos:  position{line: 469, col: 1, offset: 11468},
 			expr: &actionExpr{
-				pos: position{line: 467, col: 5, offset: 11390},
+				pos: position{line: 470, col: 5, offset: 11497},
 				run: (*parser).callonMultiplicativeExpression1,
 				expr: &seqExpr{
-					pos: position{line: 467, col: 5, offset: 11390},
+					pos: position{line: 470, col: 5, offset: 11497},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 467, col: 5, offset: 11390},
+							pos:   position{line: 470, col: 5, offset: 11497},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 467, col: 11, offset: 11396},
+								pos:  position{line: 470, col: 11, offset: 11503},
 								name: "NotExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 468, col: 5, offset: 11414},
+							pos:   position{line: 471, col: 5, offset: 11521},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 468, col: 10, offset: 11419},
+								pos: position{line: 471, col: 10, offset: 11526},
 								expr: &seqExpr{
-									pos: position{line: 468, col: 11, offset: 11420},
+									pos: position{line: 471, col: 11, offset: 11527},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 468, col: 11, offset: 11420},
+											pos:  position{line: 471, col: 11, offset: 11527},
 											name: "__",
 										},
 										&labeledExpr{
-											pos:   position{line: 468, col: 14, offset: 11423},
+											pos:   position{line: 471, col: 14, offset: 11530},
 											label: "op",
 											expr: &ruleRefExpr{
-												pos:  position{line: 468, col: 17, offset: 11426},
+												pos:  position{line: 471, col: 17, offset: 11533},
 												name: "MultiplicativeOperator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 468, col: 40, offset: 11449},
+											pos:  position{line: 471, col: 40, offset: 11556},
 											name: "__",
 										},
 										&labeledExpr{
-											pos:   position{line: 468, col: 43, offset: 11452},
+											pos:   position{line: 471, col: 43, offset: 11559},
 											label: "operand",
 											expr: &ruleRefExpr{
-												pos:  position{line: 468, col: 51, offset: 11460},
+												pos:  position{line: 471, col: 51, offset: 11567},
 												name: "NotExpression",
 											},
 										},
@@ -3660,20 +3705,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 472, col: 1, offset: 11538},
+			pos:  position{line: 475, col: 1, offset: 11645},
 			expr: &actionExpr{
-				pos: position{line: 472, col: 26, offset: 11563},
+				pos: position{line: 475, col: 26, offset: 11670},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 472, col: 27, offset: 11564},
+					pos: position{line: 475, col: 27, offset: 11671},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 472, col: 27, offset: 11564},
+							pos:        position{line: 475, col: 27, offset: 11671},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 472, col: 33, offset: 11570},
+							pos:        position{line: 475, col: 33, offset: 11677},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -3683,30 +3728,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpression",
-			pos:  position{line: 474, col: 1, offset: 11607},
+			pos:  position{line: 477, col: 1, offset: 11714},
 			expr: &choiceExpr{
-				pos: position{line: 475, col: 5, offset: 11625},
+				pos: position{line: 478, col: 5, offset: 11732},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 475, col: 5, offset: 11625},
+						pos: position{line: 478, col: 5, offset: 11732},
 						run: (*parser).callonNotExpression2,
 						expr: &seqExpr{
-							pos: position{line: 475, col: 5, offset: 11625},
+							pos: position{line: 478, col: 5, offset: 11732},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 475, col: 5, offset: 11625},
+									pos:        position{line: 478, col: 5, offset: 11732},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 475, col: 9, offset: 11629},
+									pos:  position{line: 478, col: 9, offset: 11736},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 475, col: 12, offset: 11632},
+									pos:   position{line: 478, col: 12, offset: 11739},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 475, col: 14, offset: 11634},
+										pos:  position{line: 478, col: 14, offset: 11741},
 										name: "NotExpression",
 									},
 								},
@@ -3714,7 +3759,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 478, col: 5, offset: 11702},
+						pos:  position{line: 481, col: 5, offset: 11809},
 						name: "CastExpression",
 					},
 				},
@@ -3722,50 +3767,50 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpression",
-			pos:  position{line: 480, col: 1, offset: 11718},
+			pos:  position{line: 483, col: 1, offset: 11825},
 			expr: &actionExpr{
-				pos: position{line: 481, col: 5, offset: 11737},
+				pos: position{line: 484, col: 5, offset: 11844},
 				run: (*parser).callonCastExpression1,
 				expr: &seqExpr{
-					pos: position{line: 481, col: 5, offset: 11737},
+					pos: position{line: 484, col: 5, offset: 11844},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 481, col: 5, offset: 11737},
+							pos:   position{line: 484, col: 5, offset: 11844},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 481, col: 7, offset: 11739},
+								pos:  position{line: 484, col: 7, offset: 11846},
 								name: "CallExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 481, col: 22, offset: 11754},
+							pos:   position{line: 484, col: 22, offset: 11861},
 							label: "t",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 481, col: 24, offset: 11756},
+								pos: position{line: 484, col: 24, offset: 11863},
 								expr: &actionExpr{
-									pos: position{line: 481, col: 25, offset: 11757},
+									pos: position{line: 484, col: 25, offset: 11864},
 									run: (*parser).callonCastExpression7,
 									expr: &seqExpr{
-										pos: position{line: 481, col: 25, offset: 11757},
+										pos: position{line: 484, col: 25, offset: 11864},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 481, col: 25, offset: 11757},
+												pos:  position{line: 484, col: 25, offset: 11864},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 481, col: 28, offset: 11760},
+												pos:        position{line: 484, col: 28, offset: 11867},
 												val:        ":",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 481, col: 32, offset: 11764},
+												pos:  position{line: 484, col: 32, offset: 11871},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 481, col: 35, offset: 11767},
+												pos:   position{line: 484, col: 35, offset: 11874},
 												label: "ct",
 												expr: &ruleRefExpr{
-													pos:  position{line: 481, col: 38, offset: 11770},
+													pos:  position{line: 484, col: 38, offset: 11877},
 													name: "ZngType",
 												},
 											},
@@ -3780,82 +3825,82 @@ var g = &grammar{
 		},
 		{
 			name: "ZngType",
-			pos:  position{line: 489, col: 1, offset: 11906},
+			pos:  position{line: 492, col: 1, offset: 12013},
 			expr: &choiceExpr{
-				pos: position{line: 490, col: 4, offset: 11917},
+				pos: position{line: 493, col: 4, offset: 12024},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 490, col: 4, offset: 11917},
+						pos:        position{line: 493, col: 4, offset: 12024},
 						val:        "bool",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 13, offset: 11926},
+						pos:        position{line: 493, col: 13, offset: 12033},
 						val:        "byte",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 22, offset: 11935},
+						pos:        position{line: 493, col: 22, offset: 12042},
 						val:        "int16",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 32, offset: 11945},
+						pos:        position{line: 493, col: 32, offset: 12052},
 						val:        "uint16",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 43, offset: 11956},
+						pos:        position{line: 493, col: 43, offset: 12063},
 						val:        "int32",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 53, offset: 11966},
+						pos:        position{line: 493, col: 53, offset: 12073},
 						val:        "uint32",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 4, offset: 11978},
+						pos:        position{line: 494, col: 4, offset: 12085},
 						val:        "int64",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 14, offset: 11988},
+						pos:        position{line: 494, col: 14, offset: 12095},
 						val:        "uint64",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 25, offset: 11999},
+						pos:        position{line: 494, col: 25, offset: 12106},
 						val:        "float64",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 37, offset: 12011},
+						pos:        position{line: 494, col: 37, offset: 12118},
 						val:        "string",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 48, offset: 12022},
+						pos:        position{line: 494, col: 48, offset: 12129},
 						val:        "bstring",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 492, col: 4, offset: 12035},
+						pos:        position{line: 495, col: 4, offset: 12142},
 						val:        "ip",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 492, col: 11, offset: 12042},
+						pos:        position{line: 495, col: 11, offset: 12149},
 						val:        "net",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 492, col: 19, offset: 12050},
+						pos:        position{line: 495, col: 19, offset: 12157},
 						val:        "time",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 492, col: 28, offset: 12059},
+						pos:        position{line: 495, col: 28, offset: 12166},
 						val:        "duration",
 						ignoreCase: false,
 					},
@@ -3864,43 +3909,43 @@ var g = &grammar{
 		},
 		{
 			name: "CallExpression",
-			pos:  position{line: 494, col: 1, offset: 12071},
+			pos:  position{line: 497, col: 1, offset: 12178},
 			expr: &choiceExpr{
-				pos: position{line: 495, col: 5, offset: 12090},
+				pos: position{line: 498, col: 5, offset: 12197},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 495, col: 5, offset: 12090},
+						pos: position{line: 498, col: 5, offset: 12197},
 						run: (*parser).callonCallExpression2,
 						expr: &seqExpr{
-							pos: position{line: 495, col: 5, offset: 12090},
+							pos: position{line: 498, col: 5, offset: 12197},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 495, col: 5, offset: 12090},
+									pos:   position{line: 498, col: 5, offset: 12197},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 495, col: 8, offset: 12093},
+										pos:  position{line: 498, col: 8, offset: 12200},
 										name: "FunctionName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 495, col: 21, offset: 12106},
+									pos:  position{line: 498, col: 21, offset: 12213},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 495, col: 24, offset: 12109},
+									pos:        position{line: 498, col: 24, offset: 12216},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 495, col: 28, offset: 12113},
+									pos:   position{line: 498, col: 28, offset: 12220},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 495, col: 33, offset: 12118},
+										pos:  position{line: 498, col: 33, offset: 12225},
 										name: "ArgumentList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 495, col: 46, offset: 12131},
+									pos:        position{line: 498, col: 46, offset: 12238},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3908,7 +3953,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 498, col: 5, offset: 12194},
+						pos:  position{line: 501, col: 5, offset: 12301},
 						name: "DereferenceExpression",
 					},
 				},
@@ -3916,21 +3961,21 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionName",
-			pos:  position{line: 500, col: 1, offset: 12217},
+			pos:  position{line: 503, col: 1, offset: 12324},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 12234},
+				pos: position{line: 504, col: 5, offset: 12341},
 				run: (*parser).callonFunctionName1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 5, offset: 12234},
+					pos: position{line: 504, col: 5, offset: 12341},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 5, offset: 12234},
+							pos:  position{line: 504, col: 5, offset: 12341},
 							name: "FunctionNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 501, col: 23, offset: 12252},
+							pos: position{line: 504, col: 23, offset: 12359},
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 23, offset: 12252},
+								pos:  position{line: 504, col: 23, offset: 12359},
 								name: "FunctionNameRest",
 							},
 						},
@@ -3940,9 +3985,9 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionNameStart",
-			pos:  position{line: 503, col: 1, offset: 12302},
+			pos:  position{line: 506, col: 1, offset: 12409},
 			expr: &charClassMatcher{
-				pos:        position{line: 503, col: 21, offset: 12322},
+				pos:        position{line: 506, col: 21, offset: 12429},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -3951,16 +3996,16 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionNameRest",
-			pos:  position{line: 504, col: 1, offset: 12331},
+			pos:  position{line: 507, col: 1, offset: 12438},
 			expr: &choiceExpr{
-				pos: position{line: 504, col: 20, offset: 12350},
+				pos: position{line: 507, col: 20, offset: 12457},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 504, col: 20, offset: 12350},
+						pos:  position{line: 507, col: 20, offset: 12457},
 						name: "FunctionNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 504, col: 40, offset: 12370},
+						pos:        position{line: 507, col: 40, offset: 12477},
 						val:        "[.0-9]",
 						chars:      []rune{'.'},
 						ranges:     []rune{'0', '9'},
@@ -3972,53 +4017,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 506, col: 1, offset: 12378},
+			pos:  position{line: 509, col: 1, offset: 12485},
 			expr: &choiceExpr{
-				pos: position{line: 507, col: 5, offset: 12395},
+				pos: position{line: 510, col: 5, offset: 12502},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 507, col: 5, offset: 12395},
+						pos: position{line: 510, col: 5, offset: 12502},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 507, col: 5, offset: 12395},
+							pos: position{line: 510, col: 5, offset: 12502},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 507, col: 5, offset: 12395},
+									pos:   position{line: 510, col: 5, offset: 12502},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 507, col: 11, offset: 12401},
+										pos:  position{line: 510, col: 11, offset: 12508},
 										name: "Expression",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 507, col: 22, offset: 12412},
+									pos:   position{line: 510, col: 22, offset: 12519},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 507, col: 27, offset: 12417},
+										pos: position{line: 510, col: 27, offset: 12524},
 										expr: &actionExpr{
-											pos: position{line: 507, col: 28, offset: 12418},
+											pos: position{line: 510, col: 28, offset: 12525},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 507, col: 28, offset: 12418},
+												pos: position{line: 510, col: 28, offset: 12525},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 507, col: 28, offset: 12418},
+														pos:  position{line: 510, col: 28, offset: 12525},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 507, col: 31, offset: 12421},
+														pos:        position{line: 510, col: 31, offset: 12528},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 507, col: 35, offset: 12425},
+														pos:  position{line: 510, col: 35, offset: 12532},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 507, col: 38, offset: 12428},
+														pos:   position{line: 510, col: 38, offset: 12535},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 507, col: 40, offset: 12430},
+															pos:  position{line: 510, col: 40, offset: 12537},
 															name: "Expression",
 														},
 													},
@@ -4031,10 +4076,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 510, col: 5, offset: 12546},
+						pos: position{line: 513, col: 5, offset: 12653},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 510, col: 5, offset: 12546},
+							pos:  position{line: 513, col: 5, offset: 12653},
 							name: "__",
 						},
 					},
@@ -4043,88 +4088,88 @@ var g = &grammar{
 		},
 		{
 			name: "DereferenceExpression",
-			pos:  position{line: 512, col: 1, offset: 12582},
+			pos:  position{line: 515, col: 1, offset: 12689},
 			expr: &actionExpr{
-				pos: position{line: 513, col: 5, offset: 12608},
+				pos: position{line: 516, col: 5, offset: 12715},
 				run: (*parser).callonDereferenceExpression1,
 				expr: &seqExpr{
-					pos: position{line: 513, col: 5, offset: 12608},
+					pos: position{line: 516, col: 5, offset: 12715},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 513, col: 5, offset: 12608},
+							pos:   position{line: 516, col: 5, offset: 12715},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 513, col: 10, offset: 12613},
+								pos:  position{line: 516, col: 10, offset: 12720},
 								name: "PrimaryExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 514, col: 5, offset: 12635},
+							pos:   position{line: 517, col: 5, offset: 12742},
 							label: "derefs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 514, col: 12, offset: 12642},
+								pos: position{line: 517, col: 12, offset: 12749},
 								expr: &choiceExpr{
-									pos: position{line: 515, col: 9, offset: 12652},
+									pos: position{line: 518, col: 9, offset: 12759},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 515, col: 9, offset: 12652},
+											pos: position{line: 518, col: 9, offset: 12759},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 515, col: 9, offset: 12652},
+													pos:  position{line: 518, col: 9, offset: 12759},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 515, col: 12, offset: 12655},
+													pos:        position{line: 518, col: 12, offset: 12762},
 													val:        "[",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 515, col: 16, offset: 12659},
+													pos:  position{line: 518, col: 16, offset: 12766},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 515, col: 19, offset: 12662},
+													pos:   position{line: 518, col: 19, offset: 12769},
 													label: "index",
 													expr: &ruleRefExpr{
-														pos:  position{line: 515, col: 25, offset: 12668},
+														pos:  position{line: 518, col: 25, offset: 12775},
 														name: "Expression",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 515, col: 36, offset: 12679},
+													pos:  position{line: 518, col: 36, offset: 12786},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 515, col: 39, offset: 12682},
+													pos:        position{line: 518, col: 39, offset: 12789},
 													val:        "]",
 													ignoreCase: false,
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 516, col: 9, offset: 12694},
+											pos: position{line: 519, col: 9, offset: 12801},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 516, col: 9, offset: 12694},
+													pos:  position{line: 519, col: 9, offset: 12801},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 516, col: 12, offset: 12697},
+													pos:        position{line: 519, col: 12, offset: 12804},
 													val:        ".",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 516, col: 16, offset: 12701},
+													pos:  position{line: 519, col: 16, offset: 12808},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 516, col: 20, offset: 12705},
+													pos: position{line: 519, col: 20, offset: 12812},
 													run: (*parser).callonDereferenceExpression20,
 													expr: &labeledExpr{
-														pos:   position{line: 516, col: 20, offset: 12705},
+														pos:   position{line: 519, col: 20, offset: 12812},
 														label: "field",
 														expr: &ruleRefExpr{
-															pos:  position{line: 516, col: 26, offset: 12711},
+															pos:  position{line: 519, col: 26, offset: 12818},
 															name: "fieldName",
 														},
 													},
@@ -4141,54 +4186,54 @@ var g = &grammar{
 		},
 		{
 			name: "duration",
-			pos:  position{line: 521, col: 1, offset: 12846},
+			pos:  position{line: 524, col: 1, offset: 12953},
 			expr: &choiceExpr{
-				pos: position{line: 522, col: 5, offset: 12859},
+				pos: position{line: 525, col: 5, offset: 12966},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 522, col: 5, offset: 12859},
+						pos:  position{line: 525, col: 5, offset: 12966},
 						name: "seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 523, col: 5, offset: 12871},
+						pos:  position{line: 526, col: 5, offset: 12978},
 						name: "minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 524, col: 5, offset: 12883},
+						pos:  position{line: 527, col: 5, offset: 12990},
 						name: "hours",
 					},
 					&seqExpr{
-						pos: position{line: 525, col: 5, offset: 12893},
+						pos: position{line: 528, col: 5, offset: 13000},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 525, col: 5, offset: 12893},
+								pos:  position{line: 528, col: 5, offset: 13000},
 								name: "hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 525, col: 11, offset: 12899},
+								pos:  position{line: 528, col: 11, offset: 13006},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 525, col: 13, offset: 12901},
+								pos:        position{line: 528, col: 13, offset: 13008},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 525, col: 19, offset: 12907},
+								pos:  position{line: 528, col: 19, offset: 13014},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 525, col: 21, offset: 12909},
+								pos:  position{line: 528, col: 21, offset: 13016},
 								name: "minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 526, col: 5, offset: 12921},
+						pos:  position{line: 529, col: 5, offset: 13028},
 						name: "days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 527, col: 5, offset: 12930},
+						pos:  position{line: 530, col: 5, offset: 13037},
 						name: "weeks",
 					},
 				},
@@ -4196,32 +4241,32 @@ var g = &grammar{
 		},
 		{
 			name: "sec_abbrev",
-			pos:  position{line: 529, col: 1, offset: 12937},
+			pos:  position{line: 532, col: 1, offset: 13044},
 			expr: &choiceExpr{
-				pos: position{line: 530, col: 5, offset: 12952},
+				pos: position{line: 533, col: 5, offset: 13059},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 530, col: 5, offset: 12952},
+						pos:        position{line: 533, col: 5, offset: 13059},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 531, col: 5, offset: 12966},
+						pos:        position{line: 534, col: 5, offset: 13073},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 532, col: 5, offset: 12979},
+						pos:        position{line: 535, col: 5, offset: 13086},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 533, col: 5, offset: 12990},
+						pos:        position{line: 536, col: 5, offset: 13097},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 534, col: 5, offset: 13000},
+						pos:        position{line: 537, col: 5, offset: 13107},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -4230,32 +4275,32 @@ var g = &grammar{
 		},
 		{
 			name: "min_abbrev",
-			pos:  position{line: 536, col: 1, offset: 13005},
+			pos:  position{line: 539, col: 1, offset: 13112},
 			expr: &choiceExpr{
-				pos: position{line: 537, col: 5, offset: 13020},
+				pos: position{line: 540, col: 5, offset: 13127},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 537, col: 5, offset: 13020},
+						pos:        position{line: 540, col: 5, offset: 13127},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 538, col: 5, offset: 13034},
+						pos:        position{line: 541, col: 5, offset: 13141},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 539, col: 5, offset: 13047},
+						pos:        position{line: 542, col: 5, offset: 13154},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 540, col: 5, offset: 13058},
+						pos:        position{line: 543, col: 5, offset: 13165},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 541, col: 5, offset: 13068},
+						pos:        position{line: 544, col: 5, offset: 13175},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -4264,32 +4309,32 @@ var g = &grammar{
 		},
 		{
 			name: "hour_abbrev",
-			pos:  position{line: 543, col: 1, offset: 13073},
+			pos:  position{line: 546, col: 1, offset: 13180},
 			expr: &choiceExpr{
-				pos: position{line: 544, col: 5, offset: 13089},
+				pos: position{line: 547, col: 5, offset: 13196},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 544, col: 5, offset: 13089},
+						pos:        position{line: 547, col: 5, offset: 13196},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 545, col: 5, offset: 13101},
+						pos:        position{line: 548, col: 5, offset: 13208},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 546, col: 5, offset: 13111},
+						pos:        position{line: 549, col: 5, offset: 13218},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 547, col: 5, offset: 13120},
+						pos:        position{line: 550, col: 5, offset: 13227},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 548, col: 5, offset: 13128},
+						pos:        position{line: 551, col: 5, offset: 13235},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -4298,22 +4343,22 @@ var g = &grammar{
 		},
 		{
 			name: "day_abbrev",
-			pos:  position{line: 550, col: 1, offset: 13136},
+			pos:  position{line: 553, col: 1, offset: 13243},
 			expr: &choiceExpr{
-				pos: position{line: 550, col: 14, offset: 13149},
+				pos: position{line: 553, col: 14, offset: 13256},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 550, col: 14, offset: 13149},
+						pos:        position{line: 553, col: 14, offset: 13256},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 550, col: 21, offset: 13156},
+						pos:        position{line: 553, col: 21, offset: 13263},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 550, col: 27, offset: 13162},
+						pos:        position{line: 553, col: 27, offset: 13269},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -4322,32 +4367,32 @@ var g = &grammar{
 		},
 		{
 			name: "week_abbrev",
-			pos:  position{line: 551, col: 1, offset: 13166},
+			pos:  position{line: 554, col: 1, offset: 13273},
 			expr: &choiceExpr{
-				pos: position{line: 551, col: 15, offset: 13180},
+				pos: position{line: 554, col: 15, offset: 13287},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 551, col: 15, offset: 13180},
+						pos:        position{line: 554, col: 15, offset: 13287},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 23, offset: 13188},
+						pos:        position{line: 554, col: 23, offset: 13295},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 30, offset: 13195},
+						pos:        position{line: 554, col: 30, offset: 13302},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 36, offset: 13201},
+						pos:        position{line: 554, col: 36, offset: 13308},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 41, offset: 13206},
+						pos:        position{line: 554, col: 41, offset: 13313},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -4356,42 +4401,42 @@ var g = &grammar{
 		},
 		{
 			name: "seconds",
-			pos:  position{line: 553, col: 1, offset: 13211},
+			pos:  position{line: 556, col: 1, offset: 13318},
 			expr: &choiceExpr{
-				pos: position{line: 554, col: 5, offset: 13223},
+				pos: position{line: 557, col: 5, offset: 13330},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 554, col: 5, offset: 13223},
+						pos: position{line: 557, col: 5, offset: 13330},
 						run: (*parser).callonseconds2,
 						expr: &litMatcher{
-							pos:        position{line: 554, col: 5, offset: 13223},
+							pos:        position{line: 557, col: 5, offset: 13330},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 555, col: 5, offset: 13268},
+						pos: position{line: 558, col: 5, offset: 13375},
 						run: (*parser).callonseconds4,
 						expr: &seqExpr{
-							pos: position{line: 555, col: 5, offset: 13268},
+							pos: position{line: 558, col: 5, offset: 13375},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 555, col: 5, offset: 13268},
+									pos:   position{line: 558, col: 5, offset: 13375},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 555, col: 9, offset: 13272},
+										pos:  position{line: 558, col: 9, offset: 13379},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 555, col: 16, offset: 13279},
+									pos: position{line: 558, col: 16, offset: 13386},
 									expr: &ruleRefExpr{
-										pos:  position{line: 555, col: 16, offset: 13279},
+										pos:  position{line: 558, col: 16, offset: 13386},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 555, col: 19, offset: 13282},
+									pos:  position{line: 558, col: 19, offset: 13389},
 									name: "sec_abbrev",
 								},
 							},
@@ -4402,42 +4447,42 @@ var g = &grammar{
 		},
 		{
 			name: "minutes",
-			pos:  position{line: 557, col: 1, offset: 13328},
+			pos:  position{line: 560, col: 1, offset: 13435},
 			expr: &choiceExpr{
-				pos: position{line: 558, col: 5, offset: 13340},
+				pos: position{line: 561, col: 5, offset: 13447},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 558, col: 5, offset: 13340},
+						pos: position{line: 561, col: 5, offset: 13447},
 						run: (*parser).callonminutes2,
 						expr: &litMatcher{
-							pos:        position{line: 558, col: 5, offset: 13340},
+							pos:        position{line: 561, col: 5, offset: 13447},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 559, col: 5, offset: 13386},
+						pos: position{line: 562, col: 5, offset: 13493},
 						run: (*parser).callonminutes4,
 						expr: &seqExpr{
-							pos: position{line: 559, col: 5, offset: 13386},
+							pos: position{line: 562, col: 5, offset: 13493},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 559, col: 5, offset: 13386},
+									pos:   position{line: 562, col: 5, offset: 13493},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 559, col: 9, offset: 13390},
+										pos:  position{line: 562, col: 9, offset: 13497},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 559, col: 16, offset: 13397},
+									pos: position{line: 562, col: 16, offset: 13504},
 									expr: &ruleRefExpr{
-										pos:  position{line: 559, col: 16, offset: 13397},
+										pos:  position{line: 562, col: 16, offset: 13504},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 559, col: 19, offset: 13400},
+									pos:  position{line: 562, col: 19, offset: 13507},
 									name: "min_abbrev",
 								},
 							},
@@ -4448,42 +4493,42 @@ var g = &grammar{
 		},
 		{
 			name: "hours",
-			pos:  position{line: 561, col: 1, offset: 13455},
+			pos:  position{line: 564, col: 1, offset: 13562},
 			expr: &choiceExpr{
-				pos: position{line: 562, col: 5, offset: 13465},
+				pos: position{line: 565, col: 5, offset: 13572},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 562, col: 5, offset: 13465},
+						pos: position{line: 565, col: 5, offset: 13572},
 						run: (*parser).callonhours2,
 						expr: &litMatcher{
-							pos:        position{line: 562, col: 5, offset: 13465},
+							pos:        position{line: 565, col: 5, offset: 13572},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 563, col: 5, offset: 13511},
+						pos: position{line: 566, col: 5, offset: 13618},
 						run: (*parser).callonhours4,
 						expr: &seqExpr{
-							pos: position{line: 563, col: 5, offset: 13511},
+							pos: position{line: 566, col: 5, offset: 13618},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 563, col: 5, offset: 13511},
+									pos:   position{line: 566, col: 5, offset: 13618},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 563, col: 9, offset: 13515},
+										pos:  position{line: 566, col: 9, offset: 13622},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 563, col: 16, offset: 13522},
+									pos: position{line: 566, col: 16, offset: 13629},
 									expr: &ruleRefExpr{
-										pos:  position{line: 563, col: 16, offset: 13522},
+										pos:  position{line: 566, col: 16, offset: 13629},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 563, col: 19, offset: 13525},
+									pos:  position{line: 566, col: 19, offset: 13632},
 									name: "hour_abbrev",
 								},
 							},
@@ -4494,42 +4539,42 @@ var g = &grammar{
 		},
 		{
 			name: "days",
-			pos:  position{line: 565, col: 1, offset: 13583},
+			pos:  position{line: 568, col: 1, offset: 13690},
 			expr: &choiceExpr{
-				pos: position{line: 566, col: 5, offset: 13592},
+				pos: position{line: 569, col: 5, offset: 13699},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 566, col: 5, offset: 13592},
+						pos: position{line: 569, col: 5, offset: 13699},
 						run: (*parser).callondays2,
 						expr: &litMatcher{
-							pos:        position{line: 566, col: 5, offset: 13592},
+							pos:        position{line: 569, col: 5, offset: 13699},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 567, col: 5, offset: 13640},
+						pos: position{line: 570, col: 5, offset: 13747},
 						run: (*parser).callondays4,
 						expr: &seqExpr{
-							pos: position{line: 567, col: 5, offset: 13640},
+							pos: position{line: 570, col: 5, offset: 13747},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 567, col: 5, offset: 13640},
+									pos:   position{line: 570, col: 5, offset: 13747},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 567, col: 9, offset: 13644},
+										pos:  position{line: 570, col: 9, offset: 13751},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 567, col: 16, offset: 13651},
+									pos: position{line: 570, col: 16, offset: 13758},
 									expr: &ruleRefExpr{
-										pos:  position{line: 567, col: 16, offset: 13651},
+										pos:  position{line: 570, col: 16, offset: 13758},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 567, col: 19, offset: 13654},
+									pos:  position{line: 570, col: 19, offset: 13761},
 									name: "day_abbrev",
 								},
 							},
@@ -4540,30 +4585,30 @@ var g = &grammar{
 		},
 		{
 			name: "weeks",
-			pos:  position{line: 569, col: 1, offset: 13714},
+			pos:  position{line: 572, col: 1, offset: 13821},
 			expr: &actionExpr{
-				pos: position{line: 570, col: 5, offset: 13724},
+				pos: position{line: 573, col: 5, offset: 13831},
 				run: (*parser).callonweeks1,
 				expr: &seqExpr{
-					pos: position{line: 570, col: 5, offset: 13724},
+					pos: position{line: 573, col: 5, offset: 13831},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 570, col: 5, offset: 13724},
+							pos:   position{line: 573, col: 5, offset: 13831},
 							label: "num",
 							expr: &ruleRefExpr{
-								pos:  position{line: 570, col: 9, offset: 13728},
+								pos:  position{line: 573, col: 9, offset: 13835},
 								name: "number",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 570, col: 16, offset: 13735},
+							pos: position{line: 573, col: 16, offset: 13842},
 							expr: &ruleRefExpr{
-								pos:  position{line: 570, col: 16, offset: 13735},
+								pos:  position{line: 573, col: 16, offset: 13842},
 								name: "_",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 570, col: 19, offset: 13738},
+							pos:  position{line: 573, col: 19, offset: 13845},
 							name: "week_abbrev",
 						},
 					},
@@ -4572,53 +4617,53 @@ var g = &grammar{
 		},
 		{
 			name: "number",
-			pos:  position{line: 572, col: 1, offset: 13801},
+			pos:  position{line: 575, col: 1, offset: 13908},
 			expr: &ruleRefExpr{
-				pos:  position{line: 572, col: 10, offset: 13810},
+				pos:  position{line: 575, col: 10, offset: 13917},
 				name: "unsignedInteger",
 			},
 		},
 		{
 			name: "addr",
-			pos:  position{line: 576, col: 1, offset: 13856},
+			pos:  position{line: 579, col: 1, offset: 13963},
 			expr: &actionExpr{
-				pos: position{line: 577, col: 5, offset: 13865},
+				pos: position{line: 580, col: 5, offset: 13972},
 				run: (*parser).callonaddr1,
 				expr: &labeledExpr{
-					pos:   position{line: 577, col: 5, offset: 13865},
+					pos:   position{line: 580, col: 5, offset: 13972},
 					label: "a",
 					expr: &seqExpr{
-						pos: position{line: 577, col: 8, offset: 13868},
+						pos: position{line: 580, col: 8, offset: 13975},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 577, col: 8, offset: 13868},
+								pos:  position{line: 580, col: 8, offset: 13975},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 577, col: 24, offset: 13884},
+								pos:        position{line: 580, col: 24, offset: 13991},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 577, col: 28, offset: 13888},
+								pos:  position{line: 580, col: 28, offset: 13995},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 577, col: 44, offset: 13904},
+								pos:        position{line: 580, col: 44, offset: 14011},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 577, col: 48, offset: 13908},
+								pos:  position{line: 580, col: 48, offset: 14015},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 577, col: 64, offset: 13924},
+								pos:        position{line: 580, col: 64, offset: 14031},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 577, col: 68, offset: 13928},
+								pos:  position{line: 580, col: 68, offset: 14035},
 								name: "unsignedInteger",
 							},
 						},
@@ -4628,23 +4673,23 @@ var g = &grammar{
 		},
 		{
 			name: "port",
-			pos:  position{line: 579, col: 1, offset: 13977},
+			pos:  position{line: 582, col: 1, offset: 14084},
 			expr: &actionExpr{
-				pos: position{line: 580, col: 5, offset: 13986},
+				pos: position{line: 583, col: 5, offset: 14093},
 				run: (*parser).callonport1,
 				expr: &seqExpr{
-					pos: position{line: 580, col: 5, offset: 13986},
+					pos: position{line: 583, col: 5, offset: 14093},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 580, col: 5, offset: 13986},
+							pos:        position{line: 583, col: 5, offset: 14093},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 580, col: 9, offset: 13990},
+							pos:   position{line: 583, col: 9, offset: 14097},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 580, col: 11, offset: 13992},
+								pos:  position{line: 583, col: 11, offset: 14099},
 								name: "suint",
 							},
 						},
@@ -4654,32 +4699,32 @@ var g = &grammar{
 		},
 		{
 			name: "ip6addr",
-			pos:  position{line: 584, col: 1, offset: 14148},
+			pos:  position{line: 587, col: 1, offset: 14255},
 			expr: &choiceExpr{
-				pos: position{line: 585, col: 5, offset: 14160},
+				pos: position{line: 588, col: 5, offset: 14267},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 585, col: 5, offset: 14160},
+						pos: position{line: 588, col: 5, offset: 14267},
 						run: (*parser).callonip6addr2,
 						expr: &seqExpr{
-							pos: position{line: 585, col: 5, offset: 14160},
+							pos: position{line: 588, col: 5, offset: 14267},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 585, col: 5, offset: 14160},
+									pos:   position{line: 588, col: 5, offset: 14267},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 585, col: 7, offset: 14162},
+										pos: position{line: 588, col: 7, offset: 14269},
 										expr: &ruleRefExpr{
-											pos:  position{line: 585, col: 8, offset: 14163},
+											pos:  position{line: 588, col: 8, offset: 14270},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 585, col: 20, offset: 14175},
+									pos:   position{line: 588, col: 20, offset: 14282},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 585, col: 22, offset: 14177},
+										pos:  position{line: 588, col: 22, offset: 14284},
 										name: "ip6tail",
 									},
 								},
@@ -4687,51 +4732,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 588, col: 5, offset: 14241},
+						pos: position{line: 591, col: 5, offset: 14348},
 						run: (*parser).callonip6addr9,
 						expr: &seqExpr{
-							pos: position{line: 588, col: 5, offset: 14241},
+							pos: position{line: 591, col: 5, offset: 14348},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 588, col: 5, offset: 14241},
+									pos:   position{line: 591, col: 5, offset: 14348},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 588, col: 7, offset: 14243},
+										pos:  position{line: 591, col: 7, offset: 14350},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 588, col: 11, offset: 14247},
+									pos:   position{line: 591, col: 11, offset: 14354},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 588, col: 13, offset: 14249},
+										pos: position{line: 591, col: 13, offset: 14356},
 										expr: &ruleRefExpr{
-											pos:  position{line: 588, col: 14, offset: 14250},
+											pos:  position{line: 591, col: 14, offset: 14357},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 588, col: 25, offset: 14261},
+									pos:        position{line: 591, col: 25, offset: 14368},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 588, col: 30, offset: 14266},
+									pos:   position{line: 591, col: 30, offset: 14373},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 588, col: 32, offset: 14268},
+										pos: position{line: 591, col: 32, offset: 14375},
 										expr: &ruleRefExpr{
-											pos:  position{line: 588, col: 33, offset: 14269},
+											pos:  position{line: 591, col: 33, offset: 14376},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 588, col: 45, offset: 14281},
+									pos:   position{line: 591, col: 45, offset: 14388},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 588, col: 47, offset: 14283},
+										pos:  position{line: 591, col: 47, offset: 14390},
 										name: "ip6tail",
 									},
 								},
@@ -4739,32 +4784,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 591, col: 5, offset: 14382},
+						pos: position{line: 594, col: 5, offset: 14489},
 						run: (*parser).callonip6addr22,
 						expr: &seqExpr{
-							pos: position{line: 591, col: 5, offset: 14382},
+							pos: position{line: 594, col: 5, offset: 14489},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 591, col: 5, offset: 14382},
+									pos:        position{line: 594, col: 5, offset: 14489},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 591, col: 10, offset: 14387},
+									pos:   position{line: 594, col: 10, offset: 14494},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 591, col: 12, offset: 14389},
+										pos: position{line: 594, col: 12, offset: 14496},
 										expr: &ruleRefExpr{
-											pos:  position{line: 591, col: 13, offset: 14390},
+											pos:  position{line: 594, col: 13, offset: 14497},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 591, col: 25, offset: 14402},
+									pos:   position{line: 594, col: 25, offset: 14509},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 591, col: 27, offset: 14404},
+										pos:  position{line: 594, col: 27, offset: 14511},
 										name: "ip6tail",
 									},
 								},
@@ -4772,32 +4817,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 594, col: 5, offset: 14475},
+						pos: position{line: 597, col: 5, offset: 14582},
 						run: (*parser).callonip6addr30,
 						expr: &seqExpr{
-							pos: position{line: 594, col: 5, offset: 14475},
+							pos: position{line: 597, col: 5, offset: 14582},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 594, col: 5, offset: 14475},
+									pos:   position{line: 597, col: 5, offset: 14582},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 594, col: 7, offset: 14477},
+										pos:  position{line: 597, col: 7, offset: 14584},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 594, col: 11, offset: 14481},
+									pos:   position{line: 597, col: 11, offset: 14588},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 594, col: 13, offset: 14483},
+										pos: position{line: 597, col: 13, offset: 14590},
 										expr: &ruleRefExpr{
-											pos:  position{line: 594, col: 14, offset: 14484},
+											pos:  position{line: 597, col: 14, offset: 14591},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 594, col: 25, offset: 14495},
+									pos:        position{line: 597, col: 25, offset: 14602},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -4805,10 +4850,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 597, col: 5, offset: 14563},
+						pos: position{line: 600, col: 5, offset: 14670},
 						run: (*parser).callonip6addr38,
 						expr: &litMatcher{
-							pos:        position{line: 597, col: 5, offset: 14563},
+							pos:        position{line: 600, col: 5, offset: 14670},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -4818,16 +4863,16 @@ var g = &grammar{
 		},
 		{
 			name: "ip6tail",
-			pos:  position{line: 601, col: 1, offset: 14600},
+			pos:  position{line: 604, col: 1, offset: 14707},
 			expr: &choiceExpr{
-				pos: position{line: 602, col: 5, offset: 14612},
+				pos: position{line: 605, col: 5, offset: 14719},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 602, col: 5, offset: 14612},
+						pos:  position{line: 605, col: 5, offset: 14719},
 						name: "addr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 603, col: 5, offset: 14621},
+						pos:  position{line: 606, col: 5, offset: 14728},
 						name: "h16",
 					},
 				},
@@ -4835,23 +4880,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_append",
-			pos:  position{line: 605, col: 1, offset: 14626},
+			pos:  position{line: 608, col: 1, offset: 14733},
 			expr: &actionExpr{
-				pos: position{line: 605, col: 12, offset: 14637},
+				pos: position{line: 608, col: 12, offset: 14744},
 				run: (*parser).callonh_append1,
 				expr: &seqExpr{
-					pos: position{line: 605, col: 12, offset: 14637},
+					pos: position{line: 608, col: 12, offset: 14744},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 605, col: 12, offset: 14637},
+							pos:        position{line: 608, col: 12, offset: 14744},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 605, col: 16, offset: 14641},
+							pos:   position{line: 608, col: 16, offset: 14748},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 605, col: 18, offset: 14643},
+								pos:  position{line: 608, col: 18, offset: 14750},
 								name: "h16",
 							},
 						},
@@ -4861,23 +4906,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_prepend",
-			pos:  position{line: 606, col: 1, offset: 14680},
+			pos:  position{line: 609, col: 1, offset: 14787},
 			expr: &actionExpr{
-				pos: position{line: 606, col: 13, offset: 14692},
+				pos: position{line: 609, col: 13, offset: 14799},
 				run: (*parser).callonh_prepend1,
 				expr: &seqExpr{
-					pos: position{line: 606, col: 13, offset: 14692},
+					pos: position{line: 609, col: 13, offset: 14799},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 606, col: 13, offset: 14692},
+							pos:   position{line: 609, col: 13, offset: 14799},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 606, col: 15, offset: 14694},
+								pos:  position{line: 609, col: 15, offset: 14801},
 								name: "h16",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 606, col: 19, offset: 14698},
+							pos:        position{line: 609, col: 19, offset: 14805},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -4887,31 +4932,31 @@ var g = &grammar{
 		},
 		{
 			name: "subnet",
-			pos:  position{line: 608, col: 1, offset: 14736},
+			pos:  position{line: 611, col: 1, offset: 14843},
 			expr: &actionExpr{
-				pos: position{line: 609, col: 5, offset: 14747},
+				pos: position{line: 612, col: 5, offset: 14854},
 				run: (*parser).callonsubnet1,
 				expr: &seqExpr{
-					pos: position{line: 609, col: 5, offset: 14747},
+					pos: position{line: 612, col: 5, offset: 14854},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 609, col: 5, offset: 14747},
+							pos:   position{line: 612, col: 5, offset: 14854},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 609, col: 7, offset: 14749},
+								pos:  position{line: 612, col: 7, offset: 14856},
 								name: "addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 609, col: 12, offset: 14754},
+							pos:        position{line: 612, col: 12, offset: 14861},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 609, col: 16, offset: 14758},
+							pos:   position{line: 612, col: 16, offset: 14865},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 609, col: 18, offset: 14760},
+								pos:  position{line: 612, col: 18, offset: 14867},
 								name: "unsignedInteger",
 							},
 						},
@@ -4921,31 +4966,31 @@ var g = &grammar{
 		},
 		{
 			name: "ip6subnet",
-			pos:  position{line: 613, col: 1, offset: 14844},
+			pos:  position{line: 616, col: 1, offset: 14951},
 			expr: &actionExpr{
-				pos: position{line: 614, col: 5, offset: 14858},
+				pos: position{line: 617, col: 5, offset: 14965},
 				run: (*parser).callonip6subnet1,
 				expr: &seqExpr{
-					pos: position{line: 614, col: 5, offset: 14858},
+					pos: position{line: 617, col: 5, offset: 14965},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 614, col: 5, offset: 14858},
+							pos:   position{line: 617, col: 5, offset: 14965},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 614, col: 7, offset: 14860},
+								pos:  position{line: 617, col: 7, offset: 14967},
 								name: "ip6addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 614, col: 15, offset: 14868},
+							pos:        position{line: 617, col: 15, offset: 14975},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 614, col: 19, offset: 14872},
+							pos:   position{line: 617, col: 19, offset: 14979},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 614, col: 21, offset: 14874},
+								pos:  position{line: 617, col: 21, offset: 14981},
 								name: "unsignedInteger",
 							},
 						},
@@ -4955,15 +5000,15 @@ var g = &grammar{
 		},
 		{
 			name: "unsignedInteger",
-			pos:  position{line: 618, col: 1, offset: 14948},
+			pos:  position{line: 621, col: 1, offset: 15055},
 			expr: &actionExpr{
-				pos: position{line: 619, col: 5, offset: 14968},
+				pos: position{line: 622, col: 5, offset: 15075},
 				run: (*parser).callonunsignedInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 619, col: 5, offset: 14968},
+					pos:   position{line: 622, col: 5, offset: 15075},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 619, col: 7, offset: 14970},
+						pos:  position{line: 622, col: 7, offset: 15077},
 						name: "suint",
 					},
 				},
@@ -4971,14 +5016,14 @@ var g = &grammar{
 		},
 		{
 			name: "suint",
-			pos:  position{line: 621, col: 1, offset: 15005},
+			pos:  position{line: 624, col: 1, offset: 15112},
 			expr: &actionExpr{
-				pos: position{line: 622, col: 5, offset: 15015},
+				pos: position{line: 625, col: 5, offset: 15122},
 				run: (*parser).callonsuint1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 622, col: 5, offset: 15015},
+					pos: position{line: 625, col: 5, offset: 15122},
 					expr: &charClassMatcher{
-						pos:        position{line: 622, col: 5, offset: 15015},
+						pos:        position{line: 625, col: 5, offset: 15122},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4989,15 +5034,15 @@ var g = &grammar{
 		},
 		{
 			name: "integer",
-			pos:  position{line: 624, col: 1, offset: 15054},
+			pos:  position{line: 627, col: 1, offset: 15161},
 			expr: &actionExpr{
-				pos: position{line: 625, col: 5, offset: 15066},
+				pos: position{line: 628, col: 5, offset: 15173},
 				run: (*parser).calloninteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 625, col: 5, offset: 15066},
+					pos:   position{line: 628, col: 5, offset: 15173},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 625, col: 7, offset: 15068},
+						pos:  position{line: 628, col: 7, offset: 15175},
 						name: "sinteger",
 					},
 				},
@@ -5005,17 +5050,17 @@ var g = &grammar{
 		},
 		{
 			name: "sinteger",
-			pos:  position{line: 627, col: 1, offset: 15106},
+			pos:  position{line: 630, col: 1, offset: 15213},
 			expr: &actionExpr{
-				pos: position{line: 628, col: 5, offset: 15119},
+				pos: position{line: 631, col: 5, offset: 15226},
 				run: (*parser).callonsinteger1,
 				expr: &seqExpr{
-					pos: position{line: 628, col: 5, offset: 15119},
+					pos: position{line: 631, col: 5, offset: 15226},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 628, col: 5, offset: 15119},
+							pos: position{line: 631, col: 5, offset: 15226},
 							expr: &charClassMatcher{
-								pos:        position{line: 628, col: 5, offset: 15119},
+								pos:        position{line: 631, col: 5, offset: 15226},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -5023,7 +5068,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 628, col: 11, offset: 15125},
+							pos:  position{line: 631, col: 11, offset: 15232},
 							name: "suint",
 						},
 					},
@@ -5032,15 +5077,15 @@ var g = &grammar{
 		},
 		{
 			name: "double",
-			pos:  position{line: 630, col: 1, offset: 15163},
+			pos:  position{line: 633, col: 1, offset: 15270},
 			expr: &actionExpr{
-				pos: position{line: 631, col: 5, offset: 15174},
+				pos: position{line: 634, col: 5, offset: 15281},
 				run: (*parser).callondouble1,
 				expr: &labeledExpr{
-					pos:   position{line: 631, col: 5, offset: 15174},
+					pos:   position{line: 634, col: 5, offset: 15281},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 631, col: 7, offset: 15176},
+						pos:  position{line: 634, col: 7, offset: 15283},
 						name: "sdouble",
 					},
 				},
@@ -5048,47 +5093,47 @@ var g = &grammar{
 		},
 		{
 			name: "sdouble",
-			pos:  position{line: 635, col: 1, offset: 15223},
+			pos:  position{line: 638, col: 1, offset: 15330},
 			expr: &choiceExpr{
-				pos: position{line: 636, col: 5, offset: 15235},
+				pos: position{line: 639, col: 5, offset: 15342},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 636, col: 5, offset: 15235},
+						pos: position{line: 639, col: 5, offset: 15342},
 						run: (*parser).callonsdouble2,
 						expr: &seqExpr{
-							pos: position{line: 636, col: 5, offset: 15235},
+							pos: position{line: 639, col: 5, offset: 15342},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 636, col: 5, offset: 15235},
+									pos: position{line: 639, col: 5, offset: 15342},
 									expr: &litMatcher{
-										pos:        position{line: 636, col: 5, offset: 15235},
+										pos:        position{line: 639, col: 5, offset: 15342},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 636, col: 10, offset: 15240},
+									pos: position{line: 639, col: 10, offset: 15347},
 									expr: &ruleRefExpr{
-										pos:  position{line: 636, col: 10, offset: 15240},
+										pos:  position{line: 639, col: 10, offset: 15347},
 										name: "doubleInteger",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 636, col: 25, offset: 15255},
+									pos:        position{line: 639, col: 25, offset: 15362},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 636, col: 29, offset: 15259},
+									pos: position{line: 639, col: 29, offset: 15366},
 									expr: &ruleRefExpr{
-										pos:  position{line: 636, col: 29, offset: 15259},
+										pos:  position{line: 639, col: 29, offset: 15366},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 636, col: 42, offset: 15272},
+									pos: position{line: 639, col: 42, offset: 15379},
 									expr: &ruleRefExpr{
-										pos:  position{line: 636, col: 42, offset: 15272},
+										pos:  position{line: 639, col: 42, offset: 15379},
 										name: "exponentPart",
 									},
 								},
@@ -5096,35 +5141,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 639, col: 5, offset: 15331},
+						pos: position{line: 642, col: 5, offset: 15438},
 						run: (*parser).callonsdouble13,
 						expr: &seqExpr{
-							pos: position{line: 639, col: 5, offset: 15331},
+							pos: position{line: 642, col: 5, offset: 15438},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 639, col: 5, offset: 15331},
+									pos: position{line: 642, col: 5, offset: 15438},
 									expr: &litMatcher{
-										pos:        position{line: 639, col: 5, offset: 15331},
+										pos:        position{line: 642, col: 5, offset: 15438},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 639, col: 10, offset: 15336},
+									pos:        position{line: 642, col: 10, offset: 15443},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 639, col: 14, offset: 15340},
+									pos: position{line: 642, col: 14, offset: 15447},
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 14, offset: 15340},
+										pos:  position{line: 642, col: 14, offset: 15447},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 639, col: 27, offset: 15353},
+									pos: position{line: 642, col: 27, offset: 15460},
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 27, offset: 15353},
+										pos:  position{line: 642, col: 27, offset: 15460},
 										name: "exponentPart",
 									},
 								},
@@ -5136,29 +5181,29 @@ var g = &grammar{
 		},
 		{
 			name: "doubleInteger",
-			pos:  position{line: 643, col: 1, offset: 15409},
+			pos:  position{line: 646, col: 1, offset: 15516},
 			expr: &choiceExpr{
-				pos: position{line: 644, col: 5, offset: 15427},
+				pos: position{line: 647, col: 5, offset: 15534},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 644, col: 5, offset: 15427},
+						pos:        position{line: 647, col: 5, offset: 15534},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 645, col: 5, offset: 15435},
+						pos: position{line: 648, col: 5, offset: 15542},
 						exprs: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 645, col: 5, offset: 15435},
+								pos:        position{line: 648, col: 5, offset: 15542},
 								val:        "[1-9]",
 								ranges:     []rune{'1', '9'},
 								ignoreCase: false,
 								inverted:   false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 645, col: 11, offset: 15441},
+								pos: position{line: 648, col: 11, offset: 15548},
 								expr: &charClassMatcher{
-									pos:        position{line: 645, col: 11, offset: 15441},
+									pos:        position{line: 648, col: 11, offset: 15548},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -5172,9 +5217,9 @@ var g = &grammar{
 		},
 		{
 			name: "doubleDigit",
-			pos:  position{line: 647, col: 1, offset: 15449},
+			pos:  position{line: 650, col: 1, offset: 15556},
 			expr: &charClassMatcher{
-				pos:        position{line: 647, col: 15, offset: 15463},
+				pos:        position{line: 650, col: 15, offset: 15570},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -5183,17 +5228,17 @@ var g = &grammar{
 		},
 		{
 			name: "exponentPart",
-			pos:  position{line: 649, col: 1, offset: 15470},
+			pos:  position{line: 652, col: 1, offset: 15577},
 			expr: &seqExpr{
-				pos: position{line: 649, col: 16, offset: 15485},
+				pos: position{line: 652, col: 16, offset: 15592},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 649, col: 16, offset: 15485},
+						pos:        position{line: 652, col: 16, offset: 15592},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 649, col: 21, offset: 15490},
+						pos:  position{line: 652, col: 21, offset: 15597},
 						name: "sinteger",
 					},
 				},
@@ -5201,17 +5246,17 @@ var g = &grammar{
 		},
 		{
 			name: "h16",
-			pos:  position{line: 651, col: 1, offset: 15500},
+			pos:  position{line: 654, col: 1, offset: 15607},
 			expr: &actionExpr{
-				pos: position{line: 651, col: 7, offset: 15506},
+				pos: position{line: 654, col: 7, offset: 15613},
 				run: (*parser).callonh161,
 				expr: &labeledExpr{
-					pos:   position{line: 651, col: 7, offset: 15506},
+					pos:   position{line: 654, col: 7, offset: 15613},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 651, col: 13, offset: 15512},
+						pos: position{line: 654, col: 13, offset: 15619},
 						expr: &ruleRefExpr{
-							pos:  position{line: 651, col: 13, offset: 15512},
+							pos:  position{line: 654, col: 13, offset: 15619},
 							name: "hexdigit",
 						},
 					},
@@ -5220,9 +5265,9 @@ var g = &grammar{
 		},
 		{
 			name: "hexdigit",
-			pos:  position{line: 653, col: 1, offset: 15554},
+			pos:  position{line: 656, col: 1, offset: 15661},
 			expr: &charClassMatcher{
-				pos:        position{line: 653, col: 12, offset: 15565},
+				pos:        position{line: 656, col: 12, offset: 15672},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -5231,17 +5276,17 @@ var g = &grammar{
 		},
 		{
 			name: "searchWord",
-			pos:  position{line: 655, col: 1, offset: 15578},
+			pos:  position{line: 658, col: 1, offset: 15685},
 			expr: &actionExpr{
-				pos: position{line: 656, col: 5, offset: 15593},
+				pos: position{line: 659, col: 5, offset: 15700},
 				run: (*parser).callonsearchWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 656, col: 5, offset: 15593},
+					pos:   position{line: 659, col: 5, offset: 15700},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 656, col: 11, offset: 15599},
+						pos: position{line: 659, col: 11, offset: 15706},
 						expr: &ruleRefExpr{
-							pos:  position{line: 656, col: 11, offset: 15599},
+							pos:  position{line: 659, col: 11, offset: 15706},
 							name: "searchWordPart",
 						},
 					},
@@ -5250,33 +5295,33 @@ var g = &grammar{
 		},
 		{
 			name: "searchWordPart",
-			pos:  position{line: 658, col: 1, offset: 15649},
+			pos:  position{line: 661, col: 1, offset: 15756},
 			expr: &choiceExpr{
-				pos: position{line: 659, col: 5, offset: 15668},
+				pos: position{line: 662, col: 5, offset: 15775},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 15668},
+						pos: position{line: 662, col: 5, offset: 15775},
 						run: (*parser).callonsearchWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 15668},
+							pos: position{line: 662, col: 5, offset: 15775},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 659, col: 5, offset: 15668},
+									pos:        position{line: 662, col: 5, offset: 15775},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 659, col: 10, offset: 15673},
+									pos:   position{line: 662, col: 10, offset: 15780},
 									label: "s",
 									expr: &choiceExpr{
-										pos: position{line: 659, col: 13, offset: 15676},
+										pos: position{line: 662, col: 13, offset: 15783},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 659, col: 13, offset: 15676},
+												pos:  position{line: 662, col: 13, offset: 15783},
 												name: "escapeSequence",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 659, col: 30, offset: 15693},
+												pos:  position{line: 662, col: 30, offset: 15800},
 												name: "searchEscape",
 											},
 										},
@@ -5286,18 +5331,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 660, col: 5, offset: 15730},
+						pos: position{line: 663, col: 5, offset: 15837},
 						run: (*parser).callonsearchWordPart9,
 						expr: &seqExpr{
-							pos: position{line: 660, col: 5, offset: 15730},
+							pos: position{line: 663, col: 5, offset: 15837},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 660, col: 5, offset: 15730},
+									pos: position{line: 663, col: 5, offset: 15837},
 									expr: &choiceExpr{
-										pos: position{line: 660, col: 7, offset: 15732},
+										pos: position{line: 663, col: 7, offset: 15839},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 660, col: 7, offset: 15732},
+												pos:        position{line: 663, col: 7, offset: 15839},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -5305,14 +5350,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 660, col: 42, offset: 15767},
+												pos:  position{line: 663, col: 42, offset: 15874},
 												name: "ws",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 660, col: 46, offset: 15771,
+									line: 663, col: 46, offset: 15878,
 								},
 							},
 						},
@@ -5322,34 +5367,34 @@ var g = &grammar{
 		},
 		{
 			name: "quotedString",
-			pos:  position{line: 662, col: 1, offset: 15805},
+			pos:  position{line: 665, col: 1, offset: 15912},
 			expr: &choiceExpr{
-				pos: position{line: 663, col: 5, offset: 15822},
+				pos: position{line: 666, col: 5, offset: 15929},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 663, col: 5, offset: 15822},
+						pos: position{line: 666, col: 5, offset: 15929},
 						run: (*parser).callonquotedString2,
 						expr: &seqExpr{
-							pos: position{line: 663, col: 5, offset: 15822},
+							pos: position{line: 666, col: 5, offset: 15929},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 663, col: 5, offset: 15822},
+									pos:        position{line: 666, col: 5, offset: 15929},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 663, col: 9, offset: 15826},
+									pos:   position{line: 666, col: 9, offset: 15933},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 663, col: 11, offset: 15828},
+										pos: position{line: 666, col: 11, offset: 15935},
 										expr: &ruleRefExpr{
-											pos:  position{line: 663, col: 11, offset: 15828},
+											pos:  position{line: 666, col: 11, offset: 15935},
 											name: "doubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 663, col: 29, offset: 15846},
+									pos:        position{line: 666, col: 29, offset: 15953},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5357,29 +5402,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 664, col: 5, offset: 15883},
+						pos: position{line: 667, col: 5, offset: 15990},
 						run: (*parser).callonquotedString9,
 						expr: &seqExpr{
-							pos: position{line: 664, col: 5, offset: 15883},
+							pos: position{line: 667, col: 5, offset: 15990},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 664, col: 5, offset: 15883},
+									pos:        position{line: 667, col: 5, offset: 15990},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 664, col: 9, offset: 15887},
+									pos:   position{line: 667, col: 9, offset: 15994},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 664, col: 11, offset: 15889},
+										pos: position{line: 667, col: 11, offset: 15996},
 										expr: &ruleRefExpr{
-											pos:  position{line: 664, col: 11, offset: 15889},
+											pos:  position{line: 667, col: 11, offset: 15996},
 											name: "singleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 664, col: 29, offset: 15907},
+									pos:        position{line: 667, col: 29, offset: 16014},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5391,55 +5436,55 @@ var g = &grammar{
 		},
 		{
 			name: "doubleQuotedChar",
-			pos:  position{line: 666, col: 1, offset: 15941},
+			pos:  position{line: 669, col: 1, offset: 16048},
 			expr: &choiceExpr{
-				pos: position{line: 667, col: 5, offset: 15962},
+				pos: position{line: 670, col: 5, offset: 16069},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 667, col: 5, offset: 15962},
+						pos: position{line: 670, col: 5, offset: 16069},
 						run: (*parser).callondoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 667, col: 5, offset: 15962},
+							pos: position{line: 670, col: 5, offset: 16069},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 667, col: 5, offset: 15962},
+									pos: position{line: 670, col: 5, offset: 16069},
 									expr: &choiceExpr{
-										pos: position{line: 667, col: 7, offset: 15964},
+										pos: position{line: 670, col: 7, offset: 16071},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 667, col: 7, offset: 15964},
+												pos:        position{line: 670, col: 7, offset: 16071},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 667, col: 13, offset: 15970},
+												pos:  position{line: 670, col: 13, offset: 16077},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 667, col: 26, offset: 15983,
+									line: 670, col: 26, offset: 16090,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 668, col: 5, offset: 16020},
+						pos: position{line: 671, col: 5, offset: 16127},
 						run: (*parser).callondoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 668, col: 5, offset: 16020},
+							pos: position{line: 671, col: 5, offset: 16127},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 668, col: 5, offset: 16020},
+									pos:        position{line: 671, col: 5, offset: 16127},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 668, col: 10, offset: 16025},
+									pos:   position{line: 671, col: 10, offset: 16132},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 668, col: 12, offset: 16027},
+										pos:  position{line: 671, col: 12, offset: 16134},
 										name: "escapeSequence",
 									},
 								},
@@ -5451,55 +5496,55 @@ var g = &grammar{
 		},
 		{
 			name: "singleQuotedChar",
-			pos:  position{line: 670, col: 1, offset: 16061},
+			pos:  position{line: 673, col: 1, offset: 16168},
 			expr: &choiceExpr{
-				pos: position{line: 671, col: 5, offset: 16082},
+				pos: position{line: 674, col: 5, offset: 16189},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 671, col: 5, offset: 16082},
+						pos: position{line: 674, col: 5, offset: 16189},
 						run: (*parser).callonsingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 671, col: 5, offset: 16082},
+							pos: position{line: 674, col: 5, offset: 16189},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 671, col: 5, offset: 16082},
+									pos: position{line: 674, col: 5, offset: 16189},
 									expr: &choiceExpr{
-										pos: position{line: 671, col: 7, offset: 16084},
+										pos: position{line: 674, col: 7, offset: 16191},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 671, col: 7, offset: 16084},
+												pos:        position{line: 674, col: 7, offset: 16191},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 671, col: 13, offset: 16090},
+												pos:  position{line: 674, col: 13, offset: 16197},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 671, col: 26, offset: 16103,
+									line: 674, col: 26, offset: 16210,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 672, col: 5, offset: 16140},
+						pos: position{line: 675, col: 5, offset: 16247},
 						run: (*parser).callonsingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 672, col: 5, offset: 16140},
+							pos: position{line: 675, col: 5, offset: 16247},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 672, col: 5, offset: 16140},
+									pos:        position{line: 675, col: 5, offset: 16247},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 672, col: 10, offset: 16145},
+									pos:   position{line: 675, col: 10, offset: 16252},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 672, col: 12, offset: 16147},
+										pos:  position{line: 675, col: 12, offset: 16254},
 										name: "escapeSequence",
 									},
 								},
@@ -5511,38 +5556,38 @@ var g = &grammar{
 		},
 		{
 			name: "escapeSequence",
-			pos:  position{line: 674, col: 1, offset: 16181},
+			pos:  position{line: 677, col: 1, offset: 16288},
 			expr: &choiceExpr{
-				pos: position{line: 675, col: 5, offset: 16200},
+				pos: position{line: 678, col: 5, offset: 16307},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 675, col: 5, offset: 16200},
+						pos: position{line: 678, col: 5, offset: 16307},
 						run: (*parser).callonescapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 675, col: 5, offset: 16200},
+							pos: position{line: 678, col: 5, offset: 16307},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 675, col: 5, offset: 16200},
+									pos:        position{line: 678, col: 5, offset: 16307},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 675, col: 9, offset: 16204},
+									pos:  position{line: 678, col: 9, offset: 16311},
 									name: "hexdigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 675, col: 18, offset: 16213},
+									pos:  position{line: 678, col: 18, offset: 16320},
 									name: "hexdigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 676, col: 5, offset: 16264},
+						pos:  position{line: 679, col: 5, offset: 16371},
 						name: "singleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 677, col: 5, offset: 16285},
+						pos:  position{line: 680, col: 5, offset: 16392},
 						name: "unicodeEscape",
 					},
 				},
@@ -5550,75 +5595,75 @@ var g = &grammar{
 		},
 		{
 			name: "singleCharEscape",
-			pos:  position{line: 679, col: 1, offset: 16300},
+			pos:  position{line: 682, col: 1, offset: 16407},
 			expr: &choiceExpr{
-				pos: position{line: 680, col: 5, offset: 16321},
+				pos: position{line: 683, col: 5, offset: 16428},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 680, col: 5, offset: 16321},
+						pos:        position{line: 683, col: 5, offset: 16428},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 681, col: 5, offset: 16329},
+						pos:        position{line: 684, col: 5, offset: 16436},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 682, col: 5, offset: 16337},
+						pos:        position{line: 685, col: 5, offset: 16444},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 683, col: 5, offset: 16346},
+						pos: position{line: 686, col: 5, offset: 16453},
 						run: (*parser).callonsingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 683, col: 5, offset: 16346},
+							pos:        position{line: 686, col: 5, offset: 16453},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 684, col: 5, offset: 16375},
+						pos: position{line: 687, col: 5, offset: 16482},
 						run: (*parser).callonsingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 684, col: 5, offset: 16375},
+							pos:        position{line: 687, col: 5, offset: 16482},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 685, col: 5, offset: 16404},
+						pos: position{line: 688, col: 5, offset: 16511},
 						run: (*parser).callonsingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 685, col: 5, offset: 16404},
+							pos:        position{line: 688, col: 5, offset: 16511},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 686, col: 5, offset: 16433},
+						pos: position{line: 689, col: 5, offset: 16540},
 						run: (*parser).callonsingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 686, col: 5, offset: 16433},
+							pos:        position{line: 689, col: 5, offset: 16540},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 687, col: 5, offset: 16462},
+						pos: position{line: 690, col: 5, offset: 16569},
 						run: (*parser).callonsingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 687, col: 5, offset: 16462},
+							pos:        position{line: 690, col: 5, offset: 16569},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 688, col: 5, offset: 16491},
+						pos: position{line: 691, col: 5, offset: 16598},
 						run: (*parser).callonsingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 688, col: 5, offset: 16491},
+							pos:        position{line: 691, col: 5, offset: 16598},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5628,24 +5673,24 @@ var g = &grammar{
 		},
 		{
 			name: "searchEscape",
-			pos:  position{line: 690, col: 1, offset: 16517},
+			pos:  position{line: 693, col: 1, offset: 16624},
 			expr: &choiceExpr{
-				pos: position{line: 691, col: 5, offset: 16534},
+				pos: position{line: 694, col: 5, offset: 16641},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 691, col: 5, offset: 16534},
+						pos: position{line: 694, col: 5, offset: 16641},
 						run: (*parser).callonsearchEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 691, col: 5, offset: 16534},
+							pos:        position{line: 694, col: 5, offset: 16641},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 692, col: 5, offset: 16562},
+						pos: position{line: 695, col: 5, offset: 16669},
 						run: (*parser).callonsearchEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 692, col: 5, offset: 16562},
+							pos:        position{line: 695, col: 5, offset: 16669},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -5655,41 +5700,41 @@ var g = &grammar{
 		},
 		{
 			name: "unicodeEscape",
-			pos:  position{line: 694, col: 1, offset: 16589},
+			pos:  position{line: 697, col: 1, offset: 16696},
 			expr: &choiceExpr{
-				pos: position{line: 695, col: 5, offset: 16607},
+				pos: position{line: 698, col: 5, offset: 16714},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 695, col: 5, offset: 16607},
+						pos: position{line: 698, col: 5, offset: 16714},
 						run: (*parser).callonunicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 695, col: 5, offset: 16607},
+							pos: position{line: 698, col: 5, offset: 16714},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 695, col: 5, offset: 16607},
+									pos:        position{line: 698, col: 5, offset: 16714},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 695, col: 9, offset: 16611},
+									pos:   position{line: 698, col: 9, offset: 16718},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 695, col: 16, offset: 16618},
+										pos: position{line: 698, col: 16, offset: 16725},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 16, offset: 16618},
+												pos:  position{line: 698, col: 16, offset: 16725},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 25, offset: 16627},
+												pos:  position{line: 698, col: 25, offset: 16734},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 34, offset: 16636},
+												pos:  position{line: 698, col: 34, offset: 16743},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 43, offset: 16645},
+												pos:  position{line: 698, col: 43, offset: 16752},
 												name: "hexdigit",
 											},
 										},
@@ -5699,63 +5744,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 698, col: 5, offset: 16708},
+						pos: position{line: 701, col: 5, offset: 16815},
 						run: (*parser).callonunicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 698, col: 5, offset: 16708},
+							pos: position{line: 701, col: 5, offset: 16815},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 698, col: 5, offset: 16708},
+									pos:        position{line: 701, col: 5, offset: 16815},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 698, col: 9, offset: 16712},
+									pos:        position{line: 701, col: 9, offset: 16819},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 698, col: 13, offset: 16716},
+									pos:   position{line: 701, col: 13, offset: 16823},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 698, col: 20, offset: 16723},
+										pos: position{line: 701, col: 20, offset: 16830},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 698, col: 20, offset: 16723},
+												pos:  position{line: 701, col: 20, offset: 16830},
 												name: "hexdigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 29, offset: 16732},
+												pos: position{line: 701, col: 29, offset: 16839},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 29, offset: 16732},
+													pos:  position{line: 701, col: 29, offset: 16839},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 39, offset: 16742},
+												pos: position{line: 701, col: 39, offset: 16849},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 39, offset: 16742},
+													pos:  position{line: 701, col: 39, offset: 16849},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 49, offset: 16752},
+												pos: position{line: 701, col: 49, offset: 16859},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 49, offset: 16752},
+													pos:  position{line: 701, col: 49, offset: 16859},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 59, offset: 16762},
+												pos: position{line: 701, col: 59, offset: 16869},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 59, offset: 16762},
+													pos:  position{line: 701, col: 59, offset: 16869},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 69, offset: 16772},
+												pos: position{line: 701, col: 69, offset: 16879},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 69, offset: 16772},
+													pos:  position{line: 701, col: 69, offset: 16879},
 													name: "hexdigit",
 												},
 											},
@@ -5763,7 +5808,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 698, col: 80, offset: 16783},
+									pos:        position{line: 701, col: 80, offset: 16890},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5775,28 +5820,28 @@ var g = &grammar{
 		},
 		{
 			name: "reString",
-			pos:  position{line: 702, col: 1, offset: 16837},
+			pos:  position{line: 705, col: 1, offset: 16944},
 			expr: &actionExpr{
-				pos: position{line: 703, col: 5, offset: 16850},
+				pos: position{line: 706, col: 5, offset: 16957},
 				run: (*parser).callonreString1,
 				expr: &seqExpr{
-					pos: position{line: 703, col: 5, offset: 16850},
+					pos: position{line: 706, col: 5, offset: 16957},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 703, col: 5, offset: 16850},
+							pos:        position{line: 706, col: 5, offset: 16957},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 703, col: 9, offset: 16854},
+							pos:   position{line: 706, col: 9, offset: 16961},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 703, col: 11, offset: 16856},
+								pos:  position{line: 706, col: 11, offset: 16963},
 								name: "reBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 703, col: 18, offset: 16863},
+							pos:        position{line: 706, col: 18, offset: 16970},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5806,24 +5851,24 @@ var g = &grammar{
 		},
 		{
 			name: "reBody",
-			pos:  position{line: 705, col: 1, offset: 16886},
+			pos:  position{line: 708, col: 1, offset: 16993},
 			expr: &actionExpr{
-				pos: position{line: 706, col: 5, offset: 16897},
+				pos: position{line: 709, col: 5, offset: 17004},
 				run: (*parser).callonreBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 706, col: 5, offset: 16897},
+					pos: position{line: 709, col: 5, offset: 17004},
 					expr: &choiceExpr{
-						pos: position{line: 706, col: 6, offset: 16898},
+						pos: position{line: 709, col: 6, offset: 17005},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 706, col: 6, offset: 16898},
+								pos:        position{line: 709, col: 6, offset: 17005},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 706, col: 13, offset: 16905},
+								pos:        position{line: 709, col: 13, offset: 17012},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -5834,9 +5879,9 @@ var g = &grammar{
 		},
 		{
 			name: "escapedChar",
-			pos:  position{line: 708, col: 1, offset: 16945},
+			pos:  position{line: 711, col: 1, offset: 17052},
 			expr: &charClassMatcher{
-				pos:        position{line: 709, col: 5, offset: 16961},
+				pos:        position{line: 712, col: 5, offset: 17068},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5846,37 +5891,37 @@ var g = &grammar{
 		},
 		{
 			name: "ws",
-			pos:  position{line: 711, col: 1, offset: 16976},
+			pos:  position{line: 714, col: 1, offset: 17083},
 			expr: &choiceExpr{
-				pos: position{line: 712, col: 5, offset: 16983},
+				pos: position{line: 715, col: 5, offset: 17090},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 712, col: 5, offset: 16983},
+						pos:        position{line: 715, col: 5, offset: 17090},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 713, col: 5, offset: 16992},
+						pos:        position{line: 716, col: 5, offset: 17099},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 714, col: 5, offset: 17001},
+						pos:        position{line: 717, col: 5, offset: 17108},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 715, col: 5, offset: 17010},
+						pos:        position{line: 718, col: 5, offset: 17117},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 716, col: 5, offset: 17018},
+						pos:        position{line: 719, col: 5, offset: 17125},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 717, col: 5, offset: 17031},
+						pos:        position{line: 720, col: 5, offset: 17138},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5886,33 +5931,33 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 719, col: 1, offset: 17041},
+			pos:         position{line: 722, col: 1, offset: 17148},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 719, col: 18, offset: 17058},
+				pos: position{line: 722, col: 18, offset: 17165},
 				expr: &ruleRefExpr{
-					pos:  position{line: 719, col: 18, offset: 17058},
+					pos:  position{line: 722, col: 18, offset: 17165},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 720, col: 1, offset: 17062},
+			pos:  position{line: 723, col: 1, offset: 17169},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 720, col: 6, offset: 17067},
+				pos: position{line: 723, col: 6, offset: 17174},
 				expr: &ruleRefExpr{
-					pos:  position{line: 720, col: 6, offset: 17067},
+					pos:  position{line: 723, col: 6, offset: 17174},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 722, col: 1, offset: 17072},
+			pos:  position{line: 725, col: 1, offset: 17179},
 			expr: &notExpr{
-				pos: position{line: 722, col: 7, offset: 17078},
+				pos: position{line: 725, col: 7, offset: 17185},
 				expr: &anyMatcher{
-					line: 722, col: 8, offset: 17079,
+					line: 725, col: 8, offset: 17186,
 				},
 			},
 		},
@@ -6401,6 +6446,16 @@ func (p *parser) calloneveryDur1() (interface{}, error) {
 	return p.cur.oneveryDur1(stack["dur"])
 }
 
+func (c *current) ongroupBySorted1(dir interface{}) (interface{}, error) {
+	return parseInt(dir), nil
+}
+
+func (p *parser) callongroupBySorted1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.ongroupBySorted1(stack["dir"])
+}
+
 func (c *current) onandToken1() (interface{}, error) {
 	return string(c.text), nil
 }
@@ -6722,7 +6777,7 @@ func (p *parser) callonfieldReducer1() (interface{}, error) {
 	return p.cur.onfieldReducer1(stack["op"], stack["field"])
 }
 
-func (c *current) onreducerProc1(every, reducers, keys, limit interface{}) (interface{}, error) {
+func (c *current) onreducerProc1(every, reducers, keys, sorted, limit interface{}) (interface{}, error) {
 	if OR(keys, every) != nil {
 		if keys != nil {
 			keys = keys.([]interface{})[1]
@@ -6734,7 +6789,7 @@ func (c *current) onreducerProc1(every, reducers, keys, limit interface{}) (inte
 			every = every.([]interface{})[0]
 		}
 
-		return makeGroupByProc(every, limit, keys, reducers), nil
+		return makeGroupByProc(every, sorted, limit, keys, reducers), nil
 	}
 
 	return makeReducerProc(reducers), nil
@@ -6744,7 +6799,7 @@ func (c *current) onreducerProc1(every, reducers, keys, limit interface{}) (inte
 func (p *parser) callonreducerProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onreducerProc1(stack["every"], stack["reducers"], stack["keys"], stack["limit"])
+	return p.cur.onreducerProc1(stack["every"], stack["reducers"], stack["keys"], stack["sorted"], stack["limit"])
 }
 
 func (c *current) onasClause1(v interface{}) (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -263,43 +263,47 @@ function peg$parse(input, options) {
           },
       peg$c58 = "by",
       peg$c59 = peg$literalExpectation("by", true),
-      peg$c60 = function(list) { return list },
-      peg$c61 = "every",
-      peg$c62 = peg$literalExpectation("every", true),
-      peg$c63 = function(dur) { return dur },
-      peg$c64 = "and",
-      peg$c65 = peg$literalExpectation("and", true),
-      peg$c66 = function() { return text() },
-      peg$c67 = "or",
-      peg$c68 = peg$literalExpectation("or", true),
-      peg$c69 = "in",
-      peg$c70 = peg$literalExpectation("in", true),
-      peg$c71 = "not",
-      peg$c72 = peg$literalExpectation("not", true),
-      peg$c73 = /^[A-Za-z_$]/,
-      peg$c74 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c75 = /^[0-9]/,
-      peg$c76 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c77 = ".",
-      peg$c78 = peg$literalExpectation(".", false),
-      peg$c79 = function(base, field) { return makeFieldCall("RecordFieldRead", null, field) },
-      peg$c80 = "[",
-      peg$c81 = peg$literalExpectation("[", false),
-      peg$c82 = "]",
-      peg$c83 = peg$literalExpectation("]", false),
-      peg$c84 = function(base, index) { return makeFieldCall("Index", null, index) },
-      peg$c85 = function(base, derefs) {
+      peg$c60 = ",",
+      peg$c61 = peg$literalExpectation(",", false),
+      peg$c62 = function(first, cl) { return cl },
+      peg$c63 = function(first, rest) {
+            return makeGroupByKeys(first, rest)
+          },
+      peg$c64 = function(field) { return makeGroupByKey(text(), field) },
+      peg$c65 = "every",
+      peg$c66 = peg$literalExpectation("every", true),
+      peg$c67 = function(dur) { return dur },
+      peg$c68 = "and",
+      peg$c69 = peg$literalExpectation("and", true),
+      peg$c70 = function() { return text() },
+      peg$c71 = "or",
+      peg$c72 = peg$literalExpectation("or", true),
+      peg$c73 = "in",
+      peg$c74 = peg$literalExpectation("in", true),
+      peg$c75 = "not",
+      peg$c76 = peg$literalExpectation("not", true),
+      peg$c77 = /^[A-Za-z_$]/,
+      peg$c78 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c79 = /^[0-9]/,
+      peg$c80 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c81 = ".",
+      peg$c82 = peg$literalExpectation(".", false),
+      peg$c83 = function(base, field) { return makeFieldCall("RecordFieldRead", null, field) },
+      peg$c84 = "[",
+      peg$c85 = peg$literalExpectation("[", false),
+      peg$c86 = "]",
+      peg$c87 = peg$literalExpectation("]", false),
+      peg$c88 = function(base, index) { return makeFieldCall("Index", null, index) },
+      peg$c89 = function(base, derefs) {
            return chainFieldCalls(base, derefs)
          },
-      peg$c86 = function(op, field) {
+      peg$c90 = function(op, field) {
             return makeFieldCall(op, field, null)
           },
-      peg$c87 = "len",
-      peg$c88 = peg$literalExpectation("len", true),
-      peg$c89 = function() { return "Len" },
-      peg$c90 = ",",
-      peg$c91 = peg$literalExpectation(",", false),
-      peg$c92 = function(first, rest) {
+      peg$c91 = "len",
+      peg$c92 = peg$literalExpectation("len", true),
+      peg$c93 = function() { return "Len" },
+      peg$c94 = function(first, rest) {
             let result =  [first]
 
             for(let  r of rest) {
@@ -308,65 +312,65 @@ function peg$parse(input, options) {
 
             return result
         },
-      peg$c93 = function(base, refs) { return text() },
-      peg$c94 = function(first, ref) { return ref },
-      peg$c95 = function(first, rest) {
+      peg$c95 = function(base, refs) { return text() },
+      peg$c96 = function(first, ref) { return ref },
+      peg$c97 = function(first, rest) {
         let result =  [first]
         for(let  r of rest) {
           result.push( r)
         }
         return result
         },
-      peg$c96 = function(first, rest) {
+      peg$c98 = function(first, rest) {
             let result =  [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
         },
-      peg$c97 = "count",
-      peg$c98 = peg$literalExpectation("count", true),
-      peg$c99 = function() { return "Count" },
-      peg$c100 = "sum",
-      peg$c101 = peg$literalExpectation("sum", true),
-      peg$c102 = function() { return "Sum" },
-      peg$c103 = "avg",
-      peg$c104 = peg$literalExpectation("avg", true),
-      peg$c105 = function() { return "Avg" },
-      peg$c106 = "stdev",
-      peg$c107 = peg$literalExpectation("stdev", true),
-      peg$c108 = function() { return "Stdev" },
-      peg$c109 = "sd",
-      peg$c110 = peg$literalExpectation("sd", true),
-      peg$c111 = "var",
-      peg$c112 = peg$literalExpectation("var", true),
-      peg$c113 = function() { return "Var" },
-      peg$c114 = "entropy",
-      peg$c115 = peg$literalExpectation("entropy", true),
-      peg$c116 = function() { return "Entropy" },
-      peg$c117 = "min",
-      peg$c118 = peg$literalExpectation("min", true),
-      peg$c119 = function() { return "Min" },
-      peg$c120 = "max",
-      peg$c121 = peg$literalExpectation("max", true),
-      peg$c122 = function() { return "Max" },
-      peg$c123 = "first",
-      peg$c124 = peg$literalExpectation("first", true),
-      peg$c125 = function() { return "First" },
-      peg$c126 = "last",
-      peg$c127 = peg$literalExpectation("last", true),
-      peg$c128 = function() { return "Last" },
-      peg$c129 = "countdistinct",
-      peg$c130 = peg$literalExpectation("countdistinct", true),
-      peg$c131 = function() { return "CountDistinct" },
-      peg$c132 = function(field) { return field },
-      peg$c133 = function(op, field) {
+      peg$c99 = "count",
+      peg$c100 = peg$literalExpectation("count", true),
+      peg$c101 = function() { return "Count" },
+      peg$c102 = "sum",
+      peg$c103 = peg$literalExpectation("sum", true),
+      peg$c104 = function() { return "Sum" },
+      peg$c105 = "avg",
+      peg$c106 = peg$literalExpectation("avg", true),
+      peg$c107 = function() { return "Avg" },
+      peg$c108 = "stdev",
+      peg$c109 = peg$literalExpectation("stdev", true),
+      peg$c110 = function() { return "Stdev" },
+      peg$c111 = "sd",
+      peg$c112 = peg$literalExpectation("sd", true),
+      peg$c113 = "var",
+      peg$c114 = peg$literalExpectation("var", true),
+      peg$c115 = function() { return "Var" },
+      peg$c116 = "entropy",
+      peg$c117 = peg$literalExpectation("entropy", true),
+      peg$c118 = function() { return "Entropy" },
+      peg$c119 = "min",
+      peg$c120 = peg$literalExpectation("min", true),
+      peg$c121 = function() { return "Min" },
+      peg$c122 = "max",
+      peg$c123 = peg$literalExpectation("max", true),
+      peg$c124 = function() { return "Max" },
+      peg$c125 = "first",
+      peg$c126 = peg$literalExpectation("first", true),
+      peg$c127 = function() { return "First" },
+      peg$c128 = "last",
+      peg$c129 = peg$literalExpectation("last", true),
+      peg$c130 = function() { return "Last" },
+      peg$c131 = "countdistinct",
+      peg$c132 = peg$literalExpectation("countdistinct", true),
+      peg$c133 = function() { return "CountDistinct" },
+      peg$c134 = function(field) { return field },
+      peg$c135 = function(op, field) {
           return makeReducer(op, "count", field)
         },
-      peg$c134 = function(op, field) {
+      peg$c136 = function(op, field) {
           return makeReducer(op, toLowerCase(op), field)
         },
-      peg$c135 = function(every, reducers, keys, limit) {
+      peg$c137 = function(every, reducers, keys, limit) {
           if (OR(keys, every)) {
             if (keys) {
               keys = keys[1]
@@ -383,333 +387,332 @@ function peg$parse(input, options) {
 
           return makeReducerProc(reducers)
         },
-      peg$c136 = "as",
-      peg$c137 = peg$literalExpectation("as", true),
-      peg$c138 = "=",
-      peg$c139 = peg$literalExpectation("=", false),
-      peg$c140 = function(field, f) {
+      peg$c138 = "as",
+      peg$c139 = peg$literalExpectation("as", true),
+      peg$c140 = "=",
+      peg$c141 = peg$literalExpectation("=", false),
+      peg$c142 = function(field, f) {
           return overrideReducerVar(f, field)
         },
-      peg$c141 = function(f, field) {
+      peg$c143 = function(f, field) {
           return overrideReducerVar(f, field)
         },
-      peg$c142 = function(first, rest) {
+      peg$c144 = function(first, rest) {
             let result =  [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c143 = "sort",
-      peg$c144 = peg$literalExpectation("sort", true),
-      peg$c145 = function(args, l) { return l },
-      peg$c146 = function(args, list) {
+      peg$c145 = "sort",
+      peg$c146 = peg$literalExpectation("sort", true),
+      peg$c147 = function(args, l) { return l },
+      peg$c148 = function(args, list) {
           return makeSortProc(args, list)
         },
-      peg$c147 = function(a) { return a },
-      peg$c148 = "-r",
-      peg$c149 = peg$literalExpectation("-r", false),
-      peg$c150 = function() { return makeArg("r", null) },
-      peg$c151 = "-nulls",
-      peg$c152 = peg$literalExpectation("-nulls", false),
-      peg$c153 = peg$literalExpectation("first", false),
-      peg$c154 = peg$literalExpectation("last", false),
-      peg$c155 = function(where) { return makeArg("nulls", where) },
-      peg$c156 = "top",
-      peg$c157 = peg$literalExpectation("top", true),
-      peg$c158 = function(n) { return n},
-      peg$c159 = "-flush",
-      peg$c160 = peg$literalExpectation("-flush", false),
-      peg$c161 = function(limit, flush, f) { return f },
-      peg$c162 = function(limit, flush, list) {
+      peg$c149 = function(a) { return a },
+      peg$c150 = "-r",
+      peg$c151 = peg$literalExpectation("-r", false),
+      peg$c152 = function() { return makeArg("r", null) },
+      peg$c153 = "-nulls",
+      peg$c154 = peg$literalExpectation("-nulls", false),
+      peg$c155 = peg$literalExpectation("first", false),
+      peg$c156 = peg$literalExpectation("last", false),
+      peg$c157 = function(where) { return makeArg("nulls", where) },
+      peg$c158 = "top",
+      peg$c159 = peg$literalExpectation("top", true),
+      peg$c160 = function(n) { return n},
+      peg$c161 = "-flush",
+      peg$c162 = peg$literalExpectation("-flush", false),
+      peg$c163 = function(limit, flush, f) { return f },
+      peg$c164 = function(limit, flush, list) {
           return makeTopProc(list, limit, flush)
         },
-      peg$c163 = "-limit",
-      peg$c164 = peg$literalExpectation("-limit", false),
-      peg$c165 = function(limit) { return limit },
-      peg$c166 = "-c",
-      peg$c167 = peg$literalExpectation("-c", false),
-      peg$c168 = function() { return makeArg("c", null) },
-      peg$c169 = "cut",
-      peg$c170 = peg$literalExpectation("cut", true),
-      peg$c171 = function(arg, list) {  return makeCutProc(arg, list) },
-      peg$c172 = "head",
-      peg$c173 = peg$literalExpectation("head", true),
-      peg$c174 = function(count) { return makeHeadProc(count) },
-      peg$c175 = function() { return makeHeadProc(1) },
-      peg$c176 = "tail",
-      peg$c177 = peg$literalExpectation("tail", true),
-      peg$c178 = function(count) { return makeTailProc(count) },
-      peg$c179 = function() { return makeTailProc(1) },
-      peg$c180 = "filter",
-      peg$c181 = peg$literalExpectation("filter", true),
-      peg$c182 = "uniq",
-      peg$c183 = peg$literalExpectation("uniq", true),
-      peg$c184 = function() {
+      peg$c165 = "-limit",
+      peg$c166 = peg$literalExpectation("-limit", false),
+      peg$c167 = function(limit) { return limit },
+      peg$c168 = "-c",
+      peg$c169 = peg$literalExpectation("-c", false),
+      peg$c170 = function() { return makeArg("c", null) },
+      peg$c171 = "cut",
+      peg$c172 = peg$literalExpectation("cut", true),
+      peg$c173 = function(arg, list) {  return makeCutProc(arg, list) },
+      peg$c174 = "head",
+      peg$c175 = peg$literalExpectation("head", true),
+      peg$c176 = function(count) { return makeHeadProc(count) },
+      peg$c177 = function() { return makeHeadProc(1) },
+      peg$c178 = "tail",
+      peg$c179 = peg$literalExpectation("tail", true),
+      peg$c180 = function(count) { return makeTailProc(count) },
+      peg$c181 = function() { return makeTailProc(1) },
+      peg$c182 = "filter",
+      peg$c183 = peg$literalExpectation("filter", true),
+      peg$c184 = "uniq",
+      peg$c185 = peg$literalExpectation("uniq", true),
+      peg$c186 = function() {
             return makeUniqProc(true)
           },
-      peg$c185 = function() {
+      peg$c187 = function() {
             return makeUniqProc(false)
           },
-      peg$c186 = "put",
-      peg$c187 = peg$literalExpectation("put", true),
-      peg$c188 = function(first, cl) { return cl },
-      peg$c189 = function(first, rest) {
+      peg$c188 = "put",
+      peg$c189 = peg$literalExpectation("put", true),
+      peg$c190 = function(first, rest) {
             return makePutProc(first, rest)
           },
-      peg$c190 = function(f, e) {
-            return makePutClause(f, e)
+      peg$c191 = function(f, e) {
+            return makeAssignment(f, e)
           },
-      peg$c191 = function(f) {
+      peg$c192 = function(f) {
             return chainFieldCalls(f, [])
           },
-      peg$c192 = "?",
-      peg$c193 = peg$literalExpectation("?", false),
-      peg$c194 = ":",
-      peg$c195 = peg$literalExpectation(":", false),
-      peg$c196 = function(condition, thenClause, elseClause) {
+      peg$c193 = "?",
+      peg$c194 = peg$literalExpectation("?", false),
+      peg$c195 = ":",
+      peg$c196 = peg$literalExpectation(":", false),
+      peg$c197 = function(condition, thenClause, elseClause) {
           return makeConditionalExpr(condition, thenClause, elseClause)
         },
-      peg$c197 = function(first, rest) {
+      peg$c198 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c198 = "=~",
-      peg$c199 = peg$literalExpectation("=~", false),
-      peg$c200 = "!~",
-      peg$c201 = peg$literalExpectation("!~", false),
-      peg$c202 = "!=",
-      peg$c203 = peg$literalExpectation("!=", false),
-      peg$c204 = peg$literalExpectation("in", false),
-      peg$c205 = "<=",
-      peg$c206 = peg$literalExpectation("<=", false),
-      peg$c207 = "<",
-      peg$c208 = peg$literalExpectation("<", false),
-      peg$c209 = ">=",
-      peg$c210 = peg$literalExpectation(">=", false),
-      peg$c211 = ">",
-      peg$c212 = peg$literalExpectation(">", false),
-      peg$c213 = "+",
-      peg$c214 = peg$literalExpectation("+", false),
-      peg$c215 = "/",
-      peg$c216 = peg$literalExpectation("/", false),
-      peg$c217 = function(e) {
+      peg$c199 = "=~",
+      peg$c200 = peg$literalExpectation("=~", false),
+      peg$c201 = "!~",
+      peg$c202 = peg$literalExpectation("!~", false),
+      peg$c203 = "!=",
+      peg$c204 = peg$literalExpectation("!=", false),
+      peg$c205 = peg$literalExpectation("in", false),
+      peg$c206 = "<=",
+      peg$c207 = peg$literalExpectation("<=", false),
+      peg$c208 = "<",
+      peg$c209 = peg$literalExpectation("<", false),
+      peg$c210 = ">=",
+      peg$c211 = peg$literalExpectation(">=", false),
+      peg$c212 = ">",
+      peg$c213 = peg$literalExpectation(">", false),
+      peg$c214 = "+",
+      peg$c215 = peg$literalExpectation("+", false),
+      peg$c216 = "/",
+      peg$c217 = peg$literalExpectation("/", false),
+      peg$c218 = function(e) {
               return makeUnaryExpr("!", e)
           },
-      peg$c218 = function(e, ct) { return ct },
-      peg$c219 = function(e, t) {
+      peg$c219 = function(e, ct) { return ct },
+      peg$c220 = function(e, t) {
           if (t) {
             return makeCastExpression(e, t)
           } else {
             return e
           }
         },
-      peg$c220 = "bool",
-      peg$c221 = peg$literalExpectation("bool", false),
-      peg$c222 = "byte",
-      peg$c223 = peg$literalExpectation("byte", false),
-      peg$c224 = "int16",
-      peg$c225 = peg$literalExpectation("int16", false),
-      peg$c226 = "uint16",
-      peg$c227 = peg$literalExpectation("uint16", false),
-      peg$c228 = "int32",
-      peg$c229 = peg$literalExpectation("int32", false),
-      peg$c230 = "uint32",
-      peg$c231 = peg$literalExpectation("uint32", false),
-      peg$c232 = "int64",
-      peg$c233 = peg$literalExpectation("int64", false),
-      peg$c234 = "uint64",
-      peg$c235 = peg$literalExpectation("uint64", false),
-      peg$c236 = "float64",
-      peg$c237 = peg$literalExpectation("float64", false),
-      peg$c238 = "string",
-      peg$c239 = peg$literalExpectation("string", false),
-      peg$c240 = "bstring",
-      peg$c241 = peg$literalExpectation("bstring", false),
-      peg$c242 = "ip",
-      peg$c243 = peg$literalExpectation("ip", false),
-      peg$c244 = "net",
-      peg$c245 = peg$literalExpectation("net", false),
-      peg$c246 = "time",
-      peg$c247 = peg$literalExpectation("time", false),
-      peg$c248 = "duration",
-      peg$c249 = peg$literalExpectation("duration", false),
-      peg$c250 = function(fn, args) {
+      peg$c221 = "bool",
+      peg$c222 = peg$literalExpectation("bool", false),
+      peg$c223 = "byte",
+      peg$c224 = peg$literalExpectation("byte", false),
+      peg$c225 = "int16",
+      peg$c226 = peg$literalExpectation("int16", false),
+      peg$c227 = "uint16",
+      peg$c228 = peg$literalExpectation("uint16", false),
+      peg$c229 = "int32",
+      peg$c230 = peg$literalExpectation("int32", false),
+      peg$c231 = "uint32",
+      peg$c232 = peg$literalExpectation("uint32", false),
+      peg$c233 = "int64",
+      peg$c234 = peg$literalExpectation("int64", false),
+      peg$c235 = "uint64",
+      peg$c236 = peg$literalExpectation("uint64", false),
+      peg$c237 = "float64",
+      peg$c238 = peg$literalExpectation("float64", false),
+      peg$c239 = "string",
+      peg$c240 = peg$literalExpectation("string", false),
+      peg$c241 = "bstring",
+      peg$c242 = peg$literalExpectation("bstring", false),
+      peg$c243 = "ip",
+      peg$c244 = peg$literalExpectation("ip", false),
+      peg$c245 = "net",
+      peg$c246 = peg$literalExpectation("net", false),
+      peg$c247 = "time",
+      peg$c248 = peg$literalExpectation("time", false),
+      peg$c249 = "duration",
+      peg$c250 = peg$literalExpectation("duration", false),
+      peg$c251 = function(fn, args) {
               return makeFunctionCall(fn, args)
           },
-      peg$c251 = /^[A-Za-z]/,
-      peg$c252 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
-      peg$c253 = /^[.0-9]/,
-      peg$c254 = peg$classExpectation([".", ["0", "9"]], false, false),
-      peg$c255 = function(first, e) { return e },
-      peg$c256 = function(first, rest) {
+      peg$c252 = /^[A-Za-z]/,
+      peg$c253 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
+      peg$c254 = /^[.0-9]/,
+      peg$c255 = peg$classExpectation([".", ["0", "9"]], false, false),
+      peg$c256 = function(first, e) { return e },
+      peg$c257 = function(first, rest) {
             return [first, ... rest]
         },
-      peg$c257 = function() { return [] },
-      peg$c258 = function(base, field) { return makeLiteral("string", text()) },
-      peg$c259 = function(base, derefs) {
+      peg$c258 = function() { return [] },
+      peg$c259 = function(base, field) { return makeLiteral("string", text()) },
+      peg$c260 = function(base, derefs) {
               return makeBinaryExprChain(base, derefs)
           },
-      peg$c260 = peg$literalExpectation("and", false),
-      peg$c261 = "seconds",
-      peg$c262 = peg$literalExpectation("seconds", false),
-      peg$c263 = "second",
-      peg$c264 = peg$literalExpectation("second", false),
-      peg$c265 = "secs",
-      peg$c266 = peg$literalExpectation("secs", false),
-      peg$c267 = "sec",
-      peg$c268 = peg$literalExpectation("sec", false),
-      peg$c269 = "s",
-      peg$c270 = peg$literalExpectation("s", false),
-      peg$c271 = "minutes",
-      peg$c272 = peg$literalExpectation("minutes", false),
-      peg$c273 = "minute",
-      peg$c274 = peg$literalExpectation("minute", false),
-      peg$c275 = "mins",
-      peg$c276 = peg$literalExpectation("mins", false),
-      peg$c277 = peg$literalExpectation("min", false),
-      peg$c278 = "m",
-      peg$c279 = peg$literalExpectation("m", false),
-      peg$c280 = "hours",
-      peg$c281 = peg$literalExpectation("hours", false),
-      peg$c282 = "hrs",
-      peg$c283 = peg$literalExpectation("hrs", false),
-      peg$c284 = "hr",
-      peg$c285 = peg$literalExpectation("hr", false),
-      peg$c286 = "h",
-      peg$c287 = peg$literalExpectation("h", false),
-      peg$c288 = "hour",
-      peg$c289 = peg$literalExpectation("hour", false),
-      peg$c290 = "days",
-      peg$c291 = peg$literalExpectation("days", false),
-      peg$c292 = "day",
-      peg$c293 = peg$literalExpectation("day", false),
-      peg$c294 = "d",
-      peg$c295 = peg$literalExpectation("d", false),
-      peg$c296 = "weeks",
-      peg$c297 = peg$literalExpectation("weeks", false),
-      peg$c298 = "week",
-      peg$c299 = peg$literalExpectation("week", false),
-      peg$c300 = "wks",
-      peg$c301 = peg$literalExpectation("wks", false),
-      peg$c302 = "wk",
-      peg$c303 = peg$literalExpectation("wk", false),
-      peg$c304 = "w",
-      peg$c305 = peg$literalExpectation("w", false),
-      peg$c306 = function() { return makeDuration(1) },
-      peg$c307 = function(num) { return makeDuration(num) },
-      peg$c308 = function() { return makeDuration(60) },
-      peg$c309 = function(num) { return makeDuration(num*60) },
-      peg$c310 = function() { return makeDuration(3600) },
-      peg$c311 = function(num) { return makeDuration(num*3600) },
-      peg$c312 = function() { return makeDuration(3600*24) },
-      peg$c313 = function(num) { return makeDuration(num*3600*24) },
-      peg$c314 = function(num) { return makeDuration(num*3600*24*7) },
-      peg$c315 = function(a) { return text() },
-      peg$c316 = function(a, b) {
+      peg$c261 = peg$literalExpectation("and", false),
+      peg$c262 = "seconds",
+      peg$c263 = peg$literalExpectation("seconds", false),
+      peg$c264 = "second",
+      peg$c265 = peg$literalExpectation("second", false),
+      peg$c266 = "secs",
+      peg$c267 = peg$literalExpectation("secs", false),
+      peg$c268 = "sec",
+      peg$c269 = peg$literalExpectation("sec", false),
+      peg$c270 = "s",
+      peg$c271 = peg$literalExpectation("s", false),
+      peg$c272 = "minutes",
+      peg$c273 = peg$literalExpectation("minutes", false),
+      peg$c274 = "minute",
+      peg$c275 = peg$literalExpectation("minute", false),
+      peg$c276 = "mins",
+      peg$c277 = peg$literalExpectation("mins", false),
+      peg$c278 = peg$literalExpectation("min", false),
+      peg$c279 = "m",
+      peg$c280 = peg$literalExpectation("m", false),
+      peg$c281 = "hours",
+      peg$c282 = peg$literalExpectation("hours", false),
+      peg$c283 = "hrs",
+      peg$c284 = peg$literalExpectation("hrs", false),
+      peg$c285 = "hr",
+      peg$c286 = peg$literalExpectation("hr", false),
+      peg$c287 = "h",
+      peg$c288 = peg$literalExpectation("h", false),
+      peg$c289 = "hour",
+      peg$c290 = peg$literalExpectation("hour", false),
+      peg$c291 = "days",
+      peg$c292 = peg$literalExpectation("days", false),
+      peg$c293 = "day",
+      peg$c294 = peg$literalExpectation("day", false),
+      peg$c295 = "d",
+      peg$c296 = peg$literalExpectation("d", false),
+      peg$c297 = "weeks",
+      peg$c298 = peg$literalExpectation("weeks", false),
+      peg$c299 = "week",
+      peg$c300 = peg$literalExpectation("week", false),
+      peg$c301 = "wks",
+      peg$c302 = peg$literalExpectation("wks", false),
+      peg$c303 = "wk",
+      peg$c304 = peg$literalExpectation("wk", false),
+      peg$c305 = "w",
+      peg$c306 = peg$literalExpectation("w", false),
+      peg$c307 = function() { return makeDuration(1) },
+      peg$c308 = function(num) { return makeDuration(num) },
+      peg$c309 = function() { return makeDuration(60) },
+      peg$c310 = function(num) { return makeDuration(num*60) },
+      peg$c311 = function() { return makeDuration(3600) },
+      peg$c312 = function(num) { return makeDuration(num*3600) },
+      peg$c313 = function() { return makeDuration(3600*24) },
+      peg$c314 = function(num) { return makeDuration(num*3600*24) },
+      peg$c315 = function(num) { return makeDuration(num*3600*24*7) },
+      peg$c316 = function(a) { return text() },
+      peg$c317 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c317 = "::",
-      peg$c318 = peg$literalExpectation("::", false),
-      peg$c319 = function(a, b, d, e) {
+      peg$c318 = "::",
+      peg$c319 = peg$literalExpectation("::", false),
+      peg$c320 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c320 = function(a, b) {
+      peg$c321 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c321 = function(a, b) {
+      peg$c322 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c322 = function() {
+      peg$c323 = function() {
             return "::"
           },
-      peg$c323 = function(v) { return ":" + v },
-      peg$c324 = function(v) { return v + ":" },
-      peg$c325 = function(a, m) {
+      peg$c324 = function(v) { return ":" + v },
+      peg$c325 = function(v) { return v + ":" },
+      peg$c326 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c326 = function(a, m) {
+      peg$c327 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c327 = function(s) { return parseInt(s) },
-      peg$c328 = /^[+\-]/,
-      peg$c329 = peg$classExpectation(["+", "-"], false, false),
-      peg$c330 = function(s) {
+      peg$c328 = function(s) { return parseInt(s) },
+      peg$c329 = /^[+\-]/,
+      peg$c330 = peg$classExpectation(["+", "-"], false, false),
+      peg$c331 = function(s) {
             return parseFloat(s)
         },
-      peg$c331 = function() {
+      peg$c332 = function() {
             return text()
           },
-      peg$c332 = "0",
-      peg$c333 = peg$literalExpectation("0", false),
-      peg$c334 = /^[1-9]/,
-      peg$c335 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c336 = "e",
-      peg$c337 = peg$literalExpectation("e", true),
-      peg$c338 = function(chars) { return text() },
-      peg$c339 = /^[0-9a-fA-F]/,
-      peg$c340 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c341 = function(chars) { return joinChars(chars) },
-      peg$c342 = "\\",
-      peg$c343 = peg$literalExpectation("\\", false),
-      peg$c344 = /^[\0-\x1F\\(),!><="|';]/,
-      peg$c345 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
-      peg$c346 = peg$anyExpectation(),
-      peg$c347 = "\"",
-      peg$c348 = peg$literalExpectation("\"", false),
-      peg$c349 = function(v) { return joinChars(v) },
-      peg$c350 = "'",
-      peg$c351 = peg$literalExpectation("'", false),
-      peg$c352 = "x",
-      peg$c353 = peg$literalExpectation("x", false),
-      peg$c354 = function() { return "\\" + text() },
-      peg$c355 = "b",
-      peg$c356 = peg$literalExpectation("b", false),
-      peg$c357 = function() { return "\b" },
-      peg$c358 = "f",
-      peg$c359 = peg$literalExpectation("f", false),
-      peg$c360 = function() { return "\f" },
-      peg$c361 = "n",
-      peg$c362 = peg$literalExpectation("n", false),
-      peg$c363 = function() { return "\n" },
-      peg$c364 = "r",
-      peg$c365 = peg$literalExpectation("r", false),
-      peg$c366 = function() { return "\r" },
-      peg$c367 = "t",
-      peg$c368 = peg$literalExpectation("t", false),
-      peg$c369 = function() { return "\t" },
-      peg$c370 = "v",
-      peg$c371 = peg$literalExpectation("v", false),
-      peg$c372 = function() { return "\v" },
-      peg$c373 = function() { return "=" },
-      peg$c374 = function() { return "\\*" },
-      peg$c375 = "u",
-      peg$c376 = peg$literalExpectation("u", false),
-      peg$c377 = function(chars) {
+      peg$c333 = "0",
+      peg$c334 = peg$literalExpectation("0", false),
+      peg$c335 = /^[1-9]/,
+      peg$c336 = peg$classExpectation([["1", "9"]], false, false),
+      peg$c337 = "e",
+      peg$c338 = peg$literalExpectation("e", true),
+      peg$c339 = function(chars) { return text() },
+      peg$c340 = /^[0-9a-fA-F]/,
+      peg$c341 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c342 = function(chars) { return joinChars(chars) },
+      peg$c343 = "\\",
+      peg$c344 = peg$literalExpectation("\\", false),
+      peg$c345 = /^[\0-\x1F\\(),!><="|';]/,
+      peg$c346 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
+      peg$c347 = peg$anyExpectation(),
+      peg$c348 = "\"",
+      peg$c349 = peg$literalExpectation("\"", false),
+      peg$c350 = function(v) { return joinChars(v) },
+      peg$c351 = "'",
+      peg$c352 = peg$literalExpectation("'", false),
+      peg$c353 = "x",
+      peg$c354 = peg$literalExpectation("x", false),
+      peg$c355 = function() { return "\\" + text() },
+      peg$c356 = "b",
+      peg$c357 = peg$literalExpectation("b", false),
+      peg$c358 = function() { return "\b" },
+      peg$c359 = "f",
+      peg$c360 = peg$literalExpectation("f", false),
+      peg$c361 = function() { return "\f" },
+      peg$c362 = "n",
+      peg$c363 = peg$literalExpectation("n", false),
+      peg$c364 = function() { return "\n" },
+      peg$c365 = "r",
+      peg$c366 = peg$literalExpectation("r", false),
+      peg$c367 = function() { return "\r" },
+      peg$c368 = "t",
+      peg$c369 = peg$literalExpectation("t", false),
+      peg$c370 = function() { return "\t" },
+      peg$c371 = "v",
+      peg$c372 = peg$literalExpectation("v", false),
+      peg$c373 = function() { return "\v" },
+      peg$c374 = function() { return "=" },
+      peg$c375 = function() { return "\\*" },
+      peg$c376 = "u",
+      peg$c377 = peg$literalExpectation("u", false),
+      peg$c378 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c378 = "{",
-      peg$c379 = peg$literalExpectation("{", false),
-      peg$c380 = "}",
-      peg$c381 = peg$literalExpectation("}", false),
-      peg$c382 = /^[^\/\\]/,
-      peg$c383 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c384 = "\\/",
-      peg$c385 = peg$literalExpectation("\\/", false),
-      peg$c386 = /^[\0-\x1F\\]/,
-      peg$c387 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c388 = "\t",
-      peg$c389 = peg$literalExpectation("\t", false),
-      peg$c390 = "\x0B",
-      peg$c391 = peg$literalExpectation("\x0B", false),
-      peg$c392 = "\f",
-      peg$c393 = peg$literalExpectation("\f", false),
-      peg$c394 = " ",
-      peg$c395 = peg$literalExpectation(" ", false),
-      peg$c396 = "\xA0",
-      peg$c397 = peg$literalExpectation("\xA0", false),
-      peg$c398 = "\uFEFF",
-      peg$c399 = peg$literalExpectation("\uFEFF", false),
-      peg$c400 = peg$otherExpectation("whitespace"),
+      peg$c379 = "{",
+      peg$c380 = peg$literalExpectation("{", false),
+      peg$c381 = "}",
+      peg$c382 = peg$literalExpectation("}", false),
+      peg$c383 = /^[^\/\\]/,
+      peg$c384 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c385 = "\\/",
+      peg$c386 = peg$literalExpectation("\\/", false),
+      peg$c387 = /^[\0-\x1F\\]/,
+      peg$c388 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c389 = "\t",
+      peg$c390 = peg$literalExpectation("\t", false),
+      peg$c391 = "\x0B",
+      peg$c392 = peg$literalExpectation("\x0B", false),
+      peg$c393 = "\f",
+      peg$c394 = peg$literalExpectation("\f", false),
+      peg$c395 = " ",
+      peg$c396 = peg$literalExpectation(" ", false),
+      peg$c397 = "\xA0",
+      peg$c398 = peg$literalExpectation("\xA0", false),
+      peg$c399 = "\uFEFF",
+      peg$c400 = peg$literalExpectation("\uFEFF", false),
+      peg$c401 = peg$otherExpectation("whitespace"),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -2108,8 +2111,8 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsegroupBy() {
-    var s0, s1, s2, s3;
+  function peg$parsegroupByKeys() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 2).toLowerCase() === peg$c58) {
@@ -2122,11 +2125,88 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parsefieldRefDotOnlyList();
+        s3 = peg$parsegroupByKey();
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c60(s3);
-          s0 = s1;
+          s4 = [];
+          s5 = peg$currPos;
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 44) {
+              s7 = peg$c60;
+              peg$currPos++;
+            } else {
+              s7 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c61); }
+            }
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parse__();
+              if (s8 !== peg$FAILED) {
+                s9 = peg$parsegroupByKey();
+                if (s9 !== peg$FAILED) {
+                  peg$savedPos = s5;
+                  s6 = peg$c62(s3, s9);
+                  s5 = s6;
+                } else {
+                  peg$currPos = s5;
+                  s5 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s5;
+                s5 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+          while (s5 !== peg$FAILED) {
+            s4.push(s5);
+            s5 = peg$currPos;
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 44) {
+                s7 = peg$c60;
+                peg$currPos++;
+              } else {
+                s7 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c61); }
+              }
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parse__();
+                if (s8 !== peg$FAILED) {
+                  s9 = peg$parsegroupByKey();
+                  if (s9 !== peg$FAILED) {
+                    peg$savedPos = s5;
+                    s6 = peg$c62(s3, s9);
+                    s5 = s6;
+                  } else {
+                    peg$currPos = s5;
+                    s5 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s5;
+                  s5 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s5;
+                s5 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          }
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c63(s3, s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2143,16 +2223,33 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsegroupByKey() {
+    var s0, s1;
+
+    s0 = peg$parseAssignment();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parsefieldExpr();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c64(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
   function peg$parseeveryDur() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c61) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c65) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+      if (peg$silentFails === 0) { peg$fail(peg$c66); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2160,7 +2257,7 @@ function peg$parse(input, options) {
         s3 = peg$parseduration();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c63(s3);
+          s1 = peg$c67(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2193,16 +2290,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c64) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c68) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c65); }
+      if (peg$silentFails === 0) { peg$fail(peg$c69); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c66();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -2213,16 +2310,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c67) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c71) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c68); }
+      if (peg$silentFails === 0) { peg$fail(peg$c72); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c66();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -2233,16 +2330,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c69) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c73) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c70); }
+      if (peg$silentFails === 0) { peg$fail(peg$c74); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c66();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -2253,16 +2350,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c71) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c75) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c72); }
+      if (peg$silentFails === 0) { peg$fail(peg$c76); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c66();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -2283,7 +2380,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c66();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2300,12 +2397,12 @@ function peg$parse(input, options) {
   function peg$parsefieldNameStart() {
     var s0;
 
-    if (peg$c73.test(input.charAt(peg$currPos))) {
+    if (peg$c77.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c74); }
+      if (peg$silentFails === 0) { peg$fail(peg$c78); }
     }
 
     return s0;
@@ -2316,12 +2413,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parsefieldNameStart();
     if (s0 === peg$FAILED) {
-      if (peg$c75.test(input.charAt(peg$currPos))) {
+      if (peg$c79.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
       }
     }
 
@@ -2337,17 +2434,17 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s4 = peg$c77;
+        s4 = peg$c81;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c78); }
+        if (peg$silentFails === 0) { peg$fail(peg$c82); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parsefieldName();
         if (s5 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c79(s1, s5);
+          s4 = peg$c83(s1, s5);
           s3 = s4;
         } else {
           peg$currPos = s3;
@@ -2360,25 +2457,25 @@ function peg$parse(input, options) {
       if (s3 === peg$FAILED) {
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s4 = peg$c80;
+          s4 = peg$c84;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c81); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsesuint();
           if (s5 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s6 = peg$c82;
+              s6 = peg$c86;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c83); }
+              if (peg$silentFails === 0) { peg$fail(peg$c87); }
             }
             if (s6 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c84(s1, s5);
+              s4 = peg$c88(s1, s5);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2397,17 +2494,17 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c77;
+          s4 = peg$c81;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsefieldName();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c79(s1, s5);
+            s4 = peg$c83(s1, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2420,25 +2517,25 @@ function peg$parse(input, options) {
         if (s3 === peg$FAILED) {
           s3 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s4 = peg$c80;
+            s4 = peg$c84;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c81); }
+            if (peg$silentFails === 0) { peg$fail(peg$c85); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parsesuint();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s6 = peg$c82;
+                s6 = peg$c86;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c83); }
+                if (peg$silentFails === 0) { peg$fail(peg$c87); }
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c84(s1, s5);
+                s4 = peg$c88(s1, s5);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2456,7 +2553,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c85(s1, s2);
+        s1 = peg$c89(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2510,7 +2607,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c86(s1, s5);
+                  s1 = peg$c90(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2551,16 +2648,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c87) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c91) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c88); }
+      if (peg$silentFails === 0) { peg$fail(peg$c92); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c89();
+      s1 = peg$c93();
     }
     s0 = s1;
 
@@ -2581,11 +2678,11 @@ function peg$parse(input, options) {
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c90;
+          s5 = peg$c60;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c91); }
+          if (peg$silentFails === 0) { peg$fail(peg$c61); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -2622,11 +2719,11 @@ function peg$parse(input, options) {
         }
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c90;
+            s5 = peg$c60;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c91); }
+            if (peg$silentFails === 0) { peg$fail(peg$c61); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -2657,7 +2754,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c92(s1, s2);
+        s1 = peg$c94(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2680,11 +2777,11 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s4 = peg$c77;
+        s4 = peg$c81;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c78); }
+        if (peg$silentFails === 0) { peg$fail(peg$c82); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parsefieldName();
@@ -2703,11 +2800,11 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c77;
+          s4 = peg$c81;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsefieldName();
@@ -2725,7 +2822,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c93(s1, s2);
+        s1 = peg$c95(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2753,11 +2850,11 @@ function peg$parse(input, options) {
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c90;
+          s5 = peg$c60;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c91); }
+          if (peg$silentFails === 0) { peg$fail(peg$c61); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -2768,7 +2865,7 @@ function peg$parse(input, options) {
             s7 = peg$parsefieldRefDotOnly();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c94(s1, s7);
+              s4 = peg$c96(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2795,11 +2892,11 @@ function peg$parse(input, options) {
         }
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c90;
+            s5 = peg$c60;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c91); }
+            if (peg$silentFails === 0) { peg$fail(peg$c61); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -2810,7 +2907,7 @@ function peg$parse(input, options) {
               s7 = peg$parsefieldRefDotOnly();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c94(s1, s7);
+                s4 = peg$c96(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2831,7 +2928,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c95(s1, s2);
+        s1 = peg$c97(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2859,11 +2956,11 @@ function peg$parse(input, options) {
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c90;
+          s5 = peg$c60;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c91); }
+          if (peg$silentFails === 0) { peg$fail(peg$c61); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -2900,11 +2997,11 @@ function peg$parse(input, options) {
         }
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c90;
+            s5 = peg$c60;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c91); }
+            if (peg$silentFails === 0) { peg$fail(peg$c61); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -2935,7 +3032,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c96(s1, s2);
+        s1 = peg$c98(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2953,16 +3050,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c97) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c99) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c98); }
+      if (peg$silentFails === 0) { peg$fail(peg$c100); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c99();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -2973,156 +3070,156 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c100) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c102) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c101); }
+      if (peg$silentFails === 0) { peg$fail(peg$c103); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c103) {
+      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c105) {
         s1 = input.substr(peg$currPos, 3);
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c104); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c105();
+        s1 = peg$c107();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c106) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c108) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c107); }
+          if (peg$silentFails === 0) { peg$fail(peg$c109); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c108();
+          s1 = peg$c110();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c109) {
+          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c111) {
             s1 = input.substr(peg$currPos, 2);
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c112); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c108();
+            s1 = peg$c110();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c111) {
+            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c113) {
               s1 = input.substr(peg$currPos, 3);
               peg$currPos += 3;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c112); }
+              if (peg$silentFails === 0) { peg$fail(peg$c114); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c113();
+              s1 = peg$c115();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 7).toLowerCase() === peg$c114) {
+              if (input.substr(peg$currPos, 7).toLowerCase() === peg$c116) {
                 s1 = input.substr(peg$currPos, 7);
                 peg$currPos += 7;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c115); }
+                if (peg$silentFails === 0) { peg$fail(peg$c117); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c116();
+                s1 = peg$c118();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c117) {
+                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c119) {
                   s1 = input.substr(peg$currPos, 3);
                   peg$currPos += 3;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c118); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c120); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c119();
+                  s1 = peg$c121();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c120) {
+                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c122) {
                     s1 = input.substr(peg$currPos, 3);
                     peg$currPos += 3;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c121); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c123); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c122();
+                    s1 = peg$c124();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
-                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c123) {
+                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c125) {
                       s1 = input.substr(peg$currPos, 5);
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c124); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c126); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c125();
+                      s1 = peg$c127();
                     }
                     s0 = s1;
                     if (s0 === peg$FAILED) {
                       s0 = peg$currPos;
-                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c126) {
+                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
                         s1 = input.substr(peg$currPos, 4);
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c127); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c129); }
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c128();
+                        s1 = peg$c130();
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
-                        if (input.substr(peg$currPos, 13).toLowerCase() === peg$c129) {
+                        if (input.substr(peg$currPos, 13).toLowerCase() === peg$c131) {
                           s1 = input.substr(peg$currPos, 13);
                           peg$currPos += 13;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c130); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c132); }
                         }
                         if (s1 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c131();
+                          s1 = peg$c133();
                         }
                         s0 = s1;
                       }
@@ -3156,7 +3253,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c132(s2);
+          s1 = peg$c134(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3212,7 +3309,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c133(s1, s4);
+                s1 = peg$c135(s1, s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3282,7 +3379,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c134(s1, s5);
+                  s1 = peg$c136(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3344,7 +3441,7 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          s5 = peg$parsegroupBy();
+          s5 = peg$parsegroupByKeys();
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
             s3 = s4;
@@ -3366,7 +3463,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c135(s1, s2, s3, s4);
+            s1 = peg$c137(s1, s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3392,12 +3489,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c136) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c138) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c137); }
+      if (peg$silentFails === 0) { peg$fail(peg$c139); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3435,11 +3532,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c138;
+          s3 = peg$c140;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c139); }
+          if (peg$silentFails === 0) { peg$fail(peg$c141); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -3450,7 +3547,7 @@ function peg$parse(input, options) {
             s5 = peg$parsereducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c140(s1, s5);
+              s1 = peg$c142(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3481,7 +3578,7 @@ function peg$parse(input, options) {
           s3 = peg$parseasClause();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c141(s1, s3);
+            s1 = peg$c143(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3528,11 +3625,11 @@ function peg$parse(input, options) {
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c90;
+          s5 = peg$c60;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c91); }
+          if (peg$silentFails === 0) { peg$fail(peg$c61); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -3569,11 +3666,11 @@ function peg$parse(input, options) {
         }
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c90;
+            s5 = peg$c60;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c91); }
+            if (peg$silentFails === 0) { peg$fail(peg$c61); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -3604,7 +3701,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c142(s1, s2);
+        s1 = peg$c144(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3651,12 +3748,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c143) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c145) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c144); }
+      if (peg$silentFails === 0) { peg$fail(peg$c146); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesortArgs();
@@ -3667,7 +3764,7 @@ function peg$parse(input, options) {
           s5 = peg$parsefieldExprList();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c145(s2, s5);
+            s4 = peg$c147(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -3682,7 +3779,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c146(s2, s3);
+          s1 = peg$c148(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3710,7 +3807,7 @@ function peg$parse(input, options) {
       s3 = peg$parsesortArg();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c147(s3);
+        s2 = peg$c149(s3);
         s1 = s2;
       } else {
         peg$currPos = s1;
@@ -3728,7 +3825,7 @@ function peg$parse(input, options) {
         s3 = peg$parsesortArg();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s1;
-          s2 = peg$c147(s3);
+          s2 = peg$c149(s3);
           s1 = s2;
         } else {
           peg$currPos = s1;
@@ -3747,55 +3844,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c148) {
-      s1 = peg$c148;
+    if (input.substr(peg$currPos, 2) === peg$c150) {
+      s1 = peg$c150;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c149); }
+      if (peg$silentFails === 0) { peg$fail(peg$c151); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c150();
+      s1 = peg$c152();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c151) {
-        s1 = peg$c151;
+      if (input.substr(peg$currPos, 6) === peg$c153) {
+        s1 = peg$c153;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c152); }
+        if (peg$silentFails === 0) { peg$fail(peg$c154); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c123) {
-            s4 = peg$c123;
+          if (input.substr(peg$currPos, 5) === peg$c125) {
+            s4 = peg$c125;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c153); }
+            if (peg$silentFails === 0) { peg$fail(peg$c155); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c126) {
-              s4 = peg$c126;
+            if (input.substr(peg$currPos, 4) === peg$c128) {
+              s4 = peg$c128;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c154); }
+              if (peg$silentFails === 0) { peg$fail(peg$c156); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c66();
+            s4 = peg$c70();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c155(s3);
+            s1 = peg$c157(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3818,12 +3915,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c156) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c158) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+      if (peg$silentFails === 0) { peg$fail(peg$c159); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -3832,7 +3929,7 @@ function peg$parse(input, options) {
         s4 = peg$parseunsignedInteger();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c158(s4);
+          s3 = peg$c160(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3849,12 +3946,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c159) {
-            s5 = peg$c159;
+          if (input.substr(peg$currPos, 6) === peg$c161) {
+            s5 = peg$c161;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c160); }
+            if (peg$silentFails === 0) { peg$fail(peg$c162); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3877,7 +3974,7 @@ function peg$parse(input, options) {
             s6 = peg$parsefieldExprList();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c161(s2, s3, s6);
+              s5 = peg$c163(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3892,7 +3989,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c162(s2, s3, s4);
+            s1 = peg$c164(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3920,12 +4017,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c163) {
-        s2 = peg$c163;
+      if (input.substr(peg$currPos, 6) === peg$c165) {
+        s2 = peg$c165;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c164); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3933,7 +4030,7 @@ function peg$parse(input, options) {
           s4 = peg$parseunsignedInteger();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c165(s4);
+            s1 = peg$c167(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3962,16 +4059,16 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     s2 = peg$parse_();
     if (s2 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c166) {
-        s3 = peg$c166;
+      if (input.substr(peg$currPos, 2) === peg$c168) {
+        s3 = peg$c168;
         peg$currPos += 2;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c167); }
+        if (peg$silentFails === 0) { peg$fail(peg$c169); }
       }
       if (s3 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c168();
+        s2 = peg$c170();
         s1 = s2;
       } else {
         peg$currPos = s1;
@@ -3986,16 +4083,16 @@ function peg$parse(input, options) {
       s1 = peg$currPos;
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c166) {
-          s3 = peg$c166;
+        if (input.substr(peg$currPos, 2) === peg$c168) {
+          s3 = peg$c168;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c167); }
+          if (peg$silentFails === 0) { peg$fail(peg$c169); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s1;
-          s2 = peg$c168();
+          s2 = peg$c170();
           s1 = s2;
         } else {
           peg$currPos = s1;
@@ -4014,12 +4111,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c169) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c171) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c170); }
+      if (peg$silentFails === 0) { peg$fail(peg$c172); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsecutArg();
@@ -4029,7 +4126,7 @@ function peg$parse(input, options) {
           s4 = peg$parsefieldRefDotOnlyList();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c171(s2, s4);
+            s1 = peg$c173(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4055,12 +4152,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c174) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c173); }
+      if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4068,7 +4165,7 @@ function peg$parse(input, options) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c174(s3);
+          s1 = peg$c176(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4084,16 +4181,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c172) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c174) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c173); }
+        if (peg$silentFails === 0) { peg$fail(peg$c175); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c175();
+        s1 = peg$c177();
       }
       s0 = s1;
     }
@@ -4105,12 +4202,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c176) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c178) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c177); }
+      if (peg$silentFails === 0) { peg$fail(peg$c179); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4118,7 +4215,7 @@ function peg$parse(input, options) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c178(s3);
+          s1 = peg$c180(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4134,16 +4231,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c176) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c178) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c177); }
+        if (peg$silentFails === 0) { peg$fail(peg$c179); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c179();
+        s1 = peg$c181();
       }
       s0 = s1;
     }
@@ -4155,12 +4252,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c180) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c182) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c181); }
+      if (peg$silentFails === 0) { peg$fail(peg$c183); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4190,26 +4287,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c182) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c184) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c185); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c166) {
-          s3 = peg$c166;
+        if (input.substr(peg$currPos, 2) === peg$c168) {
+          s3 = peg$c168;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c167); }
+          if (peg$silentFails === 0) { peg$fail(peg$c169); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c184();
+          s1 = peg$c186();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4225,16 +4322,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c182) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c184) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c185); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c185();
+        s1 = peg$c187();
       }
       s0 = s1;
     }
@@ -4246,36 +4343,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c186) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c188) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c187); }
+      if (peg$silentFails === 0) { peg$fail(peg$c189); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parsePutClause();
+        s3 = peg$parseAssignment();
         if (s3 !== peg$FAILED) {
           s4 = [];
           s5 = peg$currPos;
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c90;
+              s7 = peg$c60;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c91); }
+              if (peg$silentFails === 0) { peg$fail(peg$c61); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
               if (s8 !== peg$FAILED) {
-                s9 = peg$parsePutClause();
+                s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c188(s3, s9);
+                  s6 = peg$c62(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -4299,19 +4396,19 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c90;
+                s7 = peg$c60;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c91); }
+                if (peg$silentFails === 0) { peg$fail(peg$c61); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
                 if (s8 !== peg$FAILED) {
-                  s9 = peg$parsePutClause();
+                  s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c188(s3, s9);
+                    s6 = peg$c62(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -4332,7 +4429,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c189(s3, s4);
+            s1 = peg$c190(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4354,7 +4451,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsePutClause() {
+  function peg$parseAssignment() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
@@ -4363,11 +4460,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c138;
+          s3 = peg$c140;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c139); }
+          if (peg$silentFails === 0) { peg$fail(peg$c141); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4375,7 +4472,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpression();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c190(s1, s5);
+              s1 = peg$c191(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4491,7 +4588,7 @@ function peg$parse(input, options) {
     s1 = peg$parsefieldName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c191(s1);
+      s1 = peg$c192(s1);
     }
     s0 = s1;
 
@@ -4515,11 +4612,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c192;
+          s3 = peg$c193;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c193); }
+          if (peg$silentFails === 0) { peg$fail(peg$c194); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4529,11 +4626,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c194;
+                  s7 = peg$c195;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c195); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c196); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -4541,7 +4638,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpression();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c196(s1, s5, s9);
+                      s1 = peg$c197(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4652,7 +4749,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c197(s1, s2);
+        s1 = peg$c198(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4732,7 +4829,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c197(s1, s2);
+        s1 = peg$c198(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4812,7 +4909,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c197(s1, s2);
+        s1 = peg$c198(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4830,43 +4927,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c198) {
-      s1 = peg$c198;
+    if (input.substr(peg$currPos, 2) === peg$c199) {
+      s1 = peg$c199;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c199); }
+      if (peg$silentFails === 0) { peg$fail(peg$c200); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c200) {
-        s1 = peg$c200;
+      if (input.substr(peg$currPos, 2) === peg$c201) {
+        s1 = peg$c201;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c201); }
+        if (peg$silentFails === 0) { peg$fail(peg$c202); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c138;
+          s1 = peg$c140;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c139); }
+          if (peg$silentFails === 0) { peg$fail(peg$c141); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c202) {
-            s1 = peg$c202;
+          if (input.substr(peg$currPos, 2) === peg$c203) {
+            s1 = peg$c203;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c203); }
+            if (peg$silentFails === 0) { peg$fail(peg$c204); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c66();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -4879,16 +4976,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c69) {
-        s1 = peg$c69;
+      if (input.substr(peg$currPos, 2) === peg$c73) {
+        s1 = peg$c73;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c204); }
+        if (peg$silentFails === 0) { peg$fail(peg$c205); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c66();
+        s1 = peg$c70();
       }
       s0 = s1;
     }
@@ -4962,7 +5059,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c197(s1, s2);
+        s1 = peg$c198(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4980,43 +5077,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c205) {
-      s1 = peg$c205;
+    if (input.substr(peg$currPos, 2) === peg$c206) {
+      s1 = peg$c206;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c206); }
+      if (peg$silentFails === 0) { peg$fail(peg$c207); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c207;
+        s1 = peg$c208;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c208); }
+        if (peg$silentFails === 0) { peg$fail(peg$c209); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c209) {
-          s1 = peg$c209;
+        if (input.substr(peg$currPos, 2) === peg$c210) {
+          s1 = peg$c210;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c210); }
+          if (peg$silentFails === 0) { peg$fail(peg$c211); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c211;
+            s1 = peg$c212;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c212); }
+            if (peg$silentFails === 0) { peg$fail(peg$c213); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c66();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -5089,7 +5186,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c197(s1, s2);
+        s1 = peg$c198(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5108,11 +5205,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c213;
+      s1 = peg$c214;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c214); }
+      if (peg$silentFails === 0) { peg$fail(peg$c215); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
@@ -5125,7 +5222,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c66();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -5198,7 +5295,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c197(s1, s2);
+        s1 = peg$c198(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5225,16 +5322,16 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c215;
+        s1 = peg$c216;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c216); }
+        if (peg$silentFails === 0) { peg$fail(peg$c217); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c66();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -5258,7 +5355,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpression();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c217(s3);
+          s1 = peg$c218(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5289,11 +5386,11 @@ function peg$parse(input, options) {
       s3 = peg$parse__();
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s4 = peg$c194;
+          s4 = peg$c195;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c195); }
+          if (peg$silentFails === 0) { peg$fail(peg$c196); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parse__();
@@ -5301,7 +5398,7 @@ function peg$parse(input, options) {
             s6 = peg$parseZngType();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s2;
-              s3 = peg$c218(s1, s6);
+              s3 = peg$c219(s1, s6);
               s2 = s3;
             } else {
               peg$currPos = s2;
@@ -5324,7 +5421,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c219(s1, s2);
+        s1 = peg$c220(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5341,124 +5438,124 @@ function peg$parse(input, options) {
   function peg$parseZngType() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c220) {
-      s0 = peg$c220;
+    if (input.substr(peg$currPos, 4) === peg$c221) {
+      s0 = peg$c221;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c221); }
+      if (peg$silentFails === 0) { peg$fail(peg$c222); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c222) {
-        s0 = peg$c222;
+      if (input.substr(peg$currPos, 4) === peg$c223) {
+        s0 = peg$c223;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c223); }
+        if (peg$silentFails === 0) { peg$fail(peg$c224); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c224) {
-          s0 = peg$c224;
+        if (input.substr(peg$currPos, 5) === peg$c225) {
+          s0 = peg$c225;
           peg$currPos += 5;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c225); }
+          if (peg$silentFails === 0) { peg$fail(peg$c226); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c226) {
-            s0 = peg$c226;
+          if (input.substr(peg$currPos, 6) === peg$c227) {
+            s0 = peg$c227;
             peg$currPos += 6;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c227); }
+            if (peg$silentFails === 0) { peg$fail(peg$c228); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 5) === peg$c228) {
-              s0 = peg$c228;
+            if (input.substr(peg$currPos, 5) === peg$c229) {
+              s0 = peg$c229;
               peg$currPos += 5;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c229); }
+              if (peg$silentFails === 0) { peg$fail(peg$c230); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 6) === peg$c230) {
-                s0 = peg$c230;
+              if (input.substr(peg$currPos, 6) === peg$c231) {
+                s0 = peg$c231;
                 peg$currPos += 6;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c231); }
+                if (peg$silentFails === 0) { peg$fail(peg$c232); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c232) {
-                  s0 = peg$c232;
+                if (input.substr(peg$currPos, 5) === peg$c233) {
+                  s0 = peg$c233;
                   peg$currPos += 5;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c233); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c234); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 6) === peg$c234) {
-                    s0 = peg$c234;
+                  if (input.substr(peg$currPos, 6) === peg$c235) {
+                    s0 = peg$c235;
                     peg$currPos += 6;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c235); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c236); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c236) {
-                      s0 = peg$c236;
+                    if (input.substr(peg$currPos, 7) === peg$c237) {
+                      s0 = peg$c237;
                       peg$currPos += 7;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c237); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c238); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 6) === peg$c238) {
-                        s0 = peg$c238;
+                      if (input.substr(peg$currPos, 6) === peg$c239) {
+                        s0 = peg$c239;
                         peg$currPos += 6;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c239); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c240); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 7) === peg$c240) {
-                          s0 = peg$c240;
+                        if (input.substr(peg$currPos, 7) === peg$c241) {
+                          s0 = peg$c241;
                           peg$currPos += 7;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c241); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c242); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c242) {
-                            s0 = peg$c242;
+                          if (input.substr(peg$currPos, 2) === peg$c243) {
+                            s0 = peg$c243;
                             peg$currPos += 2;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c243); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c244); }
                           }
                           if (s0 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 3) === peg$c244) {
-                              s0 = peg$c244;
+                            if (input.substr(peg$currPos, 3) === peg$c245) {
+                              s0 = peg$c245;
                               peg$currPos += 3;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c245); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c246); }
                             }
                             if (s0 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c246) {
-                                s0 = peg$c246;
+                              if (input.substr(peg$currPos, 4) === peg$c247) {
+                                s0 = peg$c247;
                                 peg$currPos += 4;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c247); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c248); }
                               }
                               if (s0 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 8) === peg$c248) {
-                                  s0 = peg$c248;
+                                if (input.substr(peg$currPos, 8) === peg$c249) {
+                                  s0 = peg$c249;
                                   peg$currPos += 8;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c249); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c250); }
                                 }
                               }
                             }
@@ -5505,7 +5602,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c250(s1, s4);
+              s1 = peg$c251(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5548,7 +5645,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c66();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5565,12 +5662,12 @@ function peg$parse(input, options) {
   function peg$parseFunctionNameStart() {
     var s0;
 
-    if (peg$c251.test(input.charAt(peg$currPos))) {
+    if (peg$c252.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c252); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
 
     return s0;
@@ -5581,12 +5678,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseFunctionNameStart();
     if (s0 === peg$FAILED) {
-      if (peg$c253.test(input.charAt(peg$currPos))) {
+      if (peg$c254.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c254); }
+        if (peg$silentFails === 0) { peg$fail(peg$c255); }
       }
     }
 
@@ -5604,11 +5701,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c90;
+          s5 = peg$c60;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c91); }
+          if (peg$silentFails === 0) { peg$fail(peg$c61); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5616,7 +5713,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpression();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c255(s1, s7);
+              s4 = peg$c256(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5640,11 +5737,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c90;
+            s5 = peg$c60;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c91); }
+            if (peg$silentFails === 0) { peg$fail(peg$c61); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5652,7 +5749,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpression();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c255(s1, s7);
+                s4 = peg$c256(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5673,7 +5770,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c256(s1, s2);
+        s1 = peg$c257(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5688,7 +5785,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c257();
+        s1 = peg$c258();
       }
       s0 = s1;
     }
@@ -5707,11 +5804,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s5 = peg$c80;
+          s5 = peg$c84;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c81); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5721,11 +5818,11 @@ function peg$parse(input, options) {
               s8 = peg$parse__();
               if (s8 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s9 = peg$c82;
+                  s9 = peg$c86;
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c83); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c87); }
                 }
                 if (s9 !== peg$FAILED) {
                   s4 = [s4, s5, s6, s7, s8, s9];
@@ -5759,11 +5856,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s5 = peg$c77;
+            s5 = peg$c81;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c78); }
+            if (peg$silentFails === 0) { peg$fail(peg$c82); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5772,7 +5869,7 @@ function peg$parse(input, options) {
               s8 = peg$parsefieldName();
               if (s8 !== peg$FAILED) {
                 peg$savedPos = s7;
-                s8 = peg$c258(s1, s8);
+                s8 = peg$c259(s1, s8);
               }
               s7 = s8;
               if (s7 !== peg$FAILED) {
@@ -5801,11 +5898,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 91) {
-            s5 = peg$c80;
+            s5 = peg$c84;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c81); }
+            if (peg$silentFails === 0) { peg$fail(peg$c85); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5815,11 +5912,11 @@ function peg$parse(input, options) {
                 s8 = peg$parse__();
                 if (s8 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s9 = peg$c82;
+                    s9 = peg$c86;
                     peg$currPos++;
                   } else {
                     s9 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c83); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c87); }
                   }
                   if (s9 !== peg$FAILED) {
                     s4 = [s4, s5, s6, s7, s8, s9];
@@ -5853,11 +5950,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 46) {
-              s5 = peg$c77;
+              s5 = peg$c81;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c78); }
+              if (peg$silentFails === 0) { peg$fail(peg$c82); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
@@ -5866,7 +5963,7 @@ function peg$parse(input, options) {
                 s8 = peg$parsefieldName();
                 if (s8 !== peg$FAILED) {
                   peg$savedPos = s7;
-                  s8 = peg$c258(s1, s8);
+                  s8 = peg$c259(s1, s8);
                 }
                 s7 = s8;
                 if (s7 !== peg$FAILED) {
@@ -5892,7 +5989,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c259(s1, s2);
+        s1 = peg$c260(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5920,12 +6017,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c64) {
-                s3 = peg$c64;
+              if (input.substr(peg$currPos, 3) === peg$c68) {
+                s3 = peg$c68;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c260); }
+                if (peg$silentFails === 0) { peg$fail(peg$c261); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -5970,44 +6067,44 @@ function peg$parse(input, options) {
   function peg$parsesec_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c261) {
-      s0 = peg$c261;
+    if (input.substr(peg$currPos, 7) === peg$c262) {
+      s0 = peg$c262;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c262); }
+      if (peg$silentFails === 0) { peg$fail(peg$c263); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c263) {
-        s0 = peg$c263;
+      if (input.substr(peg$currPos, 6) === peg$c264) {
+        s0 = peg$c264;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c264); }
+        if (peg$silentFails === 0) { peg$fail(peg$c265); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c265) {
-          s0 = peg$c265;
+        if (input.substr(peg$currPos, 4) === peg$c266) {
+          s0 = peg$c266;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c266); }
+          if (peg$silentFails === 0) { peg$fail(peg$c267); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c267) {
-            s0 = peg$c267;
+          if (input.substr(peg$currPos, 3) === peg$c268) {
+            s0 = peg$c268;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c268); }
+            if (peg$silentFails === 0) { peg$fail(peg$c269); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c269;
+              s0 = peg$c270;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c270); }
+              if (peg$silentFails === 0) { peg$fail(peg$c271); }
             }
           }
         }
@@ -6020,44 +6117,44 @@ function peg$parse(input, options) {
   function peg$parsemin_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c271) {
-      s0 = peg$c271;
+    if (input.substr(peg$currPos, 7) === peg$c272) {
+      s0 = peg$c272;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c272); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c273) {
-        s0 = peg$c273;
+      if (input.substr(peg$currPos, 6) === peg$c274) {
+        s0 = peg$c274;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c274); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c275) {
-          s0 = peg$c275;
+        if (input.substr(peg$currPos, 4) === peg$c276) {
+          s0 = peg$c276;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c276); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c117) {
-            s0 = peg$c117;
+          if (input.substr(peg$currPos, 3) === peg$c119) {
+            s0 = peg$c119;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c277); }
+            if (peg$silentFails === 0) { peg$fail(peg$c278); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c278;
+              s0 = peg$c279;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c279); }
+              if (peg$silentFails === 0) { peg$fail(peg$c280); }
             }
           }
         }
@@ -6070,44 +6167,44 @@ function peg$parse(input, options) {
   function peg$parsehour_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c280) {
-      s0 = peg$c280;
+    if (input.substr(peg$currPos, 5) === peg$c281) {
+      s0 = peg$c281;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c281); }
+      if (peg$silentFails === 0) { peg$fail(peg$c282); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c282) {
-        s0 = peg$c282;
+      if (input.substr(peg$currPos, 3) === peg$c283) {
+        s0 = peg$c283;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c283); }
+        if (peg$silentFails === 0) { peg$fail(peg$c284); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c284) {
-          s0 = peg$c284;
+        if (input.substr(peg$currPos, 2) === peg$c285) {
+          s0 = peg$c285;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c285); }
+          if (peg$silentFails === 0) { peg$fail(peg$c286); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c286;
+            s0 = peg$c287;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c287); }
+            if (peg$silentFails === 0) { peg$fail(peg$c288); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c288) {
-              s0 = peg$c288;
+            if (input.substr(peg$currPos, 4) === peg$c289) {
+              s0 = peg$c289;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c289); }
+              if (peg$silentFails === 0) { peg$fail(peg$c290); }
             }
           }
         }
@@ -6120,28 +6217,28 @@ function peg$parse(input, options) {
   function peg$parseday_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c290) {
-      s0 = peg$c290;
+    if (input.substr(peg$currPos, 4) === peg$c291) {
+      s0 = peg$c291;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c291); }
+      if (peg$silentFails === 0) { peg$fail(peg$c292); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c292) {
-        s0 = peg$c292;
+      if (input.substr(peg$currPos, 3) === peg$c293) {
+        s0 = peg$c293;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c293); }
+        if (peg$silentFails === 0) { peg$fail(peg$c294); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c294;
+          s0 = peg$c295;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c295); }
+          if (peg$silentFails === 0) { peg$fail(peg$c296); }
         }
       }
     }
@@ -6152,44 +6249,44 @@ function peg$parse(input, options) {
   function peg$parseweek_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c296) {
-      s0 = peg$c296;
+    if (input.substr(peg$currPos, 5) === peg$c297) {
+      s0 = peg$c297;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c297); }
+      if (peg$silentFails === 0) { peg$fail(peg$c298); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c298) {
-        s0 = peg$c298;
+      if (input.substr(peg$currPos, 4) === peg$c299) {
+        s0 = peg$c299;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c299); }
+        if (peg$silentFails === 0) { peg$fail(peg$c300); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c300) {
-          s0 = peg$c300;
+        if (input.substr(peg$currPos, 3) === peg$c301) {
+          s0 = peg$c301;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c301); }
+          if (peg$silentFails === 0) { peg$fail(peg$c302); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c302) {
-            s0 = peg$c302;
+          if (input.substr(peg$currPos, 2) === peg$c303) {
+            s0 = peg$c303;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c303); }
+            if (peg$silentFails === 0) { peg$fail(peg$c304); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c304;
+              s0 = peg$c305;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c306); }
             }
           }
         }
@@ -6203,16 +6300,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c263) {
-      s1 = peg$c263;
+    if (input.substr(peg$currPos, 6) === peg$c264) {
+      s1 = peg$c264;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c265); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c306();
+      s1 = peg$c307();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6227,7 +6324,7 @@ function peg$parse(input, options) {
           s3 = peg$parsesec_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c307(s1);
+            s1 = peg$c308(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6250,16 +6347,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c273) {
-      s1 = peg$c273;
+    if (input.substr(peg$currPos, 6) === peg$c274) {
+      s1 = peg$c274;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c274); }
+      if (peg$silentFails === 0) { peg$fail(peg$c275); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c308();
+      s1 = peg$c309();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6274,7 +6371,7 @@ function peg$parse(input, options) {
           s3 = peg$parsemin_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c309(s1);
+            s1 = peg$c310(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6297,16 +6394,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c288) {
-      s1 = peg$c288;
+    if (input.substr(peg$currPos, 4) === peg$c289) {
+      s1 = peg$c289;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c289); }
+      if (peg$silentFails === 0) { peg$fail(peg$c290); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c310();
+      s1 = peg$c311();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6321,7 +6418,7 @@ function peg$parse(input, options) {
           s3 = peg$parsehour_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c311(s1);
+            s1 = peg$c312(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6344,16 +6441,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c292) {
-      s1 = peg$c292;
+    if (input.substr(peg$currPos, 3) === peg$c293) {
+      s1 = peg$c293;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c293); }
+      if (peg$silentFails === 0) { peg$fail(peg$c294); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c312();
+      s1 = peg$c313();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6368,7 +6465,7 @@ function peg$parse(input, options) {
           s3 = peg$parseday_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c313(s1);
+            s1 = peg$c314(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6401,7 +6498,7 @@ function peg$parse(input, options) {
         s3 = peg$parseweek_abbrev();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c314(s1);
+          s1 = peg$c315(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6427,31 +6524,31 @@ function peg$parse(input, options) {
     s2 = peg$parseunsignedInteger();
     if (s2 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c77;
+        s3 = peg$c81;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c78); }
+        if (peg$silentFails === 0) { peg$fail(peg$c82); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseunsignedInteger();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s5 = peg$c77;
+            s5 = peg$c81;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c78); }
+            if (peg$silentFails === 0) { peg$fail(peg$c82); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parseunsignedInteger();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s7 = peg$c77;
+                s7 = peg$c81;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c78); }
+                if (peg$silentFails === 0) { peg$fail(peg$c82); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parseunsignedInteger();
@@ -6488,7 +6585,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c315(s1);
+      s1 = peg$c316(s1);
     }
     s0 = s1;
 
@@ -6500,11 +6597,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c194;
+      s1 = peg$c195;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c195); }
+      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesuint();
@@ -6542,7 +6639,7 @@ function peg$parse(input, options) {
       s2 = peg$parseip6tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c316(s1, s2);
+        s1 = peg$c317(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6563,12 +6660,12 @@ function peg$parse(input, options) {
           s3 = peg$parseh_append();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c317) {
-            s3 = peg$c317;
+          if (input.substr(peg$currPos, 2) === peg$c318) {
+            s3 = peg$c318;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c318); }
+            if (peg$silentFails === 0) { peg$fail(peg$c319); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6581,7 +6678,7 @@ function peg$parse(input, options) {
               s5 = peg$parseip6tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c319(s1, s2, s4, s5);
+                s1 = peg$c320(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6605,12 +6702,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c317) {
-          s1 = peg$c317;
+        if (input.substr(peg$currPos, 2) === peg$c318) {
+          s1 = peg$c318;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c318); }
+          if (peg$silentFails === 0) { peg$fail(peg$c319); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6623,7 +6720,7 @@ function peg$parse(input, options) {
             s3 = peg$parseip6tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c320(s2, s3);
+              s1 = peg$c321(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6648,16 +6745,16 @@ function peg$parse(input, options) {
               s3 = peg$parseh_append();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c317) {
-                s3 = peg$c317;
+              if (input.substr(peg$currPos, 2) === peg$c318) {
+                s3 = peg$c318;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c318); }
+                if (peg$silentFails === 0) { peg$fail(peg$c319); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c321(s1, s2);
+                s1 = peg$c322(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6673,16 +6770,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c317) {
-              s1 = peg$c317;
+            if (input.substr(peg$currPos, 2) === peg$c318) {
+              s1 = peg$c318;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c318); }
+              if (peg$silentFails === 0) { peg$fail(peg$c319); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c322();
+              s1 = peg$c323();
             }
             s0 = s1;
           }
@@ -6709,17 +6806,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c194;
+      s1 = peg$c195;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c195); }
+      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseh16();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c323(s2);
+        s1 = peg$c324(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6740,15 +6837,15 @@ function peg$parse(input, options) {
     s1 = peg$parseh16();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c194;
+        s2 = peg$c195;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c195); }
+        if (peg$silentFails === 0) { peg$fail(peg$c196); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c324(s1);
+        s1 = peg$c325(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6769,17 +6866,17 @@ function peg$parse(input, options) {
     s1 = peg$parseaddr();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c215;
+        s2 = peg$c216;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c216); }
+        if (peg$silentFails === 0) { peg$fail(peg$c217); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c325(s1, s3);
+          s1 = peg$c326(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6804,17 +6901,17 @@ function peg$parse(input, options) {
     s1 = peg$parseip6addr();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c215;
+        s2 = peg$c216;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c216); }
+        if (peg$silentFails === 0) { peg$fail(peg$c217); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c326(s1, s3);
+          s1 = peg$c327(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6839,7 +6936,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesuint();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c327(s1);
+      s1 = peg$c328(s1);
     }
     s0 = s1;
 
@@ -6851,22 +6948,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c75.test(input.charAt(peg$currPos))) {
+    if (peg$c79.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c76); }
+      if (peg$silentFails === 0) { peg$fail(peg$c80); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c75.test(input.charAt(peg$currPos))) {
+        if (peg$c79.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
       }
     } else {
@@ -6874,7 +6971,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c66();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -6888,7 +6985,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesinteger();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c327(s1);
+      s1 = peg$c328(s1);
     }
     s0 = s1;
 
@@ -6899,12 +6996,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c328.test(input.charAt(peg$currPos))) {
+    if (peg$c329.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c329); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -6913,7 +7010,7 @@ function peg$parse(input, options) {
       s2 = peg$parsesuint();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c66();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6934,7 +7031,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesdouble();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c330(s1);
+      s1 = peg$c331(s1);
     }
     s0 = s1;
 
@@ -6968,11 +7065,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c77;
+          s3 = peg$c81;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
@@ -6992,7 +7089,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c331();
+              s1 = peg$c332();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7028,11 +7125,11 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c77;
+          s2 = peg$c81;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
@@ -7052,7 +7149,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c331();
+              s1 = peg$c332();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7079,38 +7176,38 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     if (input.charCodeAt(peg$currPos) === 48) {
-      s0 = peg$c332;
+      s0 = peg$c333;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c333); }
+      if (peg$silentFails === 0) { peg$fail(peg$c334); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$c334.test(input.charAt(peg$currPos))) {
+      if (peg$c335.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c335); }
+        if (peg$silentFails === 0) { peg$fail(peg$c336); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c75.test(input.charAt(peg$currPos))) {
+        if (peg$c79.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c75.test(input.charAt(peg$currPos))) {
+          if (peg$c79.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
           }
         }
         if (s2 !== peg$FAILED) {
@@ -7132,12 +7229,12 @@ function peg$parse(input, options) {
   function peg$parsedoubleDigit() {
     var s0;
 
-    if (peg$c75.test(input.charAt(peg$currPos))) {
+    if (peg$c79.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c76); }
+      if (peg$silentFails === 0) { peg$fail(peg$c80); }
     }
 
     return s0;
@@ -7147,12 +7244,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c336) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c337) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c337); }
+      if (peg$silentFails === 0) { peg$fail(peg$c338); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesinteger();
@@ -7187,7 +7284,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c338(s1);
+      s1 = peg$c339(s1);
     }
     s0 = s1;
 
@@ -7197,12 +7294,12 @@ function peg$parse(input, options) {
   function peg$parsehexdigit() {
     var s0;
 
-    if (peg$c339.test(input.charAt(peg$currPos))) {
+    if (peg$c340.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
 
     return s0;
@@ -7224,7 +7321,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c341(s1);
+      s1 = peg$c342(s1);
     }
     s0 = s1;
 
@@ -7236,11 +7333,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c342;
+      s1 = peg$c343;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c344); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseescapeSequence();
@@ -7263,12 +7360,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c344.test(input.charAt(peg$currPos))) {
+      if (peg$c345.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c345); }
+        if (peg$silentFails === 0) { peg$fail(peg$c346); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parsews();
@@ -7286,11 +7383,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c346); }
+          if (peg$silentFails === 0) { peg$fail(peg$c347); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c66();
+          s1 = peg$c70();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7310,11 +7407,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c347;
+      s1 = peg$c348;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+      if (peg$silentFails === 0) { peg$fail(peg$c349); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -7325,15 +7422,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c347;
+          s3 = peg$c348;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c348); }
+          if (peg$silentFails === 0) { peg$fail(peg$c349); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c349(s2);
+          s1 = peg$c350(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7350,11 +7447,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c350;
+        s1 = peg$c351;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c351); }
+        if (peg$silentFails === 0) { peg$fail(peg$c352); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7365,15 +7462,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c350;
+            s3 = peg$c351;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c351); }
+            if (peg$silentFails === 0) { peg$fail(peg$c352); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c349(s2);
+            s1 = peg$c350(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7399,11 +7496,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c347;
+      s2 = peg$c348;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+      if (peg$silentFails === 0) { peg$fail(peg$c349); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -7421,11 +7518,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c346); }
+        if (peg$silentFails === 0) { peg$fail(peg$c347); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c66();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7438,11 +7535,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c342;
+        s1 = peg$c343;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c343); }
+        if (peg$silentFails === 0) { peg$fail(peg$c344); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -7470,11 +7567,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c350;
+      s2 = peg$c351;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c351); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -7492,11 +7589,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c346); }
+        if (peg$silentFails === 0) { peg$fail(peg$c347); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c66();
+        s1 = peg$c70();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7509,11 +7606,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c342;
+        s1 = peg$c343;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c343); }
+        if (peg$silentFails === 0) { peg$fail(peg$c344); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -7539,11 +7636,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c352;
+      s1 = peg$c353;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+      if (peg$silentFails === 0) { peg$fail(peg$c354); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsehexdigit();
@@ -7551,7 +7648,7 @@ function peg$parse(input, options) {
         s3 = peg$parsehexdigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c354();
+          s1 = peg$c355();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7579,110 +7676,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c350;
+      s0 = peg$c351;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c351); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c347;
+        s0 = peg$c348;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c348); }
+        if (peg$silentFails === 0) { peg$fail(peg$c349); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c342;
+          s0 = peg$c343;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c343); }
+          if (peg$silentFails === 0) { peg$fail(peg$c344); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c355;
+            s1 = peg$c356;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c356); }
+            if (peg$silentFails === 0) { peg$fail(peg$c357); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c357();
+            s1 = peg$c358();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c358;
+              s1 = peg$c359;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c359); }
+              if (peg$silentFails === 0) { peg$fail(peg$c360); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c360();
+              s1 = peg$c361();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c361;
+                s1 = peg$c362;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c362); }
+                if (peg$silentFails === 0) { peg$fail(peg$c363); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c363();
+                s1 = peg$c364();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c364;
+                  s1 = peg$c365;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c365); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c366); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c366();
+                  s1 = peg$c367();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c367;
+                    s1 = peg$c368;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c368); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c369); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c369();
+                    s1 = peg$c370();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c370;
+                      s1 = peg$c371;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c371); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c372); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c372();
+                      s1 = peg$c373();
                     }
                     s0 = s1;
                   }
@@ -7702,15 +7799,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c138;
+      s1 = peg$c140;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c139); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c373();
+      s1 = peg$c374();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7724,7 +7821,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c374();
+        s1 = peg$c375();
       }
       s0 = s1;
     }
@@ -7737,11 +7834,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c375;
+      s1 = peg$c376;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c376); }
+      if (peg$silentFails === 0) { peg$fail(peg$c377); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7773,7 +7870,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c377(s2);
+        s1 = peg$c378(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7786,19 +7883,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c375;
+        s1 = peg$c376;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c376); }
+        if (peg$silentFails === 0) { peg$fail(peg$c377); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c378;
+          s2 = peg$c379;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c379); }
+          if (peg$silentFails === 0) { peg$fail(peg$c380); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7857,15 +7954,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c380;
+              s4 = peg$c381;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c381); }
+              if (peg$silentFails === 0) { peg$fail(peg$c382); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c377(s3);
+              s1 = peg$c378(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7893,21 +7990,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c215;
+      s1 = peg$c216;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c216); }
+      if (peg$silentFails === 0) { peg$fail(peg$c217); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsereBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c215;
+          s3 = peg$c216;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c216); }
+          if (peg$silentFails === 0) { peg$fail(peg$c217); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -7934,39 +8031,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c382.test(input.charAt(peg$currPos))) {
+    if (peg$c383.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c383); }
+      if (peg$silentFails === 0) { peg$fail(peg$c384); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c384) {
-        s2 = peg$c384;
+      if (input.substr(peg$currPos, 2) === peg$c385) {
+        s2 = peg$c385;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c385); }
+        if (peg$silentFails === 0) { peg$fail(peg$c386); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c382.test(input.charAt(peg$currPos))) {
+        if (peg$c383.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c383); }
+          if (peg$silentFails === 0) { peg$fail(peg$c384); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c384) {
-            s2 = peg$c384;
+          if (input.substr(peg$currPos, 2) === peg$c385) {
+            s2 = peg$c385;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c385); }
+            if (peg$silentFails === 0) { peg$fail(peg$c386); }
           }
         }
       }
@@ -7975,7 +8072,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c66();
+      s1 = peg$c70();
     }
     s0 = s1;
 
@@ -7985,12 +8082,12 @@ function peg$parse(input, options) {
   function peg$parseescapedChar() {
     var s0;
 
-    if (peg$c386.test(input.charAt(peg$currPos))) {
+    if (peg$c387.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c387); }
+      if (peg$silentFails === 0) { peg$fail(peg$c388); }
     }
 
     return s0;
@@ -8000,51 +8097,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c388;
+      s0 = peg$c389;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+      if (peg$silentFails === 0) { peg$fail(peg$c390); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c390;
+        s0 = peg$c391;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c391); }
+        if (peg$silentFails === 0) { peg$fail(peg$c392); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c392;
+          s0 = peg$c393;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c393); }
+          if (peg$silentFails === 0) { peg$fail(peg$c394); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c394;
+            s0 = peg$c395;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c395); }
+            if (peg$silentFails === 0) { peg$fail(peg$c396); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c396;
+              s0 = peg$c397;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c397); }
+              if (peg$silentFails === 0) { peg$fail(peg$c398); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c398;
+                s0 = peg$c399;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c399); }
+                if (peg$silentFails === 0) { peg$fail(peg$c400); }
               }
             }
           }
@@ -8072,7 +8169,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c400); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
 
     return s0;
@@ -8101,7 +8198,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c346); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {
@@ -8225,7 +8322,7 @@ function peg$parse(input, options) {
   function makeUniqProc(cflag) { return { op: "TailProc", cflag }; }
   function makeFilterProc(filter) { return { op: "FilterProc", filter }; }
 
-  function makePutClause(target, expression) { return { target, expression }; }
+  function makeAssignment(target, expression) { return { target, expression }; }
   function makePutProc(first, rest) {
     return { op: "PutProc", clauses: [first, ...rest] };
   }
@@ -8244,6 +8341,14 @@ function peg$parse(input, options) {
 
   function makeReducerProc(reducers) {
     return { op: "ReducerProc", reducers };
+  }
+
+  function makeGroupByKey(target, expression) {
+      return { op: "Assignment", target, expression };
+  }
+
+  function makeGroupByKeys(first, rest) {
+    return [first, ...rest];
   }
 
   function makeGroupByProc(duration, limit, keys, reducers) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -273,37 +273,40 @@ function peg$parse(input, options) {
       peg$c65 = "every",
       peg$c66 = peg$literalExpectation("every", true),
       peg$c67 = function(dur) { return dur },
-      peg$c68 = "and",
-      peg$c69 = peg$literalExpectation("and", true),
-      peg$c70 = function() { return text() },
-      peg$c71 = "or",
-      peg$c72 = peg$literalExpectation("or", true),
-      peg$c73 = "in",
-      peg$c74 = peg$literalExpectation("in", true),
-      peg$c75 = "not",
-      peg$c76 = peg$literalExpectation("not", true),
-      peg$c77 = /^[A-Za-z_$]/,
-      peg$c78 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c79 = /^[0-9]/,
-      peg$c80 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c81 = ".",
-      peg$c82 = peg$literalExpectation(".", false),
-      peg$c83 = function(base, field) { return makeFieldCall("RecordFieldRead", null, field) },
-      peg$c84 = "[",
-      peg$c85 = peg$literalExpectation("[", false),
-      peg$c86 = "]",
-      peg$c87 = peg$literalExpectation("]", false),
-      peg$c88 = function(base, index) { return makeFieldCall("Index", null, index) },
-      peg$c89 = function(base, derefs) {
+      peg$c68 = "-sorted",
+      peg$c69 = peg$literalExpectation("-sorted", true),
+      peg$c70 = function(dir) { return parseInt(dir) },
+      peg$c71 = "and",
+      peg$c72 = peg$literalExpectation("and", true),
+      peg$c73 = function() { return text() },
+      peg$c74 = "or",
+      peg$c75 = peg$literalExpectation("or", true),
+      peg$c76 = "in",
+      peg$c77 = peg$literalExpectation("in", true),
+      peg$c78 = "not",
+      peg$c79 = peg$literalExpectation("not", true),
+      peg$c80 = /^[A-Za-z_$]/,
+      peg$c81 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c82 = /^[0-9]/,
+      peg$c83 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c84 = ".",
+      peg$c85 = peg$literalExpectation(".", false),
+      peg$c86 = function(base, field) { return makeFieldCall("RecordFieldRead", null, field) },
+      peg$c87 = "[",
+      peg$c88 = peg$literalExpectation("[", false),
+      peg$c89 = "]",
+      peg$c90 = peg$literalExpectation("]", false),
+      peg$c91 = function(base, index) { return makeFieldCall("Index", null, index) },
+      peg$c92 = function(base, derefs) {
            return chainFieldCalls(base, derefs)
          },
-      peg$c90 = function(op, field) {
+      peg$c93 = function(op, field) {
             return makeFieldCall(op, field, null)
           },
-      peg$c91 = "len",
-      peg$c92 = peg$literalExpectation("len", true),
-      peg$c93 = function() { return "Len" },
-      peg$c94 = function(first, rest) {
+      peg$c94 = "len",
+      peg$c95 = peg$literalExpectation("len", true),
+      peg$c96 = function() { return "Len" },
+      peg$c97 = function(first, rest) {
             let result =  [first]
 
             for(let  r of rest) {
@@ -312,65 +315,65 @@ function peg$parse(input, options) {
 
             return result
         },
-      peg$c95 = function(base, refs) { return text() },
-      peg$c96 = function(first, ref) { return ref },
-      peg$c97 = function(first, rest) {
+      peg$c98 = function(base, refs) { return text() },
+      peg$c99 = function(first, ref) { return ref },
+      peg$c100 = function(first, rest) {
         let result =  [first]
         for(let  r of rest) {
           result.push( r)
         }
         return result
         },
-      peg$c98 = function(first, rest) {
+      peg$c101 = function(first, rest) {
             let result =  [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
         },
-      peg$c99 = "count",
-      peg$c100 = peg$literalExpectation("count", true),
-      peg$c101 = function() { return "Count" },
-      peg$c102 = "sum",
-      peg$c103 = peg$literalExpectation("sum", true),
-      peg$c104 = function() { return "Sum" },
-      peg$c105 = "avg",
-      peg$c106 = peg$literalExpectation("avg", true),
-      peg$c107 = function() { return "Avg" },
-      peg$c108 = "stdev",
-      peg$c109 = peg$literalExpectation("stdev", true),
-      peg$c110 = function() { return "Stdev" },
-      peg$c111 = "sd",
-      peg$c112 = peg$literalExpectation("sd", true),
-      peg$c113 = "var",
-      peg$c114 = peg$literalExpectation("var", true),
-      peg$c115 = function() { return "Var" },
-      peg$c116 = "entropy",
-      peg$c117 = peg$literalExpectation("entropy", true),
-      peg$c118 = function() { return "Entropy" },
-      peg$c119 = "min",
-      peg$c120 = peg$literalExpectation("min", true),
-      peg$c121 = function() { return "Min" },
-      peg$c122 = "max",
-      peg$c123 = peg$literalExpectation("max", true),
-      peg$c124 = function() { return "Max" },
-      peg$c125 = "first",
-      peg$c126 = peg$literalExpectation("first", true),
-      peg$c127 = function() { return "First" },
-      peg$c128 = "last",
-      peg$c129 = peg$literalExpectation("last", true),
-      peg$c130 = function() { return "Last" },
-      peg$c131 = "countdistinct",
-      peg$c132 = peg$literalExpectation("countdistinct", true),
-      peg$c133 = function() { return "CountDistinct" },
-      peg$c134 = function(field) { return field },
-      peg$c135 = function(op, field) {
+      peg$c102 = "count",
+      peg$c103 = peg$literalExpectation("count", true),
+      peg$c104 = function() { return "Count" },
+      peg$c105 = "sum",
+      peg$c106 = peg$literalExpectation("sum", true),
+      peg$c107 = function() { return "Sum" },
+      peg$c108 = "avg",
+      peg$c109 = peg$literalExpectation("avg", true),
+      peg$c110 = function() { return "Avg" },
+      peg$c111 = "stdev",
+      peg$c112 = peg$literalExpectation("stdev", true),
+      peg$c113 = function() { return "Stdev" },
+      peg$c114 = "sd",
+      peg$c115 = peg$literalExpectation("sd", true),
+      peg$c116 = "var",
+      peg$c117 = peg$literalExpectation("var", true),
+      peg$c118 = function() { return "Var" },
+      peg$c119 = "entropy",
+      peg$c120 = peg$literalExpectation("entropy", true),
+      peg$c121 = function() { return "Entropy" },
+      peg$c122 = "min",
+      peg$c123 = peg$literalExpectation("min", true),
+      peg$c124 = function() { return "Min" },
+      peg$c125 = "max",
+      peg$c126 = peg$literalExpectation("max", true),
+      peg$c127 = function() { return "Max" },
+      peg$c128 = "first",
+      peg$c129 = peg$literalExpectation("first", true),
+      peg$c130 = function() { return "First" },
+      peg$c131 = "last",
+      peg$c132 = peg$literalExpectation("last", true),
+      peg$c133 = function() { return "Last" },
+      peg$c134 = "countdistinct",
+      peg$c135 = peg$literalExpectation("countdistinct", true),
+      peg$c136 = function() { return "CountDistinct" },
+      peg$c137 = function(field) { return field },
+      peg$c138 = function(op, field) {
           return makeReducer(op, "count", field)
         },
-      peg$c136 = function(op, field) {
+      peg$c139 = function(op, field) {
           return makeReducer(op, toLowerCase(op), field)
         },
-      peg$c137 = function(every, reducers, keys, limit) {
+      peg$c140 = function(every, reducers, keys, sorted, limit) {
           if (OR(keys, every)) {
             if (keys) {
               keys = keys[1]
@@ -382,337 +385,337 @@ function peg$parse(input, options) {
               every = every[0]
             }
 
-            return makeGroupByProc(every, limit, keys, reducers)
+            return makeGroupByProc(every, sorted, limit, keys, reducers)
           }
 
           return makeReducerProc(reducers)
         },
-      peg$c138 = "as",
-      peg$c139 = peg$literalExpectation("as", true),
-      peg$c140 = "=",
-      peg$c141 = peg$literalExpectation("=", false),
-      peg$c142 = function(field, f) {
+      peg$c141 = "as",
+      peg$c142 = peg$literalExpectation("as", true),
+      peg$c143 = "=",
+      peg$c144 = peg$literalExpectation("=", false),
+      peg$c145 = function(field, f) {
           return overrideReducerVar(f, field)
         },
-      peg$c143 = function(f, field) {
+      peg$c146 = function(f, field) {
           return overrideReducerVar(f, field)
         },
-      peg$c144 = function(first, rest) {
+      peg$c147 = function(first, rest) {
             let result =  [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c145 = "sort",
-      peg$c146 = peg$literalExpectation("sort", true),
-      peg$c147 = function(args, l) { return l },
-      peg$c148 = function(args, list) {
+      peg$c148 = "sort",
+      peg$c149 = peg$literalExpectation("sort", true),
+      peg$c150 = function(args, l) { return l },
+      peg$c151 = function(args, list) {
           return makeSortProc(args, list)
         },
-      peg$c149 = function(a) { return a },
-      peg$c150 = "-r",
-      peg$c151 = peg$literalExpectation("-r", false),
-      peg$c152 = function() { return makeArg("r", null) },
-      peg$c153 = "-nulls",
-      peg$c154 = peg$literalExpectation("-nulls", false),
-      peg$c155 = peg$literalExpectation("first", false),
-      peg$c156 = peg$literalExpectation("last", false),
-      peg$c157 = function(where) { return makeArg("nulls", where) },
-      peg$c158 = "top",
-      peg$c159 = peg$literalExpectation("top", true),
-      peg$c160 = function(n) { return n},
-      peg$c161 = "-flush",
-      peg$c162 = peg$literalExpectation("-flush", false),
-      peg$c163 = function(limit, flush, f) { return f },
-      peg$c164 = function(limit, flush, list) {
+      peg$c152 = function(a) { return a },
+      peg$c153 = "-r",
+      peg$c154 = peg$literalExpectation("-r", false),
+      peg$c155 = function() { return makeArg("r", null) },
+      peg$c156 = "-nulls",
+      peg$c157 = peg$literalExpectation("-nulls", false),
+      peg$c158 = peg$literalExpectation("first", false),
+      peg$c159 = peg$literalExpectation("last", false),
+      peg$c160 = function(where) { return makeArg("nulls", where) },
+      peg$c161 = "top",
+      peg$c162 = peg$literalExpectation("top", true),
+      peg$c163 = function(n) { return n},
+      peg$c164 = "-flush",
+      peg$c165 = peg$literalExpectation("-flush", false),
+      peg$c166 = function(limit, flush, f) { return f },
+      peg$c167 = function(limit, flush, list) {
           return makeTopProc(list, limit, flush)
         },
-      peg$c165 = "-limit",
-      peg$c166 = peg$literalExpectation("-limit", false),
-      peg$c167 = function(limit) { return limit },
-      peg$c168 = "-c",
-      peg$c169 = peg$literalExpectation("-c", false),
-      peg$c170 = function() { return makeArg("c", null) },
-      peg$c171 = "cut",
-      peg$c172 = peg$literalExpectation("cut", true),
-      peg$c173 = function(arg, list) {  return makeCutProc(arg, list) },
-      peg$c174 = "head",
-      peg$c175 = peg$literalExpectation("head", true),
-      peg$c176 = function(count) { return makeHeadProc(count) },
-      peg$c177 = function() { return makeHeadProc(1) },
-      peg$c178 = "tail",
-      peg$c179 = peg$literalExpectation("tail", true),
-      peg$c180 = function(count) { return makeTailProc(count) },
-      peg$c181 = function() { return makeTailProc(1) },
-      peg$c182 = "filter",
-      peg$c183 = peg$literalExpectation("filter", true),
-      peg$c184 = "uniq",
-      peg$c185 = peg$literalExpectation("uniq", true),
-      peg$c186 = function() {
+      peg$c168 = "-limit",
+      peg$c169 = peg$literalExpectation("-limit", false),
+      peg$c170 = function(limit) { return limit },
+      peg$c171 = "-c",
+      peg$c172 = peg$literalExpectation("-c", false),
+      peg$c173 = function() { return makeArg("c", null) },
+      peg$c174 = "cut",
+      peg$c175 = peg$literalExpectation("cut", true),
+      peg$c176 = function(arg, list) {  return makeCutProc(arg, list) },
+      peg$c177 = "head",
+      peg$c178 = peg$literalExpectation("head", true),
+      peg$c179 = function(count) { return makeHeadProc(count) },
+      peg$c180 = function() { return makeHeadProc(1) },
+      peg$c181 = "tail",
+      peg$c182 = peg$literalExpectation("tail", true),
+      peg$c183 = function(count) { return makeTailProc(count) },
+      peg$c184 = function() { return makeTailProc(1) },
+      peg$c185 = "filter",
+      peg$c186 = peg$literalExpectation("filter", true),
+      peg$c187 = "uniq",
+      peg$c188 = peg$literalExpectation("uniq", true),
+      peg$c189 = function() {
             return makeUniqProc(true)
           },
-      peg$c187 = function() {
+      peg$c190 = function() {
             return makeUniqProc(false)
           },
-      peg$c188 = "put",
-      peg$c189 = peg$literalExpectation("put", true),
-      peg$c190 = function(first, rest) {
+      peg$c191 = "put",
+      peg$c192 = peg$literalExpectation("put", true),
+      peg$c193 = function(first, rest) {
             return makePutProc(first, rest)
           },
-      peg$c191 = function(f, e) {
+      peg$c194 = function(f, e) {
             return makeAssignment(f, e)
           },
-      peg$c192 = function(f) {
+      peg$c195 = function(f) {
             return chainFieldCalls(f, [])
           },
-      peg$c193 = "?",
-      peg$c194 = peg$literalExpectation("?", false),
-      peg$c195 = ":",
-      peg$c196 = peg$literalExpectation(":", false),
-      peg$c197 = function(condition, thenClause, elseClause) {
+      peg$c196 = "?",
+      peg$c197 = peg$literalExpectation("?", false),
+      peg$c198 = ":",
+      peg$c199 = peg$literalExpectation(":", false),
+      peg$c200 = function(condition, thenClause, elseClause) {
           return makeConditionalExpr(condition, thenClause, elseClause)
         },
-      peg$c198 = function(first, rest) {
+      peg$c201 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c199 = "=~",
-      peg$c200 = peg$literalExpectation("=~", false),
-      peg$c201 = "!~",
-      peg$c202 = peg$literalExpectation("!~", false),
-      peg$c203 = "!=",
-      peg$c204 = peg$literalExpectation("!=", false),
-      peg$c205 = peg$literalExpectation("in", false),
-      peg$c206 = "<=",
-      peg$c207 = peg$literalExpectation("<=", false),
-      peg$c208 = "<",
-      peg$c209 = peg$literalExpectation("<", false),
-      peg$c210 = ">=",
-      peg$c211 = peg$literalExpectation(">=", false),
-      peg$c212 = ">",
-      peg$c213 = peg$literalExpectation(">", false),
-      peg$c214 = "+",
-      peg$c215 = peg$literalExpectation("+", false),
-      peg$c216 = "/",
-      peg$c217 = peg$literalExpectation("/", false),
-      peg$c218 = function(e) {
+      peg$c202 = "=~",
+      peg$c203 = peg$literalExpectation("=~", false),
+      peg$c204 = "!~",
+      peg$c205 = peg$literalExpectation("!~", false),
+      peg$c206 = "!=",
+      peg$c207 = peg$literalExpectation("!=", false),
+      peg$c208 = peg$literalExpectation("in", false),
+      peg$c209 = "<=",
+      peg$c210 = peg$literalExpectation("<=", false),
+      peg$c211 = "<",
+      peg$c212 = peg$literalExpectation("<", false),
+      peg$c213 = ">=",
+      peg$c214 = peg$literalExpectation(">=", false),
+      peg$c215 = ">",
+      peg$c216 = peg$literalExpectation(">", false),
+      peg$c217 = "+",
+      peg$c218 = peg$literalExpectation("+", false),
+      peg$c219 = "/",
+      peg$c220 = peg$literalExpectation("/", false),
+      peg$c221 = function(e) {
               return makeUnaryExpr("!", e)
           },
-      peg$c219 = function(e, ct) { return ct },
-      peg$c220 = function(e, t) {
+      peg$c222 = function(e, ct) { return ct },
+      peg$c223 = function(e, t) {
           if (t) {
             return makeCastExpression(e, t)
           } else {
             return e
           }
         },
-      peg$c221 = "bool",
-      peg$c222 = peg$literalExpectation("bool", false),
-      peg$c223 = "byte",
-      peg$c224 = peg$literalExpectation("byte", false),
-      peg$c225 = "int16",
-      peg$c226 = peg$literalExpectation("int16", false),
-      peg$c227 = "uint16",
-      peg$c228 = peg$literalExpectation("uint16", false),
-      peg$c229 = "int32",
-      peg$c230 = peg$literalExpectation("int32", false),
-      peg$c231 = "uint32",
-      peg$c232 = peg$literalExpectation("uint32", false),
-      peg$c233 = "int64",
-      peg$c234 = peg$literalExpectation("int64", false),
-      peg$c235 = "uint64",
-      peg$c236 = peg$literalExpectation("uint64", false),
-      peg$c237 = "float64",
-      peg$c238 = peg$literalExpectation("float64", false),
-      peg$c239 = "string",
-      peg$c240 = peg$literalExpectation("string", false),
-      peg$c241 = "bstring",
-      peg$c242 = peg$literalExpectation("bstring", false),
-      peg$c243 = "ip",
-      peg$c244 = peg$literalExpectation("ip", false),
-      peg$c245 = "net",
-      peg$c246 = peg$literalExpectation("net", false),
-      peg$c247 = "time",
-      peg$c248 = peg$literalExpectation("time", false),
-      peg$c249 = "duration",
-      peg$c250 = peg$literalExpectation("duration", false),
-      peg$c251 = function(fn, args) {
+      peg$c224 = "bool",
+      peg$c225 = peg$literalExpectation("bool", false),
+      peg$c226 = "byte",
+      peg$c227 = peg$literalExpectation("byte", false),
+      peg$c228 = "int16",
+      peg$c229 = peg$literalExpectation("int16", false),
+      peg$c230 = "uint16",
+      peg$c231 = peg$literalExpectation("uint16", false),
+      peg$c232 = "int32",
+      peg$c233 = peg$literalExpectation("int32", false),
+      peg$c234 = "uint32",
+      peg$c235 = peg$literalExpectation("uint32", false),
+      peg$c236 = "int64",
+      peg$c237 = peg$literalExpectation("int64", false),
+      peg$c238 = "uint64",
+      peg$c239 = peg$literalExpectation("uint64", false),
+      peg$c240 = "float64",
+      peg$c241 = peg$literalExpectation("float64", false),
+      peg$c242 = "string",
+      peg$c243 = peg$literalExpectation("string", false),
+      peg$c244 = "bstring",
+      peg$c245 = peg$literalExpectation("bstring", false),
+      peg$c246 = "ip",
+      peg$c247 = peg$literalExpectation("ip", false),
+      peg$c248 = "net",
+      peg$c249 = peg$literalExpectation("net", false),
+      peg$c250 = "time",
+      peg$c251 = peg$literalExpectation("time", false),
+      peg$c252 = "duration",
+      peg$c253 = peg$literalExpectation("duration", false),
+      peg$c254 = function(fn, args) {
               return makeFunctionCall(fn, args)
           },
-      peg$c252 = /^[A-Za-z]/,
-      peg$c253 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
-      peg$c254 = /^[.0-9]/,
-      peg$c255 = peg$classExpectation([".", ["0", "9"]], false, false),
-      peg$c256 = function(first, e) { return e },
-      peg$c257 = function(first, rest) {
+      peg$c255 = /^[A-Za-z]/,
+      peg$c256 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
+      peg$c257 = /^[.0-9]/,
+      peg$c258 = peg$classExpectation([".", ["0", "9"]], false, false),
+      peg$c259 = function(first, e) { return e },
+      peg$c260 = function(first, rest) {
             return [first, ... rest]
         },
-      peg$c258 = function() { return [] },
-      peg$c259 = function(base, field) { return makeLiteral("string", text()) },
-      peg$c260 = function(base, derefs) {
+      peg$c261 = function() { return [] },
+      peg$c262 = function(base, field) { return makeLiteral("string", text()) },
+      peg$c263 = function(base, derefs) {
               return makeBinaryExprChain(base, derefs)
           },
-      peg$c261 = peg$literalExpectation("and", false),
-      peg$c262 = "seconds",
-      peg$c263 = peg$literalExpectation("seconds", false),
-      peg$c264 = "second",
-      peg$c265 = peg$literalExpectation("second", false),
-      peg$c266 = "secs",
-      peg$c267 = peg$literalExpectation("secs", false),
-      peg$c268 = "sec",
-      peg$c269 = peg$literalExpectation("sec", false),
-      peg$c270 = "s",
-      peg$c271 = peg$literalExpectation("s", false),
-      peg$c272 = "minutes",
-      peg$c273 = peg$literalExpectation("minutes", false),
-      peg$c274 = "minute",
-      peg$c275 = peg$literalExpectation("minute", false),
-      peg$c276 = "mins",
-      peg$c277 = peg$literalExpectation("mins", false),
-      peg$c278 = peg$literalExpectation("min", false),
-      peg$c279 = "m",
-      peg$c280 = peg$literalExpectation("m", false),
-      peg$c281 = "hours",
-      peg$c282 = peg$literalExpectation("hours", false),
-      peg$c283 = "hrs",
-      peg$c284 = peg$literalExpectation("hrs", false),
-      peg$c285 = "hr",
-      peg$c286 = peg$literalExpectation("hr", false),
-      peg$c287 = "h",
-      peg$c288 = peg$literalExpectation("h", false),
-      peg$c289 = "hour",
-      peg$c290 = peg$literalExpectation("hour", false),
-      peg$c291 = "days",
-      peg$c292 = peg$literalExpectation("days", false),
-      peg$c293 = "day",
-      peg$c294 = peg$literalExpectation("day", false),
-      peg$c295 = "d",
-      peg$c296 = peg$literalExpectation("d", false),
-      peg$c297 = "weeks",
-      peg$c298 = peg$literalExpectation("weeks", false),
-      peg$c299 = "week",
-      peg$c300 = peg$literalExpectation("week", false),
-      peg$c301 = "wks",
-      peg$c302 = peg$literalExpectation("wks", false),
-      peg$c303 = "wk",
-      peg$c304 = peg$literalExpectation("wk", false),
-      peg$c305 = "w",
-      peg$c306 = peg$literalExpectation("w", false),
-      peg$c307 = function() { return makeDuration(1) },
-      peg$c308 = function(num) { return makeDuration(num) },
-      peg$c309 = function() { return makeDuration(60) },
-      peg$c310 = function(num) { return makeDuration(num*60) },
-      peg$c311 = function() { return makeDuration(3600) },
-      peg$c312 = function(num) { return makeDuration(num*3600) },
-      peg$c313 = function() { return makeDuration(3600*24) },
-      peg$c314 = function(num) { return makeDuration(num*3600*24) },
-      peg$c315 = function(num) { return makeDuration(num*3600*24*7) },
-      peg$c316 = function(a) { return text() },
-      peg$c317 = function(a, b) {
+      peg$c264 = peg$literalExpectation("and", false),
+      peg$c265 = "seconds",
+      peg$c266 = peg$literalExpectation("seconds", false),
+      peg$c267 = "second",
+      peg$c268 = peg$literalExpectation("second", false),
+      peg$c269 = "secs",
+      peg$c270 = peg$literalExpectation("secs", false),
+      peg$c271 = "sec",
+      peg$c272 = peg$literalExpectation("sec", false),
+      peg$c273 = "s",
+      peg$c274 = peg$literalExpectation("s", false),
+      peg$c275 = "minutes",
+      peg$c276 = peg$literalExpectation("minutes", false),
+      peg$c277 = "minute",
+      peg$c278 = peg$literalExpectation("minute", false),
+      peg$c279 = "mins",
+      peg$c280 = peg$literalExpectation("mins", false),
+      peg$c281 = peg$literalExpectation("min", false),
+      peg$c282 = "m",
+      peg$c283 = peg$literalExpectation("m", false),
+      peg$c284 = "hours",
+      peg$c285 = peg$literalExpectation("hours", false),
+      peg$c286 = "hrs",
+      peg$c287 = peg$literalExpectation("hrs", false),
+      peg$c288 = "hr",
+      peg$c289 = peg$literalExpectation("hr", false),
+      peg$c290 = "h",
+      peg$c291 = peg$literalExpectation("h", false),
+      peg$c292 = "hour",
+      peg$c293 = peg$literalExpectation("hour", false),
+      peg$c294 = "days",
+      peg$c295 = peg$literalExpectation("days", false),
+      peg$c296 = "day",
+      peg$c297 = peg$literalExpectation("day", false),
+      peg$c298 = "d",
+      peg$c299 = peg$literalExpectation("d", false),
+      peg$c300 = "weeks",
+      peg$c301 = peg$literalExpectation("weeks", false),
+      peg$c302 = "week",
+      peg$c303 = peg$literalExpectation("week", false),
+      peg$c304 = "wks",
+      peg$c305 = peg$literalExpectation("wks", false),
+      peg$c306 = "wk",
+      peg$c307 = peg$literalExpectation("wk", false),
+      peg$c308 = "w",
+      peg$c309 = peg$literalExpectation("w", false),
+      peg$c310 = function() { return makeDuration(1) },
+      peg$c311 = function(num) { return makeDuration(num) },
+      peg$c312 = function() { return makeDuration(60) },
+      peg$c313 = function(num) { return makeDuration(num*60) },
+      peg$c314 = function() { return makeDuration(3600) },
+      peg$c315 = function(num) { return makeDuration(num*3600) },
+      peg$c316 = function() { return makeDuration(3600*24) },
+      peg$c317 = function(num) { return makeDuration(num*3600*24) },
+      peg$c318 = function(num) { return makeDuration(num*3600*24*7) },
+      peg$c319 = function(a) { return text() },
+      peg$c320 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c318 = "::",
-      peg$c319 = peg$literalExpectation("::", false),
-      peg$c320 = function(a, b, d, e) {
+      peg$c321 = "::",
+      peg$c322 = peg$literalExpectation("::", false),
+      peg$c323 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c321 = function(a, b) {
+      peg$c324 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c322 = function(a, b) {
+      peg$c325 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c323 = function() {
+      peg$c326 = function() {
             return "::"
           },
-      peg$c324 = function(v) { return ":" + v },
-      peg$c325 = function(v) { return v + ":" },
-      peg$c326 = function(a, m) {
+      peg$c327 = function(v) { return ":" + v },
+      peg$c328 = function(v) { return v + ":" },
+      peg$c329 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c327 = function(a, m) {
+      peg$c330 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c328 = function(s) { return parseInt(s) },
-      peg$c329 = /^[+\-]/,
-      peg$c330 = peg$classExpectation(["+", "-"], false, false),
-      peg$c331 = function(s) {
+      peg$c331 = function(s) { return parseInt(s) },
+      peg$c332 = /^[+\-]/,
+      peg$c333 = peg$classExpectation(["+", "-"], false, false),
+      peg$c334 = function(s) {
             return parseFloat(s)
         },
-      peg$c332 = function() {
+      peg$c335 = function() {
             return text()
           },
-      peg$c333 = "0",
-      peg$c334 = peg$literalExpectation("0", false),
-      peg$c335 = /^[1-9]/,
-      peg$c336 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c337 = "e",
-      peg$c338 = peg$literalExpectation("e", true),
-      peg$c339 = function(chars) { return text() },
-      peg$c340 = /^[0-9a-fA-F]/,
-      peg$c341 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c342 = function(chars) { return joinChars(chars) },
-      peg$c343 = "\\",
-      peg$c344 = peg$literalExpectation("\\", false),
-      peg$c345 = /^[\0-\x1F\\(),!><="|';]/,
-      peg$c346 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
-      peg$c347 = peg$anyExpectation(),
-      peg$c348 = "\"",
-      peg$c349 = peg$literalExpectation("\"", false),
-      peg$c350 = function(v) { return joinChars(v) },
-      peg$c351 = "'",
-      peg$c352 = peg$literalExpectation("'", false),
-      peg$c353 = "x",
-      peg$c354 = peg$literalExpectation("x", false),
-      peg$c355 = function() { return "\\" + text() },
-      peg$c356 = "b",
-      peg$c357 = peg$literalExpectation("b", false),
-      peg$c358 = function() { return "\b" },
-      peg$c359 = "f",
-      peg$c360 = peg$literalExpectation("f", false),
-      peg$c361 = function() { return "\f" },
-      peg$c362 = "n",
-      peg$c363 = peg$literalExpectation("n", false),
-      peg$c364 = function() { return "\n" },
-      peg$c365 = "r",
-      peg$c366 = peg$literalExpectation("r", false),
-      peg$c367 = function() { return "\r" },
-      peg$c368 = "t",
-      peg$c369 = peg$literalExpectation("t", false),
-      peg$c370 = function() { return "\t" },
-      peg$c371 = "v",
-      peg$c372 = peg$literalExpectation("v", false),
-      peg$c373 = function() { return "\v" },
-      peg$c374 = function() { return "=" },
-      peg$c375 = function() { return "\\*" },
-      peg$c376 = "u",
-      peg$c377 = peg$literalExpectation("u", false),
-      peg$c378 = function(chars) {
+      peg$c336 = "0",
+      peg$c337 = peg$literalExpectation("0", false),
+      peg$c338 = /^[1-9]/,
+      peg$c339 = peg$classExpectation([["1", "9"]], false, false),
+      peg$c340 = "e",
+      peg$c341 = peg$literalExpectation("e", true),
+      peg$c342 = function(chars) { return text() },
+      peg$c343 = /^[0-9a-fA-F]/,
+      peg$c344 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c345 = function(chars) { return joinChars(chars) },
+      peg$c346 = "\\",
+      peg$c347 = peg$literalExpectation("\\", false),
+      peg$c348 = /^[\0-\x1F\\(),!><="|';]/,
+      peg$c349 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
+      peg$c350 = peg$anyExpectation(),
+      peg$c351 = "\"",
+      peg$c352 = peg$literalExpectation("\"", false),
+      peg$c353 = function(v) { return joinChars(v) },
+      peg$c354 = "'",
+      peg$c355 = peg$literalExpectation("'", false),
+      peg$c356 = "x",
+      peg$c357 = peg$literalExpectation("x", false),
+      peg$c358 = function() { return "\\" + text() },
+      peg$c359 = "b",
+      peg$c360 = peg$literalExpectation("b", false),
+      peg$c361 = function() { return "\b" },
+      peg$c362 = "f",
+      peg$c363 = peg$literalExpectation("f", false),
+      peg$c364 = function() { return "\f" },
+      peg$c365 = "n",
+      peg$c366 = peg$literalExpectation("n", false),
+      peg$c367 = function() { return "\n" },
+      peg$c368 = "r",
+      peg$c369 = peg$literalExpectation("r", false),
+      peg$c370 = function() { return "\r" },
+      peg$c371 = "t",
+      peg$c372 = peg$literalExpectation("t", false),
+      peg$c373 = function() { return "\t" },
+      peg$c374 = "v",
+      peg$c375 = peg$literalExpectation("v", false),
+      peg$c376 = function() { return "\v" },
+      peg$c377 = function() { return "=" },
+      peg$c378 = function() { return "\\*" },
+      peg$c379 = "u",
+      peg$c380 = peg$literalExpectation("u", false),
+      peg$c381 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c379 = "{",
-      peg$c380 = peg$literalExpectation("{", false),
-      peg$c381 = "}",
-      peg$c382 = peg$literalExpectation("}", false),
-      peg$c383 = /^[^\/\\]/,
-      peg$c384 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c385 = "\\/",
-      peg$c386 = peg$literalExpectation("\\/", false),
-      peg$c387 = /^[\0-\x1F\\]/,
-      peg$c388 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c389 = "\t",
-      peg$c390 = peg$literalExpectation("\t", false),
-      peg$c391 = "\x0B",
-      peg$c392 = peg$literalExpectation("\x0B", false),
-      peg$c393 = "\f",
-      peg$c394 = peg$literalExpectation("\f", false),
-      peg$c395 = " ",
-      peg$c396 = peg$literalExpectation(" ", false),
-      peg$c397 = "\xA0",
-      peg$c398 = peg$literalExpectation("\xA0", false),
-      peg$c399 = "\uFEFF",
-      peg$c400 = peg$literalExpectation("\uFEFF", false),
-      peg$c401 = peg$otherExpectation("whitespace"),
+      peg$c382 = "{",
+      peg$c383 = peg$literalExpectation("{", false),
+      peg$c384 = "}",
+      peg$c385 = peg$literalExpectation("}", false),
+      peg$c386 = /^[^\/\\]/,
+      peg$c387 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c388 = "\\/",
+      peg$c389 = peg$literalExpectation("\\/", false),
+      peg$c390 = /^[\0-\x1F\\]/,
+      peg$c391 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c392 = "\t",
+      peg$c393 = peg$literalExpectation("\t", false),
+      peg$c394 = "\x0B",
+      peg$c395 = peg$literalExpectation("\x0B", false),
+      peg$c396 = "\f",
+      peg$c397 = peg$literalExpectation("\f", false),
+      peg$c398 = " ",
+      peg$c399 = peg$literalExpectation(" ", false),
+      peg$c400 = "\xA0",
+      peg$c401 = peg$literalExpectation("\xA0", false),
+      peg$c402 = "\uFEFF",
+      peg$c403 = peg$literalExpectation("\uFEFF", false),
+      peg$c404 = peg$otherExpectation("whitespace"),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -2275,6 +2278,47 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsegroupBySorted() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parse_();
+    if (s1 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c68) {
+        s2 = input.substr(peg$currPos, 7);
+        peg$currPos += 7;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c69); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse_();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsesinteger();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c70(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseequalityToken() {
     var s0;
 
@@ -2290,16 +2334,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c68) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c71) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
+      if (peg$silentFails === 0) { peg$fail(peg$c72); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -2310,16 +2354,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c71) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c74) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c72); }
+      if (peg$silentFails === 0) { peg$fail(peg$c75); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -2330,16 +2374,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c73) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c76) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c74); }
+      if (peg$silentFails === 0) { peg$fail(peg$c77); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -2350,16 +2394,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c75) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c78) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c76); }
+      if (peg$silentFails === 0) { peg$fail(peg$c79); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -2380,7 +2424,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c73();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2397,12 +2441,12 @@ function peg$parse(input, options) {
   function peg$parsefieldNameStart() {
     var s0;
 
-    if (peg$c77.test(input.charAt(peg$currPos))) {
+    if (peg$c80.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c78); }
+      if (peg$silentFails === 0) { peg$fail(peg$c81); }
     }
 
     return s0;
@@ -2413,12 +2457,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parsefieldNameStart();
     if (s0 === peg$FAILED) {
-      if (peg$c79.test(input.charAt(peg$currPos))) {
+      if (peg$c82.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c80); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
     }
 
@@ -2434,17 +2478,17 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s4 = peg$c81;
+        s4 = peg$c84;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parsefieldName();
         if (s5 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c83(s1, s5);
+          s4 = peg$c86(s1, s5);
           s3 = s4;
         } else {
           peg$currPos = s3;
@@ -2457,25 +2501,25 @@ function peg$parse(input, options) {
       if (s3 === peg$FAILED) {
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s4 = peg$c84;
+          s4 = peg$c87;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c85); }
+          if (peg$silentFails === 0) { peg$fail(peg$c88); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsesuint();
           if (s5 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s6 = peg$c86;
+              s6 = peg$c89;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c87); }
+              if (peg$silentFails === 0) { peg$fail(peg$c90); }
             }
             if (s6 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c88(s1, s5);
+              s4 = peg$c91(s1, s5);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2494,17 +2538,17 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c81;
+          s4 = peg$c84;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c82); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsefieldName();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c83(s1, s5);
+            s4 = peg$c86(s1, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2517,25 +2561,25 @@ function peg$parse(input, options) {
         if (s3 === peg$FAILED) {
           s3 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s4 = peg$c84;
+            s4 = peg$c87;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c85); }
+            if (peg$silentFails === 0) { peg$fail(peg$c88); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parsesuint();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s6 = peg$c86;
+                s6 = peg$c89;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c87); }
+                if (peg$silentFails === 0) { peg$fail(peg$c90); }
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c88(s1, s5);
+                s4 = peg$c91(s1, s5);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2553,7 +2597,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c89(s1, s2);
+        s1 = peg$c92(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2607,7 +2651,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c90(s1, s5);
+                  s1 = peg$c93(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2648,16 +2692,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c91) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c94) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c92); }
+      if (peg$silentFails === 0) { peg$fail(peg$c95); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c93();
+      s1 = peg$c96();
     }
     s0 = s1;
 
@@ -2754,7 +2798,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c94(s1, s2);
+        s1 = peg$c97(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2777,11 +2821,11 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s4 = peg$c81;
+        s4 = peg$c84;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parsefieldName();
@@ -2800,11 +2844,11 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c81;
+          s4 = peg$c84;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c82); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsefieldName();
@@ -2822,7 +2866,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c95(s1, s2);
+        s1 = peg$c98(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2865,7 +2909,7 @@ function peg$parse(input, options) {
             s7 = peg$parsefieldRefDotOnly();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c96(s1, s7);
+              s4 = peg$c99(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2907,7 +2951,7 @@ function peg$parse(input, options) {
               s7 = peg$parsefieldRefDotOnly();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c96(s1, s7);
+                s4 = peg$c99(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2928,7 +2972,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c97(s1, s2);
+        s1 = peg$c100(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3032,7 +3076,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c98(s1, s2);
+        s1 = peg$c101(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3050,16 +3094,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c99) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c102) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+      if (peg$silentFails === 0) { peg$fail(peg$c103); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c101();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -3070,156 +3114,156 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c102) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c105) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c103); }
+      if (peg$silentFails === 0) { peg$fail(peg$c106); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c107();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c105) {
+      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c108) {
         s1 = input.substr(peg$currPos, 3);
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c106); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c107();
+        s1 = peg$c110();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c108) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c111) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c109); }
+          if (peg$silentFails === 0) { peg$fail(peg$c112); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c110();
+          s1 = peg$c113();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c111) {
+          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c114) {
             s1 = input.substr(peg$currPos, 2);
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c112); }
+            if (peg$silentFails === 0) { peg$fail(peg$c115); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c110();
+            s1 = peg$c113();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c113) {
+            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c116) {
               s1 = input.substr(peg$currPos, 3);
               peg$currPos += 3;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c114); }
+              if (peg$silentFails === 0) { peg$fail(peg$c117); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c115();
+              s1 = peg$c118();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 7).toLowerCase() === peg$c116) {
+              if (input.substr(peg$currPos, 7).toLowerCase() === peg$c119) {
                 s1 = input.substr(peg$currPos, 7);
                 peg$currPos += 7;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c117); }
+                if (peg$silentFails === 0) { peg$fail(peg$c120); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c118();
+                s1 = peg$c121();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c119) {
+                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c122) {
                   s1 = input.substr(peg$currPos, 3);
                   peg$currPos += 3;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c123); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c121();
+                  s1 = peg$c124();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c122) {
+                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c125) {
                     s1 = input.substr(peg$currPos, 3);
                     peg$currPos += 3;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c123); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c126); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c124();
+                    s1 = peg$c127();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
-                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c125) {
+                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c128) {
                       s1 = input.substr(peg$currPos, 5);
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c126); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c129); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c127();
+                      s1 = peg$c130();
                     }
                     s0 = s1;
                     if (s0 === peg$FAILED) {
                       s0 = peg$currPos;
-                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c131) {
                         s1 = input.substr(peg$currPos, 4);
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c129); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c132); }
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c130();
+                        s1 = peg$c133();
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
-                        if (input.substr(peg$currPos, 13).toLowerCase() === peg$c131) {
+                        if (input.substr(peg$currPos, 13).toLowerCase() === peg$c134) {
                           s1 = input.substr(peg$currPos, 13);
                           peg$currPos += 13;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c132); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c135); }
                         }
                         if (s1 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c133();
+                          s1 = peg$c136();
                         }
                         s0 = s1;
                       }
@@ -3253,7 +3297,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c134(s2);
+          s1 = peg$c137(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3309,7 +3353,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c135(s1, s4);
+                s1 = peg$c138(s1, s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3379,7 +3423,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c136(s1, s5);
+                  s1 = peg$c139(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3457,14 +3501,23 @@ function peg$parse(input, options) {
           s3 = null;
         }
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseprocLimitArg();
+          s4 = peg$parsegroupBySorted();
           if (s4 === peg$FAILED) {
             s4 = null;
           }
           if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c137(s1, s2, s3, s4);
-            s0 = s1;
+            s5 = peg$parseprocLimitArg();
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c140(s1, s2, s3, s4, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -3489,12 +3542,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c138) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c141) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c139); }
+      if (peg$silentFails === 0) { peg$fail(peg$c142); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3532,11 +3585,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c140;
+          s3 = peg$c143;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c141); }
+          if (peg$silentFails === 0) { peg$fail(peg$c144); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -3547,7 +3600,7 @@ function peg$parse(input, options) {
             s5 = peg$parsereducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c142(s1, s5);
+              s1 = peg$c145(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3578,7 +3631,7 @@ function peg$parse(input, options) {
           s3 = peg$parseasClause();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c143(s1, s3);
+            s1 = peg$c146(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3701,7 +3754,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c144(s1, s2);
+        s1 = peg$c147(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3748,12 +3801,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c145) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c148) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c146); }
+      if (peg$silentFails === 0) { peg$fail(peg$c149); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesortArgs();
@@ -3764,7 +3817,7 @@ function peg$parse(input, options) {
           s5 = peg$parsefieldExprList();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c147(s2, s5);
+            s4 = peg$c150(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -3779,7 +3832,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c148(s2, s3);
+          s1 = peg$c151(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3807,7 +3860,7 @@ function peg$parse(input, options) {
       s3 = peg$parsesortArg();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c149(s3);
+        s2 = peg$c152(s3);
         s1 = s2;
       } else {
         peg$currPos = s1;
@@ -3825,7 +3878,7 @@ function peg$parse(input, options) {
         s3 = peg$parsesortArg();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s1;
-          s2 = peg$c149(s3);
+          s2 = peg$c152(s3);
           s1 = s2;
         } else {
           peg$currPos = s1;
@@ -3844,55 +3897,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c150) {
-      s1 = peg$c150;
+    if (input.substr(peg$currPos, 2) === peg$c153) {
+      s1 = peg$c153;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      if (peg$silentFails === 0) { peg$fail(peg$c154); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c152();
+      s1 = peg$c155();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c153) {
-        s1 = peg$c153;
+      if (input.substr(peg$currPos, 6) === peg$c156) {
+        s1 = peg$c156;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c154); }
+        if (peg$silentFails === 0) { peg$fail(peg$c157); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c125) {
-            s4 = peg$c125;
+          if (input.substr(peg$currPos, 5) === peg$c128) {
+            s4 = peg$c128;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c155); }
+            if (peg$silentFails === 0) { peg$fail(peg$c158); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c128) {
-              s4 = peg$c128;
+            if (input.substr(peg$currPos, 4) === peg$c131) {
+              s4 = peg$c131;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c156); }
+              if (peg$silentFails === 0) { peg$fail(peg$c159); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c70();
+            s4 = peg$c73();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c157(s3);
+            s1 = peg$c160(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3915,12 +3968,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c158) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c161) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c159); }
+      if (peg$silentFails === 0) { peg$fail(peg$c162); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -3929,7 +3982,7 @@ function peg$parse(input, options) {
         s4 = peg$parseunsignedInteger();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c160(s4);
+          s3 = peg$c163(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3946,12 +3999,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c161) {
-            s5 = peg$c161;
+          if (input.substr(peg$currPos, 6) === peg$c164) {
+            s5 = peg$c164;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c162); }
+            if (peg$silentFails === 0) { peg$fail(peg$c165); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3974,7 +4027,7 @@ function peg$parse(input, options) {
             s6 = peg$parsefieldExprList();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c163(s2, s3, s6);
+              s5 = peg$c166(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3989,7 +4042,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c164(s2, s3, s4);
+            s1 = peg$c167(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4017,12 +4070,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c165) {
-        s2 = peg$c165;
+      if (input.substr(peg$currPos, 6) === peg$c168) {
+        s2 = peg$c168;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c166); }
+        if (peg$silentFails === 0) { peg$fail(peg$c169); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -4030,7 +4083,7 @@ function peg$parse(input, options) {
           s4 = peg$parseunsignedInteger();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c167(s4);
+            s1 = peg$c170(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4059,16 +4112,16 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     s2 = peg$parse_();
     if (s2 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c168) {
-        s3 = peg$c168;
+      if (input.substr(peg$currPos, 2) === peg$c171) {
+        s3 = peg$c171;
         peg$currPos += 2;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c169); }
+        if (peg$silentFails === 0) { peg$fail(peg$c172); }
       }
       if (s3 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c170();
+        s2 = peg$c173();
         s1 = s2;
       } else {
         peg$currPos = s1;
@@ -4083,16 +4136,16 @@ function peg$parse(input, options) {
       s1 = peg$currPos;
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c168) {
-          s3 = peg$c168;
+        if (input.substr(peg$currPos, 2) === peg$c171) {
+          s3 = peg$c171;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c169); }
+          if (peg$silentFails === 0) { peg$fail(peg$c172); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s1;
-          s2 = peg$c170();
+          s2 = peg$c173();
           s1 = s2;
         } else {
           peg$currPos = s1;
@@ -4111,12 +4164,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c171) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c174) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c172); }
+      if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsecutArg();
@@ -4126,7 +4179,7 @@ function peg$parse(input, options) {
           s4 = peg$parsefieldRefDotOnlyList();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s2, s4);
+            s1 = peg$c176(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4152,12 +4205,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c174) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c177) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c175); }
+      if (peg$silentFails === 0) { peg$fail(peg$c178); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4165,7 +4218,7 @@ function peg$parse(input, options) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s3);
+          s1 = peg$c179(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4181,16 +4234,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c174) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c177) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+        if (peg$silentFails === 0) { peg$fail(peg$c178); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c177();
+        s1 = peg$c180();
       }
       s0 = s1;
     }
@@ -4202,12 +4255,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c178) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c181) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c179); }
+      if (peg$silentFails === 0) { peg$fail(peg$c182); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4215,7 +4268,7 @@ function peg$parse(input, options) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c180(s3);
+          s1 = peg$c183(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4231,16 +4284,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c178) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c181) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c182); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c181();
+        s1 = peg$c184();
       }
       s0 = s1;
     }
@@ -4252,12 +4305,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c182) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c185) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4287,26 +4340,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c184) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c187) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c185); }
+      if (peg$silentFails === 0) { peg$fail(peg$c188); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c168) {
-          s3 = peg$c168;
+        if (input.substr(peg$currPos, 2) === peg$c171) {
+          s3 = peg$c171;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c169); }
+          if (peg$silentFails === 0) { peg$fail(peg$c172); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c186();
+          s1 = peg$c189();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4322,16 +4375,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c184) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c187) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c185); }
+        if (peg$silentFails === 0) { peg$fail(peg$c188); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c187();
+        s1 = peg$c190();
       }
       s0 = s1;
     }
@@ -4343,12 +4396,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c188) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c191) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c189); }
+      if (peg$silentFails === 0) { peg$fail(peg$c192); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4429,7 +4482,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c190(s3, s4);
+            s1 = peg$c193(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4460,11 +4513,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c140;
+          s3 = peg$c143;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c141); }
+          if (peg$silentFails === 0) { peg$fail(peg$c144); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4472,7 +4525,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpression();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c191(s1, s5);
+              s1 = peg$c194(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4588,7 +4641,7 @@ function peg$parse(input, options) {
     s1 = peg$parsefieldName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c192(s1);
+      s1 = peg$c195(s1);
     }
     s0 = s1;
 
@@ -4612,11 +4665,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c193;
+          s3 = peg$c196;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c194); }
+          if (peg$silentFails === 0) { peg$fail(peg$c197); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4626,11 +4679,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c195;
+                  s7 = peg$c198;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c196); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c199); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -4638,7 +4691,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpression();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c197(s1, s5, s9);
+                      s1 = peg$c200(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4749,7 +4802,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
+        s1 = peg$c201(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4829,7 +4882,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
+        s1 = peg$c201(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4909,7 +4962,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
+        s1 = peg$c201(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4927,43 +4980,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c199) {
-      s1 = peg$c199;
+    if (input.substr(peg$currPos, 2) === peg$c202) {
+      s1 = peg$c202;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c200); }
+      if (peg$silentFails === 0) { peg$fail(peg$c203); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c201) {
-        s1 = peg$c201;
+      if (input.substr(peg$currPos, 2) === peg$c204) {
+        s1 = peg$c204;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c202); }
+        if (peg$silentFails === 0) { peg$fail(peg$c205); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c140;
+          s1 = peg$c143;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c141); }
+          if (peg$silentFails === 0) { peg$fail(peg$c144); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c203) {
-            s1 = peg$c203;
+          if (input.substr(peg$currPos, 2) === peg$c206) {
+            s1 = peg$c206;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c204); }
+            if (peg$silentFails === 0) { peg$fail(peg$c207); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -4976,16 +5029,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c73) {
-        s1 = peg$c73;
+      if (input.substr(peg$currPos, 2) === peg$c76) {
+        s1 = peg$c76;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c205); }
+        if (peg$silentFails === 0) { peg$fail(peg$c208); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c73();
       }
       s0 = s1;
     }
@@ -5059,7 +5112,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
+        s1 = peg$c201(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5077,43 +5130,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c206) {
-      s1 = peg$c206;
+    if (input.substr(peg$currPos, 2) === peg$c209) {
+      s1 = peg$c209;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c207); }
+      if (peg$silentFails === 0) { peg$fail(peg$c210); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c208;
+        s1 = peg$c211;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c209); }
+        if (peg$silentFails === 0) { peg$fail(peg$c212); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c210) {
-          s1 = peg$c210;
+        if (input.substr(peg$currPos, 2) === peg$c213) {
+          s1 = peg$c213;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c211); }
+          if (peg$silentFails === 0) { peg$fail(peg$c214); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c212;
+            s1 = peg$c215;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c213); }
+            if (peg$silentFails === 0) { peg$fail(peg$c216); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -5186,7 +5239,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
+        s1 = peg$c201(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5205,11 +5258,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c214;
+      s1 = peg$c217;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c215); }
+      if (peg$silentFails === 0) { peg$fail(peg$c218); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
@@ -5222,7 +5275,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -5295,7 +5348,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
+        s1 = peg$c201(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5322,16 +5375,16 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c216;
+        s1 = peg$c219;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c217); }
+        if (peg$silentFails === 0) { peg$fail(peg$c220); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -5355,7 +5408,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpression();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c218(s3);
+          s1 = peg$c221(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5386,11 +5439,11 @@ function peg$parse(input, options) {
       s3 = peg$parse__();
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s4 = peg$c195;
+          s4 = peg$c198;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c196); }
+          if (peg$silentFails === 0) { peg$fail(peg$c199); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parse__();
@@ -5398,7 +5451,7 @@ function peg$parse(input, options) {
             s6 = peg$parseZngType();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s2;
-              s3 = peg$c219(s1, s6);
+              s3 = peg$c222(s1, s6);
               s2 = s3;
             } else {
               peg$currPos = s2;
@@ -5421,7 +5474,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c220(s1, s2);
+        s1 = peg$c223(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5438,124 +5491,124 @@ function peg$parse(input, options) {
   function peg$parseZngType() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c221) {
-      s0 = peg$c221;
+    if (input.substr(peg$currPos, 4) === peg$c224) {
+      s0 = peg$c224;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c222); }
+      if (peg$silentFails === 0) { peg$fail(peg$c225); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c223) {
-        s0 = peg$c223;
+      if (input.substr(peg$currPos, 4) === peg$c226) {
+        s0 = peg$c226;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c224); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c225) {
-          s0 = peg$c225;
+        if (input.substr(peg$currPos, 5) === peg$c228) {
+          s0 = peg$c228;
           peg$currPos += 5;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c226); }
+          if (peg$silentFails === 0) { peg$fail(peg$c229); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c227) {
-            s0 = peg$c227;
+          if (input.substr(peg$currPos, 6) === peg$c230) {
+            s0 = peg$c230;
             peg$currPos += 6;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c228); }
+            if (peg$silentFails === 0) { peg$fail(peg$c231); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 5) === peg$c229) {
-              s0 = peg$c229;
+            if (input.substr(peg$currPos, 5) === peg$c232) {
+              s0 = peg$c232;
               peg$currPos += 5;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c230); }
+              if (peg$silentFails === 0) { peg$fail(peg$c233); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 6) === peg$c231) {
-                s0 = peg$c231;
+              if (input.substr(peg$currPos, 6) === peg$c234) {
+                s0 = peg$c234;
                 peg$currPos += 6;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c232); }
+                if (peg$silentFails === 0) { peg$fail(peg$c235); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c233) {
-                  s0 = peg$c233;
+                if (input.substr(peg$currPos, 5) === peg$c236) {
+                  s0 = peg$c236;
                   peg$currPos += 5;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c234); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c237); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 6) === peg$c235) {
-                    s0 = peg$c235;
+                  if (input.substr(peg$currPos, 6) === peg$c238) {
+                    s0 = peg$c238;
                     peg$currPos += 6;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c236); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c239); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c237) {
-                      s0 = peg$c237;
+                    if (input.substr(peg$currPos, 7) === peg$c240) {
+                      s0 = peg$c240;
                       peg$currPos += 7;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c241); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 6) === peg$c239) {
-                        s0 = peg$c239;
+                      if (input.substr(peg$currPos, 6) === peg$c242) {
+                        s0 = peg$c242;
                         peg$currPos += 6;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c240); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c243); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 7) === peg$c241) {
-                          s0 = peg$c241;
+                        if (input.substr(peg$currPos, 7) === peg$c244) {
+                          s0 = peg$c244;
                           peg$currPos += 7;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c242); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c245); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c243) {
-                            s0 = peg$c243;
+                          if (input.substr(peg$currPos, 2) === peg$c246) {
+                            s0 = peg$c246;
                             peg$currPos += 2;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c244); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c247); }
                           }
                           if (s0 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 3) === peg$c245) {
-                              s0 = peg$c245;
+                            if (input.substr(peg$currPos, 3) === peg$c248) {
+                              s0 = peg$c248;
                               peg$currPos += 3;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c246); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c249); }
                             }
                             if (s0 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c247) {
-                                s0 = peg$c247;
+                              if (input.substr(peg$currPos, 4) === peg$c250) {
+                                s0 = peg$c250;
                                 peg$currPos += 4;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c248); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c251); }
                               }
                               if (s0 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 8) === peg$c249) {
-                                  s0 = peg$c249;
+                                if (input.substr(peg$currPos, 8) === peg$c252) {
+                                  s0 = peg$c252;
                                   peg$currPos += 8;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c250); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c253); }
                                 }
                               }
                             }
@@ -5602,7 +5655,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c251(s1, s4);
+              s1 = peg$c254(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5645,7 +5698,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c73();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5662,12 +5715,12 @@ function peg$parse(input, options) {
   function peg$parseFunctionNameStart() {
     var s0;
 
-    if (peg$c252.test(input.charAt(peg$currPos))) {
+    if (peg$c255.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c256); }
     }
 
     return s0;
@@ -5678,12 +5731,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseFunctionNameStart();
     if (s0 === peg$FAILED) {
-      if (peg$c254.test(input.charAt(peg$currPos))) {
+      if (peg$c257.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c255); }
+        if (peg$silentFails === 0) { peg$fail(peg$c258); }
       }
     }
 
@@ -5713,7 +5766,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpression();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c256(s1, s7);
+              s4 = peg$c259(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5749,7 +5802,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpression();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c256(s1, s7);
+                s4 = peg$c259(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5770,7 +5823,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c257(s1, s2);
+        s1 = peg$c260(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5785,7 +5838,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c258();
+        s1 = peg$c261();
       }
       s0 = s1;
     }
@@ -5804,11 +5857,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s5 = peg$c84;
+          s5 = peg$c87;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c85); }
+          if (peg$silentFails === 0) { peg$fail(peg$c88); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5818,11 +5871,11 @@ function peg$parse(input, options) {
               s8 = peg$parse__();
               if (s8 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s9 = peg$c86;
+                  s9 = peg$c89;
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c87); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c90); }
                 }
                 if (s9 !== peg$FAILED) {
                   s4 = [s4, s5, s6, s7, s8, s9];
@@ -5856,11 +5909,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s5 = peg$c81;
+            s5 = peg$c84;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c82); }
+            if (peg$silentFails === 0) { peg$fail(peg$c85); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5869,7 +5922,7 @@ function peg$parse(input, options) {
               s8 = peg$parsefieldName();
               if (s8 !== peg$FAILED) {
                 peg$savedPos = s7;
-                s8 = peg$c259(s1, s8);
+                s8 = peg$c262(s1, s8);
               }
               s7 = s8;
               if (s7 !== peg$FAILED) {
@@ -5898,11 +5951,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 91) {
-            s5 = peg$c84;
+            s5 = peg$c87;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c85); }
+            if (peg$silentFails === 0) { peg$fail(peg$c88); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5912,11 +5965,11 @@ function peg$parse(input, options) {
                 s8 = peg$parse__();
                 if (s8 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s9 = peg$c86;
+                    s9 = peg$c89;
                     peg$currPos++;
                   } else {
                     s9 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c87); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c90); }
                   }
                   if (s9 !== peg$FAILED) {
                     s4 = [s4, s5, s6, s7, s8, s9];
@@ -5950,11 +6003,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 46) {
-              s5 = peg$c81;
+              s5 = peg$c84;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c82); }
+              if (peg$silentFails === 0) { peg$fail(peg$c85); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
@@ -5963,7 +6016,7 @@ function peg$parse(input, options) {
                 s8 = peg$parsefieldName();
                 if (s8 !== peg$FAILED) {
                   peg$savedPos = s7;
-                  s8 = peg$c259(s1, s8);
+                  s8 = peg$c262(s1, s8);
                 }
                 s7 = s8;
                 if (s7 !== peg$FAILED) {
@@ -5989,7 +6042,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260(s1, s2);
+        s1 = peg$c263(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6017,12 +6070,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c68) {
-                s3 = peg$c68;
+              if (input.substr(peg$currPos, 3) === peg$c71) {
+                s3 = peg$c71;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c261); }
+                if (peg$silentFails === 0) { peg$fail(peg$c264); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -6067,44 +6120,44 @@ function peg$parse(input, options) {
   function peg$parsesec_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c262) {
-      s0 = peg$c262;
+    if (input.substr(peg$currPos, 7) === peg$c265) {
+      s0 = peg$c265;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c263); }
+      if (peg$silentFails === 0) { peg$fail(peg$c266); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c264) {
-        s0 = peg$c264;
+      if (input.substr(peg$currPos, 6) === peg$c267) {
+        s0 = peg$c267;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c265); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c266) {
-          s0 = peg$c266;
+        if (input.substr(peg$currPos, 4) === peg$c269) {
+          s0 = peg$c269;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c267); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c268) {
-            s0 = peg$c268;
+          if (input.substr(peg$currPos, 3) === peg$c271) {
+            s0 = peg$c271;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c269); }
+            if (peg$silentFails === 0) { peg$fail(peg$c272); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c270;
+              s0 = peg$c273;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c271); }
+              if (peg$silentFails === 0) { peg$fail(peg$c274); }
             }
           }
         }
@@ -6117,44 +6170,44 @@ function peg$parse(input, options) {
   function peg$parsemin_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c272) {
-      s0 = peg$c272;
+    if (input.substr(peg$currPos, 7) === peg$c275) {
+      s0 = peg$c275;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c273); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c274) {
-        s0 = peg$c274;
+      if (input.substr(peg$currPos, 6) === peg$c277) {
+        s0 = peg$c277;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c275); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c276) {
-          s0 = peg$c276;
+        if (input.substr(peg$currPos, 4) === peg$c279) {
+          s0 = peg$c279;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c277); }
+          if (peg$silentFails === 0) { peg$fail(peg$c280); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c119) {
-            s0 = peg$c119;
+          if (input.substr(peg$currPos, 3) === peg$c122) {
+            s0 = peg$c122;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c278); }
+            if (peg$silentFails === 0) { peg$fail(peg$c281); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c279;
+              s0 = peg$c282;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c280); }
+              if (peg$silentFails === 0) { peg$fail(peg$c283); }
             }
           }
         }
@@ -6167,44 +6220,44 @@ function peg$parse(input, options) {
   function peg$parsehour_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c281) {
-      s0 = peg$c281;
+    if (input.substr(peg$currPos, 5) === peg$c284) {
+      s0 = peg$c284;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c285); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c283) {
-        s0 = peg$c283;
+      if (input.substr(peg$currPos, 3) === peg$c286) {
+        s0 = peg$c286;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c287); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c285) {
-          s0 = peg$c285;
+        if (input.substr(peg$currPos, 2) === peg$c288) {
+          s0 = peg$c288;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+          if (peg$silentFails === 0) { peg$fail(peg$c289); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c287;
+            s0 = peg$c290;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c288); }
+            if (peg$silentFails === 0) { peg$fail(peg$c291); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c289) {
-              s0 = peg$c289;
+            if (input.substr(peg$currPos, 4) === peg$c292) {
+              s0 = peg$c292;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c290); }
+              if (peg$silentFails === 0) { peg$fail(peg$c293); }
             }
           }
         }
@@ -6217,28 +6270,28 @@ function peg$parse(input, options) {
   function peg$parseday_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c291) {
-      s0 = peg$c291;
+    if (input.substr(peg$currPos, 4) === peg$c294) {
+      s0 = peg$c294;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c292); }
+      if (peg$silentFails === 0) { peg$fail(peg$c295); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c293) {
-        s0 = peg$c293;
+      if (input.substr(peg$currPos, 3) === peg$c296) {
+        s0 = peg$c296;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c294); }
+        if (peg$silentFails === 0) { peg$fail(peg$c297); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c295;
+          s0 = peg$c298;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c296); }
+          if (peg$silentFails === 0) { peg$fail(peg$c299); }
         }
       }
     }
@@ -6249,44 +6302,44 @@ function peg$parse(input, options) {
   function peg$parseweek_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c297) {
-      s0 = peg$c297;
+    if (input.substr(peg$currPos, 5) === peg$c300) {
+      s0 = peg$c300;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c298); }
+      if (peg$silentFails === 0) { peg$fail(peg$c301); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c299) {
-        s0 = peg$c299;
+      if (input.substr(peg$currPos, 4) === peg$c302) {
+        s0 = peg$c302;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c300); }
+        if (peg$silentFails === 0) { peg$fail(peg$c303); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c301) {
-          s0 = peg$c301;
+        if (input.substr(peg$currPos, 3) === peg$c304) {
+          s0 = peg$c304;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c302); }
+          if (peg$silentFails === 0) { peg$fail(peg$c305); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c303) {
-            s0 = peg$c303;
+          if (input.substr(peg$currPos, 2) === peg$c306) {
+            s0 = peg$c306;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c304); }
+            if (peg$silentFails === 0) { peg$fail(peg$c307); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c305;
+              s0 = peg$c308;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c306); }
+              if (peg$silentFails === 0) { peg$fail(peg$c309); }
             }
           }
         }
@@ -6300,16 +6353,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c264) {
-      s1 = peg$c264;
+    if (input.substr(peg$currPos, 6) === peg$c267) {
+      s1 = peg$c267;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c265); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c307();
+      s1 = peg$c310();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6324,7 +6377,7 @@ function peg$parse(input, options) {
           s3 = peg$parsesec_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c308(s1);
+            s1 = peg$c311(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6347,16 +6400,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c274) {
-      s1 = peg$c274;
+    if (input.substr(peg$currPos, 6) === peg$c277) {
+      s1 = peg$c277;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c275); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c309();
+      s1 = peg$c312();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6371,7 +6424,7 @@ function peg$parse(input, options) {
           s3 = peg$parsemin_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c310(s1);
+            s1 = peg$c313(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6394,16 +6447,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c289) {
-      s1 = peg$c289;
+    if (input.substr(peg$currPos, 4) === peg$c292) {
+      s1 = peg$c292;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c290); }
+      if (peg$silentFails === 0) { peg$fail(peg$c293); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c311();
+      s1 = peg$c314();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6418,7 +6471,7 @@ function peg$parse(input, options) {
           s3 = peg$parsehour_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c312(s1);
+            s1 = peg$c315(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6441,16 +6494,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c293) {
-      s1 = peg$c293;
+    if (input.substr(peg$currPos, 3) === peg$c296) {
+      s1 = peg$c296;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c294); }
+      if (peg$silentFails === 0) { peg$fail(peg$c297); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c313();
+      s1 = peg$c316();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6465,7 +6518,7 @@ function peg$parse(input, options) {
           s3 = peg$parseday_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c314(s1);
+            s1 = peg$c317(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6498,7 +6551,7 @@ function peg$parse(input, options) {
         s3 = peg$parseweek_abbrev();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c315(s1);
+          s1 = peg$c318(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6524,31 +6577,31 @@ function peg$parse(input, options) {
     s2 = peg$parseunsignedInteger();
     if (s2 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c81;
+        s3 = peg$c84;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseunsignedInteger();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s5 = peg$c81;
+            s5 = peg$c84;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c82); }
+            if (peg$silentFails === 0) { peg$fail(peg$c85); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parseunsignedInteger();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s7 = peg$c81;
+                s7 = peg$c84;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                if (peg$silentFails === 0) { peg$fail(peg$c85); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parseunsignedInteger();
@@ -6585,7 +6638,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c316(s1);
+      s1 = peg$c319(s1);
     }
     s0 = s1;
 
@@ -6597,11 +6650,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c195;
+      s1 = peg$c198;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesuint();
@@ -6639,7 +6692,7 @@ function peg$parse(input, options) {
       s2 = peg$parseip6tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c317(s1, s2);
+        s1 = peg$c320(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6660,12 +6713,12 @@ function peg$parse(input, options) {
           s3 = peg$parseh_append();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c318) {
-            s3 = peg$c318;
+          if (input.substr(peg$currPos, 2) === peg$c321) {
+            s3 = peg$c321;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c319); }
+            if (peg$silentFails === 0) { peg$fail(peg$c322); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6678,7 +6731,7 @@ function peg$parse(input, options) {
               s5 = peg$parseip6tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c320(s1, s2, s4, s5);
+                s1 = peg$c323(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6702,12 +6755,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c318) {
-          s1 = peg$c318;
+        if (input.substr(peg$currPos, 2) === peg$c321) {
+          s1 = peg$c321;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c319); }
+          if (peg$silentFails === 0) { peg$fail(peg$c322); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6720,7 +6773,7 @@ function peg$parse(input, options) {
             s3 = peg$parseip6tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c321(s2, s3);
+              s1 = peg$c324(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6745,16 +6798,16 @@ function peg$parse(input, options) {
               s3 = peg$parseh_append();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c318) {
-                s3 = peg$c318;
+              if (input.substr(peg$currPos, 2) === peg$c321) {
+                s3 = peg$c321;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c319); }
+                if (peg$silentFails === 0) { peg$fail(peg$c322); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c322(s1, s2);
+                s1 = peg$c325(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6770,16 +6823,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c318) {
-              s1 = peg$c318;
+            if (input.substr(peg$currPos, 2) === peg$c321) {
+              s1 = peg$c321;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c319); }
+              if (peg$silentFails === 0) { peg$fail(peg$c322); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c323();
+              s1 = peg$c326();
             }
             s0 = s1;
           }
@@ -6806,17 +6859,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c195;
+      s1 = peg$c198;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseh16();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c324(s2);
+        s1 = peg$c327(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6837,15 +6890,15 @@ function peg$parse(input, options) {
     s1 = peg$parseh16();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c195;
+        s2 = peg$c198;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c196); }
+        if (peg$silentFails === 0) { peg$fail(peg$c199); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c325(s1);
+        s1 = peg$c328(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6866,17 +6919,17 @@ function peg$parse(input, options) {
     s1 = peg$parseaddr();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c216;
+        s2 = peg$c219;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c217); }
+        if (peg$silentFails === 0) { peg$fail(peg$c220); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c326(s1, s3);
+          s1 = peg$c329(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6901,17 +6954,17 @@ function peg$parse(input, options) {
     s1 = peg$parseip6addr();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c216;
+        s2 = peg$c219;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c217); }
+        if (peg$silentFails === 0) { peg$fail(peg$c220); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c327(s1, s3);
+          s1 = peg$c330(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6936,7 +6989,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesuint();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c328(s1);
+      s1 = peg$c331(s1);
     }
     s0 = s1;
 
@@ -6948,22 +7001,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c79.test(input.charAt(peg$currPos))) {
+    if (peg$c82.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c80); }
+      if (peg$silentFails === 0) { peg$fail(peg$c83); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c79.test(input.charAt(peg$currPos))) {
+        if (peg$c82.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
       }
     } else {
@@ -6971,7 +7024,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -6985,7 +7038,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesinteger();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c328(s1);
+      s1 = peg$c331(s1);
     }
     s0 = s1;
 
@@ -6996,12 +7049,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c329.test(input.charAt(peg$currPos))) {
+    if (peg$c332.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c333); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -7010,7 +7063,7 @@ function peg$parse(input, options) {
       s2 = peg$parsesuint();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c73();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7031,7 +7084,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesdouble();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c331(s1);
+      s1 = peg$c334(s1);
     }
     s0 = s1;
 
@@ -7065,11 +7118,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c81;
+          s3 = peg$c84;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c82); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
@@ -7089,7 +7142,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c332();
+              s1 = peg$c335();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7125,11 +7178,11 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c81;
+          s2 = peg$c84;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c82); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
@@ -7149,7 +7202,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c332();
+              s1 = peg$c335();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7176,38 +7229,38 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     if (input.charCodeAt(peg$currPos) === 48) {
-      s0 = peg$c333;
+      s0 = peg$c336;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c334); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$c335.test(input.charAt(peg$currPos))) {
+      if (peg$c338.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c336); }
+        if (peg$silentFails === 0) { peg$fail(peg$c339); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c79.test(input.charAt(peg$currPos))) {
+        if (peg$c82.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c79.test(input.charAt(peg$currPos))) {
+          if (peg$c82.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c83); }
           }
         }
         if (s2 !== peg$FAILED) {
@@ -7229,12 +7282,12 @@ function peg$parse(input, options) {
   function peg$parsedoubleDigit() {
     var s0;
 
-    if (peg$c79.test(input.charAt(peg$currPos))) {
+    if (peg$c82.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c80); }
+      if (peg$silentFails === 0) { peg$fail(peg$c83); }
     }
 
     return s0;
@@ -7244,12 +7297,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c337) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c340) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesinteger();
@@ -7284,7 +7337,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c339(s1);
+      s1 = peg$c342(s1);
     }
     s0 = s1;
 
@@ -7294,12 +7347,12 @@ function peg$parse(input, options) {
   function peg$parsehexdigit() {
     var s0;
 
-    if (peg$c340.test(input.charAt(peg$currPos))) {
+    if (peg$c343.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
+      if (peg$silentFails === 0) { peg$fail(peg$c344); }
     }
 
     return s0;
@@ -7321,7 +7374,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c342(s1);
+      s1 = peg$c345(s1);
     }
     s0 = s1;
 
@@ -7333,11 +7386,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c343;
+      s1 = peg$c346;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c344); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseescapeSequence();
@@ -7360,12 +7413,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c345.test(input.charAt(peg$currPos))) {
+      if (peg$c348.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c346); }
+        if (peg$silentFails === 0) { peg$fail(peg$c349); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parsews();
@@ -7383,11 +7436,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c347); }
+          if (peg$silentFails === 0) { peg$fail(peg$c350); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c70();
+          s1 = peg$c73();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7407,11 +7460,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c348;
+      s1 = peg$c351;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c349); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -7422,15 +7475,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c348;
+          s3 = peg$c351;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c349); }
+          if (peg$silentFails === 0) { peg$fail(peg$c352); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c350(s2);
+          s1 = peg$c353(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7447,11 +7500,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c351;
+        s1 = peg$c354;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c352); }
+        if (peg$silentFails === 0) { peg$fail(peg$c355); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7462,15 +7515,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c351;
+            s3 = peg$c354;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c352); }
+            if (peg$silentFails === 0) { peg$fail(peg$c355); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c350(s2);
+            s1 = peg$c353(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7496,11 +7549,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c348;
+      s2 = peg$c351;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c349); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -7518,11 +7571,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c347); }
+        if (peg$silentFails === 0) { peg$fail(peg$c350); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c73();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7535,11 +7588,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c343;
+        s1 = peg$c346;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c344); }
+        if (peg$silentFails === 0) { peg$fail(peg$c347); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -7567,11 +7620,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c351;
+      s2 = peg$c354;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c352); }
+      if (peg$silentFails === 0) { peg$fail(peg$c355); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -7589,11 +7642,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c347); }
+        if (peg$silentFails === 0) { peg$fail(peg$c350); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c73();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7606,11 +7659,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c343;
+        s1 = peg$c346;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c344); }
+        if (peg$silentFails === 0) { peg$fail(peg$c347); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -7636,11 +7689,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c353;
+      s1 = peg$c356;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c354); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsehexdigit();
@@ -7648,7 +7701,7 @@ function peg$parse(input, options) {
         s3 = peg$parsehexdigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c355();
+          s1 = peg$c358();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7676,110 +7729,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c351;
+      s0 = peg$c354;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c352); }
+      if (peg$silentFails === 0) { peg$fail(peg$c355); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c348;
+        s0 = peg$c351;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c349); }
+        if (peg$silentFails === 0) { peg$fail(peg$c352); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c343;
+          s0 = peg$c346;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c344); }
+          if (peg$silentFails === 0) { peg$fail(peg$c347); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c356;
+            s1 = peg$c359;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c357); }
+            if (peg$silentFails === 0) { peg$fail(peg$c360); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c358();
+            s1 = peg$c361();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c359;
+              s1 = peg$c362;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c360); }
+              if (peg$silentFails === 0) { peg$fail(peg$c363); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c361();
+              s1 = peg$c364();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c362;
+                s1 = peg$c365;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c363); }
+                if (peg$silentFails === 0) { peg$fail(peg$c366); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c364();
+                s1 = peg$c367();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c365;
+                  s1 = peg$c368;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c366); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c369); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c367();
+                  s1 = peg$c370();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c368;
+                    s1 = peg$c371;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c369); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c372); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c370();
+                    s1 = peg$c373();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c371;
+                      s1 = peg$c374;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c372); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c375); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c373();
+                      s1 = peg$c376();
                     }
                     s0 = s1;
                   }
@@ -7799,15 +7852,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c140;
+      s1 = peg$c143;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c144); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c374();
+      s1 = peg$c377();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7821,7 +7874,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c375();
+        s1 = peg$c378();
       }
       s0 = s1;
     }
@@ -7834,11 +7887,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c376;
+      s1 = peg$c379;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c377); }
+      if (peg$silentFails === 0) { peg$fail(peg$c380); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7870,7 +7923,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c378(s2);
+        s1 = peg$c381(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7883,19 +7936,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c376;
+        s1 = peg$c379;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c377); }
+        if (peg$silentFails === 0) { peg$fail(peg$c380); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c379;
+          s2 = peg$c382;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c380); }
+          if (peg$silentFails === 0) { peg$fail(peg$c383); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7954,15 +8007,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c381;
+              s4 = peg$c384;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c382); }
+              if (peg$silentFails === 0) { peg$fail(peg$c385); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c378(s3);
+              s1 = peg$c381(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7990,21 +8043,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c216;
+      s1 = peg$c219;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c217); }
+      if (peg$silentFails === 0) { peg$fail(peg$c220); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsereBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c216;
+          s3 = peg$c219;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c217); }
+          if (peg$silentFails === 0) { peg$fail(peg$c220); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -8031,39 +8084,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c383.test(input.charAt(peg$currPos))) {
+    if (peg$c386.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c384); }
+      if (peg$silentFails === 0) { peg$fail(peg$c387); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c385) {
-        s2 = peg$c385;
+      if (input.substr(peg$currPos, 2) === peg$c388) {
+        s2 = peg$c388;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c386); }
+        if (peg$silentFails === 0) { peg$fail(peg$c389); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c383.test(input.charAt(peg$currPos))) {
+        if (peg$c386.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c384); }
+          if (peg$silentFails === 0) { peg$fail(peg$c387); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c385) {
-            s2 = peg$c385;
+          if (input.substr(peg$currPos, 2) === peg$c388) {
+            s2 = peg$c388;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c386); }
+            if (peg$silentFails === 0) { peg$fail(peg$c389); }
           }
         }
       }
@@ -8072,7 +8125,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -8082,12 +8135,12 @@ function peg$parse(input, options) {
   function peg$parseescapedChar() {
     var s0;
 
-    if (peg$c387.test(input.charAt(peg$currPos))) {
+    if (peg$c390.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+      if (peg$silentFails === 0) { peg$fail(peg$c391); }
     }
 
     return s0;
@@ -8097,51 +8150,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c389;
+      s0 = peg$c392;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c391;
+        s0 = peg$c394;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c392); }
+        if (peg$silentFails === 0) { peg$fail(peg$c395); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c393;
+          s0 = peg$c396;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c394); }
+          if (peg$silentFails === 0) { peg$fail(peg$c397); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c395;
+            s0 = peg$c398;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c396); }
+            if (peg$silentFails === 0) { peg$fail(peg$c399); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c397;
+              s0 = peg$c400;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c398); }
+              if (peg$silentFails === 0) { peg$fail(peg$c401); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c399;
+                s0 = peg$c402;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c400); }
+                if (peg$silentFails === 0) { peg$fail(peg$c403); }
               }
             }
           }
@@ -8169,7 +8222,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
 
     return s0;
@@ -8198,7 +8251,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c350); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {
@@ -8351,9 +8404,9 @@ function peg$parse(input, options) {
     return [first, ...rest];
   }
 
-  function makeGroupByProc(duration, limit, keys, reducers) {
+  function makeGroupByProc(duration, sorted, limit, keys, reducers) {
     if (limit === null) { limit = undefined; }
-    return { op: "GroupByProc", keys, reducers, duration, limit };
+      return { op: "GroupByProc", keys, reducers, duration, limit , sorted};
   }
 
   function makeUnaryExpr(operator, operand) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -227,6 +227,9 @@ groupByKey
 everyDur
   = "every"i _ dur:duration { RETURN(dur) }
 
+groupBySorted
+  = _ "-sorted"i _ dir:sinteger { RETURN(parseInt(dir)) }
+
 equalityToken
   = EqualityOperator / RelativeOperator
 
@@ -318,7 +321,7 @@ fieldReducer
   }
 
 reducerProc
-  = every:(everyDur _)? reducers:reducerList keys:(_ groupByKeys)? limit:procLimitArg? {
+  = every:(everyDur _)? reducers:reducerList keys:(_ groupByKeys)? sorted:groupBySorted? limit:procLimitArg? {
     if ISNOTNULL(OR(keys, every)) {
       if ISNOTNULL(keys) {
         keys = ASSERT_ARRAY(keys)[1]
@@ -330,7 +333,7 @@ reducerProc
         every = ASSERT_ARRAY(every)[0]
       }
 
-      RETURN(makeGroupByProc(every, limit, keys, reducers))
+      RETURN(makeGroupByProc(every, sorted, limit, keys, reducers))
     }
 
     RETURN(makeReducerProc(reducers))

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -213,8 +213,16 @@ proc
       RETURN(proc)
     }
 
-groupBy
-  = "by"i _ list:fieldRefDotOnlyList { RETURN(list) }
+groupByKeys
+  = "by"i _ first:groupByKey rest:(__ "," __ cl:groupByKey { RETURN(cl) })* {
+      RETURN(makeGroupByKeys(first, rest))
+    }
+
+
+groupByKey
+  = Assignment
+  / field:fieldExpr { RETURN(makeGroupByKey(TEXT, field)) }
+
 
 everyDur
   = "every"i _ dur:duration { RETURN(dur) }
@@ -310,7 +318,7 @@ fieldReducer
   }
 
 reducerProc
-  = every:(everyDur _)? reducers:reducerList keys:(_ groupBy)? limit:procLimitArg? {
+  = every:(everyDur _)? reducers:reducerList keys:(_ groupByKeys)? limit:procLimitArg? {
     if ISNOTNULL(OR(keys, every)) {
       if ISNOTNULL(keys) {
         keys = ASSERT_ARRAY(keys)[1]

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -406,13 +406,13 @@ uniq
     }
 
 put
-  = "put"i _ first:PutClause rest:(__ "," __ cl:PutClause { RETURN(cl) })* {
+  = "put"i _ first:Assignment rest:(__ "," __ cl:Assignment { RETURN(cl) })* {
       RETURN(makePutProc(first, rest))
     }
 
-PutClause
+Assignment
   = f:fieldName __ "=" __ e:Expression {
-      RETURN(makePutClause(f, e))
+      RETURN(makeAssignment(f, e))
     }
 
 PrimaryExpression


### PR DESCRIPTION
(currently based on groupby-computed-keys branch, and includes the commit of the time-trunc branch... will rebase as those get merged)

Now that zql can group by computed keys, `every X reducer() by field` can be computed as `reducer by ts=Time.trunc("ts", X), field`.

This PR makes that change by converting the Duration AST node (resulting from `every` in zql) into a new groupby key representing the time trunc expression.

There are still some behavioral differences brought by this PR:
1. Results for a time bin are no longer emitted as soon as record timestamps have advanced past that. Instead, they are emitted all at once on eof. This fixes #847.
2. Results are not sorted by ts. This is because they are now handled as regular keys and so fall under the "Records and spans generated by time-binning are partially ordered by timestamp coincident with search direction." groupby contract.

This second point needs some discussion and is the reason I've put this up as a draft PR. Options I see:

- Go with this new behavior and like for other groupby keys, require an explicit `sort ts` after a time-binned groupby where needed.
- Implicitly insert a `sort ts` proc after a time-binned groupby to maintain prior behavior.

I'm in favor of the first option. (I believe this is what @nwt has been advocating).
 
Also, further out, we may want to do "early emitting" of completed bins in a more general way, for _any_ key that is known to be sorted at the input point. That might be a good point to revisit this question and possibly auto-sort on timebinned groupby outputs on time-sorted streams. 

closes #828 