### PR TITLE
Rename zio/tzingio.ReadStats.BadMetaData to BadMetadata

### DIFF
--- a/zio/tzngio/reader.go
+++ b/zio/tzngio/reader.go
@@ -37,7 +37,7 @@ type ReadStats struct {
 	*skim.Stats
 	RecordsRead int `json:"records_read"`
 	BadFormat   int `json:"bad_format"`
-	BadMetaData int `json:"bad_meta_data"`
+	BadMetadata int `json:"bad_metadata"`
 	ReadFailure int `json:"read_failure"`
 	Unknown     int `json:"unknown"`
 }


### PR DESCRIPTION
Metadata is one word.