### PR TITLE
python go integration prototyping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tests/test-root
 zq-sample-data
 zql/deps/
 .idea
+python/build

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ tests/test-root
 zq-sample-data
 zql/deps/
 .idea
-python/build

--- a/Makefile
+++ b/Makefile
@@ -80,12 +80,16 @@ create-release-assets:
 		zip -r release/$${d}.zip $${d} ; \
 	done
 
+build-pyzq:
+	@mkdir -p python/build
+	@go build -buildmode=c-shared -o python/build/zq.so ./python/zq.go
+
 # CI performs these actions individually since that looks nicer in the UI;
 # this is a shortcut so that a local dev can easily run everything.
 test-ci: fmt tidy vet test-unit test-system test-zeek test-heavy
 
 clean:
-	@rm -rf dist
+	@rm -rf dist python/build
 
 .PHONY: fmt tidy vet test-unit test-system test-heavy sampledata test-ci
-.PHONY: perf-compare build install create-release-assets clean
+.PHONY: perf-compare build install create-release-assets clean build-pyzq

--- a/Makefile
+++ b/Makefile
@@ -81,15 +81,15 @@ create-release-assets:
 	done
 
 build-pyzq:
-	@mkdir -p python/build
-	@go build -buildmode=c-shared -o python/build/zq.so ./python/zq.go
+	@mkdir -p dist/pybuild
+	@go build -buildmode=c-shared -o dist/pybuild/zq.so ./python/zq.go
 
 # CI performs these actions individually since that looks nicer in the UI;
 # this is a shortcut so that a local dev can easily run everything.
 test-ci: fmt tidy vet test-unit test-system test-zeek test-heavy
 
 clean:
-	@rm -rf dist python/build
+	@rm -rf dist
 
 .PHONY: fmt tidy vet test-unit test-system test-heavy sampledata test-ci
 .PHONY: perf-compare build install create-release-assets clean build-pyzq

--- a/python/pyzq.py
+++ b/python/pyzq.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+from cffi import FFI
+
+ZQLIB = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     './build/zq.so')
+
+
+class Zq(object):
+    def __init__(self):
+        self.ffi = FFI()
+        self.ffi.cdef("""
+void free(void *ptr);
+
+typedef long GoInt;
+typedef unsigned char GoUint8;
+typedef struct { const char *p; GoInt n; } GoString;
+
+struct goresult {
+	char* r0;
+	GoUint8 r1;
+};
+
+extern struct goresult ZqlFileEval(GoString p0, GoString p1, GoString p2);
+extern struct goresult ErrorTest();
+""")
+        self.zqlib = self.ffi.dlopen(ZQLIB)
+
+    def gostring(self, refs, s):
+        """Convert a Python string to an allocated GoString."""
+        u8b = s.encode('utf-8')
+        c = self.ffi.new('char[]', u8b)
+        refs.append(c)
+        gstr = self.ffi.new('GoString*', {'p': c, 'n': len(u8b)})
+        refs.append(gstr)
+        return gstr
+
+    def result(self, res):
+        """Interpret a goresult structure, raising an exception for errors."""
+        if res.r1 == 1:
+            return
+        err = str(self.ffi.string(res.r0), 'utf-8')
+        self.zqlib.free(res.r0)
+        raise Exception(err)
+
+    def error_test(self):
+        self.result(self.zqlib.ErrorTest())
+
+    def zql_file_eval(self, zql, infile, outfile):
+        refs = []
+        gzql = self.gostring(refs, zql)
+        ginfile = self.gostring(refs, infile)
+        goutfile = self.gostring(refs, outfile)
+        self.result(self.zqlib.ZqlFileEval(gzql[0], ginfile[0], goutfile[0]))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 4:
+        raise Exception("expected args: <zql> <input-file> <output-file>")
+
+    zql = sys.argv[1]
+    infile = sys.argv[2]
+    outfile = sys.argv[3]
+
+    zq = Zq()
+    zq.zql_file_eval(zql, infile, outfile)

--- a/python/pyzq.py
+++ b/python/pyzq.py
@@ -6,7 +6,7 @@ import sys
 from cffi import FFI
 
 ZQLIB = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     './build/zq.so')
+                     '../dist/pybuild/zq.so')
 
 
 class Zq(object):

--- a/python/zq.go
+++ b/python/zq.go
@@ -1,0 +1,77 @@
+package main
+
+import "C"
+
+import (
+	"context"
+	"errors"
+
+	"github.com/brimsec/zq/driver"
+	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/detector"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zql"
+)
+
+// result converts an error into response structure expected
+// by the Python calling code. cgo does not support exporting
+// a function that returns a struct, hence the multiple return
+// values.
+// If C.CString is used to allocate a C char* string, the Python
+// side code will free it.
+func result(err error) (*C.char, bool) {
+	if err != nil {
+		return C.CString(err.Error()), false
+	}
+	return nil, true
+}
+
+// ErrorTest is only used to verify that errors are successfully passed
+// between the Go & Python realms.
+//
+//export ErrorTest
+func ErrorTest() (*C.char, bool) {
+	return result(errors.New("error test"))
+}
+
+//export ZqlFileEval
+func ZqlFileEval(inquery, inpath, outpath string) (*C.char, bool) {
+	return result(doZqlFileEval(inquery, inpath, outpath))
+}
+
+func doZqlFileEval(inquery, inpath, outpath string) error {
+	if inpath == "-" {
+		inpath = "/dev/stdin"
+	}
+	if outpath == "-" {
+		outpath = "/dev/stdout"
+	}
+	query, err := zql.ParseProc(inquery)
+	if err != nil {
+		return err
+	}
+
+	zctx := resolver.NewContext()
+	rc, err := detector.OpenFile(zctx, inpath, detector.OpenConfig{})
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	w, err := emitter.NewFile(outpath, &zio.WriterFlags{
+		Format: "zng",
+	})
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	fg, err := driver.Compile(context.Background(), query, rc, false, nano.MaxSpan, nil)
+	d := driver.NewCLI(w)
+
+	return driver.Run(fg, d, nil)
+}
+
+func main() {}


### PR DESCRIPTION
Demo of how the Python/Go integration could work. Run 'make build-pyzq',
then './python/pyzq.py <zql> <infile> <outfile>'; infile and outfile can
be "-" for stdin/stdout. This only supports ZNG format for in and out.

Closes https://github.com/brimsec/zq/issues/885 ; later work in the epic includes creating a module, exposing more operations, etc.
