### PR TITLE
Rename ReducerProc->ReduceProc

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -245,11 +245,11 @@ type (
 		Node
 		Cflag bool `json:"cflag"`
 	}
-	// A ReducerProc node represents a proc that consumes all the records
+	// A ReduceProc node represents a proc that consumes all the records
 	// in its input and processes each record with one or more reducers.
 	// After all the records have been consumed, the proc generates a single
 	// record that contains each reducer's result as a field in that record.
-	ReducerProc struct {
+	ReduceProc struct {
 		Node
 		Reducers []Reducer `json:"reducers"`
 	}
@@ -322,12 +322,12 @@ func (*TailProc) ProcNode()       {}
 func (*PassProc) ProcNode()       {}
 func (*FilterProc) ProcNode()     {}
 func (*UniqProc) ProcNode()       {}
-func (*ReducerProc) ProcNode()    {}
+func (*ReduceProc) ProcNode()     {}
 func (*GroupByProc) ProcNode()    {}
 func (*TopProc) ProcNode()        {}
 func (*PutProc) ProcNode()        {}
 
-// A Reducer is an AST node that represents any of the boom reducers.  The Op
+// A Reducer is an AST node that represents a reducer function.  The Op
 // parameter indicates the specific reducer while the Field parameter indicates
 // which field of the incoming records should be operated upon by the reducer.
 // The result is given the field name specified by the Var parameter.

--- a/ast/unpack.go
+++ b/ast/unpack.go
@@ -86,12 +86,12 @@ func unpackProc(custom Unpacker, node joe.JSON) (Proc, error) {
 		return &PutProc{Clauses: clauses}, nil
 	case "UniqProc":
 		return &UniqProc{}, nil
-	case "ReducerProc":
+	case "ReduceProc":
 		reducers, err := unpackReducers(node.Get("reducers"))
 		if err != nil {
 			return nil, err
 		}
-		return &ReducerProc{Reducers: reducers}, nil
+		return &ReduceProc{Reducers: reducers}, nil
 	case "GroupByProc":
 		keys, err := unpackAssignments(node.Get("keys"))
 		if err != nil {

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -107,7 +107,7 @@ func CompileProc(custom Compiler, node ast.Proc, c *Context, parent Proc) ([]Pro
 		}
 	}
 	switch v := node.(type) {
-	case *ast.ReducerProc:
+	case *ast.ReduceProc:
 		reducers := make([]compile.CompiledReducer, 0)
 		for _, reducer := range v.Reducers {
 			compiled, err := compile.Compile(reducer)
@@ -116,10 +116,10 @@ func CompileProc(custom Compiler, node ast.Proc, c *Context, parent Proc) ([]Pro
 			}
 			reducers = append(reducers, compiled)
 		}
-		params := ReducerParams{
+		params := ReduceParams{
 			reducers: reducers,
 		}
-		return []Proc{NewReducer(c, parent, params)}, nil
+		return []Proc{NewReduce(c, parent, params)}, nil
 
 	case *ast.GroupByProc:
 		params, err := CompileGroupBy(v, c.TypeContext)

--- a/proc/reduce.go
+++ b/proc/reduce.go
@@ -7,25 +7,25 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
-type ReducerParams struct {
+type ReduceParams struct {
 	reducers []compile.CompiledReducer
 }
 
-type Reducer struct {
+type Reduce struct {
 	Base
 	n       int
 	columns compile.Row
 }
 
-func NewReducer(c *Context, parent Proc, params ReducerParams) Proc {
+func NewReduce(c *Context, parent Proc, params ReduceParams) Proc {
 
-	return &Reducer{
+	return &Reduce{
 		Base:    Base{Context: c, Parent: parent},
 		columns: compile.Row{Defs: params.reducers},
 	}
 }
 
-func (r *Reducer) output() (*zbuf.Array, error) {
+func (r *Reduce) output() (*zbuf.Array, error) {
 	rec, err := r.columns.Result(r.Context.TypeContext)
 	if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func (r *Reducer) output() (*zbuf.Array, error) {
 	return zbuf.NewArray([]*zng.Record{rec}, nano.NewSpanTs(r.MinTs, r.MaxTs)), nil
 }
 
-func (r *Reducer) Pull() (zbuf.Batch, error) {
+func (r *Reduce) Pull() (zbuf.Batch, error) {
 	batch, err := r.Get()
 	if err != nil {
 		return nil, err
@@ -53,7 +53,7 @@ func (r *Reducer) Pull() (zbuf.Batch, error) {
 	return zbuf.NewArray([]*zng.Record{}, batch.Span()), nil
 }
 
-func (r *Reducer) consume(rec *zng.Record) {
+func (r *Reduce) consume(rec *zng.Record) {
 	r.n++
 	r.columns.Consume(rec)
 }

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -300,9 +300,9 @@ func reducersArray(reducersIn interface{}) []ast.Reducer {
 	return ret
 }
 
-func makeReducerProc(reducers interface{}) *ast.ReducerProc {
-	return &ast.ReducerProc{
-		Node:     ast.Node{"ReducerProc"},
+func makeReduceProc(reducers interface{}) *ast.ReduceProc {
+	return &ast.ReduceProc{
+		Node:     ast.Node{"ReduceProc"},
 		Reducers: reducersArray(reducers),
 	}
 }

--- a/zql/parser-support.js
+++ b/zql/parser-support.js
@@ -124,8 +124,8 @@ function makeDuration(seconds) {
   return {type: "Duration", seconds};
 }
 
-function makeReducerProc(reducers) {
-  return { op: "ReducerProc", reducers };
+function makeReduceProc(reducers) {
+  return { op: "ReduceProc", reducers };
 }
 
 function makeGroupByKey(target, expression) {

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -1211,43 +1211,43 @@ var g = &grammar{
 					},
 					&ruleRefExpr{
 						pos:  position{line: 179, col: 5, offset: 4107},
-						name: "reducerProc",
+						name: "reduceProc",
 					},
 					&actionExpr{
-						pos: position{line: 180, col: 5, offset: 4123},
+						pos: position{line: 180, col: 5, offset: 4122},
 						run: (*parser).callonproc4,
 						expr: &seqExpr{
-							pos: position{line: 180, col: 5, offset: 4123},
+							pos: position{line: 180, col: 5, offset: 4122},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 180, col: 5, offset: 4123},
+									pos:        position{line: 180, col: 5, offset: 4122},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 180, col: 9, offset: 4127},
+									pos: position{line: 180, col: 9, offset: 4126},
 									expr: &ruleRefExpr{
-										pos:  position{line: 180, col: 9, offset: 4127},
+										pos:  position{line: 180, col: 9, offset: 4126},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 180, col: 12, offset: 4130},
+									pos:   position{line: 180, col: 12, offset: 4129},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 180, col: 17, offset: 4135},
+										pos:  position{line: 180, col: 17, offset: 4134},
 										name: "procList",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 180, col: 26, offset: 4144},
+									pos: position{line: 180, col: 26, offset: 4143},
 									expr: &ruleRefExpr{
-										pos:  position{line: 180, col: 26, offset: 4144},
+										pos:  position{line: 180, col: 26, offset: 4143},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 180, col: 29, offset: 4147},
+									pos:        position{line: 180, col: 29, offset: 4146},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1259,59 +1259,59 @@ var g = &grammar{
 		},
 		{
 			name: "groupByKeys",
-			pos:  position{line: 184, col: 1, offset: 4183},
+			pos:  position{line: 184, col: 1, offset: 4182},
 			expr: &actionExpr{
-				pos: position{line: 185, col: 5, offset: 4199},
+				pos: position{line: 185, col: 5, offset: 4198},
 				run: (*parser).callongroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 185, col: 5, offset: 4199},
+					pos: position{line: 185, col: 5, offset: 4198},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 185, col: 5, offset: 4199},
+							pos:        position{line: 185, col: 5, offset: 4198},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 185, col: 11, offset: 4205},
+							pos:  position{line: 185, col: 11, offset: 4204},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 185, col: 13, offset: 4207},
+							pos:   position{line: 185, col: 13, offset: 4206},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 185, col: 19, offset: 4213},
+								pos:  position{line: 185, col: 19, offset: 4212},
 								name: "groupByKey",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 185, col: 30, offset: 4224},
+							pos:   position{line: 185, col: 30, offset: 4223},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 185, col: 35, offset: 4229},
+								pos: position{line: 185, col: 35, offset: 4228},
 								expr: &actionExpr{
-									pos: position{line: 185, col: 36, offset: 4230},
+									pos: position{line: 185, col: 36, offset: 4229},
 									run: (*parser).callongroupByKeys9,
 									expr: &seqExpr{
-										pos: position{line: 185, col: 36, offset: 4230},
+										pos: position{line: 185, col: 36, offset: 4229},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 185, col: 36, offset: 4230},
+												pos:  position{line: 185, col: 36, offset: 4229},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 185, col: 39, offset: 4233},
+												pos:        position{line: 185, col: 39, offset: 4232},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 185, col: 43, offset: 4237},
+												pos:  position{line: 185, col: 43, offset: 4236},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 185, col: 46, offset: 4240},
+												pos:   position{line: 185, col: 46, offset: 4239},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 185, col: 49, offset: 4243},
+													pos:  position{line: 185, col: 49, offset: 4242},
 													name: "groupByKey",
 												},
 											},
@@ -1326,22 +1326,22 @@ var g = &grammar{
 		},
 		{
 			name: "groupByKey",
-			pos:  position{line: 190, col: 1, offset: 4332},
+			pos:  position{line: 190, col: 1, offset: 4331},
 			expr: &choiceExpr{
-				pos: position{line: 191, col: 5, offset: 4347},
+				pos: position{line: 191, col: 5, offset: 4346},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 191, col: 5, offset: 4347},
+						pos:  position{line: 191, col: 5, offset: 4346},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 192, col: 5, offset: 4362},
+						pos: position{line: 192, col: 5, offset: 4361},
 						run: (*parser).callongroupByKey3,
 						expr: &labeledExpr{
-							pos:   position{line: 192, col: 5, offset: 4362},
+							pos:   position{line: 192, col: 5, offset: 4361},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 192, col: 11, offset: 4368},
+								pos:  position{line: 192, col: 11, offset: 4367},
 								name: "fieldExpr",
 							},
 						},
@@ -1351,27 +1351,27 @@ var g = &grammar{
 		},
 		{
 			name: "everyDur",
-			pos:  position{line: 195, col: 1, offset: 4434},
+			pos:  position{line: 195, col: 1, offset: 4433},
 			expr: &actionExpr{
-				pos: position{line: 196, col: 5, offset: 4447},
+				pos: position{line: 196, col: 5, offset: 4446},
 				run: (*parser).calloneveryDur1,
 				expr: &seqExpr{
-					pos: position{line: 196, col: 5, offset: 4447},
+					pos: position{line: 196, col: 5, offset: 4446},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 196, col: 5, offset: 4447},
+							pos:        position{line: 196, col: 5, offset: 4446},
 							val:        "every",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 196, col: 14, offset: 4456},
+							pos:  position{line: 196, col: 14, offset: 4455},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 196, col: 16, offset: 4458},
+							pos:   position{line: 196, col: 16, offset: 4457},
 							label: "dur",
 							expr: &ruleRefExpr{
-								pos:  position{line: 196, col: 20, offset: 4462},
+								pos:  position{line: 196, col: 20, offset: 4461},
 								name: "duration",
 							},
 						},
@@ -1381,16 +1381,16 @@ var g = &grammar{
 		},
 		{
 			name: "equalityToken",
-			pos:  position{line: 198, col: 1, offset: 4492},
+			pos:  position{line: 198, col: 1, offset: 4491},
 			expr: &choiceExpr{
-				pos: position{line: 199, col: 5, offset: 4510},
+				pos: position{line: 199, col: 5, offset: 4509},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 199, col: 5, offset: 4510},
+						pos:  position{line: 199, col: 5, offset: 4509},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 199, col: 24, offset: 4529},
+						pos:  position{line: 199, col: 24, offset: 4528},
 						name: "RelativeOperator",
 					},
 				},
@@ -1398,12 +1398,12 @@ var g = &grammar{
 		},
 		{
 			name: "andToken",
-			pos:  position{line: 201, col: 1, offset: 4547},
+			pos:  position{line: 201, col: 1, offset: 4546},
 			expr: &actionExpr{
-				pos: position{line: 201, col: 12, offset: 4558},
+				pos: position{line: 201, col: 12, offset: 4557},
 				run: (*parser).callonandToken1,
 				expr: &litMatcher{
-					pos:        position{line: 201, col: 12, offset: 4558},
+					pos:        position{line: 201, col: 12, offset: 4557},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -1411,12 +1411,12 @@ var g = &grammar{
 		},
 		{
 			name: "orToken",
-			pos:  position{line: 202, col: 1, offset: 4596},
+			pos:  position{line: 202, col: 1, offset: 4595},
 			expr: &actionExpr{
-				pos: position{line: 202, col: 11, offset: 4606},
+				pos: position{line: 202, col: 11, offset: 4605},
 				run: (*parser).callonorToken1,
 				expr: &litMatcher{
-					pos:        position{line: 202, col: 11, offset: 4606},
+					pos:        position{line: 202, col: 11, offset: 4605},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -1424,12 +1424,12 @@ var g = &grammar{
 		},
 		{
 			name: "inToken",
-			pos:  position{line: 203, col: 1, offset: 4643},
+			pos:  position{line: 203, col: 1, offset: 4642},
 			expr: &actionExpr{
-				pos: position{line: 203, col: 11, offset: 4653},
+				pos: position{line: 203, col: 11, offset: 4652},
 				run: (*parser).calloninToken1,
 				expr: &litMatcher{
-					pos:        position{line: 203, col: 11, offset: 4653},
+					pos:        position{line: 203, col: 11, offset: 4652},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -1437,12 +1437,12 @@ var g = &grammar{
 		},
 		{
 			name: "notToken",
-			pos:  position{line: 204, col: 1, offset: 4690},
+			pos:  position{line: 204, col: 1, offset: 4689},
 			expr: &actionExpr{
-				pos: position{line: 204, col: 12, offset: 4701},
+				pos: position{line: 204, col: 12, offset: 4700},
 				run: (*parser).callonnotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 204, col: 12, offset: 4701},
+					pos:        position{line: 204, col: 12, offset: 4700},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -1450,21 +1450,21 @@ var g = &grammar{
 		},
 		{
 			name: "fieldName",
-			pos:  position{line: 206, col: 1, offset: 4740},
+			pos:  position{line: 206, col: 1, offset: 4739},
 			expr: &actionExpr{
-				pos: position{line: 206, col: 13, offset: 4752},
+				pos: position{line: 206, col: 13, offset: 4751},
 				run: (*parser).callonfieldName1,
 				expr: &seqExpr{
-					pos: position{line: 206, col: 13, offset: 4752},
+					pos: position{line: 206, col: 13, offset: 4751},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 206, col: 13, offset: 4752},
+							pos:  position{line: 206, col: 13, offset: 4751},
 							name: "fieldNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 206, col: 28, offset: 4767},
+							pos: position{line: 206, col: 28, offset: 4766},
 							expr: &ruleRefExpr{
-								pos:  position{line: 206, col: 28, offset: 4767},
+								pos:  position{line: 206, col: 28, offset: 4766},
 								name: "fieldNameRest",
 							},
 						},
@@ -1474,9 +1474,9 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameStart",
-			pos:  position{line: 208, col: 1, offset: 4814},
+			pos:  position{line: 208, col: 1, offset: 4813},
 			expr: &charClassMatcher{
-				pos:        position{line: 208, col: 18, offset: 4831},
+				pos:        position{line: 208, col: 18, offset: 4830},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -1486,16 +1486,16 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameRest",
-			pos:  position{line: 209, col: 1, offset: 4842},
+			pos:  position{line: 209, col: 1, offset: 4841},
 			expr: &choiceExpr{
-				pos: position{line: 209, col: 17, offset: 4858},
+				pos: position{line: 209, col: 17, offset: 4857},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 209, col: 17, offset: 4858},
+						pos:  position{line: 209, col: 17, offset: 4857},
 						name: "fieldNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 209, col: 34, offset: 4875},
+						pos:        position{line: 209, col: 34, offset: 4874},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -1506,45 +1506,45 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReference",
-			pos:  position{line: 211, col: 1, offset: 4882},
+			pos:  position{line: 211, col: 1, offset: 4881},
 			expr: &actionExpr{
-				pos: position{line: 212, col: 4, offset: 4900},
+				pos: position{line: 212, col: 4, offset: 4899},
 				run: (*parser).callonfieldReference1,
 				expr: &seqExpr{
-					pos: position{line: 212, col: 4, offset: 4900},
+					pos: position{line: 212, col: 4, offset: 4899},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 212, col: 4, offset: 4900},
+							pos:   position{line: 212, col: 4, offset: 4899},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 212, col: 9, offset: 4905},
+								pos:  position{line: 212, col: 9, offset: 4904},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 212, col: 19, offset: 4915},
+							pos:   position{line: 212, col: 19, offset: 4914},
 							label: "derefs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 212, col: 26, offset: 4922},
+								pos: position{line: 212, col: 26, offset: 4921},
 								expr: &choiceExpr{
-									pos: position{line: 213, col: 8, offset: 4931},
+									pos: position{line: 213, col: 8, offset: 4930},
 									alternatives: []interface{}{
 										&actionExpr{
-											pos: position{line: 213, col: 8, offset: 4931},
+											pos: position{line: 213, col: 8, offset: 4930},
 											run: (*parser).callonfieldReference8,
 											expr: &seqExpr{
-												pos: position{line: 213, col: 8, offset: 4931},
+												pos: position{line: 213, col: 8, offset: 4930},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 213, col: 8, offset: 4931},
+														pos:        position{line: 213, col: 8, offset: 4930},
 														val:        ".",
 														ignoreCase: false,
 													},
 													&labeledExpr{
-														pos:   position{line: 213, col: 12, offset: 4935},
+														pos:   position{line: 213, col: 12, offset: 4934},
 														label: "field",
 														expr: &ruleRefExpr{
-															pos:  position{line: 213, col: 18, offset: 4941},
+															pos:  position{line: 213, col: 18, offset: 4940},
 															name: "fieldName",
 														},
 													},
@@ -1552,26 +1552,26 @@ var g = &grammar{
 											},
 										},
 										&actionExpr{
-											pos: position{line: 214, col: 8, offset: 5022},
+											pos: position{line: 214, col: 8, offset: 5021},
 											run: (*parser).callonfieldReference13,
 											expr: &seqExpr{
-												pos: position{line: 214, col: 8, offset: 5022},
+												pos: position{line: 214, col: 8, offset: 5021},
 												exprs: []interface{}{
 													&litMatcher{
-														pos:        position{line: 214, col: 8, offset: 5022},
+														pos:        position{line: 214, col: 8, offset: 5021},
 														val:        "[",
 														ignoreCase: false,
 													},
 													&labeledExpr{
-														pos:   position{line: 214, col: 12, offset: 5026},
+														pos:   position{line: 214, col: 12, offset: 5025},
 														label: "index",
 														expr: &ruleRefExpr{
-															pos:  position{line: 214, col: 18, offset: 5032},
+															pos:  position{line: 214, col: 18, offset: 5031},
 															name: "suint",
 														},
 													},
 													&litMatcher{
-														pos:        position{line: 214, col: 24, offset: 5038},
+														pos:        position{line: 214, col: 24, offset: 5037},
 														val:        "]",
 														ignoreCase: false,
 													},
@@ -1588,60 +1588,60 @@ var g = &grammar{
 		},
 		{
 			name: "fieldExpr",
-			pos:  position{line: 219, col: 1, offset: 5154},
+			pos:  position{line: 219, col: 1, offset: 5153},
 			expr: &choiceExpr{
-				pos: position{line: 220, col: 5, offset: 5168},
+				pos: position{line: 220, col: 5, offset: 5167},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 220, col: 5, offset: 5168},
+						pos: position{line: 220, col: 5, offset: 5167},
 						run: (*parser).callonfieldExpr2,
 						expr: &seqExpr{
-							pos: position{line: 220, col: 5, offset: 5168},
+							pos: position{line: 220, col: 5, offset: 5167},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 220, col: 5, offset: 5168},
+									pos:   position{line: 220, col: 5, offset: 5167},
 									label: "op",
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 8, offset: 5171},
+										pos:  position{line: 220, col: 8, offset: 5170},
 										name: "fieldOp",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 220, col: 16, offset: 5179},
+									pos: position{line: 220, col: 16, offset: 5178},
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 16, offset: 5179},
+										pos:  position{line: 220, col: 16, offset: 5178},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 220, col: 19, offset: 5182},
+									pos:        position{line: 220, col: 19, offset: 5181},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 220, col: 23, offset: 5186},
+									pos: position{line: 220, col: 23, offset: 5185},
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 23, offset: 5186},
+										pos:  position{line: 220, col: 23, offset: 5185},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 220, col: 26, offset: 5189},
+									pos:   position{line: 220, col: 26, offset: 5188},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 32, offset: 5195},
+										pos:  position{line: 220, col: 32, offset: 5194},
 										name: "fieldReference",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 220, col: 47, offset: 5210},
+									pos: position{line: 220, col: 47, offset: 5209},
 									expr: &ruleRefExpr{
-										pos:  position{line: 220, col: 47, offset: 5210},
+										pos:  position{line: 220, col: 47, offset: 5209},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 220, col: 50, offset: 5213},
+									pos:        position{line: 220, col: 50, offset: 5212},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1649,7 +1649,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 223, col: 5, offset: 5277},
+						pos:  position{line: 223, col: 5, offset: 5276},
 						name: "fieldReference",
 					},
 				},
@@ -1657,12 +1657,12 @@ var g = &grammar{
 		},
 		{
 			name: "fieldOp",
-			pos:  position{line: 225, col: 1, offset: 5293},
+			pos:  position{line: 225, col: 1, offset: 5292},
 			expr: &actionExpr{
-				pos: position{line: 226, col: 5, offset: 5305},
+				pos: position{line: 226, col: 5, offset: 5304},
 				run: (*parser).callonfieldOp1,
 				expr: &litMatcher{
-					pos:        position{line: 226, col: 5, offset: 5305},
+					pos:        position{line: 226, col: 5, offset: 5304},
 					val:        "len",
 					ignoreCase: true,
 				},
@@ -1670,50 +1670,50 @@ var g = &grammar{
 		},
 		{
 			name: "fieldExprList",
-			pos:  position{line: 228, col: 1, offset: 5335},
+			pos:  position{line: 228, col: 1, offset: 5334},
 			expr: &actionExpr{
-				pos: position{line: 229, col: 5, offset: 5353},
+				pos: position{line: 229, col: 5, offset: 5352},
 				run: (*parser).callonfieldExprList1,
 				expr: &seqExpr{
-					pos: position{line: 229, col: 5, offset: 5353},
+					pos: position{line: 229, col: 5, offset: 5352},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 229, col: 5, offset: 5353},
+							pos:   position{line: 229, col: 5, offset: 5352},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 229, col: 11, offset: 5359},
+								pos:  position{line: 229, col: 11, offset: 5358},
 								name: "fieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 229, col: 21, offset: 5369},
+							pos:   position{line: 229, col: 21, offset: 5368},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 229, col: 26, offset: 5374},
+								pos: position{line: 229, col: 26, offset: 5373},
 								expr: &seqExpr{
-									pos: position{line: 229, col: 27, offset: 5375},
+									pos: position{line: 229, col: 27, offset: 5374},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 229, col: 27, offset: 5375},
+											pos: position{line: 229, col: 27, offset: 5374},
 											expr: &ruleRefExpr{
-												pos:  position{line: 229, col: 27, offset: 5375},
+												pos:  position{line: 229, col: 27, offset: 5374},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 229, col: 30, offset: 5378},
+											pos:        position{line: 229, col: 30, offset: 5377},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 229, col: 34, offset: 5382},
+											pos: position{line: 229, col: 34, offset: 5381},
 											expr: &ruleRefExpr{
-												pos:  position{line: 229, col: 34, offset: 5382},
+												pos:  position{line: 229, col: 34, offset: 5381},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 229, col: 37, offset: 5385},
+											pos:  position{line: 229, col: 37, offset: 5384},
 											name: "fieldExpr",
 										},
 									},
@@ -1726,39 +1726,39 @@ var g = &grammar{
 		},
 		{
 			name: "fieldRefDotOnly",
-			pos:  position{line: 239, col: 1, offset: 5580},
+			pos:  position{line: 239, col: 1, offset: 5579},
 			expr: &actionExpr{
-				pos: position{line: 240, col: 5, offset: 5600},
+				pos: position{line: 240, col: 5, offset: 5599},
 				run: (*parser).callonfieldRefDotOnly1,
 				expr: &seqExpr{
-					pos: position{line: 240, col: 5, offset: 5600},
+					pos: position{line: 240, col: 5, offset: 5599},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 240, col: 5, offset: 5600},
+							pos:   position{line: 240, col: 5, offset: 5599},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 240, col: 10, offset: 5605},
+								pos:  position{line: 240, col: 10, offset: 5604},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 240, col: 20, offset: 5615},
+							pos:   position{line: 240, col: 20, offset: 5614},
 							label: "refs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 240, col: 25, offset: 5620},
+								pos: position{line: 240, col: 25, offset: 5619},
 								expr: &seqExpr{
-									pos: position{line: 240, col: 26, offset: 5621},
+									pos: position{line: 240, col: 26, offset: 5620},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 240, col: 26, offset: 5621},
+											pos:        position{line: 240, col: 26, offset: 5620},
 											val:        ".",
 											ignoreCase: false,
 										},
 										&labeledExpr{
-											pos:   position{line: 240, col: 30, offset: 5625},
+											pos:   position{line: 240, col: 30, offset: 5624},
 											label: "field",
 											expr: &ruleRefExpr{
-												pos:  position{line: 240, col: 36, offset: 5631},
+												pos:  position{line: 240, col: 36, offset: 5630},
 												name: "fieldName",
 											},
 										},
@@ -1772,56 +1772,56 @@ var g = &grammar{
 		},
 		{
 			name: "fieldRefDotOnlyList",
-			pos:  position{line: 242, col: 1, offset: 5675},
+			pos:  position{line: 242, col: 1, offset: 5674},
 			expr: &actionExpr{
-				pos: position{line: 243, col: 5, offset: 5699},
+				pos: position{line: 243, col: 5, offset: 5698},
 				run: (*parser).callonfieldRefDotOnlyList1,
 				expr: &seqExpr{
-					pos: position{line: 243, col: 5, offset: 5699},
+					pos: position{line: 243, col: 5, offset: 5698},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 243, col: 5, offset: 5699},
+							pos:   position{line: 243, col: 5, offset: 5698},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 243, col: 11, offset: 5705},
+								pos:  position{line: 243, col: 11, offset: 5704},
 								name: "fieldRefDotOnly",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 243, col: 27, offset: 5721},
+							pos:   position{line: 243, col: 27, offset: 5720},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 243, col: 32, offset: 5726},
+								pos: position{line: 243, col: 32, offset: 5725},
 								expr: &actionExpr{
-									pos: position{line: 243, col: 33, offset: 5727},
+									pos: position{line: 243, col: 33, offset: 5726},
 									run: (*parser).callonfieldRefDotOnlyList7,
 									expr: &seqExpr{
-										pos: position{line: 243, col: 33, offset: 5727},
+										pos: position{line: 243, col: 33, offset: 5726},
 										exprs: []interface{}{
 											&zeroOrOneExpr{
-												pos: position{line: 243, col: 33, offset: 5727},
+												pos: position{line: 243, col: 33, offset: 5726},
 												expr: &ruleRefExpr{
-													pos:  position{line: 243, col: 33, offset: 5727},
+													pos:  position{line: 243, col: 33, offset: 5726},
 													name: "_",
 												},
 											},
 											&litMatcher{
-												pos:        position{line: 243, col: 36, offset: 5730},
+												pos:        position{line: 243, col: 36, offset: 5729},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 243, col: 40, offset: 5734},
+												pos: position{line: 243, col: 40, offset: 5733},
 												expr: &ruleRefExpr{
-													pos:  position{line: 243, col: 40, offset: 5734},
+													pos:  position{line: 243, col: 40, offset: 5733},
 													name: "_",
 												},
 											},
 											&labeledExpr{
-												pos:   position{line: 243, col: 43, offset: 5737},
+												pos:   position{line: 243, col: 43, offset: 5736},
 												label: "ref",
 												expr: &ruleRefExpr{
-													pos:  position{line: 243, col: 47, offset: 5741},
+													pos:  position{line: 243, col: 47, offset: 5740},
 													name: "fieldRefDotOnly",
 												},
 											},
@@ -1836,50 +1836,50 @@ var g = &grammar{
 		},
 		{
 			name: "fieldNameList",
-			pos:  position{line: 251, col: 1, offset: 5921},
+			pos:  position{line: 251, col: 1, offset: 5920},
 			expr: &actionExpr{
-				pos: position{line: 252, col: 5, offset: 5939},
+				pos: position{line: 252, col: 5, offset: 5938},
 				run: (*parser).callonfieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 252, col: 5, offset: 5939},
+					pos: position{line: 252, col: 5, offset: 5938},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 252, col: 5, offset: 5939},
+							pos:   position{line: 252, col: 5, offset: 5938},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 252, col: 11, offset: 5945},
+								pos:  position{line: 252, col: 11, offset: 5944},
 								name: "fieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 252, col: 21, offset: 5955},
+							pos:   position{line: 252, col: 21, offset: 5954},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 252, col: 26, offset: 5960},
+								pos: position{line: 252, col: 26, offset: 5959},
 								expr: &seqExpr{
-									pos: position{line: 252, col: 27, offset: 5961},
+									pos: position{line: 252, col: 27, offset: 5960},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 252, col: 27, offset: 5961},
+											pos: position{line: 252, col: 27, offset: 5960},
 											expr: &ruleRefExpr{
-												pos:  position{line: 252, col: 27, offset: 5961},
+												pos:  position{line: 252, col: 27, offset: 5960},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 252, col: 30, offset: 5964},
+											pos:        position{line: 252, col: 30, offset: 5963},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 252, col: 34, offset: 5968},
+											pos: position{line: 252, col: 34, offset: 5967},
 											expr: &ruleRefExpr{
-												pos:  position{line: 252, col: 34, offset: 5968},
+												pos:  position{line: 252, col: 34, offset: 5967},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 252, col: 37, offset: 5971},
+											pos:  position{line: 252, col: 37, offset: 5970},
 											name: "fieldName",
 										},
 									},
