### PR TITLE
address more cases where typecontext should be provided

### DIFF
--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -52,7 +52,7 @@ func indexArchiveSpace(t *testing.T, datapath string, ruledef string) {
 }
 
 func indexQuery(t *testing.T, ark *Archive, query IndexQuery, opts ...FindOption) string {
-	rc, err := FindReadCloser(context.Background(), ark, query, opts...)
+	rc, err := FindReadCloser(context.Background(), resolver.NewContext(), ark, query, opts...)
 	require.NoError(t, err)
 	defer rc.Close()
 

--- a/archive/finder.go
+++ b/archive/finder.go
@@ -73,9 +73,9 @@ func AddPath(pathField string, absolutePath bool) FindOption {
 // be more efficient at large scale to allow multipe patterns that
 // are effectively OR-ed together so that there is locality of
 // access to the zdx files.
-func Find(ctx context.Context, ark *Archive, query IndexQuery, hits chan<- *zng.Record, opts ...FindOption) error {
+func Find(ctx context.Context, zctx *resolver.Context, ark *Archive, query IndexQuery, hits chan<- *zng.Record, opts ...FindOption) error {
 	opt := findOptions{
-		zctx:    resolver.NewContext(),
+		zctx:    zctx,
 		addPath: func(_ *Archive, _ SpanInfo, rec *zng.Record) (*zng.Record, error) { return rec, nil },
 	}
 	for _, o := range opts {
@@ -157,7 +157,7 @@ func (f *findReadCloser) Close() error {
 	return nil
 }
 
-func FindReadCloser(ctx context.Context, ark *Archive, query IndexQuery, opts ...FindOption) (zbuf.ReadCloser, error) {
+func FindReadCloser(ctx context.Context, zctx *resolver.Context, ark *Archive, query IndexQuery, opts ...FindOption) (zbuf.ReadCloser, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	f := &findReadCloser{
 		ctx:    ctx,
@@ -165,7 +165,7 @@ func FindReadCloser(ctx context.Context, ark *Archive, query IndexQuery, opts ..
 		hits:   make(chan *zng.Record),
 	}
 	go func() {
-		f.err = Find(ctx, ark, query, f.hits, opts...)
+		f.err = Find(ctx, zctx, ark, query, f.hits, opts...)
 		close(f.hits)
 	}()
 	return f, nil

--- a/cmd/zar/find/command.go
+++ b/cmd/zar/find/command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brimsec/zq/emitter"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
 	"github.com/mccanne/charm"
 )
 
@@ -119,9 +120,10 @@ func (c *Command) Run(args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	hits := make(chan *zng.Record)
+	zctx := resolver.NewContext()
 	var searchErr error
 	go func() {
-		searchErr = archive.Find(ctx, ark, query, hits, findOptions...)
+		searchErr = archive.Find(ctx, zctx, ark, query, hits, findOptions...)
 		close(hits)
 	}()
 	for hit := range hits {

--- a/cmd/zar/stat/command.go
+++ b/cmd/zar/stat/command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brimsec/zq/emitter"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zng/resolver"
 	"github.com/mccanne/charm"
 )
 
@@ -63,7 +64,7 @@ func (c *Command) Run(args []string) (err error) {
 		}
 	}()
 
-	rc, err := archive.Stat(context.Background(), ark)
+	rc, err := archive.Stat(context.Background(), resolver.NewContext(), ark)
 	if err != nil {
 		return err
 	}

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/brimsec/zq/pkg/ctxio"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqd/api"
 	"github.com/brimsec/zq/zqd/ingest"
 	"github.com/brimsec/zq/zqd/search"
@@ -505,7 +506,7 @@ func handleIndexSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 }
 
 type ArchiveStater interface {
-	ArchiveStat(context.Context) (zbuf.ReadCloser, error)
+	ArchiveStat(context.Context, *resolver.Context) (zbuf.ReadCloser, error)
 }
 
 func handleArchiveStat(c *Core, w http.ResponseWriter, r *http.Request) {
@@ -525,7 +526,7 @@ func handleArchiveStat(c *Core, w http.ResponseWriter, r *http.Request) {
 		respondError(c, w, r, zqe.E(zqe.Invalid, "space storage does not support archive stat"))
 		return
 	}
-	rc, err := store.ArchiveStat(ctx)
+	rc, err := store.ArchiveStat(ctx, resolver.NewContext())
 	if err != nil {
 		respondError(c, w, r, err)
 		return

--- a/zqd/search/indexsearch.go
+++ b/zqd/search/indexsearch.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/brimsec/zq/archive"
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqd/api"
 )
 
 type IndexSearcher interface {
-	IndexSearch(context.Context, archive.IndexQuery) (zbuf.ReadCloser, error)
+	IndexSearch(context.Context, *resolver.Context, archive.IndexQuery) (zbuf.ReadCloser, error)
 }
 
 type IndexSearchOp struct {
@@ -21,7 +22,7 @@ func NewIndexSearchOp(ctx context.Context, s IndexSearcher, req api.IndexSearchR
 	if err != nil {
 		return nil, err
 	}
-	rc, err := s.IndexSearch(ctx, query)
+	rc, err := s.IndexSearch(ctx, resolver.NewContext(), query)
 	if err != nil {
 		return nil, err
 	}

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -29,7 +29,7 @@ const (
 )
 
 type SearchStore interface {
-	Open(ctx context.Context, span nano.Span) (zbuf.ReadCloser, error)
+	Open(ctx context.Context, zctx *resolver.Context, span nano.Span) (zbuf.ReadCloser, error)
 }
 
 type SearchOp struct {
@@ -57,11 +57,11 @@ func NewSearchOp(ctx context.Context, s SearchStore, req api.SearchRequest) (*Se
 		return nil, err
 	}
 
-	zngReader, err := s.Open(ctx, query.Span)
+	zctx := resolver.NewContext()
+	zngReader, err := s.Open(ctx, zctx, query.Span)
 	if err != nil {
 		return nil, err
 	}
-	zctx := resolver.NewContext()
 	mapper := zbuf.NewMapper(zngReader, zctx)
 	mux, err := launch(ctx, query, mapper, zctx)
 	if err != nil {

--- a/zqd/storage/archivestore/archivestore.go
+++ b/zqd/storage/archivestore/archivestore.go
@@ -45,7 +45,7 @@ func (s *Storage) NativeDirection() zbuf.Direction {
 	return s.ark.DataSortDirection
 }
 
-func (s *Storage) Open(ctx context.Context, span nano.Span) (zbuf.ReadCloser, error) {
+func (s *Storage) Open(ctx context.Context, zctx *resolver.Context, span nano.Span) (zbuf.ReadCloser, error) {
 	var err error
 	var paths []string
 	err = archive.SpanWalk(s.ark, func(si archive.SpanInfo, zardir iosrc.URI) error {
@@ -64,7 +64,6 @@ func (s *Storage) Open(ctx context.Context, span nano.Span) (zbuf.ReadCloser, er
 	if err != nil {
 		return nil, err
 	}
-	zctx := resolver.NewContext()
 	cfg := detector.OpenConfig{Format: "zng"}
 	return detector.MultiFileReader(zctx, paths, cfg), nil
 }
@@ -114,10 +113,10 @@ func (s *Storage) Summary(_ context.Context) (storage.Summary, error) {
 	return sum, nil
 }
 
-func (s *Storage) IndexSearch(ctx context.Context, query archive.IndexQuery) (zbuf.ReadCloser, error) {
-	return archive.FindReadCloser(ctx, s.ark, query, archive.AddPath(archive.DefaultAddPathField, false))
+func (s *Storage) IndexSearch(ctx context.Context, zctx *resolver.Context, query archive.IndexQuery) (zbuf.ReadCloser, error) {
+	return archive.FindReadCloser(ctx, zctx, s.ark, query, archive.AddPath(archive.DefaultAddPathField, false))
 }
 
-func (s *Storage) ArchiveStat(ctx context.Context) (zbuf.ReadCloser, error) {
-	return archive.Stat(ctx, s.ark)
+func (s *Storage) ArchiveStat(ctx context.Context, zctx *resolver.Context) (zbuf.ReadCloser, error) {
+	return archive.Stat(ctx, zctx, s.ark)
 }

--- a/zqd/storage/filestore/filestore.go
+++ b/zqd/storage/filestore/filestore.go
@@ -65,8 +65,7 @@ func (s *Storage) join(args ...string) string {
 	return filepath.Join(args...)
 }
 
-func (s *Storage) Open(_ context.Context, span nano.Span) (zbuf.ReadCloser, error) {
-	zctx := resolver.NewContext()
+func (s *Storage) Open(_ context.Context, zctx *resolver.Context, span nano.Span) (zbuf.ReadCloser, error) {
 	f, err := fs.Open(s.join(allZngFile))
 	if err != nil {
 		if !os.IsNotExist(err) {

--- a/zqd/storage/storage.go
+++ b/zqd/storage/storage.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng/resolver"
 )
 
 type Kind string
@@ -59,7 +60,7 @@ type Summary struct {
 }
 
 type Storage interface {
-	Open(ctx context.Context, span nano.Span) (zbuf.ReadCloser, error)
+	Open(ctx context.Context, zctx *resolver.Context, span nano.Span) (zbuf.ReadCloser, error)
 	Summary(ctx context.Context) (Summary, error)
 	NativeDirection() zbuf.Direction
 }


### PR DESCRIPTION
The case in search.go is the only one that looks like it could lead to immediate trouble, but I went ahead and changed the rest of the Storage methods as well.
