### PR TITLE
zql: remove special-case timebin support

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -256,15 +256,15 @@ type (
 	// A GroupByProc node represents a proc that consumes all the records
 	// in its input, partitions the records into groups based on the values
 	// of the fields specified in the keys field (where the first key is the
-	// primary key), and applies reducers (if any) to each group. If the
-	// duration field is non-zero, then the groups further partioned by time
-	// into bins of the duration. In this case time is the primary key.
+	// primary grouping key), and applies reducers (if any) to each group. If the
+	// Duration field is non-zero, then the groups are further partioned by time
+	// into bins of the duration. In this case, the primary grouping key is ts.
 	// The Limit field specifies the number of different groups that can be
 	// aggregated over. When absent, the runtime defaults to an
 	// appropriate value.
 	// The InputSortDir field indicates that input is sorted (with
-	// direction indicated by the sign of the field) in the
-	// primary key. In this case, the proc outputs the reducer
+	// direction indicated by the sign of the field) in the primary
+	// grouping key. In this case, the proc outputs the reducer
 	// results from each key as they complete so that large inputs
 	// are processed and streamed efficiently.
 	GroupByProc struct {

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -255,23 +255,25 @@ type (
 	}
 	// A GroupByProc node represents a proc that consumes all the records
 	// in its input, partitions the records into groups based on the values
-	// of the fields specified in the keys paramater, and applies one or
-	// more reducers to each group.  If the duration parameter is non-zero,
-	// then the groups further partioned by time according to the time interval
-	// equal to the duration.  In this case, the proc transmits to its output
-	// the reducer results from each time interval as they complete so that
-	// large time ranges are processed and streamed efficiently.
-	// The limit parameter specifies the number of different groups that can
-	// be aggregated over. When absent, the runtime defaults to an appropriate value.
-	//
-	// xxx comment sorted
+	// of the fields specified in the keys field (where the first key is the
+	// primary key), and applies reducers (if any) to each group. If the
+	// duration field is non-zero, then the groups further partioned by time
+	// into bins of the duration. In this case time is the primary key.
+	// The Limit field specifies the number of different groups that can be
+	// aggregated over. When absent, the runtime defaults to an
+	// appropriate value.
+	// The InputSortDir field indicates that input is sorted (with
+	// direction indicated by the sign of the field) in the
+	// primary key. In this case, the proc outputs the reducer
+	// results from each key as they complete so that large inputs
+	// are processed and streamed efficiently.
 	GroupByProc struct {
 		Node
-		Duration Duration     `json:"duration"`
-		Limit    int          `json:"limit,omitempty"`
-		Keys     []Assignment `json:"keys"`
-		Reducers []Reducer    `json:"reducers"`
-		Sorted   int          `json:"sorted"`
+		Duration     Duration     `json:"duration"`
+		Limit        int          `json:"limit,omitempty"`
+		Keys         []Assignment `json:"keys"`
+		Reducers     []Reducer    `json:"reducers"`
+		InputSortDir int          `json:"input_sort_dir"`
 	}
 	// TopProc is similar to proc.SortProc with a few key differences:
 	// - It only sorts in descending order.

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -263,12 +263,15 @@ type (
 	// large time ranges are processed and streamed efficiently.
 	// The limit parameter specifies the number of different groups that can
 	// be aggregated over. When absent, the runtime defaults to an appropriate value.
+	//
+	// xxx comment sorted
 	GroupByProc struct {
 		Node
 		Duration Duration     `json:"duration"`
 		Limit    int          `json:"limit,omitempty"`
 		Keys     []Assignment `json:"keys"`
 		Reducers []Reducer    `json:"reducers"`
+		Sorted   int          `json:"sorted"`
 	}
 	// TopProc is similar to proc.SortProc with a few key differences:
 	// - It only sorts in descending order.

--- a/expr/sort.go
+++ b/expr/sort.go
@@ -9,6 +9,7 @@ import (
 )
 
 type SortFn func(a *zng.Record, b *zng.Record) int
+type ValueSortFn func(a zng.Value, b zng.Value) int
 type KeyCompareFn func(*zng.Record) int
 
 // Internal function that compares two values of compatible types.
@@ -34,41 +35,7 @@ func NewSortFn(nullsMax bool, fields ...FieldExprResolver) SortFn {
 		for _, resolver := range fields {
 			a := resolver(ra)
 			b := resolver(rb)
-
-			// Handle nulls according to nullsMax
-			nullA := isNull(a)
-			nullB := isNull(b)
-			if nullA && nullB {
-				continue
-			}
-			if nullA {
-				if nullsMax {
-					return 1
-				} else {
-					return -1
-				}
-			}
-			if nullB {
-				if nullsMax {
-					return -1
-				} else {
-					return 1
-				}
-			}
-
-			// If values are of different types, just compare
-			// the native representation of the type
-			if a.Type.ID() != b.Type.ID() {
-				return bytes.Compare([]byte(a.Type.String()), []byte(b.Type.String()))
-			}
-
-			sf, ok := sorters[a.Type]
-			if !ok {
-				sf = LookupSorter(a.Type)
-				sorters[a.Type] = sf
-			}
-
-			v := sf(a.Bytes, b.Bytes)
+			v := compareValues(a, b, sorters, nullsMax)
 			// If the events don't match, then return the sort
 			// info.  Otherwise, they match and we continue on
 			// on in the loop to the secondary key, etc.
@@ -79,6 +46,50 @@ func NewSortFn(nullsMax bool, fields ...FieldExprResolver) SortFn {
 		// All the keys matched with equality.
 		return 0
 	}
+}
+
+func NewValueSortFn(nullsMax bool) ValueSortFn {
+	sorters := make(map[zng.Type]comparefn)
+	return func(a, b zng.Value) int {
+		return compareValues(a, b, sorters, nullsMax)
+	}
+}
+
+func compareValues(a, b zng.Value, sorters map[zng.Type]comparefn, nullsMax bool) int {
+	// Handle nulls according to nullsMax
+	nullA := isNull(a)
+	nullB := isNull(b)
+	if nullA && nullB {
+		return 0
+	}
+	if nullA {
+		if nullsMax {
+			return 1
+		} else {
+			return -1
+		}
+	}
+	if nullB {
+		if nullsMax {
+			return -1
+		} else {
+			return 1
+		}
+	}
+
+	// If values are of different types, just compare
+	// the native representation of the type
+	if a.Type.ID() != b.Type.ID() {
+		return bytes.Compare([]byte(a.Type.String()), []byte(b.Type.String()))
+	}
+
+	sf, ok := sorters[a.Type]
+	if !ok {
+		sf = LookupSorter(a.Type)
+		sorters[a.Type] = sf
+	}
+
+	return sf(a.Bytes, b.Bytes)
 }
 
 func NewKeyCompareFn(key *zng.Record) (KeyCompareFn, error) {

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"time"
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/expr"
@@ -26,7 +25,6 @@ type GroupByKey struct {
 }
 
 type GroupByParams struct {
-	duration ast.Duration
 	limit    int
 	keys     []GroupByKey
 	reducers []compile.CompiledReducer
@@ -63,7 +61,6 @@ func CompileGroupBy(node *ast.GroupByProc, zctx *resolver.Context) (*GroupByPara
 			},
 		}
 		astKeys = append([]ast.Assignment{everyKey}, astKeys...)
-		node.Duration.Seconds = 0
 	}
 
 	for _, astKey := range astKeys {
@@ -90,7 +87,6 @@ func CompileGroupBy(node *ast.GroupByProc, zctx *resolver.Context) (*GroupByPara
 		return nil, fmt.Errorf("compiling groupby: %w", err)
 	}
 	return &GroupByParams{
-		duration: node.Duration,
 		limit:    node.Limit,
 		keys:     keys,
 		reducers: reducers,
@@ -115,9 +111,7 @@ func compileKeyExpr(ex ast.Expression) (expr.ExpressionEvaluator, error) {
 // GroupBy computes aggregations using a GroupByAggregator.
 type GroupBy struct {
 	Base
-	timeBinned bool
-	interval   time.Duration
-	agg        *GroupByAggregator
+	agg *GroupByAggregator
 }
 
 // A keyRow holds information about the key column types that result
@@ -151,47 +145,34 @@ type GroupByAggregator struct {
 	keys        []GroupByKey
 	reducerDefs []compile.CompiledReducer
 	builder     *ColumnBuilder
-	// For a regular group-by, tables has one entry with key 0.  For a
-	// time-binned group-by, tables has one entry per bin and is keyed by
-	// bin timestamp (so that a bin with span [ts, ts+timeBinDuration) has
-	// key ts).
-	tables          map[nano.Ts]map[string]*GroupByRow
-	TimeBinDuration int64 // Zero means regular group-by (no time binning).
-	reverse         bool
-	logger          *zap.Logger
-	limit           int
+	table       map[string]*GroupByRow
+	reverse     bool
+	logger      *zap.Logger
+	limit       int
 }
 
 type GroupByRow struct {
 	keycols  []zng.Column
 	keyvals  zcode.Bytes
-	ts       nano.Ts
 	reducers compile.Row
 }
 
 func NewGroupByAggregator(c *Context, params GroupByParams) *GroupByAggregator {
-	//XXX we should change this AST format... left over from Looky
-	// convert second to nano second
-	dur := int64(params.duration.Seconds) * 1000000000
-	if dur < 0 {
-		panic("dur cannot be negative")
-	}
 	limit := params.limit
 	if limit == 0 {
 		limit = defaultGroupByLimit
 	}
 	return &GroupByAggregator{
-		keys:            params.keys,
-		zctx:            c.TypeContext,
-		kctx:            resolver.NewContext(),
-		reducerDefs:     params.reducers,
-		builder:         params.builder,
-		keyRows:         make(map[int]keyRow),
-		tables:          make(map[nano.Ts]map[string]*GroupByRow),
-		TimeBinDuration: dur,
-		reverse:         c.Reverse,
-		logger:          c.Logger,
-		limit:           limit,
+		keys:        params.keys,
+		zctx:        c.TypeContext,
+		kctx:        resolver.NewContext(),
+		reducerDefs: params.reducers,
+		builder:     params.builder,
+		keyRows:     make(map[int]keyRow),
+		table:       make(map[string]*GroupByRow),
+		reverse:     c.Reverse,
+		logger:      c.Logger,
+		limit:       limit,
 	}
 }
 
@@ -199,11 +180,9 @@ func NewGroupBy(c *Context, parent Proc, params GroupByParams) *GroupBy {
 	// XXX in a subsequent PR we will isolate ast params and pass in
 	// ast.GroupByParams
 	agg := NewGroupByAggregator(c, params)
-	timeBinned := params.duration.Seconds > 0
 	return &GroupBy{
-		Base:       Base{Context: c, Parent: parent},
-		timeBinned: timeBinned,
-		agg:        agg,
+		Base: Base{Context: c, Parent: parent},
+		agg:  agg,
 	}
 }
 
@@ -213,7 +192,7 @@ func (g *GroupBy) Pull() (zbuf.Batch, error) {
 		return nil, err
 	}
 	if batch == nil {
-		return g.agg.Results(true, g.MinTs, g.MaxTs)
+		return g.agg.Results(g.MinTs, g.MaxTs)
 	}
 	for k := 0; k < batch.Length(); k++ {
 		err := g.agg.Consume(batch.Index(k))
@@ -223,26 +202,16 @@ func (g *GroupBy) Pull() (zbuf.Batch, error) {
 		}
 	}
 	batch.Unref()
-	if g.timeBinned {
-		f, err := g.agg.Results(false, g.MinTs, g.MaxTs)
-		if err != nil {
-			return nil, err
-		}
-		if f != nil {
-			return f, nil
-		}
-	}
 	return zbuf.NewArray([]*zng.Record{}, batch.Span()), nil
 }
 
-func (g *GroupByAggregator) createGroupByRow(keyCols []zng.Column, ts nano.Ts, vals zcode.Bytes) *GroupByRow {
+func (g *GroupByAggregator) createGroupByRow(keyCols []zng.Column, vals zcode.Bytes) *GroupByRow {
 	// Make a deep copy so the caller can reuse the underlying arrays.
 	v := make(zcode.Bytes, len(vals))
 	copy(v, vals)
 	return &GroupByRow{
 		keycols:  keyCols,
 		keyvals:  v,
-		ts:       ts,
 		reducers: compile.Row{Defs: g.reducerDefs},
 	}
 }
@@ -332,63 +301,27 @@ func (g *GroupByAggregator) Consume(r *zng.Record) error {
 	keyBytes = append(keyBytes, zv...)
 	g.cacheKey = keyBytes
 
-	var ts nano.Ts
-	if g.TimeBinDuration > 0 {
-		ts = r.Ts.Trunc(g.TimeBinDuration)
-	}
-	table, ok := g.tables[ts]
+	row, ok := g.table[string(keyBytes)]
 	if !ok {
-		table = make(map[string]*GroupByRow)
-		g.tables[ts] = table
-	}
-	row, ok := table[string(keyBytes)]
-	if !ok {
-		if len(table) >= g.limit {
+		if len(g.table) >= g.limit {
 			return errTooBig(g.limit)
 		}
-		row = g.createGroupByRow(keyRow.columns, ts, keyBytes[4:])
-		table[string(keyBytes)] = row
+		row = g.createGroupByRow(keyRow.columns, keyBytes[4:])
+		g.table[string(keyBytes)] = row
 	}
 	row.reducers.Consume(r)
 	return nil
 }
 
-// Results returns a batch of aggregation result records.
-// If this is a time-binned aggregation, this can be called multiple
-// times; all completed time bins at the time of the invocation are
-// returned. A final call with eof=true should be made to get the
-// final (possibly incomplete) time bin.
-// If this is not a time-binned aggregation, a single call (with
-// eof=true) should be made after all records have been Consumed()'d.
-func (g *GroupByAggregator) Results(eof bool, minTs nano.Ts, maxTs nano.Ts) (zbuf.Batch, error) {
-	var bins []nano.Ts
-	for b := range g.tables {
-		bins = append(bins, b)
+// Results returns a zbuf.Batch with all aggregation result
+// records. It should be called once after all records have been
+// Consumed()'d.
+func (g *GroupByAggregator) Results(minTs nano.Ts, maxTs nano.Ts) (zbuf.Batch, error) {
+	recs, err := g.records()
+	if err != nil {
+		return nil, err
 	}
-	if g.reverse {
-		sort.Slice(bins, func(i, j int) bool { return bins[i] > bins[j] })
-	} else {
-		sort.Slice(bins, func(i, j int) bool { return bins[i] < bins[j] })
-	}
-	var recs []*zng.Record
-	for _, b := range bins {
-		if g.TimeBinDuration > 0 && !eof {
-			// We're not yet at EOF, so for a reverse search, we haven't
-			// seen all of g.minTs's bin and should skip it.
-			// Similarly, for a forward search, we haven't seen all
-			// of g.maxTs's bin and should skip it.
-			if g.reverse && b == minTs.Trunc(g.TimeBinDuration) ||
-				!g.reverse && b == maxTs.Trunc(g.TimeBinDuration) {
-				continue
-			}
-		}
-		newRecs, err := g.recordsForTable(g.tables[b])
-		if err != nil {
-			return nil, err
-		}
-		recs = append(recs, newRecs...)
-		delete(g.tables, b)
-	}
+	g.table = nil
 	if len(recs) == 0 {
 		// Don't propagate empty batches.
 		return nil, nil
@@ -397,26 +330,23 @@ func (g *GroupByAggregator) Results(eof bool, minTs nano.Ts, maxTs nano.Ts) (zbu
 	if g.reverse {
 		first, last = last, first
 	}
-	span := nano.NewSpanTs(first.Ts, last.Ts.Add(g.TimeBinDuration))
+	span := nano.NewSpanTs(first.Ts, last.Ts)
 	return zbuf.NewArray(recs, span), nil
 }
 
-// recordsForTable returns a slice of records with one record per table entry
-// in a deterministic but undefined order.
-func (g *GroupByAggregator) recordsForTable(table map[string]*GroupByRow) ([]*zng.Record, error) {
+// records returns a slice of all records from the groupby table in a
+// deterministic but undefined order.
+func (g *GroupByAggregator) records() ([]*zng.Record, error) {
 	var keys []string
-	for k := range table {
+	for k := range g.table {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
 	var recs []*zng.Record
 	for _, k := range keys {
-		row := table[k]
+		row := g.table[k]
 		var zv zcode.Bytes
-		if g.TimeBinDuration > 0 {
-			zv = zcode.AppendPrimitive(zv, zng.EncodeTime(row.ts))
-		}
 		zv = append(zv, row.keyvals...)
 		for _, red := range row.reducers.Reducers {
 			// a reducer value is never a container
@@ -430,7 +360,10 @@ func (g *GroupByAggregator) recordsForTable(table map[string]*GroupByRow) ([]*zn
 		if err != nil {
 			return nil, err
 		}
-		r := zng.NewRecordTs(typ, row.ts, zv)
+		r, err := zng.NewRecord(typ, zv)
+		if err != nil {
+			return nil, err
+		}
 		recs = append(recs, r)
 	}
 	return recs, nil
@@ -442,15 +375,9 @@ func (g *GroupByAggregator) lookupRowType(row *GroupByRow) (*zng.TypeRecord, err
 	// descriptor since it is rare for there to be multiple descriptors
 	// or for it change from row to row.
 	n := len(g.keys) + len(g.reducerDefs)
-	if g.TimeBinDuration > 0 {
-		n++
-	}
 	cols := make([]zng.Column, 0, n)
-
-	if g.TimeBinDuration > 0 {
-		cols = append(cols, zng.NewColumn("ts", zng.TypeTime))
-	}
 	types := make([]zng.Type, len(row.keycols))
+
 	for k, col := range row.keycols {
 		types[k] = col.Type
 	}

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -49,6 +49,12 @@ func CompileGroupBy(node *ast.GroupByProc, zctx *resolver.Context) (*GroupByPara
 	keys := make([]GroupByKey, 0)
 	astKeys := node.Keys
 	var targetNames []string
+
+	if node.Sorted != 0 && node.Duration.Seconds == 0 && len(astKeys) > 0 {
+		if _, ok := astKeys[0].Expr.(ast.FieldExpr); !ok {
+			return nil, fmt.Errorf("compiling groupby: cannot use -sorted in conjunction with a computed primary key")
+		}
+	}
 	if node.Duration.Seconds > 0 {
 		everyKey := ast.Assignment{
 			Target: "ts",

--- a/proc/groupby_test.go
+++ b/proc/groupby_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/pkg/test"
+	"github.com/brimsec/zq/proc"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -242,8 +245,122 @@ func TestGroupbySystem(t *testing.T) {
 	tests().runSystem(t)
 }
 
-/* not yet
 func TestGroupbyUnit(t *testing.T) {
-	tests().runUnit(t)
+	inBatches := []string{`
+#0:record[ts:time]
+0:[1;]
+`, `
+#0:record[ts:time]
+0:[1;]
+0:[2;]
+`, `
+#0:record[ts:time]
+0:[3;]
+`}
+	outBatches := []string{
+		``,
+		`
+#0:record[ts:time,count:uint64]
+0:[1;2;]
+`, `
+#0:record[ts:time,count:uint64]
+0:[2;1;]
+`, `
+#0:record[ts:time,count:uint64]
+0:[3;1;]
+`}
+
+	inBatchesWithUnset := append(inBatches, `
+#0:record[ts:time]
+0:[-;]
+`)
+
+	outBatchesWithUnset := append(outBatches, `
+#0:record[ts:time,count:uint64]
+0:[-;1;]
+`)
+
+	inBatchesRecordKey := []string{`
+#0:record[foo:record[a:string]]
+0:[[aaa;]]
+`, `
+#0:record[foo:record[a:string]]
+0:[[baa;]]
+`}
+	inBatchesRecordKeyWithUnsetRecord := append(inBatchesRecordKey, `
+#0:record[foo:record[a:string]]
+0:[-;]
+`)
+
+	outBatchesRecordKey := []string{
+		``,
+		`
+#0:record[foo:record[a:string],count:uint64]
+0:[[aaa;]1;]
+`, `
+#0:record[foo:record[a:string],count:uint64]
+0:[[baa;]1;]
+`}
+	outBatchesRecordKeyWithUnsetRecord := append(outBatchesRecordKey, `
+#0:record[foo:record[a:string],count:uint64]
+0:[-;1;]
+`)
+	outBatchesRecordKeyWithUnsetKey := append(outBatchesRecordKey, `
+#0:record[foo:record[a:string],count:uint64]
+0:[[-;]1;]
+`)
+
+	inBatchesRev := []string{
+		`#0:record[ts:time]
+0:[-;]
+0:[10;]
+0:[8;]
+0:[7;]
+0:[6;]
+0:[2;]`,
+		`#0:record[ts:time]
+0:[1;]`}
+
+	outBatchesRev := []string{`
+#0:record[ts:time,count:uint64]
+0:[-;1;]
+0:[10;1;]
+0:[8;1;]
+0:[7;1;]
+0:[6;1;]`,
+		`#0:record[ts:time,count:uint64]
+0:[2;1;]`,
+		`#0:record[ts:time,count:uint64]
+0:[1;1;]`}
+
+	runner := func(zql string, in, out []string) func(t *testing.T) {
+		return func(t *testing.T) {
+			resolver := resolver.NewContext()
+			var inBatches []zbuf.Batch
+			for _, s := range in {
+				b, err := proc.ParseTestZng(resolver, s)
+				require.NoError(t, err, s)
+				inBatches = append(inBatches, b)
+			}
+			procTest, err := proc.NewProcTestFromSource(zql, resolver, inBatches)
+			assert.NoError(t, err)
+			for _, s := range out {
+				b, err := proc.ParseTestZng(resolver, s)
+				require.NoError(t, err, s)
+				err = procTest.Expect(b)
+				assert.NoError(t, err)
+			}
+			err = procTest.ExpectEOS()
+			assert.NoError(t, err)
+		}
+	}
+
+	t.Run("forward-sorted", runner("count() by ts -sorted 1", inBatches, outBatches))
+	t.Run("forward-sorted-with-unset", runner("count() by ts -sorted 1", inBatchesWithUnset, outBatchesWithUnset))
+	t.Run("forward-sorted-every", runner("every 1s count() -sorted 1", inBatches, outBatches))
+	t.Run("forward-sorted-record-key", runner("count() by foo -sorted 1", inBatchesRecordKey, outBatchesRecordKey))
+	t.Run("forward-sorted-nested-key", runner("count() by foo.a -sorted 1", inBatchesRecordKey, outBatchesRecordKey))
+	t.Run("forward-sorted-record-key-unset", runner("count() by foo -sorted 1", inBatchesRecordKeyWithUnsetRecord, outBatchesRecordKeyWithUnsetRecord))
+	t.Run("forward-sorted-nested-key-unset", runner("count() by foo.a -sorted 1", inBatchesRecordKeyWithUnsetRecord, outBatchesRecordKeyWithUnsetKey))
+	t.Run("reverse-sorted", runner("count() by ts -sorted -1", inBatchesRev, outBatchesRev))
 }
-*/

--- a/proc/groupby_test.go
+++ b/proc/groupby_test.go
@@ -338,14 +338,14 @@ func TestGroupbyUnit(t *testing.T) {
 			resolver := resolver.NewContext()
 			var inBatches []zbuf.Batch
 			for _, s := range in {
-				b, err := proc.ParseTestZng(resolver, s)
+				b, err := proc.ParseTestTzng(resolver, s)
 				require.NoError(t, err, s)
 				inBatches = append(inBatches, b)
 			}
 			procTest, err := proc.NewProcTestFromSource(zql, resolver, inBatches)
 			assert.NoError(t, err)
 			for _, s := range out {
-				b, err := proc.ParseTestZng(resolver, s)
+				b, err := proc.ParseTestTzng(resolver, s)
 				require.NoError(t, err, s)
 				err = procTest.Expect(b)
 				assert.NoError(t, err)

--- a/proc/utils.go
+++ b/proc/utils.go
@@ -197,7 +197,7 @@ func (p *ProcTest) Finish() error {
 	}
 }
 
-func parse(zctx *resolver.Context, src string) (*zbuf.Array, error) {
+func ParseTestZng(zctx *resolver.Context, src string) (*zbuf.Array, error) {
 	reader := tzngio.NewReader(strings.NewReader(src), zctx)
 	records := make([]*zng.Record, 0)
 	for {
@@ -220,9 +220,9 @@ func parse(zctx *resolver.Context, src string) (*zbuf.Array, error) {
 // given warning(s) are emitted.
 func TestOneProcWithWarnings(t *testing.T, zngin, zngout string, warnings []string, cmd string) {
 	zctx := resolver.NewContext()
-	recsin, err := parse(zctx, zngin)
+	recsin, err := ParseTestZng(zctx, zngin)
 	require.NoError(t, err)
-	recsout, err := parse(zctx, zngout)
+	recsout, err := ParseTestZng(zctx, zngout)
 	require.NoError(t, err)
 
 	test, err := NewProcTestFromSource(cmd, zctx, []zbuf.Batch{recsin})
@@ -265,7 +265,7 @@ func TestOneProcWithBatches(t *testing.T, cmd string, zngs ...string) {
 	resolver := resolver.NewContext()
 	var batches []zbuf.Batch
 	for _, s := range zngs {
-		b, err := parse(resolver, s)
+		b, err := ParseTestZng(resolver, s)
 		require.NoError(t, err, s)
 		batches = append(batches, b)
 	}
@@ -294,9 +294,9 @@ func TestOneProcWithBatches(t *testing.T, cmd string, zngs ...string) {
 // output records must all be present, but they may appear in any order.
 func TestOneProcUnsorted(t *testing.T, zngin, zngout string, cmd string) {
 	resolver := resolver.NewContext()
-	recsin, err := parse(resolver, zngin)
+	recsin, err := ParseTestZng(resolver, zngin)
 	require.NoError(t, err)
-	recsout, err := parse(resolver, zngout)
+	recsout, err := ParseTestZng(resolver, zngout)
 	require.NoError(t, err)
 
 	test, err := NewProcTestFromSource(cmd, resolver, []zbuf.Batch{recsin})

--- a/proc/utils.go
+++ b/proc/utils.go
@@ -197,7 +197,7 @@ func (p *ProcTest) Finish() error {
 	}
 }
 
-func ParseTestZng(zctx *resolver.Context, src string) (*zbuf.Array, error) {
+func ParseTestTzng(zctx *resolver.Context, src string) (*zbuf.Array, error) {
 	reader := tzngio.NewReader(strings.NewReader(src), zctx)
 	records := make([]*zng.Record, 0)
 	for {
@@ -220,9 +220,9 @@ func ParseTestZng(zctx *resolver.Context, src string) (*zbuf.Array, error) {
 // given warning(s) are emitted.
 func TestOneProcWithWarnings(t *testing.T, zngin, zngout string, warnings []string, cmd string) {
 	zctx := resolver.NewContext()
-	recsin, err := ParseTestZng(zctx, zngin)
+	recsin, err := ParseTestTzng(zctx, zngin)
 	require.NoError(t, err)
-	recsout, err := ParseTestZng(zctx, zngout)
+	recsout, err := ParseTestTzng(zctx, zngout)
 	require.NoError(t, err)
 
 	test, err := NewProcTestFromSource(cmd, zctx, []zbuf.Batch{recsin})
@@ -265,7 +265,7 @@ func TestOneProcWithBatches(t *testing.T, cmd string, zngs ...string) {
 	resolver := resolver.NewContext()
 	var batches []zbuf.Batch
 	for _, s := range zngs {
-		b, err := ParseTestZng(resolver, s)
+		b, err := ParseTestTzng(resolver, s)
 		require.NoError(t, err, s)
 		batches = append(batches, b)
 	}
@@ -294,9 +294,9 @@ func TestOneProcWithBatches(t *testing.T, cmd string, zngs ...string) {
 // output records must all be present, but they may appear in any order.
 func TestOneProcUnsorted(t *testing.T, zngin, zngout string, cmd string) {
 	resolver := resolver.NewContext()
-	recsin, err := ParseTestZng(resolver, zngin)
+	recsin, err := ParseTestTzng(resolver, zngin)
 	require.NoError(t, err)
-	recsout, err := ParseTestZng(resolver, zngout)
+	recsout, err := ParseTestTzng(resolver, zngout)
 	require.NoError(t, err)
 
 	test, err := NewProcTestFromSource(cmd, resolver, []zbuf.Batch{recsin})

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -345,12 +345,12 @@ func makeGroupByProc(durationIn, sortedIn, limitIn, keysIn, reducersIn interface
 	reducers := reducersArray(reducersIn)
 
 	return &ast.GroupByProc{
-		Node:     ast.Node{"GroupByProc"},
-		Duration: duration,
-		Limit:    limit,
-		Keys:     keys,
-		Reducers: reducers,
-		Sorted:   sorted,
+		Node:         ast.Node{"GroupByProc"},
+		Duration:     duration,
+		Limit:        limit,
+		Keys:         keys,
+		Reducers:     reducers,
+		InputSortDir: sorted,
 	}
 }
 

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -321,12 +321,15 @@ func makeGroupByKeys(first, rest interface{}) []ast.Assignment {
 	return keys
 }
 
-func makeGroupByProc(durationIn, limitIn, keysIn, reducersIn interface{}) *ast.GroupByProc {
+func makeGroupByProc(durationIn, sortedIn, limitIn, keysIn, reducersIn interface{}) *ast.GroupByProc {
 	var duration ast.Duration
 	if durationIn != nil {
 		duration = *(durationIn.(*ast.Duration))
 	}
-
+	var sorted int
+	if sortedIn != nil {
+		sorted = sortedIn.(int)
+	}
 	var limit int
 	if limitIn != nil {
 		limit = limitIn.(int)
@@ -347,6 +350,7 @@ func makeGroupByProc(durationIn, limitIn, keysIn, reducersIn interface{}) *ast.G
 		Limit:    limit,
 		Keys:     keys,
 		Reducers: reducers,
+		Sorted:   sorted,
 	}
 }
 

--- a/zql/parser-support.js
+++ b/zql/parser-support.js
@@ -136,9 +136,9 @@ function makeGroupByKeys(first, rest) {
   return [first, ...rest];
 }
 
-function makeGroupByProc(duration, limit, keys, reducers) {
+function makeGroupByProc(duration, sorted, limit, keys, reducers) {
   if (limit === null) { limit = undefined; }
-  return { op: "GroupByProc", keys, reducers, duration, limit };
+    return { op: "GroupByProc", keys, reducers, duration, limit , sorted};
 }
 
 function makeUnaryExpr(operator, operand) {

--- a/zql/parser-support.js
+++ b/zql/parser-support.js
@@ -136,9 +136,9 @@ function makeGroupByKeys(first, rest) {
   return [first, ...rest];
 }
 
-function makeGroupByProc(duration, sorted, limit, keys, reducers) {
+function makeGroupByProc(duration, input_sort_dir, limit, keys, reducers) {
   if (limit === null) { limit = undefined; }
-    return { op: "GroupByProc", keys, reducers, duration, limit , sorted};
+    return { op: "GroupByProc", keys, reducers, duration, limit , input_sort_dir};
 }
 
 function makeUnaryExpr(operator, operand) {

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -1380,17 +1380,51 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "equalityToken",
+			name: "groupBySorted",
 			pos:  position{line: 198, col: 1, offset: 4492},
-			expr: &choiceExpr{
+			expr: &actionExpr{
 				pos: position{line: 199, col: 5, offset: 4510},
+				run: (*parser).callongroupBySorted1,
+				expr: &seqExpr{
+					pos: position{line: 199, col: 5, offset: 4510},
+					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 199, col: 5, offset: 4510},
+							name: "_",
+						},
+						&litMatcher{
+							pos:        position{line: 199, col: 7, offset: 4512},
+							val:        "-sorted",
+							ignoreCase: true,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 199, col: 18, offset: 4523},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 199, col: 20, offset: 4525},
+							label: "dir",
+							expr: &ruleRefExpr{
+								pos:  position{line: 199, col: 24, offset: 4529},
+								name: "sinteger",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "equalityToken",
+			pos:  position{line: 201, col: 1, offset: 4569},
+			expr: &choiceExpr{
+				pos: position{line: 202, col: 5, offset: 4587},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 199, col: 5, offset: 4510},
+						pos:  position{line: 202, col: 5, offset: 4587},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 199, col: 24, offset: 4529},
+						pos:  position{line: 202, col: 24, offset: 4606},
 						name: "RelativeOperator",
 					},
 				},
@@ -1398,12 +1432,12 @@ var g = &grammar{
 		},
 		{
 			name: "andToken",
-			pos:  position{line: 201, col: 1, offset: 4547},
+			pos:  position{line: 204, col: 1, offset: 4624},
 			expr: &actionExpr{
-				pos: position{line: 201, col: 12, offset: 4558},
+				pos: position{line: 204, col: 12, offset: 4635},
 				run: (*parser).callonandToken1,
 				expr: &litMatcher{
-					pos:        position{line: 201, col: 12, offset: 4558},
+					pos:        position{line: 204, col: 12, offset: 4635},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -1411,12 +1445,12 @@ var g = &grammar{
 		},
 		{
 			name: "orToken",
-			pos:  position{line: 202, col: 1, offset: 4596},
+			pos:  position{line: 205, col: 1, offset: 4673},
 			expr: &actionExpr{
-				pos: position{line: 202, col: 11, offset: 4606},
+				pos: position{line: 205, col: 11, offset: 4683},
 				run: (*parser).callonorToken1,
 				expr: &litMatcher{
-					pos:        position{line: 202, col: 11, offset: 4606},
+					pos:        position{line: 205, col: 11, offset: 4683},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -1424,12 +1458,12 @@ var g = &grammar{
 		},
 		{
 			name: "inToken",
-			pos:  position{line: 203, col: 1, offset: 4643},
+			pos:  position{line: 206, col: 1, offset: 4720},
 			expr: &actionExpr{
-				pos: position{line: 203, col: 11, offset: 4653},
+				pos: position{line: 206, col: 11, offset: 4730},
 				run: (*parser).calloninToken1,
 				expr: &litMatcher{
-					pos:        position{line: 203, col: 11, offset: 4653},
+					pos:        position{line: 206, col: 11, offset: 4730},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -1437,12 +1471,12 @@ var g = &grammar{
 		},
 		{
 			name: "notToken",
-			pos:  position{line: 204, col: 1, offset: 4690},
+			pos:  position{line: 207, col: 1, offset: 4767},
 			expr: &actionExpr{
-				pos: position{line: 204, col: 12, offset: 4701},
+				pos: position{line: 207, col: 12, offset: 4778},
 				run: (*parser).callonnotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 204, col: 12, offset: 4701},
+					pos:        position{line: 207, col: 12, offset: 4778},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -1450,21 +1484,21 @@ var g = &grammar{
 		},
 		{
 			name: "fieldName",
-			pos:  position{line: 206, col: 1, offset: 4740},
+			pos:  position{line: 209, col: 1, offset: 4817},
 			expr: &actionExpr{
-				pos: position{line: 206, col: 13, offset: 4752},
+				pos: position{line: 209, col: 13, offset: 4829},
 				run: (*parser).callonfieldName1,
 				expr: &seqExpr{
-					pos: position{line: 206, col: 13, offset: 4752},
+					pos: position{line: 209, col: 13, offset: 4829},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 206, col: 13, offset: 4752},
+							pos:  position{line: 209, col: 13, offset: 4829},
 							name: "fieldNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 206, col: 28, offset: 4767},
+							pos: position{line: 209, col: 28, offset: 4844},
 							expr: &ruleRefExpr{
-								pos:  position{line: 206, col: 28, offset: 4767},
+								pos:  position{line: 209, col: 28, offset: 4844},
 								name: "fieldNameRest",
 							},
 						},
@@ -1474,9 +1508,9 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameStart",
-			pos:  position{line: 208, col: 1, offset: 4814},
+			pos:  position{line: 211, col: 1, offset: 4891},
 			expr: &charClassMatcher{
-				pos:        position{line: 208, col: 18, offset: 4831},
+				pos:        position{line: 211, col: 18, offset: 4908},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -1486,16 +1520,16 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameRest",
-			pos:  position{line: 209, col: 1, offset: 4842},
+			pos:  position{line: 212, col: 1, offset: 4919},
 			expr: &choiceExpr{
-				pos: position{line: 209, col: 17, offset: 4858},
+				pos: position{line: 212, col: 17, offset: 4935},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 209, col: 17, offset: 4858},
+						pos:  position{line: 212, col: 17, offset: 4935},
 						name: "fieldNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 209, col: 34, offset: 4875},
+						pos:        position{line: 212, col: 34, offset: 4952},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -1506,45 +1540,45 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReference",
-			pos:  position{line: 211, col: 1, offset: 4882},
+			pos:  position{line: 214, col: 1, offset: 4959},
 			expr: &actionExpr{
-				pos: position{line: 212, col: 4, offset: 4900},
+				pos: position{line: 215, col: 4, offset: 4977},
 				run: (*parser).callonfieldReference1,
 				expr: &seqExpr{
-					pos: position{line: 212, col: 4, offset: 4900},
+					pos: position{line: 215, col: 4, offset: 4977},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 212, col: 4, offset: 4900},
+							pos:   position{line: 215, col: 4, offset: 4977},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 212, col: 9, offset: 4905},
+								pos:  position{line: 215, col: 9, offset: 4982},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 212, col: 19, offset: 4915},
+							pos:   position{line: 215, col: 19, offset: 4992},
 							label: "derefs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 212, col: 26, offset: 4922},
+								pos: position{line: 215, col: 26, offset: 4999},
 								expr: &choiceExpr{
-									pos: position{line: 213, col: 8, offset: 4931},
+									pos: position{line: 216, col: 8, offset: 5008},
 									alternatives: []interface{}{
 										&actionExpr{
-											pos: position{line: 213, col: 8, offset: 4931},
+											pos: position{line: 216, col: 8, offset: 5008},
 											run: (*parser).callonfieldReference8,
 											expr: &seqExpr{
-												pos: position{line: 213, col: 8, offset: 4931},
+												pos: position{line: 216, col: 8, offset: 5008},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 213, col: 8, offset: 4931},
+														pos:        position{line: 216, col: 8, offset: 5008},
 														val:        ".",
 														ignoreCase: false,
 													},
 													&labeledExpr{
-														pos:   position{line: 213, col: 12, offset: 4935},
+														pos:   position{line: 216, col: 12, offset: 5012},
 														label: "field",
 														expr: &ruleRefExpr{
-															pos:  position{line: 213, col: 18, offset: 4941},
+															pos:  position{line: 216, col: 18, offset: 5018},
 															name: "fieldName",
 														},
 													},
@@ -1552,26 +1586,26 @@ var g = &grammar{
 											},
 										},
 										&actionExpr{
-											pos: position{line: 214, col: 8, offset: 5022},
+											pos: position{line: 217, col: 8, offset: 5099},
 											run: (*parser).callonfieldReference13,
 											expr: &seqExpr{
-												pos: position{line: 214, col: 8, offset: 5022},
+												pos: position{line: 217, col: 8, offset: 5099},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 214, col: 8, offset: 5022},
+														pos:        position{line: 217, col: 8, offset: 5099},
 														val:        "[",
 														ignoreCase: false,
 													},
 													&labeledExpr{
-														pos:   position{line: 214, col: 12, offset: 5026},
+														pos:   position{line: 217, col: 12, offset: 5103},
 														label: "index",
 														expr: &ruleRefExpr{
-															pos:  position{line: 214, col: 18, offset: 5032},
+															pos:  position{line: 217, col: 18, offset: 5109},
 															name: "suint",
 														},
 													},
 													&litMatcher{
-														pos:        position{line: 214, col: 24, offset: 5038},
+														pos:        position{line: 217, col: 24, offset: 5115},
 														val:        "]",
 														ignoreCase: false,
 													},
@@ -1588,60 +1622,60 @@ var g = &grammar{
 		},
 		{
 			name: "fieldExpr",
-			pos:  position{line: 219, col: 1, offset: 5154},
+			pos:  position{line: 222, col: 1, offset: 5231},
 			expr: &choiceExpr{
-				pos: position{line: 220, col: 5, offset: 5168},
+				pos: position{line: 223, col: 5, offset: 5245},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 220, col: 5, offset: 5168},
+						pos: position{line: 223, col: 5, offset: 5245},
 						run: (*parser).callonfieldExpr2,
 						expr: &seqExpr{
-							pos: position{line: 220, col: 5, offset: 5168},
+							pos: position{line: 223, col: 5, offset: 5245},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 220, col: 5, offset: 5168},
+									pos:   position{line: 223, col: 5, offset: 5245},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 8, offset: 5171},
+										pos:  position{line: 223, col: 8, offset: 5248},
 										name: "fieldOp",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 220, col: 16, offset: 5179},
+									pos: position{line: 223, col: 16, offset: 5256},
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 16, offset: 5179},
+										pos:  position{line: 223, col: 16, offset: 5256},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 220, col: 19, offset: 5182},
+									pos:        position{line: 223, col: 19, offset: 5259},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 220, col: 23, offset: 5186},
+									pos: position{line: 223, col: 23, offset: 5263},
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 23, offset: 5186},
+										pos:  position{line: 223, col: 23, offset: 5263},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 220, col: 26, offset: 5189},
+									pos:   position{line: 223, col: 26, offset: 5266},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 32, offset: 5195},
+										pos:  position{line: 223, col: 32, offset: 5272},
 										name: "fieldReference",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 220, col: 47, offset: 5210},
+									pos: position{line: 223, col: 47, offset: 5287},
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 47, offset: 5210},
+										pos:  position{line: 223, col: 47, offset: 5287},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 220, col: 50, offset: 5213},
+									pos:        position{line: 223, col: 50, offset: 5290},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1649,7 +1683,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 223, col: 5, offset: 5277},
+						pos:  position{line: 226, col: 5, offset: 5354},
 						name: "fieldReference",
 					},
 				},
@@ -1657,12 +1691,12 @@ var g = &grammar{
 		},
 		{
 			name: "fieldOp",
-			pos:  position{line: 225, col: 1, offset: 5293},
+			pos:  position{line: 228, col: 1, offset: 5370},
 			expr: &actionExpr{
-				pos: position{line: 226, col: 5, offset: 5305},
+				pos: position{line: 229, col: 5, offset: 5382},
 				run: (*parser).callonfieldOp1,
 				expr: &litMatcher{
-					pos:        position{line: 226, col: 5, offset: 5305},
+					pos:        position{line: 229, col: 5, offset: 5382},
 					val:        "len",
 					ignoreCase: true,
 				},
@@ -1670,50 +1704,50 @@ var g = &grammar{
 		},
 		{
 			name: "fieldExprList",
-			pos:  position{line: 228, col: 1, offset: 5335},
+			pos:  position{line: 231, col: 1, offset: 5412},
 			expr: &actionExpr{
-				pos: position{line: 229, col: 5, offset: 5353},
+				pos: position{line: 232, col: 5, offset: 5430},
 				run: (*parser).callonfieldExprList1,
 				expr: &seqExpr{
-					pos: position{line: 229, col: 5, offset: 5353},
+					pos: position{line: 232, col: 5, offset: 5430},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 229, col: 5, offset: 5353},
+							pos:   position{line: 232, col: 5, offset: 5430},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 229, col: 11, offset: 5359},
+								pos:  position{line: 232, col: 11, offset: 5436},
 								name: "fieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 229, col: 21, offset: 5369},
+							pos:   position{line: 232, col: 21, offset: 5446},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 229, col: 26, offset: 5374},
+								pos: position{line: 232, col: 26, offset: 5451},
 								expr: &seqExpr{
-									pos: position{line: 229, col: 27, offset: 5375},
+									pos: position{line: 232, col: 27, offset: 5452},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 229, col: 27, offset: 5375},
+											pos: position{line: 232, col: 27, offset: 5452},
 											expr: &ruleRefExpr{
-												pos:  position{line: 229, col: 27, offset: 5375},
+												pos:  position{line: 232, col: 27, offset: 5452},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 229, col: 30, offset: 5378},
+											pos:        position{line: 232, col: 30, offset: 5455},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 229, col: 34, offset: 5382},
+											pos: position{line: 232, col: 34, offset: 5459},
 											expr: &ruleRefExpr{
-												pos:  position{line: 229, col: 34, offset: 5382},
+												pos:  position{line: 232, col: 34, offset: 5459},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 229, col: 37, offset: 5385},
+											pos:  position{line: 232, col: 37, offset: 5462},
 											name: "fieldExpr",
 										},
 									},
@@ -1726,39 +1760,39 @@ var g = &grammar{
 		},
 		{
 			name: "fieldRefDotOnly",
-			pos:  position{line: 239, col: 1, offset: 5580},
+			pos:  position{line: 242, col: 1, offset: 5657},
 			expr: &actionExpr{
-				pos: position{line: 240, col: 5, offset: 5600},
+				pos: position{line: 243, col: 5, offset: 5677},
 				run: (*parser).callonfieldRefDotOnly1,
 				expr: &seqExpr{
-					pos: position{line: 240, col: 5, offset: 5600},
+					pos: position{line: 243, col: 5, offset: 5677},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 240, col: 5, offset: 5600},
+							pos:   position{line: 243, col: 5, offset: 5677},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 240, col: 10, offset: 5605},
+								pos:  position{line: 243, col: 10, offset: 5682},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 240, col: 20, offset: 5615},
+							pos:   position{line: 243, col: 20, offset: 5692},
 							label: "refs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 240, col: 25, offset: 5620},
+								pos: position{line: 243, col: 25, offset: 5697},
 								expr: &seqExpr{
-									pos: position{line: 240, col: 26, offset: 5621},
+									pos: position{line: 243, col: 26, offset: 5698},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 240, col: 26, offset: 5621},
+											pos:        position{line: 243, col: 26, offset: 5698},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&labeledExpr{
-											pos:   position{line: 240, col: 30, offset: 5625},
+											pos:   position{line: 243, col: 30, offset: 5702},
 											label: "field",
 											expr: &ruleRefExpr{
-												pos:  position{line: 240, col: 36, offset: 5631},
+												pos:  position{line: 243, col: 36, offset: 5708},
 												name: "fieldName",
 											},
 										},
@@ -1772,56 +1806,56 @@ var g = &grammar{
 		},
 		{
 			name: "fieldRefDotOnlyList",
-			pos:  position{line: 242, col: 1, offset: 5675},
+			pos:  position{line: 245, col: 1, offset: 5752},
 			expr: &actionExpr{
-				pos: position{line: 243, col: 5, offset: 5699},
+				pos: position{line: 246, col: 5, offset: 5776},
 				run: (*parser).callonfieldRefDotOnlyList1,
 				expr: &seqExpr{
-					pos: position{line: 243, col: 5, offset: 5699},
+					pos: position{line: 246, col: 5, offset: 5776},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 243, col: 5, offset: 5699},
+							pos:   position{line: 246, col: 5, offset: 5776},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 243, col: 11, offset: 5705},
+								pos:  position{line: 246, col: 11, offset: 5782},
 								name: "fieldRefDotOnly",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 243, col: 27, offset: 5721},
+							pos:   position{line: 246, col: 27, offset: 5798},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 243, col: 32, offset: 5726},
+								pos: position{line: 246, col: 32, offset: 5803},
 								expr: &actionExpr{
-									pos: position{line: 243, col: 33, offset: 5727},
+									pos: position{line: 246, col: 33, offset: 5804},
 									run: (*parser).callonfieldRefDotOnlyList7,
 									expr: &seqExpr{
-										pos: position{line: 243, col: 33, offset: 5727},
+										pos: position{line: 246, col: 33, offset: 5804},
 										exprs: []interface{}{
 											&zeroOrOneExpr{
-												pos: position{line: 243, col: 33, offset: 5727},
+												pos: position{line: 246, col: 33, offset: 5804},
 												expr: &ruleRefExpr{
-													pos:  position{line: 243, col: 33, offset: 5727},
+													pos:  position{line: 246, col: 33, offset: 5804},
 													name: "_",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 243, col: 36, offset: 5730},
+												pos:        position{line: 246, col: 36, offset: 5807},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 243, col: 40, offset: 5734},
+												pos: position{line: 246, col: 40, offset: 5811},
 												expr: &ruleRefExpr{
-													pos:  position{line: 243, col: 40, offset: 5734},
+													pos:  position{line: 246, col: 40, offset: 5811},
 													name: "_",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 243, col: 43, offset: 5737},
+												pos:   position{line: 246, col: 43, offset: 5814},
 												label: "ref",
 												expr: &ruleRefExpr{
-													pos:  position{line: 243, col: 47, offset: 5741},
+													pos:  position{line: 246, col: 47, offset: 5818},
 													name: "fieldRefDotOnly",
 												},
 											},
@@ -1836,50 +1870,50 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameList",
-			pos:  position{line: 251, col: 1, offset: 5921},
+			pos:  position{line: 254, col: 1, offset: 5998},
 			expr: &actionExpr{
-				pos: position{line: 252, col: 5, offset: 5939},
+				pos: position{line: 255, col: 5, offset: 6016},
 				run: (*parser).callonfieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 252, col: 5, offset: 5939},
+					pos: position{line: 255, col: 5, offset: 6016},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 252, col: 5, offset: 5939},
+							pos:   position{line: 255, col: 5, offset: 6016},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 252, col: 11, offset: 5945},
+								pos:  position{line: 255, col: 11, offset: 6022},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 252, col: 21, offset: 5955},
+							pos:   position{line: 255, col: 21, offset: 6032},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 252, col: 26, offset: 5960},
+								pos: position{line: 255, col: 26, offset: 6037},
 								expr: &seqExpr{
-									pos: position{line: 252, col: 27, offset: 5961},
+									pos: position{line: 255, col: 27, offset: 6038},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 252, col: 27, offset: 5961},
+											pos: position{line: 255, col: 27, offset: 6038},
 											expr: &ruleRefExpr{
-												pos:  position{line: 252, col: 27, offset: 5961},
+												pos:  position{line: 255, col: 27, offset: 6038},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 252, col: 30, offset: 5964},
+											pos:        position{line: 255, col: 30, offset: 6041},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 252, col: 34, offset: 5968},
+											pos: position{line: 255, col: 34, offset: 6045},
 											expr: &ruleRefExpr{
-												pos:  position{line: 252, col: 34, offset: 5968},
+												pos:  position{line: 255, col: 34, offset: 6045},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 252, col: 37, offset: 5971},
+											pos:  position{line: 255, col: 37, offset: 6048},
 											name: "fieldName",
 										},
 									},
@@ -1892,12 +1926,12 @@ var g = &grammar{
 		},
 		{
 			name: "countOp",
-			pos:  position{line: 260, col: 1, offset: 6164},
+			pos:  position{line: 263, col: 1, offset: 6241},
 			expr: &actionExpr{
-				pos: position{line: 261, col: 5, offset: 6176},
+				pos: position{line: 264, col: 5, offset: 6253},
 				run: (*parser).calloncountOp1,
 				expr: &litMatcher{
-					pos:        position{line: 261, col: 5, offset: 6176},
+					pos:        position{line: 264, col: 5, offset: 6253},
 					val:        "count",
 					ignoreCase: true,
 				},
@@ -1905,105 +1939,105 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReducerOp",
-			pos:  position{line: 263, col: 1, offset: 6210},
+			pos:  position{line: 266, col: 1, offset: 6287},
 			expr: &choiceExpr{
-				pos: position{line: 264, col: 5, offset: 6229},
+				pos: position{line: 267, col: 5, offset: 6306},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 264, col: 5, offset: 6229},
+						pos: position{line: 267, col: 5, offset: 6306},
 						run: (*parser).callonfieldReducerOp2,
 						expr: &litMatcher{
-							pos:        position{line: 264, col: 5, offset: 6229},
+							pos:        position{line: 267, col: 5, offset: 6306},
 							val:        "sum",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 265, col: 5, offset: 6263},
+						pos: position{line: 268, col: 5, offset: 6340},
 						run: (*parser).callonfieldReducerOp4,
 						expr: &litMatcher{
-							pos:        position{line: 265, col: 5, offset: 6263},
+							pos:        position{line: 268, col: 5, offset: 6340},
 							val:        "avg",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 266, col: 5, offset: 6297},
+						pos: position{line: 269, col: 5, offset: 6374},
 						run: (*parser).callonfieldReducerOp6,
 						expr: &litMatcher{
-							pos:        position{line: 266, col: 5, offset: 6297},
+							pos:        position{line: 269, col: 5, offset: 6374},
 							val:        "stdev",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 267, col: 5, offset: 6334},
+						pos: position{line: 270, col: 5, offset: 6411},
 						run: (*parser).callonfieldReducerOp8,
 						expr: &litMatcher{
-							pos:        position{line: 267, col: 5, offset: 6334},
+							pos:        position{line: 270, col: 5, offset: 6411},
 							val:        "sd",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 268, col: 5, offset: 6370},
+						pos: position{line: 271, col: 5, offset: 6447},
 						run: (*parser).callonfieldReducerOp10,
 						expr: &litMatcher{
-							pos:        position{line: 268, col: 5, offset: 6370},
+							pos:        position{line: 271, col: 5, offset: 6447},
 							val:        "var",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 269, col: 5, offset: 6404},
+						pos: position{line: 272, col: 5, offset: 6481},
 						run: (*parser).callonfieldReducerOp12,
 						expr: &litMatcher{
-							pos:        position{line: 269, col: 5, offset: 6404},
+							pos:        position{line: 272, col: 5, offset: 6481},
 							val:        "entropy",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 270, col: 5, offset: 6445},
+						pos: position{line: 273, col: 5, offset: 6522},
 						run: (*parser).callonfieldReducerOp14,
 						expr: &litMatcher{
-							pos:        position{line: 270, col: 5, offset: 6445},
+							pos:        position{line: 273, col: 5, offset: 6522},
 							val:        "min",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 271, col: 5, offset: 6479},
+						pos: position{line: 274, col: 5, offset: 6556},
 						run: (*parser).callonfieldReducerOp16,
 						expr: &litMatcher{
-							pos:        position{line: 271, col: 5, offset: 6479},
+							pos:        position{line: 274, col: 5, offset: 6556},
 							val:        "max",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 272, col: 5, offset: 6513},
+						pos: position{line: 275, col: 5, offset: 6590},
 						run: (*parser).callonfieldReducerOp18,
 						expr: &litMatcher{
-							pos:        position{line: 272, col: 5, offset: 6513},
+							pos:        position{line: 275, col: 5, offset: 6590},
 							val:        "first",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 273, col: 5, offset: 6551},
+						pos: position{line: 276, col: 5, offset: 6628},
 						run: (*parser).callonfieldReducerOp20,
 						expr: &litMatcher{
-							pos:        position{line: 273, col: 5, offset: 6551},
+							pos:        position{line: 276, col: 5, offset: 6628},
 							val:        "last",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 274, col: 5, offset: 6587},
+						pos: position{line: 277, col: 5, offset: 6664},
 						run: (*parser).callonfieldReducerOp22,
 						expr: &litMatcher{
-							pos:        position{line: 274, col: 5, offset: 6587},
+							pos:        position{line: 277, col: 5, offset: 6664},
 							val:        "countdistinct",
 							ignoreCase: true,
 						},
@@ -2013,32 +2047,32 @@ var g = &grammar{
 		},
 		{
 			name: "paddedFieldExpr",
-			pos:  position{line: 276, col: 1, offset: 6637},
+			pos:  position{line: 279, col: 1, offset: 6714},
 			expr: &actionExpr{
-				pos: position{line: 276, col: 19, offset: 6655},
+				pos: position{line: 279, col: 19, offset: 6732},
 				run: (*parser).callonpaddedFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 276, col: 19, offset: 6655},
+					pos: position{line: 279, col: 19, offset: 6732},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 276, col: 19, offset: 6655},
+							pos: position{line: 279, col: 19, offset: 6732},
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 19, offset: 6655},
+								pos:  position{line: 279, col: 19, offset: 6732},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 276, col: 22, offset: 6658},
+							pos:   position{line: 279, col: 22, offset: 6735},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 28, offset: 6664},
+								pos:  position{line: 279, col: 28, offset: 6741},
 								name: "fieldExpr",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 276, col: 38, offset: 6674},
+							pos: position{line: 279, col: 38, offset: 6751},
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 38, offset: 6674},
+								pos:  position{line: 279, col: 38, offset: 6751},
 								name: "_",
 							},
 						},
@@ -2048,53 +2082,53 @@ var g = &grammar{
 		},
 		{
 			name: "countReducer",
-			pos:  position{line: 278, col: 1, offset: 6700},
+			pos:  position{line: 281, col: 1, offset: 6777},
 			expr: &actionExpr{
-				pos: position{line: 279, col: 5, offset: 6717},
+				pos: position{line: 282, col: 5, offset: 6794},
 				run: (*parser).calloncountReducer1,
 				expr: &seqExpr{
-					pos: position{line: 279, col: 5, offset: 6717},
+					pos: position{line: 282, col: 5, offset: 6794},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 279, col: 5, offset: 6717},
+							pos:   position{line: 282, col: 5, offset: 6794},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 8, offset: 6720},
+								pos:  position{line: 282, col: 8, offset: 6797},
 								name: "countOp",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 279, col: 16, offset: 6728},
+							pos: position{line: 282, col: 16, offset: 6805},
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 16, offset: 6728},
+								pos:  position{line: 282, col: 16, offset: 6805},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 279, col: 19, offset: 6731},
+							pos:        position{line: 282, col: 19, offset: 6808},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 279, col: 23, offset: 6735},
+							pos:   position{line: 282, col: 23, offset: 6812},
 							label: "field",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 279, col: 29, offset: 6741},
+								pos: position{line: 282, col: 29, offset: 6818},
 								expr: &ruleRefExpr{
-									pos:  position{line: 279, col: 29, offset: 6741},
+									pos:  position{line: 282, col: 29, offset: 6818},
 									name: "paddedFieldExpr",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 279, col: 47, offset: 6759},
+							pos: position{line: 282, col: 47, offset: 6836},
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 47, offset: 6759},
+								pos:  position{line: 282, col: 47, offset: 6836},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 279, col: 50, offset: 6762},
+							pos:        position{line: 282, col: 50, offset: 6839},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2104,57 +2138,57 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReducer",
-			pos:  position{line: 283, col: 1, offset: 6821},
+			pos:  position{line: 286, col: 1, offset: 6898},
 			expr: &actionExpr{
-				pos: position{line: 284, col: 5, offset: 6838},
+				pos: position{line: 287, col: 5, offset: 6915},
 				run: (*parser).callonfieldReducer1,
 				expr: &seqExpr{
-					pos: position{line: 284, col: 5, offset: 6838},
+					pos: position{line: 287, col: 5, offset: 6915},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 284, col: 5, offset: 6838},
+							pos:   position{line: 287, col: 5, offset: 6915},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 8, offset: 6841},
+								pos:  position{line: 287, col: 8, offset: 6918},
 								name: "fieldReducerOp",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 284, col: 23, offset: 6856},
+							pos: position{line: 287, col: 23, offset: 6933},
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 23, offset: 6856},
+								pos:  position{line: 287, col: 23, offset: 6933},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 284, col: 26, offset: 6859},
+							pos:        position{line: 287, col: 26, offset: 6936},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 284, col: 30, offset: 6863},
+							pos: position{line: 287, col: 30, offset: 6940},
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 30, offset: 6863},
+								pos:  position{line: 287, col: 30, offset: 6940},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 284, col: 33, offset: 6866},
+							pos:   position{line: 287, col: 33, offset: 6943},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 39, offset: 6872},
+								pos:  position{line: 287, col: 39, offset: 6949},
 								name: "fieldExpr",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 284, col: 50, offset: 6883},
+							pos: position{line: 287, col: 50, offset: 6960},
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 50, offset: 6883},
+								pos:  position{line: 287, col: 50, offset: 6960},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 284, col: 53, offset: 6886},
+							pos:        position{line: 287, col: 53, offset: 6963},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2164,27 +2198,27 @@ var g = &grammar{
 		},
 		{
 			name: "reducerProc",
-			pos:  position{line: 288, col: 1, offset: 6953},
+			pos:  position{line: 291, col: 1, offset: 7030},
 			expr: &actionExpr{
-				pos: position{line: 289, col: 5, offset: 6969},
+				pos: position{line: 292, col: 5, offset: 7046},
 				run: (*parser).callonreducerProc1,
 				expr: &seqExpr{
-					pos: position{line: 289, col: 5, offset: 6969},
+					pos: position{line: 292, col: 5, offset: 7046},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 289, col: 5, offset: 6969},
+							pos:   position{line: 292, col: 5, offset: 7046},
 							label: "every",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 289, col: 11, offset: 6975},
+								pos: position{line: 292, col: 11, offset: 7052},
 								expr: &seqExpr{
-									pos: position{line: 289, col: 12, offset: 6976},
+									pos: position{line: 292, col: 12, offset: 7053},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 289, col: 12, offset: 6976},
+											pos:  position{line: 292, col: 12, offset: 7053},
 											name: "everyDur",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 289, col: 21, offset: 6985},
+											pos:  position{line: 292, col: 21, offset: 7062},
 											name: "_",
 										},
 									},
@@ -2192,27 +2226,27 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 289, col: 25, offset: 6989},
+							pos:   position{line: 292, col: 25, offset: 7066},
 							label: "reducers",
 							expr: &ruleRefExpr{
-								pos:  position{line: 289, col: 34, offset: 6998},
+								pos:  position{line: 292, col: 34, offset: 7075},
 								name: "reducerList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 289, col: 46, offset: 7010},
+							pos:   position{line: 292, col: 46, offset: 7087},
 							label: "keys",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 289, col: 51, offset: 7015},
+								pos: position{line: 292, col: 51, offset: 7092},
 								expr: &seqExpr{
-									pos: position{line: 289, col: 52, offset: 7016},
+									pos: position{line: 292, col: 52, offset: 7093},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 289, col: 52, offset: 7016},
+											pos:  position{line: 292, col: 52, offset: 7093},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 289, col: 54, offset: 7018},
+											pos:  position{line: 292, col: 54, offset: 7095},
 											name: "groupByKeys",
 										},
 									},
@@ -2220,12 +2254,23 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 289, col: 68, offset: 7032},
+							pos:   position{line: 292, col: 68, offset: 7109},
+							label: "sorted",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 292, col: 75, offset: 7116},
+								expr: &ruleRefExpr{
+									pos:  position{line: 292, col: 75, offset: 7116},
+									name: "groupBySorted",
+								},
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 292, col: 90, offset: 7131},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 289, col: 74, offset: 7038},
+								pos: position{line: 292, col: 96, offset: 7137},
 								expr: &ruleRefExpr{
-									pos:  position{line: 289, col: 74, offset: 7038},
+									pos:  position{line: 292, col: 96, offset: 7137},
 									name: "procLimitArg",
 								},
 							},
@@ -2236,27 +2281,27 @@ var g = &grammar{
 		},
 		{
 			name: "asClause",
-			pos:  position{line: 307, col: 1, offset: 7395},
+			pos:  position{line: 310, col: 1, offset: 7502},
 			expr: &actionExpr{
-				pos: position{line: 308, col: 5, offset: 7408},
+				pos: position{line: 311, col: 5, offset: 7515},
 				run: (*parser).callonasClause1,
 				expr: &seqExpr{
-					pos: position{line: 308, col: 5, offset: 7408},
+					pos: position{line: 311, col: 5, offset: 7515},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 308, col: 5, offset: 7408},
+							pos:        position{line: 311, col: 5, offset: 7515},
 							val:        "as",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 308, col: 11, offset: 7414},
+							pos:  position{line: 311, col: 11, offset: 7521},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 308, col: 13, offset: 7416},
+							pos:   position{line: 311, col: 13, offset: 7523},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 308, col: 15, offset: 7418},
+								pos:  position{line: 311, col: 15, offset: 7525},
 								name: "fieldName",
 							},
 						},