@@ -1892,12 +1892,12 @@ var g = &grammar{
 		},
 		{
 			name: "countOp",
-			pos:  position{line: 260, col: 1, offset: 6164},
+			pos:  position{line: 260, col: 1, offset: 6163},
 			expr: &actionExpr{
-				pos: position{line: 261, col: 5, offset: 6176},
+				pos: position{line: 261, col: 5, offset: 6175},
 				run: (*parser).calloncountOp1,
 				expr: &litMatcher{
-					pos:        position{line: 261, col: 5, offset: 6176},
+					pos:        position{line: 261, col: 5, offset: 6175},
 					val:        "count",
 					ignoreCase: true,
 				},
@@ -1905,105 +1905,105 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReducerOp",
-			pos:  position{line: 263, col: 1, offset: 6210},
+			pos:  position{line: 263, col: 1, offset: 6209},
 			expr: &choiceExpr{
-				pos: position{line: 264, col: 5, offset: 6229},
+				pos: position{line: 264, col: 5, offset: 6228},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 264, col: 5, offset: 6229},
+						pos: position{line: 264, col: 5, offset: 6228},
 						run: (*parser).callonfieldReducerOp2,
 						expr: &litMatcher{
-							pos:        position{line: 264, col: 5, offset: 6229},
+							pos:        position{line: 264, col: 5, offset: 6228},
 							val:        "sum",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 265, col: 5, offset: 6263},
+						pos: position{line: 265, col: 5, offset: 6262},
 						run: (*parser).callonfieldReducerOp4,
 						expr: &litMatcher{
-							pos:        position{line: 265, col: 5, offset: 6263},
+							pos:        position{line: 265, col: 5, offset: 6262},
 							val:        "avg",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 266, col: 5, offset: 6297},
+						pos: position{line: 266, col: 5, offset: 6296},
 						run: (*parser).callonfieldReducerOp6,
 						expr: &litMatcher{
-							pos:        position{line: 266, col: 5, offset: 6297},
+							pos:        position{line: 266, col: 5, offset: 6296},
 							val:        "stdev",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 267, col: 5, offset: 6334},
+						pos: position{line: 267, col: 5, offset: 6333},
 						run: (*parser).callonfieldReducerOp8,
 						expr: &litMatcher{
-							pos:        position{line: 267, col: 5, offset: 6334},
+							pos:        position{line: 267, col: 5, offset: 6333},
 							val:        "sd",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 268, col: 5, offset: 6370},
+						pos: position{line: 268, col: 5, offset: 6369},
 						run: (*parser).callonfieldReducerOp10,
 						expr: &litMatcher{
-							pos:        position{line: 268, col: 5, offset: 6370},
+							pos:        position{line: 268, col: 5, offset: 6369},
 							val:        "var",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 269, col: 5, offset: 6404},
+						pos: position{line: 269, col: 5, offset: 6403},
 						run: (*parser).callonfieldReducerOp12,
 						expr: &litMatcher{
-							pos:        position{line: 269, col: 5, offset: 6404},
+							pos:        position{line: 269, col: 5, offset: 6403},
 							val:        "entropy",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 270, col: 5, offset: 6445},
+						pos: position{line: 270, col: 5, offset: 6444},
 						run: (*parser).callonfieldReducerOp14,
 						expr: &litMatcher{
-							pos:        position{line: 270, col: 5, offset: 6445},
+							pos:        position{line: 270, col: 5, offset: 6444},
 							val:        "min",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 271, col: 5, offset: 6479},
+						pos: position{line: 271, col: 5, offset: 6478},
 						run: (*parser).callonfieldReducerOp16,
 						expr: &litMatcher{
-							pos:        position{line: 271, col: 5, offset: 6479},
+							pos:        position{line: 271, col: 5, offset: 6478},
 							val:        "max",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 272, col: 5, offset: 6513},
+						pos: position{line: 272, col: 5, offset: 6512},
 						run: (*parser).callonfieldReducerOp18,
 						expr: &litMatcher{
-							pos:        position{line: 272, col: 5, offset: 6513},
+							pos:        position{line: 272, col: 5, offset: 6512},
 							val:        "first",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 273, col: 5, offset: 6551},
+						pos: position{line: 273, col: 5, offset: 6550},
 						run: (*parser).callonfieldReducerOp20,
 						expr: &litMatcher{
-							pos:        position{line: 273, col: 5, offset: 6551},
+							pos:        position{line: 273, col: 5, offset: 6550},
 							val:        "last",
 							ignoreCase: true,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 274, col: 5, offset: 6587},
+						pos: position{line: 274, col: 5, offset: 6586},
 						run: (*parser).callonfieldReducerOp22,
 						expr: &litMatcher{
-							pos:        position{line: 274, col: 5, offset: 6587},
+							pos:        position{line: 274, col: 5, offset: 6586},
 							val:        "countdistinct",
 							ignoreCase: true,
 						},
@@ -2013,32 +2013,32 @@ var g = &grammar{
 		},
 		{
 			name: "paddedFieldExpr",
-			pos:  position{line: 276, col: 1, offset: 6637},
+			pos:  position{line: 276, col: 1, offset: 6636},
 			expr: &actionExpr{
-				pos: position{line: 276, col: 19, offset: 6655},
+				pos: position{line: 276, col: 19, offset: 6654},
 				run: (*parser).callonpaddedFieldExpr1,
 				expr: &seqExpr{
-					pos: position{line: 276, col: 19, offset: 6655},
+					pos: position{line: 276, col: 19, offset: 6654},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 276, col: 19, offset: 6655},
+							pos: position{line: 276, col: 19, offset: 6654},
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 19, offset: 6655},
+								pos:  position{line: 276, col: 19, offset: 6654},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 276, col: 22, offset: 6658},
+							pos:   position{line: 276, col: 22, offset: 6657},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 28, offset: 6664},
+								pos:  position{line: 276, col: 28, offset: 6663},
 								name: "fieldExpr",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 276, col: 38, offset: 6674},
+							pos: position{line: 276, col: 38, offset: 6673},
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 38, offset: 6674},
+								pos:  position{line: 276, col: 38, offset: 6673},
 								name: "_",
 							},
 						},
@@ -2048,53 +2048,53 @@ var g = &grammar{
 		},
 		{
 			name: "countReducer",
-			pos:  position{line: 278, col: 1, offset: 6700},
+			pos:  position{line: 278, col: 1, offset: 6699},
 			expr: &actionExpr{
-				pos: position{line: 279, col: 5, offset: 6717},
+				pos: position{line: 279, col: 5, offset: 6716},
 				run: (*parser).calloncountReducer1,
 				expr: &seqExpr{
-					pos: position{line: 279, col: 5, offset: 6717},
+					pos: position{line: 279, col: 5, offset: 6716},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 279, col: 5, offset: 6717},
+							pos:   position{line: 279, col: 5, offset: 6716},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 8, offset: 6720},
+								pos:  position{line: 279, col: 8, offset: 6719},
 								name: "countOp",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 279, col: 16, offset: 6728},
+							pos: position{line: 279, col: 16, offset: 6727},
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 16, offset: 6728},
+								pos:  position{line: 279, col: 16, offset: 6727},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 279, col: 19, offset: 6731},
+							pos:        position{line: 279, col: 19, offset: 6730},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 279, col: 23, offset: 6735},
+							pos:   position{line: 279, col: 23, offset: 6734},
 							label: "field",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 279, col: 29, offset: 6741},
+								pos: position{line: 279, col: 29, offset: 6740},
 								expr: &ruleRefExpr{
-									pos:  position{line: 279, col: 29, offset: 6741},
+									pos:  position{line: 279, col: 29, offset: 6740},
 									name: "paddedFieldExpr",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 279, col: 47, offset: 6759},
+							pos: position{line: 279, col: 47, offset: 6758},
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 47, offset: 6759},
+								pos:  position{line: 279, col: 47, offset: 6758},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 279, col: 50, offset: 6762},
+							pos:        position{line: 279, col: 50, offset: 6761},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2104,57 +2104,57 @@ var g = &grammar{
 		},
 		{
 			name: "fieldReducer",
-			pos:  position{line: 283, col: 1, offset: 6821},
+			pos:  position{line: 283, col: 1, offset: 6820},
 			expr: &actionExpr{
-				pos: position{line: 284, col: 5, offset: 6838},
+				pos: position{line: 284, col: 5, offset: 6837},
 				run: (*parser).callonfieldReducer1,
 				expr: &seqExpr{
-					pos: position{line: 284, col: 5, offset: 6838},
+					pos: position{line: 284, col: 5, offset: 6837},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 284, col: 5, offset: 6838},
+							pos:   position{line: 284, col: 5, offset: 6837},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 8, offset: 6841},
+								pos:  position{line: 284, col: 8, offset: 6840},
 								name: "fieldReducerOp",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 284, col: 23, offset: 6856},
+							pos: position{line: 284, col: 23, offset: 6855},
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 23, offset: 6856},
+								pos:  position{line: 284, col: 23, offset: 6855},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 284, col: 26, offset: 6859},
+							pos:        position{line: 284, col: 26, offset: 6858},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 284, col: 30, offset: 6863},
+							pos: position{line: 284, col: 30, offset: 6862},
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 30, offset: 6863},
+								pos:  position{line: 284, col: 30, offset: 6862},
 								name: "_",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 284, col: 33, offset: 6866},
+							pos:   position{line: 284, col: 33, offset: 6865},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 39, offset: 6872},
+								pos:  position{line: 284, col: 39, offset: 6871},
 								name: "fieldExpr",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 284, col: 50, offset: 6883},
+							pos: position{line: 284, col: 50, offset: 6882},
 							expr: &ruleRefExpr{
-								pos:  position{line: 284, col: 50, offset: 6883},
+								pos:  position{line: 284, col: 50, offset: 6882},
 								name: "_",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 284, col: 53, offset: 6886},
+							pos:        position{line: 284, col: 53, offset: 6885},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -2163,28 +2163,28 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "reducerProc",
-			pos:  position{line: 288, col: 1, offset: 6953},
+			name: "reduceProc",
+			pos:  position{line: 288, col: 1, offset: 6952},
 			expr: &actionExpr{
-				pos: position{line: 289, col: 5, offset: 6969},
-				run: (*parser).callonreducerProc1,
+				pos: position{line: 289, col: 5, offset: 6967},
+				run: (*parser).callonreduceProc1,
 				expr: &seqExpr{
-					pos: position{line: 289, col: 5, offset: 6969},
+					pos: position{line: 289, col: 5, offset: 6967},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 289, col: 5, offset: 6969},
+							pos:   position{line: 289, col: 5, offset: 6967},
 							label: "every",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 289, col: 11, offset: 6975},
+								pos: position{line: 289, col: 11, offset: 6973},
 								expr: &seqExpr{
-									pos: position{line: 289, col: 12, offset: 6976},
+									pos: position{line: 289, col: 12, offset: 6974},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 289, col: 12, offset: 6976},
+											pos:  position{line: 289, col: 12, offset: 6974},
 											name: "everyDur",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 289, col: 21, offset: 6985},
