### PR TITLE
add index information to zar stat

### DIFF
--- a/archive/schema.go
+++ b/archive/schema.go
@@ -1,7 +1,6 @@
 package archive
 
 import (
-	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -13,9 +12,6 @@ import (
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zcode"
-	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
 )
 
@@ -297,78 +293,4 @@ func CreateOrOpenArchive(path string, co *CreateOptions, oo *OpenOptions) (*Arch
 		}
 	}
 	return OpenArchive(path, oo)
-}
-
-// statReadCloser implements zbuf.ReadCloser
-type statReadCloser struct {
-	ctx    context.Context
-	cancel context.CancelFunc
-	ark    *Archive
-	zctx   *resolver.Context
-	recs   chan *zng.Record
-	err    error
-}
-
-func (s *statReadCloser) Read() (*zng.Record, error) {
-	select {
-	case r, ok := <-s.recs:
-		if !ok {
-			return nil, s.err
-		}
-		return r, nil
-	case <-s.ctx.Done():
-		return nil, s.ctx.Err()
-	}
-}
-
-func (s *statReadCloser) Close() error {
-	s.cancel()
-	return nil
-}
-
-func (s *statReadCloser) run() {
-	defer close(s.recs)
-
-	typ := s.zctx.MustLookupTypeRecord([]zng.Column{
-		zng.NewColumn("type", zng.TypeString),
-		zng.NewColumn("log_id", zng.TypeString),
-		zng.NewColumn("start", zng.TypeTime),
-		zng.NewColumn("duration", zng.TypeDuration),
-		zng.NewColumn("size", zng.TypeUint64),
-	})
-
-	s.err = SpanWalk(s.ark, func(si SpanInfo, zardir iosrc.URI) error {
-		fi, err := iosrc.Stat(ZarDirToLog(zardir))
-		if err != nil {
-			return err
-		}
-
-		var zv zcode.Bytes
-		zv = zng.NewString("chunk").Encode(zv)
-		zv = zng.NewString(string(si.LogID)).Encode(zv)
-		zv = zng.NewTime(si.Span.Ts).Encode(zv)
-		zv = zng.NewDuration(si.Span.Dur).Encode(zv)
-		zv = zng.NewUint64(uint64(fi.Size())).Encode(zv)
-
-		rec := zng.NewRecord(typ, zv)
-		select {
-		case s.recs <- rec:
-			return nil
-		case <-s.ctx.Done():
-			return s.ctx.Err()
-		}
-	})
-}
-
-func Stat(ctx context.Context, zctx *resolver.Context, ark *Archive) (zbuf.ReadCloser, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	s := &statReadCloser{
-		ctx:    ctx,
-		cancel: cancel,
-		ark:    ark,
-		zctx:   zctx,
-		recs:   make(chan *zng.Record),
-	}
-	go s.run()
-	return s, nil
 }

--- a/archive/stat.go
+++ b/archive/stat.go
@@ -14,7 +14,7 @@ import (
 	"github.com/brimsec/zq/zqe"
 )
 
