### PR TITLE
zq: support directory output to s3

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -16,6 +16,7 @@ import (
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/pkg/iosource"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/pkg/s3io"
 	"github.com/brimsec/zq/proc"
@@ -81,6 +82,7 @@ https://github.com/brimsec/zq
 
 func init() {
 	Zq.Add(charm.Help)
+	iosource.Register("s3", s3io.DefaultSource)
 }
 
 type Command struct {

--- a/emitter/dir_test.go
+++ b/emitter/dir_test.go
@@ -1,0 +1,66 @@
+package emitter
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/brimsec/zq/pkg/iosource"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/tzngio"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirS3Source(t *testing.T) {
+	path := "s3://testbucket/dir"
+	tzng := `
+#0:record[_path:string,foo:string]
+0:[conn;1;]
+#1:record[_path:string,bar:string]
+1:[http;2;]`
+	mock := &mockLoader{}
+	source := &iosource.Registry{}
+	source.Add("s3", mock)
+
+	mock.On("NewWriter", "s3://testbucket/dir/conn.tzng").
+		Return(&nopCloser{bytes.NewBuffer(nil)}, nil)
+	mock.On("NewWriter", "s3://testbucket/dir/http.tzng").
+		Return(&nopCloser{bytes.NewBuffer(nil)}, nil)
+
+	r := tzngio.NewReader(strings.NewReader(tzng), resolver.NewContext())
+	w, err := NewDirWithSource(path, "", os.Stderr, &zio.WriterFlags{Format: "tzng"}, source)
+	require.NoError(t, err)
+	err = zbuf.Copy(zbuf.NopFlusher(w), r)
+	require.NoError(t, err)
+	mock.AssertExpectations(t)
+}
+
+func TestDirUnknownSource(t *testing.T) {
+	source := &iosource.Registry{}
+	path := "unknown://path/unknown"
+	_, err := NewDirWithSource(path, "", os.Stderr, &zio.WriterFlags{Format: "tzng"}, source)
+	require.EqualError(t, err, "unknown: unsupported scheme")
+}
+
+type nopCloser struct{ *bytes.Buffer }
+
+func (nopCloser) Close() error { return nil }
+
+type mockLoader struct {
+	mock.Mock
+}
+
+func (s *mockLoader) NewReader(path string) (io.ReadCloser, error) {
+	args := s.Called(path)
+	return args.Get(0).(io.ReadCloser), args.Error(1)
+}
+
+func (s *mockLoader) NewWriter(path string) (io.WriteCloser, error) {
+	args := s.Called(path)
+	return args.Get(0).(io.WriteCloser), args.Error(1)
+}

--- a/go.sum
+++ b/go.sum
@@ -480,6 +480,7 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94 h1:0ngsPmuP6XIjiFRNFYlvKwSr5zff2v+uPHaffZ6/M4k=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/pkg/iosource/file.go
+++ b/pkg/iosource/file.go
@@ -22,8 +22,7 @@ func (f *FileSource) NewWriter(path string) (io.WriteCloser, error) {
 }
 
 func filePath(path string) string {
-	u, _ := url.Parse(path)
-	if u != nil {
+	if u, _ := url.Parse(path); u != nil {
 		return u.Path
 	}
 	return path

--- a/pkg/iosource/file.go
+++ b/pkg/iosource/file.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"net/url"
 	"os"
+
+	"github.com/brimsec/zq/pkg/fs"
 )
 
 var DefaultFileSource = &FileSource{Perm: 0666}
@@ -13,12 +15,12 @@ type FileSource struct {
 }
 
 func (f *FileSource) NewReader(path string) (io.ReadCloser, error) {
-	return os.Open(filePath(path))
+	return fs.Open(filePath(path))
 }
 
 func (f *FileSource) NewWriter(path string) (io.WriteCloser, error) {
 	path = filePath(path)
-	return os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, f.Perm)
+	return fs.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, f.Perm)
 }
 
 func filePath(path string) string {

--- a/pkg/iosource/file.go
+++ b/pkg/iosource/file.go
@@ -1,0 +1,30 @@
+package iosource
+
+import (
+	"io"
+	"net/url"
+	"os"
+)
+
+var DefaultFileSource = &FileSource{Perm: 0666}
+
+type FileSource struct {
+	Perm os.FileMode
+}
+
+func (f *FileSource) NewReader(path string) (io.ReadCloser, error) {
+	return os.Open(filePath(path))
+}
+
+func (f *FileSource) NewWriter(path string) (io.WriteCloser, error) {
+	path = filePath(path)
+	return os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, f.Perm)
+}
+
+func filePath(path string) string {
+	u, _ := url.Parse(path)
+	if u != nil {
+		return u.Path
+	}
+	return path
+}

--- a/pkg/iosource/iosource.go
+++ b/pkg/iosource/iosource.go
@@ -90,10 +90,7 @@ func NewWriter(path string) (io.WriteCloser, error) {
 
 func getScheme(path string) string {
 	u, _ := url.Parse(path)
-	if u == nil {
-		return FileScheme
-	}
-	if u.Scheme == "" {
+	if u == nil || u.Scheme == "" {
 		return FileScheme
 	}
 	return u.Scheme

--- a/pkg/iosource/iosource.go
+++ b/pkg/iosource/iosource.go
@@ -1,0 +1,100 @@
+package iosource
+
+import (
+	"errors"
+	"io"
+	"net/url"
+	"sync"
+)
+
+const FileScheme = "file"
+
+var (
+	DefaultRegistry = &Registry{}
+)
+
+func init() {
+	resetDefaultRegistry()
+}
+
+func resetDefaultRegistry() {
+	DefaultRegistry = &Registry{}
+	DefaultRegistry.Add(FileScheme, DefaultFileSource)
+}
+
+type Registry struct {
+	mu      sync.RWMutex
+	schemes map[string]Source
+}
+
+func (r *Registry) Add(scheme string, loader Source) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.schemes == nil {
+		r.schemes = map[string]Source{}
+	}
+	r.schemes[scheme] = loader
+}
+
+func (r *Registry) NewReader(path string) (io.ReadCloser, error) {
+	s, err := r.Source(path)
+	if err != nil {
+		return nil, err
+	}
+	return s.NewReader(path)
+}
+
+func (r *Registry) NewWriter(path string) (io.WriteCloser, error) {
+	s, err := r.Source(path)
+	if err != nil {
+		return nil, err
+	}
+	return s.NewWriter(path)
+}
+
+func (r *Registry) Source(path string) (Source, error) {
+	scheme := getScheme(path)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	loader, ok := r.schemes[scheme]
+	if !ok {
+		return nil, errors.New("unknown scheme")
+	}
+	return loader, nil
+}
+
+func (r *Registry) GetScheme(path string) (string, bool) {
+	scheme := getScheme(path)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.schemes[scheme]
+	return scheme, ok
+}
+
+type Source interface {
+	NewReader(path string) (io.ReadCloser, error)
+	NewWriter(path string) (io.WriteCloser, error)
+}
+
+func Register(scheme string, source Source) {
+	DefaultRegistry.Add(scheme, source)
+}
+
+func NewReader(path string) (io.ReadCloser, error) {
+	return DefaultRegistry.NewReader(path)
+}
+
+func NewWriter(path string) (io.WriteCloser, error) {
+	return DefaultRegistry.NewWriter(path)
+}
+
+func getScheme(path string) string {
+	u, _ := url.Parse(path)
+	if u == nil {
+		return FileScheme
+	}
+	if u.Scheme == "" {
+		return FileScheme
+	}
+	return u.Scheme
+}

--- a/pkg/iosource/iosource.go
+++ b/pkg/iosource/iosource.go
@@ -23,12 +23,16 @@ type Registry struct {
 	schemes map[string]Source
 }
 
-func (r *Registry) Add(scheme string, loader Source) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+func (r *Registry) initWithLock() {
 	if r.schemes == nil {
 		r.schemes = map[string]Source{}
 	}
+}
+
+func (r *Registry) Add(scheme string, loader Source) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.initWithLock()
 	r.schemes[scheme] = loader
 }
 
@@ -52,6 +56,7 @@ func (r *Registry) Source(path string) (Source, error) {
 	scheme := getScheme(path)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	r.initWithLock()
 	loader, ok := r.schemes[scheme]
 	if !ok {
 		return nil, errors.New("unknown scheme")
@@ -63,6 +68,7 @@ func (r *Registry) GetScheme(path string) (string, bool) {
 	scheme := getScheme(path)
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	r.initWithLock()
 	_, ok := r.schemes[scheme]
 	return scheme, ok
 }

--- a/pkg/iosource/iosource.go
+++ b/pkg/iosource/iosource.go
@@ -13,6 +13,11 @@ var DefaultRegistry = &Registry{
 	schemes: map[string]Source{"file": DefaultFileSource},
 }
 
+type Source interface {
+	NewReader(path string) (io.ReadCloser, error)
+	NewWriter(path string) (io.WriteCloser, error)
+}
+
 type Registry struct {
 	mu      sync.RWMutex
 	schemes map[string]Source
@@ -60,11 +65,6 @@ func (r *Registry) GetScheme(path string) (string, bool) {
 	defer r.mu.RUnlock()
 	_, ok := r.schemes[scheme]
 	return scheme, ok
-}
-
-type Source interface {
-	NewReader(path string) (io.ReadCloser, error)
-	NewWriter(path string) (io.WriteCloser, error)
 }
 
 func Register(scheme string, source Source) {

--- a/pkg/iosource/iosource.go
+++ b/pkg/iosource/iosource.go
@@ -9,17 +9,8 @@ import (
 
 const FileScheme = "file"
 
-var (
-	DefaultRegistry = &Registry{}
-)
-
-func init() {
-	resetDefaultRegistry()
-}
-
-func resetDefaultRegistry() {
-	DefaultRegistry = &Registry{}
-	DefaultRegistry.Add(FileScheme, DefaultFileSource)
+var DefaultRegistry = &Registry{
+	schemes: map[string]Source{"file": DefaultFileSource},
 }
 
 type Registry struct {

--- a/pkg/s3io/iosource.go
+++ b/pkg/s3io/iosource.go
@@ -15,10 +15,10 @@ type Source struct {
 	Config *aws.Config
 }
 
-func (l *Source) NewWriter(path string) (io.WriteCloser, error) {
-	return NewWriter(path, l.Config)
+func (s *Source) NewWriter(path string) (io.WriteCloser, error) {
+	return NewWriter(path, s.Config)
 }
 
-func (l *Source) NewReader(path string) (io.ReadCloser, error) {
+func (s *Source) NewReader(path string) (io.ReadCloser, error) {
 	return nil, errors.New("method unsupported")
 }

--- a/pkg/s3io/iosource.go
+++ b/pkg/s3io/iosource.go
@@ -1,0 +1,24 @@
+package s3io
+
+import (
+	"errors"
+	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/brimsec/zq/pkg/iosource"
+)
+
+var DefaultSource = &Source{}
+var _ iosource.Source = DefaultSource
+
+type Source struct {
+	Config *aws.Config
+}
+
+func (l *Source) NewWriter(path string) (io.WriteCloser, error) {
+	return NewWriter(path, l.Config)
+}
+
+func (l *Source) NewReader(path string) (io.ReadCloser, error) {
+	return nil, errors.New("method unsupported")
+}


### PR DESCRIPTION
Make emitter.Dir support s3 paths.

Actually a lot simpler than originally thought. In emitter.Dir if
dir path is a valid s3 path:
1. Do not attempt os.MkdirAll to create the directory.
2. Use path.Join instead of filepath.Join to create leaf paths.