### PR TITLE
add and use a file replacement utility function

### DIFF
--- a/pkg/fs/jsonfile.go
+++ b/pkg/fs/jsonfile.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -21,7 +20,7 @@ func MarshalJSONFile(v interface{}, filename string, perm os.FileMode) (err erro
 // and stores the result in the value pointed to by v.  Internally, Unmarshal
 // uses json.Unmarshal.
 func UnmarshalJSONFile(filename string, v interface{}) error {
-	data, err := ioutil.ReadFile(filename)
+	data, err := ReadFile(filename)
 	if err != nil {
 		return err
 	}

--- a/pkg/fs/jsonfile.go
+++ b/pkg/fs/jsonfile.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 )
@@ -10,22 +11,10 @@ import (
 // MarshalJSONFile writes the JSON encoding of v to a file named by filename.
 // The file is created atomically. If the file does not exist, Marshal creates
 // it with permissions perm.
-func MarshalJSONFile(v interface{}, filename string, perm os.FileMode) error {
-	tmppath := filename + ".tmp"
-	f, err := OpenFile(tmppath, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_EXCL, perm)
-	if err != nil {
-		return err
-	}
-	if err := json.NewEncoder(f).Encode(v); err != nil {
-		f.Close()
-		os.Remove(tmppath)
-		return err
-	}
-	if err := f.Close(); err != nil {
-		os.Remove(tmppath)
-		return err
-	}
-	return os.Rename(tmppath, filename)
+func MarshalJSONFile(v interface{}, filename string, perm os.FileMode) (err error) {
+	return ReplaceFile(filename, perm, func(w io.Writer) error {
+		return json.NewEncoder(w).Encode(v)
+	})
 }
 
 // UnmarshalJSONFile parses JSON-encoded data from the file named by filename

--- a/pkg/fs/open.go
+++ b/pkg/fs/open.go
@@ -2,7 +2,10 @@
 
 package fs
 
-import "os"
+import (
+	"io/ioutil"
+	"os"
+)
 
 func OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
 	return os.OpenFile(name, flag, perm)
@@ -14,4 +17,8 @@ func Open(name string) (*os.File, error) {
 
 func Create(name string) (*os.File, error) {
 	return OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+}
+
+func ReadFile(name string) ([]byte, error) {
+	return ioutil.ReadFile(name)
 }

--- a/pkg/fs/open_windows.go
+++ b/pkg/fs/open_windows.go
@@ -15,6 +15,7 @@
 package fs
 
 import (
+	"io/ioutil"
 	"os"
 	"syscall"
 	"unsafe"
@@ -45,6 +46,15 @@ func Open(name string) (*os.File, error) {
 
 func Create(name string) (*os.File, error) {
 	return OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+}
+
+func ReadFile(name string) ([]byte, error) {
+	f, err := Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return ioutil.ReadAll(f)
 }
 
 // syscallMode returns the syscall-specific mode bits from Go's portable mode bits.

--- a/pkg/fs/replace.go
+++ b/pkg/fs/replace.go
@@ -1,0 +1,77 @@
+package fs
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// NewFileReplacer returns an io.WriteCloser to a temporary file; on close,
+// the temp file will be atomically renamed to the given filename.
+func NewFileReplacer(filename string, perm os.FileMode) (io.WriteCloser, error) {
+	filename, err := filepath.Abs(filename)
+	if err != nil {
+		return nil, err
+	}
+	f, err := ioutil.TempFile(filepath.Dir(filename), ".tmp-"+filepath.Base(filename))
+	if err != nil {
+		return nil, err
+	}
+	return &replacer{
+		f:        f,
+		filename: filename,
+		perm:     perm,
+	}, nil
+}
+
+type replacer struct {
+	f        *os.File
+	writeErr error
+	filename string
+	perm     os.FileMode
+}
+
+func (r *replacer) Write(b []byte) (int, error) {
+	n, err := r.f.Write(b)
+	if err != nil {
+		r.writeErr = err
+	}
+	return n, err
+}
+
+func (r *replacer) Close() (err error) {
+	defer func() {
+		if err != nil || r.writeErr != nil {
+			os.Remove(r.f.Name())
+		}
+	}()
+	if err = r.f.Sync(); err != nil {
+		r.f.Close()
+		return err
+	}
+	if err = r.f.Close(); err != nil {
+		return err
+	}
+	if err = os.Chmod(r.f.Name(), r.perm); err != nil {
+		return err
+	}
+	if r.writeErr == nil {
+		return os.Rename(r.f.Name(), r.filename)
+	}
+	return nil
+}
+
+func ReplaceFile(name string, perm os.FileMode, fn func(w io.Writer) error) (err error) {
+	wc, err := NewFileReplacer(name, perm)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		closeErr := wc.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
+	return fn(wc)
+}

--- a/zqd/ingest/pcap.go
+++ b/zqd/ingest/pcap.go
@@ -3,7 +3,6 @@ package ingest
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"io"
 	"io/ioutil"
 	"os"
@@ -153,22 +152,11 @@ func (p *PcapOp) indexPcap() error {
 		return err
 	}
 	idxpath := p.pspace.PcapIndexPath()
-	tmppath := idxpath + ".tmp"
-	f, err := fs.Create(tmppath)
-	if err != nil {
+	if err := fs.MarshalJSONFile(idx, idxpath, 0600); err != nil {
 		return err
 	}
-	if err := json.NewEncoder(f).Encode(idx); err != nil {
-		f.Close()
-		return err
-	}
-	f.Close()
 	// grab span from index and use to generate space info min/max time.
-	span := idx.Span()
-	if err = p.pstore.SetSpan(span); err != nil {
-		return err
-	}
-	return os.Rename(tmppath, idxpath)
+	return p.pstore.SetSpan(idx.Span())
 }
 
 func (p *PcapOp) runZeek(ctx context.Context) error {


### PR DESCRIPTION
A few enhancements in our fs package:
* add a utility function to use when atomically replacing the contents for a file. This is based on a function `NewAtomicFileWriter` in the https://github.com/moby/moby repo; I'll add an acknowledgements entry for the (apache licensed) code if this goes in.
* add a fs version of 'ioutil.ReadFile' that uses fs.Open to get the rename semantics we want on Windows.

This also updates the filestore code to use these & other calls from package fs. There is a possibility that this resolves https://github.com/brimsec/zq/issues/613 , though that's been impossible to repro on demand.

Part of https://github.com/brimsec/brim/issues/883 .
