### PR TITLE
Make first() and last() reducers decomposable

### DIFF
--- a/reducer/first.go
+++ b/reducer/first.go
@@ -3,6 +3,7 @@ package reducer
 import (
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
 )
 
 type FirstProto struct {
@@ -25,22 +26,35 @@ func NewFirstProto(target string, field expr.FieldExprResolver) *FirstProto {
 type First struct {
 	Reducer
 	Resolver expr.FieldExprResolver
-	record   *zng.Record
+	val      *zng.Value
 }
 
 func (f *First) Consume(r *zng.Record) {
-	if f.record != nil {
+	if f.val != nil {
 		return
 	}
-	if v := f.Resolver(r); v.Type == nil {
+	v := f.Resolver(r)
+	if v.Type == nil {
 		return
 	}
-	f.record = r
+	f.val = &v
+}
+
+func (f *First) ConsumePart(p zng.Value) error {
+	if f.val != nil || p.Type == zng.TypeNull {
+		return nil
+	}
+	f.val = &p
+	return nil
 }
 
 func (f *First) Result() zng.Value {
-	if f.record == nil {
+	if f.val == nil {
 		return zng.Value{Type: zng.TypeNull, Bytes: nil}
 	}
-	return f.Resolver(f.record)
+	return *f.val
+}
+
+func (f *First) ResultPart(*resolver.Context) (zng.Value, error) {
+	return f.Result(), nil
 }

--- a/reducer/reducer_test.go
+++ b/reducer/reducer_test.go
@@ -78,6 +78,24 @@ func TestDecomposableReducers(t *testing.T) {
 			require.Equal(t, f, uint64(3))
 		}
 	})
+	t.Run("first", func(t *testing.T) {
+		proto := reducer.NewFirstProto("first", expr.CompileFieldAccess("n"))
+		for i := 0; i <= len(recs); i++ {
+			res := runOne(t, resolver, proto, i, recs)
+			f, err := zng.DecodeInt(res.Bytes)
+			require.NoError(t, err)
+			require.Equal(t, f, int64(0))
+		}
+	})
+	t.Run("last", func(t *testing.T) {
+		proto := reducer.NewLastProto("last", expr.CompileFieldAccess("n"))
+		for i := 0; i <= len(recs); i++ {
+			res := runOne(t, resolver, proto, i, recs)
+			f, err := zng.DecodeInt(res.Bytes)
+			require.NoError(t, err)
+			require.Equal(t, f, int64(10))
+		}
+	})
 	t.Run("field-min", func(t *testing.T) {
 		proto := field.NewFieldProto("min", expr.CompileFieldAccess("n"), "Min")
 		for i := 0; i <= len(recs); i++ {


### PR DESCRIPTION
I noticed this omission while writing tests for #932. Should have been done in #892 