### PR TITLE
Tail proc: don't emit nil records when input is smaller than limit

### DIFF
--- a/proc/tail.go
+++ b/proc/tail.go
@@ -22,9 +22,13 @@ func (t *Tail) tail() zbuf.Batch {
 	if t.count <= 0 {
 		return nil
 	}
-	out := make([]*zng.Record, t.limit)
-	for k := 0; k < t.limit; k++ {
-		out[k] = t.q[(t.off+k)%t.limit]
+	start := t.off
+	if t.count < t.limit {
+		start = 0
+	}
+	out := make([]*zng.Record, t.count)
+	for k := 0; k < t.count; k++ {
+		out[k] = t.q[(start+k)%t.limit]
 	}
 	t.off = 0
 	t.count = 0

--- a/tests/suite/tail/toomuch.yaml
+++ b/tests/suite/tail/toomuch.yaml
@@ -1,0 +1,9 @@
+zql: tail 2
+
+input: |
+  #0:record[x:string]
+  0:[first;]
+
+output: |
+  #0:record[x:string]
+  0:[first;]


### PR DESCRIPTION
closes #957 