### PR TITLE
Flip words to match modified example

### DIFF
--- a/zql/docs/aggregate-functions/README.md
+++ b/zql/docs/aggregate-functions/README.md
@@ -59,7 +59,7 @@ capture_loss 2
 
 #### Example #3:
 
-To count the time-sorted data set into 5-minute buckets:
+To count the data set into time-sorted 5-minute buckets:
 
 ```zq-command
 zq -f table 'every 5min count() | sort ts' *.log.gz


### PR DESCRIPTION
After talking to @henridf about the modified example in #893, I realized at the last minute that the descriptive wording with the example should change to match.