@@ -2266,48 +2311,48 @@ var g = &grammar{
 		},
 		{
 			name: "reducerExpr",
-			pos:  position{line: 310, col: 1, offset: 7447},
+			pos:  position{line: 313, col: 1, offset: 7554},
 			expr: &choiceExpr{
-				pos: position{line: 311, col: 5, offset: 7463},
+				pos: position{line: 314, col: 5, offset: 7570},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 311, col: 5, offset: 7463},
+						pos: position{line: 314, col: 5, offset: 7570},
 						run: (*parser).callonreducerExpr2,
 						expr: &seqExpr{
-							pos: position{line: 311, col: 5, offset: 7463},
+							pos: position{line: 314, col: 5, offset: 7570},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 311, col: 5, offset: 7463},
+									pos:   position{line: 314, col: 5, offset: 7570},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 311, col: 11, offset: 7469},
+										pos:  position{line: 314, col: 11, offset: 7576},
 										name: "fieldExpr",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 311, col: 21, offset: 7479},
+									pos: position{line: 314, col: 21, offset: 7586},
 									expr: &ruleRefExpr{
-										pos:  position{line: 311, col: 21, offset: 7479},
+										pos:  position{line: 314, col: 21, offset: 7586},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 311, col: 24, offset: 7482},
+									pos:        position{line: 314, col: 24, offset: 7589},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 311, col: 28, offset: 7486},
+									pos: position{line: 314, col: 28, offset: 7593},
 									expr: &ruleRefExpr{
-										pos:  position{line: 311, col: 28, offset: 7486},
+										pos:  position{line: 314, col: 28, offset: 7593},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 311, col: 31, offset: 7489},
+									pos:   position{line: 314, col: 31, offset: 7596},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 311, col: 33, offset: 7491},
+										pos:  position{line: 314, col: 33, offset: 7598},
 										name: "reducer",
 									},
 								},
@@ -2315,28 +2360,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 314, col: 5, offset: 7554},
+						pos: position{line: 317, col: 5, offset: 7661},
 						run: (*parser).callonreducerExpr13,
 						expr: &seqExpr{
-							pos: position{line: 314, col: 5, offset: 7554},
+							pos: position{line: 317, col: 5, offset: 7661},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 314, col: 5, offset: 7554},
+									pos:   position{line: 317, col: 5, offset: 7661},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 314, col: 7, offset: 7556},
+										pos:  position{line: 317, col: 7, offset: 7663},
 										name: "reducer",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 314, col: 15, offset: 7564},
