### PR TITLE
zqd listen: s3 datapath

### DIFF
--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 
 	"github.com/brimsec/zq/cmd/zqd/logger"
 	"github.com/brimsec/zq/cmd/zqd/root"
@@ -75,7 +74,7 @@ type Command struct {
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	f.StringVar(&c.listenAddr, "l", ":9867", "[addr]:port to listen on")
-	f.StringVar(&c.conf.Root, "datadir", ".", "data directory")
+	f.StringVar(&c.conf.Root, "data", "", "data location")
 	f.StringVar(&c.zeekRunnerPath, "zeekrunner", "", "path to command that generates zeek logs from pcap data")
 	f.BoolVar(&c.pprof, "pprof", false, "add pprof routes to api")
 	f.BoolVar(&c.prom, "prometheus", false, "add prometheus metrics routes to api")
@@ -128,11 +127,6 @@ func (c *Command) Run(args []string) error {
 }
 
 func (c *Command) init() error {
-	var err error
-	c.conf.Root, err = filepath.Abs(c.conf.Root)
-	if err != nil {
-		return err
-	}
 	if err := c.loadConfigFile(); err != nil {
 		return err
 	}

--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -74,7 +74,7 @@ type Command struct {
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	f.StringVar(&c.listenAddr, "l", ":9867", "[addr]:port to listen on")
-	f.StringVar(&c.conf.Root, "data", "", "data location")
+	f.StringVar(&c.conf.Root, "data", ".", "data location")
 	f.StringVar(&c.zeekRunnerPath, "zeekrunner", "", "path to command that generates zeek logs from pcap data")
 	f.BoolVar(&c.pprof, "pprof", false, "add pprof routes to api")
 	f.BoolVar(&c.prom, "prometheus", false, "add prometheus metrics routes to api")

--- a/pkg/iosrc/iosrc.go
+++ b/pkg/iosrc/iosrc.go
@@ -81,6 +81,14 @@ func Remove(uri URI) error {
 	return source.Remove(uri)
 }
 
+func RemoveAll(uri URI) error {
+	source, err := GetSource(uri)
+	if err != nil {
+		return err
+	}
+	return source.RemoveAll(uri)
+}
+
 func GetSource(uri URI) (Source, error) {
 	scheme := getScheme(uri)
 	source, ok := schemes[scheme]

--- a/pkg/iosrc/uri.go
+++ b/pkg/iosrc/uri.go
@@ -19,6 +19,9 @@ const (
 // treated as files and resolved as absolute paths using filepath.Abs.
 // path is an empty, Scheme is set to file.
 func ParseURI(path string) (URI, error) {
+	if path == "" {
+		return URI{}, nil
+	}
 	// First resolve stdio keywords in to fully-formed uri.
 	path = stdio(path)
 	var err error
@@ -53,9 +56,9 @@ func (p URI) AppendPath(elem ...string) URI {
 	return p
 }
 
-func (p URI) String() string {
-	u := url.URL(p)
-	return (&u).String()
+func (u URI) String() string {
+	url := url.URL(u)
+	return url.String()
 }
 
 func (u URI) RelPath(target URI) string {
@@ -63,6 +66,23 @@ func (u URI) RelPath(target URI) string {
 		u.Path += "/"
 	}
 	return strings.TrimPrefix(target.Path, u.Path)
+}
+
+func (u URI) IsZero() bool {
+	return u == URI{}
+}
+
+func (u URI) MarshalText() ([]byte, error) {
+	return []byte(u.String()), nil
+}
+
+func (u *URI) UnmarshalText(b []byte) error {
+	uri, err := ParseURI(string(b))
+	if err != nil {
+		return err
+	}
+	*u = uri
+	return nil
 }
 
 // Maybe rawurl is of the form scheme:path.

--- a/pkg/iosrc/uri_test.go
+++ b/pkg/iosrc/uri_test.go
@@ -1,6 +1,7 @@
 package iosrc
 
 import (
+	"encoding/json"
 	"os"
 	"path"
 	"path/filepath"
@@ -33,4 +34,29 @@ func TestURIRelative(t *testing.T) {
 	u1, err := ParseURI("relative/path")
 	require.NoError(t, err)
 	assert.Equal(t, expected, u1.String())
+}
+
+type jsonStruct struct{ Test URI }
+
+func TestURIJSON(t *testing.T) {
+	expected := "s3://test-bucket/test/key"
+	u, err := ParseURI(expected)
+	require.NoError(t, err)
+	d, err := json.Marshal(jsonStruct{u})
+	require.NoError(t, err)
+	var out jsonStruct
+	require.NoError(t, json.Unmarshal(d, &out))
+	assert.Equal(t, expected, out.Test.String())
+}
+
+func TestURIParseEmpty(t *testing.T) {
+	u, err := ParseURI("")
+	require.NoError(t, err)
+	assert.Equal(t, u, URI{})
+	assert.True(t, u.IsZero())
+}
+
+func TestURISerializeEmpty(t *testing.T) {
+	var u URI
+	assert.Equal(t, "", u.String())
 }

--- a/tests/suite/zqd/s3/info.yaml
+++ b/tests/suite/zqd/s3/info.yaml
@@ -4,7 +4,7 @@ script: |
   echo ===
   zapi -h $ZQD_HOST new -d ./root -k archivestore testsp
   echo ===
-  zapi -h $ZQD_HOST -s testsp get -f tzng "s=harefoot-raucous"
+  zapi -h $ZQD_HOST info testsp | egrep -v 'data_path|id|pcap_path'
 
 inputs:
   - name: babble.tzng
@@ -18,5 +18,10 @@ outputs:
       ===
       testsp: space created
       ===
-      #0:record[ts:time,s:string,v:int64]
-      0:[1587508881.0613914;harefoot-raucous;137;]
+      testsp
+        name:         testsp
+        storage_kind: archivestore
+        span:         2020-04-21T22:40:30Z+2h43m9.993714061s
+        size:         34.34KB
+        pcap_support: false
+        pcap_size:    0B

--- a/tests/suite/zqd/s3/invalid.yaml
+++ b/tests/suite/zqd/s3/invalid.yaml
@@ -1,0 +1,20 @@
+script: |
+  source services.sh s3://bucket/zqdroot
+  zapi -h $ZQD_HOST new testsp
+  zapi -h $ZQD_HOST -s testsp post -f babble.tzng
+  zapi -h $ZQD_HOST -s testsp pcappost -f babble.tzng
+
+inputs:
+  - name: services.sh
+    source: ../services.sh
+  - name: babble.tzng
+    source: ../../zdx/babble.tzng
+  - name: ng.pcap
+    source: ../../pcap/ng.pcap
+
+outputs:
+  - name: stderr
+    data: |
+      couldn't create new space testsp: status code 400: cannot create file storage space on non-file backed data path
+      status code 400: cannot create file storage space on non-file backed data path
+      status code 400: cannot create file storage space on non-file backed data path

--- a/tests/suite/zqd/s3/ls.yaml
+++ b/tests/suite/zqd/s3/ls.yaml
@@ -1,0 +1,20 @@
+script: |
+  source services.sh s3://bucket/zqdroot
+  zapi -h $ZQD_HOST new -d s3://bucket/zartest -k archivestore testsp1
+  zapi -h $ZQD_HOST new -d s3://bucket/zartest -k archivestore testsp2
+  zapi -h $ZQD_HOST new -d s3://bucket/zartest -k archivestore testsp3
+  echo ===
+  zapi -h $ZQD_HOST ls
+
+inputs:
+  - name: services.sh
+    source: ../services.sh
+
+outputs:
+  - name: stdout
+    data: |
+      testsp1: space created
+      testsp2: space created
+      testsp3: space created
+      ===
+      testsp1   testsp2   testsp3

--- a/tests/suite/zqd/s3/rm.yaml
+++ b/tests/suite/zqd/s3/rm.yaml
@@ -1,0 +1,20 @@
+script: |
+  source services.sh s3://bucket/zqdroot
+  zapi -h $ZQD_HOST new -d s3://bucket/zartest -k archivestore testsp
+  echo ===
+  zapi -h $ZQD_HOST rm testsp
+  echo ===
+  zapi -h $ZQD_HOST ls
+
+inputs:
+  - name: services.sh
+    source: ../services.sh
+
+outputs:
+  - name: stdout
+    data: |
+      testsp: space created
+      ===
+      testsp: space removed
+      ===
+      no spaces exist

--- a/tests/suite/zqd/s3/s3root.yaml
+++ b/tests/suite/zqd/s3/s3root.yaml
@@ -1,10 +1,12 @@
 script: |
-  source services.sh
-  zar import -s 20KiB -R ./root -data s3://bucket/zartest babble.tzng
+  source services.sh s3://bucket/zqdroot
+  zar import -s 20KiB -R s3://bucket/zartest babble.tzng
   echo ===
-  zapi -h $ZQD_HOST new -d ./root -k archivestore testsp
+  zapi -h $ZQD_HOST new -d s3://bucket/zartest -k archivestore testsp
   echo ===
   zapi -h $ZQD_HOST info testsp | awk '!/id|pcap_path/{print }'
+  echo ===
+  zapi -h $ZQD_HOST -s testsp get -f tzng "s=harefoot-raucous"
 
 inputs:
   - name: babble.tzng
@@ -20,9 +22,12 @@ outputs:
       ===
       testsp
         name:         testsp
-        data_path:    ./root
+        data_path:    s3://bucket/zartest
         storage_kind: archivestore
         span:         2020-04-21T22:40:30Z+2h43m9.993714061s
         size:         34.34KB
         pcap_support: false
         pcap_size:    0B
+      ===
+      #0:record[ts:time,s:string,v:int64]
+      0:[1587508881.0613914;harefoot-raucous;137;]

--- a/tests/suite/zqd/s3/search.yaml
+++ b/tests/suite/zqd/s3/search.yaml
@@ -1,10 +1,8 @@
 script: |
-  source services.sh
+  source services.sh s3://bucket/zqdroot
   zar import -s 20KiB -R s3://bucket/zartest babble.tzng
   echo ===
   zapi -h $ZQD_HOST new -d s3://bucket/zartest -k archivestore testsp
-  echo ===
-  zapi -h $ZQD_HOST info testsp | awk '!/id|pcap_path/{print }'
   echo ===
   zapi -h $ZQD_HOST -s testsp get -f tzng "s=harefoot-raucous"
 
@@ -19,15 +17,6 @@ outputs:
     data: |
       ===
       testsp: space created
-      ===
-      testsp
-        name:         testsp
-        data_path:    s3://bucket/zartest
-        storage_kind: archivestore
-        span:         2020-04-21T22:40:30Z+2h43m9.993714061s
-        size:         34.34KB
-        pcap_support: false
-        pcap_size:    0B
       ===
       #0:record[ts:time,s:string,v:int64]
       0:[1587508881.0613914;harefoot-raucous;137;]

--- a/tests/suite/zqd/services.sh
+++ b/tests/suite/zqd/services.sh
@@ -33,7 +33,7 @@ export AWS_ACCESS_KEY_ID=minioadmin
 export AWS_SECRET_ACCESS_KEY=minioadmin
 export AWS_S3_ENDPOINT=http://localhost:$(cat $portdir/minio)
 
-zqd listen -l=localhost:0 -portfile="$portdir/zqd" -data=$zqdroot 2> zqd.error &
+zqd listen -l=localhost:0 -portfile="$portdir/zqd" -data="$zqdroot" 2> zqd.error &
 zqdpid=$!
 trap "rm -rf $portdir; kill -9 $miniopid $zqdpid" EXIT
 

--- a/tests/suite/zqd/services.sh
+++ b/tests/suite/zqd/services.sh
@@ -13,8 +13,13 @@ function awaitfile {
   done
 }
 
+zqdroot=$1
+if [ -z "$zqdroot" ]; then
+  zqdroot=zqdroot
+  mkdir -p zqdroot
+fi
+
 mkdir -p s3/bucket
-mkdir -p zqdroot
 portdir=$(mktemp -d)
 
 
@@ -28,7 +33,7 @@ export AWS_ACCESS_KEY_ID=minioadmin
 export AWS_SECRET_ACCESS_KEY=minioadmin
 export AWS_S3_ENDPOINT=http://localhost:$(cat $portdir/minio)
 
-zqd listen -l=localhost:0 -portfile="$portdir/zqd" -datadir=./zqdroot &
+zqd listen -l=localhost:0 -portfile="$portdir/zqd" -data=$zqdroot 2> zqd.error &
 zqdpid=$!
 trap "rm -rf $portdir; kill -9 $miniopid $zqdpid" EXIT
 

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zio/ndjsonio"
 	"github.com/brimsec/zq/zio/zjsonio"
@@ -98,7 +99,7 @@ func (s *SpaceID) Set(str string) error {
 type SpaceInfo struct {
 	ID          SpaceID      `json:"id"`
 	Name        string       `json:"name"`
-	DataPath    string       `json:"data_path"`
+	DataPath    iosrc.URI    `json:"data_path"`
 	StorageKind storage.Kind `json:"storage_kind"`
 	Span        *nano.Span   `json:"span,omitempty"`
 	Size        int64        `json:"size" unit:"bytes"`

--- a/zqd/core.go
+++ b/zqd/core.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"sync/atomic"
 
+	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zqd/space"
 	"github.com/brimsec/zq/zqd/zeek"
 	"go.uber.org/zap"
@@ -25,7 +26,7 @@ type VersionMessage struct {
 var Version VersionMessage
 
 type Core struct {
-	Root         string
+	Root         iosrc.URI
 	ZeekLauncher zeek.Launcher
 	spaces       *space.Manager
 	taskCount    int64
@@ -37,12 +38,16 @@ func NewCore(conf Config) (*Core, error) {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	spaces, err := space.NewManager(conf.Root, conf.Logger)
+	root, err := iosrc.ParseURI(conf.Root)
+	if err != nil {
+		return nil, err
+	}
+	spaces, err := space.NewManager(root, conf.Logger)
 	if err != nil {
 		return nil, err
 	}
 	return &Core{
-		Root:         conf.Root,
+		Root:         root,
 		ZeekLauncher: conf.ZeekLauncher,
 		spaces:       spaces,
 		logger:       logger,

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -206,7 +206,7 @@ func TestSpaceList(t *testing.T) {
 			expected = append(expected, api.SpaceInfo{
 				ID:          sp.ID,
 				Name:        n,
-				DataPath:    filepath.Join(c.Root, string(sp.ID)),
+				DataPath:    c.Root.AppendPath(string(sp.ID)),
 				StorageKind: storage.FileStore,
 			})
 		}
@@ -219,10 +219,10 @@ func TestSpaceList(t *testing.T) {
 
 	// Delete dir from one space, then simulate a restart by
 	// creating a new Core pointing to the same root.
-	require.NoError(t, os.RemoveAll(filepath.Join(c.Root, string(expected[2].ID))))
+	require.NoError(t, os.RemoveAll(filepath.Join(c.Root.Filepath(), string(expected[2].ID))))
 	expected = append(expected[:2], expected[3:]...)
 
-	c, client, done = newCoreAtDir(t, c.Root)
+	_, client, done = newCoreAtDir(t, c.Root.Filepath())
 	defer done()
 
 	list, err := client.SpaceList(ctx)
@@ -283,7 +283,7 @@ func TestSpacePostNameOnly(t *testing.T) {
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	assert.Equal(t, "test", sp.Name)
-	assert.Equal(t, filepath.Join(c.Root, string(sp.ID)), sp.DataPath)
+	assert.Equal(t, c.Root.AppendPath(string(sp.ID)), sp.DataPath)
 	assert.Regexp(t, "^sp", sp.ID)
 }
 
@@ -336,7 +336,7 @@ func TestSpacePostDataPath(t *testing.T) {
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{DataPath: datapath})
 	require.NoError(t, err)
 	assert.Equal(t, "mypcap.brim", sp.Name)
-	assert.Equal(t, datapath, sp.DataPath)
+	assert.Equal(t, datapath, sp.DataPath.Filepath())
 }
 
 func TestSpacePut(t *testing.T) {

--- a/zqd/handlers_zeek_test.go
+++ b/zqd/handlers_zeek_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -66,7 +65,7 @@ func TestPcapPostSuccess(t *testing.T) {
 		assert.Equal(t, p.pcapfile, info.PcapPath)
 	})
 	t.Run("PcapIndexExists", func(t *testing.T) {
-		require.FileExists(t, filepath.Join(p.core.Root, string(p.space.ID), space.PcapIndexFile))
+		require.FileExists(t, p.core.Root.AppendPath(string(p.space.ID), space.PcapIndexFile).Filepath())
 	})
 	t.Run("TaskStartMessage", func(t *testing.T) {
 		status := p.payloads[0].(*api.TaskStart)
@@ -291,6 +290,6 @@ func (r *pcapPostResult) readPayloads(t *testing.T, stream *api.Stream) {
 }
 
 func (r *pcapPostResult) cleanup() {
-	os.RemoveAll(r.core.Root)
+	os.RemoveAll(r.core.Root.Filepath())
 	r.srv.Close()
 }

--- a/zqd/space/archivesubspace.go
+++ b/zqd/space/archivesubspace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zqd/api"
 )
@@ -22,10 +23,11 @@ func (s *archiveSubspace) Info(ctx context.Context) (api.SpaceInfo, error) {
 	if sum.Span.Dur > 0 {
 		span = &sum.Span
 	}
-	var name, dp string
+	var name string
+	var dp iosrc.URI
 	err = s.findConfig(func(i int) error {
 		name = s.parent.conf.Subspaces[i].Name
-		dp = s.parent.conf.DataPath
+		dp = s.parent.conf.DataURI
 		return nil
 	})
 	return api.SpaceInfo{

--- a/zqd/space/config.go
+++ b/zqd/space/config.go
@@ -81,9 +81,11 @@ func loadConfig(spaceURI iosrc.URI) (config, error) {
 	if err != nil {
 		return c, err
 	}
-	defer r.Close()
 	data, err := ioutil.ReadAll(r)
 	if err != nil {
+		return c, err
+	}
+	if err := r.Close(); err != nil {
 		return c, err
 	}
 	var vc versionCheck

--- a/zqd/space/config.go
+++ b/zqd/space/config.go
@@ -1,15 +1,19 @@
 package space
 
 import (
+	"encoding/json"
 	"fmt"
-	"path/filepath"
+	"io"
+	"io/ioutil"
+	"path"
 	"strings"
 	"unicode"
 
-	"github.com/brimsec/zq/pkg/fs"
+	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zqd/api"
 	"github.com/brimsec/zq/zqd/storage"
 	"github.com/brimsec/zq/zqe"
+	"github.com/segmentio/ksuid"
 )
 
 func invalidSpaceNameRune(r rune) bool {
@@ -20,9 +24,18 @@ func validSpaceName(s string) bool {
 	return strings.IndexFunc(s, invalidSpaceNameRune) == -1
 }
 
-const configVersion = 1
+const configVersion = 2
 
 type config struct {
+	Version   int              `json:"version"`
+	Name      string           `json:"name"`
+	DataURI   iosrc.URI        `json:"data_uri"`
+	PcapPath  string           `json:"pcap_path"`
+	Storage   storage.Config   `json:"storage"`
+	Subspaces []subspaceConfig `json:"subspaces"`
+}
+
+type configV1 struct {
 	Version  int    `json:"version"`
 	Name     string `json:"name"`
 	DataPath string `json:"data_path"`
@@ -31,6 +44,12 @@ type config struct {
 	PcapPath  string           `json:"packet_path"`
 	Storage   storage.Config   `json:"storage"`
 	Subspaces []subspaceConfig `json:"subspaces"`
+}
+
+// versionCheck is used to establish the version of the loaded config file.
+// This must always remain the same as the Version field in config.
+type versionCheck struct {
+	Version int `json:"version"`
 }
 
 type subspaceConfig struct {
@@ -55,26 +74,124 @@ func (c config) subspaceIndex(id api.SpaceID) int {
 }
 
 // loadConfig loads the contents of config.json in a space's path.
-func loadConfig(spacePath string) (config, error) {
+func loadConfig(spaceURI iosrc.URI) (config, error) {
 	var c config
-	path := filepath.Join(spacePath, configFile)
-	if err := fs.UnmarshalJSONFile(path, &c); err != nil {
+	p := spaceURI.AppendPath(configFile)
+	r, err := iosrc.NewReader(p)
+	if err != nil {
 		return c, err
+	}
+	defer r.Close()
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return c, err
+	}
+	var vc versionCheck
+	if err := json.Unmarshal(data, &vc); err != nil {
+		return c, err
+	}
+	if vc.Version > configVersion {
+		return c, fmt.Errorf("space config version %d ahead of binary version %d", vc.Version, configVersion)
+	}
+	if vc.Version < configVersion {
+		return migrateConfig(vc.Version, data, spaceURI)
+	}
+	return c, json.Unmarshal(data, &c)
+}
+
+type migrator func([]byte, iosrc.URI) (int, []byte, error)
+
+func migrateConfig(version int, data []byte, spaceURI iosrc.URI) (config, error) {
+	var m migrator
+	for version < configVersion {
+		switch version {
+		case 0:
+			m = migrateConfigV1
+		case 1:
+			m = migrateConfigV2
+		default:
+			return config{}, fmt.Errorf("unsupported config migration %d", version)
+		}
+		var err error
+		if version, data, err = m(data, spaceURI); err != nil {
+			return config{}, err
+		}
+	}
+	var c config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return c, err
+	}
+	return c, writeConfig(spaceURI, c)
+}
+
+func migrateConfigV1(data []byte, spaceURI iosrc.URI) (int, []byte, error) {
+	var c configV1
+	if err := json.Unmarshal(data, &c); err != nil {
+		return 0, nil, err
 	}
 	if c.Name == "" {
 		// Ensure that name is not blank for spaces created before the
 		// zq#721 work to use space ids.
-		c.Name = filepath.Base(spacePath)
+		c.Name = path.Base(spaceURI.Path)
+	} else {
+		// In version 0 names were not required to be unique. Since this should
+		// be a rare case that any version 0 config files exist, append a uuid
+		// to ensure uniqueness.
+		id := ksuid.New()
+		c.Name = c.Name + "_" + id.String()
+		c.Name = safeName(c.Name)
 	}
 	if c.Storage.Kind == storage.UnknownStore {
 		c.Storage.Kind = storage.FileStore
 	}
-	return c, nil
+	d, err := json.Marshal(c)
+	return 1, d, err
 }
 
-func writeConfig(spacePath string, c config) error {
-	path := filepath.Join(spacePath, configFile)
-	return fs.MarshalJSONFile(c, path, 0644)
+func migrateConfigV2(data []byte, _ iosrc.URI) (int, []byte, error) {
+	var v1 configV1
+	if err := json.Unmarshal(data, &v1); err != nil {
+		return 0, nil, err
+	}
+	if v1.DataPath == "." {
+		v1.DataPath = ""
+	}
+	du, err := iosrc.ParseURI(v1.DataPath)
+	if err != nil {
+		return 0, nil, err
+	}
+	c := config{
+		Version:   2,
+		Name:      v1.Name,
+		DataURI:   du,
+		PcapPath:  v1.PcapPath,
+		Storage:   v1.Storage,
+		Subspaces: v1.Subspaces,
+	}
+	d, err := json.Marshal(c)
+	return 2, d, err
+}
+
+func writeConfig(spaceURI iosrc.URI, c config) error {
+	src, err := iosrc.GetSource(spaceURI)
+	if err != nil {
+		return err
+	}
+	uri := spaceURI.AppendPath(configFile)
+	var w io.WriteCloser
+	if replacer, ok := src.(iosrc.ReplacerAble); ok {
+		w, err = replacer.NewReplacer(uri)
+	} else {
+		w, err = src.NewWriter(uri)
+	}
+	if err != nil {
+		return err
+	}
+	if err := json.NewEncoder(w).Encode(c); err != nil {
+		w.Close()
+		return err
+	}
+	return w.Close()
 }
 
 func validateName(names map[string]api.SpaceID, name string) error {
@@ -91,10 +208,8 @@ func validateName(names map[string]api.SpaceID, name string) error {
 }
 
 // safeName converts the proposed name to a name that adheres to the constraints
-// placed on a space's name (i.e. follows the name regex and is unique). In
-// order to ensure the generated name is unique this should be called with the
-// manager lock held.
-func safeName(names map[string]api.SpaceID, proposed string) string {
+// placed on a space's name (i.e. follows the name regex).
+func safeName(proposed string) string {
 	var sb strings.Builder
 	for _, r := range proposed {
 		if invalidSpaceNameRune(r) {
@@ -102,13 +217,15 @@ func safeName(names map[string]api.SpaceID, proposed string) string {
 		}
 		sb.WriteRune(r)
 	}
-	base := sb.String()
-	name := base
-	// ensure uniqueness
+	return sb.String()
+}
+
+func uniqueName(names map[string]api.SpaceID, proposed string) string {
+	name := proposed
 	for i := 1; ; i++ {
 		if _, ok := names[name]; !ok {
 			return name
 		}
-		name = fmt.Sprintf("%s_%02d", base, i)
+		name = fmt.Sprintf("%s_%02d", proposed, i)
 	}
 }

--- a/zqd/space/manager_test.go
+++ b/zqd/space/manager_test.go
@@ -10,49 +10,89 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/pkg/fs"
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/zqd/api"
+	"github.com/brimsec/zq/zqd/storage"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
+
+func TestV2Migration(t *testing.T) {
+	root, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(root)
+	u, err := iosrc.ParseURI(root)
+	require.NoError(t, err)
+
+	id := testWriteConfig(t, root, configV1{
+		Version:  1,
+		Name:     "test",
+		DataPath: ".",
+		PcapPath: "/tmp/dir",
+		Storage: storage.Config{
+			Kind: storage.FileStore,
+		},
+	})
+
+	_, err = NewManager(u, zap.NewNop())
+	require.NoError(t, err)
+	var c config
+	err = fs.UnmarshalJSONFile(filepath.Join(root, id.String(), configFile), &c)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test", c.Name)
+	assert.Equal(t, "", c.DataURI.String())
+	assert.Equal(t, "/tmp/dir", c.PcapPath)
+	assert.Equal(t, 2, c.Version)
+}
 
 func TestV1Migration(t *testing.T) {
 	t.Run("InvalidCharacters", func(t *testing.T) {
 		root, err := ioutil.TempDir("", "")
 		require.NoError(t, err)
 		defer os.RemoveAll(root)
+		u, err := iosrc.ParseURI(root)
+		require.NoError(t, err)
 
-		testWriteConfig(t, root, config{Name: "name/𝚭𝚴𝚪/stuff"})
+		testWriteConfig(t, root, configV1{Name: "name/𝚭𝚴𝚪/stuff"})
 
-		mgr, err := NewManager(root, zap.NewNop())
+		mgr, err := NewManager(u, zap.NewNop())
 		require.NoError(t, err)
 		list, err := mgr.List(context.Background())
 		require.NoError(t, err)
 		require.Len(t, list, 1)
-		require.Equal(t, "name_𝚭𝚴𝚪_stuff", list[0].Name)
+		require.Regexp(t, "name_𝚭𝚴𝚪_stuff_", list[0].Name)
 	})
 	t.Run("DuplicateNames", func(t *testing.T) {
 		root, err := ioutil.TempDir("", "")
 		require.NoError(t, err)
 		defer os.RemoveAll(root)
+		u, err := iosrc.ParseURI(root)
+		require.NoError(t, err)
 
-		testWriteConfig(t, root, config{Name: "testname"})
-		testWriteConfig(t, root, config{Name: "testname"})
+		testWriteConfig(t, root, configV1{Name: "testname"})
+		testWriteConfig(t, root, configV1{Name: "testname"})
 
-		mgr, err := NewManager(root, zap.NewNop())
+		mgr, err := NewManager(u, zap.NewNop())
 		require.NoError(t, err)
 		list, err := mgr.List(context.Background())
 		require.NoError(t, err)
 		require.Len(t, list, 2)
 		sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
-		require.Equal(t, "testname", list[0].Name)
-		require.Equal(t, "testname_01", list[1].Name)
+		require.Regexp(t, "testname_", list[0].Name)
+		require.Regexp(t, "testname_", list[1].Name)
+		require.NotEqual(t, list[0].Name, list[1].Name)
 	})
 }
 
 var counter int
 
-func testWriteConfig(t *testing.T, root string, c config) {
+func testWriteConfig(t *testing.T, root string, c interface{}) api.SpaceID {
 	counter++
-	spdir := filepath.Join(root, fmt.Sprintf("sp_%d", counter))
+	id := fmt.Sprintf("sp_%d", counter)
+	spdir := filepath.Join(root, id)
 	require.NoError(t, os.Mkdir(spdir, 0700))
 	require.NoError(t, fs.MarshalJSONFile(c, filepath.Join(spdir, configFile), 0600))
+	return api.SpaceID(id)
 }

--- a/zqd/storage/archivestore/archivestore.go
+++ b/zqd/storage/archivestore/archivestore.go
@@ -13,7 +13,7 @@ import (
 	"github.com/brimsec/zq/zqd/storage"
 )
 
-func Load(path string, cfg *storage.ArchiveConfig) (*Storage, error) {
+func Load(path iosrc.URI, cfg *storage.ArchiveConfig) (*Storage, error) {
 	co := &archive.CreateOptions{}
 	if cfg != nil && cfg.CreateOptions != nil {
 		co.LogSizeThreshold = cfg.CreateOptions.LogSizeThreshold
@@ -22,7 +22,7 @@ func Load(path string, cfg *storage.ArchiveConfig) (*Storage, error) {
 	if cfg != nil && cfg.OpenOptions != nil {
 		oo.LogFilter = cfg.OpenOptions.LogFilter
 	}
-	ark, err := archive.CreateOrOpenArchive(path, co, oo)
+	ark, err := archive.CreateOrOpenArchive(path.String(), co, oo)
 	if err != nil {
 		return nil, err
 	}

--- a/zqd/storage/filestore/filestore.go
+++ b/zqd/storage/filestore/filestore.go
@@ -3,6 +3,7 @@ package filestore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/fs"
+	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
@@ -35,9 +37,12 @@ var (
 	zngWriteProc = zql.MustParseProc("sort -r ts")
 )
 
-func Load(path string) (*Storage, error) {
+func Load(path iosrc.URI) (*Storage, error) {
+	if path.Scheme != "file" {
+		return nil, fmt.Errorf("unsupported FileStore scheme %q", path)
+	}
 	s := &Storage{
-		path:       path,
+		path:       path.Filepath(),
 		index:      zngio.NewTimeIndex(),
 		streamsize: defaultStreamSize,
 		wsem:       semaphore.NewWeighted(1),

--- a/zqd/storage/filestore/filestore_test.go
+++ b/zqd/storage/filestore/filestore_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
@@ -32,7 +33,9 @@ func TestFailOnConcurrentWrites(t *testing.T) {
 	defer func() {
 		os.RemoveAll(dir)
 	}()
-	store, err := Load(dir)
+	u, err := iosrc.ParseURI(dir)
+	require.NoError(t, err)
+	store, err := Load(u)
 	require.NoError(t, err)
 	zctx := resolver.NewContext()
 	wr := &waitReader{dur: time.Second * 5}
@@ -59,7 +62,9 @@ func TestRewriteNoRecords(t *testing.T) {
 	defer func() {
 		os.RemoveAll(dir)
 	}()
-	store, err := Load(dir)
+	u, err := iosrc.ParseURI(dir)
+	require.NoError(t, err)
+	store, err := Load(u)
 	require.NoError(t, err)
 
 	sp := nano.Span{Ts: 10, Dur: 10}


### PR DESCRIPTION
Support starting zqd with the datapath set to an s3 path. For now zqd
instances with s3 path's only allow creation of archive spaces. For s3
backed spaces return a 400 error on attempts to create a filestore space.

Closes #1051 