### PR TITLE
Make s3io.Reader an io.Seeker

### DIFF
--- a/archive/finder.go
+++ b/archive/finder.go
@@ -46,7 +46,11 @@ func AddPath(pathField string, absolutePath bool) FindOption {
 		opt.addPath = func(ark *Archive, si SpanInfo, rec *zng.Record) (*zng.Record, error) {
 			var path string
 			if absolutePath {
-				path = si.LogID.Path(ark).String()
+				if ark.DataPath.Scheme == "file" {
+					path = si.LogID.Path(ark).Filepath()
+				} else {
+					path = si.LogID.Path(ark).String()
+				}
 			} else {
 				path = string(si.LogID)
 			}

--- a/pkg/s3io/reader.go
+++ b/pkg/s3io/reader.go
@@ -1,0 +1,97 @@
+package s3io
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+type Reader struct {
+	downloader *s3manager.Downloader
+	bucket     string
+	key        string
+	size       int64
+	offset     int64
+}
+
+func NewReader(path string, cfg *aws.Config) (*Reader, error) {
+	info, err := Stat(path, cfg)
+	if err != nil {
+		return nil, err
+	}
+	bucket, key, err := parsePath(path)
+	if err != nil {
+		return nil, err
+	}
+	client := newClient(cfg)
+	downloader := s3manager.NewDownloaderWithClient(client)
+	return &Reader{
+		downloader: downloader,
+		bucket:     bucket,
+		key:        key,
+		size:       *info.ContentLength,
+	}, nil
+}
+
+var errInvalidOffset = errors.New("Seek: invalid offset")
+
+func (r *Reader) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+	case io.SeekCurrent:
+		offset += r.offset
+	case io.SeekEnd:
+		offset += r.size
+	default:
+		return 0, fmt.Errorf("%d: unknown whence value", whence)
+	}
+	if offset < 0 {
+		return 0, errInvalidOffset
+	}
+	r.offset = offset
+	return offset, nil
+}
+
+func (r *Reader) bytesRange(num int) string {
+	return fmt.Sprintf("bytes=%d-%d", r.offset, r.offset+int64(num)-1)
+}
+
+func (r *Reader) Read(p []byte) (int, error) {
+	if r.offset >= r.size {
+		return 0, io.EOF
+	}
+
+	n := len(p)
+	getObjRange := r.bytesRange(n)
+	getObj := &s3.GetObjectInput{
+		Bucket: aws.String(r.bucket),
+		Key:    aws.String(r.key),
+	}
+	if len(getObjRange) > 0 {
+		getObj.Range = aws.String(getObjRange)
+	}
+
+	wab := aws.NewWriteAtBuffer(p)
+	bytesDownloaded, err := r.downloader.Download(wab, getObj)
+	if err != nil {
+		return 0, err
+	}
+
+	buf := wab.Bytes()
+	if len(buf) > n {
+		// backing buffer reassigned, copy over some of the data
+		copy(p, buf)
+		bytesDownloaded = int64(n)
+	}
+	r.offset += bytesDownloaded
+
+	return int(bytesDownloaded), err
+}
+
+func (r *Reader) Close() error {
+	return nil
+}

--- a/pkg/s3io/reader.go
+++ b/pkg/s3io/reader.go
@@ -64,11 +64,11 @@ func (r *Reader) Read(p []byte) (int, error) {
 	}
 	if len(p) == 0 {
 		return 0, nil
-	}	
+	}
 	getObj := &s3.GetObjectInput{
 		Bucket: aws.String(r.bucket),
 		Key:    aws.String(r.key),
-		Range:  aws.String(r.bytesRange(len(p)))
+		Range:  aws.String(r.bytesRange(len(p))),
 	}
 	wab := aws.NewWriteAtBuffer(p)
 	bytesDownloaded, err := r.downloader.Download(wab, getObj)
@@ -77,10 +77,10 @@ func (r *Reader) Read(p []byte) (int, error) {
 	}
 
 	buf := wab.Bytes()