+									pos:  position{line: 317, col: 15, offset: 7671},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 314, col: 17, offset: 7566},
+									pos:   position{line: 317, col: 17, offset: 7673},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 314, col: 23, offset: 7572},
+										pos:  position{line: 317, col: 23, offset: 7679},
 										name: "asClause",
 									},
 								},
@@ -2344,7 +2389,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 5, offset: 7636},
+						pos:  position{line: 320, col: 5, offset: 7743},
 						name: "reducer",
 					},
 				},
@@ -2352,16 +2397,16 @@ var g = &grammar{
 		},
 		{
 			name: "reducer",
-			pos:  position{line: 319, col: 1, offset: 7645},
+			pos:  position{line: 322, col: 1, offset: 7752},
 			expr: &choiceExpr{
-				pos: position{line: 320, col: 5, offset: 7657},
+				pos: position{line: 323, col: 5, offset: 7764},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 5, offset: 7657},
+						pos:  position{line: 323, col: 5, offset: 7764},
 						name: "countReducer",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 321, col: 5, offset: 7674},
+						pos:  position{line: 324, col: 5, offset: 7781},
 						name: "fieldReducer",
 					},
 				},
@@ -2369,50 +2414,50 @@ var g = &grammar{
 		},
 		{
 			name: "reducerList",
-			pos:  position{line: 323, col: 1, offset: 7688},
+			pos:  position{line: 326, col: 1, offset: 7795},
 			expr: &actionExpr{
-				pos: position{line: 324, col: 5, offset: 7704},
+				pos: position{line: 327, col: 5, offset: 7811},
 				run: (*parser).callonreducerList1,
 				expr: &seqExpr{
-					pos: position{line: 324, col: 5, offset: 7704},
+					pos: position{line: 327, col: 5, offset: 7811},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 324, col: 5, offset: 7704},
+							pos:   position{line: 327, col: 5, offset: 7811},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 324, col: 11, offset: 7710},
+								pos:  position{line: 327, col: 11, offset: 7817},
 								name: "reducerExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 324, col: 23, offset: 7722},
+							pos:   position{line: 327, col: 23, offset: 7829},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 324, col: 28, offset: 7727},
+								pos: position{line: 327, col: 28, offset: 7834},
 								expr: &seqExpr{
-									pos: position{line: 324, col: 29, offset: 7728},
+									pos: position{line: 327, col: 29, offset: 7835},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 324, col: 29, offset: 7728},
+											pos: position{line: 327, col: 29, offset: 7835},
 											expr: &ruleRefExpr{
-												pos:  position{line: 324, col: 29, offset: 7728},
+												pos:  position{line: 327, col: 29, offset: 7835},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 324, col: 32, offset: 7731},
+											pos:        position{line: 327, col: 32, offset: 7838},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 324, col: 36, offset: 7735},
+											pos: position{line: 327, col: 36, offset: 7842},
 											expr: &ruleRefExpr{
-												pos:  position{line: 324, col: 36, offset: 7735},
+												pos:  position{line: 327, col: 36, offset: 7842},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 324, col: 39, offset: 7738},
+											pos:  position{line: 327, col: 39, offset: 7845},
 											name: "reducerExpr",
 										},
 									},
@@ -2425,40 +2470,40 @@ var g = &grammar{
 		},
 		{
 			name: "simpleProc",
-			pos:  position{line: 332, col: 1, offset: 7935},
+			pos:  position{line: 335, col: 1, offset: 8042},
 			expr: &choiceExpr{
-				pos: position{line: 333, col: 5, offset: 7950},
+				pos: position{line: 336, col: 5, offset: 8057},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 333, col: 5, offset: 7950},
+						pos:  position{line: 336, col: 5, offset: 8057},
 						name: "sort",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 334, col: 5, offset: 7959},
+						pos:  position{line: 337, col: 5, offset: 8066},
 						name: "top",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 335, col: 5, offset: 7967},
+						pos:  position{line: 338, col: 5, offset: 8074},
 						name: "cut",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 336, col: 5, offset: 7975},
+						pos:  position{line: 339, col: 5, offset: 8082},
 						name: "head",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 337, col: 5, offset: 7984},
+						pos:  position{line: 340, col: 5, offset: 8091},
 						name: "tail",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 338, col: 5, offset: 7993},
+						pos:  position{line: 341, col: 5, offset: 8100},
 						name: "filter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 339, col: 5, offset: 8004},
+						pos:  position{line: 342, col: 5, offset: 8111},
 						name: "uniq",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 340, col: 5, offset: 8013},
+						pos:  position{line: 343, col: 5, offset: 8120},
 						name: "put",
 					},
 				},
@@ -2466,46 +2511,46 @@ var g = &grammar{
 		},
 		{
 			name: "sort",
-			pos:  position{line: 342, col: 1, offset: 8018},
+			pos:  position{line: 345, col: 1, offset: 8125},
 			expr: &actionExpr{
-				pos: position{line: 343, col: 5, offset: 8027},
+				pos: position{line: 346, col: 5, offset: 8134},
 				run: (*parser).callonsort1,
 				expr: &seqExpr{
-					pos: position{line: 343, col: 5, offset: 8027},
+					pos: position{line: 346, col: 5, offset: 8134},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 343, col: 5, offset: 8027},
+							pos:        position{line: 346, col: 5, offset: 8134},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 343, col: 13, offset: 8035},
+							pos:   position{line: 346, col: 13, offset: 8142},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 343, col: 18, offset: 8040},
+								pos:  position{line: 346, col: 18, offset: 8147},
 								name: "sortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 343, col: 27, offset: 8049},
+							pos:   position{line: 346, col: 27, offset: 8156},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 343, col: 32, offset: 8054},
+								pos: position{line: 346, col: 32, offset: 8161},
 								expr: &actionExpr{
-									pos: position{line: 343, col: 33, offset: 8055},
+									pos: position{line: 346, col: 33, offset: 8162},
 									run: (*parser).callonsort8,
 									expr: &seqExpr{
-										pos: position{line: 343, col: 33, offset: 8055},
+										pos: position{line: 346, col: 33, offset: 8162},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 343, col: 33, offset: 8055},
+												pos:  position{line: 346, col: 33, offset: 8162},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 343, col: 35, offset: 8057},
+												pos:   position{line: 346, col: 35, offset: 8164},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 343, col: 37, offset: 8059},
+													pos:  position{line: 346, col: 37, offset: 8166},
 													name: "fieldExprList",
 												},
 											},
@@ -2520,24 +2565,24 @@ var g = &grammar{
 		},
 		{
 			name: "sortArgs",
-			pos:  position{line: 347, col: 1, offset: 8136},
+			pos:  position{line: 350, col: 1, offset: 8243},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 347, col: 12, offset: 8147},
+				pos: position{line: 350, col: 12, offset: 8254},
 				expr: &actionExpr{
-					pos: position{line: 347, col: 13, offset: 8148},
+					pos: position{line: 350, col: 13, offset: 8255},
 					run: (*parser).callonsortArgs2,
 					expr: &seqExpr{
-						pos: position{line: 347, col: 13, offset: 8148},
+						pos: position{line: 350, col: 13, offset: 8255},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 347, col: 13, offset: 8148},
+								pos:  position{line: 350, col: 13, offset: 8255},
 								name: "_",
 							},
 							&labeledExpr{
-								pos:   position{line: 347, col: 15, offset: 8150},
+								pos:   position{line: 350, col: 15, offset: 8257},
 								label: "a",
 								expr: &ruleRefExpr{
-									pos:  position{line: 347, col: 17, offset: 8152},
+									pos:  position{line: 350, col: 17, offset: 8259},
 									name: "sortArg",
 								},
 							},
@@ -2548,50 +2593,50 @@ var g = &grammar{
 		},
 		{
 			name: "sortArg",
-			pos:  position{line: 349, col: 1, offset: 8181},
+			pos:  position{line: 352, col: 1, offset: 8288},
 			expr: &choiceExpr{
-				pos: position{line: 350, col: 5, offset: 8193},
+				pos: position{line: 353, col: 5, offset: 8300},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 350, col: 5, offset: 8193},
+						pos: position{line: 353, col: 5, offset: 8300},
 						run: (*parser).callonsortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 350, col: 5, offset: 8193},
+							pos:        position{line: 353, col: 5, offset: 8300},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 351, col: 5, offset: 8236},
+						pos: position{line: 354, col: 5, offset: 8343},
 						run: (*parser).callonsortArg4,
 						expr: &seqExpr{
-							pos: position{line: 351, col: 5, offset: 8236},
+							pos: position{line: 354, col: 5, offset: 8343},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 351, col: 5, offset: 8236},
+									pos:        position{line: 354, col: 5, offset: 8343},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 14, offset: 8245},
+									pos:  position{line: 354, col: 14, offset: 8352},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 351, col: 16, offset: 8247},
+									pos:   position{line: 354, col: 16, offset: 8354},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 351, col: 23, offset: 8254},
+										pos: position{line: 354, col: 23, offset: 8361},
 										run: (*parser).callonsortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 351, col: 24, offset: 8255},
+											pos: position{line: 354, col: 24, offset: 8362},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 351, col: 24, offset: 8255},
+													pos:        position{line: 354, col: 24, offset: 8362},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 351, col: 34, offset: 8265},
+													pos:        position{line: 354, col: 34, offset: 8372},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2607,38 +2652,38 @@ var g = &grammar{
 		},
 		{
 			name: "top",
-			pos:  position{line: 353, col: 1, offset: 8347},
+			pos:  position{line: 356, col: 1, offset: 8454},
 			expr: &actionExpr{
-				pos: position{line: 354, col: 5, offset: 8355},
+				pos: position{line: 357, col: 5, offset: 8462},
 				run: (*parser).callontop1,
 				expr: &seqExpr{
-					pos: position{line: 354, col: 5, offset: 8355},
+					pos: position{line: 357, col: 5, offset: 8462},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 354, col: 5, offset: 8355},
+							pos:        position{line: 357, col: 5, offset: 8462},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 12, offset: 8362},
+							pos:   position{line: 357, col: 12, offset: 8469},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 354, col: 18, offset: 8368},
+								pos: position{line: 357, col: 18, offset: 8475},
 								expr: &actionExpr{
-									pos: position{line: 354, col: 19, offset: 8369},
+									pos: position{line: 357, col: 19, offset: 8476},
 									run: (*parser).callontop6,
 									expr: &seqExpr{
-										pos: position{line: 354, col: 19, offset: 8369},
+										pos: position{line: 357, col: 19, offset: 8476},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 354, col: 19, offset: 8369},
+												pos:  position{line: 357, col: 19, offset: 8476},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 354, col: 21, offset: 8371},
+												pos:   position{line: 357, col: 21, offset: 8478},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 354, col: 23, offset: 8373},
+													pos:  position{line: 357, col: 23, offset: 8480},
 													name: "unsignedInteger",
 												},
 											},
@@ -2648,19 +2693,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 58, offset: 8408},
+							pos:   position{line: 357, col: 58, offset: 8515},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 354, col: 64, offset: 8414},
+								pos: position{line: 357, col: 64, offset: 8521},
 								expr: &seqExpr{
-									pos: position{line: 354, col: 65, offset: 8415},
+									pos: position{line: 357, col: 65, offset: 8522},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 354, col: 65, offset: 8415},
+											pos:  position{line: 357, col: 65, offset: 8522},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 354, col: 67, offset: 8417},
+											pos:        position{line: 357, col: 67, offset: 8524},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2669,25 +2714,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 78, offset: 8428},
+							pos:   position{line: 357, col: 78, offset: 8535},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 354, col: 83, offset: 8433},
+								pos: position{line: 357, col: 83, offset: 8540},
 								expr: &actionExpr{
-									pos: position{line: 354, col: 84, offset: 8434},
+									pos: position{line: 357, col: 84, offset: 8541},
 									run: (*parser).callontop18,
 									expr: &seqExpr{
-										pos: position{line: 354, col: 84, offset: 8434},
+										pos: position{line: 357, col: 84, offset: 8541},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 354, col: 84, offset: 8434},
+												pos:  position{line: 357, col: 84, offset: 8541},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 354, col: 86, offset: 8436},
+												pos:   position{line: 357, col: 86, offset: 8543},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 354, col: 88, offset: 8438},
+													pos:  position{line: 357, col: 88, offset: 8545},
 													name: "fieldExprList",
 												},
 											},
@@ -2702,31 +2747,31 @@ var g = &grammar{
 		},
 		{
 			name: "procLimitArg",
-			pos:  position{line: 358, col: 1, offset: 8527},
+			pos:  position{line: 361, col: 1, offset: 8634},
 			expr: &actionExpr{
-				pos: position{line: 359, col: 5, offset: 8544},
+				pos: position{line: 362, col: 5, offset: 8651},
 				run: (*parser).callonprocLimitArg1,
 				expr: &seqExpr{
-					pos: position{line: 359, col: 5, offset: 8544},
+					pos: position{line: 362, col: 5, offset: 8651},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 359, col: 5, offset: 8544},
+							pos:  position{line: 362, col: 5, offset: 8651},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 359, col: 7, offset: 8546},
+							pos:        position{line: 362, col: 7, offset: 8653},
 							val:        "-limit",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 359, col: 16, offset: 8555},
+							pos:  position{line: 362, col: 16, offset: 8662},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 359, col: 18, offset: 8557},
+							pos:   position{line: 362, col: 18, offset: 8664},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 359, col: 24, offset: 8563},
+								pos:  position{line: 362, col: 24, offset: 8670},
 								name: "unsignedInteger",
 							},
 						},
@@ -2736,21 +2781,21 @@ var g = &grammar{
 		},
 		{
 			name: "cutArg",
-			pos:  position{line: 361, col: 1, offset: 8602},
+			pos:  position{line: 364, col: 1, offset: 8709},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 361, col: 10, offset: 8611},
+				pos: position{line: 364, col: 10, offset: 8718},
 				expr: &actionExpr{
-					pos: position{line: 361, col: 11, offset: 8612},
+					pos: position{line: 364, col: 11, offset: 8719},
 					run: (*parser).calloncutArg2,
 					expr: &seqExpr{
-						pos: position{line: 361, col: 11, offset: 8612},
+						pos: position{line: 364, col: 11, offset: 8719},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 361, col: 11, offset: 8612},
+								pos:  position{line: 364, col: 11, offset: 8719},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 361, col: 13, offset: 8614},
+								pos:        position{line: 364, col: 13, offset: 8721},
 								val:        "-c",
 								ignoreCase: false,
 							},
@@ -2761,35 +2806,35 @@ var g = &grammar{
 		},
 		{
 			name: "cut",
-			pos:  position{line: 363, col: 1, offset: 8656},
+			pos:  position{line: 366, col: 1, offset: 8763},
 			expr: &actionExpr{
-				pos: position{line: 364, col: 5, offset: 8664},
+				pos: position{line: 367, col: 5, offset: 8771},
 				run: (*parser).calloncut1,
 				expr: &seqExpr{
-					pos: position{line: 364, col: 5, offset: 8664},
+					pos: position{line: 367, col: 5, offset: 8771},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 364, col: 5, offset: 8664},
+							pos:        position{line: 367, col: 5, offset: 8771},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 364, col: 12, offset: 8671},
+							pos:   position{line: 367, col: 12, offset: 8778},
 							label: "arg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 364, col: 16, offset: 8675},
+								pos:  position{line: 367, col: 16, offset: 8782},
 								name: "cutArg",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 364, col: 23, offset: 8682},
+							pos:  position{line: 367, col: 23, offset: 8789},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 364, col: 25, offset: 8684},
+							pos:   position{line: 367, col: 25, offset: 8791},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 364, col: 30, offset: 8689},
+								pos:  position{line: 367, col: 30, offset: 8796},
 								name: "fieldRefDotOnlyList",
 							},
 						},
@@ -2799,30 +2844,30 @@ var g = &grammar{
 		},
 		{
 			name: "head",
-			pos:  position{line: 365, col: 1, offset: 8744},
+			pos:  position{line: 368, col: 1, offset: 8851},
 			expr: &choiceExpr{
-				pos: position{line: 366, col: 5, offset: 8753},
+				pos: position{line: 369, col: 5, offset: 8860},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 366, col: 5, offset: 8753},
+						pos: position{line: 369, col: 5, offset: 8860},
 						run: (*parser).callonhead2,
 						expr: &seqExpr{
-							pos: position{line: 366, col: 5, offset: 8753},
+							pos: position{line: 369, col: 5, offset: 8860},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 366, col: 5, offset: 8753},
+									pos:        position{line: 369, col: 5, offset: 8860},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 366, col: 13, offset: 8761},
+									pos:  position{line: 369, col: 13, offset: 8868},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 366, col: 15, offset: 8763},
+									pos:   position{line: 369, col: 15, offset: 8870},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 366, col: 21, offset: 8769},
+										pos:  position{line: 369, col: 21, offset: 8876},
 										name: "unsignedInteger",
 									},
 								},
@@ -2830,10 +2875,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 367, col: 5, offset: 8825},
+						pos: position{line: 370, col: 5, offset: 8932},
 						run: (*parser).callonhead8,
 						expr: &litMatcher{
-							pos:        position{line: 367, col: 5, offset: 8825},
+							pos:        position{line: 370, col: 5, offset: 8932},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2843,30 +2888,30 @@ var g = &grammar{
 		},
 		{
 			name: "tail",
-			pos:  position{line: 368, col: 1, offset: 8865},
+			pos:  position{line: 371, col: 1, offset: 8972},
 			expr: &choiceExpr{
-				pos: position{line: 369, col: 5, offset: 8874},
+				pos: position{line: 372, col: 5, offset: 8981},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 369, col: 5, offset: 8874},
+						pos: position{line: 372, col: 5, offset: 8981},
 						run: (*parser).callontail2,
 						expr: &seqExpr{
-							pos: position{line: 369, col: 5, offset: 8874},
+							pos: position{line: 372, col: 5, offset: 8981},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 369, col: 5, offset: 8874},
+									pos:        position{line: 372, col: 5, offset: 8981},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 369, col: 13, offset: 8882},
+									pos:  position{line: 372, col: 13, offset: 8989},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 369, col: 15, offset: 8884},
+									pos:   position{line: 372, col: 15, offset: 8991},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 369, col: 21, offset: 8890},
+										pos:  position{line: 372, col: 21, offset: 8997},
 										name: "unsignedInteger",
 									},
 								},
@@ -2874,10 +2919,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 370, col: 5, offset: 8946},
+						pos: position{line: 373, col: 5, offset: 9053},
 						run: (*parser).callontail8,
 						expr: &litMatcher{
-							pos:        position{line: 370, col: 5, offset: 8946},
+							pos:        position{line: 373, col: 5, offset: 9053},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2887,27 +2932,27 @@ var g = &grammar{
 		},
 		{
 			name: "filter",
-			pos:  position{line: 372, col: 1, offset: 8987},
+			pos:  position{line: 375, col: 1, offset: 9094},
 			expr: &actionExpr{
-				pos: position{line: 373, col: 5, offset: 8998},
+				pos: position{line: 376, col: 5, offset: 9105},
 				run: (*parser).callonfilter1,
 				expr: &seqExpr{
-					pos: position{line: 373, col: 5, offset: 8998},
+					pos: position{line: 376, col: 5, offset: 9105},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 373, col: 5, offset: 8998},
+							pos:        position{line: 376, col: 5, offset: 9105},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 373, col: 15, offset: 9008},
+							pos:  position{line: 376, col: 15, offset: 9115},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 373, col: 17, offset: 9010},
+							pos:   position{line: 376, col: 17, offset: 9117},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 373, col: 22, offset: 9015},
+								pos:  position{line: 376, col: 22, offset: 9122},
 								name: "searchExpr",
 							},
 						},
@@ -2917,27 +2962,27 @@ var g = &grammar{
 		},
 		{
 			name: "uniq",
-			pos:  position{line: 376, col: 1, offset: 9073},
+			pos:  position{line: 379, col: 1, offset: 9180},
 			expr: &choiceExpr{
-				pos: position{line: 377, col: 5, offset: 9082},
+				pos: position{line: 380, col: 5, offset: 9189},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 377, col: 5, offset: 9082},
+						pos: position{line: 380, col: 5, offset: 9189},
 						run: (*parser).callonuniq2,
 						expr: &seqExpr{
-							pos: position{line: 377, col: 5, offset: 9082},
+							pos: position{line: 380, col: 5, offset: 9189},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 377, col: 5, offset: 9082},
+									pos:        position{line: 380, col: 5, offset: 9189},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 377, col: 13, offset: 9090},
+									pos:  position{line: 380, col: 13, offset: 9197},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 377, col: 15, offset: 9092},
+									pos:        position{line: 380, col: 15, offset: 9199},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2945,10 +2990,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 380, col: 5, offset: 9146},
+						pos: position{line: 383, col: 5, offset: 9253},
 						run: (*parser).callonuniq7,
 						expr: &litMatcher{
-							pos:        position{line: 380, col: 5, offset: 9146},
+							pos:        position{line: 383, col: 5, offset: 9253},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2958,59 +3003,59 @@ var g = &grammar{
 		},
 		{
 			name: "put",
-			pos:  position{line: 384, col: 1, offset: 9201},
+			pos:  position{line: 387, col: 1, offset: 9308},
 			expr: &actionExpr{
-				pos: position{line: 385, col: 5, offset: 9209},
+				pos: position{line: 388, col: 5, offset: 9316},
 				run: (*parser).callonput1,
 				expr: &seqExpr{
-					pos: position{line: 385, col: 5, offset: 9209},
+					pos: position{line: 388, col: 5, offset: 9316},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 385, col: 5, offset: 9209},
+							pos:        position{line: 388, col: 5, offset: 9316},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 385, col: 12, offset: 9216},
+							pos:  position{line: 388, col: 12, offset: 9323},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 385, col: 14, offset: 9218},
+							pos:   position{line: 388, col: 14, offset: 9325},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 385, col: 20, offset: 9224},
+								pos:  position{line: 388, col: 20, offset: 9331},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 385, col: 31, offset: 9235},
+							pos:   position{line: 388, col: 31, offset: 9342},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 385, col: 36, offset: 9240},
+								pos: position{line: 388, col: 36, offset: 9347},
 								expr: &actionExpr{
-									pos: position{line: 385, col: 37, offset: 9241},
+									pos: position{line: 388, col: 37, offset: 9348},
 									run: (*parser).callonput9,
 									expr: &seqExpr{
-										pos: position{line: 385, col: 37, offset: 9241},
+										pos: position{line: 388, col: 37, offset: 9348},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 385, col: 37, offset: 9241},
+												pos:  position{line: 388, col: 37, offset: 9348},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 385, col: 40, offset: 9244},
+												pos:        position{line: 388, col: 40, offset: 9351},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 385, col: 44, offset: 9248},
+												pos:  position{line: 388, col: 44, offset: 9355},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 385, col: 47, offset: 9251},
+												pos:   position{line: 388, col: 47, offset: 9358},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 385, col: 50, offset: 9254},
+													pos:  position{line: 388, col: 50, offset: 9361},
 													name: "Assignment",
 												},
 											},
@@ -3025,39 +3070,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 389, col: 1, offset: 9338},
+			pos:  position{line: 392, col: 1, offset: 9445},
 			expr: &actionExpr{
-				pos: position{line: 390, col: 5, offset: 9353},
+				pos: position{line: 393, col: 5, offset: 9460},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 390, col: 5, offset: 9353},
+					pos: position{line: 393, col: 5, offset: 9460},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 390, col: 5, offset: 9353},
+							pos:   position{line: 393, col: 5, offset: 9460},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 390, col: 7, offset: 9355},
+								pos:  position{line: 393, col: 7, offset: 9462},
 								name: "fieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 390, col: 17, offset: 9365},
+							pos:  position{line: 393, col: 17, offset: 9472},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 390, col: 20, offset: 9368},
+							pos:        position{line: 393, col: 20, offset: 9475},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 390, col: 24, offset: 9372},
+							pos:  position{line: 393, col: 24, offset: 9479},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 390, col: 27, offset: 9375},
+							pos:   position{line: 393, col: 27, offset: 9482},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 390, col: 29, offset: 9377},
+								pos:  position{line: 393, col: 29, offset: 9484},
 								name: "Expression",
 							},
 						},
@@ -3067,79 +3112,79 @@ var g = &grammar{
 		},
 		{
 			name: "PrimaryExpression",
-			pos:  position{line: 394, col: 1, offset: 9436},
+			pos:  position{line: 397, col: 1, offset: 9543},
 			expr: &choiceExpr{
-				pos: position{line: 395, col: 5, offset: 9458},
+				pos: position{line: 398, col: 5, offset: 9565},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 395, col: 5, offset: 9458},
+						pos:  position{line: 398, col: 5, offset: 9565},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 396, col: 5, offset: 9476},
+						pos:  position{line: 399, col: 5, offset: 9583},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 397, col: 5, offset: 9494},
+						pos:  position{line: 400, col: 5, offset: 9601},
 						name: "PortLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 398, col: 5, offset: 9510},
+						pos:  position{line: 401, col: 5, offset: 9617},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 399, col: 5, offset: 9528},
+						pos:  position{line: 402, col: 5, offset: 9635},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 400, col: 5, offset: 9547},
+						pos:  position{line: 403, col: 5, offset: 9654},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 401, col: 5, offset: 9564},
+						pos:  position{line: 404, col: 5, offset: 9671},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 402, col: 5, offset: 9583},
+						pos:  position{line: 405, col: 5, offset: 9690},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 403, col: 5, offset: 9602},
+						pos:  position{line: 406, col: 5, offset: 9709},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 404, col: 5, offset: 9618},
+						pos:  position{line: 407, col: 5, offset: 9725},
 						name: "FieldReference",
 					},
 					&actionExpr{
-						pos: position{line: 405, col: 5, offset: 9637},
+						pos: position{line: 408, col: 5, offset: 9744},
 						run: (*parser).callonPrimaryExpression12,
 						expr: &seqExpr{
-							pos: position{line: 405, col: 5, offset: 9637},
+							pos: position{line: 408, col: 5, offset: 9744},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 405, col: 5, offset: 9637},
+									pos:        position{line: 408, col: 5, offset: 9744},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 405, col: 9, offset: 9641},
+									pos:  position{line: 408, col: 9, offset: 9748},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 405, col: 12, offset: 9644},
+									pos:   position{line: 408, col: 12, offset: 9751},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 405, col: 17, offset: 9649},
+										pos:  position{line: 408, col: 17, offset: 9756},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 405, col: 28, offset: 9660},
+									pos:  position{line: 408, col: 28, offset: 9767},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 405, col: 31, offset: 9663},
+									pos:        position{line: 408, col: 31, offset: 9770},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3151,15 +3196,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldReference",
-			pos:  position{line: 407, col: 1, offset: 9689},
+			pos:  position{line: 410, col: 1, offset: 9796},
 			expr: &actionExpr{
-				pos: position{line: 408, col: 5, offset: 9708},
+				pos: position{line: 411, col: 5, offset: 9815},
 				run: (*parser).callonFieldReference1,
 				expr: &labeledExpr{
-					pos:   position{line: 408, col: 5, offset: 9708},
+					pos:   position{line: 411, col: 5, offset: 9815},
 					label: "f",
 					expr: &ruleRefExpr{
-						pos:  position{line: 408, col: 7, offset: 9710},
+						pos:  position{line: 411, col: 7, offset: 9817},
 						name: "fieldName",
 					},
 				},
@@ -3167,71 +3212,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expression",
-			pos:  position{line: 418, col: 1, offset: 9959},
+			pos:  position{line: 421, col: 1, offset: 10066},
 			expr: &ruleRefExpr{
-				pos:  position{line: 418, col: 14, offset: 9972},
+				pos:  position{line: 421, col: 14, offset: 10079},
 				name: "ConditionalExpression",
 			},
 		},
 		{
 			name: "ConditionalExpression",
-			pos:  position{line: 420, col: 1, offset: 9995},
+			pos:  position{line: 423, col: 1, offset: 10102},
 			expr: &choiceExpr{
-				pos: position{line: 421, col: 5, offset: 10021},
+				pos: position{line: 424, col: 5, offset: 10128},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 421, col: 5, offset: 10021},
+						pos: position{line: 424, col: 5, offset: 10128},
 						run: (*parser).callonConditionalExpression2,
 						expr: &seqExpr{
-							pos: position{line: 421, col: 5, offset: 10021},
+							pos: position{line: 424, col: 5, offset: 10128},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 421, col: 5, offset: 10021},
+									pos:   position{line: 424, col: 5, offset: 10128},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 421, col: 15, offset: 10031},
+										pos:  position{line: 424, col: 15, offset: 10138},
 										name: "LogicalORExpression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 421, col: 35, offset: 10051},
+									pos:  position{line: 424, col: 35, offset: 10158},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 421, col: 38, offset: 10054},
+									pos:        position{line: 424, col: 38, offset: 10161},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 421, col: 42, offset: 10058},
+									pos:  position{line: 424, col: 42, offset: 10165},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 421, col: 45, offset: 10061},
+									pos:   position{line: 424, col: 45, offset: 10168},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 421, col: 56, offset: 10072},
+										pos:  position{line: 424, col: 56, offset: 10179},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 421, col: 67, offset: 10083},
+									pos:  position{line: 424, col: 67, offset: 10190},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 421, col: 70, offset: 10086},
+									pos:        position{line: 424, col: 70, offset: 10193},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 421, col: 74, offset: 10090},
+									pos:  position{line: 424, col: 74, offset: 10197},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 421, col: 77, offset: 10093},
+									pos:   position{line: 424, col: 77, offset: 10200},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 421, col: 88, offset: 10104},
+										pos:  position{line: 424, col: 88, offset: 10211},
 										name: "Expression",
 									},
 								},
@@ -3239,7 +3284,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 424, col: 5, offset: 10196},
+						pos:  position{line: 427, col: 5, offset: 10303},
 						name: "LogicalORExpression",
 					},
 				},
@@ -3247,43 +3292,43 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalORExpression",
-			pos:  position{line: 426, col: 1, offset: 10217},
+			pos:  position{line: 429, col: 1, offset: 10324},
 			expr: &actionExpr{
-				pos: position{line: 427, col: 5, offset: 10241},
+				pos: position{line: 430, col: 5, offset: 10348},
 				run: (*parser).callonLogicalORExpression1,
 				expr: &seqExpr{
-					pos: position{line: 427, col: 5, offset: 10241},
+					pos: position{line: 430, col: 5, offset: 10348},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 427, col: 5, offset: 10241},
+							pos:   position{line: 430, col: 5, offset: 10348},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 427, col: 11, offset: 10247},
+								pos:  position{line: 430, col: 11, offset: 10354},
 								name: "LogicalANDExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 428, col: 5, offset: 10272},
+							pos:   position{line: 431, col: 5, offset: 10379},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 428, col: 10, offset: 10277},
+								pos: position{line: 431, col: 10, offset: 10384},
 								expr: &seqExpr{
-									pos: position{line: 428, col: 11, offset: 10278},
+									pos: position{line: 431, col: 11, offset: 10385},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 11, offset: 10278},
+											pos:  position{line: 431, col: 11, offset: 10385},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 14, offset: 10281},
+											pos:  position{line: 431, col: 14, offset: 10388},
 											name: "orToken",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 22, offset: 10289},
+											pos:  position{line: 431, col: 22, offset: 10396},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 25, offset: 10292},
+											pos:  position{line: 431, col: 25, offset: 10399},
 											name: "LogicalANDExpression",
 										},
 									},
@@ -3296,43 +3341,43 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalANDExpression",
-			pos:  position{line: 432, col: 1, offset: 10377},
+			pos:  position{line: 435, col: 1, offset: 10484},
 			expr: &actionExpr{
-				pos: position{line: 433, col: 5, offset: 10402},
+				pos: position{line: 436, col: 5, offset: 10509},
 				run: (*parser).callonLogicalANDExpression1,
 				expr: &seqExpr{
-					pos: position{line: 433, col: 5, offset: 10402},
+					pos: position{line: 436, col: 5, offset: 10509},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 433, col: 5, offset: 10402},
+							pos:   position{line: 436, col: 5, offset: 10509},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 433, col: 11, offset: 10408},
+								pos:  position{line: 436, col: 11, offset: 10515},
 								name: "EqualityCompareExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 434, col: 5, offset: 10438},
+							pos:   position{line: 437, col: 5, offset: 10545},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 434, col: 10, offset: 10443},
+								pos: position{line: 437, col: 10, offset: 10550},
 								expr: &seqExpr{
-									pos: position{line: 434, col: 11, offset: 10444},
+									pos: position{line: 437, col: 11, offset: 10551},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 434, col: 11, offset: 10444},
+											pos:  position{line: 437, col: 11, offset: 10551},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 434, col: 14, offset: 10447},
+											pos:  position{line: 437, col: 14, offset: 10554},
 											name: "andToken",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 434, col: 23, offset: 10456},
+											pos:  position{line: 437, col: 23, offset: 10563},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 434, col: 26, offset: 10459},
+											pos:  position{line: 437, col: 26, offset: 10566},
 											name: "EqualityCompareExpression",
 										},
 									},
