### PR TITLE
Decomposable reducers

### DIFF
--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/expr"
-	"github.com/brimsec/zq/reducer"
 	"github.com/brimsec/zq/reducer/compile"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zcode"
@@ -385,7 +384,7 @@ func (g *GroupByAggregator) records(eof bool) ([]*zng.Record, error) {
 		zv = append(zv, row.keyvals...)
 		for _, red := range row.reducers.Reducers {
 			// a reducer value is never a container
-			v := reducer.Result(red)
+			v := red.Result()
 			if v.IsContainer() {
 				panic("internal bug: reducer result cannot be a container!")
 			}
@@ -419,7 +418,7 @@ func (g *GroupByAggregator) lookupRowType(row *GroupByRow) (*zng.TypeRecord, err
 	}
 	cols = append(cols, g.builder.TypedColumns(types)...)
 	for k, red := range row.reducers.Reducers {
-		z := reducer.Result(red)
+		z := red.Result()
 		cols = append(cols, zng.NewColumn(row.reducers.Defs[k].Target(), z.Type))
 	}
 	// This could be more efficient but it's only done during group-by output...

--- a/reducer/avg.go
+++ b/reducer/avg.go
@@ -2,7 +2,9 @@ package reducer
 
 import (
 	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zngnative"
 )
 
@@ -53,4 +55,54 @@ func (a *Avg) Result() zng.Value {
 		return zng.NewFloat64(a.sum / float64(a.count))
 	}
 	return zng.Value{Type: zng.TypeFloat64}
+}
+
+const (
+	sumName   = "sum"
+	countName = "count"
+)
+
+func (a *Avg) ConsumePart(p zng.Value) error {
+	rType, ok := p.Type.(*zng.TypeRecord)
+	if !ok {
+		return ErrBadValue
+	}
+	rec, err := zng.NewRecord(rType, p.Bytes)
+	if err != nil {
+		return ErrBadValue
+	}
+	sumVal, err := rec.ValueByField(sumName)
+	if err != nil || sumVal.Type != zng.TypeFloat64 {
+		return ErrBadValue
+	}
+	sum, err := zng.DecodeFloat64(sumVal.Bytes)
+	if err != nil {
+		return ErrBadValue
+	}
+	countVal, err := rec.ValueByField(countName)
+	if err != nil || countVal.Type != zng.TypeUint64 {
+		return ErrBadValue
+	}
+	count, err := zng.DecodeUint(countVal.Bytes)
+	if err != nil {
+		return ErrBadValue
+	}
+	a.sum, a.count = sum, count
+	return nil
+}
+
+func (a *Avg) ResultPart(zctx *resolver.Context) (zng.Value, error) {
+	var zv zcode.Bytes
+	zv = zng.NewFloat64(a.sum).Encode(zv)
+	zv = zng.NewUint64(a.count).Encode(zv)
+
+	cols := []zng.Column{
+		zng.NewColumn(sumName, zng.TypeFloat64),
+		zng.NewColumn(countName, zng.TypeUint64),
+	}
+	typ, err := zctx.LookupTypeRecord(cols)
+	if err != nil {
+		return zng.Value{}, err
+	}
+	return zng.Value{Type: typ, Bytes: zv}, nil
 }

--- a/reducer/avg.go
+++ b/reducer/avg.go
@@ -15,7 +15,7 @@ func (ap *AvgProto) Target() string {
 	return ap.target
 }
 
-func (ap *AvgProto) Instantiate(*zng.Record) Interface {
+func (ap *AvgProto) Instantiate() Interface {
 	return &Avg{Resolver: ap.resolver}
 }
 

--- a/reducer/compile/compile.go
+++ b/reducer/compile/compile.go
@@ -8,7 +8,6 @@ import (
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/reducer"
 	"github.com/brimsec/zq/reducer/field"
-	"github.com/brimsec/zq/zng"
 )
 
 var (
@@ -18,7 +17,7 @@ var (
 
 type CompiledReducer interface {
 	Target() string // The name of the field where results are stored.
-	Instantiate(*zng.Record) reducer.Interface
+	Instantiate() reducer.Interface
 }
 
 func Compile(params ast.Reducer) (CompiledReducer, error) {

--- a/reducer/compile/row.go
+++ b/reducer/compile/row.go
@@ -24,7 +24,7 @@ func (r *Row) Touch(rec *zng.Record) {
 	if r.Reducers == nil {
 		r.Reducers = make([]reducer.Interface, len(r.Defs))
 	}
-	for k, _ := range r.Defs {
+	for k := range r.Defs {
 		if r.Reducers[k] != nil {
 			continue
 		}
@@ -49,7 +49,7 @@ func (r *Row) Result(zctx *resolver.Context) (*zng.Record, error) {
 	columns := make([]zng.Column, n)
 	var zv zcode.Bytes
 	for k, red := range r.Reducers {
-		val := reducer.Result(red)
+		val := red.Result()
 		columns[k] = zng.NewColumn(r.Defs[k].Target(), val.Type)
 		zv = val.Encode(zv)
 	}

--- a/reducer/compile/row.go
+++ b/reducer/compile/row.go
@@ -28,7 +28,7 @@ func (r *Row) Touch(rec *zng.Record) {
 		if r.Reducers[k] != nil {
 			continue
 		}
-		red := r.Defs[k].Instantiate(rec)
+		red := r.Defs[k].Instantiate()
 		r.Reducers[k] = red
 		r.n++
 	}

--- a/reducer/count.go
+++ b/reducer/count.go
@@ -14,7 +14,7 @@ func (cp *CountProto) Target() string {
 	return cp.target
 }
 
-func (cp *CountProto) Instantiate(*zng.Record) Interface {
+func (cp *CountProto) Instantiate() Interface {
 	return &Count{Resolver: cp.resolver}
 }
 

--- a/reducer/count.go
+++ b/reducer/count.go
@@ -3,6 +3,7 @@ package reducer
 import (
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
 )
 
 type CountProto struct {
@@ -39,4 +40,17 @@ func (c *Count) Consume(r *zng.Record) {
 
 func (c *Count) Result() zng.Value {
 	return zng.NewUint64(c.count)
+}
+
+func (c *Count) ConsumePart(p zng.Value) error {
+	u, err := zng.DecodeUint(p.Bytes)
+	if err != nil {
+		return err
+	}
+	c.count += u
+	return nil
+}
+
+func (c *Count) ResultPart(*resolver.Context) (zng.Value, error) {
+	return c.Result(), nil
 }

--- a/reducer/countdistinct.go
+++ b/reducer/countdistinct.go
@@ -15,7 +15,7 @@ func (cdp *CountDistinctProto) Target() string {
 	return cdp.target
 }
 
-func (cdp *CountDistinctProto) Instantiate(*zng.Record) Interface {
+func (cdp *CountDistinctProto) Instantiate() Interface {
 	return &CountDistinct{
 		Resolver: cdp.resolver,
 		sketch:   hyperloglog.New(),

--- a/reducer/field/field.go
+++ b/reducer/field/field.go
@@ -21,12 +21,8 @@ func (fp *FieldProto) Target() string {
 	return fp.target
 }
 
-func (fp *FieldProto) Instantiate(rec *zng.Record) reducer.Interface {
-	v := fp.resolver(rec)
-	if v.Type == nil {
-		v.Type = zng.TypeNull
-	}
-	return &FieldReducer{op: fp.op, resolver: fp.resolver, typ: v.Type}
+func (fp *FieldProto) Instantiate() reducer.Interface {
+	return &FieldReducer{op: fp.op, resolver: fp.resolver}
 }
 
 func NewFieldProto(target string, resolver expr.FieldExprResolver, op string) *FieldProto {
@@ -43,6 +39,9 @@ type FieldReducer struct {
 
 func (fr *FieldReducer) Result() zng.Value {
 	if fr.fn == nil {
+		if fr.typ == nil {
+			return zng.Value{Type: zng.TypeNull, Bytes: nil}
+		}
 		return zng.Value{Type: fr.typ, Bytes: nil}
 	}
 	return fr.fn.Result()
@@ -58,6 +57,9 @@ func (fr *FieldReducer) Consume(r *zng.Record) {
 	if val.Type == nil {
 		fr.FieldNotFound++
 		return
+	}
+	if fr.typ == nil {
+		fr.typ = val.Type
 	}
 	if val.Bytes == nil {
 		return

--- a/reducer/field/field.go
+++ b/reducer/field/field.go
@@ -4,6 +4,7 @@ import (
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/reducer"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
 )
 
 type Streamfn interface {
@@ -58,6 +59,10 @@ func (fr *FieldReducer) Consume(r *zng.Record) {
 		fr.FieldNotFound++
 		return
 	}
+	fr.consumeVal(val)
+}
+
+func (fr *FieldReducer) consumeVal(val zng.Value) {
 	if fr.typ == nil {
 		fr.typ = val.Type
 	}
@@ -84,4 +89,13 @@ func (fr *FieldReducer) Consume(r *zng.Record) {
 	if fr.fn.Consume(val) == zng.ErrTypeMismatch {
 		fr.TypeMismatch++
 	}
+}
+
+func (fr *FieldReducer) ResultPart(*resolver.Context) (zng.Value, error) {
+	return fr.Result(), nil
+}
+
+func (fr *FieldReducer) ConsumePart(v zng.Value) error {
+	fr.consumeVal(v)
+	return nil
 }

--- a/reducer/first.go
+++ b/reducer/first.go
@@ -14,12 +14,8 @@ func (fp *FirstProto) Target() string {
 	return fp.target
 }
 
-func (fp *FirstProto) Instantiate(rec *zng.Record) Interface {
-	v := fp.resolver(rec)
-	if v.Type == nil {
-		v.Type = zng.TypeNull
-	}
-	return &First{Resolver: fp.resolver, typ: v.Type}
+func (fp *FirstProto) Instantiate() Interface {
+	return &First{Resolver: fp.resolver}
 }
 
 func NewFirstProto(target string, field expr.FieldExprResolver) *FirstProto {
@@ -29,7 +25,6 @@ func NewFirstProto(target string, field expr.FieldExprResolver) *FirstProto {
 type First struct {
 	Reducer
 	Resolver expr.FieldExprResolver
-	typ      zng.Type
 	record   *zng.Record
 }
 
@@ -45,7 +40,7 @@ func (f *First) Consume(r *zng.Record) {
 
 func (f *First) Result() zng.Value {
 	if f.record == nil {
-		return zng.Value{Type: f.typ, Bytes: nil}
+		return zng.Value{Type: zng.TypeNull, Bytes: nil}
 	}
 	return f.Resolver(f.record)
 }

--- a/reducer/last.go
+++ b/reducer/last.go
@@ -14,12 +14,8 @@ func (lp *LastProto) Target() string {
 	return lp.target
 }
 
-func (lp *LastProto) Instantiate(rec *zng.Record) Interface {
-	v := lp.resolver(rec)
-	if v.Type == nil {
-		v.Type = zng.TypeNull
-	}
-	return &Last{Resolver: lp.resolver, typ: v.Type}
+func (lp *LastProto) Instantiate() Interface {
+	return &Last{Resolver: lp.resolver}
 }
 
 func NewLastProto(target string, resolver expr.FieldExprResolver) *LastProto {
@@ -29,7 +25,6 @@ func NewLastProto(target string, resolver expr.FieldExprResolver) *LastProto {
 type Last struct {
 	Reducer
 	Resolver expr.FieldExprResolver
-	typ      zng.Type
 	record   *zng.Record
 }
 
@@ -43,7 +38,7 @@ func (l *Last) Consume(r *zng.Record) {
 func (l *Last) Result() zng.Value {
 	r := l.record
 	if r == nil {
-		return zng.Value{Type: l.typ, Bytes: nil}
+		return zng.Value{Type: zng.TypeNull, Bytes: nil}
 	}
 	return l.Resolver(r)
 }

--- a/reducer/reducer.go
+++ b/reducer/reducer.go
@@ -19,14 +19,6 @@ type Interface interface {
 	Result() zng.Value
 }
 
-// Result returns the Interface's result or a zng.Unset value if r is nil.
-func Result(r Interface) zng.Value {
-	if r == nil {
-		return zng.Value{}
-	}
-	return r.Result()
-}
-
 type Stats struct {
 	TypeMismatch  int64
 	FieldNotFound int64

--- a/reducer/reducer.go
+++ b/reducer/reducer.go
@@ -8,15 +8,22 @@ import (
 	"errors"
 
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
 )
 
 var (
-	ErrUnsupportedType = errors.New("unsupported type")
+	ErrBadValue = errors.New("bad value")
 )
 
 type Interface interface {
 	Consume(*zng.Record)
 	Result() zng.Value
+}
+
+type Decomposable interface {
+	Interface
+	ConsumePart(zng.Value) error
+	ResultPart(*resolver.Context) (zng.Value, error)
 }
 
 type Stats struct {

--- a/reducer/reducer_test.go
+++ b/reducer/reducer_test.go
@@ -1,0 +1,109 @@
+package reducer_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/reducer"
+	"github.com/brimsec/zq/reducer/compile"
+	"github.com/brimsec/zq/reducer/field"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/tzngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/stretchr/testify/require"
+)
+
+func parse(zctx *resolver.Context, src string) (*zbuf.Array, error) {
+	reader := tzngio.NewReader(strings.NewReader(src), zctx)
+	records := make([]*zng.Record, 0)
+	for {
+		rec, err := reader.Read()
+		if err != nil {
+			return nil, err
+		}
+		if rec == nil {
+			break
+		}
+		records = append(records, rec)
+	}
+
+	return zbuf.NewArray(records, nano.MaxSpan), nil
+}
+
+func runOne(t *testing.T, zctx *resolver.Context, proto compile.CompiledReducer, i int, recs []*zng.Record) zng.Value {
+	red := proto.Instantiate().(reducer.Decomposable)
+	for _, rec := range recs[:i] {
+		red.Consume(rec)
+	}
+	part, err := red.ResultPart(zctx)
+	require.NoError(t, err)
+	red = proto.Instantiate().(reducer.Decomposable)
+	err = red.ConsumePart(part)
+	require.NoError(t, err)
+	for _, rec := range recs[i:] {
+		red.Consume(rec)
+	}
+	return red.Result()
+}
+
+func TestDecomposableReducers(t *testing.T) {
+	const input = `
+#0:record[n:int32]
+0:[0;]
+0:[5;]
+0:[10;]
+`
+	resolver := resolver.NewContext()
+	b, err := parse(resolver, input)
+	require.NoError(t, err)
+	recs := b.Records()
+
+	t.Run("avg", func(t *testing.T) {
+		proto := reducer.NewAvgProto("avg", expr.CompileFieldAccess("n"))
+		for i := 0; i <= len(recs); i++ {
+			res := runOne(t, resolver, proto, i, recs)
+			f, err := zng.DecodeFloat64(res.Bytes)
+			require.NoError(t, err)
+			require.Equal(t, f, 5.)
+		}
+	})
+	t.Run("count", func(t *testing.T) {
+		proto := reducer.NewCountProto("avg", expr.CompileFieldAccess("n"))
+		for i := 0; i <= len(recs); i++ {
+			res := runOne(t, resolver, proto, i, recs)
+			f, err := zng.DecodeUint(res.Bytes)
+			require.NoError(t, err)
+			require.Equal(t, f, uint64(3))
+		}
+	})
+	t.Run("field-min", func(t *testing.T) {
+		proto := field.NewFieldProto("min", expr.CompileFieldAccess("n"), "Min")
+		for i := 0; i <= len(recs); i++ {
+			res := runOne(t, resolver, proto, i, recs)
+			f, err := zng.DecodeInt(res.Bytes)
+			require.NoError(t, err)
+			require.Equal(t, f, int64(0))
+		}
+	})
+	t.Run("field-max", func(t *testing.T) {
+		proto := field.NewFieldProto("min", expr.CompileFieldAccess("n"), "Max")
+		for i := 0; i <= len(recs); i++ {
+			res := runOne(t, resolver, proto, i, recs)
+			f, err := zng.DecodeInt(res.Bytes)
+			require.NoError(t, err)
+			require.Equal(t, f, int64(10))
+		}
+	})
+	t.Run("field-sum", func(t *testing.T) {
+		proto := field.NewFieldProto("min", expr.CompileFieldAccess("n"), "Sum")
+		for i := 0; i <= len(recs); i++ {
+			res := runOne(t, resolver, proto, i, recs)
+			f, err := zng.DecodeInt(res.Bytes)
+			require.NoError(t, err)
+			require.Equal(t, f, int64(15))
+		}
+	})
+}

--- a/reducer/reducer_test.go
+++ b/reducer/reducer_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/expr"
-	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/reducer"
 	"github.com/brimsec/zq/reducer/compile"
 	"github.com/brimsec/zq/reducer/field"
@@ -30,7 +29,7 @@ func parse(zctx *resolver.Context, src string) (*zbuf.Array, error) {
 		records = append(records, rec)
 	}
 
-	return zbuf.NewArray(records, nano.MaxSpan), nil
+	return zbuf.NewArray(records), nil
 }
 
 func runOne(t *testing.T, zctx *resolver.Context, proto compile.CompiledReducer, i int, recs []*zng.Record) zng.Value {

--- a/reducer/reducer_test.go
+++ b/reducer/reducer_test.go
@@ -71,7 +71,7 @@ func TestDecomposableReducers(t *testing.T) {
 		}
 	})
 	t.Run("count", func(t *testing.T) {
-		proto := reducer.NewCountProto("avg", expr.CompileFieldAccess("n"))
+		proto := reducer.NewCountProto("count", expr.CompileFieldAccess("n"))
 		for i := 0; i <= len(recs); i++ {
 			res := runOne(t, resolver, proto, i, recs)
 			f, err := zng.DecodeUint(res.Bytes)
@@ -89,7 +89,7 @@ func TestDecomposableReducers(t *testing.T) {
 		}
 	})
 	t.Run("field-max", func(t *testing.T) {
-		proto := field.NewFieldProto("min", expr.CompileFieldAccess("n"), "Max")
+		proto := field.NewFieldProto("max", expr.CompileFieldAccess("n"), "Max")
 		for i := 0; i <= len(recs); i++ {
 			res := runOne(t, resolver, proto, i, recs)
 			f, err := zng.DecodeInt(res.Bytes)
@@ -98,7 +98,7 @@ func TestDecomposableReducers(t *testing.T) {
 		}
 	})
 	t.Run("field-sum", func(t *testing.T) {
-		proto := field.NewFieldProto("min", expr.CompileFieldAccess("n"), "Sum")
+		proto := field.NewFieldProto("sum", expr.CompileFieldAccess("n"), "Sum")
 		for i := 0; i <= len(recs); i++ {
 			res := runOne(t, resolver, proto, i, recs)
 			f, err := zng.DecodeInt(res.Bytes)


### PR DESCRIPTION
Add a `ConsumePart()` and `ResultPart()` methods and implement them in reducers that perform "decomposable aggregations". And a couple of supporting commits before that.

Decomposition isn't used yet (other than in the test), but putting it up as a self-contained standalone change on the journey to spillable groupby.