### PR TITLE
Enable most go vet analyzers in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test-one: test-run
 endif
 
 vet:
-	@go vet -copylocks ./...
+	@go vet -composites=false -stdmethods=false ./...
 
 fmt:
 	@res=$$(go fmt ./...); \

--- a/filter/compare.go
+++ b/filter/compare.go
@@ -73,7 +73,6 @@ func CompareBool(op string, pattern bool) (Predicate, error) {
 		}
 		return compare(b, pattern)
 	}, nil
-	return nil, fmt.Errorf("bad comparator for boolean type: %s", op)
 }
 
 var compareInt = map[string]func(int64, int64) bool{

--- a/pcap/pcapio/ngread.go
+++ b/pcap/pcapio/ngread.go
@@ -306,5 +306,4 @@ func (r *NgReader) Read() ([]byte, BlockType, error) {
 			return nil, 0, errInvalidf("pcap-ng deprecated type packet not supported")
 		}
 	}
-	return nil, 0, nil
 }

--- a/pkg/nano/span.go
+++ b/pkg/nano/span.go
@@ -81,7 +81,6 @@ func (s Span) Partition(ts Ts, n int) int {
 	// division has truncated the value of partitionSize.
 	if i > n-1 {
 		panic("this shouldn't happen now")
-		i = n - 1
 	}
 
 	return i

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -253,7 +253,7 @@ type ZTest struct {
 	OutputFlags  string `yaml:"output-flags,omitempty"`
 	ErrorRE      string `yaml:"errorRE"`
 	errRegex     *regexp.Regexp
-	Warnings     string `yaml:"warnings",omitempty"`
+	Warnings     string `yaml:"warnings,omitempty"`
 	// shell mode params
 	Script  string `yaml:"script,omitempty"`
 	Inputs  []File `yaml:"inputs,omitempty"`


### PR DESCRIPTION
CI runs go vet via "make vet", but the only analyzer enabled is
copylocks.  Enable most analyzers and fix resulting reports.

This leaves two analyzers disabled.
* composites generates 214 reports, warranting a separate change
* stdmethods complains about zio/zngio.Seeker.Seek, which I don't want to change