### PR TITLE
ztest: return compilation error as string

### DIFF
--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -590,7 +590,7 @@ func runzq(bindir, ZQL, outputFormat, outputFlags string, inputs ...string) (out
 	}
 	muxOutput, err := driver.Compile(context.Background(), zctx, proc, zr, "", false, nano.MaxSpan, zap.NewNop())
 	if err != nil {
-		return "", "", err
+		return "", err.Error(), err
 	}
 	var zflags zio.WriterFlags
 	var flags flag.FlagSet


### PR DESCRIPTION
Previously, compilation errors weren't returned as the "warnOrError"
return argument of ztest.runzq(), and so a zql-style test couldn't
check for those. This change allows zql-style ztests to check for
compilation errors.