### PR TITLE
force mtime update on metadata file update

### DIFF
--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -110,7 +110,6 @@ func TestOpenOptions(t *testing.T) {
 }
 
 func TestImportWhileOpen(t *testing.T) {
-	t.Skip("skipping due to test failures, see brim#883")
 	// Create an archive with initial data
 	datapath, err := ioutil.TempDir("", "")
 	require.NoError(t, err)

--- a/archive/schema.go
+++ b/archive/schema.go
@@ -48,7 +48,14 @@ type IndexInfo struct {
 }
 
 func (c *Metadata) Write(path string) error {
-	return fs.MarshalJSONFile(c, path, 0600)
+	if err := fs.MarshalJSONFile(c, path, 0600); err != nil {
+		return err
+	}
+	// Ensure the mtime is updated on the file. This Chtimes call was required
+	// due to failures seen in CI, when an mtime change wasn't observed after
+	// some writes. See https://github.com/brimsec/brim/issues/883.
+	now := time.Now()
+	return os.Chtimes(path, now, now)
 }
 
 func MetadataRead(path string) (*Metadata, time.Time, error) {


### PR DESCRIPTION
After some research and experimentation, it seems that the simplest & most reliable way to ensure the mtime is always updated is to directly set it via `os.Chtimes`. I tried an approach of stat'ing the file before the update, then stat'ing it afterwards, but it seems more efficient to just always do so.
