### PR TITLE
zq: return error of writer.Close

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -259,6 +259,7 @@ func (c *Command) Run(args []string) error {
 		d.SetWarningsWriter(os.Stderr)
 	}
 	if err := driver.Run(mux, d, nil); err != nil {
+		writer.Close()
 		return err
 	}
 	return writer.Close()

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -261,9 +261,6 @@ func (c *Command) Run(args []string) error {
 	if err := driver.Run(mux, d, nil); err != nil {
 		return err
 	}
-	// If writer is an s3 error it could have important information as to
-	// whether the request was written successfully. Cannot do a simple defer
-	// writer.Close() here.
 	return writer.Close()
 }
 


### PR DESCRIPTION
Because of the way s3manager is written, we may only find out about
an s3 error until after Writer.Close is called. The zq command was
ignoring writer.Close errors. Do not do this.

Closes #900