@@ -3345,43 +3390,43 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpression",
-			pos:  position{line: 438, col: 1, offset: 10549},
+			pos:  position{line: 441, col: 1, offset: 10656},
 			expr: &actionExpr{
-				pos: position{line: 439, col: 5, offset: 10579},
+				pos: position{line: 442, col: 5, offset: 10686},
 				run: (*parser).callonEqualityCompareExpression1,
 				expr: &seqExpr{
-					pos: position{line: 439, col: 5, offset: 10579},
+					pos: position{line: 442, col: 5, offset: 10686},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 439, col: 5, offset: 10579},
+							pos:   position{line: 442, col: 5, offset: 10686},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 439, col: 11, offset: 10585},
+								pos:  position{line: 442, col: 11, offset: 10692},
 								name: "RelativeExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 5, offset: 10608},
+							pos:   position{line: 443, col: 5, offset: 10715},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 440, col: 10, offset: 10613},
+								pos: position{line: 443, col: 10, offset: 10720},
 								expr: &seqExpr{
-									pos: position{line: 440, col: 11, offset: 10614},
+									pos: position{line: 443, col: 11, offset: 10721},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 11, offset: 10614},
+											pos:  position{line: 443, col: 11, offset: 10721},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 14, offset: 10617},
+											pos:  position{line: 443, col: 14, offset: 10724},
 											name: "EqualityComparator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 33, offset: 10636},
+											pos:  position{line: 443, col: 33, offset: 10743},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 36, offset: 10639},
+											pos:  position{line: 443, col: 36, offset: 10746},
 											name: "RelativeExpression",
 										},
 									},
@@ -3394,30 +3439,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 444, col: 1, offset: 10722},
+			pos:  position{line: 447, col: 1, offset: 10829},
 			expr: &actionExpr{
-				pos: position{line: 444, col: 20, offset: 10741},
+				pos: position{line: 447, col: 20, offset: 10848},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 444, col: 21, offset: 10742},
+					pos: position{line: 447, col: 21, offset: 10849},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 444, col: 21, offset: 10742},
+							pos:        position{line: 447, col: 21, offset: 10849},
 							val:        "=~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 28, offset: 10749},
+							pos:        position{line: 447, col: 28, offset: 10856},
 							val:        "!~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 35, offset: 10756},
+							pos:        position{line: 447, col: 35, offset: 10863},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 41, offset: 10762},
+							pos:        position{line: 447, col: 41, offset: 10869},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3427,19 +3472,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 446, col: 1, offset: 10800},
+			pos:  position{line: 449, col: 1, offset: 10907},
 			expr: &choiceExpr{
-				pos: position{line: 447, col: 5, offset: 10823},
+				pos: position{line: 450, col: 5, offset: 10930},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 447, col: 5, offset: 10823},
+						pos:  position{line: 450, col: 5, offset: 10930},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 448, col: 5, offset: 10844},
+						pos: position{line: 451, col: 5, offset: 10951},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 448, col: 5, offset: 10844},
+							pos:        position{line: 451, col: 5, offset: 10951},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3449,43 +3494,43 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpression",
-			pos:  position{line: 450, col: 1, offset: 10881},
+			pos:  position{line: 453, col: 1, offset: 10988},
 			expr: &actionExpr{
-				pos: position{line: 451, col: 5, offset: 10904},
+				pos: position{line: 454, col: 5, offset: 11011},
 				run: (*parser).callonRelativeExpression1,
 				expr: &seqExpr{
-					pos: position{line: 451, col: 5, offset: 10904},
+					pos: position{line: 454, col: 5, offset: 11011},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 451, col: 5, offset: 10904},
+							pos:   position{line: 454, col: 5, offset: 11011},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 451, col: 11, offset: 10910},
+								pos:  position{line: 454, col: 11, offset: 11017},
 								name: "AdditiveExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 452, col: 5, offset: 10933},
+							pos:   position{line: 455, col: 5, offset: 11040},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 452, col: 10, offset: 10938},
+								pos: position{line: 455, col: 10, offset: 11045},
 								expr: &seqExpr{
-									pos: position{line: 452, col: 11, offset: 10939},
+									pos: position{line: 455, col: 11, offset: 11046},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 11, offset: 10939},
+											pos:  position{line: 455, col: 11, offset: 11046},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 14, offset: 10942},
+											pos:  position{line: 455, col: 14, offset: 11049},
 											name: "RelativeOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 31, offset: 10959},
+											pos:  position{line: 455, col: 31, offset: 11066},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 34, offset: 10962},
+											pos:  position{line: 455, col: 34, offset: 11069},
 											name: "AdditiveExpression",
 										},
 									},
@@ -3498,30 +3543,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 456, col: 1, offset: 11045},
+			pos:  position{line: 459, col: 1, offset: 11152},
 			expr: &actionExpr{
-				pos: position{line: 456, col: 20, offset: 11064},
+				pos: position{line: 459, col: 20, offset: 11171},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 456, col: 21, offset: 11065},
+					pos: position{line: 459, col: 21, offset: 11172},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 456, col: 21, offset: 11065},
+							pos:        position{line: 459, col: 21, offset: 11172},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 28, offset: 11072},
+							pos:        position{line: 459, col: 28, offset: 11179},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 34, offset: 11078},
+							pos:        position{line: 459, col: 34, offset: 11185},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 41, offset: 11085},
+							pos:        position{line: 459, col: 41, offset: 11192},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -3531,43 +3576,43 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpression",
-			pos:  position{line: 458, col: 1, offset: 11122},
+			pos:  position{line: 461, col: 1, offset: 11229},
 			expr: &actionExpr{
-				pos: position{line: 459, col: 5, offset: 11145},
+				pos: position{line: 462, col: 5, offset: 11252},
 				run: (*parser).callonAdditiveExpression1,
 				expr: &seqExpr{
-					pos: position{line: 459, col: 5, offset: 11145},
+					pos: position{line: 462, col: 5, offset: 11252},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 459, col: 5, offset: 11145},
+							pos:   position{line: 462, col: 5, offset: 11252},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 459, col: 11, offset: 11151},
+								pos:  position{line: 462, col: 11, offset: 11258},
 								name: "MultiplicativeExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 460, col: 5, offset: 11180},
+							pos:   position{line: 463, col: 5, offset: 11287},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 460, col: 10, offset: 11185},
+								pos: position{line: 463, col: 10, offset: 11292},
 								expr: &seqExpr{
-									pos: position{line: 460, col: 11, offset: 11186},
+									pos: position{line: 463, col: 11, offset: 11293},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 11, offset: 11186},
+											pos:  position{line: 463, col: 11, offset: 11293},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 14, offset: 11189},
+											pos:  position{line: 463, col: 14, offset: 11296},
 											name: "AdditiveOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 31, offset: 11206},
+											pos:  position{line: 463, col: 31, offset: 11313},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 34, offset: 11209},
+											pos:  position{line: 463, col: 34, offset: 11316},
 											name: "MultiplicativeExpression",
 										},
 									},
@@ -3580,20 +3625,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 464, col: 1, offset: 11298},
+			pos:  position{line: 467, col: 1, offset: 11405},
 			expr: &actionExpr{
-				pos: position{line: 464, col: 20, offset: 11317},
+				pos: position{line: 467, col: 20, offset: 11424},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 464, col: 21, offset: 11318},
+					pos: position{line: 467, col: 21, offset: 11425},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 464, col: 21, offset: 11318},
+							pos:        position{line: 467, col: 21, offset: 11425},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 464, col: 27, offset: 11324},
+							pos:        position{line: 467, col: 27, offset: 11431},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3603,50 +3648,50 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpression",
-			pos:  position{line: 466, col: 1, offset: 11361},
+			pos:  position{line: 469, col: 1, offset: 11468},
 			expr: &actionExpr{
-				pos: position{line: 467, col: 5, offset: 11390},
+				pos: position{line: 470, col: 5, offset: 11497},
 				run: (*parser).callonMultiplicativeExpression1,
 				expr: &seqExpr{
-					pos: position{line: 467, col: 5, offset: 11390},
+					pos: position{line: 470, col: 5, offset: 11497},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 467, col: 5, offset: 11390},
+							pos:   position{line: 470, col: 5, offset: 11497},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 467, col: 11, offset: 11396},
+								pos:  position{line: 470, col: 11, offset: 11503},
 								name: "NotExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 468, col: 5, offset: 11414},
+							pos:   position{line: 471, col: 5, offset: 11521},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 468, col: 10, offset: 11419},
+								pos: position{line: 471, col: 10, offset: 11526},
 								expr: &seqExpr{
-									pos: position{line: 468, col: 11, offset: 11420},
+									pos: position{line: 471, col: 11, offset: 11527},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 468, col: 11, offset: 11420},
+											pos:  position{line: 471, col: 11, offset: 11527},
 											name: "__",
 										},
 										&labeledExpr{
-											pos:   position{line: 468, col: 14, offset: 11423},
+											pos:   position{line: 471, col: 14, offset: 11530},
 											label: "op",
 											expr: &ruleRefExpr{
-												pos:  position{line: 468, col: 17, offset: 11426},
+												pos:  position{line: 471, col: 17, offset: 11533},
 												name: "MultiplicativeOperator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 468, col: 40, offset: 11449},
+											pos:  position{line: 471, col: 40, offset: 11556},
 											name: "__",
 										},
 										&labeledExpr{
-											pos:   position{line: 468, col: 43, offset: 11452},
+											pos:   position{line: 471, col: 43, offset: 11559},
 											label: "operand",
 											expr: &ruleRefExpr{
-												pos:  position{line: 468, col: 51, offset: 11460},
+												pos:  position{line: 471, col: 51, offset: 11567},
 												name: "NotExpression",
 											},
 										},
@@ -3660,20 +3705,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 472, col: 1, offset: 11538},
+			pos:  position{line: 475, col: 1, offset: 11645},
 			expr: &actionExpr{
-				pos: position{line: 472, col: 26, offset: 11563},
+				pos: position{line: 475, col: 26, offset: 11670},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 472, col: 27, offset: 11564},
+					pos: position{line: 475, col: 27, offset: 11671},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 472, col: 27, offset: 11564},
+							pos:        position{line: 475, col: 27, offset: 11671},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 472, col: 33, offset: 11570},
+							pos:        position{line: 475, col: 33, offset: 11677},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -3683,30 +3728,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpression",
-			pos:  position{line: 474, col: 1, offset: 11607},
+			pos:  position{line: 477, col: 1, offset: 11714},
 			expr: &choiceExpr{
-				pos: position{line: 475, col: 5, offset: 11625},
+				pos: position{line: 478, col: 5, offset: 11732},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 475, col: 5, offset: 11625},
+						pos: position{line: 478, col: 5, offset: 11732},
 						run: (*parser).callonNotExpression2,
 						expr: &seqExpr{
-							pos: position{line: 475, col: 5, offset: 11625},
+							pos: position{line: 478, col: 5, offset: 11732},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 475, col: 5, offset: 11625},
+									pos:        position{line: 478, col: 5, offset: 11732},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 475, col: 9, offset: 11629},
+									pos:  position{line: 478, col: 9, offset: 11736},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 475, col: 12, offset: 11632},
+									pos:   position{line: 478, col: 12, offset: 11739},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 475, col: 14, offset: 11634},
+										pos:  position{line: 478, col: 14, offset: 11741},
 										name: "NotExpression",
 									},
 								},
@@ -3714,7 +3759,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 478, col: 5, offset: 11702},
+						pos:  position{line: 481, col: 5, offset: 11809},
 						name: "CastExpression",
 					},
 				},
@@ -3722,50 +3767,50 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpression",
-			pos:  position{line: 480, col: 1, offset: 11718},
+			pos:  position{line: 483, col: 1, offset: 11825},
 			expr: &actionExpr{
-				pos: position{line: 481, col: 5, offset: 11737},
+				pos: position{line: 484, col: 5, offset: 11844},
 				run: (*parser).callonCastExpression1,
 				expr: &seqExpr{
-					pos: position{line: 481, col: 5, offset: 11737},
+					pos: position{line: 484, col: 5, offset: 11844},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 481, col: 5, offset: 11737},
+							pos:   position{line: 484, col: 5, offset: 11844},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 481, col: 7, offset: 11739},
+								pos:  position{line: 484, col: 7, offset: 11846},
 								name: "CallExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 481, col: 22, offset: 11754},
+							pos:   position{line: 484, col: 22, offset: 11861},
 							label: "t",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 481, col: 24, offset: 11756},
+								pos: position{line: 484, col: 24, offset: 11863},
 								expr: &actionExpr{
-									pos: position{line: 481, col: 25, offset: 11757},
+									pos: position{line: 484, col: 25, offset: 11864},
 									run: (*parser).callonCastExpression7,
 									expr: &seqExpr{
-										pos: position{line: 481, col: 25, offset: 11757},
+										pos: position{line: 484, col: 25, offset: 11864},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 481, col: 25, offset: 11757},
+												pos:  position{line: 484, col: 25, offset: 11864},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 481, col: 28, offset: 11760},
+												pos:        position{line: 484, col: 28, offset: 11867},
 												val:        ":",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 481, col: 32, offset: 11764},
+												pos:  position{line: 484, col: 32, offset: 11871},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 481, col: 35, offset: 11767},
+												pos:   position{line: 484, col: 35, offset: 11874},
 												label: "ct",
 												expr: &ruleRefExpr{
-													pos:  position{line: 481, col: 38, offset: 11770},
+													pos:  position{line: 484, col: 38, offset: 11877},
 													name: "ZngType",
 												},
 											},
@@ -3780,82 +3825,82 @@ var g = &grammar{
 		},
 		{
 			name: "ZngType",
-			pos:  position{line: 489, col: 1, offset: 11906},
+			pos:  position{line: 492, col: 1, offset: 12013},
 			expr: &choiceExpr{
-				pos: position{line: 490, col: 4, offset: 11917},
+				pos: position{line: 493, col: 4, offset: 12024},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 490, col: 4, offset: 11917},
+						pos:        position{line: 493, col: 4, offset: 12024},
 						val:        "bool",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 13, offset: 11926},
+						pos:        position{line: 493, col: 13, offset: 12033},
 						val:        "byte",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 22, offset: 11935},
+						pos:        position{line: 493, col: 22, offset: 12042},
 						val:        "int16",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 32, offset: 11945},
+						pos:        position{line: 493, col: 32, offset: 12052},
 						val:        "uint16",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 43, offset: 11956},
+						pos:        position{line: 493, col: 43, offset: 12063},
 						val:        "int32",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 53, offset: 11966},
+						pos:        position{line: 493, col: 53, offset: 12073},
 						val:        "uint32",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 4, offset: 11978},
+						pos:        position{line: 494, col: 4, offset: 12085},
 						val:        "int64",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 14, offset: 11988},
+						pos:        position{line: 494, col: 14, offset: 12095},
 						val:        "uint64",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 25, offset: 11999},
+						pos:        position{line: 494, col: 25, offset: 12106},
 						val:        "float64",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 37, offset: 12011},
+						pos:        position{line: 494, col: 37, offset: 12118},
 						val:        "string",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 48, offset: 12022},
+						pos:        position{line: 494, col: 48, offset: 12129},
 						val:        "bstring",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 492, col: 4, offset: 12035},
+						pos:        position{line: 495, col: 4, offset: 12142},
 						val:        "ip",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 492, col: 11, offset: 12042},
+						pos:        position{line: 495, col: 11, offset: 12149},
 						val:        "net",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 492, col: 19, offset: 12050},
+						pos:        position{line: 495, col: 19, offset: 12157},
 						val:        "time",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 492, col: 28, offset: 12059},
+						pos:        position{line: 495, col: 28, offset: 12166},
 						val:        "duration",
 						ignoreCase: false,
 					},
@@ -3864,43 +3909,43 @@ var g = &grammar{
 		},
 		{
 			name: "CallExpression",
-			pos:  position{line: 494, col: 1, offset: 12071},
+			pos:  position{line: 497, col: 1, offset: 12178},
 			expr: &choiceExpr{
-				pos: position{line: 495, col: 5, offset: 12090},
+				pos: position{line: 498, col: 5, offset: 12197},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 495, col: 5, offset: 12090},
+						pos: position{line: 498, col: 5, offset: 12197},
 						run: (*parser).callonCallExpression2,
 						expr: &seqExpr{
-							pos: position{line: 495, col: 5, offset: 12090},
+							pos: position{line: 498, col: 5, offset: 12197},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 495, col: 5, offset: 12090},
+									pos:   position{line: 498, col: 5, offset: 12197},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 495, col: 8, offset: 12093},
+										pos:  position{line: 498, col: 8, offset: 12200},
 										name: "FunctionName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 495, col: 21, offset: 12106},
+									pos:  position{line: 498, col: 21, offset: 12213},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 495, col: 24, offset: 12109},
+									pos:        position{line: 498, col: 24, offset: 12216},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 495, col: 28, offset: 12113},
+									pos:   position{line: 498, col: 28, offset: 12220},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 495, col: 33, offset: 12118},
+										pos:  position{line: 498, col: 33, offset: 12225},
 										name: "ArgumentList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 495, col: 46, offset: 12131},
+									pos:        position{line: 498, col: 46, offset: 12238},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3908,7 +3953,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 498, col: 5, offset: 12194},
+						pos:  position{line: 501, col: 5, offset: 12301},
 						name: "DereferenceExpression",
 					},
 				},
@@ -3916,21 +3961,21 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionName",
-			pos:  position{line: 500, col: 1, offset: 12217},
+			pos:  position{line: 503, col: 1, offset: 12324},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 12234},
+				pos: position{line: 504, col: 5, offset: 12341},
 				run: (*parser).callonFunctionName1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 5, offset: 12234},
+					pos: position{line: 504, col: 5, offset: 12341},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 5, offset: 12234},
+							pos:  position{line: 504, col: 5, offset: 12341},
 							name: "FunctionNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 501, col: 23, offset: 12252},
+							pos: position{line: 504, col: 23, offset: 12359},
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 23, offset: 12252},
+								pos:  position{line: 504, col: 23, offset: 12359},
 								name: "FunctionNameRest",
 							},
 						},
@@ -3940,9 +3985,9 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionNameStart",
-			pos:  position{line: 503, col: 1, offset: 12302},
+			pos:  position{line: 506, col: 1, offset: 12409},
 			expr: &charClassMatcher{
-				pos:        position{line: 503, col: 21, offset: 12322},
+				pos:        position{line: 506, col: 21, offset: 12429},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -3951,16 +3996,16 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionNameRest",
-			pos:  position{line: 504, col: 1, offset: 12331},
+			pos:  position{line: 507, col: 1, offset: 12438},
 			expr: &choiceExpr{
-				pos: position{line: 504, col: 20, offset: 12350},
+				pos: position{line: 507, col: 20, offset: 12457},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 504, col: 20, offset: 12350},
+						pos:  position{line: 507, col: 20, offset: 12457},
 						name: "FunctionNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 504, col: 40, offset: 12370},
+						pos:        position{line: 507, col: 40, offset: 12477},
 						val:        "[.0-9]",
 						chars:      []rune{'.'},
 						ranges:     []rune{'0', '9'},
@@ -3972,53 +4017,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 506, col: 1, offset: 12378},
+			pos:  position{line: 509, col: 1, offset: 12485},
 			expr: &choiceExpr{
-				pos: position{line: 507, col: 5, offset: 12395},
+				pos: position{line: 510, col: 5, offset: 12502},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 507, col: 5, offset: 12395},
+						pos: position{line: 510, col: 5, offset: 12502},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 507, col: 5, offset: 12395},
+							pos: position{line: 510, col: 5, offset: 12502},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 507, col: 5, offset: 12395},
+									pos:   position{line: 510, col: 5, offset: 12502},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 507, col: 11, offset: 12401},
+										pos:  position{line: 510, col: 11, offset: 12508},
 										name: "Expression",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 507, col: 22, offset: 12412},
+									pos:   position{line: 510, col: 22, offset: 12519},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 507, col: 27, offset: 12417},
+										pos: position{line: 510, col: 27, offset: 12524},
 										expr: &actionExpr{
-											pos: position{line: 507, col: 28, offset: 12418},
+											pos: position{line: 510, col: 28, offset: 12525},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 507, col: 28, offset: 12418},
+												pos: position{line: 510, col: 28, offset: 12525},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 507, col: 28, offset: 12418},
+														pos:  position{line: 510, col: 28, offset: 12525},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 507, col: 31, offset: 12421},
+														pos:        position{line: 510, col: 31, offset: 12528},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 507, col: 35, offset: 12425},
+														pos:  position{line: 510, col: 35, offset: 12532},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 507, col: 38, offset: 12428},
+														pos:   position{line: 510, col: 38, offset: 12535},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 507, col: 40, offset: 12430},
+															pos:  position{line: 510, col: 40, offset: 12537},
 															name: "Expression",
 														},
 													},
@@ -4031,10 +4076,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 510, col: 5, offset: 12546},
+						pos: position{line: 513, col: 5, offset: 12653},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 510, col: 5, offset: 12546},
+							pos:  position{line: 513, col: 5, offset: 12653},
 							name: "__",
 						},
 					},
@@ -4043,88 +4088,88 @@ var g = &grammar{
 		},
 		{
 			name: "DereferenceExpression",
-			pos:  position{line: 512, col: 1, offset: 12582},
+			pos:  position{line: 515, col: 1, offset: 12689},
 			expr: &actionExpr{
-				pos: position{line: 513, col: 5, offset: 12608},
+				pos: position{line: 516, col: 5, offset: 12715},
 				run: (*parser).callonDereferenceExpression1,
 				expr: &seqExpr{
-					pos: position{line: 513, col: 5, offset: 12608},
+					pos: position{line: 516, col: 5, offset: 12715},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 513, col: 5, offset: 12608},
+							pos:   position{line: 516, col: 5, offset: 12715},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 513, col: 10, offset: 12613},
+								pos:  position{line: 516, col: 10, offset: 12720},
 								name: "PrimaryExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 514, col: 5, offset: 12635},
+							pos:   position{line: 517, col: 5, offset: 12742},
 							label: "derefs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 514, col: 12, offset: 12642},
+								pos: position{line: 517, col: 12, offset: 12749},
 								expr: &choiceExpr{
-									pos: position{line: 515, col: 9, offset: 12652},
+									pos: position{line: 518, col: 9, offset: 12759},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 515, col: 9, offset: 12652},
+											pos: position{line: 518, col: 9, offset: 12759},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 515, col: 9, offset: 12652},
+													pos:  position{line: 518, col: 9, offset: 12759},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 515, col: 12, offset: 12655},
+													pos:        position{line: 518, col: 12, offset: 12762},
 													val:        "[",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 515, col: 16, offset: 12659},
+													pos:  position{line: 518, col: 16, offset: 12766},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 515, col: 19, offset: 12662},
+													pos:   position{line: 518, col: 19, offset: 12769},
 													label: "index",
 													expr: &ruleRefExpr{
-														pos:  position{line: 515, col: 25, offset: 12668},
+														pos:  position{line: 518, col: 25, offset: 12775},
 														name: "Expression",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 515, col: 36, offset: 12679},
+													pos:  position{line: 518, col: 36, offset: 12786},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 515, col: 39, offset: 12682},
+													pos:        position{line: 518, col: 39, offset: 12789},
 													val:        "]",
 													ignoreCase: false,
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 516, col: 9, offset: 12694},
+											pos: position{line: 519, col: 9, offset: 12801},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 516, col: 9, offset: 12694},
+													pos:  position{line: 519, col: 9, offset: 12801},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 516, col: 12, offset: 12697},
+													pos:        position{line: 519, col: 12, offset: 12804},
 													val:        ".",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 516, col: 16, offset: 12701},
+													pos:  position{line: 519, col: 16, offset: 12808},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 516, col: 20, offset: 12705},
+													pos: position{line: 519, col: 20, offset: 12812},
 													run: (*parser).callonDereferenceExpression20,
 													expr: &labeledExpr{
-														pos:   position{line: 516, col: 20, offset: 12705},
+														pos:   position{line: 519, col: 20, offset: 12812},
 														label: "field",
 														expr: &ruleRefExpr{
-															pos:  position{line: 516, col: 26, offset: 12711},
+															pos:  position{line: 519, col: 26, offset: 12818},
 															name: "fieldName",
 														},
 													},
@@ -4141,54 +4186,54 @@ var g = &grammar{
 		},
 		{
 			name: "duration",
-			pos:  position{line: 521, col: 1, offset: 12846},
+			pos:  position{line: 524, col: 1, offset: 12953},
 			expr: &choiceExpr{
-				pos: position{line: 522, col: 5, offset: 12859},
+				pos: position{line: 525, col: 5, offset: 12966},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 522, col: 5, offset: 12859},
+						pos:  position{line: 525, col: 5, offset: 12966},
 						name: "seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 523, col: 5, offset: 12871},
+						pos:  position{line: 526, col: 5, offset: 12978},
 						name: "minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 524, col: 5, offset: 12883},
+						pos:  position{line: 527, col: 5, offset: 12990},
 						name: "hours",
 					},
 					&seqExpr{
-						pos: position{line: 525, col: 5, offset: 12893},
+						pos: position{line: 528, col: 5, offset: 13000},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 525, col: 5, offset: 12893},
+								pos:  position{line: 528, col: 5, offset: 13000},
 								name: "hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 525, col: 11, offset: 12899},
+								pos:  position{line: 528, col: 11, offset: 13006},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 525, col: 13, offset: 12901},
+								pos:        position{line: 528, col: 13, offset: 13008},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 525, col: 19, offset: 12907},
+								pos:  position{line: 528, col: 19, offset: 13014},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 525, col: 21, offset: 12909},
+								pos:  position{line: 528, col: 21, offset: 13016},
 								name: "minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 526, col: 5, offset: 12921},
+						pos:  position{line: 529, col: 5, offset: 13028},
 						name: "days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 527, col: 5, offset: 12930},
+						pos:  position{line: 530, col: 5, offset: 13037},
 						name: "weeks",
 					},
 				},
@@ -4196,32 +4241,32 @@ var g = &grammar{
 		},
 		{
 			name: "sec_abbrev",
-			pos:  position{line: 529, col: 1, offset: 12937},
+			pos:  position{line: 532, col: 1, offset: 13044},
 			expr: &choiceExpr{
-				pos: position{line: 530, col: 5, offset: 12952},
+				pos: position{line: 533, col: 5, offset: 13059},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 530, col: 5, offset: 12952},
+						pos:        position{line: 533, col: 5, offset: 13059},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 531, col: 5, offset: 12966},
+						pos:        position{line: 534, col: 5, offset: 13073},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 532, col: 5, offset: 12979},
+						pos:        position{line: 535, col: 5, offset: 13086},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 533, col: 5, offset: 12990},
+						pos:        position{line: 536, col: 5, offset: 13097},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 534, col: 5, offset: 13000},
+						pos:        position{line: 537, col: 5, offset: 13107},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -4230,32 +4275,32 @@ var g = &grammar{
 		},
 		{
 			name: "min_abbrev",
-			pos:  position{line: 536, col: 1, offset: 13005},
+			pos:  position{line: 539, col: 1, offset: 13112},
 			expr: &choiceExpr{
-				pos: position{line: 537, col: 5, offset: 13020},
+				pos: position{line: 540, col: 5, offset: 13127},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 537, col: 5, offset: 13020},
+						pos:        position{line: 540, col: 5, offset: 13127},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 538, col: 5, offset: 13034},
+						pos:        position{line: 541, col: 5, offset: 13141},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 539, col: 5, offset: 13047},
+						pos:        position{line: 542, col: 5, offset: 13154},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 540, col: 5, offset: 13058},
+						pos:        position{line: 543, col: 5, offset: 13165},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 541, col: 5, offset: 13068},
+						pos:        position{line: 544, col: 5, offset: 13175},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -4264,32 +4309,32 @@ var g = &grammar{
 		},
 		{
 			name: "hour_abbrev",
-			pos:  position{line: 543, col: 1, offset: 13073},
+			pos:  position{line: 546, col: 1, offset: 13180},
 			expr: &choiceExpr{
-				pos: position{line: 544, col: 5, offset: 13089},
+				pos: position{line: 547, col: 5, offset: 13196},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 544, col: 5, offset: 13089},
+						pos:        position{line: 547, col: 5, offset: 13196},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 545, col: 5, offset: 13101},
+						pos:        position{line: 548, col: 5, offset: 13208},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 546, col: 5, offset: 13111},
+						pos:        position{line: 549, col: 5, offset: 13218},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 547, col: 5, offset: 13120},
+						pos:        position{line: 550, col: 5, offset: 13227},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 548, col: 5, offset: 13128},
+						pos:        position{line: 551, col: 5, offset: 13235},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -4298,22 +4343,22 @@ var g = &grammar{
 		},
 		{
 			name: "day_abbrev",
-			pos:  position{line: 550, col: 1, offset: 13136},
+			pos:  position{line: 553, col: 1, offset: 13243},
 			expr: &choiceExpr{
-				pos: position{line: 550, col: 14, offset: 13149},
+				pos: position{line: 553, col: 14, offset: 13256},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 550, col: 14, offset: 13149},
+						pos:        position{line: 553, col: 14, offset: 13256},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 550, col: 21, offset: 13156},
+						pos:        position{line: 553, col: 21, offset: 13263},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 550, col: 27, offset: 13162},
+						pos:        position{line: 553, col: 27, offset: 13269},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -4322,32 +4367,32 @@ var g = &grammar{
 		},
 		{
 			name: "week_abbrev",
-			pos:  position{line: 551, col: 1, offset: 13166},
+			pos:  position{line: 554, col: 1, offset: 13273},
 			expr: &choiceExpr{
-				pos: position{line: 551, col: 15, offset: 13180},
+				pos: position{line: 554, col: 15, offset: 13287},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 551, col: 15, offset: 13180},
+						pos:        position{line: 554, col: 15, offset: 13287},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 23, offset: 13188},
+						pos:        position{line: 554, col: 23, offset: 13295},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 30, offset: 13195},
+						pos:        position{line: 554, col: 30, offset: 13302},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 36, offset: 13201},
+						pos:        position{line: 554, col: 36, offset: 13308},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 41, offset: 13206},
+						pos:        position{line: 554, col: 41, offset: 13313},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -4356,42 +4401,42 @@ var g = &grammar{
 		},
 		{
 			name: "seconds",
-			pos:  position{line: 553, col: 1, offset: 13211},
+			pos:  position{line: 556, col: 1, offset: 13318},
 			expr: &choiceExpr{
-				pos: position{line: 554, col: 5, offset: 13223},
+				pos: position{line: 557, col: 5, offset: 13330},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 554, col: 5, offset: 13223},
+						pos: position{line: 557, col: 5, offset: 13330},
 						run: (*parser).callonseconds2,
 						expr: &litMatcher{
-							pos:        position{line: 554, col: 5, offset: 13223},
+							pos:        position{line: 557, col: 5, offset: 13330},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 555, col: 5, offset: 13268},
+						pos: position{line: 558, col: 5, offset: 13375},
 						run: (*parser).callonseconds4,
 						expr: &seqExpr{
-							pos: position{line: 555, col: 5, offset: 13268},
+							pos: position{line: 558, col: 5, offset: 13375},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 555, col: 5, offset: 13268},
+									pos:   position{line: 558, col: 5, offset: 13375},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 555, col: 9, offset: 13272},
+										pos:  position{line: 558, col: 9, offset: 13379},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 555, col: 16, offset: 13279},
+									pos: position{line: 558, col: 16, offset: 13386},
 									expr: &ruleRefExpr{
-										pos:  position{line: 555, col: 16, offset: 13279},
+										pos:  position{line: 558, col: 16, offset: 13386},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 555, col: 19, offset: 13282},
+									pos:  position{line: 558, col: 19, offset: 13389},
 									name: "sec_abbrev",
 								},
 							},
@@ -4402,42 +4447,42 @@ var g = &grammar{
 		},
 		{
 			name: "minutes",
-			pos:  position{line: 557, col: 1, offset: 13328},
+			pos:  position{line: 560, col: 1, offset: 13435},
 			expr: &choiceExpr{
-				pos: position{line: 558, col: 5, offset: 13340},
+				pos: position{line: 561, col: 5, offset: 13447},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 558, col: 5, offset: 13340},
+						pos: position{line: 561, col: 5, offset: 13447},
 						run: (*parser).callonminutes2,
 						expr: &litMatcher{
-							pos:        position{line: 558, col: 5, offset: 13340},
+							pos:        position{line: 561, col: 5, offset: 13447},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 559, col: 5, offset: 13386},
+						pos: position{line: 562, col: 5, offset: 13493},
 						run: (*parser).callonminutes4,
 						expr: &seqExpr{
-							pos: position{line: 559, col: 5, offset: 13386},
+							pos: position{line: 562, col: 5, offset: 13493},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 559, col: 5, offset: 13386},
+									pos:   position{line: 562, col: 5, offset: 13493},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 559, col: 9, offset: 13390},
+										pos:  position{line: 562, col: 9, offset: 13497},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 559, col: 16, offset: 13397},
+									pos: position{line: 562, col: 16, offset: 13504},
 									expr: &ruleRefExpr{
-										pos:  position{line: 559, col: 16, offset: 13397},
+										pos:  position{line: 562, col: 16, offset: 13504},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 559, col: 19, offset: 13400},
+									pos:  position{line: 562, col: 19, offset: 13507},
 									name: "min_abbrev",
 								},
 							},
