### PR TITLE
Clarify enum & other alpha notice polish

### DIFF
--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -5,10 +5,10 @@
 > the zq output format is subject to change.  In this branch,
 > zq attempts to implement everything herein excepting:
 >
-> * the bytes type is not yet implemented,
-> * it is not yet possible to validate enums against a set of allowed values.
+> * the `bytes` type is not yet implemented,
+> * the `enum` type is not yet implemented.
 >
-> Also, we are contemplating reducing the number of primitive types, e.g.,
+> Also, we are contemplating reducing the number of [primitive types](#5-primitive-types), e.g.,
 > the number of variations in integer types.
 
 * [1. Introduction](#1-introduction)


### PR DESCRIPTION
The prior alpha notice made it sound like `enum` was partially implemented in `zq`, but from a user perspective it's not there at all.

```
$ cat enum.tzng 
#0:record[foo:enum]
0:[bar;]

$ zq -i tzng -t enum.tzng 
enum.tzng: line 1: unknown type: enum
```

Here I'm updating the alpha notice to reflect this. While I was in there, I made a couple formatting adjustments & added a hyperlink.