### PR TITLE
No commas in Content-Disposition header

### DIFF
--- a/pcap/flow.go
+++ b/pcap/flow.go
@@ -25,7 +25,7 @@ func NewFlow(src net.IP, srcPort int, dst net.IP, dstPort int) Flow {
 }
 
 func (f Flow) String() string {
-	return f.S0.String() + ";" + f.S1.String()
+	return f.S0.String() + "-" + f.S1.String()
 }
 
 func ParseSocket(s string) (Socket, error) {

--- a/pcap/flow.go
+++ b/pcap/flow.go
@@ -25,7 +25,7 @@ func NewFlow(src net.IP, srcPort int, dst net.IP, dstPort int) Flow {
 }
 
 func (f Flow) String() string {
-	return f.S0.String() + "," + f.S1.String()
+	return f.S0.String() + ";" + f.S1.String()
 }
 
 func ParseSocket(s string) (Socket, error) {


### PR DESCRIPTION




Apparently Chrome blocks responses from servers when the Content-Disposition field has a "," comma in the `filename=` part of the header. As you can see below, zqd returns a comma in that field when downloading pcaps.


```
~/work/brim > curl -v "http://localhost:9867/space/sp_1epqHG5yltrjlPwbLfB6fyXwO5I/pcap?ts_sec=1582646595&ts_ns=986756000&duration_sec=0&duration_ns=60027000&proto=tcp&src_host=192.168.1.110&src_port=57540&dst_host=172.217.1.138&dst_port=443"

< HTTP/1.1 200 OK
< Content-Disposition: inline; filename=1582646595.986756_tcp_192.168.1.110:57540,172.217.1.138:443.pcap
< Content-Type: application/vnd.tcpdump.pcap
< X-Request-Id: 12
< Date: Fri, 17 Jul 2020 23:33:57 GMT
< Content-Length: 348
```

Here's a picture of the error in the dev tools:

<img width="529" alt="image" src="https://user-images.githubusercontent.com/3460638/87839389-7fc7e600-c84f-11ea-9772-ae8a9b37af37.png">


Here's the answer to the question on SO
https://stackoverflow.com/a/14836763/3499804

Without the comma in the header, things work fine. This was not an issue previously because this was the last place Brim used Node to make the request to the backend, instead of Chrome's `fetch`.

I picked a semi-colon as a replacement arbitrarily. Happy to change it to something else.