+											pos:  position{line: 289, col: 21, offset: 6983},
 											name: "_",
 										},
 									},
@@ -2192,27 +2192,27 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 289, col: 25, offset: 6989},
+							pos:   position{line: 289, col: 25, offset: 6987},
 							label: "reducers",
 							expr: &ruleRefExpr{
-								pos:  position{line: 289, col: 34, offset: 6998},
+								pos:  position{line: 289, col: 34, offset: 6996},
 								name: "reducerList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 289, col: 46, offset: 7010},
+							pos:   position{line: 289, col: 46, offset: 7008},
 							label: "keys",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 289, col: 51, offset: 7015},
+								pos: position{line: 289, col: 51, offset: 7013},
 								expr: &seqExpr{
-									pos: position{line: 289, col: 52, offset: 7016},
+									pos: position{line: 289, col: 52, offset: 7014},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 289, col: 52, offset: 7016},
+											pos:  position{line: 289, col: 52, offset: 7014},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 289, col: 54, offset: 7018},
+											pos:  position{line: 289, col: 54, offset: 7016},
 											name: "groupByKeys",
 										},
 									},
@@ -2220,12 +2220,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 289, col: 68, offset: 7032},
+							pos:   position{line: 289, col: 68, offset: 7030},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 289, col: 74, offset: 7038},
+								pos: position{line: 289, col: 74, offset: 7036},
 								expr: &ruleRefExpr{
-									pos:  position{line: 289, col: 74, offset: 7038},
+									pos:  position{line: 289, col: 74, offset: 7036},
 									name: "procLimitArg",
 								},
 							},
@@ -2236,27 +2236,27 @@ var g = &grammar{
 		},
 		{
 			name: "asClause",
-			pos:  position{line: 307, col: 1, offset: 7395},
+			pos:  position{line: 307, col: 1, offset: 7392},
 			expr: &actionExpr{
-				pos: position{line: 308, col: 5, offset: 7408},
+				pos: position{line: 308, col: 5, offset: 7405},
 				run: (*parser).callonasClause1,
 				expr: &seqExpr{
-					pos: position{line: 308, col: 5, offset: 7408},
+					pos: position{line: 308, col: 5, offset: 7405},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 308, col: 5, offset: 7408},
+							pos:        position{line: 308, col: 5, offset: 7405},
 							val:        "as",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 308, col: 11, offset: 7414},
+							pos:  position{line: 308, col: 11, offset: 7411},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 308, col: 13, offset: 7416},
+							pos:   position{line: 308, col: 13, offset: 7413},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 308, col: 15, offset: 7418},
+								pos:  position{line: 308, col: 15, offset: 7415},
 								name: "fieldName",
 							},
 						},
@@ -2266,48 +2266,48 @@ var g = &grammar{
 		},
 		{
 			name: "reducerExpr",
-			pos:  position{line: 310, col: 1, offset: 7447},
+			pos:  position{line: 310, col: 1, offset: 7444},
 			expr: &choiceExpr{
-				pos: position{line: 311, col: 5, offset: 7463},
+				pos: position{line: 311, col: 5, offset: 7460},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 311, col: 5, offset: 7463},
+						pos: position{line: 311, col: 5, offset: 7460},
 						run: (*parser).callonreducerExpr2,
 						expr: &seqExpr{
-							pos: position{line: 311, col: 5, offset: 7463},
+							pos: position{line: 311, col: 5, offset: 7460},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 311, col: 5, offset: 7463},
+									pos:   position{line: 311, col: 5, offset: 7460},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 311, col: 11, offset: 7469},
+										pos:  position{line: 311, col: 11, offset: 7466},
 										name: "fieldExpr",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 311, col: 21, offset: 7479},
+									pos: position{line: 311, col: 21, offset: 7476},
 									expr: &ruleRefExpr{
-										pos:  position{line: 311, col: 21, offset: 7479},
+										pos:  position{line: 311, col: 21, offset: 7476},
 										name: "_",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 311, col: 24, offset: 7482},
+									pos:        position{line: 311, col: 24, offset: 7479},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 311, col: 28, offset: 7486},
+									pos: position{line: 311, col: 28, offset: 7483},
 									expr: &ruleRefExpr{
-										pos:  position{line: 311, col: 28, offset: 7486},
+										pos:  position{line: 311, col: 28, offset: 7483},
 										name: "_",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 311, col: 31, offset: 7489},
+									pos:   position{line: 311, col: 31, offset: 7486},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 311, col: 33, offset: 7491},
+										pos:  position{line: 311, col: 33, offset: 7488},
 										name: "reducer",
 									},
 								},
@@ -2315,28 +2315,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 314, col: 5, offset: 7554},
+						pos: position{line: 314, col: 5, offset: 7551},
 						run: (*parser).callonreducerExpr13,
 						expr: &seqExpr{
-							pos: position{line: 314, col: 5, offset: 7554},
+							pos: position{line: 314, col: 5, offset: 7551},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 314, col: 5, offset: 7554},
+									pos:   position{line: 314, col: 5, offset: 7551},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 314, col: 7, offset: 7556},
+										pos:  position{line: 314, col: 7, offset: 7553},
 										name: "reducer",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 314, col: 15, offset: 7564},
+									pos:  position{line: 314, col: 15, offset: 7561},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 314, col: 17, offset: 7566},
+									pos:   position{line: 314, col: 17, offset: 7563},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 314, col: 23, offset: 7572},
+										pos:  position{line: 314, col: 23, offset: 7569},
 										name: "asClause",
 									},
 								},
@@ -2344,7 +2344,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 5, offset: 7636},
+						pos:  position{line: 317, col: 5, offset: 7633},
 						name: "reducer",
 					},
 				},
@@ -2352,16 +2352,16 @@ var g = &grammar{
 		},
 		{
 			name: "reducer",
-			pos:  position{line: 319, col: 1, offset: 7645},
+			pos:  position{line: 319, col: 1, offset: 7642},
 			expr: &choiceExpr{
-				pos: position{line: 320, col: 5, offset: 7657},
+				pos: position{line: 320, col: 5, offset: 7654},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 5, offset: 7657},
+						pos:  position{line: 320, col: 5, offset: 7654},
 						name: "countReducer",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 321, col: 5, offset: 7674},
+						pos:  position{line: 321, col: 5, offset: 7671},
 						name: "fieldReducer",
 					},
 				},
@@ -2369,50 +2369,50 @@ var g = &grammar{
 		},
 		{
 			name: "reducerList",
-			pos:  position{line: 323, col: 1, offset: 7688},
+			pos:  position{line: 323, col: 1, offset: 7685},
 			expr: &actionExpr{
-				pos: position{line: 324, col: 5, offset: 7704},
+				pos: position{line: 324, col: 5, offset: 7701},
 				run: (*parser).callonreducerList1,
 				expr: &seqExpr{
-					pos: position{line: 324, col: 5, offset: 7704},
+					pos: position{line: 324, col: 5, offset: 7701},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 324, col: 5, offset: 7704},
+							pos:   position{line: 324, col: 5, offset: 7701},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 324, col: 11, offset: 7710},
+								pos:  position{line: 324, col: 11, offset: 7707},
 								name: "reducerExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 324, col: 23, offset: 7722},
+							pos:   position{line: 324, col: 23, offset: 7719},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 324, col: 28, offset: 7727},
+								pos: position{line: 324, col: 28, offset: 7724},
 								expr: &seqExpr{
-									pos: position{line: 324, col: 29, offset: 7728},
+									pos: position{line: 324, col: 29, offset: 7725},
 									exprs: []interface{}{
 										&zeroOrOneExpr{
-											pos: position{line: 324, col: 29, offset: 7728},
+											pos: position{line: 324, col: 29, offset: 7725},
 											expr: &ruleRefExpr{
-												pos:  position{line: 324, col: 29, offset: 7728},
+												pos:  position{line: 324, col: 29, offset: 7725},
 												name: "_",
 											},
 										},
 										&litMatcher{
-											pos:        position{line: 324, col: 32, offset: 7731},
+											pos:        position{line: 324, col: 32, offset: 7728},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 324, col: 36, offset: 7735},
+											pos: position{line: 324, col: 36, offset: 7732},
 											expr: &ruleRefExpr{
-												pos:  position{line: 324, col: 36, offset: 7735},
+												pos:  position{line: 324, col: 36, offset: 7732},
 												name: "_",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 324, col: 39, offset: 7738},
+											pos:  position{line: 324, col: 39, offset: 7735},
 											name: "reducerExpr",
 										},
 									},
@@ -2425,40 +2425,40 @@ var g = &grammar{
 		},
 		{
 			name: "simpleProc",
-			pos:  position{line: 332, col: 1, offset: 7935},
+			pos:  position{line: 332, col: 1, offset: 7932},
 			expr: &choiceExpr{
-				pos: position{line: 333, col: 5, offset: 7950},
+				pos: position{line: 333, col: 5, offset: 7947},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 333, col: 5, offset: 7950},
+						pos:  position{line: 333, col: 5, offset: 7947},
 						name: "sort",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 334, col: 5, offset: 7959},
+						pos:  position{line: 334, col: 5, offset: 7956},
 						name: "top",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 335, col: 5, offset: 7967},
+						pos:  position{line: 335, col: 5, offset: 7964},
 						name: "cut",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 336, col: 5, offset: 7975},
+						pos:  position{line: 336, col: 5, offset: 7972},
 						name: "head",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 337, col: 5, offset: 7984},
+						pos:  position{line: 337, col: 5, offset: 7981},
 						name: "tail",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 338, col: 5, offset: 7993},
+						pos:  position{line: 338, col: 5, offset: 7990},
 						name: "filter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 339, col: 5, offset: 8004},
+						pos:  position{line: 339, col: 5, offset: 8001},
 						name: "uniq",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 340, col: 5, offset: 8013},
+						pos:  position{line: 340, col: 5, offset: 8010},
 						name: "put",
 					},
 				},
@@ -2466,46 +2466,46 @@ var g = &grammar{
 		},
 		{
 			name: "sort",
-			pos:  position{line: 342, col: 1, offset: 8018},
+			pos:  position{line: 342, col: 1, offset: 8015},
 			expr: &actionExpr{
-				pos: position{line: 343, col: 5, offset: 8027},
+				pos: position{line: 343, col: 5, offset: 8024},
 				run: (*parser).callonsort1,
 				expr: &seqExpr{
-					pos: position{line: 343, col: 5, offset: 8027},
+					pos: position{line: 343, col: 5, offset: 8024},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 343, col: 5, offset: 8027},
+							pos:        position{line: 343, col: 5, offset: 8024},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 343, col: 13, offset: 8035},
+							pos:   position{line: 343, col: 13, offset: 8032},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 343, col: 18, offset: 8040},
+								pos:  position{line: 343, col: 18, offset: 8037},
 								name: "sortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 343, col: 27, offset: 8049},
+							pos:   position{line: 343, col: 27, offset: 8046},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 343, col: 32, offset: 8054},
+								pos: position{line: 343, col: 32, offset: 8051},
 								expr: &actionExpr{
-									pos: position{line: 343, col: 33, offset: 8055},
+									pos: position{line: 343, col: 33, offset: 8052},
 									run: (*parser).callonsort8,
 									expr: &seqExpr{
-										pos: position{line: 343, col: 33, offset: 8055},
+										pos: position{line: 343, col: 33, offset: 8052},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 343, col: 33, offset: 8055},
+												pos:  position{line: 343, col: 33, offset: 8052},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 343, col: 35, offset: 8057},
+												pos:   position{line: 343, col: 35, offset: 8054},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 343, col: 37, offset: 8059},
+													pos:  position{line: 343, col: 37, offset: 8056},
 													name: "fieldExprList",
 												},
 											},
@@ -2520,24 +2520,24 @@ var g = &grammar{
 		},
 		{
 			name: "sortArgs",
-			pos:  position{line: 347, col: 1, offset: 8136},
+			pos:  position{line: 347, col: 1, offset: 8133},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 347, col: 12, offset: 8147},
+				pos: position{line: 347, col: 12, offset: 8144},
 				expr: &actionExpr{
-					pos: position{line: 347, col: 13, offset: 8148},
+					pos: position{line: 347, col: 13, offset: 8145},
 					run: (*parser).callonsortArgs2,
 					expr: &seqExpr{
-						pos: position{line: 347, col: 13, offset: 8148},
+						pos: position{line: 347, col: 13, offset: 8145},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 347, col: 13, offset: 8148},
+								pos:  position{line: 347, col: 13, offset: 8145},
 								name: "_",
 							},
 							&labeledExpr{
-								pos:   position{line: 347, col: 15, offset: 8150},
+								pos:   position{line: 347, col: 15, offset: 8147},
 								label: "a",
 								expr: &ruleRefExpr{
-									pos:  position{line: 347, col: 17, offset: 8152},
+									pos:  position{line: 347, col: 17, offset: 8149},
 									name: "sortArg",
 								},
 							},
@@ -2548,50 +2548,50 @@ var g = &grammar{
 		},
 		{
 			name: "sortArg",
-			pos:  position{line: 349, col: 1, offset: 8181},
+			pos:  position{line: 349, col: 1, offset: 8178},
 			expr: &choiceExpr{
-				pos: position{line: 350, col: 5, offset: 8193},
+				pos: position{line: 350, col: 5, offset: 8190},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 350, col: 5, offset: 8193},
+						pos: position{line: 350, col: 5, offset: 8190},
 						run: (*parser).callonsortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 350, col: 5, offset: 8193},
+							pos:        position{line: 350, col: 5, offset: 8190},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 351, col: 5, offset: 8236},
+						pos: position{line: 351, col: 5, offset: 8233},
 						run: (*parser).callonsortArg4,
 						expr: &seqExpr{
-							pos: position{line: 351, col: 5, offset: 8236},
+							pos: position{line: 351, col: 5, offset: 8233},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 351, col: 5, offset: 8236},
+									pos:        position{line: 351, col: 5, offset: 8233},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 14, offset: 8245},
+									pos:  position{line: 351, col: 14, offset: 8242},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 351, col: 16, offset: 8247},
+									pos:   position{line: 351, col: 16, offset: 8244},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 351, col: 23, offset: 8254},
+										pos: position{line: 351, col: 23, offset: 8251},
 										run: (*parser).callonsortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 351, col: 24, offset: 8255},
+											pos: position{line: 351, col: 24, offset: 8252},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 351, col: 24, offset: 8255},
+													pos:        position{line: 351, col: 24, offset: 8252},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 351, col: 34, offset: 8265},
+													pos:        position{line: 351, col: 34, offset: 8262},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2607,38 +2607,38 @@ var g = &grammar{
 		},
 		{
 			name: "top",
-			pos:  position{line: 353, col: 1, offset: 8347},
+			pos:  position{line: 353, col: 1, offset: 8344},
 			expr: &actionExpr{
-				pos: position{line: 354, col: 5, offset: 8355},
+				pos: position{line: 354, col: 5, offset: 8352},
 				run: (*parser).callontop1,
 				expr: &seqExpr{
-					pos: position{line: 354, col: 5, offset: 8355},
+					pos: position{line: 354, col: 5, offset: 8352},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 354, col: 5, offset: 8355},
+							pos:        position{line: 354, col: 5, offset: 8352},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 12, offset: 8362},
+							pos:   position{line: 354, col: 12, offset: 8359},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 354, col: 18, offset: 8368},
+								pos: position{line: 354, col: 18, offset: 8365},
 								expr: &actionExpr{
-									pos: position{line: 354, col: 19, offset: 8369},
+									pos: position{line: 354, col: 19, offset: 8366},
 									run: (*parser).callontop6,
 									expr: &seqExpr{
-										pos: position{line: 354, col: 19, offset: 8369},
+										pos: position{line: 354, col: 19, offset: 8366},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 354, col: 19, offset: 8369},
+												pos:  position{line: 354, col: 19, offset: 8366},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 354, col: 21, offset: 8371},
+												pos:   position{line: 354, col: 21, offset: 8368},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 354, col: 23, offset: 8373},
+													pos:  position{line: 354, col: 23, offset: 8370},
 													name: "unsignedInteger",
 												},
 											},
@@ -2648,19 +2648,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 58, offset: 8408},
+							pos:   position{line: 354, col: 58, offset: 8405},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 354, col: 64, offset: 8414},
+								pos: position{line: 354, col: 64, offset: 8411},
 								expr: &seqExpr{
-									pos: position{line: 354, col: 65, offset: 8415},
+									pos: position{line: 354, col: 65, offset: 8412},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 354, col: 65, offset: 8415},
+											pos:  position{line: 354, col: 65, offset: 8412},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 354, col: 67, offset: 8417},
+											pos:        position{line: 354, col: 67, offset: 8414},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2669,25 +2669,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 78, offset: 8428},
+							pos:   position{line: 354, col: 78, offset: 8425},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 354, col: 83, offset: 8433},
+								pos: position{line: 354, col: 83, offset: 8430},
 								expr: &actionExpr{
-									pos: position{line: 354, col: 84, offset: 8434},
+									pos: position{line: 354, col: 84, offset: 8431},
 									run: (*parser).callontop18,
 									expr: &seqExpr{
-										pos: position{line: 354, col: 84, offset: 8434},
+										pos: position{line: 354, col: 84, offset: 8431},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 354, col: 84, offset: 8434},
+												pos:  position{line: 354, col: 84, offset: 8431},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 354, col: 86, offset: 8436},
+												pos:   position{line: 354, col: 86, offset: 8433},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 354, col: 88, offset: 8438},
+													pos:  position{line: 354, col: 88, offset: 8435},
 													name: "fieldExprList",
 												},
 											},
@@ -2702,31 +2702,31 @@ var g = &grammar{
 		},
 		{
 			name: "procLimitArg",
-			pos:  position{line: 358, col: 1, offset: 8527},
+			pos:  position{line: 358, col: 1, offset: 8524},
 			expr: &actionExpr{
-				pos: position{line: 359, col: 5, offset: 8544},
+				pos: position{line: 359, col: 5, offset: 8541},
 				run: (*parser).callonprocLimitArg1,
 				expr: &seqExpr{
-					pos: position{line: 359, col: 5, offset: 8544},
+					pos: position{line: 359, col: 5, offset: 8541},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 359, col: 5, offset: 8544},
+							pos:  position{line: 359, col: 5, offset: 8541},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 359, col: 7, offset: 8546},
+							pos:        position{line: 359, col: 7, offset: 8543},
 							val:        "-limit",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 359, col: 16, offset: 8555},
+							pos:  position{line: 359, col: 16, offset: 8552},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 359, col: 18, offset: 8557},
+							pos:   position{line: 359, col: 18, offset: 8554},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 359, col: 24, offset: 8563},
+								pos:  position{line: 359, col: 24, offset: 8560},
 								name: "unsignedInteger",
 							},
 						},
@@ -2736,21 +2736,21 @@ var g = &grammar{
 		},
 		{
 			name: "cutArg",
-			pos:  position{line: 361, col: 1, offset: 8602},
+			pos:  position{line: 361, col: 1, offset: 8599},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 361, col: 10, offset: 8611},
+				pos: position{line: 361, col: 10, offset: 8608},
 				expr: &actionExpr{
-					pos: position{line: 361, col: 11, offset: 8612},
+					pos: position{line: 361, col: 11, offset: 8609},
 					run: (*parser).calloncutArg2,
 					expr: &seqExpr{
-						pos: position{line: 361, col: 11, offset: 8612},
+						pos: position{line: 361, col: 11, offset: 8609},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 361, col: 11, offset: 8612},
+								pos:  position{line: 361, col: 11, offset: 8609},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 361, col: 13, offset: 8614},
+								pos:        position{line: 361, col: 13, offset: 8611},
 								val:        "-c",
 								ignoreCase: false,
 							},
@@ -2761,35 +2761,35 @@ var g = &grammar{
 		},
 		{
 			name: "cut",
-			pos:  position{line: 363, col: 1, offset: 8656},
+			pos:  position{line: 363, col: 1, offset: 8653},
 			expr: &actionExpr{
-				pos: position{line: 364, col: 5, offset: 8664},
+				pos: position{line: 364, col: 5, offset: 8661},
 				run: (*parser).calloncut1,
 				expr: &seqExpr{
-					pos: position{line: 364, col: 5, offset: 8664},
+					pos: position{line: 364, col: 5, offset: 8661},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 364, col: 5, offset: 8664},
+							pos:        position{line: 364, col: 5, offset: 8661},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 364, col: 12, offset: 8671},
+							pos:   position{line: 364, col: 12, offset: 8668},
 							label: "arg",
 							expr: &ruleRefExpr{
-								pos:  position{line: 364, col: 16, offset: 8675},
+								pos:  position{line: 364, col: 16, offset: 8672},
 								name: "cutArg",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 364, col: 23, offset: 8682},
+							pos:  position{line: 364, col: 23, offset: 8679},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 364, col: 25, offset: 8684},
+							pos:   position{line: 364, col: 25, offset: 8681},
 							label: "list",
 							expr: &ruleRefExpr{
-								pos:  position{line: 364, col: 30, offset: 8689},
+								pos:  position{line: 364, col: 30, offset: 8686},
 								name: "fieldRefDotOnlyList",
 							},
 						},
