### PR TITLE
make zar zq use the parallel scanner

### DIFF
--- a/archive/walk.go
+++ b/archive/walk.go
@@ -1,9 +1,16 @@
 package archive
 
 import (
+	"context"
+	"io"
 	"strings"
 
+	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/scanner"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/detector"
+	"github.com/brimsec/zq/zng/resolver"
 )
 
 func ZarDirToLog(uri iosrc.URI) iosrc.URI {
@@ -65,4 +72,74 @@ func SpanWalk(ark *Archive, v SpanVisitor) error {
 // each such directory and all of its contents.
 func RmDirs(ark *Archive) error {
 	return Walk(ark, ark.dataSrc.RemoveAll)
+}
+
+type multiSource struct {
+	ark   *Archive
+	paths []string
+}
+
+// NewMultiSource returns a driver.MultiSource for an Archive. If no paths are
+// specified, the MultiSource will send a source for each chunk file, and
+// report the same ordering as the archive. Otherwise, the sources come from
+// localizing the given paths to each chunk's directory (recognizing "_" as the
+// chunk file itself), with no defined ordering.
+func NewMultiSource(ark *Archive, paths []string) driver.MultiSource {
+	if len(paths) == 0 {
+		paths = []string{"_"}
+	}
+	ms := &multiSource{
+		ark:   ark,
+		paths: paths,
+	}
+	return ms
+}
+
+func (ams *multiSource) OrderInfo() (string, bool) {
+	if len(ams.paths) == 1 && ams.paths[0] == "_" {
+		return "ts", ams.ark.DataSortDirection == zbuf.DirTimeReverse
+	}
+	return "", false
+}
+
+type archiveSource struct {
+	scanner.Scanner
+	io.Closer
+}
+
+func (ams *multiSource) SendSources(ctx context.Context, zctx *resolver.Context, sf driver.SourceFilter, srcChan chan driver.SourceOpener) error {
+	return SpanWalk(ams.ark, func(si SpanInfo, zardir iosrc.URI) error {
+		if !sf.Span.Overlaps(si.Span) {
+			return nil
+		}
+		so := func() (driver.ScannerCloser, error) {
+			// In the future, we could determine if any microindex in
+			// this zardir would be useful as a filter by comparing the
+			// filter expression in sf.FilterExpr against the available
+			// indices, then run a Find against the index to avoid reading
+			// the entire chunk.
+			var paths []string
+			for _, input := range ams.paths {
+				p := Localize(zardir, input)
+				// XXX Detector doesn't support file uri's.
+				if p.Scheme == "file" {
+					paths = append(paths, p.Filepath())
+				} else {
+					paths = append(paths, p.String())
+				}
+			}
+			rc := detector.MultiFileReader(zctx, paths, detector.OpenConfig{Format: "zng"})
+			sn, err := scanner.NewScanner(ctx, rc, sf.Filter, sf.FilterExpr, sf.Span)
+			if err != nil {
+				return nil, err
+			}
+			return &archiveSource{Scanner: sn, Closer: rc}, nil
+		}
+		select {
+		case srcChan <- so:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
 }

--- a/cmd/zar/main.go
+++ b/cmd/zar/main.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/brimsec/zq/cmd/zar/import"
 	_ "github.com/brimsec/zq/cmd/zar/index"
 	_ "github.com/brimsec/zq/cmd/zar/ls"
+	_ "github.com/brimsec/zq/cmd/zar/map"
 	_ "github.com/brimsec/zq/cmd/zar/rm"
 	_ "github.com/brimsec/zq/cmd/zar/rmdirs"
 	"github.com/brimsec/zq/cmd/zar/root"

--- a/cmd/zar/map/command.go
+++ b/cmd/zar/map/command.go
@@ -1,0 +1,162 @@
+package zarmap
+
+import (
+	"errors"
+	"flag"
+	"os"
+
+	"github.com/brimsec/zq/archive"
+	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/cmd/zar/root"
+	"github.com/brimsec/zq/driver"
+	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/pkg/signalctx"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/detector"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zql"
+	"github.com/mccanne/charm"
+)
+
+var Map = &charm.Spec{
+	Name:  "map",
+	Usage: "map [-R root] [options] [zql] file [file...]",
+	Short: "execute ZQL for each archive directory",
+	Long: `
+"zar map" executes a ZQL query on one or more files in each of the
+chunk directories of a zar archive, sending its output to either stdout,
+or to a per-directory file, specified via "-o". Input file names are
+relative to each zar subdirectory, and the special name "_" refers to
+the chunk file itself.
+`,
+	New: New,
+}
+
+func init() {
+	root.Zar.Add(Map)
+}
+
+type Command struct {
+	*root.Command
+	forceBinary  bool
+	outputFile   string
+	quiet        bool
+	root         string
+	stopErr      bool
+	textShortcut bool
+	writerFlags  zio.WriterFlags
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	f.BoolVar(&c.forceBinary, "B", false, "allow binary zng be sent to a terminal output")
+	f.StringVar(&c.outputFile, "o", "", "output file relative to zar directory")
+	f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.BoolVar(&c.stopErr, "e", true, "stop upon input errors")
+	f.BoolVar(&c.textShortcut, "t", false, "use format tzng independent of -f option")
+	c.writerFlags.SetFlags(f)
+	return c, nil
+}
+
+//XXX lots here copied from zq command... we should refactor into a tools package
+func (c *Command) Run(args []string) error {
+	if len(args) == 0 {
+		return errors.New("zar map needs input arguments")
+	}
+
+	if c.outputFile == "-" {
+		c.outputFile = ""
+	}
+	if c.textShortcut {
+		c.writerFlags.Format = "tzng"
+	}
+	if c.outputFile == "" && c.writerFlags.Format == "zng" && emitter.IsTerminal(os.Stdout) && !c.forceBinary {
+		return errors.New("map: writing binary zng data to terminal; override with -B or use -t for text.")
+	}
+
+	// Don't allow non-zng to be written inside the archive.
+	if c.outputFile != "" && c.writerFlags.Format != "zng" {
+		return errors.New("zq: only ZNG format allowed for chunk associated files")
+	}
+
+	ctx, cancel := signalctx.New(os.Interrupt)
+	defer cancel()
+
+	ark, err := archive.OpenArchive(c.root, nil)
+	if err != nil {
+		return err
+	}
+
+	// XXX this is parallelizable except for writing to stdout when
+	// concatenating results
+	return archive.Walk(ark, func(zardir iosrc.URI) error {
+		inputs := args
+		var query ast.Proc
+		first := archive.Localize(zardir, inputs[0])
+		ok, err := iosrc.Exists(first)
+		if err != nil {
+			return err
+		}
+		if ok {
+			query, err = zql.ParseProc("*")
+			if err != nil {
+				return err
+			}
+		} else {
+			query, err = zql.ParseProc(inputs[0])
+			if err != nil {
+				return err
+			}
+			inputs = inputs[1:]
+		}
+		var paths []string
+		for _, input := range inputs {
+			p := archive.Localize(zardir, input)
+			// XXX Doing this because detector doesn't support file uri's. At
+			// some point it should.
+			if p.Scheme == "file" {
+				paths = append(paths, p.Filepath())
+			} else {
+				paths = append(paths, p.String())
+			}
+		}
+		zctx := resolver.NewContext()
+		cfg := detector.OpenConfig{Format: "zng"}
+		rc := detector.MultiFileReader(zctx, paths, cfg)
+		defer rc.Close()
+		reader := zbuf.Reader(rc)
+		wch := make(chan string, 5)
+		if !c.stopErr {
+			reader = zbuf.NewWarningReader(reader, wch)
+		}
+		writer, err := c.openOutput(zardir)
+		if err != nil {
+			return err
+		}
+		defer writer.Close()
+		d := driver.NewCLI(writer)
+		if !c.quiet {
+			d.SetWarningsWriter(os.Stderr)
+		}
+		return driver.Run(ctx, d, query, zctx, reader, driver.Config{
+			ReaderSortKey:     "ts",
+			ReaderSortReverse: ark.DataSortDirection == zbuf.DirTimeReverse,
+			Warnings:          wch,
+		})
+	})
+}
+
+func (c *Command) openOutput(zardir iosrc.URI) (zbuf.WriteCloser, error) {
+	path := ""
+	if c.outputFile != "" {
+		path = zardir.AppendPath(c.outputFile).String()
+	}
+	w, err := emitter.NewFile(path, &c.writerFlags)
+	if err != nil {
+		return nil, err
+	}
+	return w, nil
+}

--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -6,15 +6,11 @@ import (
 	"os"
 
 	"github.com/brimsec/zq/archive"
-	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/cmd/zar/root"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
-	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/signalctx"
-	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
-	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
 	"github.com/mccanne/charm"
@@ -22,12 +18,14 @@ import (
 
 var Zq = &charm.Spec{
 	Name:  "zq",
-	Usage: "zq [-R root] [options] [zql] file [file...]",
-	Short: "walk an archive and run zql queries",
+	Usage: "zq [-R root] [options] zql [file...]",
+	Short: "execute ZQL against all archive directories",
 	Long: `
-"zar zq" executes a ZQL query against each chunk or associated file in an 
-archive. The special name "_" refers to chunk file itelf, and other names
-are interpreted relative to the chunk's associated file directory.
+"zar zq" executes a ZQL query against one or more files from all the directories
+of an archive, generating a single result. By default, the chunk file in each
+directory is used, but one or more files may be specified. The special file
+name "_" refers to the chunk file itself, and other names are interpreted
+relative to each chunk's directory.
 `,
 	New: New,
 }
@@ -38,27 +36,41 @@ func init() {
 
 type Command struct {
 	*root.Command
-	root       string
-	outputFile string
-	stopErr    bool
-	quiet      bool
+	forceBinary  bool
+	outputFile   string
+	quiet        bool
+	root         string
+	stopErr      bool
+	textShortcut bool
+	writerFlags  zio.WriterFlags
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
-	f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
+	f.BoolVar(&c.forceBinary, "B", false, "allow binary zng be sent to a terminal output")
 	f.StringVar(&c.outputFile, "o", "", "write data to output file")
+	f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
 	f.BoolVar(&c.stopErr, "e", true, "stop upon input errors")
-
+	f.BoolVar(&c.textShortcut, "t", false, "use format tzng independent of -f option")
+	c.writerFlags.SetFlags(f)
 	return c, nil
 }
 
-//XXX lots here copied from zq command... we should refactor into a tools package
 func (c *Command) Run(args []string) error {
-	//XXX
 	if c.outputFile == "-" {
 		c.outputFile = ""
+	}
+	if c.textShortcut {
+		c.writerFlags.Format = "tzng"
+	}
+	if c.outputFile == "" && c.writerFlags.Format == "zng" && emitter.IsTerminal(os.Stdout) && !c.forceBinary {
+		return errors.New("writing binary zng data to terminal; override with -B or use -t for text.")
+	}
+
+	query, err := zql.ParseProc(args[0])
+	if err != nil {
+		return err
 	}
 
 	ark, err := archive.OpenArchive(c.root, nil)
@@ -66,81 +78,26 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 
-	if len(args) == 0 {
-		return errors.New("zar zq needs input arguments")
+	msrc := archive.NewMultiSource(ark, args[1:])
+
+	writer, err := emitter.NewFile(c.outputFile, &c.writerFlags)
+	if err != nil {
+		return err
 	}
+	defer writer.Close()
+
+	d := driver.NewCLI(writer)
+	if !c.quiet {
+		d.SetWarningsWriter(os.Stderr)
+	}
+
+	zctx := resolver.NewContext()
+	wch := make(chan string, 5)
 
 	ctx, cancel := signalctx.New(os.Interrupt)
 	defer cancel()
 
-	// XXX this is parallelizable except for writing to stdout when
-	// concatenating results
-	return archive.Walk(ark, func(zardir iosrc.URI) error {
-		inputs := args
-		var query ast.Proc
-		first := archive.Localize(zardir, inputs[0])
-		ok, err := iosrc.Exists(first)
-		if err != nil {
-			return err
-		}
-		if ok {
-			query, err = zql.ParseProc("*")
-			if err != nil {
-				return err
-			}
-		} else {
-			query, err = zql.ParseProc(inputs[0])
-			if err != nil {
-				return err
-			}
-			inputs = inputs[1:]
-		}
-		var paths []string
-		for _, input := range inputs {
-			p := archive.Localize(zardir, input)
-			// XXX Doing this because detector doesn't support file uri's. At
-			// some point it should.
-			if p.Scheme == "file" {
-				paths = append(paths, p.Filepath())
-			} else {
-				paths = append(paths, p.String())
-			}
-		}
-		zctx := resolver.NewContext()
-		cfg := detector.OpenConfig{Format: "zng"}
-		rc := detector.MultiFileReader(zctx, paths, cfg)
-		defer rc.Close()
-		reader := zbuf.Reader(rc)
-		wch := make(chan string, 5)
-		if !c.stopErr {
-			reader = zbuf.NewWarningReader(reader, wch)
-		}
-		writer, err := c.openOutput(zardir, c.outputFile)
-		if err != nil {
-			return err
-		}
-		defer writer.Close()
-		d := driver.NewCLI(writer)
-		if !c.quiet {
-			d.SetWarningsWriter(os.Stderr)
-		}
-		return driver.Run(ctx, d, query, zctx, reader, driver.Config{
-			ReaderSortKey:     "ts",
-			ReaderSortReverse: ark.DataSortDirection == zbuf.DirTimeReverse,
-			Warnings:          wch,
-		})
+	return driver.MultiRun(ctx, d, query, zctx, msrc, driver.MultiConfig{
+		Warnings: wch,
 	})
-}
-
-func (c *Command) openOutput(zardir iosrc.URI, filename string) (zbuf.WriteCloser, error) {
-	path := filename
-	// prepend path if not stdout
-	if path != "" {
-		path = zardir.AppendPath(filename).String()
-	}
-	w, err := emitter.NewFile(path, &zio.WriterFlags{Format: "zng"})
-	if err != nil {
-		return nil, err
-	}
-	return w, nil
 }

--- a/emitter/file.go
+++ b/emitter/file.go
@@ -34,7 +34,7 @@ func NewFile(path string, flags *zio.WriterFlags) (*zio.Writer, error) {
 	return NewFileWithSource(uri, flags, src)
 }
 
-func isTerminal(w io.Writer) bool {
+func IsTerminal(w io.Writer) bool {
 	if f, ok := w.(*os.File); ok {
 		if terminal.IsTerminal(int(f.Fd())) {
 			return true
@@ -55,7 +55,7 @@ func NewFileWithSource(path iosrc.URI, flags *zio.WriterFlags, source iosrc.Sour
 		// that has multiple stdio users.
 		wc = &noClose{f}
 		// Don't buffer terminal output.
-		if !isTerminal(f) {
+		if !IsTerminal(f) {
 			wc = bufwriter.New(wc)
 		}
 	} else {

--- a/tests/suite/zar/index-custom-input.yaml
+++ b/tests/suite/zar/index-custom-input.yaml
@@ -2,7 +2,7 @@
 script: |
   mkdir logs
   zar import -R ./logs babble.tzng
-  zar zq -q -o sums.zng -R ./logs "sum(v) by s" _
+  zar map -q -o sums.zng -R ./logs "sum(v) by s" _
   zar index -f 20000 -i sums.zng -q -R ./logs -o index.zng -z "put key=s | sort key"
   zdx section -t -s 1 logs/20200422/1587518620.0622373.zng.zar/index.zng
 

--- a/tests/suite/zar/map.yaml
+++ b/tests/suite/zar/map.yaml
@@ -1,12 +1,11 @@
 script: |
   mkdir logs
   zar import -s 20KiB -R ./logs babble.tzng
-  zar zq -R ./logs "count()" | zq -t -
+  zar map -R ./logs "count()" _ | zq -t -
   echo ===
   zar map -R ./logs -o count.zng "count()" _
-  zar zq -R ./logs "* | sort -r count" count.zng | zq -t -
-  echo ===
-  zar zq -R ./logs "sum(count)" count.zng | zq -t -
+  zq -t "*" ./logs/20200422/1587518620.0622373.zng.zar/count.zng
+  zq -t "*" ./logs/20200421/1587509477.06313454.zng.zar/count.zng
 
 inputs:
   - name: babble.tzng
@@ -16,11 +15,10 @@ outputs:
   - name: stdout
     data: |
       #0:record[count:uint64]
-      0:[1000;]
-      ===
-      #0:record[count:uint64]
       0:[939;]
       0:[61;]
       ===
-      #0:record[sum:uint64]
-      0:[1000;]
+      #0:record[count:uint64]
+      0:[939;]
+      #0:record[count:uint64]
+      0:[61;]

--- a/tests/suite/zar/s3/rm.yaml
+++ b/tests/suite/zar/s3/rm.yaml
@@ -1,7 +1,7 @@
 script: |
   source minio.sh
   zar import -s 20KiB -R ./root -data s3://bucket/zartest babble.tzng
-  zar zq -R ./root -o count.zng "count()" _
+  zar map -R ./root -o count.zng "count()" _
   echo ===
   zar ls -l -R ./root
   echo ===

--- a/tests/suite/zar/s3/rmdirs.yaml
+++ b/tests/suite/zar/s3/rmdirs.yaml
@@ -1,7 +1,7 @@
 script: |
   source minio.sh
   zar import -s 20KiB -R ./root -data s3://bucket/zartest babble.tzng
-  zar zq -R ./root -o count.zng "count()" _
+  zar map -R ./root -o count.zng "count()" _
   echo ===
   zar ls -l -R ./root
   echo ===

--- a/tests/suite/zar/s3/s3root.yaml
+++ b/tests/suite/zar/s3/s3root.yaml
@@ -7,7 +7,7 @@ script: |
   echo ===
   zar find -relative -R s3://bucket/zartest v=106
   echo ===
-  zar zq -R s3://bucket/zartest "count()" _ | zq -t -
+  zar zq -R s3://bucket/zartest "count()" | zq -t -
 
 inputs:
   - name: babble.tzng
@@ -25,5 +25,4 @@ outputs:
       20200422/1587518620.0622373.zng
       ===
       #0:record[count:uint64]
-      0:[939;]
-      0:[61;]
+      0:[1000;]

--- a/tests/suite/zar/s3/zq.yaml
+++ b/tests/suite/zar/s3/zq.yaml
@@ -1,7 +1,7 @@
 script: |
   source minio.sh
   zar import -s 20KiB -R ./root -data s3://bucket/zartest babble.tzng
-  zar zq -R ./root -o count.zng "count()" _
+  zar map -R ./root -o count.zng "count()" _
   echo ===
   zar ls -l -R ./root
 


### PR DESCRIPTION
Adjust `zar zq` to use the parallel scanner from https://github.com/brimsec/zq/pull/1074 . This took a `zar zq` operation on my mac to find a single record in a 4.5GB zar archive from ~70 seconds to ~14 seconds.

However, this raised an interesting question about the intended usage of `zar zq`. In its pre-existing form, it expects to run sequentially on each zar directory, processing the zng file for that zar directory, and sending its output to either 1: an aggregate (like stdout), or 2: to a new file inside the zar directory of the file it just processed. 

The parallel scanning (as implemented in https://github.com/brimsec/zq/pull/1074 ) only makes sense to use with behavior 1. I've keyed the different behaviors off the `-o` output flag in the current state, but that was intended as a proof of concept. I think it makes sense to have different zar subcommands for these behaviors, and was thinking of keeping behavior 1 as `zar zq`, and behavior 2 as `zar map`.


