### PR TITLE
s3io: strip starting slash from key

### DIFF
--- a/pkg/s3io/s3io.go
+++ b/pkg/s3io/s3io.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -38,6 +39,7 @@ func parsePath(path string) (bucket, key string, err error) {
 	}
 	bucket = u.Host
 	key = u.Path
+	key = strings.TrimPrefix(key, "/")
 	return
 }
 

--- a/pkg/s3io/s3io.go
+++ b/pkg/s3io/s3io.go
@@ -38,8 +38,7 @@ func parsePath(path string) (bucket, key string, err error) {
 		err = ErrInvalidS3Path
 	}
 	bucket = u.Host
-	key = u.Path
-	key = strings.TrimPrefix(key, "/")
+	key = strings.TrimPrefix(u.Path, "/")
 	return
 }
 

--- a/tests/suite/zar/s3/find-index-type.yaml
+++ b/tests/suite/zar/s3/find-index-type.yaml
@@ -7,6 +7,8 @@ script: |
   zar find -relative -R . :ip=192.168.2.1
   zar find -relative -R . :ip=192.168.1.1
   echo ===
+  zar ls -l -R .
+  echo ===
   zq -t "count(key)" s3://bucket/zartest/20091119/1258594907.85978.zng.zar/zdx-type-ip.zng # check unset not indexed
 
 inputs:
@@ -24,6 +26,9 @@ outputs:
       20091119/1258594907.85978.zng
       20091119/1258594907.85978.zng
       20091119/1258594907.85978.zng
+      ===
+      s3://bucket/zartest/20091119/1258594907.85978.zng.zar
+      	zdx-type-ip.zng
       ===
       #0:record[count:uint64]
       0:[3;]


### PR DESCRIPTION
This was causing an issue on the real s3 api for the Prefix property
of the delete batch and list batch api methods. Works for minio's
mock s3 implementation, not for the real s3 api. As it turns out
the starting "/" is not needed for keys, just strip it in
s3io.parsePath.

Closes #1026 & #1024