### PR TITLE
Fix alias bug with context resets

### DIFF
--- a/tests/formats/zng/zctx-alias-reset-2.yaml
+++ b/tests/formats/zng/zctx-alias-reset-2.yaml
@@ -1,0 +1,22 @@
+# Test that type aliases are properly reset and reusable after stream boundaries
+
+script: |
+  zq -b 2 in.tzng | zq -t "count() by proto" -
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[ts:time]
+      0:[1425565512.963801;]
+      #zenum=string
+      #1:record[ts:time,proto:zenum]
+      1:[1425565514.419939;udp;]
+      1:[1425565514.419939;udp;]
+
+outputs:
+  - name: stdout
+    data: |
+      #zenum=string
+      #0:record[proto:zenum,count:uint64]
+      0:[udp;2;]
+

--- a/tests/formats/zng/zctx-alias-reset.yaml
+++ b/tests/formats/zng/zctx-alias-reset.yaml
@@ -1,0 +1,24 @@
+# Test that type aliases are properly reset and reusable after stream boundaries
+
+script: |
+  zq -b 2 in.tzng | zq -t -
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[ts:time]
+      0:[1425565512.963801;]
+      #zenum=string
+      #1:record[ts:time,proto:zenum]
+      1:[1425565514.419939;udp;]
+      1:[1425565514.419939;udp;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[ts:time]
+      0:[1425565512.963801;]
+      #zenum=string
+      #1:record[ts:time,proto:zenum]
+      1:[1425565514.419939;udp;]
+      1:[1425565514.419939;udp;]

--- a/zng/resolver/context.go
+++ b/zng/resolver/context.go
@@ -124,7 +124,8 @@ func recordKey(columns []zng.Column) string {
 	for _, col := range columns {
 		id := col.Type.ID()
 		if alias, ok := col.Type.(*zng.TypeAlias); ok {
-			id = alias.AliasID()
+			key += fmt.Sprintf("%s:%s/%d;", col.Name, alias.Name, alias.ID())
+			continue
 		}
 		key += fmt.Sprintf("%s:%d;", col.Name, id)
 	}


### PR DESCRIPTION
The fix here is to use the "value" of the alias type (consisting of the alias name and aliased type ID) rather than the alias ID when building a record key. This avoids the issue where alias IDs for the same alias could be different in different batches. (The underlying problem seems to be that the Cocke and Schwartz algorithm isn't being applied to alias IDs... but I digress).


closes #866 