### PR TITLE
ensure output order for rename test

### DIFF
--- a/tests/suite/rename/rename-share.yaml
+++ b/tests/suite/rename/rename-share.yaml
@@ -1,12 +1,12 @@
 # tests that a rename isn't visible to other procs operating on same records.
-zql: (rename id2=id; cut id.orig_h)
+zql: (rename id2=id; cut id.orig_h) | sort id
 
 input: |
   #0:record[id:record[orig_h:port,resp_h:port]]
   0:[[39681;3389;]]
 
 output: |
-  #0:record[id2:record[orig_h:port,resp_h:port]]
-  0:[[39681;3389;]]
-  #1:record[id:record[orig_h:port]]
-  1:[[39681;]]
+  #0:record[id:record[orig_h:port]]
+  0:[[39681;]]
+  #1:record[id2:record[orig_h:port,resp_h:port]]
+  1:[[39681;3389;]]


### PR DESCRIPTION
I saw this test error on a PR unrelated to rename, which I believe is because the test didn't enforce any ordering on its output:
```
    TestZTest/suite/rename/rename-share: ztest.go:435: /home/runner/work/zq/zq/tests/suite/rename/rename-share.yaml: expected and actual outputs differ:
        expected and actual outputs differ:
        --- expected
        +++ actual
        @@ -1,5 +1,5 @@
        -#0:record[id2:record[orig_h:port,resp_h:port]]
        -0:[[39681;3389;]]
        -#1:record[id:record[orig_h:port]]
        -1:[[39681;]]
        +#0:record[id:record[orig_h:port]]
        +0:[[39681;]]
        +#1:record[id2:record[orig_h:port,resp_h:port]]
        +1:[[39681;3389;]]
```