@@ -4448,42 +4493,42 @@ var g = &grammar{
 		},
 		{
 			name: "hours",
-			pos:  position{line: 561, col: 1, offset: 13455},
+			pos:  position{line: 564, col: 1, offset: 13562},
 			expr: &choiceExpr{
-				pos: position{line: 562, col: 5, offset: 13465},
+				pos: position{line: 565, col: 5, offset: 13572},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 562, col: 5, offset: 13465},
+						pos: position{line: 565, col: 5, offset: 13572},
 						run: (*parser).callonhours2,
 						expr: &litMatcher{
-							pos:        position{line: 562, col: 5, offset: 13465},
+							pos:        position{line: 565, col: 5, offset: 13572},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 563, col: 5, offset: 13511},
+						pos: position{line: 566, col: 5, offset: 13618},
 						run: (*parser).callonhours4,
 						expr: &seqExpr{
-							pos: position{line: 563, col: 5, offset: 13511},
+							pos: position{line: 566, col: 5, offset: 13618},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 563, col: 5, offset: 13511},
+									pos:   position{line: 566, col: 5, offset: 13618},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 563, col: 9, offset: 13515},
+										pos:  position{line: 566, col: 9, offset: 13622},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 563, col: 16, offset: 13522},
+									pos: position{line: 566, col: 16, offset: 13629},
 									expr: &ruleRefExpr{
-										pos:  position{line: 563, col: 16, offset: 13522},
+										pos:  position{line: 566, col: 16, offset: 13629},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 563, col: 19, offset: 13525},
+									pos:  position{line: 566, col: 19, offset: 13632},
 									name: "hour_abbrev",
 								},
 							},
@@ -4494,42 +4539,42 @@ var g = &grammar{
 		},
 		{
 			name: "days",
-			pos:  position{line: 565, col: 1, offset: 13583},
+			pos:  position{line: 568, col: 1, offset: 13690},
 			expr: &choiceExpr{
-				pos: position{line: 566, col: 5, offset: 13592},
+				pos: position{line: 569, col: 5, offset: 13699},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 566, col: 5, offset: 13592},
+						pos: position{line: 569, col: 5, offset: 13699},
 						run: (*parser).callondays2,
 						expr: &litMatcher{
-							pos:        position{line: 566, col: 5, offset: 13592},
+							pos:        position{line: 569, col: 5, offset: 13699},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 567, col: 5, offset: 13640},
+						pos: position{line: 570, col: 5, offset: 13747},
 						run: (*parser).callondays4,
 						expr: &seqExpr{
-							pos: position{line: 567, col: 5, offset: 13640},
+							pos: position{line: 570, col: 5, offset: 13747},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 567, col: 5, offset: 13640},
+									pos:   position{line: 570, col: 5, offset: 13747},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 567, col: 9, offset: 13644},
+										pos:  position{line: 570, col: 9, offset: 13751},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 567, col: 16, offset: 13651},
+									pos: position{line: 570, col: 16, offset: 13758},
 									expr: &ruleRefExpr{
-										pos:  position{line: 567, col: 16, offset: 13651},
+										pos:  position{line: 570, col: 16, offset: 13758},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 567, col: 19, offset: 13654},
+									pos:  position{line: 570, col: 19, offset: 13761},
 									name: "day_abbrev",
 								},
 							},
@@ -4540,30 +4585,30 @@ var g = &grammar{
 		},
 		{
 			name: "weeks",
-			pos:  position{line: 569, col: 1, offset: 13714},
+			pos:  position{line: 572, col: 1, offset: 13821},
 			expr: &actionExpr{
-				pos: position{line: 570, col: 5, offset: 13724},
+				pos: position{line: 573, col: 5, offset: 13831},
 				run: (*parser).callonweeks1,
 				expr: &seqExpr{
-					pos: position{line: 570, col: 5, offset: 13724},
+					pos: position{line: 573, col: 5, offset: 13831},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 570, col: 5, offset: 13724},
+							pos:   position{line: 573, col: 5, offset: 13831},
 							label: "num",
 							expr: &ruleRefExpr{
-								pos:  position{line: 570, col: 9, offset: 13728},
+								pos:  position{line: 573, col: 9, offset: 13835},
 								name: "number",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 570, col: 16, offset: 13735},
+							pos: position{line: 573, col: 16, offset: 13842},
 							expr: &ruleRefExpr{
-								pos:  position{line: 570, col: 16, offset: 13735},
+								pos:  position{line: 573, col: 16, offset: 13842},
 								name: "_",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 570, col: 19, offset: 13738},
+							pos:  position{line: 573, col: 19, offset: 13845},
 							name: "week_abbrev",
 						},
 					},
@@ -4572,53 +4617,53 @@ var g = &grammar{
 		},
 		{
 			name: "number",
-			pos:  position{line: 572, col: 1, offset: 13801},
+			pos:  position{line: 575, col: 1, offset: 13908},
 			expr: &ruleRefExpr{
-				pos:  position{line: 572, col: 10, offset: 13810},
+				pos:  position{line: 575, col: 10, offset: 13917},
 				name: "unsignedInteger",
 			},
 		},
 		{
 			name: "addr",
-			pos:  position{line: 576, col: 1, offset: 13856},
+			pos:  position{line: 579, col: 1, offset: 13963},
 			expr: &actionExpr{
-				pos: position{line: 577, col: 5, offset: 13865},
+				pos: position{line: 580, col: 5, offset: 13972},
 				run: (*parser).callonaddr1,
 				expr: &labeledExpr{
-					pos:   position{line: 577, col: 5, offset: 13865},
+					pos:   position{line: 580, col: 5, offset: 13972},
 					label: "a",
 					expr: &seqExpr{
-						pos: position{line: 577, col: 8, offset: 13868},
+						pos: position{line: 580, col: 8, offset: 13975},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 577, col: 8, offset: 13868},
+								pos:  position{line: 580, col: 8, offset: 13975},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 577, col: 24, offset: 13884},
+								pos:        position{line: 580, col: 24, offset: 13991},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 577, col: 28, offset: 13888},
+								pos:  position{line: 580, col: 28, offset: 13995},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 577, col: 44, offset: 13904},
+								pos:        position{line: 580, col: 44, offset: 14011},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 577, col: 48, offset: 13908},
+								pos:  position{line: 580, col: 48, offset: 14015},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 577, col: 64, offset: 13924},
+								pos:        position{line: 580, col: 64, offset: 14031},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 577, col: 68, offset: 13928},
+								pos:  position{line: 580, col: 68, offset: 14035},
 								name: "unsignedInteger",
 							},
 						},
@@ -4628,23 +4673,23 @@ var g = &grammar{
 		},
 		{
 			name: "port",
-			pos:  position{line: 579, col: 1, offset: 13977},
+			pos:  position{line: 582, col: 1, offset: 14084},
 			expr: &actionExpr{
-				pos: position{line: 580, col: 5, offset: 13986},
+				pos: position{line: 583, col: 5, offset: 14093},
 				run: (*parser).callonport1,
 				expr: &seqExpr{
-					pos: position{line: 580, col: 5, offset: 13986},
+					pos: position{line: 583, col: 5, offset: 14093},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 580, col: 5, offset: 13986},
+							pos:        position{line: 583, col: 5, offset: 14093},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 580, col: 9, offset: 13990},
+							pos:   position{line: 583, col: 9, offset: 14097},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 580, col: 11, offset: 13992},
+								pos:  position{line: 583, col: 11, offset: 14099},
 								name: "suint",
 							},
 						},
@@ -4654,32 +4699,32 @@ var g = &grammar{
 		},
 		{
 			name: "ip6addr",
-			pos:  position{line: 584, col: 1, offset: 14148},
+			pos:  position{line: 587, col: 1, offset: 14255},
 			expr: &choiceExpr{
-				pos: position{line: 585, col: 5, offset: 14160},
+				pos: position{line: 588, col: 5, offset: 14267},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 585, col: 5, offset: 14160},
+						pos: position{line: 588, col: 5, offset: 14267},
 						run: (*parser).callonip6addr2,
 						expr: &seqExpr{
-							pos: position{line: 585, col: 5, offset: 14160},
+							pos: position{line: 588, col: 5, offset: 14267},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 585, col: 5, offset: 14160},
+									pos:   position{line: 588, col: 5, offset: 14267},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 585, col: 7, offset: 14162},
+										pos: position{line: 588, col: 7, offset: 14269},
 										expr: &ruleRefExpr{
-											pos:  position{line: 585, col: 8, offset: 14163},
+											pos:  position{line: 588, col: 8, offset: 14270},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 585, col: 20, offset: 14175},
+									pos:   position{line: 588, col: 20, offset: 14282},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 585, col: 22, offset: 14177},
+										pos:  position{line: 588, col: 22, offset: 14284},
 										name: "ip6tail",
 									},
 								},
@@ -4687,51 +4732,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 588, col: 5, offset: 14241},
+						pos: position{line: 591, col: 5, offset: 14348},
 						run: (*parser).callonip6addr9,
 						expr: &seqExpr{
-							pos: position{line: 588, col: 5, offset: 14241},
+							pos: position{line: 591, col: 5, offset: 14348},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 588, col: 5, offset: 14241},
+									pos:   position{line: 591, col: 5, offset: 14348},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 588, col: 7, offset: 14243},
+										pos:  position{line: 591, col: 7, offset: 14350},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 588, col: 11, offset: 14247},
+									pos:   position{line: 591, col: 11, offset: 14354},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 588, col: 13, offset: 14249},
+										pos: position{line: 591, col: 13, offset: 14356},
 										expr: &ruleRefExpr{
-											pos:  position{line: 588, col: 14, offset: 14250},
+											pos:  position{line: 591, col: 14, offset: 14357},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 588, col: 25, offset: 14261},
+									pos:        position{line: 591, col: 25, offset: 14368},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 588, col: 30, offset: 14266},
+									pos:   position{line: 591, col: 30, offset: 14373},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 588, col: 32, offset: 14268},
+										pos: position{line: 591, col: 32, offset: 14375},
 										expr: &ruleRefExpr{
-											pos:  position{line: 588, col: 33, offset: 14269},
+											pos:  position{line: 591, col: 33, offset: 14376},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 588, col: 45, offset: 14281},
+									pos:   position{line: 591, col: 45, offset: 14388},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 588, col: 47, offset: 14283},
+										pos:  position{line: 591, col: 47, offset: 14390},
 										name: "ip6tail",
 									},
 								},
@@ -4739,32 +4784,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 591, col: 5, offset: 14382},
+						pos: position{line: 594, col: 5, offset: 14489},
 						run: (*parser).callonip6addr22,
 						expr: &seqExpr{
-							pos: position{line: 591, col: 5, offset: 14382},
+							pos: position{line: 594, col: 5, offset: 14489},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 591, col: 5, offset: 14382},
+									pos:        position{line: 594, col: 5, offset: 14489},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 591, col: 10, offset: 14387},
+									pos:   position{line: 594, col: 10, offset: 14494},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 591, col: 12, offset: 14389},
+										pos: position{line: 594, col: 12, offset: 14496},
 										expr: &ruleRefExpr{
-											pos:  position{line: 591, col: 13, offset: 14390},
+											pos:  position{line: 594, col: 13, offset: 14497},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 591, col: 25, offset: 14402},
+									pos:   position{line: 594, col: 25, offset: 14509},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 591, col: 27, offset: 14404},
+										pos:  position{line: 594, col: 27, offset: 14511},
 										name: "ip6tail",
 									},
 								},
@@ -4772,32 +4817,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 594, col: 5, offset: 14475},
+						pos: position{line: 597, col: 5, offset: 14582},
 						run: (*parser).callonip6addr30,
 						expr: &seqExpr{
-							pos: position{line: 594, col: 5, offset: 14475},
+							pos: position{line: 597, col: 5, offset: 14582},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 594, col: 5, offset: 14475},
+									pos:   position{line: 597, col: 5, offset: 14582},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 594, col: 7, offset: 14477},
+										pos:  position{line: 597, col: 7, offset: 14584},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 594, col: 11, offset: 14481},
+									pos:   position{line: 597, col: 11, offset: 14588},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 594, col: 13, offset: 14483},
+										pos: position{line: 597, col: 13, offset: 14590},
 										expr: &ruleRefExpr{
-											pos:  position{line: 594, col: 14, offset: 14484},
+											pos:  position{line: 597, col: 14, offset: 14591},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 594, col: 25, offset: 14495},
+									pos:        position{line: 597, col: 25, offset: 14602},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -4805,10 +4850,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 597, col: 5, offset: 14563},
+						pos: position{line: 600, col: 5, offset: 14670},
 						run: (*parser).callonip6addr38,
 						expr: &litMatcher{
-							pos:        position{line: 597, col: 5, offset: 14563},
+							pos:        position{line: 600, col: 5, offset: 14670},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -4818,16 +4863,16 @@ var g = &grammar{
 		},
 		{
 			name: "ip6tail",
-			pos:  position{line: 601, col: 1, offset: 14600},
+			pos:  position{line: 604, col: 1, offset: 14707},
 			expr: &choiceExpr{
-				pos: position{line: 602, col: 5, offset: 14612},
+				pos: position{line: 605, col: 5, offset: 14719},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 602, col: 5, offset: 14612},
+						pos:  position{line: 605, col: 5, offset: 14719},
 						name: "addr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 603, col: 5, offset: 14621},
+						pos:  position{line: 606, col: 5, offset: 14728},
 						name: "h16",
 					},
 				},
@@ -4835,23 +4880,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_append",
-			pos:  position{line: 605, col: 1, offset: 14626},
+			pos:  position{line: 608, col: 1, offset: 14733},
 			expr: &actionExpr{
-				pos: position{line: 605, col: 12, offset: 14637},
+				pos: position{line: 608, col: 12, offset: 14744},
 				run: (*parser).callonh_append1,
 				expr: &seqExpr{
-					pos: position{line: 605, col: 12, offset: 14637},
+					pos: position{line: 608, col: 12, offset: 14744},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 605, col: 12, offset: 14637},
+							pos:        position{line: 608, col: 12, offset: 14744},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 605, col: 16, offset: 14641},
+							pos:   position{line: 608, col: 16, offset: 14748},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 605, col: 18, offset: 14643},
+								pos:  position{line: 608, col: 18, offset: 14750},
 								name: "h16",
 							},
 						},
@@ -4861,23 +4906,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_prepend",
-			pos:  position{line: 606, col: 1, offset: 14680},
+			pos:  position{line: 609, col: 1, offset: 14787},
 			expr: &actionExpr{
-				pos: position{line: 606, col: 13, offset: 14692},
+				pos: position{line: 609, col: 13, offset: 14799},
 				run: (*parser).callonh_prepend1,
 				expr: &seqExpr{
-					pos: position{line: 606, col: 13, offset: 14692},
+					pos: position{line: 609, col: 13, offset: 14799},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 606, col: 13, offset: 14692},
+							pos:   position{line: 609, col: 13, offset: 14799},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 606, col: 15, offset: 14694},
+								pos:  position{line: 609, col: 15, offset: 14801},
 								name: "h16",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 606, col: 19, offset: 14698},
+							pos:        position{line: 609, col: 19, offset: 14805},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -4887,31 +4932,31 @@ var g = &grammar{
 		},
 		{
 			name: "subnet",
-			pos:  position{line: 608, col: 1, offset: 14736},
+			pos:  position{line: 611, col: 1, offset: 14843},
 			expr: &actionExpr{
-				pos: position{line: 609, col: 5, offset: 14747},
+				pos: position{line: 612, col: 5, offset: 14854},
 				run: (*parser).callonsubnet1,
 				expr: &seqExpr{
-					pos: position{line: 609, col: 5, offset: 14747},
+					pos: position{line: 612, col: 5, offset: 14854},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 609, col: 5, offset: 14747},
+							pos:   position{line: 612, col: 5, offset: 14854},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 609, col: 7, offset: 14749},
+								pos:  position{line: 612, col: 7, offset: 14856},
 								name: "addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 609, col: 12, offset: 14754},
+							pos:        position{line: 612, col: 12, offset: 14861},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 609, col: 16, offset: 14758},
+							pos:   position{line: 612, col: 16, offset: 14865},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 609, col: 18, offset: 14760},
+								pos:  position{line: 612, col: 18, offset: 14867},
 								name: "unsignedInteger",
 							},
 						},
@@ -4921,31 +4966,31 @@ var g = &grammar{
 		},
 		{
 			name: "ip6subnet",
-			pos:  position{line: 613, col: 1, offset: 14844},
+			pos:  position{line: 616, col: 1, offset: 14951},
 			expr: &actionExpr{
-				pos: position{line: 614, col: 5, offset: 14858},
+				pos: position{line: 617, col: 5, offset: 14965},
 				run: (*parser).callonip6subnet1,
 				expr: &seqExpr{
-					pos: position{line: 614, col: 5, offset: 14858},
+					pos: position{line: 617, col: 5, offset: 14965},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 614, col: 5, offset: 14858},
+							pos:   position{line: 617, col: 5, offset: 14965},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 614, col: 7, offset: 14860},
+								pos:  position{line: 617, col: 7, offset: 14967},
 								name: "ip6addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 614, col: 15, offset: 14868},
+							pos:        position{line: 617, col: 15, offset: 14975},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 614, col: 19, offset: 14872},
+							pos:   position{line: 617, col: 19, offset: 14979},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 614, col: 21, offset: 14874},
+								pos:  position{line: 617, col: 21, offset: 14981},
 								name: "unsignedInteger",
 							},
 						},
@@ -4955,15 +5000,15 @@ var g = &grammar{
 		},
 		{
 			name: "unsignedInteger",
-			pos:  position{line: 618, col: 1, offset: 14948},
+			pos:  position{line: 621, col: 1, offset: 15055},
 			expr: &actionExpr{
-				pos: position{line: 619, col: 5, offset: 14968},
+				pos: position{line: 622, col: 5, offset: 15075},
 				run: (*parser).callonunsignedInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 619, col: 5, offset: 14968},
+					pos:   position{line: 622, col: 5, offset: 15075},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 619, col: 7, offset: 14970},
+						pos:  position{line: 622, col: 7, offset: 15077},
 						name: "suint",
 					},
 				},
@@ -4971,14 +5016,14 @@ var g = &grammar{
 		},
 		{
 			name: "suint",
-			pos:  position{line: 621, col: 1, offset: 15005},
+			pos:  position{line: 624, col: 1, offset: 15112},
 			expr: &actionExpr{
-				pos: position{line: 622, col: 5, offset: 15015},
+				pos: position{line: 625, col: 5, offset: 15122},
 				run: (*parser).callonsuint1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 622, col: 5, offset: 15015},
+					pos: position{line: 625, col: 5, offset: 15122},
 					expr: &charClassMatcher{
-						pos:        position{line: 622, col: 5, offset: 15015},
+						pos:        position{line: 625, col: 5, offset: 15122},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4989,15 +5034,15 @@ var g = &grammar{
 		},
 		{
 			name: "integer",
-			pos:  position{line: 624, col: 1, offset: 15054},
+			pos:  position{line: 627, col: 1, offset: 15161},
 			expr: &actionExpr{
-				pos: position{line: 625, col: 5, offset: 15066},
+				pos: position{line: 628, col: 5, offset: 15173},
 				run: (*parser).calloninteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 625, col: 5, offset: 15066},
+					pos:   position{line: 628, col: 5, offset: 15173},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 625, col: 7, offset: 15068},
+						pos:  position{line: 628, col: 7, offset: 15175},
 						name: "sinteger",
 					},
 				},
@@ -5005,17 +5050,17 @@ var g = &grammar{
 		},
 		{
 			name: "sinteger",
-			pos:  position{line: 627, col: 1, offset: 15106},
+			pos:  position{line: 630, col: 1, offset: 15213},
 			expr: &actionExpr{
-				pos: position{line: 628, col: 5, offset: 15119},
+				pos: position{line: 631, col: 5, offset: 15226},
 				run: (*parser).callonsinteger1,
 				expr: &seqExpr{
-					pos: position{line: 628, col: 5, offset: 15119},
+					pos: position{line: 631, col: 5, offset: 15226},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 628, col: 5, offset: 15119},
+							pos: position{line: 631, col: 5, offset: 15226},
 							expr: &charClassMatcher{
-								pos:        position{line: 628, col: 5, offset: 15119},
+								pos:        position{line: 631, col: 5, offset: 15226},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -5023,7 +5068,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 628, col: 11, offset: 15125},
+							pos:  position{line: 631, col: 11, offset: 15232},
 							name: "suint",
 						},
 					},
@@ -5032,15 +5077,15 @@ var g = &grammar{
 		},
 		{
 			name: "double",
-			pos:  position{line: 630, col: 1, offset: 15163},
+			pos:  position{line: 633, col: 1, offset: 15270},
 			expr: &actionExpr{
-				pos: position{line: 631, col: 5, offset: 15174},
+				pos: position{line: 634, col: 5, offset: 15281},
 				run: (*parser).callondouble1,
 				expr: &labeledExpr{
-					pos:   position{line: 631, col: 5, offset: 15174},
+					pos:   position{line: 634, col: 5, offset: 15281},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 631, col: 7, offset: 15176},
+						pos:  position{line: 634, col: 7, offset: 15283},
 						name: "sdouble",
 					},
 				},
@@ -5048,47 +5093,47 @@ var g = &grammar{
 		},
 		{
 			name: "sdouble",
-			pos:  position{line: 635, col: 1, offset: 15223},
+			pos:  position{line: 638, col: 1, offset: 15330},
 			expr: &choiceExpr{
-				pos: position{line: 636, col: 5, offset: 15235},
+				pos: position{line: 639, col: 5, offset: 15342},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 636, col: 5, offset: 15235},
+						pos: position{line: 639, col: 5, offset: 15342},
 						run: (*parser).callonsdouble2,
 						expr: &seqExpr{
-							pos: position{line: 636, col: 5, offset: 15235},
+							pos: position{line: 639, col: 5, offset: 15342},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 636, col: 5, offset: 15235},
+									pos: position{line: 639, col: 5, offset: 15342},
 									expr: &litMatcher{
-										pos:        position{line: 636, col: 5, offset: 15235},
+										pos:        position{line: 639, col: 5, offset: 15342},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 636, col: 10, offset: 15240},
+									pos: position{line: 639, col: 10, offset: 15347},
 									expr: &ruleRefExpr{
-										pos:  position{line: 636, col: 10, offset: 15240},
+										pos:  position{line: 639, col: 10, offset: 15347},
 										name: "doubleInteger",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 636, col: 25, offset: 15255},
+									pos:        position{line: 639, col: 25, offset: 15362},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 636, col: 29, offset: 15259},
+									pos: position{line: 639, col: 29, offset: 15366},
 									expr: &ruleRefExpr{
-										pos:  position{line: 636, col: 29, offset: 15259},
+										pos:  position{line: 639, col: 29, offset: 15366},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 636, col: 42, offset: 15272},
+									pos: position{line: 639, col: 42, offset: 15379},
 									expr: &ruleRefExpr{
-										pos:  position{line: 636, col: 42, offset: 15272},
+										pos:  position{line: 639, col: 42, offset: 15379},
 										name: "exponentPart",
 									},
 								},
@@ -5096,35 +5141,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 639, col: 5, offset: 15331},
+						pos: position{line: 642, col: 5, offset: 15438},
 						run: (*parser).callonsdouble13,
 						expr: &seqExpr{
-							pos: position{line: 639, col: 5, offset: 15331},
+							pos: position{line: 642, col: 5, offset: 15438},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 639, col: 5, offset: 15331},
+									pos: position{line: 642, col: 5, offset: 15438},
 									expr: &litMatcher{
-										pos:        position{line: 639, col: 5, offset: 15331},
+										pos:        position{line: 642, col: 5, offset: 15438},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 639, col: 10, offset: 15336},
+									pos:        position{line: 642, col: 10, offset: 15443},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 639, col: 14, offset: 15340},
+									pos: position{line: 642, col: 14, offset: 15447},
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 14, offset: 15340},
+										pos:  position{line: 642, col: 14, offset: 15447},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 639, col: 27, offset: 15353},
+									pos: position{line: 642, col: 27, offset: 15460},
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 27, offset: 15353},
+										pos:  position{line: 642, col: 27, offset: 15460},
 										name: "exponentPart",
 									},
 								},
@@ -5136,29 +5181,29 @@ var g = &grammar{
 		},
 		{
 			name: "doubleInteger",
-			pos:  position{line: 643, col: 1, offset: 15409},
+			pos:  position{line: 646, col: 1, offset: 15516},
 			expr: &choiceExpr{
-				pos: position{line: 644, col: 5, offset: 15427},
+				pos: position{line: 647, col: 5, offset: 15534},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 644, col: 5, offset: 15427},
+						pos:        position{line: 647, col: 5, offset: 15534},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 645, col: 5, offset: 15435},
+						pos: position{line: 648, col: 5, offset: 15542},
 						exprs: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 645, col: 5, offset: 15435},
+								pos:        position{line: 648, col: 5, offset: 15542},
 								val:        "[1-9]",
 								ranges:     []rune{'1', '9'},
 								ignoreCase: false,
 								inverted:   false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 645, col: 11, offset: 15441},
+								pos: position{line: 648, col: 11, offset: 15548},
 								expr: &charClassMatcher{
-									pos:        position{line: 645, col: 11, offset: 15441},
+									pos:        position{line: 648, col: 11, offset: 15548},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -5172,9 +5217,9 @@ var g = &grammar{
 		},
 		{
 			name: "doubleDigit",
-			pos:  position{line: 647, col: 1, offset: 15449},
+			pos:  position{line: 650, col: 1, offset: 15556},
 			expr: &charClassMatcher{
-				pos:        position{line: 647, col: 15, offset: 15463},
+				pos:        position{line: 650, col: 15, offset: 15570},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -5183,17 +5228,17 @@ var g = &grammar{
 		},
 		{
 			name: "exponentPart",
-			pos:  position{line: 649, col: 1, offset: 15470},
+			pos:  position{line: 652, col: 1, offset: 15577},
 			expr: &seqExpr{
-				pos: position{line: 649, col: 16, offset: 15485},
+				pos: position{line: 652, col: 16, offset: 15592},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 649, col: 16, offset: 15485},
+						pos:        position{line: 652, col: 16, offset: 15592},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 649, col: 21, offset: 15490},
+						pos:  position{line: 652, col: 21, offset: 15597},
 						name: "sinteger",
 					},
 				},
@@ -5201,17 +5246,17 @@ var g = &grammar{
 		},
 		{
 			name: "h16",
-			pos:  position{line: 651, col: 1, offset: 15500},
+			pos:  position{line: 654, col: 1, offset: 15607},
 			expr: &actionExpr{
-				pos: position{line: 651, col: 7, offset: 15506},
+				pos: position{line: 654, col: 7, offset: 15613},
 				run: (*parser).callonh161,
 				expr: &labeledExpr{
-					pos:   position{line: 651, col: 7, offset: 15506},
+					pos:   position{line: 654, col: 7, offset: 15613},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 651, col: 13, offset: 15512},
+						pos: position{line: 654, col: 13, offset: 15619},
 						expr: &ruleRefExpr{
-							pos:  position{line: 651, col: 13, offset: 15512},
+							pos:  position{line: 654, col: 13, offset: 15619},
 							name: "hexdigit",
 						},
 					},
@@ -5220,9 +5265,9 @@ var g = &grammar{
 		},
 		{
 			name: "hexdigit",
-			pos:  position{line: 653, col: 1, offset: 15554},
+			pos:  position{line: 656, col: 1, offset: 15661},
 			expr: &charClassMatcher{
-				pos:        position{line: 653, col: 12, offset: 15565},
+				pos:        position{line: 656, col: 12, offset: 15672},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -5231,17 +5276,17 @@ var g = &grammar{
 		},
 		{
 			name: "searchWord",
-			pos:  position{line: 655, col: 1, offset: 15578},
+			pos:  position{line: 658, col: 1, offset: 15685},
 			expr: &actionExpr{
-				pos: position{line: 656, col: 5, offset: 15593},
+				pos: position{line: 659, col: 5, offset: 15700},
 				run: (*parser).callonsearchWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 656, col: 5, offset: 15593},
+					pos:   position{line: 659, col: 5, offset: 15700},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 656, col: 11, offset: 15599},
+						pos: position{line: 659, col: 11, offset: 15706},
 						expr: &ruleRefExpr{
-							pos:  position{line: 656, col: 11, offset: 15599},
+							pos:  position{line: 659, col: 11, offset: 15706},
 							name: "searchWordPart",
 						},
 					},
@@ -5250,33 +5295,33 @@ var g = &grammar{
 		},
 		{
 			name: "searchWordPart",
-			pos:  position{line: 658, col: 1, offset: 15649},
+			pos:  position{line: 661, col: 1, offset: 15756},
 			expr: &choiceExpr{
-				pos: position{line: 659, col: 5, offset: 15668},
+				pos: position{line: 662, col: 5, offset: 15775},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 15668},
+						pos: position{line: 662, col: 5, offset: 15775},
 						run: (*parser).callonsearchWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 15668},
+							pos: position{line: 662, col: 5, offset: 15775},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 659, col: 5, offset: 15668},
+									pos:        position{line: 662, col: 5, offset: 15775},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 659, col: 10, offset: 15673},
+									pos:   position{line: 662, col: 10, offset: 15780},
 									label: "s",
 									expr: &choiceExpr{
-										pos: position{line: 659, col: 13, offset: 15676},
+										pos: position{line: 662, col: 13, offset: 15783},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 659, col: 13, offset: 15676},
+												pos:  position{line: 662, col: 13, offset: 15783},
 												name: "escapeSequence",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 659, col: 30, offset: 15693},
+												pos:  position{line: 662, col: 30, offset: 15800},
 												name: "searchEscape",
 											},
 										},
@@ -5286,18 +5331,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 660, col: 5, offset: 15730},
+						pos: position{line: 663, col: 5, offset: 15837},
 						run: (*parser).callonsearchWordPart9,
 						expr: &seqExpr{
-							pos: position{line: 660, col: 5, offset: 15730},
+							pos: position{line: 663, col: 5, offset: 15837},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 660, col: 5, offset: 15730},
+									pos: position{line: 663, col: 5, offset: 15837},
 									expr: &choiceExpr{
-										pos: position{line: 660, col: 7, offset: 15732},
+										pos: position{line: 663, col: 7, offset: 15839},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 660, col: 7, offset: 15732},
+												pos:        position{line: 663, col: 7, offset: 15839},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -5305,14 +5350,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 660, col: 42, offset: 15767},
+												pos:  position{line: 663, col: 42, offset: 15874},
 												name: "ws",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 660, col: 46, offset: 15771,
+									line: 663, col: 46, offset: 15878,
 								},
 							},
 						},
@@ -5322,34 +5367,34 @@ var g = &grammar{
 		},
 		{
 			name: "quotedString",
-			pos:  position{line: 662, col: 1, offset: 15805},
+			pos:  position{line: 665, col: 1, offset: 15912},
 			expr: &choiceExpr{
-				pos: position{line: 663, col: 5, offset: 15822},
+				pos: position{line: 666, col: 5, offset: 15929},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 663, col: 5, offset: 15822},
+						pos: position{line: 666, col: 5, offset: 15929},
 						run: (*parser).callonquotedString2,
 						expr: &seqExpr{
-							pos: position{line: 663, col: 5, offset: 15822},
+							pos: position{line: 666, col: 5, offset: 15929},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 663, col: 5, offset: 15822},
+									pos:        position{line: 666, col: 5, offset: 15929},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 663, col: 9, offset: 15826},
+									pos:   position{line: 666, col: 9, offset: 15933},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 663, col: 11, offset: 15828},
+										pos: position{line: 666, col: 11, offset: 15935},
 										expr: &ruleRefExpr{
-											pos:  position{line: 663, col: 11, offset: 15828},
+											pos:  position{line: 666, col: 11, offset: 15935},
 											name: "doubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 663, col: 29, offset: 15846},
+									pos:        position{line: 666, col: 29, offset: 15953},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5357,29 +5402,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 664, col: 5, offset: 15883},
+						pos: position{line: 667, col: 5, offset: 15990},
 						run: (*parser).callonquotedString9,
 						expr: &seqExpr{
-							pos: position{line: 664, col: 5, offset: 15883},
+							pos: position{line: 667, col: 5, offset: 15990},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 664, col: 5, offset: 15883},
+									pos:        position{line: 667, col: 5, offset: 15990},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 664, col: 9, offset: 15887},
+									pos:   position{line: 667, col: 9, offset: 15994},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 664, col: 11, offset: 15889},
+										pos: position{line: 667, col: 11, offset: 15996},
 										expr: &ruleRefExpr{
-											pos:  position{line: 664, col: 11, offset: 15889},
+											pos:  position{line: 667, col: 11, offset: 15996},
 											name: "singleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 664, col: 29, offset: 15907},
+									pos:        position{line: 667, col: 29, offset: 16014},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5391,55 +5436,55 @@ var g = &grammar{
 		},
 		{
 			name: "doubleQuotedChar",
-			pos:  position{line: 666, col: 1, offset: 15941},
+			pos:  position{line: 669, col: 1, offset: 16048},
 			expr: &choiceExpr{
-				pos: position{line: 667, col: 5, offset: 15962},
+				pos: position{line: 670, col: 5, offset: 16069},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 667, col: 5, offset: 15962},
+						pos: position{line: 670, col: 5, offset: 16069},
 						run: (*parser).callondoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 667, col: 5, offset: 15962},
+							pos: position{line: 670, col: 5, offset: 16069},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 667, col: 5, offset: 15962},
+									pos: position{line: 670, col: 5, offset: 16069},
 									expr: &choiceExpr{
-										pos: position{line: 667, col: 7, offset: 15964},
+										pos: position{line: 670, col: 7, offset: 16071},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 667, col: 7, offset: 15964},
+												pos:        position{line: 670, col: 7, offset: 16071},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 667, col: 13, offset: 15970},
+												pos:  position{line: 670, col: 13, offset: 16077},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 667, col: 26, offset: 15983,
+									line: 670, col: 26, offset: 16090,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 668, col: 5, offset: 16020},
+						pos: position{line: 671, col: 5, offset: 16127},
 						run: (*parser).callondoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 668, col: 5, offset: 16020},
