### PR TITLE
create iosrc.Reader to implement ReadAt and Seek

### DIFF
--- a/pkg/iosrc/file.go
+++ b/pkg/iosrc/file.go
@@ -15,7 +15,7 @@ type FileSource struct {
 	Perm os.FileMode
 }
 
-func (f *FileSource) NewReader(uri URI) (io.ReadCloser, error) {
+func (f *FileSource) NewReader(uri URI) (Reader, error) {
 	r, err := fs.Open(uri.Filepath())
 	return r, wrapfileError(uri, err)
 }

--- a/pkg/iosrc/iosrc.go
+++ b/pkg/iosrc/iosrc.go
@@ -17,8 +17,15 @@ var schemes = map[string]Source{
 	"s3":    defaultS3Source,
 }
 
+type Reader interface {
+	io.Reader
+	io.ReaderAt
+	io.Seeker
+	io.Closer
+}
+
 type Source interface {
-	NewReader(URI) (io.ReadCloser, error)
+	NewReader(URI) (Reader, error)
 	NewWriter(URI) (io.WriteCloser, error)
 	Remove(URI) error
 	RemoveAll(URI) error
@@ -42,7 +49,7 @@ type ReplacerAble interface {
 	NewReplacer(URI) (io.WriteCloser, error)
 }
 
-func NewReader(uri URI) (io.ReadCloser, error) {
+func NewReader(uri URI) (Reader, error) {
 	source, err := GetSource(uri)
 	if err != nil {
 		return nil, err

--- a/pkg/iosrc/mock/mock_source.go
+++ b/pkg/iosrc/mock/mock_source.go
@@ -50,10 +50,10 @@ func (mr *MockSourceMockRecorder) Exists(arg0 interface{}) *gomock.Call {
 }
 
 // NewReader mocks base method
-func (m *MockSource) NewReader(arg0 iosrc.URI) (io.ReadCloser, error) {
+func (m *MockSource) NewReader(arg0 iosrc.URI) (iosrc.Reader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewReader", arg0)
-	ret0, _ := ret[0].(io.ReadCloser)
+	ret0, _ := ret[0].(iosrc.Reader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/iosrc/s3.go
+++ b/pkg/iosrc/s3.go
@@ -25,7 +25,7 @@ func (s *s3Source) NewWriter(u URI) (io.WriteCloser, error) {
 	return w, wrapErr(err)
 }
 
-func (s *s3Source) NewReader(u URI) (io.ReadCloser, error) {
+func (s *s3Source) NewReader(u URI) (Reader, error) {
 	r, err := s3io.NewReader(u.String(), s.Config)
 	return r, wrapErr(err)
 }

--- a/pkg/iosrc/stdio.go
+++ b/pkg/iosrc/stdio.go
@@ -13,7 +13,7 @@ var defaultStdioSource = &StdioSource{}
 
 type StdioSource struct{}
 
-func (f *StdioSource) NewReader(uri URI) (io.ReadCloser, error) {
+func (f *StdioSource) NewReader(uri URI) (Reader, error) {
 	return getStdioSource(uri)
 }
 


### PR DESCRIPTION
This change extends the reader interface returned by iosrc.Source.NewReader
to allow sub-systems like the micro-indexer to seek and do ReadAt's.
The new interface type, iosrc.Reader, comprises io.Reader, ReaderAt,
Seeker, and Closer.  In particular, this change will allow an iosrc.Reader
to be wrapped in an io.SectionReader.