@@ -2799,30 +2799,30 @@ var g = &grammar{
 		},
 		{
 			name: "head",
-			pos:  position{line: 365, col: 1, offset: 8744},
+			pos:  position{line: 365, col: 1, offset: 8741},
 			expr: &choiceExpr{
-				pos: position{line: 366, col: 5, offset: 8753},
+				pos: position{line: 366, col: 5, offset: 8750},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 366, col: 5, offset: 8753},
+						pos: position{line: 366, col: 5, offset: 8750},
 						run: (*parser).callonhead2,
 						expr: &seqExpr{
-							pos: position{line: 366, col: 5, offset: 8753},
+							pos: position{line: 366, col: 5, offset: 8750},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 366, col: 5, offset: 8753},
+									pos:        position{line: 366, col: 5, offset: 8750},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 366, col: 13, offset: 8761},
+									pos:  position{line: 366, col: 13, offset: 8758},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 366, col: 15, offset: 8763},
+									pos:   position{line: 366, col: 15, offset: 8760},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 366, col: 21, offset: 8769},
+										pos:  position{line: 366, col: 21, offset: 8766},
 										name: "unsignedInteger",
 									},
 								},
@@ -2830,10 +2830,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 367, col: 5, offset: 8825},
+						pos: position{line: 367, col: 5, offset: 8822},
 						run: (*parser).callonhead8,
 						expr: &litMatcher{
-							pos:        position{line: 367, col: 5, offset: 8825},
+							pos:        position{line: 367, col: 5, offset: 8822},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2843,30 +2843,30 @@ var g = &grammar{
 		},
 		{
 			name: "tail",
-			pos:  position{line: 368, col: 1, offset: 8865},
+			pos:  position{line: 368, col: 1, offset: 8862},
 			expr: &choiceExpr{
-				pos: position{line: 369, col: 5, offset: 8874},
+				pos: position{line: 369, col: 5, offset: 8871},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 369, col: 5, offset: 8874},
+						pos: position{line: 369, col: 5, offset: 8871},
 						run: (*parser).callontail2,
 						expr: &seqExpr{
-							pos: position{line: 369, col: 5, offset: 8874},
+							pos: position{line: 369, col: 5, offset: 8871},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 369, col: 5, offset: 8874},
+									pos:        position{line: 369, col: 5, offset: 8871},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 369, col: 13, offset: 8882},
+									pos:  position{line: 369, col: 13, offset: 8879},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 369, col: 15, offset: 8884},
+									pos:   position{line: 369, col: 15, offset: 8881},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 369, col: 21, offset: 8890},
+										pos:  position{line: 369, col: 21, offset: 8887},
 										name: "unsignedInteger",
 									},
 								},
@@ -2874,10 +2874,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 370, col: 5, offset: 8946},
+						pos: position{line: 370, col: 5, offset: 8943},
 						run: (*parser).callontail8,
 						expr: &litMatcher{
-							pos:        position{line: 370, col: 5, offset: 8946},
+							pos:        position{line: 370, col: 5, offset: 8943},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2887,27 +2887,27 @@ var g = &grammar{
 		},
 		{
 			name: "filter",
-			pos:  position{line: 372, col: 1, offset: 8987},
+			pos:  position{line: 372, col: 1, offset: 8984},
 			expr: &actionExpr{
-				pos: position{line: 373, col: 5, offset: 8998},
+				pos: position{line: 373, col: 5, offset: 8995},
 				run: (*parser).callonfilter1,
 				expr: &seqExpr{
-					pos: position{line: 373, col: 5, offset: 8998},
+					pos: position{line: 373, col: 5, offset: 8995},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 373, col: 5, offset: 8998},
+							pos:        position{line: 373, col: 5, offset: 8995},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 373, col: 15, offset: 9008},
+							pos:  position{line: 373, col: 15, offset: 9005},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 373, col: 17, offset: 9010},
+							pos:   position{line: 373, col: 17, offset: 9007},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 373, col: 22, offset: 9015},
+								pos:  position{line: 373, col: 22, offset: 9012},
 								name: "searchExpr",
 							},
 						},
@@ -2917,27 +2917,27 @@ var g = &grammar{
 		},
 		{
 			name: "uniq",
-			pos:  position{line: 376, col: 1, offset: 9073},
+			pos:  position{line: 376, col: 1, offset: 9070},
 			expr: &choiceExpr{
-				pos: position{line: 377, col: 5, offset: 9082},
+				pos: position{line: 377, col: 5, offset: 9079},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 377, col: 5, offset: 9082},
+						pos: position{line: 377, col: 5, offset: 9079},
 						run: (*parser).callonuniq2,
 						expr: &seqExpr{
-							pos: position{line: 377, col: 5, offset: 9082},
+							pos: position{line: 377, col: 5, offset: 9079},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 377, col: 5, offset: 9082},
+									pos:        position{line: 377, col: 5, offset: 9079},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 377, col: 13, offset: 9090},
+									pos:  position{line: 377, col: 13, offset: 9087},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 377, col: 15, offset: 9092},
+									pos:        position{line: 377, col: 15, offset: 9089},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2945,10 +2945,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 380, col: 5, offset: 9146},
+						pos: position{line: 380, col: 5, offset: 9143},
 						run: (*parser).callonuniq7,
 						expr: &litMatcher{
-							pos:        position{line: 380, col: 5, offset: 9146},
+							pos:        position{line: 380, col: 5, offset: 9143},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2958,59 +2958,59 @@ var g = &grammar{
 		},
 		{
 			name: "put",
-			pos:  position{line: 384, col: 1, offset: 9201},
+			pos:  position{line: 384, col: 1, offset: 9198},
 			expr: &actionExpr{
-				pos: position{line: 385, col: 5, offset: 9209},
+				pos: position{line: 385, col: 5, offset: 9206},
 				run: (*parser).callonput1,
 				expr: &seqExpr{
-					pos: position{line: 385, col: 5, offset: 9209},
+					pos: position{line: 385, col: 5, offset: 9206},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 385, col: 5, offset: 9209},
+							pos:        position{line: 385, col: 5, offset: 9206},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 385, col: 12, offset: 9216},
+							pos:  position{line: 385, col: 12, offset: 9213},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 385, col: 14, offset: 9218},
+							pos:   position{line: 385, col: 14, offset: 9215},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 385, col: 20, offset: 9224},
+								pos:  position{line: 385, col: 20, offset: 9221},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 385, col: 31, offset: 9235},
+							pos:   position{line: 385, col: 31, offset: 9232},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 385, col: 36, offset: 9240},
+								pos: position{line: 385, col: 36, offset: 9237},
 								expr: &actionExpr{
-									pos: position{line: 385, col: 37, offset: 9241},
+									pos: position{line: 385, col: 37, offset: 9238},
 									run: (*parser).callonput9,
 									expr: &seqExpr{
-										pos: position{line: 385, col: 37, offset: 9241},
+										pos: position{line: 385, col: 37, offset: 9238},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 385, col: 37, offset: 9241},
+												pos:  position{line: 385, col: 37, offset: 9238},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 385, col: 40, offset: 9244},
+												pos:        position{line: 385, col: 40, offset: 9241},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 385, col: 44, offset: 9248},
+												pos:  position{line: 385, col: 44, offset: 9245},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 385, col: 47, offset: 9251},
+												pos:   position{line: 385, col: 47, offset: 9248},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 385, col: 50, offset: 9254},
+													pos:  position{line: 385, col: 50, offset: 9251},
 													name: "Assignment",
 												},
 											},
@@ -3025,39 +3025,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 389, col: 1, offset: 9338},
+			pos:  position{line: 389, col: 1, offset: 9335},
 			expr: &actionExpr{
-				pos: position{line: 390, col: 5, offset: 9353},
+				pos: position{line: 390, col: 5, offset: 9350},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 390, col: 5, offset: 9353},
+					pos: position{line: 390, col: 5, offset: 9350},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 390, col: 5, offset: 9353},
+							pos:   position{line: 390, col: 5, offset: 9350},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 390, col: 7, offset: 9355},
+								pos:  position{line: 390, col: 7, offset: 9352},
 								name: "fieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 390, col: 17, offset: 9365},
+							pos:  position{line: 390, col: 17, offset: 9362},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 390, col: 20, offset: 9368},
+							pos:        position{line: 390, col: 20, offset: 9365},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 390, col: 24, offset: 9372},
+							pos:  position{line: 390, col: 24, offset: 9369},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 390, col: 27, offset: 9375},
+							pos:   position{line: 390, col: 27, offset: 9372},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 390, col: 29, offset: 9377},
+								pos:  position{line: 390, col: 29, offset: 9374},
 								name: "Expression",
 							},
 						},
@@ -3067,79 +3067,79 @@ var g = &grammar{
 		},
 		{
 			name: "PrimaryExpression",
-			pos:  position{line: 394, col: 1, offset: 9436},
+			pos:  position{line: 394, col: 1, offset: 9433},
 			expr: &choiceExpr{
-				pos: position{line: 395, col: 5, offset: 9458},
+				pos: position{line: 395, col: 5, offset: 9455},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 395, col: 5, offset: 9458},
+						pos:  position{line: 395, col: 5, offset: 9455},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 396, col: 5, offset: 9476},
+						pos:  position{line: 396, col: 5, offset: 9473},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 397, col: 5, offset: 9494},
+						pos:  position{line: 397, col: 5, offset: 9491},
 						name: "PortLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 398, col: 5, offset: 9510},
+						pos:  position{line: 398, col: 5, offset: 9507},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 399, col: 5, offset: 9528},
+						pos:  position{line: 399, col: 5, offset: 9525},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 400, col: 5, offset: 9547},
+						pos:  position{line: 400, col: 5, offset: 9544},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 401, col: 5, offset: 9564},
+						pos:  position{line: 401, col: 5, offset: 9561},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 402, col: 5, offset: 9583},
+						pos:  position{line: 402, col: 5, offset: 9580},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 403, col: 5, offset: 9602},
+						pos:  position{line: 403, col: 5, offset: 9599},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 404, col: 5, offset: 9618},
+						pos:  position{line: 404, col: 5, offset: 9615},
 						name: "FieldReference",
 					},
 					&actionExpr{
-						pos: position{line: 405, col: 5, offset: 9637},
+						pos: position{line: 405, col: 5, offset: 9634},
 						run: (*parser).callonPrimaryExpression12,
 						expr: &seqExpr{
-							pos: position{line: 405, col: 5, offset: 9637},
+							pos: position{line: 405, col: 5, offset: 9634},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 405, col: 5, offset: 9637},
+									pos:        position{line: 405, col: 5, offset: 9634},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 405, col: 9, offset: 9641},
+									pos:  position{line: 405, col: 9, offset: 9638},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 405, col: 12, offset: 9644},
+									pos:   position{line: 405, col: 12, offset: 9641},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 405, col: 17, offset: 9649},
+										pos:  position{line: 405, col: 17, offset: 9646},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 405, col: 28, offset: 9660},
+									pos:  position{line: 405, col: 28, offset: 9657},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 405, col: 31, offset: 9663},
+									pos:        position{line: 405, col: 31, offset: 9660},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3151,15 +3151,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldReference",
-			pos:  position{line: 407, col: 1, offset: 9689},
+			pos:  position{line: 407, col: 1, offset: 9686},
 			expr: &actionExpr{
-				pos: position{line: 408, col: 5, offset: 9708},
+				pos: position{line: 408, col: 5, offset: 9705},
 				run: (*parser).callonFieldReference1,
 				expr: &labeledExpr{
-					pos:   position{line: 408, col: 5, offset: 9708},
+					pos:   position{line: 408, col: 5, offset: 9705},
 					label: "f",
 					expr: &ruleRefExpr{
-						pos:  position{line: 408, col: 7, offset: 9710},
+						pos:  position{line: 408, col: 7, offset: 9707},
 						name: "fieldName",
 					},
 				},
@@ -3167,71 +3167,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expression",
-			pos:  position{line: 418, col: 1, offset: 9959},
+			pos:  position{line: 418, col: 1, offset: 9956},
 			expr: &ruleRefExpr{
-				pos:  position{line: 418, col: 14, offset: 9972},
+				pos:  position{line: 418, col: 14, offset: 9969},
 				name: "ConditionalExpression",
 			},
 		},
 		{
 			name: "ConditionalExpression",
-			pos:  position{line: 420, col: 1, offset: 9995},
+			pos:  position{line: 420, col: 1, offset: 9992},
 			expr: &choiceExpr{
-				pos: position{line: 421, col: 5, offset: 10021},
+				pos: position{line: 421, col: 5, offset: 10018},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 421, col: 5, offset: 10021},
+						pos: position{line: 421, col: 5, offset: 10018},
 						run: (*parser).callonConditionalExpression2,
 						expr: &seqExpr{
-							pos: position{line: 421, col: 5, offset: 10021},
+							pos: position{line: 421, col: 5, offset: 10018},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 421, col: 5, offset: 10021},
+									pos:   position{line: 421, col: 5, offset: 10018},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 421, col: 15, offset: 10031},
+										pos:  position{line: 421, col: 15, offset: 10028},
 										name: "LogicalORExpression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 421, col: 35, offset: 10051},
+									pos:  position{line: 421, col: 35, offset: 10048},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 421, col: 38, offset: 10054},
+									pos:        position{line: 421, col: 38, offset: 10051},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 421, col: 42, offset: 10058},
+									pos:  position{line: 421, col: 42, offset: 10055},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 421, col: 45, offset: 10061},
+									pos:   position{line: 421, col: 45, offset: 10058},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 421, col: 56, offset: 10072},
+										pos:  position{line: 421, col: 56, offset: 10069},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 421, col: 67, offset: 10083},
+									pos:  position{line: 421, col: 67, offset: 10080},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 421, col: 70, offset: 10086},
+									pos:        position{line: 421, col: 70, offset: 10083},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 421, col: 74, offset: 10090},
+									pos:  position{line: 421, col: 74, offset: 10087},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 421, col: 77, offset: 10093},
+									pos:   position{line: 421, col: 77, offset: 10090},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 421, col: 88, offset: 10104},
+										pos:  position{line: 421, col: 88, offset: 10101},
 										name: "Expression",
 									},
 								},
@@ -3239,7 +3239,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 424, col: 5, offset: 10196},
+						pos:  position{line: 424, col: 5, offset: 10193},
 						name: "LogicalORExpression",
 					},
 				},
@@ -3247,43 +3247,43 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalORExpression",
-			pos:  position{line: 426, col: 1, offset: 10217},
+			pos:  position{line: 426, col: 1, offset: 10214},
 			expr: &actionExpr{
-				pos: position{line: 427, col: 5, offset: 10241},
+				pos: position{line: 427, col: 5, offset: 10238},
 				run: (*parser).callonLogicalORExpression1,
 				expr: &seqExpr{
-					pos: position{line: 427, col: 5, offset: 10241},
+					pos: position{line: 427, col: 5, offset: 10238},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 427, col: 5, offset: 10241},
+							pos:   position{line: 427, col: 5, offset: 10238},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 427, col: 11, offset: 10247},
+								pos:  position{line: 427, col: 11, offset: 10244},
 								name: "LogicalANDExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 428, col: 5, offset: 10272},
+							pos:   position{line: 428, col: 5, offset: 10269},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 428, col: 10, offset: 10277},
+								pos: position{line: 428, col: 10, offset: 10274},
 								expr: &seqExpr{
-									pos: position{line: 428, col: 11, offset: 10278},
+									pos: position{line: 428, col: 11, offset: 10275},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 11, offset: 10278},
+											pos:  position{line: 428, col: 11, offset: 10275},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 14, offset: 10281},
+											pos:  position{line: 428, col: 14, offset: 10278},
 											name: "orToken",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 22, offset: 10289},
+											pos:  position{line: 428, col: 22, offset: 10286},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 428, col: 25, offset: 10292},
+											pos:  position{line: 428, col: 25, offset: 10289},
 											name: "LogicalANDExpression",
 										},
 									},
@@ -3296,43 +3296,43 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalANDExpression",
-			pos:  position{line: 432, col: 1, offset: 10377},
+			pos:  position{line: 432, col: 1, offset: 10374},
 			expr: &actionExpr{
-				pos: position{line: 433, col: 5, offset: 10402},
+				pos: position{line: 433, col: 5, offset: 10399},
 				run: (*parser).callonLogicalANDExpression1,
 				expr: &seqExpr{
-					pos: position{line: 433, col: 5, offset: 10402},
+					pos: position{line: 433, col: 5, offset: 10399},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 433, col: 5, offset: 10402},
+							pos:   position{line: 433, col: 5, offset: 10399},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 433, col: 11, offset: 10408},
+								pos:  position{line: 433, col: 11, offset: 10405},
 								name: "EqualityCompareExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 434, col: 5, offset: 10438},
+							pos:   position{line: 434, col: 5, offset: 10435},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 434, col: 10, offset: 10443},
+								pos: position{line: 434, col: 10, offset: 10440},
 								expr: &seqExpr{
-									pos: position{line: 434, col: 11, offset: 10444},
+									pos: position{line: 434, col: 11, offset: 10441},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 434, col: 11, offset: 10444},
+											pos:  position{line: 434, col: 11, offset: 10441},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 434, col: 14, offset: 10447},
+											pos:  position{line: 434, col: 14, offset: 10444},
 											name: "andToken",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 434, col: 23, offset: 10456},
+											pos:  position{line: 434, col: 23, offset: 10453},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 434, col: 26, offset: 10459},
+											pos:  position{line: 434, col: 26, offset: 10456},
 											name: "EqualityCompareExpression",
 										},
 									},
@@ -3345,43 +3345,43 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpression",
-			pos:  position{line: 438, col: 1, offset: 10549},
+			pos:  position{line: 438, col: 1, offset: 10546},
 			expr: &actionExpr{
-				pos: position{line: 439, col: 5, offset: 10579},
+				pos: position{line: 439, col: 5, offset: 10576},
 				run: (*parser).callonEqualityCompareExpression1,
 				expr: &seqExpr{
-					pos: position{line: 439, col: 5, offset: 10579},
+					pos: position{line: 439, col: 5, offset: 10576},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 439, col: 5, offset: 10579},
+							pos:   position{line: 439, col: 5, offset: 10576},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 439, col: 11, offset: 10585},
+								pos:  position{line: 439, col: 11, offset: 10582},
 								name: "RelativeExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 5, offset: 10608},
+							pos:   position{line: 440, col: 5, offset: 10605},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 440, col: 10, offset: 10613},
+								pos: position{line: 440, col: 10, offset: 10610},
 								expr: &seqExpr{
-									pos: position{line: 440, col: 11, offset: 10614},
+									pos: position{line: 440, col: 11, offset: 10611},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 11, offset: 10614},
+											pos:  position{line: 440, col: 11, offset: 10611},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 14, offset: 10617},
+											pos:  position{line: 440, col: 14, offset: 10614},
 											name: "EqualityComparator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 33, offset: 10636},
+											pos:  position{line: 440, col: 33, offset: 10633},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 440, col: 36, offset: 10639},
+											pos:  position{line: 440, col: 36, offset: 10636},
 											name: "RelativeExpression",
 										},
 									},
@@ -3394,30 +3394,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 444, col: 1, offset: 10722},
+			pos:  position{line: 444, col: 1, offset: 10719},
 			expr: &actionExpr{
-				pos: position{line: 444, col: 20, offset: 10741},
+				pos: position{line: 444, col: 20, offset: 10738},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 444, col: 21, offset: 10742},
+					pos: position{line: 444, col: 21, offset: 10739},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 444, col: 21, offset: 10742},
+							pos:        position{line: 444, col: 21, offset: 10739},
 							val:        "=~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 28, offset: 10749},
+							pos:        position{line: 444, col: 28, offset: 10746},
 							val:        "!~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 35, offset: 10756},
