### PR TITLE
Space name constraints

### DIFF
--- a/pkg/fs/jsonfile.go
+++ b/pkg/fs/jsonfile.go
@@ -36,9 +36,8 @@ func UnmarshalJSONFile(filename string, v interface{}) error {
 	if err != nil {
 		return err
 	}
-
-	if err = json.Unmarshal(data, v); err != nil {
-		return fmt.Errorf("%s: unmarshaling error: %s", filename, err)
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("%s: unmarshaling error: %w", filename, err)
 	}
 	return nil
 }

--- a/pkg/fs/jsonfile.go
+++ b/pkg/fs/jsonfile.go
@@ -1,0 +1,44 @@
+package fs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+// MarshalJSONFile writes the JSON encoding of v to a file named by filename.
+// The file is created atomically. If the file does not exist, Marshal creates
+// it with permissions perm.  Internally MarshalJSONFile uses json.Marshal.
+func MarshalJSONFile(v interface{}, filename string, perm os.FileMode) error {
+	tmppath := filename + ".tmp"
+	f, err := OpenFile(tmppath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_EXCL, perm)
+	if err != nil {
+		return err
+	}
+	if err := json.NewEncoder(f).Encode(v); err != nil {
+		f.Close()
+		os.Remove(tmppath)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmppath)
+		return err
+	}
+	return os.Rename(tmppath, filename)
+}
+
+// UnmarshalJSONFile parses JSON-encoded data from the file named by filename
+// and stores the result in the value pointed to by v.  Internally, Unmarshal
+// uses json.Unmarshal.
+func UnmarshalJSONFile(filename string, v interface{}) error {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	if err = json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("%s: unmarshaling error: %s", filename, err)
+	}
+	return nil
+}

