### PR TITLE
Fix "every" entry in v0.15.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ zq repo, check the git log.
 * pcap: Report more detailed error information (#844)
 * zql: Add a new function `Time.trunc()` (#842)
 * zql: Support grouping by computed keys (#860)
-* zq: Change implementation of `-every X` to use a computed groupby key (#828)
+* zq: Change implementation of `every X` to use a computed groupby key (#893)
 * zql: Clean up the [ZQL docs](https://github.com/brimsec/zq/tree/master/zql/docs) (#884)
 * zql: Change `cut` processor to emit any matching fields (#899)
 * zq: Allow output to an S3 bucket (#889)


### PR DESCRIPTION
I made a mistake when compiling the `v0.15.0` changelog, copying `-every` as shown in the opening text of https://github.com/brimsec/zq/issues/828 rather than plain `every` which is the actual syntax. Thanks to @nwt for spotting this. I've already made the correction in the "live" notes on the Releases tab and on my announcement on public Slack, so, doubling back to fix it here.

While I'm at it, another mistake I noticed: I'd accidentally linked to the Issue rather than the PR, which goes against convention, so I've corrected that here.