+							pos:        position{line: 444, col: 35, offset: 10753},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 41, offset: 10762},
+							pos:        position{line: 444, col: 41, offset: 10759},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3427,19 +3427,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 446, col: 1, offset: 10800},
+			pos:  position{line: 446, col: 1, offset: 10797},
 			expr: &choiceExpr{
-				pos: position{line: 447, col: 5, offset: 10823},
+				pos: position{line: 447, col: 5, offset: 10820},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 447, col: 5, offset: 10823},
+						pos:  position{line: 447, col: 5, offset: 10820},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 448, col: 5, offset: 10844},
+						pos: position{line: 448, col: 5, offset: 10841},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 448, col: 5, offset: 10844},
+							pos:        position{line: 448, col: 5, offset: 10841},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3449,43 +3449,43 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpression",
-			pos:  position{line: 450, col: 1, offset: 10881},
+			pos:  position{line: 450, col: 1, offset: 10878},
 			expr: &actionExpr{
-				pos: position{line: 451, col: 5, offset: 10904},
+				pos: position{line: 451, col: 5, offset: 10901},
 				run: (*parser).callonRelativeExpression1,
 				expr: &seqExpr{
-					pos: position{line: 451, col: 5, offset: 10904},
+					pos: position{line: 451, col: 5, offset: 10901},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 451, col: 5, offset: 10904},
+							pos:   position{line: 451, col: 5, offset: 10901},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 451, col: 11, offset: 10910},
+								pos:  position{line: 451, col: 11, offset: 10907},
 								name: "AdditiveExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 452, col: 5, offset: 10933},
+							pos:   position{line: 452, col: 5, offset: 10930},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 452, col: 10, offset: 10938},
+								pos: position{line: 452, col: 10, offset: 10935},
 								expr: &seqExpr{
-									pos: position{line: 452, col: 11, offset: 10939},
+									pos: position{line: 452, col: 11, offset: 10936},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 11, offset: 10939},
+											pos:  position{line: 452, col: 11, offset: 10936},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 14, offset: 10942},
+											pos:  position{line: 452, col: 14, offset: 10939},
 											name: "RelativeOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 31, offset: 10959},
+											pos:  position{line: 452, col: 31, offset: 10956},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 452, col: 34, offset: 10962},
+											pos:  position{line: 452, col: 34, offset: 10959},
 											name: "AdditiveExpression",
 										},
 									},
@@ -3498,30 +3498,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 456, col: 1, offset: 11045},
+			pos:  position{line: 456, col: 1, offset: 11042},
 			expr: &actionExpr{
-				pos: position{line: 456, col: 20, offset: 11064},
+				pos: position{line: 456, col: 20, offset: 11061},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 456, col: 21, offset: 11065},
+					pos: position{line: 456, col: 21, offset: 11062},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 456, col: 21, offset: 11065},
+							pos:        position{line: 456, col: 21, offset: 11062},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 28, offset: 11072},
+							pos:        position{line: 456, col: 28, offset: 11069},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 34, offset: 11078},
+							pos:        position{line: 456, col: 34, offset: 11075},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 41, offset: 11085},
+							pos:        position{line: 456, col: 41, offset: 11082},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -3531,43 +3531,43 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpression",
-			pos:  position{line: 458, col: 1, offset: 11122},
+			pos:  position{line: 458, col: 1, offset: 11119},
 			expr: &actionExpr{
-				pos: position{line: 459, col: 5, offset: 11145},
+				pos: position{line: 459, col: 5, offset: 11142},
 				run: (*parser).callonAdditiveExpression1,
 				expr: &seqExpr{
-					pos: position{line: 459, col: 5, offset: 11145},
+					pos: position{line: 459, col: 5, offset: 11142},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 459, col: 5, offset: 11145},
+							pos:   position{line: 459, col: 5, offset: 11142},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 459, col: 11, offset: 11151},
+								pos:  position{line: 459, col: 11, offset: 11148},
 								name: "MultiplicativeExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 460, col: 5, offset: 11180},
+							pos:   position{line: 460, col: 5, offset: 11177},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 460, col: 10, offset: 11185},
+								pos: position{line: 460, col: 10, offset: 11182},
 								expr: &seqExpr{
-									pos: position{line: 460, col: 11, offset: 11186},
+									pos: position{line: 460, col: 11, offset: 11183},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 11, offset: 11186},
+											pos:  position{line: 460, col: 11, offset: 11183},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 14, offset: 11189},
+											pos:  position{line: 460, col: 14, offset: 11186},
 											name: "AdditiveOperator",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 31, offset: 11206},
+											pos:  position{line: 460, col: 31, offset: 11203},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 460, col: 34, offset: 11209},
+											pos:  position{line: 460, col: 34, offset: 11206},
 											name: "MultiplicativeExpression",
 										},
 									},
@@ -3580,20 +3580,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 464, col: 1, offset: 11298},
+			pos:  position{line: 464, col: 1, offset: 11295},
 			expr: &actionExpr{
-				pos: position{line: 464, col: 20, offset: 11317},
+				pos: position{line: 464, col: 20, offset: 11314},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 464, col: 21, offset: 11318},
+					pos: position{line: 464, col: 21, offset: 11315},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 464, col: 21, offset: 11318},
+							pos:        position{line: 464, col: 21, offset: 11315},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 464, col: 27, offset: 11324},
+							pos:        position{line: 464, col: 27, offset: 11321},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3603,50 +3603,50 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpression",
-			pos:  position{line: 466, col: 1, offset: 11361},
+			pos:  position{line: 466, col: 1, offset: 11358},
 			expr: &actionExpr{
-				pos: position{line: 467, col: 5, offset: 11390},
+				pos: position{line: 467, col: 5, offset: 11387},
 				run: (*parser).callonMultiplicativeExpression1,
 				expr: &seqExpr{
-					pos: position{line: 467, col: 5, offset: 11390},
+					pos: position{line: 467, col: 5, offset: 11387},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 467, col: 5, offset: 11390},
+							pos:   position{line: 467, col: 5, offset: 11387},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 467, col: 11, offset: 11396},
+								pos:  position{line: 467, col: 11, offset: 11393},
 								name: "NotExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 468, col: 5, offset: 11414},
+							pos:   position{line: 468, col: 5, offset: 11411},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 468, col: 10, offset: 11419},
+								pos: position{line: 468, col: 10, offset: 11416},
 								expr: &seqExpr{
-									pos: position{line: 468, col: 11, offset: 11420},
+									pos: position{line: 468, col: 11, offset: 11417},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 468, col: 11, offset: 11420},
+											pos:  position{line: 468, col: 11, offset: 11417},
 											name: "__",
 										},
 										&labeledExpr{
-											pos:   position{line: 468, col: 14, offset: 11423},
+											pos:   position{line: 468, col: 14, offset: 11420},
 											label: "op",
 											expr: &ruleRefExpr{
-												pos:  position{line: 468, col: 17, offset: 11426},
+												pos:  position{line: 468, col: 17, offset: 11423},
 												name: "MultiplicativeOperator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 468, col: 40, offset: 11449},
+											pos:  position{line: 468, col: 40, offset: 11446},
 											name: "__",
 										},
 										&labeledExpr{
-											pos:   position{line: 468, col: 43, offset: 11452},
+											pos:   position{line: 468, col: 43, offset: 11449},
 											label: "operand",
 											expr: &ruleRefExpr{
-												pos:  position{line: 468, col: 51, offset: 11460},
+												pos:  position{line: 468, col: 51, offset: 11457},
 												name: "NotExpression",
 											},
 										},
@@ -3660,20 +3660,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 472, col: 1, offset: 11538},
+			pos:  position{line: 472, col: 1, offset: 11535},
 			expr: &actionExpr{
-				pos: position{line: 472, col: 26, offset: 11563},
+				pos: position{line: 472, col: 26, offset: 11560},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 472, col: 27, offset: 11564},
+					pos: position{line: 472, col: 27, offset: 11561},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 472, col: 27, offset: 11564},
+							pos:        position{line: 472, col: 27, offset: 11561},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 472, col: 33, offset: 11570},
+							pos:        position{line: 472, col: 33, offset: 11567},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -3683,30 +3683,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpression",
-			pos:  position{line: 474, col: 1, offset: 11607},
+			pos:  position{line: 474, col: 1, offset: 11604},
 			expr: &choiceExpr{
-				pos: position{line: 475, col: 5, offset: 11625},
+				pos: position{line: 475, col: 5, offset: 11622},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 475, col: 5, offset: 11625},
+						pos: position{line: 475, col: 5, offset: 11622},
 						run: (*parser).callonNotExpression2,
 						expr: &seqExpr{
-							pos: position{line: 475, col: 5, offset: 11625},
+							pos: position{line: 475, col: 5, offset: 11622},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 475, col: 5, offset: 11625},
+									pos:        position{line: 475, col: 5, offset: 11622},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 475, col: 9, offset: 11629},
+									pos:  position{line: 475, col: 9, offset: 11626},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 475, col: 12, offset: 11632},
+									pos:   position{line: 475, col: 12, offset: 11629},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 475, col: 14, offset: 11634},
+										pos:  position{line: 475, col: 14, offset: 11631},
 										name: "NotExpression",
 									},
 								},
@@ -3714,7 +3714,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 478, col: 5, offset: 11702},
+						pos:  position{line: 478, col: 5, offset: 11699},
 						name: "CastExpression",
 					},
 				},
@@ -3722,50 +3722,50 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpression",
-			pos:  position{line: 480, col: 1, offset: 11718},
+			pos:  position{line: 480, col: 1, offset: 11715},
 			expr: &actionExpr{
-				pos: position{line: 481, col: 5, offset: 11737},
+				pos: position{line: 481, col: 5, offset: 11734},
 				run: (*parser).callonCastExpression1,
 				expr: &seqExpr{
-					pos: position{line: 481, col: 5, offset: 11737},
+					pos: position{line: 481, col: 5, offset: 11734},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 481, col: 5, offset: 11737},
+							pos:   position{line: 481, col: 5, offset: 11734},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 481, col: 7, offset: 11739},
+								pos:  position{line: 481, col: 7, offset: 11736},
 								name: "CallExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 481, col: 22, offset: 11754},
+							pos:   position{line: 481, col: 22, offset: 11751},
 							label: "t",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 481, col: 24, offset: 11756},
+								pos: position{line: 481, col: 24, offset: 11753},
 								expr: &actionExpr{
-									pos: position{line: 481, col: 25, offset: 11757},
+									pos: position{line: 481, col: 25, offset: 11754},
 									run: (*parser).callonCastExpression7,
 									expr: &seqExpr{
-										pos: position{line: 481, col: 25, offset: 11757},
+										pos: position{line: 481, col: 25, offset: 11754},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 481, col: 25, offset: 11757},
+												pos:  position{line: 481, col: 25, offset: 11754},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 481, col: 28, offset: 11760},
+												pos:        position{line: 481, col: 28, offset: 11757},
 												val:        ":",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 481, col: 32, offset: 11764},
+												pos:  position{line: 481, col: 32, offset: 11761},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 481, col: 35, offset: 11767},
+												pos:   position{line: 481, col: 35, offset: 11764},
 												label: "ct",
 												expr: &ruleRefExpr{
-													pos:  position{line: 481, col: 38, offset: 11770},
+													pos:  position{line: 481, col: 38, offset: 11767},
 													name: "ZngType",
 												},
 											},
@@ -3780,82 +3780,82 @@ var g = &grammar{
 		},
 		{
 			name: "ZngType",
-			pos:  position{line: 489, col: 1, offset: 11906},
+			pos:  position{line: 489, col: 1, offset: 11903},
 			expr: &choiceExpr{
-				pos: position{line: 490, col: 4, offset: 11917},
+				pos: position{line: 490, col: 4, offset: 11914},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 490, col: 4, offset: 11917},
+						pos:        position{line: 490, col: 4, offset: 11914},
 						val:        "bool",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 13, offset: 11926},
+						pos:        position{line: 490, col: 13, offset: 11923},
 						val:        "byte",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 22, offset: 11935},
+						pos:        position{line: 490, col: 22, offset: 11932},
 						val:        "int16",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 32, offset: 11945},
+						pos:        position{line: 490, col: 32, offset: 11942},
 						val:        "uint16",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 43, offset: 11956},
+						pos:        position{line: 490, col: 43, offset: 11953},
 						val:        "int32",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 490, col: 53, offset: 11966},
+						pos:        position{line: 490, col: 53, offset: 11963},
 						val:        "uint32",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 4, offset: 11978},
+						pos:        position{line: 491, col: 4, offset: 11975},
 						val:        "int64",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 14, offset: 11988},
+						pos:        position{line: 491, col: 14, offset: 11985},
 						val:        "uint64",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 25, offset: 11999},
+						pos:        position{line: 491, col: 25, offset: 11996},
 						val:        "float64",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 37, offset: 12011},
+						pos:        position{line: 491, col: 37, offset: 12008},
 						val:        "string",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 491, col: 48, offset: 12022},
+						pos:        position{line: 491, col: 48, offset: 12019},
 						val:        "bstring",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 492, col: 4, offset: 12035},
+						pos:        position{line: 492, col: 4, offset: 12032},
 						val:        "ip",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 492, col: 11, offset: 12042},
+						pos:        position{line: 492, col: 11, offset: 12039},
 						val:        "net",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 492, col: 19, offset: 12050},
+						pos:        position{line: 492, col: 19, offset: 12047},
 						val:        "time",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 492, col: 28, offset: 12059},
+						pos:        position{line: 492, col: 28, offset: 12056},
 						val:        "duration",
 						ignoreCase: false,
 					},
@@ -3864,43 +3864,43 @@ var g = &grammar{
 		},
 		{
 			name: "CallExpression",
-			pos:  position{line: 494, col: 1, offset: 12071},
+			pos:  position{line: 494, col: 1, offset: 12068},
 			expr: &choiceExpr{
-				pos: position{line: 495, col: 5, offset: 12090},
+				pos: position{line: 495, col: 5, offset: 12087},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 495, col: 5, offset: 12090},
+						pos: position{line: 495, col: 5, offset: 12087},
 						run: (*parser).callonCallExpression2,
 						expr: &seqExpr{
-							pos: position{line: 495, col: 5, offset: 12090},
+							pos: position{line: 495, col: 5, offset: 12087},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 495, col: 5, offset: 12090},
+									pos:   position{line: 495, col: 5, offset: 12087},
 									label: "fn",
 									expr: &ruleRefExpr{
-										pos:  position{line: 495, col: 8, offset: 12093},
+										pos:  position{line: 495, col: 8, offset: 12090},
 										name: "FunctionName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 495, col: 21, offset: 12106},
+									pos:  position{line: 495, col: 21, offset: 12103},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 495, col: 24, offset: 12109},
+									pos:        position{line: 495, col: 24, offset: 12106},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 495, col: 28, offset: 12113},
+									pos:   position{line: 495, col: 28, offset: 12110},
 									label: "args",
 									expr: &ruleRefExpr{
-										pos:  position{line: 495, col: 33, offset: 12118},
+										pos:  position{line: 495, col: 33, offset: 12115},
 										name: "ArgumentList",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 495, col: 46, offset: 12131},
+									pos:        position{line: 495, col: 46, offset: 12128},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3908,7 +3908,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 498, col: 5, offset: 12194},
+						pos:  position{line: 498, col: 5, offset: 12191},
 						name: "DereferenceExpression",
 					},
 				},
@@ -3916,21 +3916,21 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionName",
-			pos:  position{line: 500, col: 1, offset: 12217},
+			pos:  position{line: 500, col: 1, offset: 12214},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 12234},
+				pos: position{line: 501, col: 5, offset: 12231},
 				run: (*parser).callonFunctionName1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 5, offset: 12234},
+					pos: position{line: 501, col: 5, offset: 12231},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 5, offset: 12234},
+							pos:  position{line: 501, col: 5, offset: 12231},
 							name: "FunctionNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 501, col: 23, offset: 12252},
+							pos: position{line: 501, col: 23, offset: 12249},
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 23, offset: 12252},
+								pos:  position{line: 501, col: 23, offset: 12249},
 								name: "FunctionNameRest",
 							},
 						},
@@ -3940,9 +3940,9 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionNameStart",
-			pos:  position{line: 503, col: 1, offset: 12302},
+			pos:  position{line: 503, col: 1, offset: 12299},
 			expr: &charClassMatcher{
-				pos:        position{line: 503, col: 21, offset: 12322},
+				pos:        position{line: 503, col: 21, offset: 12319},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -3951,16 +3951,16 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionNameRest",
-			pos:  position{line: 504, col: 1, offset: 12331},
+			pos:  position{line: 504, col: 1, offset: 12328},
 			expr: &choiceExpr{
-				pos: position{line: 504, col: 20, offset: 12350},
+				pos: position{line: 504, col: 20, offset: 12347},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 504, col: 20, offset: 12350},
+						pos:  position{line: 504, col: 20, offset: 12347},
 						name: "FunctionNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 504, col: 40, offset: 12370},
+						pos:        position{line: 504, col: 40, offset: 12367},
 						val:        "[.0-9]",
 						chars:      []rune{'.'},
 						ranges:     []rune{'0', '9'},
@@ -3972,53 +3972,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 506, col: 1, offset: 12378},
+			pos:  position{line: 506, col: 1, offset: 12375},
 			expr: &choiceExpr{
-				pos: position{line: 507, col: 5, offset: 12395},
+				pos: position{line: 507, col: 5, offset: 12392},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 507, col: 5, offset: 12395},
+						pos: position{line: 507, col: 5, offset: 12392},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 507, col: 5, offset: 12395},
+							pos: position{line: 507, col: 5, offset: 12392},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 507, col: 5, offset: 12395},
+									pos:   position{line: 507, col: 5, offset: 12392},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 507, col: 11, offset: 12401},
+										pos:  position{line: 507, col: 11, offset: 12398},
 										name: "Expression",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 507, col: 22, offset: 12412},
+									pos:   position{line: 507, col: 22, offset: 12409},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 507, col: 27, offset: 12417},
+										pos: position{line: 507, col: 27, offset: 12414},
 										expr: &actionExpr{
-											pos: position{line: 507, col: 28, offset: 12418},
+											pos: position{line: 507, col: 28, offset: 12415},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 507, col: 28, offset: 12418},
+												pos: position{line: 507, col: 28, offset: 12415},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 507, col: 28, offset: 12418},
+														pos:  position{line: 507, col: 28, offset: 12415},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 507, col: 31, offset: 12421},
+														pos:        position{line: 507, col: 31, offset: 12418},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 507, col: 35, offset: 12425},
+														pos:  position{line: 507, col: 35, offset: 12422},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 507, col: 38, offset: 12428},
+														pos:   position{line: 507, col: 38, offset: 12425},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 507, col: 40, offset: 12430},
+															pos:  position{line: 507, col: 40, offset: 12427},
 															name: "Expression",
 														},
 													},
@@ -4031,10 +4031,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 510, col: 5, offset: 12546},
+						pos: position{line: 510, col: 5, offset: 12543},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 510, col: 5, offset: 12546},
+							pos:  position{line: 510, col: 5, offset: 12543},
 							name: "__",
 						},
 					},
@@ -4043,88 +4043,88 @@ var g = &grammar{
 		},
 		{
 			name: "DereferenceExpression",
-			pos:  position{line: 512, col: 1, offset: 12582},
+			pos:  position{line: 512, col: 1, offset: 12579},
 			expr: &actionExpr{
-				pos: position{line: 513, col: 5, offset: 12608},
+				pos: position{line: 513, col: 5, offset: 12605},
 				run: (*parser).callonDereferenceExpression1,
 				expr: &seqExpr{
-					pos: position{line: 513, col: 5, offset: 12608},
+					pos: position{line: 513, col: 5, offset: 12605},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 513, col: 5, offset: 12608},
+							pos:   position{line: 513, col: 5, offset: 12605},
 							label: "base",
 							expr: &ruleRefExpr{
-								pos:  position{line: 513, col: 10, offset: 12613},
+								pos:  position{line: 513, col: 10, offset: 12610},
 								name: "PrimaryExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 514, col: 5, offset: 12635},
+							pos:   position{line: 514, col: 5, offset: 12632},
 							label: "derefs",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 514, col: 12, offset: 12642},
+								pos: position{line: 514, col: 12, offset: 12639},
 								expr: &choiceExpr{
-									pos: position{line: 515, col: 9, offset: 12652},
+									pos: position{line: 515, col: 9, offset: 12649},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 515, col: 9, offset: 12652},
+											pos: position{line: 515, col: 9, offset: 12649},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 515, col: 9, offset: 12652},
+													pos:  position{line: 515, col: 9, offset: 12649},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 515, col: 12, offset: 12655},
+													pos:        position{line: 515, col: 12, offset: 12652},
 													val:        "[",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 515, col: 16, offset: 12659},
+													pos:  position{line: 515, col: 16, offset: 12656},
 													name: "__",
 												},
 												&labeledExpr{
-													pos:   position{line: 515, col: 19, offset: 12662},
+													pos:   position{line: 515, col: 19, offset: 12659},
 													label: "index",
 													expr: &ruleRefExpr{
-														pos:  position{line: 515, col: 25, offset: 12668},
+														pos:  position{line: 515, col: 25, offset: 12665},
 														name: "Expression",
 													},
 												},
 												&ruleRefExpr{
-													pos:  position{line: 515, col: 36, offset: 12679},
+													pos:  position{line: 515, col: 36, offset: 12676},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 515, col: 39, offset: 12682},
+													pos:        position{line: 515, col: 39, offset: 12679},
 													val:        "]",
 													ignoreCase: false,
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 516, col: 9, offset: 12694},
+											pos: position{line: 516, col: 9, offset: 12691},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 516, col: 9, offset: 12694},
+													pos:  position{line: 516, col: 9, offset: 12691},
 													name: "__",
 												},
 												&litMatcher{
-													pos:        position{line: 516, col: 12, offset: 12697},
+													pos:        position{line: 516, col: 12, offset: 12694},
 													val:        ".",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 516, col: 16, offset: 12701},
