### PR TITLE
expose archive stats as zng stream

### DIFF
--- a/archive/schema.go
+++ b/archive/schema.go
@@ -247,6 +247,7 @@ func CreateOrOpenArchive(path string, co *CreateOptions, oo *OpenOptions) (*Arch
 	return OpenArchive(path, oo)
 }
 
+// statReadCloser implements zbuf.ReadCloser
 type statReadCloser struct {
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -276,7 +277,7 @@ func (s *statReadCloser) run() {
 	defer close(s.recs)
 
 	zctx := resolver.NewContext()
-	chunkTyp := zctx.MustLookupTypeRecord([]zng.Column{
+	typ := zctx.MustLookupTypeRecord([]zng.Column{
 		zng.NewColumn("type", zng.TypeString),
 		zng.NewColumn("log_id", zng.TypeString),
 		zng.NewColumn("start", zng.TypeTime),
@@ -297,7 +298,7 @@ func (s *statReadCloser) run() {
 		zv = zng.NewDuration(si.Span.Dur).Encode(zv)
 		zv = zng.NewUint64(uint64(fi.Size())).Encode(zv)
 
-		rec := zng.NewRecord(chunkTyp, zv)
+		rec := zng.NewRecord(typ, zv)
 		select {
 		case s.recs <- rec:
 			return nil

--- a/archive/schema.go
+++ b/archive/schema.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -11,6 +12,9 @@ import (
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
 )
 
@@ -241,4 +245,76 @@ func CreateOrOpenArchive(path string, co *CreateOptions, oo *OpenOptions) (*Arch
 		}
 	}
 	return OpenArchive(path, oo)
+}
+
+type statReadCloser struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	ark    *Archive
+	recs   chan *zng.Record
+	err    error
+}
+
+func (s *statReadCloser) Read() (*zng.Record, error) {
+	select {
+	case r, ok := <-s.recs:
+		if !ok {
+			return nil, s.err
+		}
+		return r, nil
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	}
+}
+
+func (s *statReadCloser) Close() error {
+	s.cancel()
+	return nil
+}
+
+func (s *statReadCloser) run() {
+	defer close(s.recs)
+
+	zctx := resolver.NewContext()
+	chunkTyp := zctx.MustLookupTypeRecord([]zng.Column{
+		zng.NewColumn("type", zng.TypeString),
+		zng.NewColumn("log_id", zng.TypeString),
+		zng.NewColumn("start", zng.TypeTime),
+		zng.NewColumn("duration", zng.TypeDuration),
+		zng.NewColumn("size", zng.TypeUint64),
+	})
+
+	s.err = SpanWalk(s.ark, func(si SpanInfo, zardir string) error {
+		fi, err := os.Stat(ZarDirToLog(zardir))
+		if err != nil {
+			return err
+		}
+
+		var zv zcode.Bytes
+		zv = zng.NewString("chunk").Encode(zv)
+		zv = zng.NewString(string(si.LogID)).Encode(zv)
+		zv = zng.NewTime(si.Span.Ts).Encode(zv)
+		zv = zng.NewDuration(si.Span.Dur).Encode(zv)
+		zv = zng.NewUint64(uint64(fi.Size())).Encode(zv)
+
+		rec := zng.NewRecord(chunkTyp, zv)
+		select {
+		case s.recs <- rec:
+			return nil
+		case <-s.ctx.Done():
+			return s.ctx.Err()
+		}
+	})
+}
+
+func Stat(ctx context.Context, ark *Archive) (zbuf.ReadCloser, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	s := &statReadCloser{
+		ctx:    ctx,
+		cancel: cancel,
+		recs:   make(chan *zng.Record),
+		ark:    ark,
+	}
+	go s.run()
+	return s, nil
 }

--- a/cmd/zar/main.go
+++ b/cmd/zar/main.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/brimsec/zq/cmd/zar/rm"
 	_ "github.com/brimsec/zq/cmd/zar/rmdirs"
 	"github.com/brimsec/zq/cmd/zar/root"
+	_ "github.com/brimsec/zq/cmd/zar/stat"
 	_ "github.com/brimsec/zq/cmd/zar/zq"
 )
 

--- a/cmd/zar/stat/command.go
+++ b/cmd/zar/stat/command.go
@@ -1,0 +1,78 @@
+package stat
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"os"
+
+	"github.com/brimsec/zq/archive"
+	"github.com/brimsec/zq/cmd/zar/root"
+	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/mccanne/charm"
+)
+
+var Stat = &charm.Spec{
+	Name:  "stat",
+	Usage: "stat [options]",
+	Short: "archive component statistics",
+	Long: `
+"zar stat" generates a ZNG stream with information about the chunks in
+an archive.
+`,
+	New: New,
+}
+
+func init() {
+	root.Zar.Add(Stat)
+}
+
+type Command struct {
+	*root.Command
+	root   string
+	format string
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.StringVar(&c.format, "f", "table", "output format")
+	return c, nil
+}
+
+func (c *Command) Run(args []string) (err error) {
+	if len(args) > 0 {
+		return errors.New("zar stat: too many arguments")
+	}
+
+	ark, err := archive.OpenArchive(c.root, nil)
+	if err != nil {
+		return err
+	}
+
+	wc, err := emitter.NewFile("", &zio.WriterFlags{Format: c.format})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		wcErr := wc.Close()
+		if err == nil {
+			err = wcErr
+		}
+	}()
+
+	rc, err := archive.Stat(context.Background(), ark)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		rcErr := rc.Close()
+		if err == nil {
+			err = rcErr
+		}
+	}()
+
+	return zbuf.Copy(wc, rc)
+}

--- a/cmd/zar/stat/command.go
+++ b/cmd/zar/stat/command.go
@@ -38,7 +38,7 @@ type Command struct {
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
-	f.StringVar(&c.format, "f", "table", "output format")
+	f.StringVar(&c.format, "f", "table", "format for output data [zng,ndjson,table,text,zeek,zjson,tzng] (default \"table\")")
 	return c, nil
 }
 

--- a/tests/suite/zar/stat.yaml
+++ b/tests/suite/zar/stat.yaml
@@ -1,0 +1,28 @@
+script: |
+  mkdir logs
+  zar import -s 20KiB -R ./logs babble.tzng
+  zar ls -R ./logs
+  echo ===
+  zar stat -R ./logs
+  echo ===
+  zar stat -R ./logs -f tzng
+  echo ===
+
+inputs:
+  - name: babble.tzng
+    source: ../zdx/babble.tzng
+
+outputs:
+  - name: stdout
+    data: |
+      logs/20200422/1587518620.0622373.zng.zar
+      logs/20200421/1587512288.06249439.zng.zar
+      ===
+      TYPE  LOG_ID                           START                DURATION       SIZE
+      chunk 20200422/1587518620.0622373.zng  1587512305.069789040 6314.992448261 21761
+      chunk 20200421/1587512288.06249439.zng 1587508830.068523240 3457.993971151 13152
+      ===
+      #0:record[type:string,log_id:string,start:time,duration:duration,size:uint64]
+      0:[chunk;20200422/1587518620.0622373.zng;1587512305.06978904;6314.992448261;21761;]
+      0:[chunk;20200421/1587512288.06249439.zng;1587508830.06852324;3457.993971151;13152;]
+      ===

--- a/zqd/api/connection.go
+++ b/zqd/api/connection.go
@@ -238,6 +238,19 @@ func (c *Connection) IndexSearch(ctx context.Context, space SpaceID, search Inde
 	return NewZngSearch(r), nil
 }
 
+func (c *Connection) ArchiveStat(ctx context.Context, space SpaceID, params map[string]string) (Search, error) {
+	req := c.Request(ctx).
+		SetQueryParam("format", "zng")
+	req.SetQueryParams(params)
+	req.Method = http.MethodGet
+	req.URL = path.Join("/space", string(space), "archivestat")
+	r, err := c.stream(req)
+	if err != nil {
+		return nil, err
+	}
+	return NewZngSearch(r), nil
+}
+
 func (c *Connection) PcapPost(ctx context.Context, space SpaceID, payload PcapPostRequest) (*Stream, error) {
 	req := c.Request(ctx).
 		SetBody(payload)

--- a/zqd/handler.go
+++ b/zqd/handler.go
@@ -36,6 +36,7 @@ func NewHandler(core *Core, logger *zap.Logger) http.Handler {
 	h.Handle("/space/{space}/pcap", handlePcapPost).Methods("POST")
 	h.Handle("/space/{space}/log", handleLogPost).Methods("POST")
 	h.Handle("/space/{space}/indexsearch", handleIndexSearch).Methods("POST")
+	h.Handle("/space/{space}/archivestat", handleArchiveStat).Methods("GET")
 	h.Handle("/space/{space}/subspace", handleSubspacePost).Methods("POST")
 	h.Handle("/search", handleSearch).Methods("POST")
 	h.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {

--- a/zqd/search/indexsearch.go
+++ b/zqd/search/indexsearch.go
@@ -29,28 +29,5 @@ func NewIndexSearchOp(ctx context.Context, s IndexSearcher, req api.IndexSearchR
 }
 
 func (s *IndexSearchOp) Run(out Output) (err error) {
-	if err = out.SendControl(&api.TaskStart{"TaskStart", 0}); err != nil {
-		return
-	}
-	defer func() {
-		if err != nil {
-			verr := api.Error{Type: "INTERNAL", Message: err.Error()}
-			out.End(&api.TaskEnd{"TaskEnd", 0, &verr})
-			return
-		}
-		err = out.End(&api.TaskEnd{"TaskEnd", 0, nil})
-	}()
-
-	for {
-		var b zbuf.Batch
-		if b, err = zbuf.ReadBatch(s, DefaultMTU); err != nil {
-			return
-		}
-		if b == nil {
-			return
-		}
-		if err = out.SendBatch(0, b); err != nil {
-			return
-		}
-	}
+	return SendFromReader(out, s)
 }

--- a/zqd/search/output.go
+++ b/zqd/search/output.go
@@ -1,0 +1,40 @@
+package search
+
+import (
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zqd/api"
+)
+
+type Output interface {
+	SendBatch(int, zbuf.Batch) error
+	SendControl(interface{}) error
+	End(interface{}) error
+	ContentType() string
+}
+
+func SendFromReader(out Output, r zbuf.Reader) (err error) {
+	if err = out.SendControl(&api.TaskStart{"TaskStart", 0}); err != nil {
+		return
+	}
+	defer func() {
+		if err != nil {
+			verr := api.Error{Type: "INTERNAL", Message: err.Error()}
+			out.End(&api.TaskEnd{"TaskEnd", 0, &verr})
+			return
+		}
+		err = out.End(&api.TaskEnd{"TaskEnd", 0, nil})
+	}()
+
+	for {
+		var b zbuf.Batch
+		if b, err = zbuf.ReadBatch(r, DefaultMTU); err != nil {
+			return
+		}
+		if b == nil {
+			return
+		}
+		if err = out.SendBatch(0, b); err != nil {
+			return
+		}
+	}
+}

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -91,13 +91,6 @@ func (s *SearchOp) Run(output Output) error {
 	return d.end(0)
 }
 
-type Output interface {
-	SendBatch(int, zbuf.Batch) error
-	SendControl(interface{}) error
-	End(interface{}) error
-	ContentType() string
-}
-
 // A Query is the internal representation of search query describing a source
 // of tuples, a "search" applied to the tuples producing a set of matched
 // tuples, and a proc to the process the tuples

--- a/zqd/storage/archivestore/archivestore.go
+++ b/zqd/storage/archivestore/archivestore.go
@@ -110,3 +110,7 @@ func (s *Storage) Summary(_ context.Context) (storage.Summary, error) {
 func (s *Storage) IndexSearch(ctx context.Context, query archive.IndexQuery) (zbuf.ReadCloser, error) {
 	return archive.FindReadCloser(ctx, s.ark, query, archive.AddPath(archive.DefaultAddPathField, false))
 }
+
+func (s *Storage) ArchiveStat(ctx context.Context) (zbuf.ReadCloser, error) {
+	return archive.Stat(ctx, s.ark)
+}


### PR DESCRIPTION
This adds a `zar stat` cli command and a corresponding api endpoint (`GET /space/{space}/archivestat`). Each returns a ZNG stream with a record per chunk containing the chunk's id, start, duration, and size. The intended use case is for Brim to display an overview of the data in the archive.

The api endpoint doesn't support running a zql expression against the returned data, but that's an easy separate addition. There's also no info yet provided for the type, field, or custom indices in the archive, but that's intended, which is why there's a `type: chunk` field in the currently returned records.
