### PR TITLE
Don't zero ast.GroupByProc.Duration after moving to key

### DIFF
--- a/driver/compile.go
+++ b/driver/compile.go
@@ -105,7 +105,6 @@ func ReplaceGroupByProcDurationWithKey(p ast.Proc) {
 						}},
 				},
 			}
-			p.Duration.Seconds = 0
 			p.Keys = append([]ast.ExpressionAssignment{durationKey}, p.Keys...)
 		}
 	case *ast.ParallelProc:

--- a/proc/groupby_test.go
+++ b/proc/groupby_test.go
@@ -476,10 +476,11 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 		t := i / recsPerTs
 		data = append(data, fmt.Sprintf("0:[%d;1.1.1.%d;]", t, i%uniqueIpsPerTs))
 	}
-	proc, err := zql.ParseProc("every 1s count() by ip")
-	assert.NoError(t, err)
 
 	runOne := func(inputSortKey string) []string {
+		proc, err := zql.ParseProc("every 1s count() by ip")
+		assert.NoError(t, err)
+
 		zctx := resolver.NewContext()
 		zr := tzngio.NewReader(strings.NewReader(strings.Join(data, "\n")), zctx)
 		cr := &countReader{r: zr}


### PR DESCRIPTION
After translating the "Duration" field of ast.GroupByProc into a key, leave the duration rather than zeroing it out. This allows subsequent AST users (such as #1022) to easily check for `every` without having to pore over groupby expression ASTs.