-// statReadCloser implements zbuf.ReadCloser
+// statReadCloser implements zbuf.ReadCloser.
 type statReadCloser struct {
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -89,15 +89,15 @@ func (s *statReadCloser) indexRecord(si SpanInfo, zardir iosrc.URI, indexPath st
 	}
 	if s.indexBuilders[indexPath] == nil {
 		keycols := make([]zng.Column, len(info.Keys))
-		for i := range info.Keys {
+		for i, k := range info.Keys {
 			keycols[i] = zng.Column{
-				Name: info.Keys[i].Name,
+				Name: k.Name,
 				Type: zng.TypeString,
 			}
 		}
 		keyrec := s.zctx.MustLookupTypeRecord(keycols)
 
-		indexBuilder := zng.NewBuilder(s.zctx.MustLookupTypeRecord([]zng.Column{
+		s.indexBuilders[indexPath] = zng.NewBuilder(s.zctx.MustLookupTypeRecord([]zng.Column{
 			zng.NewColumn("type", zng.TypeString),
 			zng.NewColumn("log_id", zng.TypeString),
 			zng.NewColumn("index_id", zng.TypeString),
@@ -105,7 +105,6 @@ func (s *statReadCloser) indexRecord(si SpanInfo, zardir iosrc.URI, indexPath st
 			zng.NewColumn("size", zng.TypeUint64),
 			zng.NewColumn("keys", keyrec),
 		}))
-		s.indexBuilders[indexPath] = indexBuilder
 	}
 
 	if len(s.indexBuilders[indexPath].Type.Columns) != 5+len(info.Keys) {

--- a/archive/stat.go
+++ b/archive/stat.go
@@ -1,0 +1,170 @@
+package archive
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zdx"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zqe"
+)
+
+// statReadCloser implements zbuf.ReadCloser
+type statReadCloser struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	ark    *Archive
+	zctx   *resolver.Context
+	recs   chan *zng.Record
+	err    error
+
+	chunkBuilder  *zng.Builder
+	indexBuilders map[string]*zng.Builder
+}
+
+func (s *statReadCloser) Read() (*zng.Record, error) {
+	select {
+	case r, ok := <-s.recs:
+		if !ok {
+			return nil, s.err
+		}
+		return r, nil
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	}
+}
+
+func (s *statReadCloser) Close() error {
+	s.cancel()
+	return nil
+}
+
+func (s *statReadCloser) chunkRecord(si SpanInfo, zardir iosrc.URI) error {
+	fi, err := iosrc.Stat(ZarDirToLog(zardir))
+	if err != nil {
+		return err
+	}
+
+	if s.chunkBuilder == nil {
+		s.chunkBuilder = zng.NewBuilder(s.zctx.MustLookupTypeRecord([]zng.Column{
+			zng.NewColumn("type", zng.TypeString),
+			zng.NewColumn("log_id", zng.TypeString),
+			zng.NewColumn("start", zng.TypeTime),
+			zng.NewColumn("duration", zng.TypeDuration),
+			zng.NewColumn("size", zng.TypeUint64),
+		}))
+	}
+
+	rec := s.chunkBuilder.Build(
+		zng.EncodeString("chunk"),
+		zng.EncodeString(string(si.LogID)),
+		zng.EncodeTime(si.Span.Ts),
+		zng.EncodeDuration(si.Span.Dur),
+		zng.EncodeUint(uint64(fi.Size())),
+	).Keep()
+	select {
+	case s.recs <- rec:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
+}
+
+func (s *statReadCloser) indexRecord(si SpanInfo, zardir iosrc.URI, indexPath string) error {
+	info, err := zdx.Stat(zardir.AppendPath(indexPath))
+	if err != nil {
+		if errors.Is(err, zqe.E(zqe.NotFound)) {
+			return nil
+		}
+		return err
+	}
+
+	if s.indexBuilders == nil {
+		s.indexBuilders = make(map[string]*zng.Builder)
+	}
+	if s.indexBuilders[indexPath] == nil {
+		keycols := make([]zng.Column, len(info.Keys))
+		for i := range info.Keys {
+			keycols[i] = zng.Column{
+				Name: info.Keys[i].Name,
+				Type: zng.TypeString,
+			}
+		}
+		keyrec := s.zctx.MustLookupTypeRecord(keycols)
+
+		indexBuilder := zng.NewBuilder(s.zctx.MustLookupTypeRecord([]zng.Column{
+			zng.NewColumn("type", zng.TypeString),
+			zng.NewColumn("log_id", zng.TypeString),
+			zng.NewColumn("index_id", zng.TypeString),
+			zng.NewColumn("index_type", zng.TypeString),
+			zng.NewColumn("size", zng.TypeUint64),
+			zng.NewColumn("keys", keyrec),
+		}))
+		s.indexBuilders[indexPath] = indexBuilder
+	}
+
+	if len(s.indexBuilders[indexPath].Type.Columns) != 5+len(info.Keys) {
+		return zqe.E("key record differs in index files %s %s", indexPath, si.LogID)
+	}
+	var keybytes zcode.Bytes
+	for i := range info.Keys {
+		keybytes = zcode.AppendPrimitive(keybytes, zng.EncodeString(info.Keys[i].TypeName))
+	}
+
+	rec := s.indexBuilders[indexPath].Build(
+		zng.EncodeString("index"),
+		zng.EncodeString(string(si.LogID)),
+		zng.EncodeString(indexPath),
+		zng.EncodeString(s.ark.indexes[indexPath].Type),
+		zng.EncodeUint(uint64(info.Size)),
+		keybytes,
+	).Keep()
+	select {
+	case s.recs <- rec:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
+}
+
+func (s *statReadCloser) run() {
+	defer close(s.recs)
+
+	var indexPaths []string
+	for k := range s.ark.indexes {
+		indexPaths = append(indexPaths, k)
+	}
+	sort.Strings(indexPaths)
+
+	s.err = SpanWalk(s.ark, func(si SpanInfo, zardir iosrc.URI) error {
+		if err := s.chunkRecord(si, zardir); err != nil {
+			return err
+		}
+
+		for _, indexPath := range indexPaths {
+			if err := s.indexRecord(si, zardir, indexPath); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+func Stat(ctx context.Context, zctx *resolver.Context, ark *Archive) (zbuf.ReadCloser, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	s := &statReadCloser{
+		ctx:    ctx,
+		cancel: cancel,
+		ark:    ark,
+		zctx:   zctx,
+		recs:   make(chan *zng.Record),
+	}
+	go s.run()
+	return s, nil
+}

--- a/archive/stat.go
+++ b/archive/stat.go
@@ -111,8 +111,8 @@ func (s *statReadCloser) indexRecord(si SpanInfo, zardir iosrc.URI, indexPath st
 		return zqe.E("key record differs in index files %s %s", indexPath, si.LogID)
 	}
 	var keybytes zcode.Bytes
-	for i := range info.Keys {
-		keybytes = zcode.AppendPrimitive(keybytes, zng.EncodeString(info.Keys[i].TypeName))
+	for _, k := range info.Keys {
+		keybytes = zcode.AppendPrimitive(keybytes, zng.EncodeString(k.TypeName))
 	}
 
 	rec := s.indexBuilders[indexPath].Build(

--- a/tests/suite/zar/stat.yaml
+++ b/tests/suite/zar/stat.yaml
@@ -1,6 +1,8 @@
 script: |
   mkdir logs
   zar import -s 20KiB -R ./logs babble.tzng
+  zar index -R ./logs -q :string
+  zar index -R ./logs -q v
   zar ls -relative -R ./logs
   echo ===
   zar stat -R ./logs
@@ -18,11 +20,23 @@ outputs:
       20200422/1587518620.0622373.zng.zar
       20200421/1587512288.06249439.zng.zar
       ===
+      TYPE  LOG_ID                          START                DURATION       SIZE
+      chunk 20200422/1587518620.0622373.zng 1587512305.069789040 6314.992448261 21761
+      TYPE  LOG_ID                          INDEX_ID        INDEX_TYPE SIZE  KEYS.KEY
+      index 20200422/1587518620.0622373.zng zdx-field-v     field      2537  int64
+      index 20200422/1587518620.0622373.zng zdx-type-string type       15775 string
       TYPE  LOG_ID                           START                DURATION       SIZE
-      chunk 20200422/1587518620.0622373.zng  1587512305.069789040 6314.992448261 21761
       chunk 20200421/1587512288.06249439.zng 1587508830.068523240 3457.993971151 13152
+      TYPE  LOG_ID                           INDEX_ID        INDEX_TYPE SIZE KEYS.KEY
+      index 20200421/1587512288.06249439.zng zdx-field-v     field      1868 int64
+      index 20200421/1587512288.06249439.zng zdx-type-string type       9546 string
       ===
       #0:record[type:string,log_id:string,start:time,duration:duration,size:uint64]
       0:[chunk;20200422/1587518620.0622373.zng;1587512305.06978904;6314.992448261;21761;]
+      #1:record[type:string,log_id:string,index_id:string,index_type:string,size:uint64,keys:record[key:string]]
+      1:[index;20200422/1587518620.0622373.zng;zdx-field-v;field;2537;[int64;]]
+      1:[index;20200422/1587518620.0622373.zng;zdx-type-string;type;15775;[string;]]
       0:[chunk;20200421/1587512288.06249439.zng;1587508830.06852324;3457.993971151;13152;]
+      1:[index;20200421/1587512288.06249439.zng;zdx-field-v;field;1868;[int64;]]
+      1:[index;20200421/1587512288.06249439.zng;zdx-type-string;type;9546;[string;]]
       ===

--- a/tests/suite/zar/stat.yaml
+++ b/tests/suite/zar/stat.yaml
@@ -1,8 +1,7 @@
 script: |
   mkdir logs
   zar import -s 20KiB -R ./logs babble.tzng
-  zar index -R ./logs -q :string
-  zar index -R ./logs -q v
+  zar index -R ./logs -q :string v
   zar ls -relative -R ./logs
   echo ===
   zar stat -R ./logs

--- a/zdx/finder.go
+++ b/zdx/finder.go
@@ -37,6 +37,66 @@ func (f *Finder) Keys() *zng.TypeRecord {
 	return f.keys
 }
 
+type InfoKey struct {
+	Name     string
+	TypeName string
+}
+
+type Info struct {
+	Size int64
+	Keys []InfoKey
+}
+
+// Stat returns summary information about the zdx index at uri.
+func Stat(uri iosrc.URI) (*Info, error) {
+	level := 0
+	var size int64
+	for {
+		path := filename(uri, level)
+		si, err := iosrc.Stat(path)
+		if err != nil {
+			if errors.Is(err, zqe.E(zqe.NotFound)) {
+				break
+			}
+			return nil, err
+		}
+		level += 1
+		size += si.Size()
+	}
+	if level == 0 {
+		return nil, zqe.E(zqe.NotFound)
+	}
+	r, err := newReader(resolver.NewContext(), uri, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	rec, err := r.Read()
+	if err != nil {
+		return nil, err
+	}
+	if rec == nil {
+		// files exists but is empty
+		return nil, fmt.Errorf("%s: cannnot read zdx header", uri)
+	}
+	_, keysType, err := ParseHeader(rec)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", uri.String(), err)
+	}
+	keys := make([]InfoKey, len(keysType.Columns))
+	for i := range keysType.Columns {
+		keys[i] = InfoKey{
+			Name:     keysType.Columns[i].Name,
+			TypeName: keysType.Columns[i].Type.String(),
+		}
+	}
+	return &Info{
+		Size: size,
+		Keys: keys,
+	}, nil
+}
+
 // Open prepares the underlying zdx index for lookups.  It opens the file
 // and reads the header, returning errors if the file is corrrupt, doesn't
 // exist, or its zdx header is invalid.  If the index exists but is empty,

--- a/zdx/finder.go
+++ b/zdx/finder.go
@@ -49,18 +49,17 @@ type Info struct {
 
 // Stat returns summary information about the zdx index at uri.
 func Stat(uri iosrc.URI) (*Info, error) {
-	level := 0
+	var level int
 	var size int64
 	for {
-		path := filename(uri, level)
-		si, err := iosrc.Stat(path)
+		si, err := iosrc.Stat(filename(uri, level))
 		if err != nil {
 			if errors.Is(err, zqe.E(zqe.NotFound)) {
 				break
 			}
 			return nil, err
 		}
-		level += 1
+		level++
 		size += si.Size()
 	}
 	if level == 0 {
@@ -82,13 +81,13 @@ func Stat(uri iosrc.URI) (*Info, error) {
 	}
 	_, keysType, err := ParseHeader(rec)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", uri.String(), err)
+		return nil, fmt.Errorf("%s: %w", uri, err)
 	}
 	keys := make([]InfoKey, len(keysType.Columns))
-	for i := range keysType.Columns {
+	for i, c := range keysType.Columns {
 		keys[i] = InfoKey{
-			Name:     keysType.Columns[i].Name,
-			TypeName: keysType.Columns[i].Type.String(),
+			Name:     c.Name,
+			TypeName: c.Type.String(),
 		}
 	}
 	return &Info{

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -1003,6 +1003,7 @@ func TestArchiveStat(t *testing.T) {
 	datapath := createTempDir(t)
 	thresh := int64(20 * 1024)
 	createArchiveSpace(t, datapath, thresh, "../tests/suite/zdx/babble.tzng")
+	indexArchiveSpace(t, datapath, "v")
 
 	root := createTempDir(t)
 	_, client, done := newCoreAtDir(t, root)
@@ -1020,7 +1021,10 @@ func TestArchiveStat(t *testing.T) {
 	exp := `
 #0:record[type:string,log_id:string,start:time,duration:duration,size:uint64]
 0:[chunk;20200422/1587518620.0622373.zng;1587512305.06978904;6314.992448261;21761;]
+#1:record[type:string,log_id:string,index_id:string,index_type:string,size:uint64,keys:record[key:string]]
+1:[index;20200422/1587518620.0622373.zng;zdx-field-v;field;2537;[int64;]]
 0:[chunk;20200421/1587512288.06249439.zng;1587508830.06852324;3457.993971151;13152;]
+1:[index;20200421/1587512288.06249439.zng;zdx-field-v;field;1868;[int64;]]
 `
 	res := archiveStat(t, client, sp.ID)
 	assert.Equal(t, test.Trim(exp), res)


### PR DESCRIPTION
Adds index information to the results of the `zar stat` command and the `/space/{spaceid}/archivestat` api.
 
Closes #990 

