### PR TITLE
add dot and underscore to allowed space chars

### DIFF
--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -302,14 +302,18 @@ func TestSpaceInvalidName(t *testing.T) {
 	_, client, done := newCore(t)
 	defer done()
 	t.Run("Post", func(t *testing.T) {
-		_, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test.bad"})
-		require.EqualError(t, err, "status code 400: name must contain only characters [a-zA-Z0-9_]")
+		_, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test-is.good"})
+		require.NoError(t, err)
+	})
+	t.Run("Post", func(t *testing.T) {
+		_, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test!bad"})
+		require.EqualError(t, err, "status code 400: invalid space name")
 	})
 	t.Run("Put", func(t *testing.T) {
 		sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 		require.NoError(t, err)
-		err = client.SpacePut(ctx, sp.ID, api.SpacePutRequest{Name: "test.bad"})
-		require.EqualError(t, err, "status code 400: name must contain only characters [a-zA-Z0-9_]")
+		err = client.SpacePut(ctx, sp.ID, api.SpacePutRequest{Name: "test!bad"})
+		require.EqualError(t, err, "status code 400: invalid space name")
 	})
 }
 

--- a/zqd/space/config.go
+++ b/zqd/space/config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/brimsec/zq/zqe"
 )
 
-var nameRegexp = regexp.MustCompile("[^a-zA-Z0-9_]")
+var nameRegexp = regexp.MustCompile("[^-.a-zA-Z0-9_]")
 
 const configVersion = 1
 
@@ -76,7 +76,7 @@ func validateName(names map[string]api.SpaceID, name string) error {
 		return zqe.E(zqe.Invalid, "cannot set name to an empty string")
 	}
 	if nameRegexp.MatchString(name) {
-		return zqe.E(zqe.Invalid, "name must contain only characters [a-zA-Z0-9_]")
+		return zqe.E(zqe.Invalid, "invalid space name")
 	}
 	if _, ok := names[name]; ok {
 		return zqe.E(zqe.Conflict, "space with name '%s' already exists", name)


### PR DESCRIPTION
Add "." and "_"  to the allowed characters for space names to allow Brim integration tests to pass. I've verified the Brim integration tests pass locally, will put up a draft Brim PR showing tests passing in CI.

Related to https://github.com/brimsec/zq/issues/791 ; we may further change the space name restriction after this as well.

