### PR TITLE
Groupby: remove deterministic output order

### DIFF
--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"sort"
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/expr"
@@ -371,7 +370,6 @@ func (g *GroupByAggregator) records(eof bool) ([]*zng.Record, error) {
 	for k := range g.table {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
 
 	var recs []*zng.Record
 	for _, k := range keys {

--- a/zql/docs/aggregate-functions/README.md
+++ b/zql/docs/aggregate-functions/README.md
@@ -23,38 +23,38 @@ To count how many events there are of each Zeek log type in the sample data
 set:
 
 ```zq-command
-zq -f table 'count() by _path' *.log.gz
+zq -f table 'count() by _path | sort' *.log.gz
 ```
 
 #### Output:
 ```zq-output
 _PATH        COUNT
-pe           21
-dns          53615
-dpd          25
-ftp          93
-ntp          904
-rdp          4122
+capture_loss 2
 rfb          3
-ssh          22
-ssl          35493
-conn         1021952
-http         144034
-ntlm         422
-smtp         1188
-snmp         65
-x509         10013
-files        162986
 stats        5
-weird        24048
-modbus       129
-notice       64
-syslog       2378
-dce_rpc      78
 kerberos     11
 smb_files    12
+pe           21
+ssh          22
+dpd          25
+notice       64
+snmp         65
+dce_rpc      78
+ftp          93
+modbus       129
 smb_mapping  393
-capture_loss 2
+ntlm         422
+ntp          904
+smtp         1188
+syslog       2378
+rdp          4122
+x509         10013
+weird        24048
+ssl          35493
+dns          53615
+http         144034
+files        162986
+conn         1021952
 ```
 
 #### Example #3:

--- a/zql/docs/search-syntax/README.md
+++ b/zql/docs/search-syntax/README.md
@@ -62,15 +62,15 @@ zq -t 'cut server_tree_name' ntlm.log.gz # Shorthand for: zq '* | cut server_tre
 
 #### Example #2:
 ```zq-command
-zq -t 'count() by _path' *.log.gz  # Shorthand for: zq '* | count() by _path' *.log.gz
+zq -t 'count() by _path | sort' *.log.gz  # Shorthand for: zq '* | count() by _path | sort' *.log.gz
 ```
 
 #### Output:
 ```zq-output head:4
 #0:record[_path:string,count:uint64]
-0:[pe;21;]
-0:[dns;53615;]
-0:[dpd;25;]
+0:[capture_loss;2;]
+0:[rfb;3;]
+0:[stats;5;]
 ...
 ```
 


### PR DESCRIPTION
Groupby previously output records in "deterministic but undefined"
order. Given the "undefined" component, this deterministic order
wasn't of great use, other than to slightly simplify certain tests. 

With this change, output order is non-deterministic (it is the result of a go map iteration).

We've talked about removing this for some time, and the coming arrival
of spillable groupby makes now a good time to do it.

closes #871 

