### PR TITLE
Remove proc.Context.Reverse

### DIFF
--- a/driver/compile.go
+++ b/driver/compile.go
@@ -50,7 +50,6 @@ func CompileWarningsChCustom(ctx context.Context, custom proc.Compiler, program 
 		Context:     ctx,
 		TypeContext: resolver.NewContext(),
 		Logger:      logger,
-		Reverse:     reverse,
 		Warnings:    ch,
 	}
 	leaves, err := proc.CompileProc(custom, program, pctx, scanner)

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -43,7 +43,6 @@ type Context struct {
 	context.Context
 	TypeContext *resolver.Context
 	Logger      *zap.Logger
-	Reverse     bool
 	Warnings    chan string
 }
 


### PR DESCRIPTION
This field doesn't make sense given our current ideas about record ordering. (And in truth, it never did!)