+													pos:  position{line: 516, col: 16, offset: 12698},
 													name: "__",
 												},
 												&actionExpr{
-													pos: position{line: 516, col: 20, offset: 12705},
+													pos: position{line: 516, col: 20, offset: 12702},
 													run: (*parser).callonDereferenceExpression20,
 													expr: &labeledExpr{
-														pos:   position{line: 516, col: 20, offset: 12705},
+														pos:   position{line: 516, col: 20, offset: 12702},
 														label: "field",
 														expr: &ruleRefExpr{
-															pos:  position{line: 516, col: 26, offset: 12711},
+															pos:  position{line: 516, col: 26, offset: 12708},
 															name: "fieldName",
 														},
 													},
@@ -4141,54 +4141,54 @@ var g = &grammar{
 		},
 		{
 			name: "duration",
-			pos:  position{line: 521, col: 1, offset: 12846},
+			pos:  position{line: 521, col: 1, offset: 12843},
 			expr: &choiceExpr{
-				pos: position{line: 522, col: 5, offset: 12859},
+				pos: position{line: 522, col: 5, offset: 12856},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 522, col: 5, offset: 12859},
+						pos:  position{line: 522, col: 5, offset: 12856},
 						name: "seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 523, col: 5, offset: 12871},
+						pos:  position{line: 523, col: 5, offset: 12868},
 						name: "minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 524, col: 5, offset: 12883},
+						pos:  position{line: 524, col: 5, offset: 12880},
 						name: "hours",
 					},
 					&seqExpr{
-						pos: position{line: 525, col: 5, offset: 12893},
+						pos: position{line: 525, col: 5, offset: 12890},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 525, col: 5, offset: 12893},
+								pos:  position{line: 525, col: 5, offset: 12890},
 								name: "hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 525, col: 11, offset: 12899},
+								pos:  position{line: 525, col: 11, offset: 12896},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 525, col: 13, offset: 12901},
+								pos:        position{line: 525, col: 13, offset: 12898},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 525, col: 19, offset: 12907},
+								pos:  position{line: 525, col: 19, offset: 12904},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 525, col: 21, offset: 12909},
+								pos:  position{line: 525, col: 21, offset: 12906},
 								name: "minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 526, col: 5, offset: 12921},
+						pos:  position{line: 526, col: 5, offset: 12918},
 						name: "days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 527, col: 5, offset: 12930},
+						pos:  position{line: 527, col: 5, offset: 12927},
 						name: "weeks",
 					},
 				},
@@ -4196,32 +4196,32 @@ var g = &grammar{
 		},
 		{
 			name: "sec_abbrev",
-			pos:  position{line: 529, col: 1, offset: 12937},
+			pos:  position{line: 529, col: 1, offset: 12934},
 			expr: &choiceExpr{
-				pos: position{line: 530, col: 5, offset: 12952},
+				pos: position{line: 530, col: 5, offset: 12949},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 530, col: 5, offset: 12952},
+						pos:        position{line: 530, col: 5, offset: 12949},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 531, col: 5, offset: 12966},
+						pos:        position{line: 531, col: 5, offset: 12963},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 532, col: 5, offset: 12979},
+						pos:        position{line: 532, col: 5, offset: 12976},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 533, col: 5, offset: 12990},
+						pos:        position{line: 533, col: 5, offset: 12987},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 534, col: 5, offset: 13000},
+						pos:        position{line: 534, col: 5, offset: 12997},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -4230,32 +4230,32 @@ var g = &grammar{
 		},
 		{
 			name: "min_abbrev",
-			pos:  position{line: 536, col: 1, offset: 13005},
+			pos:  position{line: 536, col: 1, offset: 13002},
 			expr: &choiceExpr{
-				pos: position{line: 537, col: 5, offset: 13020},
+				pos: position{line: 537, col: 5, offset: 13017},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 537, col: 5, offset: 13020},
+						pos:        position{line: 537, col: 5, offset: 13017},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 538, col: 5, offset: 13034},
+						pos:        position{line: 538, col: 5, offset: 13031},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 539, col: 5, offset: 13047},
+						pos:        position{line: 539, col: 5, offset: 13044},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 540, col: 5, offset: 13058},
+						pos:        position{line: 540, col: 5, offset: 13055},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 541, col: 5, offset: 13068},
+						pos:        position{line: 541, col: 5, offset: 13065},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -4264,32 +4264,32 @@ var g = &grammar{
 		},
 		{
 			name: "hour_abbrev",
-			pos:  position{line: 543, col: 1, offset: 13073},
+			pos:  position{line: 543, col: 1, offset: 13070},
 			expr: &choiceExpr{
-				pos: position{line: 544, col: 5, offset: 13089},
+				pos: position{line: 544, col: 5, offset: 13086},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 544, col: 5, offset: 13089},
+						pos:        position{line: 544, col: 5, offset: 13086},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 545, col: 5, offset: 13101},
+						pos:        position{line: 545, col: 5, offset: 13098},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 546, col: 5, offset: 13111},
+						pos:        position{line: 546, col: 5, offset: 13108},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 547, col: 5, offset: 13120},
+						pos:        position{line: 547, col: 5, offset: 13117},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 548, col: 5, offset: 13128},
+						pos:        position{line: 548, col: 5, offset: 13125},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -4298,22 +4298,22 @@ var g = &grammar{
 		},
 		{
 			name: "day_abbrev",
-			pos:  position{line: 550, col: 1, offset: 13136},
+			pos:  position{line: 550, col: 1, offset: 13133},
 			expr: &choiceExpr{
-				pos: position{line: 550, col: 14, offset: 13149},
+				pos: position{line: 550, col: 14, offset: 13146},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 550, col: 14, offset: 13149},
+						pos:        position{line: 550, col: 14, offset: 13146},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 550, col: 21, offset: 13156},
+						pos:        position{line: 550, col: 21, offset: 13153},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 550, col: 27, offset: 13162},
+						pos:        position{line: 550, col: 27, offset: 13159},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -4322,32 +4322,32 @@ var g = &grammar{
 		},
 		{
 			name: "week_abbrev",
-			pos:  position{line: 551, col: 1, offset: 13166},
+			pos:  position{line: 551, col: 1, offset: 13163},
 			expr: &choiceExpr{
-				pos: position{line: 551, col: 15, offset: 13180},
+				pos: position{line: 551, col: 15, offset: 13177},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 551, col: 15, offset: 13180},
+						pos:        position{line: 551, col: 15, offset: 13177},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 23, offset: 13188},
+						pos:        position{line: 551, col: 23, offset: 13185},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 30, offset: 13195},
+						pos:        position{line: 551, col: 30, offset: 13192},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 36, offset: 13201},
+						pos:        position{line: 551, col: 36, offset: 13198},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 551, col: 41, offset: 13206},
+						pos:        position{line: 551, col: 41, offset: 13203},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -4356,42 +4356,42 @@ var g = &grammar{
 		},
 		{
 			name: "seconds",
-			pos:  position{line: 553, col: 1, offset: 13211},
+			pos:  position{line: 553, col: 1, offset: 13208},
 			expr: &choiceExpr{
-				pos: position{line: 554, col: 5, offset: 13223},
+				pos: position{line: 554, col: 5, offset: 13220},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 554, col: 5, offset: 13223},
+						pos: position{line: 554, col: 5, offset: 13220},
 						run: (*parser).callonseconds2,
 						expr: &litMatcher{
-							pos:        position{line: 554, col: 5, offset: 13223},
+							pos:        position{line: 554, col: 5, offset: 13220},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 555, col: 5, offset: 13268},
+						pos: position{line: 555, col: 5, offset: 13265},
 						run: (*parser).callonseconds4,
 						expr: &seqExpr{
-							pos: position{line: 555, col: 5, offset: 13268},
+							pos: position{line: 555, col: 5, offset: 13265},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 555, col: 5, offset: 13268},
+									pos:   position{line: 555, col: 5, offset: 13265},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 555, col: 9, offset: 13272},
+										pos:  position{line: 555, col: 9, offset: 13269},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 555, col: 16, offset: 13279},
+									pos: position{line: 555, col: 16, offset: 13276},
 									expr: &ruleRefExpr{
-										pos:  position{line: 555, col: 16, offset: 13279},
+										pos:  position{line: 555, col: 16, offset: 13276},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 555, col: 19, offset: 13282},
+									pos:  position{line: 555, col: 19, offset: 13279},
 									name: "sec_abbrev",
 								},
 							},
@@ -4402,42 +4402,42 @@ var g = &grammar{
 		},
 		{
 			name: "minutes",
-			pos:  position{line: 557, col: 1, offset: 13328},
+			pos:  position{line: 557, col: 1, offset: 13325},
 			expr: &choiceExpr{
-				pos: position{line: 558, col: 5, offset: 13340},
+				pos: position{line: 558, col: 5, offset: 13337},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 558, col: 5, offset: 13340},
+						pos: position{line: 558, col: 5, offset: 13337},
 						run: (*parser).callonminutes2,
 						expr: &litMatcher{
-							pos:        position{line: 558, col: 5, offset: 13340},
+							pos:        position{line: 558, col: 5, offset: 13337},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 559, col: 5, offset: 13386},
+						pos: position{line: 559, col: 5, offset: 13383},
 						run: (*parser).callonminutes4,
 						expr: &seqExpr{
-							pos: position{line: 559, col: 5, offset: 13386},
+							pos: position{line: 559, col: 5, offset: 13383},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 559, col: 5, offset: 13386},
+									pos:   position{line: 559, col: 5, offset: 13383},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 559, col: 9, offset: 13390},
+										pos:  position{line: 559, col: 9, offset: 13387},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 559, col: 16, offset: 13397},
+									pos: position{line: 559, col: 16, offset: 13394},
 									expr: &ruleRefExpr{
-										pos:  position{line: 559, col: 16, offset: 13397},
+										pos:  position{line: 559, col: 16, offset: 13394},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 559, col: 19, offset: 13400},
+									pos:  position{line: 559, col: 19, offset: 13397},
 									name: "min_abbrev",
 								},
 							},
@@ -4448,42 +4448,42 @@ var g = &grammar{
 		},
 		{
 			name: "hours",
-			pos:  position{line: 561, col: 1, offset: 13455},
+			pos:  position{line: 561, col: 1, offset: 13452},
 			expr: &choiceExpr{
-				pos: position{line: 562, col: 5, offset: 13465},
+				pos: position{line: 562, col: 5, offset: 13462},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 562, col: 5, offset: 13465},
+						pos: position{line: 562, col: 5, offset: 13462},
 						run: (*parser).callonhours2,
 						expr: &litMatcher{
-							pos:        position{line: 562, col: 5, offset: 13465},
+							pos:        position{line: 562, col: 5, offset: 13462},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 563, col: 5, offset: 13511},
+						pos: position{line: 563, col: 5, offset: 13508},
 						run: (*parser).callonhours4,
 						expr: &seqExpr{
-							pos: position{line: 563, col: 5, offset: 13511},
+							pos: position{line: 563, col: 5, offset: 13508},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 563, col: 5, offset: 13511},
+									pos:   position{line: 563, col: 5, offset: 13508},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 563, col: 9, offset: 13515},
+										pos:  position{line: 563, col: 9, offset: 13512},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 563, col: 16, offset: 13522},
+									pos: position{line: 563, col: 16, offset: 13519},
 									expr: &ruleRefExpr{
-										pos:  position{line: 563, col: 16, offset: 13522},
+										pos:  position{line: 563, col: 16, offset: 13519},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 563, col: 19, offset: 13525},
+									pos:  position{line: 563, col: 19, offset: 13522},
 									name: "hour_abbrev",
 								},
 							},
@@ -4494,42 +4494,42 @@ var g = &grammar{
 		},
 		{
 			name: "days",
-			pos:  position{line: 565, col: 1, offset: 13583},
+			pos:  position{line: 565, col: 1, offset: 13580},
 			expr: &choiceExpr{
-				pos: position{line: 566, col: 5, offset: 13592},
+				pos: position{line: 566, col: 5, offset: 13589},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 566, col: 5, offset: 13592},
+						pos: position{line: 566, col: 5, offset: 13589},
 						run: (*parser).callondays2,
 						expr: &litMatcher{
-							pos:        position{line: 566, col: 5, offset: 13592},
+							pos:        position{line: 566, col: 5, offset: 13589},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 567, col: 5, offset: 13640},
+						pos: position{line: 567, col: 5, offset: 13637},
 						run: (*parser).callondays4,
 						expr: &seqExpr{
-							pos: position{line: 567, col: 5, offset: 13640},
+							pos: position{line: 567, col: 5, offset: 13637},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 567, col: 5, offset: 13640},
+									pos:   position{line: 567, col: 5, offset: 13637},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 567, col: 9, offset: 13644},
+										pos:  position{line: 567, col: 9, offset: 13641},
 										name: "number",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 567, col: 16, offset: 13651},
+									pos: position{line: 567, col: 16, offset: 13648},
 									expr: &ruleRefExpr{
-										pos:  position{line: 567, col: 16, offset: 13651},
+										pos:  position{line: 567, col: 16, offset: 13648},
 										name: "_",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 567, col: 19, offset: 13654},
+									pos:  position{line: 567, col: 19, offset: 13651},
 									name: "day_abbrev",
 								},
 							},
@@ -4540,30 +4540,30 @@ var g = &grammar{
 		},
 		{
 			name: "weeks",
-			pos:  position{line: 569, col: 1, offset: 13714},
+			pos:  position{line: 569, col: 1, offset: 13711},
 			expr: &actionExpr{
-				pos: position{line: 570, col: 5, offset: 13724},
+				pos: position{line: 570, col: 5, offset: 13721},
 				run: (*parser).callonweeks1,
 				expr: &seqExpr{
-					pos: position{line: 570, col: 5, offset: 13724},
+					pos: position{line: 570, col: 5, offset: 13721},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 570, col: 5, offset: 13724},
+							pos:   position{line: 570, col: 5, offset: 13721},
 							label: "num",
 							expr: &ruleRefExpr{
-								pos:  position{line: 570, col: 9, offset: 13728},
+								pos:  position{line: 570, col: 9, offset: 13725},
 								name: "number",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 570, col: 16, offset: 13735},
+							pos: position{line: 570, col: 16, offset: 13732},
 							expr: &ruleRefExpr{
-								pos:  position{line: 570, col: 16, offset: 13735},
+								pos:  position{line: 570, col: 16, offset: 13732},
 								name: "_",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 570, col: 19, offset: 13738},
+							pos:  position{line: 570, col: 19, offset: 13735},
 							name: "week_abbrev",
 						},
 					},
@@ -4572,53 +4572,53 @@ var g = &grammar{
 		},
 		{
 			name: "number",
-			pos:  position{line: 572, col: 1, offset: 13801},
+			pos:  position{line: 572, col: 1, offset: 13798},
 			expr: &ruleRefExpr{
-				pos:  position{line: 572, col: 10, offset: 13810},
+				pos:  position{line: 572, col: 10, offset: 13807},
 				name: "unsignedInteger",
 			},
 		},
 		{
 			name: "addr",
-			pos:  position{line: 576, col: 1, offset: 13856},
+			pos:  position{line: 576, col: 1, offset: 13853},
 			expr: &actionExpr{
-				pos: position{line: 577, col: 5, offset: 13865},
+				pos: position{line: 577, col: 5, offset: 13862},
 				run: (*parser).callonaddr1,
 				expr: &labeledExpr{
-					pos:   position{line: 577, col: 5, offset: 13865},
+					pos:   position{line: 577, col: 5, offset: 13862},
 					label: "a",
 					expr: &seqExpr{
-						pos: position{line: 577, col: 8, offset: 13868},
+						pos: position{line: 577, col: 8, offset: 13865},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 577, col: 8, offset: 13868},
+								pos:  position{line: 577, col: 8, offset: 13865},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 577, col: 24, offset: 13884},
+								pos:        position{line: 577, col: 24, offset: 13881},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 577, col: 28, offset: 13888},
+								pos:  position{line: 577, col: 28, offset: 13885},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 577, col: 44, offset: 13904},
+								pos:        position{line: 577, col: 44, offset: 13901},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 577, col: 48, offset: 13908},
+								pos:  position{line: 577, col: 48, offset: 13905},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 577, col: 64, offset: 13924},
+								pos:        position{line: 577, col: 64, offset: 13921},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 577, col: 68, offset: 13928},
+								pos:  position{line: 577, col: 68, offset: 13925},
 								name: "unsignedInteger",
 							},
 						},
@@ -4628,23 +4628,23 @@ var g = &grammar{
 		},
 		{
 			name: "port",
-			pos:  position{line: 579, col: 1, offset: 13977},
+			pos:  position{line: 579, col: 1, offset: 13974},
 			expr: &actionExpr{
-				pos: position{line: 580, col: 5, offset: 13986},
+				pos: position{line: 580, col: 5, offset: 13983},
 				run: (*parser).callonport1,
 				expr: &seqExpr{
-					pos: position{line: 580, col: 5, offset: 13986},
+					pos: position{line: 580, col: 5, offset: 13983},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 580, col: 5, offset: 13986},
+							pos:        position{line: 580, col: 5, offset: 13983},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 580, col: 9, offset: 13990},
+							pos:   position{line: 580, col: 9, offset: 13987},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 580, col: 11, offset: 13992},
+								pos:  position{line: 580, col: 11, offset: 13989},
 								name: "suint",
 							},
 						},
@@ -4654,32 +4654,32 @@ var g = &grammar{
 		},
 		{
 			name: "ip6addr",
-			pos:  position{line: 584, col: 1, offset: 14148},
+			pos:  position{line: 584, col: 1, offset: 14145},
 			expr: &choiceExpr{
-				pos: position{line: 585, col: 5, offset: 14160},
+				pos: position{line: 585, col: 5, offset: 14157},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 585, col: 5, offset: 14160},
+						pos: position{line: 585, col: 5, offset: 14157},
 						run: (*parser).callonip6addr2,
 						expr: &seqExpr{
-							pos: position{line: 585, col: 5, offset: 14160},
+							pos: position{line: 585, col: 5, offset: 14157},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 585, col: 5, offset: 14160},
+									pos:   position{line: 585, col: 5, offset: 14157},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 585, col: 7, offset: 14162},
+										pos: position{line: 585, col: 7, offset: 14159},
 										expr: &ruleRefExpr{
-											pos:  position{line: 585, col: 8, offset: 14163},
+											pos:  position{line: 585, col: 8, offset: 14160},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 585, col: 20, offset: 14175},
+									pos:   position{line: 585, col: 20, offset: 14172},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 585, col: 22, offset: 14177},
+										pos:  position{line: 585, col: 22, offset: 14174},
 										name: "ip6tail",
 									},
 								},
@@ -4687,51 +4687,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 588, col: 5, offset: 14241},
+						pos: position{line: 588, col: 5, offset: 14238},
 						run: (*parser).callonip6addr9,
 						expr: &seqExpr{
-							pos: position{line: 588, col: 5, offset: 14241},
+							pos: position{line: 588, col: 5, offset: 14238},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 588, col: 5, offset: 14241},
+									pos:   position{line: 588, col: 5, offset: 14238},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 588, col: 7, offset: 14243},
+										pos:  position{line: 588, col: 7, offset: 14240},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 588, col: 11, offset: 14247},
+									pos:   position{line: 588, col: 11, offset: 14244},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 588, col: 13, offset: 14249},
+										pos: position{line: 588, col: 13, offset: 14246},
 										expr: &ruleRefExpr{
-											pos:  position{line: 588, col: 14, offset: 14250},
+											pos:  position{line: 588, col: 14, offset: 14247},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 588, col: 25, offset: 14261},
+									pos:        position{line: 588, col: 25, offset: 14258},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 588, col: 30, offset: 14266},
+									pos:   position{line: 588, col: 30, offset: 14263},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 588, col: 32, offset: 14268},
+										pos: position{line: 588, col: 32, offset: 14265},
 										expr: &ruleRefExpr{
-											pos:  position{line: 588, col: 33, offset: 14269},
+											pos:  position{line: 588, col: 33, offset: 14266},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 588, col: 45, offset: 14281},
+									pos:   position{line: 588, col: 45, offset: 14278},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 588, col: 47, offset: 14283},
+										pos:  position{line: 588, col: 47, offset: 14280},
 										name: "ip6tail",
 									},
 								},