+							pos: position{line: 671, col: 5, offset: 16127},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 668, col: 5, offset: 16020},
+									pos:        position{line: 671, col: 5, offset: 16127},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 668, col: 10, offset: 16025},
+									pos:   position{line: 671, col: 10, offset: 16132},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 668, col: 12, offset: 16027},
+										pos:  position{line: 671, col: 12, offset: 16134},
 										name: "escapeSequence",
 									},
 								},
@@ -5451,55 +5496,55 @@ var g = &grammar{
 		},
 		{
 			name: "singleQuotedChar",
-			pos:  position{line: 670, col: 1, offset: 16061},
+			pos:  position{line: 673, col: 1, offset: 16168},
 			expr: &choiceExpr{
-				pos: position{line: 671, col: 5, offset: 16082},
+				pos: position{line: 674, col: 5, offset: 16189},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 671, col: 5, offset: 16082},
+						pos: position{line: 674, col: 5, offset: 16189},
 						run: (*parser).callonsingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 671, col: 5, offset: 16082},
+							pos: position{line: 674, col: 5, offset: 16189},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 671, col: 5, offset: 16082},
+									pos: position{line: 674, col: 5, offset: 16189},
 									expr: &choiceExpr{
-										pos: position{line: 671, col: 7, offset: 16084},
+										pos: position{line: 674, col: 7, offset: 16191},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 671, col: 7, offset: 16084},
+												pos:        position{line: 674, col: 7, offset: 16191},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 671, col: 13, offset: 16090},
+												pos:  position{line: 674, col: 13, offset: 16197},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 671, col: 26, offset: 16103,
+									line: 674, col: 26, offset: 16210,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 672, col: 5, offset: 16140},
+						pos: position{line: 675, col: 5, offset: 16247},
 						run: (*parser).callonsingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 672, col: 5, offset: 16140},
+							pos: position{line: 675, col: 5, offset: 16247},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 672, col: 5, offset: 16140},
+									pos:        position{line: 675, col: 5, offset: 16247},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 672, col: 10, offset: 16145},
+									pos:   position{line: 675, col: 10, offset: 16252},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 672, col: 12, offset: 16147},
+										pos:  position{line: 675, col: 12, offset: 16254},
 										name: "escapeSequence",
 									},
 								},
@@ -5511,38 +5556,38 @@ var g = &grammar{
 		},
 		{
 			name: "escapeSequence",
-			pos:  position{line: 674, col: 1, offset: 16181},
+			pos:  position{line: 677, col: 1, offset: 16288},
 			expr: &choiceExpr{
-				pos: position{line: 675, col: 5, offset: 16200},
+				pos: position{line: 678, col: 5, offset: 16307},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 675, col: 5, offset: 16200},
+						pos: position{line: 678, col: 5, offset: 16307},
 						run: (*parser).callonescapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 675, col: 5, offset: 16200},
+							pos: position{line: 678, col: 5, offset: 16307},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 675, col: 5, offset: 16200},
+									pos:        position{line: 678, col: 5, offset: 16307},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 675, col: 9, offset: 16204},
+									pos:  position{line: 678, col: 9, offset: 16311},
 									name: "hexdigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 675, col: 18, offset: 16213},
+									pos:  position{line: 678, col: 18, offset: 16320},
 									name: "hexdigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 676, col: 5, offset: 16264},
+						pos:  position{line: 679, col: 5, offset: 16371},
 						name: "singleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 677, col: 5, offset: 16285},
+						pos:  position{line: 680, col: 5, offset: 16392},
 						name: "unicodeEscape",
 					},
 				},
@@ -5550,75 +5595,75 @@ var g = &grammar{
 		},
 		{
 			name: "singleCharEscape",
-			pos:  position{line: 679, col: 1, offset: 16300},
+			pos:  position{line: 682, col: 1, offset: 16407},
 			expr: &choiceExpr{
-				pos: position{line: 680, col: 5, offset: 16321},
+				pos: position{line: 683, col: 5, offset: 16428},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 680, col: 5, offset: 16321},
+						pos:        position{line: 683, col: 5, offset: 16428},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 681, col: 5, offset: 16329},
+						pos:        position{line: 684, col: 5, offset: 16436},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 682, col: 5, offset: 16337},
+						pos:        position{line: 685, col: 5, offset: 16444},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 683, col: 5, offset: 16346},
+						pos: position{line: 686, col: 5, offset: 16453},
 						run: (*parser).callonsingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 683, col: 5, offset: 16346},
+							pos:        position{line: 686, col: 5, offset: 16453},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 684, col: 5, offset: 16375},
+						pos: position{line: 687, col: 5, offset: 16482},
 						run: (*parser).callonsingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 684, col: 5, offset: 16375},
+							pos:        position{line: 687, col: 5, offset: 16482},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 685, col: 5, offset: 16404},
+						pos: position{line: 688, col: 5, offset: 16511},
 						run: (*parser).callonsingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 685, col: 5, offset: 16404},
+							pos:        position{line: 688, col: 5, offset: 16511},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 686, col: 5, offset: 16433},
+						pos: position{line: 689, col: 5, offset: 16540},
 						run: (*parser).callonsingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 686, col: 5, offset: 16433},
+							pos:        position{line: 689, col: 5, offset: 16540},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 687, col: 5, offset: 16462},
+						pos: position{line: 690, col: 5, offset: 16569},
 						run: (*parser).callonsingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 687, col: 5, offset: 16462},
+							pos:        position{line: 690, col: 5, offset: 16569},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 688, col: 5, offset: 16491},
+						pos: position{line: 691, col: 5, offset: 16598},
 						run: (*parser).callonsingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 688, col: 5, offset: 16491},
+							pos:        position{line: 691, col: 5, offset: 16598},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5628,24 +5673,24 @@ var g = &grammar{
 		},
 		{
 			name: "searchEscape",
-			pos:  position{line: 690, col: 1, offset: 16517},
+			pos:  position{line: 693, col: 1, offset: 16624},
 			expr: &choiceExpr{
-				pos: position{line: 691, col: 5, offset: 16534},
+				pos: position{line: 694, col: 5, offset: 16641},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 691, col: 5, offset: 16534},
+						pos: position{line: 694, col: 5, offset: 16641},
 						run: (*parser).callonsearchEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 691, col: 5, offset: 16534},
+							pos:        position{line: 694, col: 5, offset: 16641},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 692, col: 5, offset: 16562},
+						pos: position{line: 695, col: 5, offset: 16669},
 						run: (*parser).callonsearchEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 692, col: 5, offset: 16562},
+							pos:        position{line: 695, col: 5, offset: 16669},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -5655,41 +5700,41 @@ var g = &grammar{
 		},
 		{
 			name: "unicodeEscape",
-			pos:  position{line: 694, col: 1, offset: 16589},
+			pos:  position{line: 697, col: 1, offset: 16696},
 			expr: &choiceExpr{
-				pos: position{line: 695, col: 5, offset: 16607},
+				pos: position{line: 698, col: 5, offset: 16714},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 695, col: 5, offset: 16607},
+						pos: position{line: 698, col: 5, offset: 16714},
 						run: (*parser).callonunicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 695, col: 5, offset: 16607},
+							pos: position{line: 698, col: 5, offset: 16714},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 695, col: 5, offset: 16607},
+									pos:        position{line: 698, col: 5, offset: 16714},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 695, col: 9, offset: 16611},
+									pos:   position{line: 698, col: 9, offset: 16718},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 695, col: 16, offset: 16618},
+										pos: position{line: 698, col: 16, offset: 16725},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 16, offset: 16618},
+												pos:  position{line: 698, col: 16, offset: 16725},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 25, offset: 16627},
+												pos:  position{line: 698, col: 25, offset: 16734},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 34, offset: 16636},
+												pos:  position{line: 698, col: 34, offset: 16743},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 43, offset: 16645},
+												pos:  position{line: 698, col: 43, offset: 16752},
 												name: "hexdigit",
 											},
 										},
@@ -5699,63 +5744,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 698, col: 5, offset: 16708},
+						pos: position{line: 701, col: 5, offset: 16815},
 						run: (*parser).callonunicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 698, col: 5, offset: 16708},
+							pos: position{line: 701, col: 5, offset: 16815},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 698, col: 5, offset: 16708},
+									pos:        position{line: 701, col: 5, offset: 16815},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 698, col: 9, offset: 16712},
+									pos:        position{line: 701, col: 9, offset: 16819},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 698, col: 13, offset: 16716},
+									pos:   position{line: 701, col: 13, offset: 16823},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 698, col: 20, offset: 16723},
+										pos: position{line: 701, col: 20, offset: 16830},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 698, col: 20, offset: 16723},
+												pos:  position{line: 701, col: 20, offset: 16830},
 												name: "hexdigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 29, offset: 16732},
+												pos: position{line: 701, col: 29, offset: 16839},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 29, offset: 16732},
+													pos:  position{line: 701, col: 29, offset: 16839},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 39, offset: 16742},
+												pos: position{line: 701, col: 39, offset: 16849},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 39, offset: 16742},
+													pos:  position{line: 701, col: 39, offset: 16849},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 49, offset: 16752},
+												pos: position{line: 701, col: 49, offset: 16859},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 49, offset: 16752},
+													pos:  position{line: 701, col: 49, offset: 16859},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 59, offset: 16762},
+												pos: position{line: 701, col: 59, offset: 16869},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 59, offset: 16762},
+													pos:  position{line: 701, col: 59, offset: 16869},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 69, offset: 16772},
+												pos: position{line: 701, col: 69, offset: 16879},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 69, offset: 16772},
+													pos:  position{line: 701, col: 69, offset: 16879},
 													name: "hexdigit",
 												},
 											},
@@ -5763,7 +5808,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 698, col: 80, offset: 16783},
+									pos:        position{line: 701, col: 80, offset: 16890},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5775,28 +5820,28 @@ var g = &grammar{
 		},
 		{
 			name: "reString",
-			pos:  position{line: 702, col: 1, offset: 16837},
+			pos:  position{line: 705, col: 1, offset: 16944},
 			expr: &actionExpr{
-				pos: position{line: 703, col: 5, offset: 16850},
+				pos: position{line: 706, col: 5, offset: 16957},
 				run: (*parser).callonreString1,
 				expr: &seqExpr{
-					pos: position{line: 703, col: 5, offset: 16850},
+					pos: position{line: 706, col: 5, offset: 16957},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 703, col: 5, offset: 16850},
+							pos:        position{line: 706, col: 5, offset: 16957},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 703, col: 9, offset: 16854},
+							pos:   position{line: 706, col: 9, offset: 16961},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 703, col: 11, offset: 16856},
+								pos:  position{line: 706, col: 11, offset: 16963},
 								name: "reBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 703, col: 18, offset: 16863},
+							pos:        position{line: 706, col: 18, offset: 16970},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5806,24 +5851,24 @@ var g = &grammar{
 		},
 		{
 			name: "reBody",
-			pos:  position{line: 705, col: 1, offset: 16886},
+			pos:  position{line: 708, col: 1, offset: 16993},
 			expr: &actionExpr{
-				pos: position{line: 706, col: 5, offset: 16897},
+				pos: position{line: 709, col: 5, offset: 17004},
 				run: (*parser).callonreBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 706, col: 5, offset: 16897},
+					pos: position{line: 709, col: 5, offset: 17004},
 					expr: &choiceExpr{
-						pos: position{line: 706, col: 6, offset: 16898},
+						pos: position{line: 709, col: 6, offset: 17005},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 706, col: 6, offset: 16898},
+								pos:        position{line: 709, col: 6, offset: 17005},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 706, col: 13, offset: 16905},
+								pos:        position{line: 709, col: 13, offset: 17012},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -5834,9 +5879,9 @@ var g = &grammar{
 		},
 		{
 			name: "escapedChar",
-			pos:  position{line: 708, col: 1, offset: 16945},
+			pos:  position{line: 711, col: 1, offset: 17052},
 			expr: &charClassMatcher{
-				pos:        position{line: 709, col: 5, offset: 16961},
+				pos:        position{line: 712, col: 5, offset: 17068},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5846,37 +5891,37 @@ var g = &grammar{
 		},
 		{
 			name: "ws",
-			pos:  position{line: 711, col: 1, offset: 16976},
+			pos:  position{line: 714, col: 1, offset: 17083},
 			expr: &choiceExpr{
-				pos: position{line: 712, col: 5, offset: 16983},
+				pos: position{line: 715, col: 5, offset: 17090},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 712, col: 5, offset: 16983},
+						pos:        position{line: 715, col: 5, offset: 17090},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 713, col: 5, offset: 16992},
+						pos:        position{line: 716, col: 5, offset: 17099},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 714, col: 5, offset: 17001},
+						pos:        position{line: 717, col: 5, offset: 17108},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 715, col: 5, offset: 17010},
+						pos:        position{line: 718, col: 5, offset: 17117},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 716, col: 5, offset: 17018},
+						pos:        position{line: 719, col: 5, offset: 17125},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 717, col: 5, offset: 17031},
+						pos:        position{line: 720, col: 5, offset: 17138},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5886,33 +5931,33 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 719, col: 1, offset: 17041},
+			pos:         position{line: 722, col: 1, offset: 17148},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 719, col: 18, offset: 17058},
+				pos: position{line: 722, col: 18, offset: 17165},
 				expr: &ruleRefExpr{
-					pos:  position{line: 719, col: 18, offset: 17058},
+					pos:  position{line: 722, col: 18, offset: 17165},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 720, col: 1, offset: 17062},
+			pos:  position{line: 723, col: 1, offset: 17169},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 720, col: 6, offset: 17067},
+				pos: position{line: 723, col: 6, offset: 17174},
 				expr: &ruleRefExpr{
-					pos:  position{line: 720, col: 6, offset: 17067},
+					pos:  position{line: 723, col: 6, offset: 17174},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 722, col: 1, offset: 17072},
+			pos:  position{line: 725, col: 1, offset: 17179},
 			expr: &notExpr{
-				pos: position{line: 722, col: 7, offset: 17078},
+				pos: position{line: 725, col: 7, offset: 17185},
 				expr: &anyMatcher{
-					line: 722, col: 8, offset: 17079,
+					line: 725, col: 8, offset: 17186,
 				},
 			},
 		},
@@ -6401,6 +6446,16 @@ func (p *parser) calloneveryDur1() (interface{}, error) {
 	return p.cur.oneveryDur1(stack["dur"])
 }
 
+func (c *current) ongroupBySorted1(dir interface{}) (interface{}, error) {
+	return parseInt(dir), nil
+}
+
+func (p *parser) callongroupBySorted1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.ongroupBySorted1(stack["dir"])
+}
+
 func (c *current) onandToken1() (interface{}, error) {
 	return string(c.text), nil
 }
@@ -6722,7 +6777,7 @@ func (p *parser) callonfieldReducer1() (interface{}, error) {
 	return p.cur.onfieldReducer1(stack["op"], stack["field"])
 }
 
