### PR TITLE
Check key type consistency in custom indexes

### DIFF
--- a/tests/suite/zar/custom-index-multitype-error.yaml
+++ b/tests/suite/zar/custom-index-multitype-error.yaml
@@ -1,0 +1,16 @@
+script: |
+  zar import -R . multitype.tzng
+  zar index -R . -q -o custom -k id.orig_h -z "cut id.orig_h | sort" _
+
+inputs:
+  - name: multitype.tzng
+    data: |
+      #0:record[_path:string,ts:time,id:record[orig_h:ip]]
+      0:[smb_cmd;1258594907.85978;[192.168.2.1;]]
+      #1:record[_path:string,ts:time,id:record[orig_h:string]]
+      1:[smb_cmd;1258594907.85978;[192.168.2.1;]]
+
+outputs:
+  - name: stderr
+    regexp: |
+      key type changed from record\[id:record\[orig_h:ip\]\] to record\[id:record\[orig_h:string\]\]

--- a/tests/suite/zar/multikey-index.yaml
+++ b/tests/suite/zar/multikey-index.yaml
@@ -4,7 +4,6 @@ script: |
   zar index -q -R ./logs -o index -k sum,s -z "sum(v) by s | sort sum,s"
   zar find -R ./logs -relative -z -x index 149 wailer-strick | zq -t -
 
-
 inputs:
   - name: babble.tzng
     source: ../zdx/babble.tzng

--- a/tests/suite/zar/multikey-index.yaml
+++ b/tests/suite/zar/multikey-index.yaml
@@ -1,0 +1,17 @@
+script: |
+  mkdir logs
+  zar import -s 2500B -R ./logs babble.tzng
+  zar index -q -R ./logs -o index -k sum,s -z "sum(v) by s | sort sum,s"
+  zar find -R ./logs -relative -z -x index 149 wailer-strick | zq -t -
+
+
+inputs:
+  - name: babble.tzng
+    source: ../zdx/babble.tzng
+
+outputs:
+  - name: stdout
+    data: |
+      #zfile=string
+      #0:record[s:string,sum:int64,_log:zfile]
+      0:[wailer-strick;149;20200421/1587511734.06734765.zng;]


### PR DESCRIPTION
closes #815 

While in there I noticed we didn't have a test for multi-key custom indexes and so added one in the first commit. The second commit has the actual fix and a test verifying the fix.