### PR TITLE
support S3 ZAR_ROOT

### DIFF
--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -133,7 +133,7 @@ func TestImportWhileOpen(t *testing.T) {
 	update2, err := ark1.UpdateCheck()
 	require.NoError(t, err)
 	if !assert.Equal(t, 3, update2) {
-		if fi, err := os.Stat(ark1.mdPath()); err == nil {
+		if fi, err := iosrc.Stat(ark1.mdURI()); err == nil {
 			fmt.Fprintf(os.Stderr, "metadata mtime: %v, mdModTime %v", fi.ModTime(), ark1.mdModTime)
 		}
 	}
@@ -175,7 +175,7 @@ func TestImportWhileOpen(t *testing.T) {
 	assert.Equal(t, exp, postSpans)
 
 	if !assert.Equal(t, 4, ark1.mdUpdateCount) {
-		if fi, err := os.Stat(ark1.mdPath()); err == nil {
+		if fi, err := iosrc.Stat(ark1.mdURI()); err == nil {
 			fmt.Fprintf(os.Stderr, "metadata mtime: %v, ark1.mdModTime %v, ark2.mdModTime %v", fi.ModTime(), ark1.mdModTime, ark2.mdModTime)
 		}
 	}

--- a/archive/schema.go
+++ b/archive/schema.go
@@ -51,7 +51,7 @@ func (c *Metadata) Write(uri iosrc.URI) error {
 	if err != nil {
 		return err
 	}
-	rep, ok := src.(iosrc.Replaceable)
+	rep, ok := src.(iosrc.ReplacerAble)
 	if !ok {
 		return zqe.E("scheme does not support metadata updates: %s", uri)
 	}

--- a/archive/schema.go
+++ b/archive/schema.go
@@ -257,12 +257,16 @@ func OpenArchive(rpath string, oo *OpenOptions) (*Archive, error) {
 	if err != nil {
 		return nil, err
 	}
+	return openArchive(root, oo)
+}
+
+func openArchive(root iosrc.URI, oo *OpenOptions) (*Archive, error) {
 	m, mtime, err := MetadataRead(root.AppendPath(metadataFilename))
 	if err != nil {
 		return nil, err
 	}
 	if m.DataPath == "." {
-		m.DataPath = rpath
+		m.DataPath = root.String()
 	}
 	dpuri, err := iosrc.ParseURI(m.DataPath)
 	if err != nil {
@@ -334,5 +338,5 @@ func CreateOrOpenArchive(rpath string, co *CreateOptions, oo *OpenOptions) (*Arc
 		}
 	}
 
-	return OpenArchive(rpath, oo)
+	return openArchive(root, oo)
 }

--- a/pkg/iosrc/file.go
+++ b/pkg/iosrc/file.go
@@ -56,6 +56,10 @@ func (s *FileSource) Exists(uri URI) (bool, error) {
 	return true, nil
 }
 
+func (s *FileSource) NewReplacer(uri URI) (io.WriteCloser, error) {
+	return fs.NewFileReplacer(uri.Filepath(), s.Perm)
+}
+
 func wrapfileError(uri URI, err error) error {
 	if os.IsNotExist(err) {
 		return zqe.E(zqe.NotFound, uri.String())

--- a/pkg/iosrc/iosrc.go
+++ b/pkg/iosrc/iosrc.go
@@ -39,6 +39,11 @@ type DirMaker interface {
 	MkdirAll(URI, os.FileMode) error
 }
 
+// A Replaceable source supports atomic updates to a URI.
+type Replaceable interface {
+	NewReplacer(URI) (io.WriteCloser, error)
+}
+
 type Registry struct {
 	mu      sync.RWMutex
 	schemes map[string]Source

--- a/pkg/iosrc/iosrc.go
+++ b/pkg/iosrc/iosrc.go
@@ -39,8 +39,8 @@ type DirMaker interface {
 	MkdirAll(URI, os.FileMode) error
 }
 
-// A Replaceable source supports atomic updates to a URI.
-type Replaceable interface {
+// A ReplacerAble source supports atomic updates to a URI.
+type ReplacerAble interface {
 	NewReplacer(URI) (io.WriteCloser, error)
 }
 

--- a/pkg/s3io/source.go
+++ b/pkg/s3io/source.go
@@ -56,6 +56,11 @@ func (s *Source) Stat(uri iosrc.URI) (iosrc.Info, error) {
 	return info(*out), nil
 }
 
+func (s *Source) NewReplacer(uri iosrc.URI) (io.WriteCloser, error) {
+	// Updates to S3 objects are atomic.
+	return s.NewWriter(uri)
+}
+
 func wrapErr(err error) error {
 	var reqerr awserr.RequestFailure
 	if errors.As(err, &reqerr) && reqerr.StatusCode() == http.StatusNotFound {

--- a/tests/suite/zar/s3/s3root.yaml
+++ b/tests/suite/zar/s3/s3root.yaml
@@ -13,7 +13,7 @@ inputs:
   - name: babble.tzng
     source: ../../zdx/babble.tzng
   - name: minio.sh
-    source: ./minio.sh
+    source: minio.sh
 
 outputs:
   - name: stdout

--- a/tests/suite/zar/s3/s3root.yaml
+++ b/tests/suite/zar/s3/s3root.yaml
@@ -1,0 +1,29 @@
+script: |
+  source minio.sh
+  zar import -s 20KiB -R s3://bucket/zartest babble.tzng
+  zar index -q -R s3://bucket/zartest v
+  echo ===
+  zar ls -R s3://bucket/zartest
+  echo ===
+  zar find -relative -R s3://bucket/zartest v=106
+  echo ===
+  zar zq -R s3://bucket/zartest "count()" _ | zq -t -
+
+inputs:
+  - name: babble.tzng
+    source: ../../zdx/babble.tzng
+  - name: minio.sh
+    source: ./minio.sh
+
+outputs:
+  - name: stdout
+    data: |
+      ===
+      s3://bucket/zartest/20200422/1587518620.0622373.zng.zar
+      s3://bucket/zartest/20200421/1587512288.06249439.zng.zar
+      ===
+      20200422/1587518620.0622373.zng
+      ===
+      #0:record[count:uint64]
+      0:[622;]
+      0:[378;]

--- a/tests/suite/zqd/archive-s3/info.yaml
+++ b/tests/suite/zqd/archive-s3/info.yaml
@@ -10,7 +10,7 @@ inputs:
   - name: babble.tzng
     source: ../../zdx/babble.tzng
   - name: services.sh
-    source: ./services.sh
+    source: services.sh
 
 outputs:
   - name: stdout

--- a/tests/suite/zqd/archive-s3/s3root.yaml
+++ b/tests/suite/zqd/archive-s3/s3root.yaml
@@ -1,0 +1,33 @@
+script: |
+  source services.sh
+  zar import -s 20KiB -R s3://bucket/zartest babble.tzng
+  echo ===
+  zapi -h $ZQD_HOST new -d s3://bucket/zartest -k archivestore testsp
+  echo ===
+  zapi -h $ZQD_HOST info testsp | awk '!/id|pcap_path/{print }'
+  echo ===
+  zapi -h $ZQD_HOST -s testsp get -f tzng "s=harefoot-raucous"
+
+inputs:
+  - name: babble.tzng
+    source: ../../zdx/babble.tzng
+  - name: services.sh
+    source: ./services.sh
+
+outputs:
+  - name: stdout
+    data: |
+      ===
+      testsp: space created
+      ===
+      testsp
+        name:         testsp
+        data_path:    s3://bucket/zartest
+        storage_kind: archivestore
+        span:         2020-04-21T22:40:30Z+2h43m9.993714061s
+        size:         34.91KB
+        pcap_support: false
+        pcap_size:    0B
+      ===
+      #0:record[ts:time,s:string,v:int64]
+      0:[1587508881.0613914;harefoot-raucous;137;]

--- a/tests/suite/zqd/archive-s3/s3root.yaml
+++ b/tests/suite/zqd/archive-s3/s3root.yaml
@@ -12,7 +12,7 @@ inputs:
   - name: babble.tzng
     source: ../../zdx/babble.tzng
   - name: services.sh
-    source: ./services.sh
+    source: services.sh
 
 outputs:
   - name: stdout

--- a/tests/suite/zqd/archive-s3/search.yaml
+++ b/tests/suite/zqd/archive-s3/search.yaml
@@ -10,7 +10,7 @@ inputs:
   - name: babble.tzng
     source: ../../zdx/babble.tzng
   - name: services.sh
-    source: ./services.sh
+    source: services.sh
 
 outputs:
   - name: stdout


### PR DESCRIPTION
Support using S3 based zar roots. The first commit is just the plumbing of essentially replacing `path string` with `uri iosrc.URI`; the second commit has the metadata read/write changes needed for S3 support.