-func (c *current) onreducerProc1(every, reducers, keys, limit interface{}) (interface{}, error) {
+func (c *current) onreducerProc1(every, reducers, keys, sorted, limit interface{}) (interface{}, error) {
 	if OR(keys, every) != nil {
 		if keys != nil {
 			keys = keys.([]interface{})[1]
@@ -6734,7 +6789,7 @@ func (c *current) onreducerProc1(every, reducers, keys, limit interface{}) (inte
 			every = every.([]interface{})[0]
 		}
 
-		return makeGroupByProc(every, limit, keys, reducers), nil
+		return makeGroupByProc(every, sorted, limit, keys, reducers), nil
 	}
 
 	return makeReducerProc(reducers), nil
@@ -6744,7 +6799,7 @@ func (c *current) onreducerProc1(every, reducers, keys, limit interface{}) (inte
 func (p *parser) callonreducerProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onreducerProc1(stack["every"], stack["reducers"], stack["keys"], stack["limit"])
+	return p.cur.onreducerProc1(stack["every"], stack["reducers"], stack["keys"], stack["sorted"], stack["limit"])
 }
 
 func (c *current) onasClause1(v interface{}) (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -8404,9 +8404,9 @@ function peg$parse(input, options) {
     return [first, ...rest];
   }
 
-  function makeGroupByProc(duration, sorted, limit, keys, reducers) {
+  function makeGroupByProc(duration, input_sort_dir, limit, keys, reducers) {
     if (limit === null) { limit = undefined; }
-      return { op: "GroupByProc", keys, reducers, duration, limit , sorted};
+      return { op: "GroupByProc", keys, reducers, duration, limit , input_sort_dir};
   }
 
   function makeUnaryExpr(operator, operand) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -273,37 +273,40 @@ function peg$parse(input, options) {
       peg$c65 = "every",
       peg$c66 = peg$literalExpectation("every", true),
       peg$c67 = function(dur) { return dur },
-      peg$c68 = "and",
-      peg$c69 = peg$literalExpectation("and", true),
-      peg$c70 = function() { return text() },
-      peg$c71 = "or",
-      peg$c72 = peg$literalExpectation("or", true),
-      peg$c73 = "in",
-      peg$c74 = peg$literalExpectation("in", true),
-      peg$c75 = "not",
-      peg$c76 = peg$literalExpectation("not", true),
-      peg$c77 = /^[A-Za-z_$]/,
-      peg$c78 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c79 = /^[0-9]/,
-      peg$c80 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c81 = ".",
-      peg$c82 = peg$literalExpectation(".", false),
-      peg$c83 = function(base, field) { return makeFieldCall("RecordFieldRead", null, field) },
-      peg$c84 = "[",
-      peg$c85 = peg$literalExpectation("[", false),
-      peg$c86 = "]",
-      peg$c87 = peg$literalExpectation("]", false),
-      peg$c88 = function(base, index) { return makeFieldCall("Index", null, index) },
-      peg$c89 = function(base, derefs) {
+      peg$c68 = "-sorted",
+      peg$c69 = peg$literalExpectation("-sorted", true),
+      peg$c70 = function(dir) { return parseInt(dir) },
+      peg$c71 = "and",
+      peg$c72 = peg$literalExpectation("and", true),
+      peg$c73 = function() { return text() },
+      peg$c74 = "or",
+      peg$c75 = peg$literalExpectation("or", true),
+      peg$c76 = "in",
+      peg$c77 = peg$literalExpectation("in", true),
+      peg$c78 = "not",
+      peg$c79 = peg$literalExpectation("not", true),
+      peg$c80 = /^[A-Za-z_$]/,
+      peg$c81 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c82 = /^[0-9]/,
+      peg$c83 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c84 = ".",
+      peg$c85 = peg$literalExpectation(".", false),
+      peg$c86 = function(base, field) { return makeFieldCall("RecordFieldRead", null, field) },
+      peg$c87 = "[",
+      peg$c88 = peg$literalExpectation("[", false),
+      peg$c89 = "]",
+      peg$c90 = peg$literalExpectation("]", false),
+      peg$c91 = function(base, index) { return makeFieldCall("Index", null, index) },
+      peg$c92 = function(base, derefs) {
            return chainFieldCalls(base, derefs)
          },
-      peg$c90 = function(op, field) {
+      peg$c93 = function(op, field) {
             return makeFieldCall(op, field, null)
           },
-      peg$c91 = "len",
-      peg$c92 = peg$literalExpectation("len", true),
-      peg$c93 = function() { return "Len" },
-      peg$c94 = function(first, rest) {
+      peg$c94 = "len",
+      peg$c95 = peg$literalExpectation("len", true),
+      peg$c96 = function() { return "Len" },
+      peg$c97 = function(first, rest) {
             let result =  [first]
 
             for(let  r of rest) {
@@ -312,65 +315,65 @@ function peg$parse(input, options) {
 
             return result
         },
-      peg$c95 = function(base, refs) { return text() },
-      peg$c96 = function(first, ref) { return ref },
-      peg$c97 = function(first, rest) {
+      peg$c98 = function(base, refs) { return text() },
+      peg$c99 = function(first, ref) { return ref },
+      peg$c100 = function(first, rest) {
         let result =  [first]
         for(let  r of rest) {
           result.push( r)
         }
         return result
         },
-      peg$c98 = function(first, rest) {
+      peg$c101 = function(first, rest) {
             let result =  [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
         },
-      peg$c99 = "count",
-      peg$c100 = peg$literalExpectation("count", true),
-      peg$c101 = function() { return "Count" },
-      peg$c102 = "sum",
-      peg$c103 = peg$literalExpectation("sum", true),
-      peg$c104 = function() { return "Sum" },
-      peg$c105 = "avg",
-      peg$c106 = peg$literalExpectation("avg", true),
-      peg$c107 = function() { return "Avg" },
-      peg$c108 = "stdev",
-      peg$c109 = peg$literalExpectation("stdev", true),
-      peg$c110 = function() { return "Stdev" },
-      peg$c111 = "sd",
-      peg$c112 = peg$literalExpectation("sd", true),
-      peg$c113 = "var",
-      peg$c114 = peg$literalExpectation("var", true),
-      peg$c115 = function() { return "Var" },
-      peg$c116 = "entropy",
-      peg$c117 = peg$literalExpectation("entropy", true),
-      peg$c118 = function() { return "Entropy" },
-      peg$c119 = "min",
-      peg$c120 = peg$literalExpectation("min", true),
-      peg$c121 = function() { return "Min" },
-      peg$c122 = "max",
-      peg$c123 = peg$literalExpectation("max", true),
-      peg$c124 = function() { return "Max" },
-      peg$c125 = "first",
-      peg$c126 = peg$literalExpectation("first", true),
-      peg$c127 = function() { return "First" },
-      peg$c128 = "last",
-      peg$c129 = peg$literalExpectation("last", true),
-      peg$c130 = function() { return "Last" },
-      peg$c131 = "countdistinct",
-      peg$c132 = peg$literalExpectation("countdistinct", true),
-      peg$c133 = function() { return "CountDistinct" },
-      peg$c134 = function(field) { return field },
-      peg$c135 = function(op, field) {
+      peg$c102 = "count",
+      peg$c103 = peg$literalExpectation("count", true),
+      peg$c104 = function() { return "Count" },
+      peg$c105 = "sum",
+      peg$c106 = peg$literalExpectation("sum", true),
+      peg$c107 = function() { return "Sum" },
+      peg$c108 = "avg",
+      peg$c109 = peg$literalExpectation("avg", true),
+      peg$c110 = function() { return "Avg" },
+      peg$c111 = "stdev",
+      peg$c112 = peg$literalExpectation("stdev", true),
+      peg$c113 = function() { return "Stdev" },
+      peg$c114 = "sd",
+      peg$c115 = peg$literalExpectation("sd", true),
+      peg$c116 = "var",
+      peg$c117 = peg$literalExpectation("var", true),
+      peg$c118 = function() { return "Var" },
+      peg$c119 = "entropy",
+      peg$c120 = peg$literalExpectation("entropy", true),
+      peg$c121 = function() { return "Entropy" },
+      peg$c122 = "min",
+      peg$c123 = peg$literalExpectation("min", true),
+      peg$c124 = function() { return "Min" },
+      peg$c125 = "max",
+      peg$c126 = peg$literalExpectation("max", true),
+      peg$c127 = function() { return "Max" },
+      peg$c128 = "first",
+      peg$c129 = peg$literalExpectation("first", true),
+      peg$c130 = function() { return "First" },
+      peg$c131 = "last",
+      peg$c132 = peg$literalExpectation("last", true),
+      peg$c133 = function() { return "Last" },
+      peg$c134 = "countdistinct",
+      peg$c135 = peg$literalExpectation("countdistinct", true),
+      peg$c136 = function() { return "CountDistinct" },
+      peg$c137 = function(field) { return field },
+      peg$c138 = function(op, field) {
           return makeReducer(op, "count", field)
         },
-      peg$c136 = function(op, field) {
+      peg$c139 = function(op, field) {
           return makeReducer(op, toLowerCase(op), field)
         },
-      peg$c137 = function(every, reducers, keys, limit) {
+      peg$c140 = function(every, reducers, keys, sorted, limit) {
           if (OR(keys, every)) {
             if (keys) {
               keys = keys[1]
@@ -382,337 +385,337 @@ function peg$parse(input, options) {
               every = every[0]
             }
 
-            return makeGroupByProc(every, limit, keys, reducers)
+            return makeGroupByProc(every, sorted, limit, keys, reducers)
           }
 
           return makeReducerProc(reducers)
         },
-      peg$c138 = "as",
-      peg$c139 = peg$literalExpectation("as", true),
-      peg$c140 = "=",
-      peg$c141 = peg$literalExpectation("=", false),
-      peg$c142 = function(field, f) {
+      peg$c141 = "as",
+      peg$c142 = peg$literalExpectation("as", true),
+      peg$c143 = "=",
+      peg$c144 = peg$literalExpectation("=", false),
+      peg$c145 = function(field, f) {
           return overrideReducerVar(f, field)
         },
-      peg$c143 = function(f, field) {
+      peg$c146 = function(f, field) {
           return overrideReducerVar(f, field)
         },
-      peg$c144 = function(first, rest) {
+      peg$c147 = function(first, rest) {
             let result =  [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c145 = "sort",
-      peg$c146 = peg$literalExpectation("sort", true),
-      peg$c147 = function(args, l) { return l },
-      peg$c148 = function(args, list) {
+      peg$c148 = "sort",
+      peg$c149 = peg$literalExpectation("sort", true),
+      peg$c150 = function(args, l) { return l },
+      peg$c151 = function(args, list) {
           return makeSortProc(args, list)
         },
-      peg$c149 = function(a) { return a },
-      peg$c150 = "-r",
-      peg$c151 = peg$literalExpectation("-r", false),
-      peg$c152 = function() { return makeArg("r", null) },
-      peg$c153 = "-nulls",
-      peg$c154 = peg$literalExpectation("-nulls", false),
-      peg$c155 = peg$literalExpectation("first", false),
-      peg$c156 = peg$literalExpectation("last", false),
-      peg$c157 = function(where) { return makeArg("nulls", where) },
-      peg$c158 = "top",
-      peg$c159 = peg$literalExpectation("top", true),
-      peg$c160 = function(n) { return n},
-      peg$c161 = "-flush",
-      peg$c162 = peg$literalExpectation("-flush", false),
-      peg$c163 = function(limit, flush, f) { return f },
-      peg$c164 = function(limit, flush, list) {
+      peg$c152 = function(a) { return a },
+      peg$c153 = "-r",
+      peg$c154 = peg$literalExpectation("-r", false),
+      peg$c155 = function() { return makeArg("r", null) },
+      peg$c156 = "-nulls",
+      peg$c157 = peg$literalExpectation("-nulls", false),
+      peg$c158 = peg$literalExpectation("first", false),
+      peg$c159 = peg$literalExpectation("last", false),
+      peg$c160 = function(where) { return makeArg("nulls", where) },
+      peg$c161 = "top",
+      peg$c162 = peg$literalExpectation("top", true),
+      peg$c163 = function(n) { return n},
+      peg$c164 = "-flush",
+      peg$c165 = peg$literalExpectation("-flush", false),
+      peg$c166 = function(limit, flush, f) { return f },
+      peg$c167 = function(limit, flush, list) {
           return makeTopProc(list, limit, flush)
         },
-      peg$c165 = "-limit",
-      peg$c166 = peg$literalExpectation("-limit", false),
-      peg$c167 = function(limit) { return limit },
-      peg$c168 = "-c",
-      peg$c169 = peg$literalExpectation("-c", false),
-      peg$c170 = function() { return makeArg("c", null) },
-      peg$c171 = "cut",
-      peg$c172 = peg$literalExpectation("cut", true),
-      peg$c173 = function(arg, list) {  return makeCutProc(arg, list) },
-      peg$c174 = "head",
-      peg$c175 = peg$literalExpectation("head", true),
-      peg$c176 = function(count) { return makeHeadProc(count) },
-      peg$c177 = function() { return makeHeadProc(1) },
-      peg$c178 = "tail",
-      peg$c179 = peg$literalExpectation("tail", true),
-      peg$c180 = function(count) { return makeTailProc(count) },
-      peg$c181 = function() { return makeTailProc(1) },
-      peg$c182 = "filter",
-      peg$c183 = peg$literalExpectation("filter", true),
-      peg$c184 = "uniq",
-      peg$c185 = peg$literalExpectation("uniq", true),
-      peg$c186 = function() {
+      peg$c168 = "-limit",
+      peg$c169 = peg$literalExpectation("-limit", false),
+      peg$c170 = function(limit) { return limit },
+      peg$c171 = "-c",
+      peg$c172 = peg$literalExpectation("-c", false),
+      peg$c173 = function() { return makeArg("c", null) },
+      peg$c174 = "cut",
+      peg$c175 = peg$literalExpectation("cut", true),
+      peg$c176 = function(arg, list) {  return makeCutProc(arg, list) },
+      peg$c177 = "head",
+      peg$c178 = peg$literalExpectation("head", true),
+      peg$c179 = function(count) { return makeHeadProc(count) },
+      peg$c180 = function() { return makeHeadProc(1) },
+      peg$c181 = "tail",
+      peg$c182 = peg$literalExpectation("tail", true),
+      peg$c183 = function(count) { return makeTailProc(count) },
+      peg$c184 = function() { return makeTailProc(1) },
+      peg$c185 = "filter",
+      peg$c186 = peg$literalExpectation("filter", true),
+      peg$c187 = "uniq",
+      peg$c188 = peg$literalExpectation("uniq", true),
+      peg$c189 = function() {
             return makeUniqProc(true)
           },
-      peg$c187 = function() {
+      peg$c190 = function() {
             return makeUniqProc(false)
           },
-      peg$c188 = "put",
-      peg$c189 = peg$literalExpectation("put", true),
-      peg$c190 = function(first, rest) {
+      peg$c191 = "put",
+      peg$c192 = peg$literalExpectation("put", true),
+      peg$c193 = function(first, rest) {
             return makePutProc(first, rest)
           },
-      peg$c191 = function(f, e) {
+      peg$c194 = function(f, e) {
             return makeAssignment(f, e)
           },
-      peg$c192 = function(f) {
+      peg$c195 = function(f) {
             return chainFieldCalls(f, [])
           },
-      peg$c193 = "?",
-      peg$c194 = peg$literalExpectation("?", false),
-      peg$c195 = ":",
-      peg$c196 = peg$literalExpectation(":", false),
-      peg$c197 = function(condition, thenClause, elseClause) {
+      peg$c196 = "?",
+      peg$c197 = peg$literalExpectation("?", false),
+      peg$c198 = ":",
+      peg$c199 = peg$literalExpectation(":", false),
+      peg$c200 = function(condition, thenClause, elseClause) {
           return makeConditionalExpr(condition, thenClause, elseClause)
         },
-      peg$c198 = function(first, rest) {
+      peg$c201 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c199 = "=~",
-      peg$c200 = peg$literalExpectation("=~", false),
-      peg$c201 = "!~",
-      peg$c202 = peg$literalExpectation("!~", false),
-      peg$c203 = "!=",
-      peg$c204 = peg$literalExpectation("!=", false),
-      peg$c205 = peg$literalExpectation("in", false),
-      peg$c206 = "<=",
-      peg$c207 = peg$literalExpectation("<=", false),
-      peg$c208 = "<",
-      peg$c209 = peg$literalExpectation("<", false),
-      peg$c210 = ">=",
-      peg$c211 = peg$literalExpectation(">=", false),
-      peg$c212 = ">",
-      peg$c213 = peg$literalExpectation(">", false),
-      peg$c214 = "+",
-      peg$c215 = peg$literalExpectation("+", false),
-      peg$c216 = "/",
-      peg$c217 = peg$literalExpectation("/", false),
-      peg$c218 = function(e) {
+      peg$c202 = "=~",
+      peg$c203 = peg$literalExpectation("=~", false),
+      peg$c204 = "!~",
+      peg$c205 = peg$literalExpectation("!~", false),
+      peg$c206 = "!=",
+      peg$c207 = peg$literalExpectation("!=", false),
+      peg$c208 = peg$literalExpectation("in", false),
+      peg$c209 = "<=",
+      peg$c210 = peg$literalExpectation("<=", false),
+      peg$c211 = "<",
+      peg$c212 = peg$literalExpectation("<", false),
+      peg$c213 = ">=",
+      peg$c214 = peg$literalExpectation(">=", false),
+      peg$c215 = ">",
+      peg$c216 = peg$literalExpectation(">", false),
+      peg$c217 = "+",
+      peg$c218 = peg$literalExpectation("+", false),
+      peg$c219 = "/",
+      peg$c220 = peg$literalExpectation("/", false),
+      peg$c221 = function(e) {
               return makeUnaryExpr("!", e)
           },
-      peg$c219 = function(e, ct) { return ct },
-      peg$c220 = function(e, t) {
+      peg$c222 = function(e, ct) { return ct },
+      peg$c223 = function(e, t) {
           if (t) {
             return makeCastExpression(e, t)
           } else {
             return e
           }
         },
-      peg$c221 = "bool",
-      peg$c222 = peg$literalExpectation("bool", false),
-      peg$c223 = "byte",
-      peg$c224 = peg$literalExpectation("byte", false),
-      peg$c225 = "int16",
-      peg$c226 = peg$literalExpectation("int16", false),
-      peg$c227 = "uint16",
-      peg$c228 = peg$literalExpectation("uint16", false),
-      peg$c229 = "int32",
-      peg$c230 = peg$literalExpectation("int32", false),
-      peg$c231 = "uint32",
-      peg$c232 = peg$literalExpectation("uint32", false),
-      peg$c233 = "int64",
-      peg$c234 = peg$literalExpectation("int64", false),
-      peg$c235 = "uint64",
-      peg$c236 = peg$literalExpectation("uint64", false),
-      peg$c237 = "float64",
-      peg$c238 = peg$literalExpectation("float64", false),
-      peg$c239 = "string",
-      peg$c240 = peg$literalExpectation("string", false),
-      peg$c241 = "bstring",
-      peg$c242 = peg$literalExpectation("bstring", false),
-      peg$c243 = "ip",
-      peg$c244 = peg$literalExpectation("ip", false),
-      peg$c245 = "net",
-      peg$c246 = peg$literalExpectation("net", false),
-      peg$c247 = "time",
-      peg$c248 = peg$literalExpectation("time", false),
-      peg$c249 = "duration",
-      peg$c250 = peg$literalExpectation("duration", false),
-      peg$c251 = function(fn, args) {
+      peg$c224 = "bool",
+      peg$c225 = peg$literalExpectation("bool", false),
+      peg$c226 = "byte",
+      peg$c227 = peg$literalExpectation("byte", false),
+      peg$c228 = "int16",
+      peg$c229 = peg$literalExpectation("int16", false),
+      peg$c230 = "uint16",
+      peg$c231 = peg$literalExpectation("uint16", false),
+      peg$c232 = "int32",
+      peg$c233 = peg$literalExpectation("int32", false),
+      peg$c234 = "uint32",
+      peg$c235 = peg$literalExpectation("uint32", false),
+      peg$c236 = "int64",
+      peg$c237 = peg$literalExpectation("int64", false),
+      peg$c238 = "uint64",
+      peg$c239 = peg$literalExpectation("uint64", false),
+      peg$c240 = "float64",
+      peg$c241 = peg$literalExpectation("float64", false),
+      peg$c242 = "string",
+      peg$c243 = peg$literalExpectation("string", false),
+      peg$c244 = "bstring",
+      peg$c245 = peg$literalExpectation("bstring", false),
+      peg$c246 = "ip",
+      peg$c247 = peg$literalExpectation("ip", false),
+      peg$c248 = "net",
+      peg$c249 = peg$literalExpectation("net", false),
+      peg$c250 = "time",
+      peg$c251 = peg$literalExpectation("time", false),
+      peg$c252 = "duration",
+      peg$c253 = peg$literalExpectation("duration", false),
+      peg$c254 = function(fn, args) {
               return makeFunctionCall(fn, args)
           },
-      peg$c252 = /^[A-Za-z]/,
-      peg$c253 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
-      peg$c254 = /^[.0-9]/,
-      peg$c255 = peg$classExpectation([".", ["0", "9"]], false, false),
-      peg$c256 = function(first, e) { return e },
-      peg$c257 = function(first, rest) {
+      peg$c255 = /^[A-Za-z]/,
+      peg$c256 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
+      peg$c257 = /^[.0-9]/,
+      peg$c258 = peg$classExpectation([".", ["0", "9"]], false, false),
+      peg$c259 = function(first, e) { return e },
+      peg$c260 = function(first, rest) {
             return [first, ... rest]
         },
-      peg$c258 = function() { return [] },
-      peg$c259 = function(base, field) { return makeLiteral("string", text()) },
-      peg$c260 = function(base, derefs) {
+      peg$c261 = function() { return [] },
+      peg$c262 = function(base, field) { return makeLiteral("string", text()) },
+      peg$c263 = function(base, derefs) {
               return makeBinaryExprChain(base, derefs)
           },
-      peg$c261 = peg$literalExpectation("and", false),
-      peg$c262 = "seconds",
-      peg$c263 = peg$literalExpectation("seconds", false),
-      peg$c264 = "second",
-      peg$c265 = peg$literalExpectation("second", false),
-      peg$c266 = "secs",
-      peg$c267 = peg$literalExpectation("secs", false),
-      peg$c268 = "sec",
-      peg$c269 = peg$literalExpectation("sec", false),
-      peg$c270 = "s",
-      peg$c271 = peg$literalExpectation("s", false),
-      peg$c272 = "minutes",
-      peg$c273 = peg$literalExpectation("minutes", false),
-      peg$c274 = "minute",
-      peg$c275 = peg$literalExpectation("minute", false),
-      peg$c276 = "mins",
-      peg$c277 = peg$literalExpectation("mins", false),
-      peg$c278 = peg$literalExpectation("min", false),
-      peg$c279 = "m",
-      peg$c280 = peg$literalExpectation("m", false),
-      peg$c281 = "hours",
-      peg$c282 = peg$literalExpectation("hours", false),
-      peg$c283 = "hrs",
-      peg$c284 = peg$literalExpectation("hrs", false),
-      peg$c285 = "hr",
-      peg$c286 = peg$literalExpectation("hr", false),
-      peg$c287 = "h",
-      peg$c288 = peg$literalExpectation("h", false),
-      peg$c289 = "hour",
-      peg$c290 = peg$literalExpectation("hour", false),
-      peg$c291 = "days",
-      peg$c292 = peg$literalExpectation("days", false),
-      peg$c293 = "day",
-      peg$c294 = peg$literalExpectation("day", false),
-      peg$c295 = "d",
-      peg$c296 = peg$literalExpectation("d", false),
-      peg$c297 = "weeks",
-      peg$c298 = peg$literalExpectation("weeks", false),
-      peg$c299 = "week",
-      peg$c300 = peg$literalExpectation("week", false),
-      peg$c301 = "wks",
-      peg$c302 = peg$literalExpectation("wks", false),
-      peg$c303 = "wk",
-      peg$c304 = peg$literalExpectation("wk", false),
-      peg$c305 = "w",
-      peg$c306 = peg$literalExpectation("w", false),
-      peg$c307 = function() { return makeDuration(1) },
-      peg$c308 = function(num) { return makeDuration(num) },
-      peg$c309 = function() { return makeDuration(60) },
-      peg$c310 = function(num) { return makeDuration(num*60) },
-      peg$c311 = function() { return makeDuration(3600) },
-      peg$c312 = function(num) { return makeDuration(num*3600) },
-      peg$c313 = function() { return makeDuration(3600*24) },
-      peg$c314 = function(num) { return makeDuration(num*3600*24) },
-      peg$c315 = function(num) { return makeDuration(num*3600*24*7) },
-      peg$c316 = function(a) { return text() },
-      peg$c317 = function(a, b) {
+      peg$c264 = peg$literalExpectation("and", false),
+      peg$c265 = "seconds",
+      peg$c266 = peg$literalExpectation("seconds", false),
+      peg$c267 = "second",
+      peg$c268 = peg$literalExpectation("second", false),
+      peg$c269 = "secs",
+      peg$c270 = peg$literalExpectation("secs", false),
+      peg$c271 = "sec",
+      peg$c272 = peg$literalExpectation("sec", false),
+      peg$c273 = "s",
+      peg$c274 = peg$literalExpectation("s", false),
+      peg$c275 = "minutes",
+      peg$c276 = peg$literalExpectation("minutes", false),
+      peg$c277 = "minute",
+      peg$c278 = peg$literalExpectation("minute", false),
+      peg$c279 = "mins",
+      peg$c280 = peg$literalExpectation("mins", false),
+      peg$c281 = peg$literalExpectation("min", false),
+      peg$c282 = "m",
+      peg$c283 = peg$literalExpectation("m", false),
+      peg$c284 = "hours",
+      peg$c285 = peg$literalExpectation("hours", false),
+      peg$c286 = "hrs",
+      peg$c287 = peg$literalExpectation("hrs", false),
+      peg$c288 = "hr",
+      peg$c289 = peg$literalExpectation("hr", false),
+      peg$c290 = "h",
+      peg$c291 = peg$literalExpectation("h", false),
+      peg$c292 = "hour",
+      peg$c293 = peg$literalExpectation("hour", false),
+      peg$c294 = "days",
+      peg$c295 = peg$literalExpectation("days", false),
+      peg$c296 = "day",
+      peg$c297 = peg$literalExpectation("day", false),
+      peg$c298 = "d",
+      peg$c299 = peg$literalExpectation("d", false),
+      peg$c300 = "weeks",
+      peg$c301 = peg$literalExpectation("weeks", false),
+      peg$c302 = "week",
+      peg$c303 = peg$literalExpectation("week", false),
+      peg$c304 = "wks",
+      peg$c305 = peg$literalExpectation("wks", false),
+      peg$c306 = "wk",
+      peg$c307 = peg$literalExpectation("wk", false),
+      peg$c308 = "w",
+      peg$c309 = peg$literalExpectation("w", false),
+      peg$c310 = function() { return makeDuration(1) },
+      peg$c311 = function(num) { return makeDuration(num) },
+      peg$c312 = function() { return makeDuration(60) },
+      peg$c313 = function(num) { return makeDuration(num*60) },
+      peg$c314 = function() { return makeDuration(3600) },
+      peg$c315 = function(num) { return makeDuration(num*3600) },
+      peg$c316 = function() { return makeDuration(3600*24) },
+      peg$c317 = function(num) { return makeDuration(num*3600*24) },
+      peg$c318 = function(num) { return makeDuration(num*3600*24*7) },
+      peg$c319 = function(a) { return text() },
+      peg$c320 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c318 = "::",
-      peg$c319 = peg$literalExpectation("::", false),
-      peg$c320 = function(a, b, d, e) {
+      peg$c321 = "::",
+      peg$c322 = peg$literalExpectation("::", false),
+      peg$c323 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c321 = function(a, b) {
+      peg$c324 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c322 = function(a, b) {
+      peg$c325 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c323 = function() {
+      peg$c326 = function() {
             return "::"
           },
-      peg$c324 = function(v) { return ":" + v },
-      peg$c325 = function(v) { return v + ":" },
-      peg$c326 = function(a, m) {
+      peg$c327 = function(v) { return ":" + v },
+      peg$c328 = function(v) { return v + ":" },
+      peg$c329 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c327 = function(a, m) {
+      peg$c330 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c328 = function(s) { return parseInt(s) },
-      peg$c329 = /^[+\-]/,
-      peg$c330 = peg$classExpectation(["+", "-"], false, false),
-      peg$c331 = function(s) {
+      peg$c331 = function(s) { return parseInt(s) },
+      peg$c332 = /^[+\-]/,
+      peg$c333 = peg$classExpectation(["+", "-"], false, false),
+      peg$c334 = function(s) {
             return parseFloat(s)
         },
-      peg$c332 = function() {
+      peg$c335 = function() {
             return text()
           },
-      peg$c333 = "0",
-      peg$c334 = peg$literalExpectation("0", false),
-      peg$c335 = /^[1-9]/,
-      peg$c336 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c337 = "e",
-      peg$c338 = peg$literalExpectation("e", true),
-      peg$c339 = function(chars) { return text() },
-      peg$c340 = /^[0-9a-fA-F]/,
-      peg$c341 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c342 = function(chars) { return joinChars(chars) },
-      peg$c343 = "\\",
-      peg$c344 = peg$literalExpectation("\\", false),
-      peg$c345 = /^[\0-\x1F\\(),!><="|';]/,
-      peg$c346 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
-      peg$c347 = peg$anyExpectation(),
-      peg$c348 = "\"",
-      peg$c349 = peg$literalExpectation("\"", false),
-      peg$c350 = function(v) { return joinChars(v) },
-      peg$c351 = "'",
-      peg$c352 = peg$literalExpectation("'", false),
-      peg$c353 = "x",
-      peg$c354 = peg$literalExpectation("x", false),
-      peg$c355 = function() { return "\\" + text() },
-      peg$c356 = "b",
-      peg$c357 = peg$literalExpectation("b", false),
-      peg$c358 = function() { return "\b" },
-      peg$c359 = "f",
-      peg$c360 = peg$literalExpectation("f", false),
-      peg$c361 = function() { return "\f" },
-      peg$c362 = "n",
-      peg$c363 = peg$literalExpectation("n", false),
-      peg$c364 = function() { return "\n" },
-      peg$c365 = "r",
-      peg$c366 = peg$literalExpectation("r", false),
-      peg$c367 = function() { return "\r" },
-      peg$c368 = "t",
-      peg$c369 = peg$literalExpectation("t", false),
-      peg$c370 = function() { return "\t" },
-      peg$c371 = "v",
-      peg$c372 = peg$literalExpectation("v", false),
-      peg$c373 = function() { return "\v" },
-      peg$c374 = function() { return "=" },
-      peg$c375 = function() { return "\\*" },
-      peg$c376 = "u",
-      peg$c377 = peg$literalExpectation("u", false),
-      peg$c378 = function(chars) {
+      peg$c336 = "0",
+      peg$c337 = peg$literalExpectation("0", false),
+      peg$c338 = /^[1-9]/,
+      peg$c339 = peg$classExpectation([["1", "9"]], false, false),
+      peg$c340 = "e",
+      peg$c341 = peg$literalExpectation("e", true),
+      peg$c342 = function(chars) { return text() },
+      peg$c343 = /^[0-9a-fA-F]/,
+      peg$c344 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c345 = function(chars) { return joinChars(chars) },
+      peg$c346 = "\\",
+      peg$c347 = peg$literalExpectation("\\", false),
+      peg$c348 = /^[\0-\x1F\\(),!><="|';]/,
+      peg$c349 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
+      peg$c350 = peg$anyExpectation(),
+      peg$c351 = "\"",
+      peg$c352 = peg$literalExpectation("\"", false),
+      peg$c353 = function(v) { return joinChars(v) },
+      peg$c354 = "'",
+      peg$c355 = peg$literalExpectation("'", false),
+      peg$c356 = "x",
+      peg$c357 = peg$literalExpectation("x", false),
+      peg$c358 = function() { return "\\" + text() },
+      peg$c359 = "b",
+      peg$c360 = peg$literalExpectation("b", false),
+      peg$c361 = function() { return "\b" },
+      peg$c362 = "f",
+      peg$c363 = peg$literalExpectation("f", false),
+      peg$c364 = function() { return "\f" },
+      peg$c365 = "n",
+      peg$c366 = peg$literalExpectation("n", false),
+      peg$c367 = function() { return "\n" },
+      peg$c368 = "r",
+      peg$c369 = peg$literalExpectation("r", false),
+      peg$c370 = function() { return "\r" },
+      peg$c371 = "t",
+      peg$c372 = peg$literalExpectation("t", false),
+      peg$c373 = function() { return "\t" },
+      peg$c374 = "v",
+      peg$c375 = peg$literalExpectation("v", false),
+      peg$c376 = function() { return "\v" },
+      peg$c377 = function() { return "=" },
+      peg$c378 = function() { return "\\*" },
+      peg$c379 = "u",
+      peg$c380 = peg$literalExpectation("u", false),
+      peg$c381 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c379 = "{",
-      peg$c380 = peg$literalExpectation("{", false),
-      peg$c381 = "}",
-      peg$c382 = peg$literalExpectation("}", false),
-      peg$c383 = /^[^\/\\]/,
-      peg$c384 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c385 = "\\/",
-      peg$c386 = peg$literalExpectation("\\/", false),
-      peg$c387 = /^[\0-\x1F\\]/,
-      peg$c388 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c389 = "\t",
-      peg$c390 = peg$literalExpectation("\t", false),
-      peg$c391 = "\x0B",
-      peg$c392 = peg$literalExpectation("\x0B", false),
-      peg$c393 = "\f",
-      peg$c394 = peg$literalExpectation("\f", false),
-      peg$c395 = " ",
-      peg$c396 = peg$literalExpectation(" ", false),
-      peg$c397 = "\xA0",
-      peg$c398 = peg$literalExpectation("\xA0", false),
-      peg$c399 = "\uFEFF",
-      peg$c400 = peg$literalExpectation("\uFEFF", false),
-      peg$c401 = peg$otherExpectation("whitespace"),
+      peg$c382 = "{",
+      peg$c383 = peg$literalExpectation("{", false),
+      peg$c384 = "}",
+      peg$c385 = peg$literalExpectation("}", false),
+      peg$c386 = /^[^\/\\]/,
+      peg$c387 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c388 = "\\/",
+      peg$c389 = peg$literalExpectation("\\/", false),
+      peg$c390 = /^[\0-\x1F\\]/,
+      peg$c391 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c392 = "\t",
+      peg$c393 = peg$literalExpectation("\t", false),
+      peg$c394 = "\x0B",
+      peg$c395 = peg$literalExpectation("\x0B", false),
+      peg$c396 = "\f",
+      peg$c397 = peg$literalExpectation("\f", false),
+      peg$c398 = " ",
+      peg$c399 = peg$literalExpectation(" ", false),
+      peg$c400 = "\xA0",
+      peg$c401 = peg$literalExpectation("\xA0", false),
+      peg$c402 = "\uFEFF",
+      peg$c403 = peg$literalExpectation("\uFEFF", false),
+      peg$c404 = peg$otherExpectation("whitespace"),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -2275,6 +2278,47 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsegroupBySorted() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parse_();
+    if (s1 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 7).toLowerCase() === peg$c68) {
+        s2 = input.substr(peg$currPos, 7);
+        peg$currPos += 7;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c69); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse_();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parsesinteger();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c70(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseequalityToken() {
     var s0;
 
@@ -2290,16 +2334,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c68) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c71) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
+      if (peg$silentFails === 0) { peg$fail(peg$c72); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -2310,16 +2354,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c71) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c74) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c72); }
+      if (peg$silentFails === 0) { peg$fail(peg$c75); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -2330,16 +2374,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c73) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c76) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c74); }
+      if (peg$silentFails === 0) { peg$fail(peg$c77); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -2350,16 +2394,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c75) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c78) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c76); }
+      if (peg$silentFails === 0) { peg$fail(peg$c79); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -2380,7 +2424,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c73();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2397,12 +2441,12 @@ function peg$parse(input, options) {
   function peg$parsefieldNameStart() {
     var s0;
 
-    if (peg$c77.test(input.charAt(peg$currPos))) {
+    if (peg$c80.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c78); }
+      if (peg$silentFails === 0) { peg$fail(peg$c81); }
     }
 
     return s0;
@@ -2413,12 +2457,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parsefieldNameStart();
     if (s0 === peg$FAILED) {
-      if (peg$c79.test(input.charAt(peg$currPos))) {
+      if (peg$c82.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c80); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
     }
 
@@ -2434,17 +2478,17 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s4 = peg$c81;
+        s4 = peg$c84;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parsefieldName();
         if (s5 !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c83(s1, s5);
+          s4 = peg$c86(s1, s5);
           s3 = s4;
         } else {
           peg$currPos = s3;
@@ -2457,25 +2501,25 @@ function peg$parse(input, options) {
       if (s3 === peg$FAILED) {
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s4 = peg$c84;
+          s4 = peg$c87;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c85); }
+          if (peg$silentFails === 0) { peg$fail(peg$c88); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsesuint();
           if (s5 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s6 = peg$c86;
+              s6 = peg$c89;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c87); }
+              if (peg$silentFails === 0) { peg$fail(peg$c90); }
             }
             if (s6 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c88(s1, s5);
+              s4 = peg$c91(s1, s5);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2494,17 +2538,17 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c81;
+          s4 = peg$c84;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c82); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsefieldName();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c83(s1, s5);
+            s4 = peg$c86(s1, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2517,25 +2561,25 @@ function peg$parse(input, options) {
         if (s3 === peg$FAILED) {
           s3 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s4 = peg$c84;
+            s4 = peg$c87;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c85); }
+            if (peg$silentFails === 0) { peg$fail(peg$c88); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parsesuint();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s6 = peg$c86;
+                s6 = peg$c89;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c87); }
+                if (peg$silentFails === 0) { peg$fail(peg$c90); }
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c88(s1, s5);
+                s4 = peg$c91(s1, s5);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2553,7 +2597,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c89(s1, s2);
+        s1 = peg$c92(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2607,7 +2651,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c90(s1, s5);
+                  s1 = peg$c93(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2648,16 +2692,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c91) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c94) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c92); }
+      if (peg$silentFails === 0) { peg$fail(peg$c95); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c93();
+      s1 = peg$c96();
     }
     s0 = s1;
 
@@ -2754,7 +2798,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c94(s1, s2);
+        s1 = peg$c97(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2777,11 +2821,11 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s4 = peg$c81;
+        s4 = peg$c84;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
       if (s4 !== peg$FAILED) {
         s5 = peg$parsefieldName();
@@ -2800,11 +2844,11 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c81;
+          s4 = peg$c84;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c82); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsefieldName();
@@ -2822,7 +2866,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c95(s1, s2);
+        s1 = peg$c98(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2865,7 +2909,7 @@ function peg$parse(input, options) {
             s7 = peg$parsefieldRefDotOnly();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c96(s1, s7);
+              s4 = peg$c99(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2907,7 +2951,7 @@ function peg$parse(input, options) {
               s7 = peg$parsefieldRefDotOnly();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c96(s1, s7);
+                s4 = peg$c99(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2928,7 +2972,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c97(s1, s2);
+        s1 = peg$c100(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3032,7 +3076,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c98(s1, s2);
+        s1 = peg$c101(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3050,16 +3094,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c99) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c102) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+      if (peg$silentFails === 0) { peg$fail(peg$c103); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c101();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -3070,156 +3114,156 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c102) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c105) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c103); }
+      if (peg$silentFails === 0) { peg$fail(peg$c106); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c107();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c105) {
+      if (input.substr(peg$currPos, 3).toLowerCase() === peg$c108) {
         s1 = input.substr(peg$currPos, 3);
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c106); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c107();
+        s1 = peg$c110();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c108) {
+        if (input.substr(peg$currPos, 5).toLowerCase() === peg$c111) {
           s1 = input.substr(peg$currPos, 5);
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c109); }
+          if (peg$silentFails === 0) { peg$fail(peg$c112); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c110();
+          s1 = peg$c113();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c111) {
+          if (input.substr(peg$currPos, 2).toLowerCase() === peg$c114) {
             s1 = input.substr(peg$currPos, 2);
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c112); }
+            if (peg$silentFails === 0) { peg$fail(peg$c115); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c110();
+            s1 = peg$c113();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c113) {
+            if (input.substr(peg$currPos, 3).toLowerCase() === peg$c116) {
               s1 = input.substr(peg$currPos, 3);
               peg$currPos += 3;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c114); }
+              if (peg$silentFails === 0) { peg$fail(peg$c117); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c115();
+              s1 = peg$c118();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 7).toLowerCase() === peg$c116) {
+              if (input.substr(peg$currPos, 7).toLowerCase() === peg$c119) {
                 s1 = input.substr(peg$currPos, 7);
                 peg$currPos += 7;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c117); }
+                if (peg$silentFails === 0) { peg$fail(peg$c120); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c118();
+                s1 = peg$c121();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c119) {
+                if (input.substr(peg$currPos, 3).toLowerCase() === peg$c122) {
                   s1 = input.substr(peg$currPos, 3);
                   peg$currPos += 3;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c123); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c121();
+                  s1 = peg$c124();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c122) {
+                  if (input.substr(peg$currPos, 3).toLowerCase() === peg$c125) {
                     s1 = input.substr(peg$currPos, 3);
                     peg$currPos += 3;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c123); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c126); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c124();
+                    s1 = peg$c127();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
-                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c125) {
+                    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c128) {
                       s1 = input.substr(peg$currPos, 5);
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c126); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c129); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c127();
+                      s1 = peg$c130();
                     }
                     s0 = s1;
                     if (s0 === peg$FAILED) {
                       s0 = peg$currPos;
-                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+                      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c131) {
                         s1 = input.substr(peg$currPos, 4);
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c129); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c132); }
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c130();
+                        s1 = peg$c133();
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
-                        if (input.substr(peg$currPos, 13).toLowerCase() === peg$c131) {
+                        if (input.substr(peg$currPos, 13).toLowerCase() === peg$c134) {
                           s1 = input.substr(peg$currPos, 13);
                           peg$currPos += 13;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c132); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c135); }
                         }
                         if (s1 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c133();
+                          s1 = peg$c136();
                         }
                         s0 = s1;
                       }
@@ -3253,7 +3297,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c134(s2);
+          s1 = peg$c137(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3309,7 +3353,7 @@ function peg$parse(input, options) {
               }
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c135(s1, s4);
+                s1 = peg$c138(s1, s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3379,7 +3423,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c136(s1, s5);
+                  s1 = peg$c139(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3457,14 +3501,23 @@ function peg$parse(input, options) {
           s3 = null;
         }
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseprocLimitArg();
+          s4 = peg$parsegroupBySorted();
           if (s4 === peg$FAILED) {
             s4 = null;
           }
           if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c137(s1, s2, s3, s4);
-            s0 = s1;
+            s5 = peg$parseprocLimitArg();
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c140(s1, s2, s3, s4, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -3489,12 +3542,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c138) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c141) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c139); }
+      if (peg$silentFails === 0) { peg$fail(peg$c142); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3532,11 +3585,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c140;
+          s3 = peg$c143;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c141); }
+          if (peg$silentFails === 0) { peg$fail(peg$c144); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -3547,7 +3600,7 @@ function peg$parse(input, options) {
             s5 = peg$parsereducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c142(s1, s5);
+              s1 = peg$c145(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3578,7 +3631,7 @@ function peg$parse(input, options) {
           s3 = peg$parseasClause();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c143(s1, s3);
+            s1 = peg$c146(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3701,7 +3754,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c144(s1, s2);
+        s1 = peg$c147(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3748,12 +3801,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c145) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c148) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c146); }
+      if (peg$silentFails === 0) { peg$fail(peg$c149); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesortArgs();
@@ -3764,7 +3817,7 @@ function peg$parse(input, options) {
           s5 = peg$parsefieldExprList();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c147(s2, s5);
+            s4 = peg$c150(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -3779,7 +3832,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c148(s2, s3);
+          s1 = peg$c151(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3807,7 +3860,7 @@ function peg$parse(input, options) {
       s3 = peg$parsesortArg();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c149(s3);
+        s2 = peg$c152(s3);
         s1 = s2;
       } else {
         peg$currPos = s1;
@@ -3825,7 +3878,7 @@ function peg$parse(input, options) {
         s3 = peg$parsesortArg();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s1;
-          s2 = peg$c149(s3);
+          s2 = peg$c152(s3);
           s1 = s2;
         } else {
           peg$currPos = s1;
@@ -3844,55 +3897,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c150) {
-      s1 = peg$c150;
+    if (input.substr(peg$currPos, 2) === peg$c153) {
+      s1 = peg$c153;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      if (peg$silentFails === 0) { peg$fail(peg$c154); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c152();
+      s1 = peg$c155();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c153) {
-        s1 = peg$c153;
+      if (input.substr(peg$currPos, 6) === peg$c156) {
+        s1 = peg$c156;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c154); }
+        if (peg$silentFails === 0) { peg$fail(peg$c157); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c125) {
-            s4 = peg$c125;
+          if (input.substr(peg$currPos, 5) === peg$c128) {
+            s4 = peg$c128;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c155); }
+            if (peg$silentFails === 0) { peg$fail(peg$c158); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c128) {
-              s4 = peg$c128;
+            if (input.substr(peg$currPos, 4) === peg$c131) {
+              s4 = peg$c131;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c156); }
+              if (peg$silentFails === 0) { peg$fail(peg$c159); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c70();
+            s4 = peg$c73();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c157(s3);
+            s1 = peg$c160(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3915,12 +3968,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c158) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c161) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c159); }
+      if (peg$silentFails === 0) { peg$fail(peg$c162); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -3929,7 +3982,7 @@ function peg$parse(input, options) {
         s4 = peg$parseunsignedInteger();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c160(s4);
+          s3 = peg$c163(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3946,12 +3999,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c161) {
-            s5 = peg$c161;
+          if (input.substr(peg$currPos, 6) === peg$c164) {
+            s5 = peg$c164;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c162); }
+            if (peg$silentFails === 0) { peg$fail(peg$c165); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3974,7 +4027,7 @@ function peg$parse(input, options) {
             s6 = peg$parsefieldExprList();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c163(s2, s3, s6);
+              s5 = peg$c166(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3989,7 +4042,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c164(s2, s3, s4);
+            s1 = peg$c167(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4017,12 +4070,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c165) {
-        s2 = peg$c165;
+      if (input.substr(peg$currPos, 6) === peg$c168) {
+        s2 = peg$c168;
         peg$currPos += 6;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c166); }
+        if (peg$silentFails === 0) { peg$fail(peg$c169); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -4030,7 +4083,7 @@ function peg$parse(input, options) {
           s4 = peg$parseunsignedInteger();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c167(s4);
+            s1 = peg$c170(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4059,16 +4112,16 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     s2 = peg$parse_();
     if (s2 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c168) {
-        s3 = peg$c168;
+      if (input.substr(peg$currPos, 2) === peg$c171) {
+        s3 = peg$c171;
         peg$currPos += 2;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c169); }
+        if (peg$silentFails === 0) { peg$fail(peg$c172); }
       }
       if (s3 !== peg$FAILED) {
         peg$savedPos = s1;
-        s2 = peg$c170();
+        s2 = peg$c173();
         s1 = s2;
       } else {
         peg$currPos = s1;
@@ -4083,16 +4136,16 @@ function peg$parse(input, options) {
       s1 = peg$currPos;
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c168) {
-          s3 = peg$c168;
+        if (input.substr(peg$currPos, 2) === peg$c171) {
+          s3 = peg$c171;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c169); }
+          if (peg$silentFails === 0) { peg$fail(peg$c172); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s1;
-          s2 = peg$c170();
+          s2 = peg$c173();
           s1 = s2;
         } else {
           peg$currPos = s1;
@@ -4111,12 +4164,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c171) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c174) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c172); }
+      if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsecutArg();
@@ -4126,7 +4179,7 @@ function peg$parse(input, options) {
           s4 = peg$parsefieldRefDotOnlyList();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s2, s4);
+            s1 = peg$c176(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4152,12 +4205,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c174) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c177) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c175); }
+      if (peg$silentFails === 0) { peg$fail(peg$c178); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4165,7 +4218,7 @@ function peg$parse(input, options) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s3);
+          s1 = peg$c179(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4181,16 +4234,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c174) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c177) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+        if (peg$silentFails === 0) { peg$fail(peg$c178); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c177();
+        s1 = peg$c180();
       }
       s0 = s1;
     }
@@ -4202,12 +4255,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c178) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c181) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c179); }
+      if (peg$silentFails === 0) { peg$fail(peg$c182); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4215,7 +4268,7 @@ function peg$parse(input, options) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c180(s3);
+          s1 = peg$c183(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4231,16 +4284,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c178) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c181) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c182); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c181();
+        s1 = peg$c184();
       }
       s0 = s1;
     }
@@ -4252,12 +4305,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c182) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c185) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4287,26 +4340,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c184) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c187) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c185); }
+      if (peg$silentFails === 0) { peg$fail(peg$c188); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c168) {
-          s3 = peg$c168;
+        if (input.substr(peg$currPos, 2) === peg$c171) {
+          s3 = peg$c171;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c169); }
+          if (peg$silentFails === 0) { peg$fail(peg$c172); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c186();
+          s1 = peg$c189();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4322,16 +4375,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c184) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c187) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c185); }
+        if (peg$silentFails === 0) { peg$fail(peg$c188); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c187();
+        s1 = peg$c190();
       }
       s0 = s1;
     }
@@ -4343,12 +4396,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c188) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c191) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c189); }
+      if (peg$silentFails === 0) { peg$fail(peg$c192); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4429,7 +4482,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c190(s3, s4);
+            s1 = peg$c193(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4460,11 +4513,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c140;
+          s3 = peg$c143;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c141); }
+          if (peg$silentFails === 0) { peg$fail(peg$c144); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4472,7 +4525,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpression();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c191(s1, s5);
+              s1 = peg$c194(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4588,7 +4641,7 @@ function peg$parse(input, options) {
     s1 = peg$parsefieldName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c192(s1);
+      s1 = peg$c195(s1);
     }
     s0 = s1;
 
@@ -4612,11 +4665,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c193;
+          s3 = peg$c196;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c194); }
+          if (peg$silentFails === 0) { peg$fail(peg$c197); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4626,11 +4679,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c195;
+                  s7 = peg$c198;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c196); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c199); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -4638,7 +4691,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpression();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c197(s1, s5, s9);
+                      s1 = peg$c200(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4749,7 +4802,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
+        s1 = peg$c201(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4829,7 +4882,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
+        s1 = peg$c201(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4909,7 +4962,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
+        s1 = peg$c201(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4927,43 +4980,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c199) {
-      s1 = peg$c199;
+    if (input.substr(peg$currPos, 2) === peg$c202) {
+      s1 = peg$c202;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c200); }
+      if (peg$silentFails === 0) { peg$fail(peg$c203); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c201) {
-        s1 = peg$c201;
+      if (input.substr(peg$currPos, 2) === peg$c204) {
+        s1 = peg$c204;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c202); }
+        if (peg$silentFails === 0) { peg$fail(peg$c205); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c140;
+          s1 = peg$c143;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c141); }
+          if (peg$silentFails === 0) { peg$fail(peg$c144); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c203) {
-            s1 = peg$c203;
+          if (input.substr(peg$currPos, 2) === peg$c206) {
+            s1 = peg$c206;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c204); }
+            if (peg$silentFails === 0) { peg$fail(peg$c207); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -4976,16 +5029,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c73) {
-        s1 = peg$c73;
+      if (input.substr(peg$currPos, 2) === peg$c76) {
+        s1 = peg$c76;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c205); }
+        if (peg$silentFails === 0) { peg$fail(peg$c208); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c73();
       }
       s0 = s1;
     }
@@ -5059,7 +5112,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
+        s1 = peg$c201(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5077,43 +5130,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c206) {
-      s1 = peg$c206;
+    if (input.substr(peg$currPos, 2) === peg$c209) {
+      s1 = peg$c209;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c207); }
+      if (peg$silentFails === 0) { peg$fail(peg$c210); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c208;
+        s1 = peg$c211;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c209); }
+        if (peg$silentFails === 0) { peg$fail(peg$c212); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c210) {
-          s1 = peg$c210;
+        if (input.substr(peg$currPos, 2) === peg$c213) {
+          s1 = peg$c213;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c211); }
+          if (peg$silentFails === 0) { peg$fail(peg$c214); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c212;
+            s1 = peg$c215;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c213); }
+            if (peg$silentFails === 0) { peg$fail(peg$c216); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -5186,7 +5239,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
+        s1 = peg$c201(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5205,11 +5258,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c214;
+      s1 = peg$c217;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c215); }
+      if (peg$silentFails === 0) { peg$fail(peg$c218); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
@@ -5222,7 +5275,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -5295,7 +5348,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
+        s1 = peg$c201(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5322,16 +5375,16 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c216;
+        s1 = peg$c219;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c217); }
+        if (peg$silentFails === 0) { peg$fail(peg$c220); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -5355,7 +5408,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpression();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c218(s3);
+          s1 = peg$c221(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5386,11 +5439,11 @@ function peg$parse(input, options) {
       s3 = peg$parse__();
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s4 = peg$c195;
+          s4 = peg$c198;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c196); }
+          if (peg$silentFails === 0) { peg$fail(peg$c199); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parse__();
@@ -5398,7 +5451,7 @@ function peg$parse(input, options) {
             s6 = peg$parseZngType();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s2;
-              s3 = peg$c219(s1, s6);
+              s3 = peg$c222(s1, s6);
               s2 = s3;
             } else {
               peg$currPos = s2;
@@ -5421,7 +5474,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c220(s1, s2);
+        s1 = peg$c223(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5438,124 +5491,124 @@ function peg$parse(input, options) {
   function peg$parseZngType() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c221) {
-      s0 = peg$c221;
+    if (input.substr(peg$currPos, 4) === peg$c224) {
+      s0 = peg$c224;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c222); }
+      if (peg$silentFails === 0) { peg$fail(peg$c225); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c223) {
-        s0 = peg$c223;
+      if (input.substr(peg$currPos, 4) === peg$c226) {
+        s0 = peg$c226;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c224); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c225) {
-          s0 = peg$c225;
+        if (input.substr(peg$currPos, 5) === peg$c228) {
+          s0 = peg$c228;
           peg$currPos += 5;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c226); }
+          if (peg$silentFails === 0) { peg$fail(peg$c229); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c227) {
-            s0 = peg$c227;
+          if (input.substr(peg$currPos, 6) === peg$c230) {
+            s0 = peg$c230;
             peg$currPos += 6;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c228); }
+            if (peg$silentFails === 0) { peg$fail(peg$c231); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 5) === peg$c229) {
-              s0 = peg$c229;
+            if (input.substr(peg$currPos, 5) === peg$c232) {
+              s0 = peg$c232;
               peg$currPos += 5;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c230); }
+              if (peg$silentFails === 0) { peg$fail(peg$c233); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 6) === peg$c231) {
-                s0 = peg$c231;
+              if (input.substr(peg$currPos, 6) === peg$c234) {
+                s0 = peg$c234;
                 peg$currPos += 6;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c232); }
+                if (peg$silentFails === 0) { peg$fail(peg$c235); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c233) {
-                  s0 = peg$c233;
+                if (input.substr(peg$currPos, 5) === peg$c236) {
+                  s0 = peg$c236;
                   peg$currPos += 5;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c234); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c237); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 6) === peg$c235) {
-                    s0 = peg$c235;
+                  if (input.substr(peg$currPos, 6) === peg$c238) {
+                    s0 = peg$c238;
                     peg$currPos += 6;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c236); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c239); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c237) {
-                      s0 = peg$c237;
+                    if (input.substr(peg$currPos, 7) === peg$c240) {
+                      s0 = peg$c240;
                       peg$currPos += 7;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c241); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 6) === peg$c239) {
-                        s0 = peg$c239;
+                      if (input.substr(peg$currPos, 6) === peg$c242) {
+                        s0 = peg$c242;
                         peg$currPos += 6;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c240); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c243); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 7) === peg$c241) {
-                          s0 = peg$c241;
+                        if (input.substr(peg$currPos, 7) === peg$c244) {
+                          s0 = peg$c244;
                           peg$currPos += 7;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c242); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c245); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c243) {
-                            s0 = peg$c243;
+                          if (input.substr(peg$currPos, 2) === peg$c246) {
+                            s0 = peg$c246;
                             peg$currPos += 2;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c244); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c247); }
                           }
                           if (s0 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 3) === peg$c245) {
-                              s0 = peg$c245;
+                            if (input.substr(peg$currPos, 3) === peg$c248) {
+                              s0 = peg$c248;
                               peg$currPos += 3;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c246); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c249); }
                             }
                             if (s0 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 4) === peg$c247) {
-                                s0 = peg$c247;
+                              if (input.substr(peg$currPos, 4) === peg$c250) {
+                                s0 = peg$c250;
                                 peg$currPos += 4;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c248); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c251); }
                               }
                               if (s0 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 8) === peg$c249) {
-                                  s0 = peg$c249;
+                                if (input.substr(peg$currPos, 8) === peg$c252) {
+                                  s0 = peg$c252;
                                   peg$currPos += 8;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c250); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c253); }
                                 }
                               }
                             }