--- a/pkg/fs/jsonfile.go
+++ b/pkg/fs/jsonfile.go
@@ -9,7 +9,7 @@ import (
 
 // MarshalJSONFile writes the JSON encoding of v to a file named by filename.
 // The file is created atomically. If the file does not exist, Marshal creates
-// it with permissions perm.  Internally MarshalJSONFile uses json.Marshal.
+// it with permissions perm.
 func MarshalJSONFile(v interface{}, filename string, perm os.FileMode) error {
 	tmppath := filename + ".tmp"
 	f, err := OpenFile(tmppath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_EXCL, perm)

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -254,17 +254,19 @@ func handleSpacePut(c *Core, w http.ResponseWriter, r *http.Request) {
 	if s == nil {
 		return
 	}
+
 	_, cancel, err := s.StartOp(r.Context())
 	if err != nil {
 		respondError(c, w, r, err)
 		return
 	}
 	defer cancel()
+
 	var req api.SpacePutRequest
 	if !request(c, w, r, &req) {
 		return
 	}
-	if err := s.Update(req); err != nil {
+	if err := c.spaces.UpdateSpace(s, req); err != nil {
 		respondError(c, w, r, err)
 		return
 	}

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -302,6 +302,22 @@ func TestSpacePostDuplicateName(t *testing.T) {
 	require.Equal(t, api.ErrSpaceExists, err)
 }
 
+func TestSpaceInvalidName(t *testing.T) {
+	ctx := context.Background()
+	_, client, done := newCore(t)
+	defer done()
+	t.Run("Post", func(t *testing.T) {
+		_, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test.bad"})
+		require.EqualError(t, err, "status code 400: name must contain only characters [a-zA-Z0-9_]")
+	})
+	t.Run("Put", func(t *testing.T) {
+		sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
+		require.NoError(t, err)
+		err = client.SpacePut(ctx, sp.ID, api.SpacePutRequest{Name: "test.bad"})
+		require.EqualError(t, err, "status code 400: name must contain only characters [a-zA-Z0-9_]")
+	})
+}
+
 func TestSpacePutDuplicateName(t *testing.T) {
 	ctx := context.Background()
 	_, client, done := newCore(t)

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -311,7 +311,7 @@ func TestSpacePutDuplicateName(t *testing.T) {
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test1"})
 	require.NoError(t, err)
 	err = client.SpacePut(ctx, sp.ID, api.SpacePutRequest{Name: "test"})
-	require.Regexp(t, "space with name 'test' already exists", err.Error())
+	assert.EqualError(t, err, "status code 409: space with name 'test' already exists")
 }
 
 func TestSpacePostDataPath(t *testing.T) {

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -191,11 +191,6 @@ func TestSearchError(t *testing.T) {
 	})
 }
 
-// XXX duplicate name tests:
-// - create space with dup name
-// - create subspace with dup name
-// - change name to dup name
-
 func TestSpaceList(t *testing.T) {
 	names := []string{"sp1", "sp2", "sp3", "sp4"}
 	var expected []api.SpaceInfo

--- a/zqd/space/archivespace.go
+++ b/zqd/space/archivespace.go
@@ -15,8 +15,8 @@ type archiveSpace struct {
 	spaceBase
 	path string
 
-	// muConf protects changes to configuration changes.
-	muConf sync.Mutex
+	// confmu protects changes to configuration changes.
+	confmu sync.Mutex
 	conf   config
 }
 
@@ -26,26 +26,43 @@ func (s *archiveSpace) Info(ctx context.Context) (api.SpaceInfo, error) {
 		return api.SpaceInfo{}, err
 	}
 
+	s.confmu.Lock()
+	defer s.confmu.Unlock()
 	si.Name = s.conf.Name
 	si.DataPath = s.conf.DataPath
 	return si, nil
 }
 
-func (s *archiveSpace) Update(req api.SpacePutRequest) error {
+func (s *archiveSpace) Name() string {
+	s.confmu.Lock()
+	defer s.confmu.Unlock()
+	return s.conf.Name
+}
+
+func (s *archiveSpace) update(req api.SpacePutRequest) error {
 	if req.Name == "" {
 		return zqe.E(zqe.Invalid, "cannot set name to an empty string")
 	}
 
-	s.muConf.Lock()
-	defer s.muConf.Unlock()
+	s.confmu.Lock()
+	defer s.confmu.Unlock()
 
-	s.conf.Name = req.Name
-	return s.conf.save(s.path)
+	conf := s.conf.clone()
+	conf.Name = req.Name
+	return s.updateConfigWithLock(conf)
+}
+
+func (s *archiveSpace) updateConfigWithLock(conf config) error {
+	if err := writeConfig(s.path, conf); err != nil {
+		return err
+	}
+	s.conf = conf
+	return nil
 }
 
 func (s *archiveSpace) delete() error {
-	s.muConf.Lock()
-	defer s.muConf.Unlock()
+	s.confmu.Lock()
+	defer s.confmu.Unlock()
 
 	if len(s.conf.Subspaces) != 0 {
 		return zqe.E(zqe.Conflict, "cannot delete space with subspaces")
@@ -61,12 +78,8 @@ func (s *archiveSpace) delete() error {
 }
 
 func (s *archiveSpace) CreateSubspace(req api.SubspacePostRequest) (*archiveSubspace, error) {
-	if req.Name == "" {
-		return nil, zqe.E(zqe.Invalid, "cannot set name to an empty string")
-	}
-
-	s.muConf.Lock()
-	defer s.muConf.Unlock()
+	s.confmu.Lock()
+	defer s.confmu.Unlock()
 
 	substore, err := archivestore.Load(s.conf.DataPath, &storage.ArchiveConfig{
 		OpenOptions: &req.OpenOptions,
@@ -80,8 +93,9 @@ func (s *archiveSpace) CreateSubspace(req api.SubspacePostRequest) (*archiveSubs
 		Name:        req.Name,
 		OpenOptions: req.OpenOptions,
 	}
-	s.conf.Subspaces = append(s.conf.Subspaces, subcfg)
-	if err := s.conf.save(s.path); err != nil {
+	newconf := s.conf.clone()
+	newconf.Subspaces = append(newconf.Subspaces, subcfg)
+	if err := s.updateConfigWithLock(newconf); err != nil {
 		return nil, err
 	}
 

--- a/zqd/space/archivespace.go
+++ b/zqd/space/archivespace.go
@@ -15,8 +15,7 @@ type archiveSpace struct {
 	spaceBase
 	path string
 
-	// confmu protects changes to configuration changes.
-	confmu sync.Mutex
+	confMu sync.Mutex
 	conf   config
 }
 
@@ -26,16 +25,16 @@ func (s *archiveSpace) Info(ctx context.Context) (api.SpaceInfo, error) {
 		return api.SpaceInfo{}, err
 	}
 
-	s.confmu.Lock()
-	defer s.confmu.Unlock()
+	s.confMu.Lock()
+	defer s.confMu.Unlock()
 	si.Name = s.conf.Name
 	si.DataPath = s.conf.DataPath
 	return si, nil
 }
 
 func (s *archiveSpace) Name() string {
-	s.confmu.Lock()
-	defer s.confmu.Unlock()
+	s.confMu.Lock()
+	defer s.confMu.Unlock()
 	return s.conf.Name
 }
 
@@ -44,8 +43,8 @@ func (s *archiveSpace) update(req api.SpacePutRequest) error {
 		return zqe.E(zqe.Invalid, "cannot set name to an empty string")
 	}
 
-	s.confmu.Lock()
-	defer s.confmu.Unlock()
+	s.confMu.Lock()
+	defer s.confMu.Unlock()
 
 	conf := s.conf.clone()
 	conf.Name = req.Name
@@ -61,8 +60,8 @@ func (s *archiveSpace) updateConfigWithLock(conf config) error {
 }
 
 func (s *archiveSpace) delete() error {
-	s.confmu.Lock()
-	defer s.confmu.Unlock()
+	s.confMu.Lock()
+	defer s.confMu.Unlock()
 
 	if len(s.conf.Subspaces) != 0 {
 		return zqe.E(zqe.Conflict, "cannot delete space with subspaces")
@@ -78,8 +77,8 @@ func (s *archiveSpace) delete() error {
 }
 
 func (s *archiveSpace) CreateSubspace(req api.SubspacePostRequest) (*archiveSubspace, error) {
-	s.confmu.Lock()
-	defer s.confmu.Unlock()
+	s.confMu.Lock()
+	defer s.confMu.Unlock()
 
 	substore, err := archivestore.Load(s.conf.DataPath, &storage.ArchiveConfig{
 		OpenOptions: &req.OpenOptions,

--- a/zqd/space/archivesubspace.go
+++ b/zqd/space/archivesubspace.go
@@ -13,17 +13,17 @@ type archiveSubspace struct {
 	parent *archiveSpace
 }
 
-func (s *archiveSubspace) Info(ctx context.Context) (info api.SpaceInfo, err error) {
+func (s *archiveSubspace) Info(ctx context.Context) (api.SpaceInfo, error) {
 	sum, err := s.store.Summary(ctx)
 	if err != nil {
-		return info, err
+		return api.SpaceInfo{}, err
 	}
 	var span *nano.Span
 	if sum.Span.Dur > 0 {
 		span = &sum.Span
 	}
 	var name, dp string
-	s.findConfig(func(i int) error {
+	err = s.findConfig(func(i int) error {
 		name = s.parent.conf.Subspaces[i].Name
 		dp = s.parent.conf.DataPath
 		return nil
@@ -36,7 +36,7 @@ func (s *archiveSubspace) Info(ctx context.Context) (info api.SpaceInfo, err err
 		Size:        sum.DataBytes,
 		Span:        span,
 		ParentID:    s.parent.ID(),
-	}, nil
+	}, err
 }
 
 func (s *archiveSubspace) update(req api.SpacePutRequest) error {
@@ -72,8 +72,8 @@ func (s *archiveSubspace) Name() string {
 }
 
 func (s *archiveSubspace) findConfig(fn func(int) error) error {
-	s.parent.confmu.Lock()
-	defer s.parent.confmu.Unlock()
+	s.parent.confMu.Lock()
+	defer s.parent.confMu.Unlock()
 	i := s.parent.conf.subspaceIndex(s.id)
 	if i == -1 {
 		// should not happen

--- a/zqd/space/archivesubspace.go
+++ b/zqd/space/archivesubspace.go
@@ -55,10 +55,7 @@ func (s *archiveSubspace) delete() error {
 	return s.findConfig(func(i int) error {
 		conf := s.parent.conf.clone()
 		conf.Subspaces = append(conf.Subspaces[:i], conf.Subspaces[i+1:]...)
-		if err := s.parent.updateConfigWithLock(conf); err != nil {
-			return err
-		}
-		return nil
+		return s.parent.updateConfigWithLock(conf)
 	})
 }
 

--- a/zqd/space/archivesubspace.go
+++ b/zqd/space/archivesubspace.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zqd/api"
-	"github.com/brimsec/zq/zqe"
 )
 
 type archiveSubspace struct {
@@ -14,43 +13,37 @@ type archiveSubspace struct {
 	parent *archiveSpace
 }
 
-func (s *archiveSubspace) Info(ctx context.Context) (api.SpaceInfo, error) {
+func (s *archiveSubspace) Info(ctx context.Context) (info api.SpaceInfo, err error) {
 	sum, err := s.store.Summary(ctx)
 	if err != nil {
-		return api.SpaceInfo{}, err
+		return info, err
 	}
 	var span *nano.Span
 	if sum.Span.Dur > 0 {
 		span = &sum.Span
 	}
-	var name string
-	err = s.findConfig(func(i int) error {
+	var name, dp string
+	s.findConfig(func(i int) error {
 		name = s.parent.conf.Subspaces[i].Name
+		dp = s.parent.conf.DataPath
 		return nil
 	})
-	if err != nil {
-		return api.SpaceInfo{}, err
-	}
-	spaceInfo := api.SpaceInfo{
+	return api.SpaceInfo{
 		ID:          s.id,
 		Name:        name,
-		DataPath:    s.parent.conf.DataPath,
+		DataPath:    dp,
 		StorageKind: sum.Kind,
 		Size:        sum.DataBytes,
 		Span:        span,
 		ParentID:    s.parent.ID(),
-	}
-	return spaceInfo, nil
+	}, nil
 }
 
-func (s *archiveSubspace) Update(req api.SpacePutRequest) error {
-	if req.Name == "" {
-		return zqe.E(zqe.Invalid, "cannot set name to an empty string")
-	}
-
+func (s *archiveSubspace) update(req api.SpacePutRequest) error {
 	return s.findConfig(func(i int) error {
-		s.parent.conf.Subspaces[i].Name = req.Name
-		return s.parent.conf.save(s.parent.path)
+		conf := s.parent.conf.clone()
+		conf.Subspaces[i].Name = req.Name
+		return s.parent.updateConfigWithLock(conf)
 	})
 }
 
@@ -60,20 +53,34 @@ func (s *archiveSubspace) delete() error {
 	}
 
 	return s.findConfig(func(i int) error {
-		s.parent.conf.Subspaces = append(s.parent.conf.Subspaces[:i], s.parent.conf.Subspaces[i+1:]...)
-		return s.parent.conf.save(s.parent.path)
+		conf := s.parent.conf.clone()
+		conf.Subspaces = append(conf.Subspaces[:i], conf.Subspaces[i+1:]...)
+		if err := s.parent.updateConfigWithLock(conf); err != nil {
+			return err
+		}
+		return nil
 	})
 }
 
-func (s *archiveSubspace) findConfig(fn func(i int) error) error {
-	s.parent.muConf.Lock()
-	defer s.parent.muConf.Unlock()
-
-	for i := range s.parent.conf.Subspaces {
-		if s.parent.conf.Subspaces[i].ID == s.id {
-			return fn(i)
-		}
+func (s *archiveSubspace) Name() string {
+	var name string
+	err := s.findConfig(func(i int) error {
+		name = s.parent.conf.Subspaces[i].Name
+		return nil
+	})
+	if err != nil {
+		panic(err)
 	}
-	// should not happen
-	return fmt.Errorf("subspace %s cannot find conf in parent %s", s.id, s.parent.id)
+	return name
+}
+
+func (s *archiveSubspace) findConfig(fn func(int) error) error {
+	s.parent.confmu.Lock()
+	defer s.parent.confmu.Unlock()
+	i := s.parent.conf.subspaceIndex(s.id)
+	if i == -1 {
+		// should not happen
+		return fmt.Errorf("subspace %s cannot find conf in parent %s", s.id, s.parent.id)
+	}
+	return fn(i)
 }

--- a/zqd/space/config.go
+++ b/zqd/space/config.go
@@ -1,0 +1,105 @@
+package space
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/brimsec/zq/pkg/fs"
+	"github.com/brimsec/zq/zqd/api"
+	"github.com/brimsec/zq/zqd/storage"
+	"github.com/brimsec/zq/zqe"
+)
+
+var nameRegexp = regexp.MustCompile("[^a-zA-Z0-9_]")
+
+const configVersion = 1
+
+type config struct {
+	Version  int    `json:"version"`
+	Name     string `json:"name"`
+	DataPath string `json:"data_path"`
+	// XXX PcapPath should be named pcap_path in json land. To avoid having to
+	// do a migration we'll keep this as-is for now.
+	PcapPath  string           `json:"packet_path"`
+	Storage   storage.Config   `json:"storage"`
+	Subspaces []subspaceConfig `json:"subspaces"`
+}
+
+type subspaceConfig struct {
+	ID          api.SpaceID                `json:"id"`
+	Name        string                     `json:"name"`
+	OpenOptions storage.ArchiveOpenOptions `json:"open_options"`
+}
+
+func (c config) clone() config {
+	n := c
+	n.Subspaces = append([]subspaceConfig{}, c.Subspaces...)
+	return n
+}
+
+func (c config) subspaceIndex(id api.SpaceID) int {
+	for i, sub := range c.Subspaces {
+		if sub.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+// loadConfig loads the contents of config.json in a space's path.
+func loadConfig(spacePath string) (config, error) {
+	var c config
+	path := filepath.Join(spacePath, configFile)
+	if err := fs.UnmarshalJSONFile(path, &c); err != nil {
+		return c, err
+	}
+	if c.Name == "" {
+		// Ensure that name is not blank for spaces created before the
+		// zq#721 work to use space ids.
+		c.Name = filepath.Base(spacePath)
+	}
+	if c.Storage.Kind == storage.UnknownStore {
+		c.Storage.Kind = storage.FileStore
+	}
+	return c, nil
+}
+
+func writeConfig(spacePath string, c config) error {
+	path := filepath.Join(spacePath, configFile)
+	return fs.MarshalJSONFile(c, path, 0644)
+}
+
+func validateName(names map[string]api.SpaceID, name string) error {
+	if name == "" {
+		return zqe.E(zqe.Invalid, "cannot set name to an empty string")
+	}
+	if nameRegexp.MatchString(name) {
+		return zqe.E(zqe.Invalid, "name must contain only characters [a-zA-Z0-9_]")
+	}
+	if _, exists := names[name]; exists {
+		return zqe.E(zqe.Conflict, "space with name '%s' already exists", name)
+	}
+	return nil
+}
+
+// safeName converts the proposed name to a name that adheres to the constraints
+// placed on a space's name (i.e. follows the name regex and is unique). In
+// order to ensure the generated name is unique this should be called with the
+// manager lock held.
+func safeName(names map[string]api.SpaceID, proposed string) string {
+	base := filepath.Base(proposed)
+	base = strings.ReplaceAll(base, " ", "_")
+	base = strings.ReplaceAll(base, ".", "_")
+	base = strings.ReplaceAll(base, "-", "_")
+	base = nameRegexp.ReplaceAllString(base, "")
+	name := base
+	// ensure uniqueness
+	for i := 1; ; i++ {
+		if _, ok := names[name]; !ok {
+			return name
+		}
+		name = fmt.Sprintf("%s_%02d", base, i)
+	}
+}

--- a/zqd/space/config.go
+++ b/zqd/space/config.go
@@ -78,7 +78,7 @@ func validateName(names map[string]api.SpaceID, name string) error {
 	if nameRegexp.MatchString(name) {
 		return zqe.E(zqe.Invalid, "name must contain only characters [a-zA-Z0-9_]")
 	}
-	if _, exists := names[name]; exists {
+	if _, ok := names[name]; ok {
 		return zqe.E(zqe.Conflict, "space with name '%s' already exists", name)
 	}
 	return nil

--- a/zqd/space/filespace.go
+++ b/zqd/space/filespace.go
@@ -17,8 +17,7 @@ type fileSpace struct {
 	spaceBase
 	path string
 
-	// confmu protects changes to configuration changes.
-	confmu sync.Mutex
+	confMu sync.Mutex
 	conf   config
 }
 
@@ -41,8 +40,8 @@ func (s *fileSpace) Info(ctx context.Context) (api.SpaceInfo, error) {
 }
 
 func (s *fileSpace) Name() string {
-	s.confmu.Lock()
-	defer s.confmu.Unlock()
+	s.confMu.Lock()
+	defer s.confMu.Unlock()
 	return s.conf.Name
 }
 
@@ -50,16 +49,16 @@ func (s *fileSpace) update(req api.SpacePutRequest) error {
 	if req.Name == "" {
 		return zqe.E(zqe.Invalid, "cannot set name to an empty string")
 	}
-	s.confmu.Lock()
-	defer s.confmu.Unlock()
+	s.confMu.Lock()
+	defer s.confMu.Unlock()
 	conf := s.conf.clone()
 	conf.Name = req.Name
 	return s.updateConfigWithLock(conf)
 }
 
 func (s *fileSpace) SetPcapPath(pcapPath string) error {
-	s.confmu.Lock()
-	defer s.confmu.Unlock()
+	s.confMu.Lock()
+	defer s.confMu.Unlock()
 	conf := s.conf.clone()
 	conf.PcapPath = pcapPath
 	return s.updateConfigWithLock(conf)
@@ -104,7 +103,7 @@ func filesize(path string) (int64, error) {
 }
 
 func (s *fileSpace) PcapPath() string {
-	s.confmu.Lock()
-	defer s.confmu.Unlock()
+	s.confMu.Lock()
+	defer s.confMu.Unlock()
 	return s.conf.PcapPath
 }

--- a/zqd/space/filespace.go
+++ b/zqd/space/filespace.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/brimsec/zq/zqd/api"
 	"github.com/brimsec/zq/zqe"
@@ -15,7 +16,10 @@ const PcapIndexFile = "packets.idx.json"
 type fileSpace struct {
 	spaceBase
 	path string
-	conf config
+
+	// confmu protects changes to configuration changes.
+	confmu sync.Mutex
+	conf   config
 }
 
 func (s *fileSpace) Info(ctx context.Context) (api.SpaceInfo, error) {
@@ -36,12 +40,37 @@ func (s *fileSpace) Info(ctx context.Context) (api.SpaceInfo, error) {
 	return si, nil
 }
 
-func (s *fileSpace) Update(req api.SpacePutRequest) error {
+func (s *fileSpace) Name() string {
+	s.confmu.Lock()
+	defer s.confmu.Unlock()
+	return s.conf.Name
+}
+
+func (s *fileSpace) update(req api.SpacePutRequest) error {
 	if req.Name == "" {
 		return zqe.E(zqe.Invalid, "cannot set name to an empty string")
 	}
-	s.conf.Name = req.Name
-	return s.conf.save(s.path)
+	s.confmu.Lock()
+	defer s.confmu.Unlock()
+	conf := s.conf.clone()
+	conf.Name = req.Name
+	return s.updateConfigWithLock(conf)
+}
+
+func (s *fileSpace) SetPcapPath(pcapPath string) error {
+	s.confmu.Lock()
+	defer s.confmu.Unlock()
+	conf := s.conf.clone()
+	conf.PcapPath = pcapPath
+	return s.updateConfigWithLock(conf)
+}
+
+func (s *fileSpace) updateConfigWithLock(conf config) error {
+	if err := writeConfig(s.path, conf); err != nil {
+		return err
+	}
+	s.conf = conf
+	return nil
 }
 
 func (s *fileSpace) delete() error {
@@ -74,11 +103,8 @@ func filesize(path string) (int64, error) {
 	return f.Size(), nil
 }
 
-func (s *fileSpace) SetPcapPath(pcapPath string) error {
-	s.conf.PcapPath = pcapPath
-	return s.conf.save(s.path)
-}
-
 func (s *fileSpace) PcapPath() string {
+	s.confmu.Lock()
+	defer s.confmu.Unlock()
 	return s.conf.PcapPath
 }

--- a/zqd/space/manager.go
+++ b/zqd/space/manager.go
@@ -77,7 +77,7 @@ func (m *Manager) Create(req api.SpacePostRequest) (Space, error) {
 	if req.Name == "" && req.DataPath == "" {
 		return nil, zqe.E(zqe.Invalid, "must supply non-empty name or dataPath")
 	}
-	// If name is not set then derrive name from DataPath; removing and
+	// If name is not set then derive name from DataPath, removing and
 	// replacing invalid characters.
 	if req.Name == "" {
 		req.Name = safeName(m.names, req.DataPath)

--- a/zqd/space/manager.go
+++ b/zqd/space/manager.go
@@ -2,7 +2,6 @@ package space
 
 import (
 	"context"
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -18,6 +17,7 @@ type Manager struct {
 	rootPath string
 	spacesMu sync.Mutex
 	spaces   map[api.SpaceID]Space
+	names    map[string]api.SpaceID
 	logger   *zap.Logger
 }
 
@@ -25,6 +25,7 @@ func NewManager(root string, logger *zap.Logger) (*Manager, error) {
 	mgr := &Manager{
 		rootPath: root,
 		spaces:   make(map[api.SpaceID]Space),
+		names:    make(map[string]api.SpaceID),
 		logger:   logger,
 	}
 
@@ -45,12 +46,25 @@ func NewManager(root string, logger *zap.Logger) (*Manager, error) {
 			continue
 		}
 
+		if config.Version < 1 {
+			config.Name = safeName(mgr.names, config.Name)
+			for _, sub := range config.Subspaces {
+				sub.Name = safeName(mgr.names, sub.Name)
+			}
+			config.Version = configVersion
+			if err := writeConfig(path, config); err != nil {
+				logger.Error("error migrating config", zap.Error(err))
+				continue
+			}
+		}
+
 		spaces, err := loadSpaces(path, config)
 		if err != nil {
 			return nil, err
 		}
 		for _, s := range spaces {
 			mgr.spaces[s.ID()] = s
+			mgr.names[s.Name()] = s.ID()
 		}
 	}
 
@@ -60,21 +74,23 @@ func NewManager(root string, logger *zap.Logger) (*Manager, error) {
 func (m *Manager) Create(req api.SpacePostRequest) (Space, error) {
 	m.spacesMu.Lock()
 	defer m.spacesMu.Unlock()
-
 	if req.Name == "" && req.DataPath == "" {
 		return nil, zqe.E(zqe.Invalid, "must supply non-empty name or dataPath")
 	}
-
+	// If name is not set then derrive name from DataPath; removing and
+	// replacing invalid characters.
+	if req.Name == "" {
+		req.Name = safeName(m.names, req.DataPath)
+	}
+	if err := validateName(m.names, req.Name); err != nil {
+		return nil, err
+	}
 	var storecfg storage.Config
 	if req.Storage != nil {
 		storecfg = *req.Storage
 	}
 	if storecfg.Kind == storage.UnknownStore {
 		storecfg.Kind = storage.FileStore
-	}
-
-	if req.Name == "" {
-		req.Name = filepath.Base(req.DataPath)
 	}
 	id := newSpaceID()
 	path := filepath.Join(m.rootPath, string(id))
@@ -84,46 +100,60 @@ func (m *Manager) Create(req api.SpacePostRequest) (Space, error) {
 	if req.DataPath == "" {
 		req.DataPath = path
 	}
-	c := config{
-		Name:     req.Name,
-		DataPath: req.DataPath,
-		Storage:  storecfg,
-	}
-	if err := c.save(path); err != nil {
+	conf := config{Name: req.Name, DataPath: req.DataPath, Storage: storecfg}
+	if err := writeConfig(path, conf); err != nil {
 		os.RemoveAll(path)
 		return nil, err
 	}
-
-	if _, exists := m.spaces[id]; exists {
-		m.logger.Error("created duplicate space id", zap.String("id", string(id)))
-		return nil, errors.New("created duplicate space id (this should not happen)")
-	}
-
-	spaces, err := loadSpaces(path, c)
+	spaces, err := loadSpaces(path, conf)
 	if err != nil {
 		return nil, err
 	}
-	if len(spaces) != 1 {
-		panic("multiple spaces created during space create")
-	}
-	m.spaces[id] = spaces[0]
-	return spaces[0], nil
+	s := spaces[0]
+	m.spaces[s.ID()] = s
+	m.names[s.Name()] = s.ID()
+	return s, err
 }
 
 func (m *Manager) CreateSubspace(parent Space, req api.SubspacePostRequest) (Space, error) {
 	m.spacesMu.Lock()
 	defer m.spacesMu.Unlock()
-
+	if err := validateName(m.names, req.Name); err != nil {
+		return nil, err
+	}
 	as, ok := parent.(*archiveSpace)
 	if !ok {
 		return nil, zqe.E(zqe.Invalid, "space does not support creating subspaces")
 	}
+
 	s, err := as.CreateSubspace(req)
 	if err != nil {
 		return nil, err
 	}
 	m.spaces[s.ID()] = s
+	m.names[s.Name()] = s.ID()
 	return s, nil
+}
+
+func (m *Manager) UpdateSpace(space Space, req api.SpacePutRequest) error {
+	m.spacesMu.Lock()
+	defer m.spacesMu.Unlock()
+	if err := validateName(m.names, req.Name); err != nil {
+		return err
+	}
+
+	// Right now you can only update a name in a SpacePutRequest but eventually
+	// there will be other options.
+	oldname := space.Name()
+	if oldname == req.Name {
+		return nil
+	}
+	if err := space.update(req); err != nil {
+		return err
+	}
+	delete(m.names, oldname)
+	m.names[space.Name()] = space.ID()
+	return nil
 }
 
 func (m *Manager) Get(id api.SpaceID) (Space, error) {
@@ -144,13 +174,15 @@ func (m *Manager) Delete(id api.SpaceID) error {
 		return err
 	}
 
+	m.spacesMu.Lock()
+	defer m.spacesMu.Unlock()
+	name := space.Name()
 	if err := space.delete(); err != nil {
 		return err
 	}
 
-	m.spacesMu.Lock()
-	defer m.spacesMu.Unlock()
 	delete(m.spaces, id)
+	delete(m.names, name)
 	return nil
 }
 

--- a/zqd/space/manager.go
+++ b/zqd/space/manager.go
@@ -53,7 +53,7 @@ func NewManager(root string, logger *zap.Logger) (*Manager, error) {
 			}
 			config.Version = configVersion
 			if err := writeConfig(path, config); err != nil {
-				logger.Error("error migrating config", zap.Error(err))
+				logger.Error("Error migrating config", zap.Error(err))
 				continue
 			}
 		}

--- a/zqd/space/manager_test.go
+++ b/zqd/space/manager_test.go
@@ -1,0 +1,58 @@
+package space
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/brimsec/zq/pkg/fs"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestV1Migration(t *testing.T) {
+	t.Run("InvalidCharacters", func(t *testing.T) {
+		root, err := ioutil.TempDir("", "")
+		require.NoError(t, err)
+		defer os.RemoveAll(root)
+
+		testWriteConfig(t, root, config{Name: "name-with &*(&stuff"})
+
+		mgr, err := NewManager(root, zap.NewNop())
+		require.NoError(t, err)
+		list, err := mgr.List(context.Background())
+		require.NoError(t, err)
+		require.Len(t, list, 1)
+		require.Equal(t, "name_with_stuff", list[0].Name)
+	})
+	t.Run("DuplicateNames", func(t *testing.T) {
+		root, err := ioutil.TempDir("", "")
+		require.NoError(t, err)
+		defer os.RemoveAll(root)
+
+		testWriteConfig(t, root, config{Name: "testname"})
+		testWriteConfig(t, root, config{Name: "testname"})
+
+		mgr, err := NewManager(root, zap.NewNop())
+		require.NoError(t, err)
+		list, err := mgr.List(context.Background())
+		require.NoError(t, err)
+		require.Len(t, list, 2)
+		sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
+		require.Equal(t, "testname", list[0].Name)
+		require.Equal(t, "testname_01", list[1].Name)
+	})
+}
+
+var counter int
+
+func testWriteConfig(t *testing.T, root string, c config) {
+	counter++
+	spdir := filepath.Join(root, fmt.Sprintf("sp_%d", counter))
+	require.NoError(t, os.Mkdir(spdir, 0700))
+	require.NoError(t, fs.MarshalJSONFile(c, filepath.Join(spdir, configFile), 0600))
+}


### PR DESCRIPTION
Enfore the following constraints on space names:
- Must only contain characters [a-zA-Z0-9_]
- Names must be unqiue

Add a Version field to space config and migrate the names of old configs
to the new standard.

Also:
- Add mutex protection file space config.
- add JSONFile functions to package `fs`. Used for atomic update of json files.

closes #791