### PR TITLE
CI test for ZNG output check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - zng-output-check
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.14'
-    - uses: actions/checkout@v1
-    - run: make install
-    - run: make zng-output-check
+      - uses: actions/checkout@v1
+      - run: make install
+      - run: make zng-output-check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - zng-output-check
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - zng-output-check
 
 jobs:
   test:
@@ -39,3 +40,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+  zng-output-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: make zng-output-check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,5 +43,9 @@ jobs:
   zng-output-check:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.14'
     - uses: actions/checkout@v1
+    - run: make install
     - run: make zng-output-check

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ test-zeek: bin/$(ZEEKPATH)
 perf-compare: build $(SAMPLEDATA)
 	scripts/comparison-test.sh
 
+zng-output-check: build $(SAMPLEDATA)
+	scripts/zng-output-check.sh
+
 # If the build recipe changes, please also change npm/build.
 build:
 	@mkdir -p dist

--- a/scripts/zng-output-check.sh
+++ b/scripts/zng-output-check.sh
@@ -14,7 +14,6 @@
 
 set -eo pipefail
 
-git clone --depth=1 https://github.com/brimsec/zq-sample-data.git
 cd zq-sample-data
 
 mkdir -p zng && \

--- a/scripts/zng-output-check.sh
+++ b/scripts/zng-output-check.sh
@@ -14,9 +14,9 @@
 
 set -eo pipefail
 
-DIR=$(mktemp -d)
-git clone --depth=1 https://github.com/brimsec/zq-sample-data.git "$DIR"
-cd "$DIR"
+git clone --depth=1 https://github.com/brimsec/zq-sample-data.git
+cd zq-sample-data
+
 mkdir -p zng && \
 for file in zeek-default/*
 do

--- a/scripts/zng-output-check.sh
+++ b/scripts/zng-output-check.sh
@@ -16,25 +16,6 @@ set -eo pipefail
 
 cd zq-sample-data
 
-mkdir -p zng && \
-for file in zeek-default/*
-do
-  zq -f zng "$file" \
-      | gzip -n > zng/"$(basename "$file" | sed 's/\.log\.gz//')".zng.gz
-done
-mkdir -p zng-uncompressed && \
-for file in zeek-default/*
-do
-  zq -f zng -znglz4blocksize 0 "$file" \
-      | gzip -n > zng-uncompressed/"$(basename "$file" | sed 's/\.log\.gz//')".zng.gz
-done
-mkdir -p tzng && \
-for file in zeek-default/*
-do
-  zq -f tzng "$file" \
-      | gzip -n > tzng/"$(basename "$file" | sed 's/\.log\.gz//')".tzng.gz
-done
-
 scripts/check_md5sums.sh zng
 ZNG_SUCCESS="$?"
 echo
@@ -43,8 +24,6 @@ ZNG_UNCOMPRESSED_SUCCESS="$?"
 echo
 scripts/check_md5sums.sh tzng
 TZNG_SUCCESS="$?"
-
-rm -rf "$DIR"
 
 if (( ZNG_SUCCESS == 0 && TZNG_SUCCESS == 0 && ZNG_UNCOMPRESSED_SUCCESS == 0 )); then
   exit 0

--- a/scripts/zng-output-check.sh
+++ b/scripts/zng-output-check.sh
@@ -12,10 +12,11 @@
 # checks that the MD5 hashes for the outputs still match the hashes stored
 # in the zq-sample-data repo.
 
-set -eo pipefail
+# We're intentionally not running with "set -eo pipefail" because we want to
+# let all permutations run and allow the final error text to be seen before
+# explicitly returning the intended error code.
 
 cd zq-sample-data
-
 scripts/check_md5sums.sh zng
 ZNG_SUCCESS="$?"
 echo


### PR DESCRIPTION
See the comments in the script in this PR for the background/motivation.

An example of the test passing with current `zq` and [zq-sample-data](https://github.com/brimsec/zq-sample-data):

https://github.com/brimsec/zq/actions/runs/196891811

I also simulated a failure by creating a branch on which I reverted the commit `6b19b3b` where ZNG compression was enabled, and let this script run against the ZNG data currently in zq-sample-data. Since the current ZNG data in zq-sample-data is compressed but the failure branch was creating uncompressed output, the test failed as shown here:

https://github.com/brimsec/zq/actions/runs/196887459

Before I started writing this test, I'd thought that maybe I'd only let this Action run post-merge since we expect it to fail rarely and it's not a catastrophe if the zq-sample-data is briefly out of date. However, once I saw how it could run as a parallel job, I figured I'd take a shot at letting it run parallel alongside the existing CI. The overall runtime for the CI seems roughly in line with where it was before, and I figure developers might appreciate knowing this info sooner if they introduced some kind of ZNG output bug that wouldn't otherwise have been caught. However, if anyone wants to hold me to my initial sentiment, I won't fight it.