### PR TITLE
Remove reducer boilerplate

### DIFF
--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -286,7 +286,7 @@ func merger(zctx *resolver.Context, builder *ColumnBuilder, keys []GroupByKey, r
 		cols := builder.TypedColumns(types)
 		for i, red := range row.Reducers {
 			v := red.Result()
-			cols = append(cols, zng.NewColumn(row.Defs[i].Target(), v.Type))
+			cols = append(cols, zng.NewColumn(row.Defs[i].Target, v.Type))
 			zv = v.Encode(zv)
 		}
 		typ, err := zctx.LookupTypeRecord(cols)
@@ -687,7 +687,7 @@ func (g *GroupByAggregator) lookupRowType(row *GroupByRow, decompose bool) (*zng
 		} else {
 			z = red.Result()
 		}
-		cols = append(cols, zng.NewColumn(row.reducers.Defs[k].Target(), z.Type))
+		cols = append(cols, zng.NewColumn(row.reducers.Defs[k].Target, z.Type))
 	}
 	// This could be more efficient but it's only done during group-by output...
 	return g.zctx.LookupTypeRecord(cols)

--- a/reducer/avg.go
+++ b/reducer/avg.go
@@ -8,31 +8,6 @@ import (
 	"github.com/brimsec/zq/zngnative"
 )
 