@@ -4739,32 +4739,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 591, col: 5, offset: 14382},
+						pos: position{line: 591, col: 5, offset: 14379},
 						run: (*parser).callonip6addr22,
 						expr: &seqExpr{
-							pos: position{line: 591, col: 5, offset: 14382},
+							pos: position{line: 591, col: 5, offset: 14379},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 591, col: 5, offset: 14382},
+									pos:        position{line: 591, col: 5, offset: 14379},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 591, col: 10, offset: 14387},
+									pos:   position{line: 591, col: 10, offset: 14384},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 591, col: 12, offset: 14389},
+										pos: position{line: 591, col: 12, offset: 14386},
 										expr: &ruleRefExpr{
-											pos:  position{line: 591, col: 13, offset: 14390},
+											pos:  position{line: 591, col: 13, offset: 14387},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 591, col: 25, offset: 14402},
+									pos:   position{line: 591, col: 25, offset: 14399},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 591, col: 27, offset: 14404},
+										pos:  position{line: 591, col: 27, offset: 14401},
 										name: "ip6tail",
 									},
 								},
@@ -4772,32 +4772,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 594, col: 5, offset: 14475},
+						pos: position{line: 594, col: 5, offset: 14472},
 						run: (*parser).callonip6addr30,
 						expr: &seqExpr{
-							pos: position{line: 594, col: 5, offset: 14475},
+							pos: position{line: 594, col: 5, offset: 14472},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 594, col: 5, offset: 14475},
+									pos:   position{line: 594, col: 5, offset: 14472},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 594, col: 7, offset: 14477},
+										pos:  position{line: 594, col: 7, offset: 14474},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 594, col: 11, offset: 14481},
+									pos:   position{line: 594, col: 11, offset: 14478},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 594, col: 13, offset: 14483},
+										pos: position{line: 594, col: 13, offset: 14480},
 										expr: &ruleRefExpr{
-											pos:  position{line: 594, col: 14, offset: 14484},
+											pos:  position{line: 594, col: 14, offset: 14481},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 594, col: 25, offset: 14495},
+									pos:        position{line: 594, col: 25, offset: 14492},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -4805,10 +4805,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 597, col: 5, offset: 14563},
+						pos: position{line: 597, col: 5, offset: 14560},
 						run: (*parser).callonip6addr38,
 						expr: &litMatcher{
-							pos:        position{line: 597, col: 5, offset: 14563},
+							pos:        position{line: 597, col: 5, offset: 14560},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -4818,16 +4818,16 @@ var g = &grammar{
 		},
 		{
 			name: "ip6tail",
-			pos:  position{line: 601, col: 1, offset: 14600},
+			pos:  position{line: 601, col: 1, offset: 14597},
 			expr: &choiceExpr{
-				pos: position{line: 602, col: 5, offset: 14612},
+				pos: position{line: 602, col: 5, offset: 14609},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 602, col: 5, offset: 14612},
+						pos:  position{line: 602, col: 5, offset: 14609},
 						name: "addr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 603, col: 5, offset: 14621},
+						pos:  position{line: 603, col: 5, offset: 14618},
 						name: "h16",
 					},
 				},
@@ -4835,23 +4835,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_append",
-			pos:  position{line: 605, col: 1, offset: 14626},
+			pos:  position{line: 605, col: 1, offset: 14623},
 			expr: &actionExpr{
-				pos: position{line: 605, col: 12, offset: 14637},
+				pos: position{line: 605, col: 12, offset: 14634},
 				run: (*parser).callonh_append1,
 				expr: &seqExpr{
-					pos: position{line: 605, col: 12, offset: 14637},
+					pos: position{line: 605, col: 12, offset: 14634},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 605, col: 12, offset: 14637},
+							pos:        position{line: 605, col: 12, offset: 14634},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 605, col: 16, offset: 14641},
+							pos:   position{line: 605, col: 16, offset: 14638},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 605, col: 18, offset: 14643},
+								pos:  position{line: 605, col: 18, offset: 14640},
 								name: "h16",
 							},
 						},
@@ -4861,23 +4861,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_prepend",
-			pos:  position{line: 606, col: 1, offset: 14680},
+			pos:  position{line: 606, col: 1, offset: 14677},
 			expr: &actionExpr{
-				pos: position{line: 606, col: 13, offset: 14692},
+				pos: position{line: 606, col: 13, offset: 14689},
 				run: (*parser).callonh_prepend1,
 				expr: &seqExpr{
-					pos: position{line: 606, col: 13, offset: 14692},
+					pos: position{line: 606, col: 13, offset: 14689},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 606, col: 13, offset: 14692},
+							pos:   position{line: 606, col: 13, offset: 14689},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 606, col: 15, offset: 14694},
+								pos:  position{line: 606, col: 15, offset: 14691},
 								name: "h16",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 606, col: 19, offset: 14698},
+							pos:        position{line: 606, col: 19, offset: 14695},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -4887,31 +4887,31 @@ var g = &grammar{
 		},
 		{
 			name: "subnet",
-			pos:  position{line: 608, col: 1, offset: 14736},
+			pos:  position{line: 608, col: 1, offset: 14733},
 			expr: &actionExpr{
-				pos: position{line: 609, col: 5, offset: 14747},
+				pos: position{line: 609, col: 5, offset: 14744},
 				run: (*parser).callonsubnet1,
 				expr: &seqExpr{
-					pos: position{line: 609, col: 5, offset: 14747},
+					pos: position{line: 609, col: 5, offset: 14744},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 609, col: 5, offset: 14747},
+							pos:   position{line: 609, col: 5, offset: 14744},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 609, col: 7, offset: 14749},
+								pos:  position{line: 609, col: 7, offset: 14746},
 								name: "addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 609, col: 12, offset: 14754},
+							pos:        position{line: 609, col: 12, offset: 14751},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 609, col: 16, offset: 14758},
+							pos:   position{line: 609, col: 16, offset: 14755},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 609, col: 18, offset: 14760},
+								pos:  position{line: 609, col: 18, offset: 14757},
 								name: "unsignedInteger",
 							},
 						},
@@ -4921,31 +4921,31 @@ var g = &grammar{
 		},
 		{
 			name: "ip6subnet",
-			pos:  position{line: 613, col: 1, offset: 14844},
+			pos:  position{line: 613, col: 1, offset: 14841},
 			expr: &actionExpr{
-				pos: position{line: 614, col: 5, offset: 14858},
+				pos: position{line: 614, col: 5, offset: 14855},
 				run: (*parser).callonip6subnet1,
 				expr: &seqExpr{
-					pos: position{line: 614, col: 5, offset: 14858},
+					pos: position{line: 614, col: 5, offset: 14855},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 614, col: 5, offset: 14858},
+							pos:   position{line: 614, col: 5, offset: 14855},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 614, col: 7, offset: 14860},
+								pos:  position{line: 614, col: 7, offset: 14857},
 								name: "ip6addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 614, col: 15, offset: 14868},
+							pos:        position{line: 614, col: 15, offset: 14865},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 614, col: 19, offset: 14872},
+							pos:   position{line: 614, col: 19, offset: 14869},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 614, col: 21, offset: 14874},
+								pos:  position{line: 614, col: 21, offset: 14871},
 								name: "unsignedInteger",
 							},
 						},
@@ -4955,15 +4955,15 @@ var g = &grammar{
 		},
 		{
 			name: "unsignedInteger",
-			pos:  position{line: 618, col: 1, offset: 14948},
+			pos:  position{line: 618, col: 1, offset: 14945},
 			expr: &actionExpr{
-				pos: position{line: 619, col: 5, offset: 14968},
+				pos: position{line: 619, col: 5, offset: 14965},
 				run: (*parser).callonunsignedInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 619, col: 5, offset: 14968},
+					pos:   position{line: 619, col: 5, offset: 14965},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 619, col: 7, offset: 14970},
+						pos:  position{line: 619, col: 7, offset: 14967},
 						name: "suint",
 					},
 				},
@@ -4971,14 +4971,14 @@ var g = &grammar{
 		},
 		{
 			name: "suint",
-			pos:  position{line: 621, col: 1, offset: 15005},
+			pos:  position{line: 621, col: 1, offset: 15002},
 			expr: &actionExpr{
-				pos: position{line: 622, col: 5, offset: 15015},
+				pos: position{line: 622, col: 5, offset: 15012},
 				run: (*parser).callonsuint1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 622, col: 5, offset: 15015},
+					pos: position{line: 622, col: 5, offset: 15012},
 					expr: &charClassMatcher{
-						pos:        position{line: 622, col: 5, offset: 15015},
+						pos:        position{line: 622, col: 5, offset: 15012},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4989,15 +4989,15 @@ var g = &grammar{
 		},
 		{
 			name: "integer",
-			pos:  position{line: 624, col: 1, offset: 15054},
+			pos:  position{line: 624, col: 1, offset: 15051},
 			expr: &actionExpr{
-				pos: position{line: 625, col: 5, offset: 15066},
+				pos: position{line: 625, col: 5, offset: 15063},
 				run: (*parser).calloninteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 625, col: 5, offset: 15066},
+					pos:   position{line: 625, col: 5, offset: 15063},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 625, col: 7, offset: 15068},
+						pos:  position{line: 625, col: 7, offset: 15065},
 						name: "sinteger",
 					},
 				},
@@ -5005,17 +5005,17 @@ var g = &grammar{
 		},
 		{
 			name: "sinteger",
-			pos:  position{line: 627, col: 1, offset: 15106},
+			pos:  position{line: 627, col: 1, offset: 15103},
 			expr: &actionExpr{
-				pos: position{line: 628, col: 5, offset: 15119},
+				pos: position{line: 628, col: 5, offset: 15116},
 				run: (*parser).callonsinteger1,
 				expr: &seqExpr{
-					pos: position{line: 628, col: 5, offset: 15119},
+					pos: position{line: 628, col: 5, offset: 15116},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 628, col: 5, offset: 15119},
+							pos: position{line: 628, col: 5, offset: 15116},
 							expr: &charClassMatcher{
-								pos:        position{line: 628, col: 5, offset: 15119},
+								pos:        position{line: 628, col: 5, offset: 15116},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -5023,7 +5023,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 628, col: 11, offset: 15125},
+							pos:  position{line: 628, col: 11, offset: 15122},
 							name: "suint",
 						},
 					},
@@ -5032,15 +5032,15 @@ var g = &grammar{
 		},
 		{
 			name: "double",
-			pos:  position{line: 630, col: 1, offset: 15163},
+			pos:  position{line: 630, col: 1, offset: 15160},
 			expr: &actionExpr{
-				pos: position{line: 631, col: 5, offset: 15174},
+				pos: position{line: 631, col: 5, offset: 15171},
 				run: (*parser).callondouble1,
 				expr: &labeledExpr{
-					pos:   position{line: 631, col: 5, offset: 15174},
+					pos:   position{line: 631, col: 5, offset: 15171},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 631, col: 7, offset: 15176},
+						pos:  position{line: 631, col: 7, offset: 15173},
 						name: "sdouble",
 					},
 				},
@@ -5048,47 +5048,47 @@ var g = &grammar{
 		},
 		{
 			name: "sdouble",
-			pos:  position{line: 635, col: 1, offset: 15223},
+			pos:  position{line: 635, col: 1, offset: 15220},
 			expr: &choiceExpr{
-				pos: position{line: 636, col: 5, offset: 15235},
+				pos: position{line: 636, col: 5, offset: 15232},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 636, col: 5, offset: 15235},
+						pos: position{line: 636, col: 5, offset: 15232},
 						run: (*parser).callonsdouble2,
 						expr: &seqExpr{
-							pos: position{line: 636, col: 5, offset: 15235},
+							pos: position{line: 636, col: 5, offset: 15232},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 636, col: 5, offset: 15235},
+									pos: position{line: 636, col: 5, offset: 15232},
 									expr: &litMatcher{
-										pos:        position{line: 636, col: 5, offset: 15235},
+										pos:        position{line: 636, col: 5, offset: 15232},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 636, col: 10, offset: 15240},
+									pos: position{line: 636, col: 10, offset: 15237},
 									expr: &ruleRefExpr{
-										pos:  position{line: 636, col: 10, offset: 15240},
+										pos:  position{line: 636, col: 10, offset: 15237},
 										name: "doubleInteger",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 636, col: 25, offset: 15255},
+									pos:        position{line: 636, col: 25, offset: 15252},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 636, col: 29, offset: 15259},
+									pos: position{line: 636, col: 29, offset: 15256},
 									expr: &ruleRefExpr{
-										pos:  position{line: 636, col: 29, offset: 15259},
+										pos:  position{line: 636, col: 29, offset: 15256},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 636, col: 42, offset: 15272},
+									pos: position{line: 636, col: 42, offset: 15269},
 									expr: &ruleRefExpr{
-										pos:  position{line: 636, col: 42, offset: 15272},
+										pos:  position{line: 636, col: 42, offset: 15269},
 										name: "exponentPart",
 									},
 								},
@@ -5096,35 +5096,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 639, col: 5, offset: 15331},
+						pos: position{line: 639, col: 5, offset: 15328},
 						run: (*parser).callonsdouble13,
 						expr: &seqExpr{
-							pos: position{line: 639, col: 5, offset: 15331},
+							pos: position{line: 639, col: 5, offset: 15328},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 639, col: 5, offset: 15331},
+									pos: position{line: 639, col: 5, offset: 15328},
 									expr: &litMatcher{
-										pos:        position{line: 639, col: 5, offset: 15331},
+										pos:        position{line: 639, col: 5, offset: 15328},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 639, col: 10, offset: 15336},
+									pos:        position{line: 639, col: 10, offset: 15333},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 639, col: 14, offset: 15340},
+									pos: position{line: 639, col: 14, offset: 15337},
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 14, offset: 15340},
+										pos:  position{line: 639, col: 14, offset: 15337},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 639, col: 27, offset: 15353},
+									pos: position{line: 639, col: 27, offset: 15350},
 									expr: &ruleRefExpr{
-										pos:  position{line: 639, col: 27, offset: 15353},
+										pos:  position{line: 639, col: 27, offset: 15350},
 										name: "exponentPart",
 									},
 								},
@@ -5136,29 +5136,29 @@ var g = &grammar{
 		},
 		{
 			name: "doubleInteger",
-			pos:  position{line: 643, col: 1, offset: 15409},
+			pos:  position{line: 643, col: 1, offset: 15406},
 			expr: &choiceExpr{
-				pos: position{line: 644, col: 5, offset: 15427},
+				pos: position{line: 644, col: 5, offset: 15424},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 644, col: 5, offset: 15427},
+						pos:        position{line: 644, col: 5, offset: 15424},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 645, col: 5, offset: 15435},
+						pos: position{line: 645, col: 5, offset: 15432},
 						exprs: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 645, col: 5, offset: 15435},
+								pos:        position{line: 645, col: 5, offset: 15432},
 								val:        "[1-9]",
 								ranges:     []rune{'1', '9'},
 								ignoreCase: false,
 								inverted:   false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 645, col: 11, offset: 15441},
+								pos: position{line: 645, col: 11, offset: 15438},
 								expr: &charClassMatcher{
-									pos:        position{line: 645, col: 11, offset: 15441},
+									pos:        position{line: 645, col: 11, offset: 15438},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -5172,9 +5172,9 @@ var g = &grammar{
 		},
 		{
 			name: "doubleDigit",
-			pos:  position{line: 647, col: 1, offset: 15449},
+			pos:  position{line: 647, col: 1, offset: 15446},
 			expr: &charClassMatcher{
-				pos:        position{line: 647, col: 15, offset: 15463},
+				pos:        position{line: 647, col: 15, offset: 15460},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -5183,17 +5183,17 @@ var g = &grammar{
 		},
 		{
 			name: "exponentPart",
-			pos:  position{line: 649, col: 1, offset: 15470},
+			pos:  position{line: 649, col: 1, offset: 15467},
 			expr: &seqExpr{
-				pos: position{line: 649, col: 16, offset: 15485},
+				pos: position{line: 649, col: 16, offset: 15482},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 649, col: 16, offset: 15485},
+						pos:        position{line: 649, col: 16, offset: 15482},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 649, col: 21, offset: 15490},
+						pos:  position{line: 649, col: 21, offset: 15487},
 						name: "sinteger",
 					},
 				},
@@ -5201,17 +5201,17 @@ var g = &grammar{
 		},
 		{
 			name: "h16",
-			pos:  position{line: 651, col: 1, offset: 15500},
+			pos:  position{line: 651, col: 1, offset: 15497},
 			expr: &actionExpr{
-				pos: position{line: 651, col: 7, offset: 15506},
+				pos: position{line: 651, col: 7, offset: 15503},
 				run: (*parser).callonh161,
 				expr: &labeledExpr{
-					pos:   position{line: 651, col: 7, offset: 15506},
+					pos:   position{line: 651, col: 7, offset: 15503},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 651, col: 13, offset: 15512},
+						pos: position{line: 651, col: 13, offset: 15509},
 						expr: &ruleRefExpr{
-							pos:  position{line: 651, col: 13, offset: 15512},
+							pos:  position{line: 651, col: 13, offset: 15509},
 							name: "hexdigit",
 						},
 					},
@@ -5220,9 +5220,9 @@ var g = &grammar{
 		},
 		{
 			name: "hexdigit",
-			pos:  position{line: 653, col: 1, offset: 15554},
+			pos:  position{line: 653, col: 1, offset: 15551},
 			expr: &charClassMatcher{
-				pos:        position{line: 653, col: 12, offset: 15565},
+				pos:        position{line: 653, col: 12, offset: 15562},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -5231,17 +5231,17 @@ var g = &grammar{
 		},
 		{
 			name: "searchWord",
-			pos:  position{line: 655, col: 1, offset: 15578},
+			pos:  position{line: 655, col: 1, offset: 15575},
 			expr: &actionExpr{
-				pos: position{line: 656, col: 5, offset: 15593},
+				pos: position{line: 656, col: 5, offset: 15590},
 				run: (*parser).callonsearchWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 656, col: 5, offset: 15593},
+					pos:   position{line: 656, col: 5, offset: 15590},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 656, col: 11, offset: 15599},
+						pos: position{line: 656, col: 11, offset: 15596},
 						expr: &ruleRefExpr{
-							pos:  position{line: 656, col: 11, offset: 15599},
+							pos:  position{line: 656, col: 11, offset: 15596},
 							name: "searchWordPart",
 						},
 					},
@@ -5250,33 +5250,33 @@ var g = &grammar{
 		},
 		{
 			name: "searchWordPart",
-			pos:  position{line: 658, col: 1, offset: 15649},
+			pos:  position{line: 658, col: 1, offset: 15646},
 			expr: &choiceExpr{
-				pos: position{line: 659, col: 5, offset: 15668},
+				pos: position{line: 659, col: 5, offset: 15665},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 15668},
+						pos: position{line: 659, col: 5, offset: 15665},
 						run: (*parser).callonsearchWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 15668},
+							pos: position{line: 659, col: 5, offset: 15665},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 659, col: 5, offset: 15668},
+									pos:        position{line: 659, col: 5, offset: 15665},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 659, col: 10, offset: 15673},
+									pos:   position{line: 659, col: 10, offset: 15670},
 									label: "s",
 									expr: &choiceExpr{
-										pos: position{line: 659, col: 13, offset: 15676},
+										pos: position{line: 659, col: 13, offset: 15673},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 659, col: 13, offset: 15676},
+												pos:  position{line: 659, col: 13, offset: 15673},
 												name: "escapeSequence",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 659, col: 30, offset: 15693},
+												pos:  position{line: 659, col: 30, offset: 15690},
 												name: "searchEscape",
 											},
 										},
@@ -5286,18 +5286,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 660, col: 5, offset: 15730},
+						pos: position{line: 660, col: 5, offset: 15727},
 						run: (*parser).callonsearchWordPart9,
 						expr: &seqExpr{
-							pos: position{line: 660, col: 5, offset: 15730},
+							pos: position{line: 660, col: 5, offset: 15727},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 660, col: 5, offset: 15730},
+									pos: position{line: 660, col: 5, offset: 15727},
 									expr: &choiceExpr{
-										pos: position{line: 660, col: 7, offset: 15732},
+										pos: position{line: 660, col: 7, offset: 15729},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 660, col: 7, offset: 15732},
+												pos:        position{line: 660, col: 7, offset: 15729},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -5305,14 +5305,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 660, col: 42, offset: 15767},
+												pos:  position{line: 660, col: 42, offset: 15764},
 												name: "ws",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 660, col: 46, offset: 15771,
+									line: 660, col: 46, offset: 15768,
 								},
 							},
 						},
