### PR TITLE
Clarify cut documentation

### DIFF
--- a/zql/docs/processors/README.md
+++ b/zql/docs/processors/README.md
@@ -62,6 +62,36 @@ TS                UID                NAME                             ADDL      
 ...
 ```
 
+#### Example #3:
+
+If the requested list of named fields returns no results, `cut` returns a warning.
+
+```zq-command
+zq -f table 'cut nothere,alsoabsent' weird.log.gz 
+```
+
+#### Output:
+```zq-output
+Cut fields nothere,alsoabsent not present together in input
+```
+
+#### Example #4:
+
+As long as some of the named fields are present, these will be returned. No warning is generated for absent fields in this case.
+
+```zq-command head:4
+zq -f table 'cut nothere,name' weird.log.gz
+```
+
+#### Output:
+```zq-output
+NAME
+TCP_ack_underflow_or_misorder
+truncated_header
+above_hole_data_without_any_acks
+...
+```
+
 ---
 
 ## `filter`

--- a/zql/docs/processors/README.md
+++ b/zql/docs/processors/README.md
@@ -79,12 +79,12 @@ Cut fields nothere,alsoabsent not present together in input
 
 As long as some of the named fields are present, these will be returned. No warning is generated for absent fields in this case.
 
-```zq-command head:4
+```zq-command
 zq -f table 'cut nothere,name' weird.log.gz
 ```
 
 #### Output:
-```zq-output
+```zq-output head:4
 NAME
 TCP_ack_underflow_or_misorder
 truncated_header


### PR DESCRIPTION
While verifying the enhancement in https://github.com/brimsec/zq/pull/899, I considered if a docs update for `cut` was necessary. The new behavior of returning partial results definitely did what we needed in terms of eliminating the user-perceived buggy behavior in the Brim app tracked in https://github.com/brimsec/zq/issues/852. But as I get into in a closing comment there, particularly when used via `zq`, the fact that a single-character typo in a field name can make the difference between returning a column of data or silently returning no column at all concerns me. As a user, I've always been more in favor of floating warnings in these cases to be friendly in alerting users to their possible mistakes. At the same time, I know these code changes come at a cost, and we can rationalize putting off some of these smaller code changes on the grounds that users may never notice or care enough enough to spot  or complain about the absence of such a warning.

Taking the non-code approach for now, here I add a couple additional examples that illustrate what should be expected. I briefly considered describing the "you won't get a warning" behavior in the main table describing the processor also/instead, but it feels like enough of a corner case that it's ok to let it live in the examples to benefit the deeper readers.

Of course, if seeing this laid out creates consensus for changing `cut`'s behavior to add a warning rather than documenting it as-is, I'd be open to that discussion.