### PR TITLE
Use proc.ColumnBuilder in zio/ndjsonio.inferParser

### DIFF
--- a/zio/ndjsonio/inferparser.go
+++ b/zio/ndjsonio/inferparser.go
@@ -59,11 +59,11 @@ func (p *inferParser) parseObject(b []byte) (zng.Value, error) {
 	for _, v := range zngValues {
 		columnBuilder.Append(v.Bytes, zng.IsContainerType(zng.AliasedType(v.Type)))
 	}
-	bytes_, err := columnBuilder.Encode()
+	zbytes, err := columnBuilder.Encode()
 	if err != nil {
 		return zng.Value{}, err
 	}
-	return zng.Value{Type: typ, Bytes: bytes_}, nil
+	return zng.Value{Type: typ, Bytes: zbytes}, nil
 }
 
 func (p *inferParser) parseValue(raw []byte, typ jsonparser.ValueType) (zng.Value, error) {

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -99,6 +99,11 @@ func TestNDJSON(t *testing.T) {
 			output: `{ "s": "foo", "nest": { "s": "bar", "n": 5 }}`,
 		},
 		{
+			name:   "legacy nested fields with multiple levels of nesting",
+			input:  `{ "a.b.1": 1, "a.b.2": 2, "a.b.c.3": 3, "a.b.c.4": 4 }`,
+			output: `{ "a": { "b": { "1": 1, "2": 2, "c": { "3": 3, "4": 4 } } } }`,
+		},
+		{
 			name:   "string with unicode escape",
 			input:  `{ "s": "Hello\u002c world!" }`,
 			output: `{ "s": "Hello, world!" }`,


### PR DESCRIPTION
A zio/ndjsonio.Reader without type configuration produces incorrect output for '{"a.b.c":1}' and panics on '{"a.b.c":1,"a.b.d":2}'. Fix by using proc.ColumnBuilder in zio/ndjsonio.(*inferParser).parseObject.

Closes #747.

This allocates a new ColumnBuilder on every successful trip through parseObject. That isn't great, but effective reuse doesn't seem trivial since there's no guarantee the next record will have the same fields, so I'm kicking that can down the road.