### PR TITLE
groupby: run main loop in separate goroutine

### DIFF
--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -196,12 +196,12 @@ func NewGroupBy(c *Context, parent Proc, params GroupByParams) *GroupBy {
 }
 
 func (g *GroupBy) Pull() (zbuf.Batch, error) {
-	g.once.Do(func() { go g.runLoop(g.resultCh) })
+	g.once.Do(func() { go g.run(g.resultCh) })
 	r := <-g.resultCh
 	return r.Batch, r.Err
 }
 
-func (g *GroupBy) runLoop(ch chan Result) {
+func (g *GroupBy) run(ch chan Result) {
 	defer close(ch)
 	for {
 		batch, err := g.Get()
@@ -210,7 +210,7 @@ func (g *GroupBy) runLoop(ch chan Result) {
 			return
 		}
 		if batch == nil {
-			 g.sendResult(g.agg.Results(true))
+			g.sendResult(g.agg.Results(true))
 			g.sendResult(nil, nil)
 			return
 		}

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -196,13 +196,13 @@ func NewGroupBy(c *Context, parent Proc, params GroupByParams) *GroupBy {
 }
 
 func (g *GroupBy) Pull() (zbuf.Batch, error) {
-	g.once.Do(func() { go g.run(g.resultCh) })
+	g.once.Do(func() { go g.run() })
 	r := <-g.resultCh
 	return r.Batch, r.Err
 }
 
-func (g *GroupBy) run(ch chan Result) {
-	defer close(ch)
+func (g *GroupBy) run() {
+	defer close(g.resultCh)
 	for {
 		batch, err := g.Get()
 		if err != nil {

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -210,14 +210,12 @@ func (g *GroupBy) runLoop(ch chan Result) {
 			return
 		}
 		if batch == nil {
-			b, err := g.agg.Results(true)
-			g.sendResult(b, err)
+			 g.sendResult(g.agg.Results(true))
 			g.sendResult(nil, nil)
 			return
 		}
 		for k := 0; k < batch.Length(); k++ {
-			err := g.agg.Consume(batch.Index(k))
-			if err != nil {
+			if err := g.agg.Consume(batch.Index(k)); err != nil {
 				batch.Unref()
 				g.sendResult(nil, err)
 				return

--- a/proc/groupby_test.go
+++ b/proc/groupby_test.go
@@ -273,7 +273,6 @@ func TestGroupbyUnit(t *testing.T) {
 0:[3;]
 `}
 	outBatches := []string{
-		``,
 		`
 #0:record[ts:time,count:uint64]
 0:[1;2;]
@@ -308,7 +307,6 @@ func TestGroupbyUnit(t *testing.T) {
 `)
 
 	outBatchesRecordKey := []string{
-		``,
 		`
 #0:record[foo:record[a:string],count:uint64]
 0:[[aaa;]1;]


### PR DESCRIPTION
This is primarily prepwork for spillable groupby, but it also cleans up existing groupby's operation a little, by no longer emitting empty batches (as can be seen from the test expectation change).