### PR TITLE
Change ZQL cut to emit any matching fields

### DIFF
--- a/tests/suite/cut/cut-foo-bar.yaml
+++ b/tests/suite/cut/cut-foo-bar.yaml
@@ -1,0 +1,25 @@
+zql: cut foo, bar
+
+input: |
+  #0:record[foo:string]
+  0:[foo0;]
+  #1:record[foo:string,goo:string]
+  1:[foo1;goo1;]
+  #2:record[bar:string]
+  2:[bar2;]
+  #3:record[goo:string,bar:string]
+  3:[goo3;bar3;]
+  #4:record[bar:string,goo:string,foo:string]
+  4:[bar4;goo4;foo4;]
+  #5:record[goo:string]
+  5:[goo5;]
+
+output: |
+  #0:record[foo:string]
+  0:[foo0;]
+  0:[foo1;]
+  #1:record[bar:string]
+  1:[bar2;]
+  1:[bar3;]
+  #2:record[foo:string,bar:string]
+  2:[foo4;bar4;]

--- a/zdx/writer.go
+++ b/zdx/writer.go
@@ -85,7 +85,7 @@ func newWriter(zctx *resolver.Context, path string, keyFields []string, framesiz
 		header:      hdr,
 		frameThresh: framesize,
 		frameEnd:    int64(framesize),
-		cutter:      proc.NewCutter(zctx, false, keyFields),
+		cutter:      proc.NewStrictCutter(zctx, false, keyFields),
 	}, nil
 }
 


### PR DESCRIPTION
ZQL cut emits a record for each input record containing all of the
specified field.  Instead, emit a record if the input contains any of
the specified fields.

Should close #852.