-type AvgProto struct {
-	target              string
-	resolver, tresolver expr.FieldExprResolver
-}
-
-func NewAvgProto(target string, tresolver, resolver expr.FieldExprResolver) *AvgProto {
-	return &AvgProto{
-		target:    target,
-		tresolver: tresolver,
-		resolver:  resolver,
-	}
-}
-
-func (ap *AvgProto) Target() string {
-	return ap.target
-}
-
-func (ap *AvgProto) TargetResolver() expr.FieldExprResolver {
-	return ap.tresolver
-}
-
-func (ap *AvgProto) Instantiate() Interface {
-	return &Avg{Resolver: ap.resolver}
-}
-
 type Avg struct {
 	Reducer
 	Resolver expr.FieldExprResolver

--- a/reducer/compile/row.go
+++ b/reducer/compile/row.go
@@ -34,7 +34,7 @@ func (r *Row) ConsumePart(rec *zng.Record) error {
 		if !ok {
 			return errors.New("reducer row doesn't decompose")
 		}
-		resolver := r.Defs[i].TargetResolver()
+		resolver := r.Defs[i].TargetResolver
 		if err := dec.ConsumePart(resolver(rec)); err != nil {
 			return err
 		}
@@ -49,7 +49,7 @@ func (r *Row) Result(zctx *resolver.Context) (*zng.Record, error) {
 	var zv zcode.Bytes
 	for k, red := range r.Reducers {
 		val := red.Result()
-		columns[k] = zng.NewColumn(r.Defs[k].Target(), val.Type)
+		columns[k] = zng.NewColumn(r.Defs[k].Target, val.Type)
 		zv = val.Encode(zv)
 	}
 	typ, err := zctx.LookupTypeRecord(columns)

--- a/reducer/count.go
+++ b/reducer/count.go
@@ -6,31 +6,6 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-type CountProto struct {
-	target              string
-	resolver, tresolver expr.FieldExprResolver
-}
-
-func NewCountProto(target string, tresolver, resolver expr.FieldExprResolver) *CountProto {
-	return &CountProto{
-		target:    target,
-		resolver:  resolver,
-		tresolver: tresolver,
-	}
-}
-
-func (cp *CountProto) Target() string {
-	return cp.target
-}
-
-func (cp *CountProto) TargetResolver() expr.FieldExprResolver {
-	return cp.tresolver
-}
-
-func (cp *CountProto) Instantiate() Interface {
-	return &Count{Resolver: cp.resolver}
-}
-
 type Count struct {
 	Reducer
 	Resolver expr.FieldExprResolver

--- a/reducer/countdistinct.go
+++ b/reducer/countdistinct.go
@@ -6,40 +6,19 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
-type CountDistinctProto struct {
-	target              string
-	resolver, tresolver expr.FieldExprResolver
-}
-
-func NewCountDistinctProto(target string, tresolver, resolver expr.FieldExprResolver) *CountDistinctProto {
-	return &CountDistinctProto{
-		target:    target,
-		tresolver: tresolver,
-		resolver:  resolver,
-	}
-}
-
-func (cdp *CountDistinctProto) Target() string {
-	return cdp.target
-}
-
-func (cdp *CountDistinctProto) Instantiate() Interface {
-	return &CountDistinct{
-		Resolver: cdp.resolver,
-		sketch:   hyperloglog.New(),
-	}
-}
-
-func (cdp *CountDistinctProto) TargetResolver() expr.FieldExprResolver {
-	return cdp.tresolver
-}
-
 // CountDistinct uses hyperloglog to approximate the count of unique values for
 // a field.
 type CountDistinct struct {
 	Reducer
 	Resolver expr.FieldExprResolver
 	sketch   *hyperloglog.Sketch
+}
+
+func NewCountDistinct(resolver expr.FieldExprResolver) *CountDistinct {
+	return &CountDistinct{
+		Resolver: resolver,
+		sketch:   hyperloglog.New(),
+	}
 }
 
 func (c *CountDistinct) Consume(r *zng.Record) {

--- a/reducer/first.go
+++ b/reducer/first.go
@@ -6,35 +6,14 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-type FirstProto struct {
-	target              string
-	resolver, tresolver expr.FieldExprResolver
-}
-
-func NewFirstProto(target string, tresolver, resolver expr.FieldExprResolver) *FirstProto {
-	return &FirstProto{
-		target:    target,
-		tresolver: tresolver,
-		resolver:  resolver,
-	}
-}
-
-func (fp *FirstProto) Target() string {
-	return fp.target
-}
-
-func (fp *FirstProto) Instantiate() Interface {
-	return &First{Resolver: fp.resolver}
-}
-
-func (fp *FirstProto) TargetResolver() expr.FieldExprResolver {
-	return fp.tresolver
-}
-
 type First struct {
 	Reducer
 	Resolver expr.FieldExprResolver
 	val      *zng.Value
+}
+
+func NewFirstReducer(resolver expr.FieldExprResolver) Interface {
+	return &First{Resolver: resolver}
 }
 
 func (f *First) Consume(r *zng.Record) {

--- a/reducer/last.go
+++ b/reducer/last.go
@@ -6,31 +6,6 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-type LastProto struct {
-	target              string
-	resolver, tresolver expr.FieldExprResolver
-}
-
-func NewLastProto(target string, tresolver, resolver expr.FieldExprResolver) *LastProto {
-	return &LastProto{
-		target:    target,
-		tresolver: tresolver,
-		resolver:  resolver,
-	}
-}
-
-func (lp *LastProto) Target() string {
-	return lp.target
-}
-
-func (lp *LastProto) Instantiate() Interface {
-	return &Last{Resolver: lp.resolver}
-}
-
-func (lp *LastProto) TargetResolver() expr.FieldExprResolver {
-	return lp.tresolver
-}
-
 type Last struct {
 	Reducer
 	Resolver expr.FieldExprResolver

--- a/reducer/reducer_test.go
+++ b/reducer/reducer_test.go
@@ -4,10 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/reducer"
 	"github.com/brimsec/zq/reducer/compile"
-	"github.com/brimsec/zq/reducer/field"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
@@ -32,14 +31,14 @@ func parse(zctx *resolver.Context, src string) (*zbuf.Array, error) {
 	return zbuf.NewArray(records), nil
 }
 
-func runOne(t *testing.T, zctx *resolver.Context, proto compile.CompiledReducer, i int, recs []*zng.Record) zng.Value {
-	red := proto.Instantiate().(reducer.Decomposable)
+func runOne(t *testing.T, zctx *resolver.Context, cred compile.CompiledReducer, i int, recs []*zng.Record) zng.Value {
+	red := cred.Instantiate().(reducer.Decomposable)
 	for _, rec := range recs[:i] {
 		red.Consume(rec)
 	}
 	part, err := red.ResultPart(zctx)
 	require.NoError(t, err)
-	red = proto.Instantiate().(reducer.Decomposable)
+	red = cred.Instantiate().(reducer.Decomposable)
 	err = red.ConsumePart(part)
 	require.NoError(t, err)
 	for _, rec := range recs[i:] {
@@ -60,64 +59,77 @@ func TestDecomposableReducers(t *testing.T) {
 	require.NoError(t, err)
 	recs := b.Records()
 
+	makeReducer := func(op, field string) compile.CompiledReducer {
+		cred, err := compile.Compile(ast.Reducer{
+			Node: ast.Node{Op: op},
+			Var:  strings.ToLower(op),
+			Field: &ast.FieldRead{
+				Node:  ast.Node{Op: "FieldRead"},
+				Field: field,
+			},
+		})
+		require.NoError(t, err)
+		return cred
+	}
+
 	t.Run("avg", func(t *testing.T) {
-		proto := reducer.NewAvgProto("avg", nil, expr.CompileFieldAccess("n"))
+		cred := makeReducer("Avg", "n")
 		for i := 0; i <= len(recs); i++ {
-			res := runOne(t, resolver, proto, i, recs)
+			res := runOne(t, resolver, cred, i, recs)
 			f, err := zng.DecodeFloat64(res.Bytes)
 			require.NoError(t, err)
 			require.Equal(t, f, 5.)
 		}
 	})
 	t.Run("count", func(t *testing.T) {
-		proto := reducer.NewCountProto("count", nil, expr.CompileFieldAccess("n"))
+		cred := makeReducer("Count", "n")
 		for i := 0; i <= len(recs); i++ {
-			res := runOne(t, resolver, proto, i, recs)
+			res := runOne(t, resolver, cred, i, recs)
 			f, err := zng.DecodeUint(res.Bytes)
 			require.NoError(t, err)
 			require.Equal(t, f, uint64(3))
 		}
 	})
 	t.Run("first", func(t *testing.T) {
-		proto := reducer.NewFirstProto("first", nil, expr.CompileFieldAccess("n"))
+		cred := makeReducer("First", "n")
 		for i := 0; i <= len(recs); i++ {
-			res := runOne(t, resolver, proto, i, recs)
+			res := runOne(t, resolver, cred, i, recs)
 			f, err := zng.DecodeInt(res.Bytes)
 			require.NoError(t, err)
 			require.Equal(t, f, int64(0))
 		}
 	})
 	t.Run("last", func(t *testing.T) {
-		proto := reducer.NewLastProto("last", nil, expr.CompileFieldAccess("n"))
+		cred := makeReducer("Last", "n")
 		for i := 0; i <= len(recs); i++ {
-			res := runOne(t, resolver, proto, i, recs)
+			res := runOne(t, resolver, cred, i, recs)
 			f, err := zng.DecodeInt(res.Bytes)
 			require.NoError(t, err)
 			require.Equal(t, f, int64(10))
 		}
 	})
 	t.Run("field-min", func(t *testing.T) {
-		proto := field.NewFieldProto("min", nil, expr.CompileFieldAccess("n"), "Min")
+		cred := makeReducer("Min", "n")
 		for i := 0; i <= len(recs); i++ {
-			res := runOne(t, resolver, proto, i, recs)
+			res := runOne(t, resolver, cred, i, recs)
 			f, err := zng.DecodeInt(res.Bytes)
 			require.NoError(t, err)
 			require.Equal(t, f, int64(0))
 		}
 	})
 	t.Run("field-max", func(t *testing.T) {
-		proto := field.NewFieldProto("max", nil, expr.CompileFieldAccess("n"), "Max")
+		cred := makeReducer("Max", "n")
 		for i := 0; i <= len(recs); i++ {
-			res := runOne(t, resolver, proto, i, recs)
+			res := runOne(t, resolver, cred, i, recs)
 			f, err := zng.DecodeInt(res.Bytes)
 			require.NoError(t, err)
 			require.Equal(t, f, int64(10))
 		}
 	})
 	t.Run("field-sum", func(t *testing.T) {
-		proto := field.NewFieldProto("sum", nil, expr.CompileFieldAccess("n"), "Sum")
+		cred := makeReducer("Sum", "n")
 		for i := 0; i <= len(recs); i++ {
-			res := runOne(t, resolver, proto, i, recs)
+			res := runOne(t, resolver, cred, i, recs)
 			f, err := zng.DecodeInt(res.Bytes)
 			require.NoError(t, err)
 			require.Equal(t, f, int64(15))


### PR DESCRIPTION
On top of https://github.com/brimsec/zq/pull/932: removes the pre-existing boilerplate code (`New<Reducer>Proto` and related) for creating reducers.