@@ -5602,7 +5655,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c251(s1, s4);
+              s1 = peg$c254(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5645,7 +5698,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c73();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5662,12 +5715,12 @@ function peg$parse(input, options) {
   function peg$parseFunctionNameStart() {
     var s0;
 
-    if (peg$c252.test(input.charAt(peg$currPos))) {
+    if (peg$c255.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c256); }
     }
 
     return s0;
@@ -5678,12 +5731,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseFunctionNameStart();
     if (s0 === peg$FAILED) {
-      if (peg$c254.test(input.charAt(peg$currPos))) {
+      if (peg$c257.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c255); }
+        if (peg$silentFails === 0) { peg$fail(peg$c258); }
       }
     }
 
@@ -5713,7 +5766,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpression();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c256(s1, s7);
+              s4 = peg$c259(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5749,7 +5802,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpression();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c256(s1, s7);
+                s4 = peg$c259(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5770,7 +5823,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c257(s1, s2);
+        s1 = peg$c260(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5785,7 +5838,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c258();
+        s1 = peg$c261();
       }
       s0 = s1;
     }
@@ -5804,11 +5857,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s5 = peg$c84;
+          s5 = peg$c87;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c85); }
+          if (peg$silentFails === 0) { peg$fail(peg$c88); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5818,11 +5871,11 @@ function peg$parse(input, options) {
               s8 = peg$parse__();
               if (s8 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s9 = peg$c86;
+                  s9 = peg$c89;
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c87); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c90); }
                 }
                 if (s9 !== peg$FAILED) {
                   s4 = [s4, s5, s6, s7, s8, s9];
@@ -5856,11 +5909,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s5 = peg$c81;
+            s5 = peg$c84;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c82); }
+            if (peg$silentFails === 0) { peg$fail(peg$c85); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5869,7 +5922,7 @@ function peg$parse(input, options) {
               s8 = peg$parsefieldName();
               if (s8 !== peg$FAILED) {
                 peg$savedPos = s7;
-                s8 = peg$c259(s1, s8);
+                s8 = peg$c262(s1, s8);
               }
               s7 = s8;
               if (s7 !== peg$FAILED) {
@@ -5898,11 +5951,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 91) {
-            s5 = peg$c84;
+            s5 = peg$c87;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c85); }
+            if (peg$silentFails === 0) { peg$fail(peg$c88); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5912,11 +5965,11 @@ function peg$parse(input, options) {
                 s8 = peg$parse__();
                 if (s8 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s9 = peg$c86;
+                    s9 = peg$c89;
                     peg$currPos++;
                   } else {
                     s9 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c87); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c90); }
                   }
                   if (s9 !== peg$FAILED) {
                     s4 = [s4, s5, s6, s7, s8, s9];
@@ -5950,11 +6003,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 46) {
-              s5 = peg$c81;
+              s5 = peg$c84;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c82); }
+              if (peg$silentFails === 0) { peg$fail(peg$c85); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
@@ -5963,7 +6016,7 @@ function peg$parse(input, options) {
                 s8 = peg$parsefieldName();
                 if (s8 !== peg$FAILED) {
                   peg$savedPos = s7;
-                  s8 = peg$c259(s1, s8);
+                  s8 = peg$c262(s1, s8);
                 }
                 s7 = s8;
                 if (s7 !== peg$FAILED) {
@@ -5989,7 +6042,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260(s1, s2);
+        s1 = peg$c263(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6017,12 +6070,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c68) {
-                s3 = peg$c68;
+              if (input.substr(peg$currPos, 3) === peg$c71) {
+                s3 = peg$c71;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c261); }
+                if (peg$silentFails === 0) { peg$fail(peg$c264); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -6067,44 +6120,44 @@ function peg$parse(input, options) {
   function peg$parsesec_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c262) {
-      s0 = peg$c262;
+    if (input.substr(peg$currPos, 7) === peg$c265) {
+      s0 = peg$c265;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c263); }
+      if (peg$silentFails === 0) { peg$fail(peg$c266); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c264) {
-        s0 = peg$c264;
+      if (input.substr(peg$currPos, 6) === peg$c267) {
+        s0 = peg$c267;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c265); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c266) {
-          s0 = peg$c266;
+        if (input.substr(peg$currPos, 4) === peg$c269) {
+          s0 = peg$c269;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c267); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c268) {
-            s0 = peg$c268;
+          if (input.substr(peg$currPos, 3) === peg$c271) {
+            s0 = peg$c271;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c269); }
+            if (peg$silentFails === 0) { peg$fail(peg$c272); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c270;
+              s0 = peg$c273;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c271); }
+              if (peg$silentFails === 0) { peg$fail(peg$c274); }
             }
           }
         }
@@ -6117,44 +6170,44 @@ function peg$parse(input, options) {
   function peg$parsemin_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c272) {
-      s0 = peg$c272;
+    if (input.substr(peg$currPos, 7) === peg$c275) {
+      s0 = peg$c275;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c273); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c274) {
-        s0 = peg$c274;
+      if (input.substr(peg$currPos, 6) === peg$c277) {
+        s0 = peg$c277;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c275); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c276) {
-          s0 = peg$c276;
+        if (input.substr(peg$currPos, 4) === peg$c279) {
+          s0 = peg$c279;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c277); }
+          if (peg$silentFails === 0) { peg$fail(peg$c280); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c119) {
-            s0 = peg$c119;
+          if (input.substr(peg$currPos, 3) === peg$c122) {
+            s0 = peg$c122;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c278); }
+            if (peg$silentFails === 0) { peg$fail(peg$c281); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c279;
+              s0 = peg$c282;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c280); }
+              if (peg$silentFails === 0) { peg$fail(peg$c283); }
             }
           }
         }
@@ -6167,44 +6220,44 @@ function peg$parse(input, options) {
   function peg$parsehour_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c281) {
-      s0 = peg$c281;
+    if (input.substr(peg$currPos, 5) === peg$c284) {
+      s0 = peg$c284;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c285); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c283) {
-        s0 = peg$c283;
+      if (input.substr(peg$currPos, 3) === peg$c286) {
+        s0 = peg$c286;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c287); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c285) {
-          s0 = peg$c285;
+        if (input.substr(peg$currPos, 2) === peg$c288) {
+          s0 = peg$c288;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+          if (peg$silentFails === 0) { peg$fail(peg$c289); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c287;
+            s0 = peg$c290;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c288); }
+            if (peg$silentFails === 0) { peg$fail(peg$c291); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c289) {
-              s0 = peg$c289;
+            if (input.substr(peg$currPos, 4) === peg$c292) {
+              s0 = peg$c292;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c290); }
+              if (peg$silentFails === 0) { peg$fail(peg$c293); }
             }
           }
         }
@@ -6217,28 +6270,28 @@ function peg$parse(input, options) {
   function peg$parseday_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c291) {
-      s0 = peg$c291;
+    if (input.substr(peg$currPos, 4) === peg$c294) {
+      s0 = peg$c294;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c292); }
+      if (peg$silentFails === 0) { peg$fail(peg$c295); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c293) {
-        s0 = peg$c293;
+      if (input.substr(peg$currPos, 3) === peg$c296) {
+        s0 = peg$c296;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c294); }
+        if (peg$silentFails === 0) { peg$fail(peg$c297); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c295;
+          s0 = peg$c298;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c296); }
+          if (peg$silentFails === 0) { peg$fail(peg$c299); }
         }
       }
     }
@@ -6249,44 +6302,44 @@ function peg$parse(input, options) {
   function peg$parseweek_abbrev() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c297) {
-      s0 = peg$c297;
+    if (input.substr(peg$currPos, 5) === peg$c300) {
+      s0 = peg$c300;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c298); }
+      if (peg$silentFails === 0) { peg$fail(peg$c301); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c299) {
-        s0 = peg$c299;
+      if (input.substr(peg$currPos, 4) === peg$c302) {
+        s0 = peg$c302;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c300); }
+        if (peg$silentFails === 0) { peg$fail(peg$c303); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c301) {
-          s0 = peg$c301;
+        if (input.substr(peg$currPos, 3) === peg$c304) {
+          s0 = peg$c304;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c302); }
+          if (peg$silentFails === 0) { peg$fail(peg$c305); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c303) {
-            s0 = peg$c303;
+          if (input.substr(peg$currPos, 2) === peg$c306) {
+            s0 = peg$c306;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c304); }
+            if (peg$silentFails === 0) { peg$fail(peg$c307); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c305;
+              s0 = peg$c308;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c306); }
+              if (peg$silentFails === 0) { peg$fail(peg$c309); }
             }
           }
         }
@@ -6300,16 +6353,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c264) {
-      s1 = peg$c264;
+    if (input.substr(peg$currPos, 6) === peg$c267) {
+      s1 = peg$c267;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c265); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c307();
+      s1 = peg$c310();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6324,7 +6377,7 @@ function peg$parse(input, options) {
           s3 = peg$parsesec_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c308(s1);
+            s1 = peg$c311(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6347,16 +6400,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c274) {
-      s1 = peg$c274;
+    if (input.substr(peg$currPos, 6) === peg$c277) {
+      s1 = peg$c277;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c275); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c309();
+      s1 = peg$c312();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6371,7 +6424,7 @@ function peg$parse(input, options) {
           s3 = peg$parsemin_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c310(s1);
+            s1 = peg$c313(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6394,16 +6447,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c289) {
-      s1 = peg$c289;
+    if (input.substr(peg$currPos, 4) === peg$c292) {
+      s1 = peg$c292;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c290); }
+      if (peg$silentFails === 0) { peg$fail(peg$c293); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c311();
+      s1 = peg$c314();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6418,7 +6471,7 @@ function peg$parse(input, options) {
           s3 = peg$parsehour_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c312(s1);
+            s1 = peg$c315(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6441,16 +6494,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c293) {
-      s1 = peg$c293;
+    if (input.substr(peg$currPos, 3) === peg$c296) {
+      s1 = peg$c296;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c294); }
+      if (peg$silentFails === 0) { peg$fail(peg$c297); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c313();
+      s1 = peg$c316();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6465,7 +6518,7 @@ function peg$parse(input, options) {
           s3 = peg$parseday_abbrev();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c314(s1);
+            s1 = peg$c317(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6498,7 +6551,7 @@ function peg$parse(input, options) {
         s3 = peg$parseweek_abbrev();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c315(s1);
+          s1 = peg$c318(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6524,31 +6577,31 @@ function peg$parse(input, options) {
     s2 = peg$parseunsignedInteger();
     if (s2 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c81;
+        s3 = peg$c84;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseunsignedInteger();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s5 = peg$c81;
+            s5 = peg$c84;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c82); }
+            if (peg$silentFails === 0) { peg$fail(peg$c85); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parseunsignedInteger();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s7 = peg$c81;
+                s7 = peg$c84;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                if (peg$silentFails === 0) { peg$fail(peg$c85); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parseunsignedInteger();
@@ -6585,7 +6638,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c316(s1);
+      s1 = peg$c319(s1);
     }
     s0 = s1;
 
@@ -6597,11 +6650,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c195;
+      s1 = peg$c198;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesuint();
@@ -6639,7 +6692,7 @@ function peg$parse(input, options) {
       s2 = peg$parseip6tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c317(s1, s2);
+        s1 = peg$c320(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6660,12 +6713,12 @@ function peg$parse(input, options) {
           s3 = peg$parseh_append();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c318) {
-            s3 = peg$c318;
+          if (input.substr(peg$currPos, 2) === peg$c321) {
+            s3 = peg$c321;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c319); }
+            if (peg$silentFails === 0) { peg$fail(peg$c322); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6678,7 +6731,7 @@ function peg$parse(input, options) {
               s5 = peg$parseip6tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c320(s1, s2, s4, s5);
+                s1 = peg$c323(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6702,12 +6755,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c318) {
-          s1 = peg$c318;
+        if (input.substr(peg$currPos, 2) === peg$c321) {
+          s1 = peg$c321;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c319); }
+          if (peg$silentFails === 0) { peg$fail(peg$c322); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6720,7 +6773,7 @@ function peg$parse(input, options) {
             s3 = peg$parseip6tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c321(s2, s3);
+              s1 = peg$c324(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6745,16 +6798,16 @@ function peg$parse(input, options) {
               s3 = peg$parseh_append();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c318) {
-                s3 = peg$c318;
+              if (input.substr(peg$currPos, 2) === peg$c321) {
+                s3 = peg$c321;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c319); }
+                if (peg$silentFails === 0) { peg$fail(peg$c322); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c322(s1, s2);
+                s1 = peg$c325(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6770,16 +6823,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c318) {
-              s1 = peg$c318;
+            if (input.substr(peg$currPos, 2) === peg$c321) {
+              s1 = peg$c321;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c319); }
+              if (peg$silentFails === 0) { peg$fail(peg$c322); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c323();
+              s1 = peg$c326();
             }
             s0 = s1;
           }
@@ -6806,17 +6859,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c195;
+      s1 = peg$c198;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c199); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseh16();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c324(s2);
+        s1 = peg$c327(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6837,15 +6890,15 @@ function peg$parse(input, options) {
     s1 = peg$parseh16();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c195;
+        s2 = peg$c198;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c196); }
+        if (peg$silentFails === 0) { peg$fail(peg$c199); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c325(s1);
+        s1 = peg$c328(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6866,17 +6919,17 @@ function peg$parse(input, options) {
     s1 = peg$parseaddr();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c216;
+        s2 = peg$c219;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c217); }
+        if (peg$silentFails === 0) { peg$fail(peg$c220); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c326(s1, s3);
+          s1 = peg$c329(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6901,17 +6954,17 @@ function peg$parse(input, options) {
     s1 = peg$parseip6addr();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c216;
+        s2 = peg$c219;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c217); }
+        if (peg$silentFails === 0) { peg$fail(peg$c220); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c327(s1, s3);
+          s1 = peg$c330(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6936,7 +6989,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesuint();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c328(s1);
+      s1 = peg$c331(s1);
     }
     s0 = s1;
 
@@ -6948,22 +7001,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c79.test(input.charAt(peg$currPos))) {
+    if (peg$c82.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c80); }
+      if (peg$silentFails === 0) { peg$fail(peg$c83); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c79.test(input.charAt(peg$currPos))) {
+        if (peg$c82.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
       }
     } else {
@@ -6971,7 +7024,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -6985,7 +7038,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesinteger();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c328(s1);
+      s1 = peg$c331(s1);
     }
     s0 = s1;
 
@@ -6996,12 +7049,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c329.test(input.charAt(peg$currPos))) {
+    if (peg$c332.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c333); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -7010,7 +7063,7 @@ function peg$parse(input, options) {
       s2 = peg$parsesuint();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c73();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7031,7 +7084,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesdouble();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c331(s1);
+      s1 = peg$c334(s1);
     }
     s0 = s1;
 
@@ -7065,11 +7118,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c81;
+          s3 = peg$c84;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c82); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
@@ -7089,7 +7142,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c332();
+              s1 = peg$c335();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7125,11 +7178,11 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c81;
+          s2 = peg$c84;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c82); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
@@ -7149,7 +7202,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c332();
+              s1 = peg$c335();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7176,38 +7229,38 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     if (input.charCodeAt(peg$currPos) === 48) {
-      s0 = peg$c333;
+      s0 = peg$c336;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c334); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$c335.test(input.charAt(peg$currPos))) {
+      if (peg$c338.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c336); }
+        if (peg$silentFails === 0) { peg$fail(peg$c339); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c79.test(input.charAt(peg$currPos))) {
+        if (peg$c82.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c79.test(input.charAt(peg$currPos))) {
+          if (peg$c82.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c83); }
           }
         }
         if (s2 !== peg$FAILED) {
@@ -7229,12 +7282,12 @@ function peg$parse(input, options) {
   function peg$parsedoubleDigit() {
     var s0;
 
-    if (peg$c79.test(input.charAt(peg$currPos))) {
+    if (peg$c82.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c80); }
+      if (peg$silentFails === 0) { peg$fail(peg$c83); }
     }
 
     return s0;
@@ -7244,12 +7297,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c337) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c340) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesinteger();
@@ -7284,7 +7337,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c339(s1);
+      s1 = peg$c342(s1);
     }
     s0 = s1;
 
@@ -7294,12 +7347,12 @@ function peg$parse(input, options) {
   function peg$parsehexdigit() {
     var s0;
 
-    if (peg$c340.test(input.charAt(peg$currPos))) {
+    if (peg$c343.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
+      if (peg$silentFails === 0) { peg$fail(peg$c344); }
     }
 
     return s0;
@@ -7321,7 +7374,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c342(s1);
+      s1 = peg$c345(s1);
     }
     s0 = s1;
 
@@ -7333,11 +7386,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c343;
+      s1 = peg$c346;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c344); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseescapeSequence();
@@ -7360,12 +7413,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c345.test(input.charAt(peg$currPos))) {
+      if (peg$c348.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c346); }
+        if (peg$silentFails === 0) { peg$fail(peg$c349); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parsews();
@@ -7383,11 +7436,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c347); }
+          if (peg$silentFails === 0) { peg$fail(peg$c350); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c70();
+          s1 = peg$c73();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7407,11 +7460,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c348;
+      s1 = peg$c351;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c349); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -7422,15 +7475,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c348;
+          s3 = peg$c351;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c349); }
+          if (peg$silentFails === 0) { peg$fail(peg$c352); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c350(s2);
+          s1 = peg$c353(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7447,11 +7500,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c351;
+        s1 = peg$c354;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c352); }
+        if (peg$silentFails === 0) { peg$fail(peg$c355); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7462,15 +7515,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c351;
+            s3 = peg$c354;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c352); }
+            if (peg$silentFails === 0) { peg$fail(peg$c355); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c350(s2);
+            s1 = peg$c353(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7496,11 +7549,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c348;
+      s2 = peg$c351;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c349); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -7518,11 +7571,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c347); }
+        if (peg$silentFails === 0) { peg$fail(peg$c350); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c73();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7535,11 +7588,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c343;
+        s1 = peg$c346;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c344); }
+        if (peg$silentFails === 0) { peg$fail(peg$c347); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -7567,11 +7620,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c351;
+      s2 = peg$c354;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c352); }
+      if (peg$silentFails === 0) { peg$fail(peg$c355); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -7589,11 +7642,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c347); }
+        if (peg$silentFails === 0) { peg$fail(peg$c350); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70();
+        s1 = peg$c73();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7606,11 +7659,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c343;
+        s1 = peg$c346;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c344); }
+        if (peg$silentFails === 0) { peg$fail(peg$c347); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -7636,11 +7689,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c353;
+      s1 = peg$c356;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c354); }
+      if (peg$silentFails === 0) { peg$fail(peg$c357); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsehexdigit();
@@ -7648,7 +7701,7 @@ function peg$parse(input, options) {
         s3 = peg$parsehexdigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c355();
+          s1 = peg$c358();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7676,110 +7729,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c351;
+      s0 = peg$c354;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c352); }
+      if (peg$silentFails === 0) { peg$fail(peg$c355); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c348;
+        s0 = peg$c351;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c349); }
+        if (peg$silentFails === 0) { peg$fail(peg$c352); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c343;
+          s0 = peg$c346;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c344); }
+          if (peg$silentFails === 0) { peg$fail(peg$c347); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c356;
+            s1 = peg$c359;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c357); }
+            if (peg$silentFails === 0) { peg$fail(peg$c360); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c358();
+            s1 = peg$c361();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c359;
+              s1 = peg$c362;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c360); }
+              if (peg$silentFails === 0) { peg$fail(peg$c363); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c361();
+              s1 = peg$c364();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c362;
+                s1 = peg$c365;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c363); }
+                if (peg$silentFails === 0) { peg$fail(peg$c366); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c364();
+                s1 = peg$c367();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c365;
+                  s1 = peg$c368;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c366); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c369); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c367();
+                  s1 = peg$c370();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c368;
+                    s1 = peg$c371;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c369); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c372); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c370();
+                    s1 = peg$c373();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c371;
+                      s1 = peg$c374;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c372); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c375); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c373();
+                      s1 = peg$c376();
                     }
                     s0 = s1;
                   }
@@ -7799,15 +7852,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c140;
+      s1 = peg$c143;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c144); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c374();
+      s1 = peg$c377();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7821,7 +7874,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c375();
+        s1 = peg$c378();
       }
       s0 = s1;
     }
@@ -7834,11 +7887,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c376;
+      s1 = peg$c379;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c377); }
+      if (peg$silentFails === 0) { peg$fail(peg$c380); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7870,7 +7923,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c378(s2);
+        s1 = peg$c381(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7883,19 +7936,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c376;
+        s1 = peg$c379;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c377); }
+        if (peg$silentFails === 0) { peg$fail(peg$c380); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c379;
+          s2 = peg$c382;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c380); }
+          if (peg$silentFails === 0) { peg$fail(peg$c383); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7954,15 +8007,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c381;
+              s4 = peg$c384;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c382); }
+              if (peg$silentFails === 0) { peg$fail(peg$c385); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c378(s3);
+              s1 = peg$c381(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7990,21 +8043,21 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c216;
+      s1 = peg$c219;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c217); }
+      if (peg$silentFails === 0) { peg$fail(peg$c220); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsereBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c216;
+          s3 = peg$c219;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c217); }
+          if (peg$silentFails === 0) { peg$fail(peg$c220); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -8031,39 +8084,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c383.test(input.charAt(peg$currPos))) {
+    if (peg$c386.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c384); }
+      if (peg$silentFails === 0) { peg$fail(peg$c387); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c385) {
-        s2 = peg$c385;
+      if (input.substr(peg$currPos, 2) === peg$c388) {
+        s2 = peg$c388;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c386); }
+        if (peg$silentFails === 0) { peg$fail(peg$c389); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c383.test(input.charAt(peg$currPos))) {
+        if (peg$c386.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c384); }
+          if (peg$silentFails === 0) { peg$fail(peg$c387); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c385) {
-            s2 = peg$c385;
+          if (input.substr(peg$currPos, 2) === peg$c388) {
+            s2 = peg$c388;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c386); }
+            if (peg$silentFails === 0) { peg$fail(peg$c389); }
           }
         }
       }
@@ -8072,7 +8125,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c70();
+      s1 = peg$c73();
     }
     s0 = s1;
 
@@ -8082,12 +8135,12 @@ function peg$parse(input, options) {
   function peg$parseescapedChar() {
     var s0;
 
-    if (peg$c387.test(input.charAt(peg$currPos))) {
+    if (peg$c390.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+      if (peg$silentFails === 0) { peg$fail(peg$c391); }
     }
 
     return s0;
@@ -8097,51 +8150,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c389;
+      s0 = peg$c392;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c391;
+        s0 = peg$c394;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c392); }
+        if (peg$silentFails === 0) { peg$fail(peg$c395); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c393;
+          s0 = peg$c396;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c394); }
+          if (peg$silentFails === 0) { peg$fail(peg$c397); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c395;
+            s0 = peg$c398;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c396); }
+            if (peg$silentFails === 0) { peg$fail(peg$c399); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c397;
+              s0 = peg$c400;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c398); }
+              if (peg$silentFails === 0) { peg$fail(peg$c401); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c399;
+                s0 = peg$c402;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c400); }
+                if (peg$silentFails === 0) { peg$fail(peg$c403); }
               }
             }
           }
@@ -8169,7 +8222,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c401); }
+      if (peg$silentFails === 0) { peg$fail(peg$c404); }
     }
 
     return s0;
@@ -8198,7 +8251,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c350); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {
@@ -8351,9 +8404,9 @@ function peg$parse(input, options) {
     return [first, ...rest];
   }
 
-  function makeGroupByProc(duration, limit, keys, reducers) {
+  function makeGroupByProc(duration, sorted, limit, keys, reducers) {
     if (limit === null) { limit = undefined; }
-    return { op: "GroupByProc", keys, reducers, duration, limit };
+      return { op: "GroupByProc", keys, reducers, duration, limit , sorted};
   }
 
   function makeUnaryExpr(operator, operand) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -227,6 +227,9 @@ groupByKey
 everyDur
   = "every"i _ dur:duration { RETURN(dur) }
 
+groupBySorted
+  = _ "-sorted"i _ dir:sinteger { RETURN(parseInt(dir)) }
+
 equalityToken
   = EqualityOperator / RelativeOperator
 
@@ -318,7 +321,7 @@ fieldReducer
   }
 
 reducerProc
-  = every:(everyDur _)? reducers:reducerList keys:(_ groupByKeys)? limit:procLimitArg? {
+  = every:(everyDur _)? reducers:reducerList keys:(_ groupByKeys)? sorted:groupBySorted? limit:procLimitArg? {
     if ISNOTNULL(OR(keys, every)) {
       if ISNOTNULL(keys) {
         keys = ASSERT_ARRAY(keys)[1]
@@ -330,7 +333,7 @@ reducerProc
         every = ASSERT_ARRAY(every)[0]
       }
 
-      RETURN(makeGroupByProc(every, limit, keys, reducers))
+      RETURN(makeGroupByProc(every, sorted, limit, keys, reducers))
     }
 
     RETURN(makeReducerProc(reducers))


### PR DESCRIPTION
This PR removes the special-case "timebinning" support in the groupby proc, using the new computed groupby key facility introduced in #860. The zql `every` syntax remains such that `every x count() by y` is effectively translated to `count() by ts=time.Trunc(ts, x), y`.

The prior timebinning assumed that input was always forward-sorted in time, and it would output time-bin keys as soon as time (as observed on input records) had advanced past a bin. This assumption is a remnant of a prior system (when we believed that "time was on our side") where records _were_ guaranteed to be time-sorted, but the guarantee is not present in zq or zqd, and so the assumption could lead to silently incorrect results.

Nonetheless, the early emit facility is useful, and has been reimplemented, in a general way that is no specific to time bins. It is enabled by passing the `-sorted <dir>` argument to groupby (where `dir` should be `1` or `-1` to indicate the input sort order), which signals that the input is sorted in the primary key.

For example: `every 1h count() by _path -sorted 1` could be used to tell groupby that input records are forward-ordered by time and can be early-emitted.

closes #828 
closes #847 

