### PR TITLE
remove file sync from replacer

### DIFF
--- a/pkg/fs/replace.go
+++ b/pkg/fs/replace.go
@@ -46,10 +46,6 @@ func (r *replacer) Close() (err error) {
 			os.Remove(r.f.Name())
 		}
 	}()
-	if err = r.f.Sync(); err != nil {
-		r.f.Close()
-		return err
-	}
 	if err = r.f.Close(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Replacer is used to update files for zar and zqd. We don't rely on
stability guarantees for the data; we just rely on the atomic properties
of the rename operation. So there's no need to suffer the performance
hit of flushing to disk.

fyi, I verified that this sync (present or not) did not impact the work in https://github.com/brimsec/zq/pull/956 .