-	if len(buf) > n {
+	if len(buf) > len(p) {
 		// backing buffer reassigned, copy over some of the data
 		copy(p, buf)
-		bytesDownloaded = int64(n)
+		bytesDownloaded = int64(len(p))
 	}
 	r.offset += bytesDownloaded
 

--- a/pkg/s3io/reader.go
+++ b/pkg/s3io/reader.go
@@ -62,17 +62,14 @@ func (r *Reader) Read(p []byte) (int, error) {
 	if r.offset >= r.size {
 		return 0, io.EOF
 	}
-
-	n := len(p)
-	getObjRange := r.bytesRange(n)
+	if len(p) == 0 {
+		return 0, nil
+	}	
 	getObj := &s3.GetObjectInput{
 		Bucket: aws.String(r.bucket),
 		Key:    aws.String(r.key),
+		Range:  aws.String(r.bytesRange(len(p)))
 	}
-	if len(getObjRange) > 0 {
-		getObj.Range = aws.String(getObjRange)
-	}
-
 	wab := aws.NewWriteAtBuffer(p)
 	bytesDownloaded, err := r.downloader.Download(wab, getObj)
 	if err != nil {

--- a/pkg/s3io/reader.go
+++ b/pkg/s3io/reader.go
@@ -37,8 +37,6 @@ func NewReader(path string, cfg *aws.Config) (*Reader, error) {
 	}, nil
 }
 
-var errInvalidOffset = errors.New("Seek: invalid offset")
-
 func (r *Reader) Seek(offset int64, whence int) (int64, error) {
 	switch whence {
 	case io.SeekStart:
@@ -47,10 +45,10 @@ func (r *Reader) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekEnd:
 		offset += r.size
 	default:
-		return 0, fmt.Errorf("%d: unknown whence value", whence)
+		return 0, errors.New("s3io.Reader.Seek: invalid whence")
 	}
 	if offset < 0 {
-		return 0, errInvalidOffset
+		return 0, errors.New("s3io.Reader.Seek: negative position")
 	}
 	r.offset = offset
 	return offset, nil

--- a/pkg/s3io/s3io.go
+++ b/pkg/s3io/s3io.go
@@ -97,21 +97,6 @@ func (w *Writer) Close() error {
 	return w.err
 }
 
-func NewReader(path string, cfg *aws.Config) (io.ReadCloser, error) {
-	bucket, key, err := parsePath(path)
-	if err != nil {
-		return nil, err
-	}
-	res, err := newClient(cfg).GetObject(&s3.GetObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.Body, nil
-}
-
 func Stat(path string, cfg *aws.Config) (*s3.HeadObjectOutput, error) {
 	bucket, key, err := parsePath(path)
 	if err != nil {

--- a/tests/suite/zar/s3/find-index-type.yaml
+++ b/tests/suite/zar/s3/find-index-type.yaml
@@ -1,0 +1,29 @@
+script: |
+  source minio.sh
+  zar import -R . -data s3://bucket/zartest log.tzng
+  zar index -q -R . :ip
+  zar find -relative -R . :ip=1.1.1.1
+  zar find -relative -R . :ip=192.168.1.102
+  zar find -relative -R . :ip=192.168.2.1
+  zar find -relative -R . :ip=192.168.1.1
+  echo ===
+  zq -t "count(key)" s3://bucket/zartest/20091119/1258594907.85978.zng.zar/zdx-type-ip.zng # check unset not indexed
+
+inputs:
+  - name: log.tzng
+    data: |
+      #0:record[_path:string,ts:time,uid:bstring,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port],referenced_file:record[ts:time,uid:bstring,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port],fuid:bstring]]
+      0:[smb_cmd;1258594907.85978;Chjxid42dvvzIzdeG8;[192.168.1.102;1076;192.168.2.1;139;][1258594907.85978;Chjxid42dvvzIzdeG8;[-;1076;192.168.1.1;139;]ZYjxid42dvvzIzdeG8;]]
+  - name: minio.sh
+    source: ./minio.sh
+
+
+outputs:
+  - name: stdout
+    data: |
+      20091119/1258594907.85978.zng
+      20091119/1258594907.85978.zng
+      20091119/1258594907.85978.zng
+      ===
+      #0:record[count:uint64]
+      0:[3;]


### PR DESCRIPTION
This functionality is needed for the zar find command to work.

Add system test for zar index and zar find commands.

Part of #972 & #973