### PR TITLE
groupby: Add support for partial reducer results

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -267,6 +267,12 @@ type (
 	// The Limit field specifies the number of different groups that can be
 	// aggregated over. When absent, the runtime defaults to an
 	// appropriate value.
+	// If EmitPart is true, the proc will produce decomposed
+	// output results, using the reducer.ResultPart()
+	// method. Likewise, if ConsumePart is true, the proc will
+	// expect decomposed inputs, using the reducer.ResultPart()
+	// method. It is an error for either of these flags to be true
+	// if any reducer in Reducers is non-decomposable.
 	GroupByProc struct {
 		Node
 		Duration     Duration               `json:"duration"`
@@ -274,6 +280,8 @@ type (
 		Limit        int                    `json:"limit,omitempty"`
 		Keys         []ExpressionAssignment `json:"keys"`
 		Reducers     []Reducer              `json:"reducers"`
+		ConsumePart  bool                   `json:"consume_part"`
+		EmitPart     bool                   `json:"emit_part"`
 	}
 	// TopProc is similar to proc.SortProc with a few key differences:
 	// - It only sorts in descending order.

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -71,7 +71,7 @@ func CompileGroupBy(node *ast.GroupByProc, zctx *resolver.Context) (*GroupByPara
 		return nil, fmt.Errorf("compiling groupby: %w", err)
 	}
 	if (node.ConsumePart || node.EmitPart) && !decomposable(reducers) {
-		return nil, fmt.Errorf("partial input or output requested with non-decomposable reducers")
+		return nil, errors.New("partial input or output requested with non-decomposable reducers")
 	}
 	return &GroupByParams{
 		limit:        node.Limit,
@@ -411,11 +411,10 @@ func (g *GroupByAggregator) Consume(r *zng.Record) error {
 	}
 
 	if g.consumePart {
-		err = row.reducers.ConsumePart(r)
-	} else {
-		row.reducers.Consume(r)
+		return row.reducers.ConsumePart(r)
 	}
-	return err
+	row.reducers.Consume(r)
+	return nil
 }
 
 func (g *GroupByAggregator) spillTable(eof bool) error {

--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -27,6 +27,8 @@ type GroupByParams struct {
 	keys         []GroupByKey
 	reducers     []compile.CompiledReducer
 	builder      *ColumnBuilder
+	consumePart  bool
+	emitPart     bool
 }
 
 type errTooBig int
@@ -68,12 +70,17 @@ func CompileGroupBy(node *ast.GroupByProc, zctx *resolver.Context) (*GroupByPara
 	if err != nil {
 		return nil, fmt.Errorf("compiling groupby: %w", err)
 	}
+	if (node.ConsumePart || node.EmitPart) && !decomposable(reducers) {
+		return nil, fmt.Errorf("partial input or output requested with non-decomposable reducers")
+	}
 	return &GroupByParams{
 		limit:        node.Limit,
 		keys:         keys,
 		reducers:     reducers,
 		builder:      builder,
 		inputSortDir: node.InputSortDir,
+		consumePart:  node.ConsumePart,
+		emitPart:     node.EmitPart,
 	}, nil
 }
 
@@ -141,6 +148,8 @@ type GroupByAggregator struct {
 	maxSpillKey  *zng.Value
 	inputSortDir int
 	runManager   *runManager
+	consumePart  bool
+	emitPart     bool
 }
 
 type GroupByRow struct {
@@ -198,6 +207,8 @@ func NewGroupByAggregator(c *Context, params GroupByParams) *GroupByAggregator {
 		keyCompare:   keyCompare,
 		keysCompare:  keysCompare,
 		valueCompare: valueCompare,
+		consumePart:  params.consumePart,
+		emitPart:     params.emitPart,
 	}
 }
 
@@ -398,8 +409,13 @@ func (g *GroupByAggregator) Consume(r *zng.Record) error {
 		row = g.createGroupByRow(keyRow.columns, keyBytes[4:], prim)
 		g.table[string(keyBytes)] = row
 	}
-	row.reducers.Consume(r)
-	return nil
+
+	if g.consumePart {
+		err = row.reducers.ConsumePart(r)
+	} else {
+		row.reducers.Consume(r)
+	}
+	return err
 }
 
 func (g *GroupByAggregator) spillTable(eof bool) error {
@@ -448,13 +464,13 @@ func (g *GroupByAggregator) updateMaxSpillKey(v zng.Value) {
 	}
 }
 
-// Results returns a batch of aggregation result records. If the input
-// is sorted in the primary key, only keys that are completed are
-// returned. A final call with eof=true should be made to get the
-// final keys.
+// Results returns a batch of aggregation result records. Upon eof,
+// this should be called repeatedly until a nil batch is returned. If
+// the input is sorted in the primary key, Results can be called
+// before eof, and keys that are completed will returned.
 func (g *GroupByAggregator) Results(eof bool) (zbuf.Batch, error) {
 	if g.runManager == nil {
-		return g.readTable(eof, false)
+		return g.readTable(eof, g.emitPart)
 	}
 	if eof {
 		// EOF: spill in-memory table before merging all files for output.
@@ -545,7 +561,16 @@ func (g *GroupByAggregator) nextResultFromSpills() (*zng.Record, error) {
 	}
 	cols := g.builder.TypedColumns(types)
 	for i, red := range row.Reducers {
-		v := red.Result()
+		var v zng.Value
+		if g.emitPart {
+			vv, err := red.(reducer.Decomposable).ResultPart(g.zctx)
+			if err != nil {
+				return nil, err
+			}
+			v = vv
+		} else {
+			v = red.Result()
+		}
 		cols = append(cols, zng.NewColumn(row.Defs[i].Target, v.Type))
 		zbytes = v.Encode(zbytes)
 	}


### PR DESCRIPTION
This PR adds two flags to `ast.GroupbyProc` to indicate that inputs (resp outputs) are partial results from/for decomposable reducers. The flags are not currently exposed in ZQL as they are intended for use by AST transformations (such as those coming in #1022).

I haven't added tests in this PR and plan to add them with #1022, unless there are objections.

closes #1023 

