### PR TITLE
zql/Makefile: fix "make run"

### DIFF
--- a/zql/Makefile
+++ b/zql/Makefile
@@ -17,7 +17,7 @@ PEGJS_ARGS = --allowed-start-rules start,Expression
 
 all: zql.go zql.js zql.es.js
 
-run: all
+run: zql.go zql.js
 	go run ./main
 
 $(PEGJS):


### PR DESCRIPTION
make run doesn't need the ES module to be built.