@@ -5322,34 +5322,34 @@ var g = &grammar{
 		},
 		{
 			name: "quotedString",
-			pos:  position{line: 662, col: 1, offset: 15805},
+			pos:  position{line: 662, col: 1, offset: 15802},
 			expr: &choiceExpr{
-				pos: position{line: 663, col: 5, offset: 15822},
+				pos: position{line: 663, col: 5, offset: 15819},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 663, col: 5, offset: 15822},
+						pos: position{line: 663, col: 5, offset: 15819},
 						run: (*parser).callonquotedString2,
 						expr: &seqExpr{
-							pos: position{line: 663, col: 5, offset: 15822},
+							pos: position{line: 663, col: 5, offset: 15819},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 663, col: 5, offset: 15822},
+									pos:        position{line: 663, col: 5, offset: 15819},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 663, col: 9, offset: 15826},
+									pos:   position{line: 663, col: 9, offset: 15823},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 663, col: 11, offset: 15828},
+										pos: position{line: 663, col: 11, offset: 15825},
 										expr: &ruleRefExpr{
-											pos:  position{line: 663, col: 11, offset: 15828},
+											pos:  position{line: 663, col: 11, offset: 15825},
 											name: "doubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 663, col: 29, offset: 15846},
+									pos:        position{line: 663, col: 29, offset: 15843},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5357,29 +5357,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 664, col: 5, offset: 15883},
+						pos: position{line: 664, col: 5, offset: 15880},
 						run: (*parser).callonquotedString9,
 						expr: &seqExpr{
-							pos: position{line: 664, col: 5, offset: 15883},
+							pos: position{line: 664, col: 5, offset: 15880},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 664, col: 5, offset: 15883},
+									pos:        position{line: 664, col: 5, offset: 15880},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 664, col: 9, offset: 15887},
+									pos:   position{line: 664, col: 9, offset: 15884},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 664, col: 11, offset: 15889},
+										pos: position{line: 664, col: 11, offset: 15886},
 										expr: &ruleRefExpr{
-											pos:  position{line: 664, col: 11, offset: 15889},
+											pos:  position{line: 664, col: 11, offset: 15886},
 											name: "singleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 664, col: 29, offset: 15907},
+									pos:        position{line: 664, col: 29, offset: 15904},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5391,55 +5391,55 @@ var g = &grammar{
 		},
 		{
 			name: "doubleQuotedChar",
-			pos:  position{line: 666, col: 1, offset: 15941},
+			pos:  position{line: 666, col: 1, offset: 15938},
 			expr: &choiceExpr{
-				pos: position{line: 667, col: 5, offset: 15962},
+				pos: position{line: 667, col: 5, offset: 15959},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 667, col: 5, offset: 15962},
+						pos: position{line: 667, col: 5, offset: 15959},
 						run: (*parser).callondoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 667, col: 5, offset: 15962},
+							pos: position{line: 667, col: 5, offset: 15959},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 667, col: 5, offset: 15962},
+									pos: position{line: 667, col: 5, offset: 15959},
 									expr: &choiceExpr{
-										pos: position{line: 667, col: 7, offset: 15964},
+										pos: position{line: 667, col: 7, offset: 15961},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 667, col: 7, offset: 15964},
+												pos:        position{line: 667, col: 7, offset: 15961},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 667, col: 13, offset: 15970},
+												pos:  position{line: 667, col: 13, offset: 15967},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 667, col: 26, offset: 15983,
+									line: 667, col: 26, offset: 15980,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 668, col: 5, offset: 16020},
+						pos: position{line: 668, col: 5, offset: 16017},
 						run: (*parser).callondoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 668, col: 5, offset: 16020},
+							pos: position{line: 668, col: 5, offset: 16017},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 668, col: 5, offset: 16020},
+									pos:        position{line: 668, col: 5, offset: 16017},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 668, col: 10, offset: 16025},
+									pos:   position{line: 668, col: 10, offset: 16022},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 668, col: 12, offset: 16027},
+										pos:  position{line: 668, col: 12, offset: 16024},
 										name: "escapeSequence",
 									},
 								},
@@ -5451,55 +5451,55 @@ var g = &grammar{
 		},
 		{
 			name: "singleQuotedChar",
-			pos:  position{line: 670, col: 1, offset: 16061},
+			pos:  position{line: 670, col: 1, offset: 16058},
 			expr: &choiceExpr{
-				pos: position{line: 671, col: 5, offset: 16082},
+				pos: position{line: 671, col: 5, offset: 16079},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 671, col: 5, offset: 16082},
+						pos: position{line: 671, col: 5, offset: 16079},
 						run: (*parser).callonsingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 671, col: 5, offset: 16082},
+							pos: position{line: 671, col: 5, offset: 16079},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 671, col: 5, offset: 16082},
+									pos: position{line: 671, col: 5, offset: 16079},
 									expr: &choiceExpr{
-										pos: position{line: 671, col: 7, offset: 16084},
+										pos: position{line: 671, col: 7, offset: 16081},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 671, col: 7, offset: 16084},
+												pos:        position{line: 671, col: 7, offset: 16081},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 671, col: 13, offset: 16090},
+												pos:  position{line: 671, col: 13, offset: 16087},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 671, col: 26, offset: 16103,
+									line: 671, col: 26, offset: 16100,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 672, col: 5, offset: 16140},
+						pos: position{line: 672, col: 5, offset: 16137},
 						run: (*parser).callonsingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 672, col: 5, offset: 16140},
+							pos: position{line: 672, col: 5, offset: 16137},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 672, col: 5, offset: 16140},
+									pos:        position{line: 672, col: 5, offset: 16137},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 672, col: 10, offset: 16145},
+									pos:   position{line: 672, col: 10, offset: 16142},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 672, col: 12, offset: 16147},
+										pos:  position{line: 672, col: 12, offset: 16144},
 										name: "escapeSequence",
 									},
 								},
@@ -5511,38 +5511,38 @@ var g = &grammar{
 		},
 		{
 			name: "escapeSequence",
-			pos:  position{line: 674, col: 1, offset: 16181},
+			pos:  position{line: 674, col: 1, offset: 16178},
 			expr: &choiceExpr{
-				pos: position{line: 675, col: 5, offset: 16200},
+				pos: position{line: 675, col: 5, offset: 16197},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 675, col: 5, offset: 16200},
+						pos: position{line: 675, col: 5, offset: 16197},
 						run: (*parser).callonescapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 675, col: 5, offset: 16200},
+							pos: position{line: 675, col: 5, offset: 16197},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 675, col: 5, offset: 16200},
+									pos:        position{line: 675, col: 5, offset: 16197},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 675, col: 9, offset: 16204},
+									pos:  position{line: 675, col: 9, offset: 16201},
 									name: "hexdigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 675, col: 18, offset: 16213},
+									pos:  position{line: 675, col: 18, offset: 16210},
 									name: "hexdigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 676, col: 5, offset: 16264},
+						pos:  position{line: 676, col: 5, offset: 16261},
 						name: "singleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 677, col: 5, offset: 16285},
+						pos:  position{line: 677, col: 5, offset: 16282},
 						name: "unicodeEscape",
 					},
 				},
@@ -5550,75 +5550,75 @@ var g = &grammar{
 		},
 		{
 			name: "singleCharEscape",
-			pos:  position{line: 679, col: 1, offset: 16300},
+			pos:  position{line: 679, col: 1, offset: 16297},
 			expr: &choiceExpr{
-				pos: position{line: 680, col: 5, offset: 16321},
+				pos: position{line: 680, col: 5, offset: 16318},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 680, col: 5, offset: 16321},
+						pos:        position{line: 680, col: 5, offset: 16318},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 681, col: 5, offset: 16329},
+						pos:        position{line: 681, col: 5, offset: 16326},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 682, col: 5, offset: 16337},
+						pos:        position{line: 682, col: 5, offset: 16334},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 683, col: 5, offset: 16346},
+						pos: position{line: 683, col: 5, offset: 16343},
 						run: (*parser).callonsingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 683, col: 5, offset: 16346},
+							pos:        position{line: 683, col: 5, offset: 16343},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 684, col: 5, offset: 16375},
+						pos: position{line: 684, col: 5, offset: 16372},
 						run: (*parser).callonsingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 684, col: 5, offset: 16375},
+							pos:        position{line: 684, col: 5, offset: 16372},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 685, col: 5, offset: 16404},
+						pos: position{line: 685, col: 5, offset: 16401},
 						run: (*parser).callonsingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 685, col: 5, offset: 16404},
+							pos:        position{line: 685, col: 5, offset: 16401},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 686, col: 5, offset: 16433},
+						pos: position{line: 686, col: 5, offset: 16430},
 						run: (*parser).callonsingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 686, col: 5, offset: 16433},
+							pos:        position{line: 686, col: 5, offset: 16430},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 687, col: 5, offset: 16462},
+						pos: position{line: 687, col: 5, offset: 16459},
 						run: (*parser).callonsingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 687, col: 5, offset: 16462},
+							pos:        position{line: 687, col: 5, offset: 16459},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 688, col: 5, offset: 16491},
+						pos: position{line: 688, col: 5, offset: 16488},
 						run: (*parser).callonsingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 688, col: 5, offset: 16491},
+							pos:        position{line: 688, col: 5, offset: 16488},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5628,24 +5628,24 @@ var g = &grammar{
 		},
 		{
 			name: "searchEscape",
-			pos:  position{line: 690, col: 1, offset: 16517},
+			pos:  position{line: 690, col: 1, offset: 16514},
 			expr: &choiceExpr{
-				pos: position{line: 691, col: 5, offset: 16534},
+				pos: position{line: 691, col: 5, offset: 16531},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 691, col: 5, offset: 16534},
+						pos: position{line: 691, col: 5, offset: 16531},
 						run: (*parser).callonsearchEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 691, col: 5, offset: 16534},
+							pos:        position{line: 691, col: 5, offset: 16531},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 692, col: 5, offset: 16562},
+						pos: position{line: 692, col: 5, offset: 16559},
 						run: (*parser).callonsearchEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 692, col: 5, offset: 16562},
+							pos:        position{line: 692, col: 5, offset: 16559},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -5655,41 +5655,41 @@ var g = &grammar{
 		},
 		{
 			name: "unicodeEscape",
-			pos:  position{line: 694, col: 1, offset: 16589},
+			pos:  position{line: 694, col: 1, offset: 16586},
 			expr: &choiceExpr{
-				pos: position{line: 695, col: 5, offset: 16607},
+				pos: position{line: 695, col: 5, offset: 16604},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 695, col: 5, offset: 16607},
+						pos: position{line: 695, col: 5, offset: 16604},
 						run: (*parser).callonunicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 695, col: 5, offset: 16607},
+							pos: position{line: 695, col: 5, offset: 16604},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 695, col: 5, offset: 16607},
+									pos:        position{line: 695, col: 5, offset: 16604},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 695, col: 9, offset: 16611},
+									pos:   position{line: 695, col: 9, offset: 16608},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 695, col: 16, offset: 16618},
+										pos: position{line: 695, col: 16, offset: 16615},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 16, offset: 16618},
+												pos:  position{line: 695, col: 16, offset: 16615},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 25, offset: 16627},
+												pos:  position{line: 695, col: 25, offset: 16624},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 34, offset: 16636},
+												pos:  position{line: 695, col: 34, offset: 16633},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 43, offset: 16645},
+												pos:  position{line: 695, col: 43, offset: 16642},
 												name: "hexdigit",
 											},
 										},
@@ -5699,63 +5699,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 698, col: 5, offset: 16708},
+						pos: position{line: 698, col: 5, offset: 16705},
 						run: (*parser).callonunicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 698, col: 5, offset: 16708},
+							pos: position{line: 698, col: 5, offset: 16705},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 698, col: 5, offset: 16708},
+									pos:        position{line: 698, col: 5, offset: 16705},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 698, col: 9, offset: 16712},
+									pos:        position{line: 698, col: 9, offset: 16709},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 698, col: 13, offset: 16716},
+									pos:   position{line: 698, col: 13, offset: 16713},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 698, col: 20, offset: 16723},
+										pos: position{line: 698, col: 20, offset: 16720},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 698, col: 20, offset: 16723},
+												pos:  position{line: 698, col: 20, offset: 16720},
 												name: "hexdigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 29, offset: 16732},
+												pos: position{line: 698, col: 29, offset: 16729},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 29, offset: 16732},
+													pos:  position{line: 698, col: 29, offset: 16729},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 39, offset: 16742},
+												pos: position{line: 698, col: 39, offset: 16739},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 39, offset: 16742},
+													pos:  position{line: 698, col: 39, offset: 16739},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 49, offset: 16752},
+												pos: position{line: 698, col: 49, offset: 16749},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 49, offset: 16752},
+													pos:  position{line: 698, col: 49, offset: 16749},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 59, offset: 16762},
+												pos: position{line: 698, col: 59, offset: 16759},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 59, offset: 16762},
+													pos:  position{line: 698, col: 59, offset: 16759},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 698, col: 69, offset: 16772},
+												pos: position{line: 698, col: 69, offset: 16769},
 												expr: &ruleRefExpr{
-													pos:  position{line: 698, col: 69, offset: 16772},
+													pos:  position{line: 698, col: 69, offset: 16769},
 													name: "hexdigit",
 												},
 											},
@@ -5763,7 +5763,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 698, col: 80, offset: 16783},
+									pos:        position{line: 698, col: 80, offset: 16780},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5775,28 +5775,28 @@ var g = &grammar{
 		},
 		{
 			name: "reString",
-			pos:  position{line: 702, col: 1, offset: 16837},
+			pos:  position{line: 702, col: 1, offset: 16834},
 			expr: &actionExpr{
-				pos: position{line: 703, col: 5, offset: 16850},
+				pos: position{line: 703, col: 5, offset: 16847},
 				run: (*parser).callonreString1,
 				expr: &seqExpr{
-					pos: position{line: 703, col: 5, offset: 16850},
+					pos: position{line: 703, col: 5, offset: 16847},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 703, col: 5, offset: 16850},
+							pos:        position{line: 703, col: 5, offset: 16847},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 703, col: 9, offset: 16854},
+							pos:   position{line: 703, col: 9, offset: 16851},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 703, col: 11, offset: 16856},
+								pos:  position{line: 703, col: 11, offset: 16853},
 								name: "reBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 703, col: 18, offset: 16863},
+							pos:        position{line: 703, col: 18, offset: 16860},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5806,24 +5806,24 @@ var g = &grammar{
 		},
 		{
 			name: "reBody",
-			pos:  position{line: 705, col: 1, offset: 16886},
+			pos:  position{line: 705, col: 1, offset: 16883},
 			expr: &actionExpr{
-				pos: position{line: 706, col: 5, offset: 16897},
+				pos: position{line: 706, col: 5, offset: 16894},
 				run: (*parser).callonreBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 706, col: 5, offset: 16897},
+					pos: position{line: 706, col: 5, offset: 16894},
 					expr: &choiceExpr{
-						pos: position{line: 706, col: 6, offset: 16898},
+						pos: position{line: 706, col: 6, offset: 16895},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 706, col: 6, offset: 16898},
+								pos:        position{line: 706, col: 6, offset: 16895},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 706, col: 13, offset: 16905},
+								pos:        position{line: 706, col: 13, offset: 16902},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -5834,9 +5834,9 @@ var g = &grammar{
 		},
 		{
 			name: "escapedChar",
-			pos:  position{line: 708, col: 1, offset: 16945},
+			pos:  position{line: 708, col: 1, offset: 16942},
 			expr: &charClassMatcher{
-				pos:        position{line: 709, col: 5, offset: 16961},
+				pos:        position{line: 709, col: 5, offset: 16958},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5846,37 +5846,37 @@ var g = &grammar{
 		},
 		{
 			name: "ws",
-			pos:  position{line: 711, col: 1, offset: 16976},
+			pos:  position{line: 711, col: 1, offset: 16973},
 			expr: &choiceExpr{
-				pos: position{line: 712, col: 5, offset: 16983},
+				pos: position{line: 712, col: 5, offset: 16980},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 712, col: 5, offset: 16983},
+						pos:        position{line: 712, col: 5, offset: 16980},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 713, col: 5, offset: 16992},
+						pos:        position{line: 713, col: 5, offset: 16989},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 714, col: 5, offset: 17001},
+						pos:        position{line: 714, col: 5, offset: 16998},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 715, col: 5, offset: 17010},
+						pos:        position{line: 715, col: 5, offset: 17007},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 716, col: 5, offset: 17018},
+						pos:        position{line: 716, col: 5, offset: 17015},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 717, col: 5, offset: 17031},
+						pos:        position{line: 717, col: 5, offset: 17028},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5886,33 +5886,33 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 719, col: 1, offset: 17041},
+			pos:         position{line: 719, col: 1, offset: 17038},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 719, col: 18, offset: 17058},
+				pos: position{line: 719, col: 18, offset: 17055},
 				expr: &ruleRefExpr{
-					pos:  position{line: 719, col: 18, offset: 17058},
+					pos:  position{line: 719, col: 18, offset: 17055},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 720, col: 1, offset: 17062},
+			pos:  position{line: 720, col: 1, offset: 17059},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 720, col: 6, offset: 17067},
+				pos: position{line: 720, col: 6, offset: 17064},
 				expr: &ruleRefExpr{
-					pos:  position{line: 720, col: 6, offset: 17067},
+					pos:  position{line: 720, col: 6, offset: 17064},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 722, col: 1, offset: 17072},
+			pos:  position{line: 722, col: 1, offset: 17069},
 			expr: &notExpr{
-				pos: position{line: 722, col: 7, offset: 17078},
+				pos: position{line: 722, col: 7, offset: 17075},
 				expr: &anyMatcher{
-					line: 722, col: 8, offset: 17079,
+					line: 722, col: 8, offset: 17076,
 				},
 			},
 		},
@@ -6722,7 +6722,7 @@ func (p *parser) callonfieldReducer1() (interface{}, error) {
 	return p.cur.onfieldReducer1(stack["op"], stack["field"])
 }
 
-func (c *current) onreducerProc1(every, reducers, keys, limit interface{}) (interface{}, error) {
+func (c *current) onreduceProc1(every, reducers, keys, limit interface{}) (interface{}, error) {
 	if OR(keys, every) != nil {
 		if keys != nil {
 			keys = keys.([]interface{})[1]
@@ -6737,14 +6737,14 @@ func (c *current) onreducerProc1(every, reducers, keys, limit interface{}) (inte
 		return makeGroupByProc(every, limit, keys, reducers), nil
 	}
 
-	return makeReducerProc(reducers), nil
+	return makeReduceProc(reducers), nil
 
 }
 
-func (p *parser) callonreducerProc1() (interface{}, error) {
+func (p *parser) callonreduceProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onreducerProc1(stack["every"], stack["reducers"], stack["keys"], stack["limit"])
+	return p.cur.onreduceProc1(stack["every"], stack["reducers"], stack["keys"], stack["limit"])
 }
 
 func (c *current) onasClause1(v interface{}) (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -385,7 +385,7 @@ function peg$parse(input, options) {
             return makeGroupByProc(every, limit, keys, reducers)
           }
 
-          return makeReducerProc(reducers)
+          return makeReduceProc(reducers)
         },
       peg$c138 = "as",
       peg$c139 = peg$literalExpectation("as", true),
@@ -2051,7 +2051,7 @@ function peg$parse(input, options) {
 
     s0 = peg$parsesimpleProc();
     if (s0 === peg$FAILED) {
-      s0 = peg$parsereducerProc();
+      s0 = peg$parsereduceProc();
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
@@ -3413,7 +3413,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsereducerProc() {
+  function peg$parsereduceProc() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
@@ -8339,8 +8339,8 @@ function peg$parse(input, options) {
     return {type: "Duration", seconds};
   }
 
-  function makeReducerProc(reducers) {
-    return { op: "ReducerProc", reducers };
+  function makeReduceProc(reducers) {
+    return { op: "ReduceProc", reducers };
   }
 
   function makeGroupByKey(target, expression) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -208,7 +208,7 @@ parallelChain
 
 proc
   = simpleProc
-  / reducerProc
+  / reduceProc
   / "(" _? proc:procList _? ")" {
       RETURN(proc)
     }
@@ -317,7 +317,7 @@ fieldReducer
     RETURN(makeReducer(op, toLowerCase(op), field))
   }
 
-reducerProc
+reduceProc
   = every:(everyDur _)? reducers:reducerList keys:(_ groupByKeys)? limit:procLimitArg? {
     if ISNOTNULL(OR(keys, every)) {
       if ISNOTNULL(keys) {
@@ -333,7 +333,7 @@ reducerProc
       RETURN(makeGroupByProc(every, limit, keys, reducers))
     }
 
-    RETURN(makeReducerProc(reducers))
+    RETURN(makeReduceProc(reducers))
   }
 
 asClause


### PR DESCRIPTION
None of the other proc names use the "-er" action-noun suffix form.

(Why now? I ran into this when I wanted to move some reducer-stuff into proc/reducer.go.)