### PR TITLE
Perform head call before s3 remove

### DIFF
--- a/cmd/zar/rm/command.go
+++ b/cmd/zar/rm/command.go
@@ -41,16 +41,6 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	return c, nil
 }
 
-func fileExists(path string) bool {
-	if path == "-" {
-		return true
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	return !info.IsDir()
-}
 func (c *Command) Run(args []string) error {
 	if len(args) == 0 {
 		return errors.New("zar rm: no file specified")

--- a/pkg/s3io/s3io.go
+++ b/pkg/s3io/s3io.go
@@ -126,6 +126,9 @@ func Remove(path string, cfg *aws.Config) error {
 	if err != nil {
 		return err
 	}
+	if _, err := head(bucket, key, cfg); err != nil {
+		return err
+	}
 	_, err = newClient(cfg).DeleteObject(&s3.DeleteObjectInput{
 		Key:    &key,
 		Bucket: &bucket,
@@ -138,6 +141,10 @@ func Stat(path string, cfg *aws.Config) (*s3.HeadObjectOutput, error) {
 	if err != nil {
 		return nil, err
 	}
+	return head(bucket, key, cfg)
+}
+
+func head(bucket, key string, cfg *aws.Config) (*s3.HeadObjectOutput, error) {
 	return newClient(cfg).HeadObject(&s3.HeadObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),

--- a/pkg/s3io/source.go
+++ b/pkg/s3io/source.go
@@ -31,11 +31,11 @@ func (s *Source) NewReader(uri iosrc.URI) (io.ReadCloser, error) {
 }
 
 func (s *Source) Remove(uri iosrc.URI) error {
-	return Remove(uri.String(), s.Config)
+	return wrapErr(Remove(uri.String(), s.Config))
 }
 
 func (s *Source) RemoveAll(uri iosrc.URI) error {
-	return RemoveAll(uri.String(), s.Config)
+	return wrapErr(RemoveAll(uri.String(), s.Config))
 }
 
 func (s *Source) Exists(uri iosrc.URI) (bool, error) {

--- a/tests/suite/zar/s3/rm.yaml
+++ b/tests/suite/zar/s3/rm.yaml
@@ -6,6 +6,8 @@ script: |
   zar ls -l -R ./root
   echo ===
   zar rm -R ./root count.zng
+  echo ===
+  zar rm -R ./root count.zng
 
 inputs:
   - name: babble.tzng
@@ -24,3 +26,6 @@ outputs:
       ===
       s3://bucket/zartest/20200422/1587518620.0622373.zng.zar/count.zng: removed
       s3://bucket/zartest/20200421/1587512288.06249439.zng.zar/count.zng: removed
+      ===
+      s3://bucket/zartest/20200422/1587518620.0622373.zng.zar/count.zng: not found
+      s3://bucket/zartest/20200421/1587512288.06249439.zng.zar/count.zng: not found


### PR DESCRIPTION
The s3 api will return 204 on a delete object call whether or not
the object exists. Do a s3 Head call on the object before deleting
to verify that the requested object does in fact exist.

Closes #1025