### PR TITLE
merge driver.Compile into driver.Run

### DIFF
--- a/archive/import.go
+++ b/archive/import.go
@@ -131,13 +131,8 @@ func Import(ctx context.Context, ark *Archive, zctx *resolver.Context, r zbuf.Re
 		return err
 	}
 
-	fg, err := driver.Compile(ctx, proc, zctx, r, driver.Config{})
-	if err != nil {
-		return err
-	}
-
 	id := &importDriver{ark: ark}
-	if err := driver.Run(fg, id, nil); err != nil {
+	if err := driver.Run(ctx, id, proc, zctx, r, driver.Config{}); err != nil {
 		return fmt.Errorf("archive.Import: run failed: %w", err)
 	}
 

--- a/archive/indexer.go
+++ b/archive/indexer.go
@@ -56,16 +56,12 @@ func runOne(zardir iosrc.URI, rule Rule, inputPath iosrc.URI, progress chan<- st
 		return err
 	}
 	defer fgi.Close()
-	out, err := driver.Compile(context.TODO(), rule.proc, zctx, r, driver.Config{
-		Custom: &compiler{},
-	})
-	if err != nil {
-		return err
-	}
 	if progress != nil {
 		progress <- fmt.Sprintf("%s: creating index %s", inputPath, rule.Path(zardir))
 	}
-	return driver.Run(out, fgi, nil)
+	return driver.Run(context.TODO(), fgi, rule.proc, zctx, r, driver.Config{
+		Custom: &compiler{},
+	})
 }
 
 func run(zardir iosrc.URI, rules []Rule, logPath iosrc.URI, progress chan<- string) error {

--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -121,19 +121,15 @@ func (c *Command) Run(args []string) error {
 			return err
 		}
 		defer writer.Close()
-		mux, err := driver.Compile(context.Background(), query, zctx, reader, driver.Config{
-			ReaderSortKey:     "ts",
-			ReaderSortReverse: ark.DataSortDirection == zbuf.DirTimeReverse,
-			Warnings:          wch,
-		})
-		if err != nil {
-			return err
-		}
 		d := driver.NewCLI(writer)
 		if !c.quiet {
 			d.SetWarningsWriter(os.Stderr)
 		}
-		return driver.Run(mux, d, nil)
+		return driver.Run(context.Background(), d, query, zctx, reader, driver.Config{
+			ReaderSortKey:     "ts",
+			ReaderSortReverse: ark.DataSortDirection == zbuf.DirTimeReverse,
+			Warnings:          wch,
+		})
 	})
 }
 

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -246,18 +246,13 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	mux, err := driver.Compile(context.Background(), query, c.zctx, reader, driver.Config{
-		Warnings: wch,
-	})
-	if err != nil {
-		writer.Close()
-		return err
-	}
 	d := driver.NewCLI(writer)
 	if !c.quiet {
 		d.SetWarningsWriter(os.Stderr)
 	}
-	if err := driver.Run(mux, d, nil); err != nil {
+	if err := driver.Run(context.Background(), d, query, c.zctx, reader, driver.Config{
+		Warnings: wch,
+	}); err != nil {
 		writer.Close()
 		return err
 	}

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/expr"
@@ -22,13 +23,10 @@ type Config struct {
 	ReaderSortReverse bool
 	Span              nano.Span
 	Warnings          chan string
+	StatsTick         <-chan time.Time
 }
 
-// Compile takes an AST, an input reader, and configuration parameters,
-// and compiles it into a runnable flowgraph, returning a
-// proc.MuxOutput that which brings together all of the flowgraphs
-// tails, and is ready to be Pull()'d from.
-func Compile(ctx context.Context, program ast.Proc, zctx *resolver.Context, reader zbuf.Reader, cfg Config) (*MuxOutput, error) {
+func compileMux(ctx context.Context, program ast.Proc, zctx *resolver.Context, reader zbuf.Reader, cfg Config) (*MuxOutput, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = zap.NewNop()
 	}

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -26,7 +26,7 @@ type Config struct {
 	StatsTick         <-chan time.Time
 }
 
-func compileMux(ctx context.Context, program ast.Proc, zctx *resolver.Context, reader zbuf.Reader, cfg Config) (*MuxOutput, error) {
+func compileMux(ctx context.Context, program ast.Proc, zctx *resolver.Context, reader zbuf.Reader, cfg Config) (*muxOutput, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = zap.NewNop()
 	}
@@ -63,7 +63,7 @@ func compileMux(ctx context.Context, program ast.Proc, zctx *resolver.Context, r
 	if err != nil {
 		return nil, err
 	}
-	return NewMuxOutput(pctx, leaves, scanner), nil
+	return newMuxOutput(pctx, leaves, scanner), nil
 }
 
 // liftFilter removes the filter at the head of the flowgraph AST, if

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -22,11 +22,11 @@ type Config struct {
 	ReaderSortKey     string
 	ReaderSortReverse bool
 	Span              nano.Span
-	Warnings          chan string
 	StatsTick         <-chan time.Time
+	Warnings          chan string
 }
 
-func compileMux(ctx context.Context, program ast.Proc, zctx *resolver.Context, reader zbuf.Reader, cfg Config) (*muxOutput, error) {
+func compile(ctx context.Context, program ast.Proc, zctx *resolver.Context, reader zbuf.Reader, cfg Config) (*muxOutput, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = zap.NewNop()
 	}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -27,11 +27,11 @@ func Run(ctx context.Context, d Driver, program ast.Proc, zctx *resolver.Context
 	return runMux(mux, d, cfg.StatsTick)
 }
 
-func runMux(out *MuxOutput, d Driver, statsTickCh <-chan time.Time) error {
+func runMux(out *muxOutput, d Driver, statsTickCh <-chan time.Time) error {
 	for !out.Complete() {
 		chunk := out.Pull(statsTickCh)
 		if chunk.Err != nil {
-			if chunk.Err == ErrTimeout {
+			if chunk.Err == errTimeout {
 				if err := d.Stats(out.Stats()); err != nil {
 					return err
 				}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -23,7 +23,7 @@ func Run(ctx context.Context, d Driver, program ast.Proc, zctx *resolver.Context
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	mux, err := compileMux(ctx, program, zctx, reader, cfg)
+	mux, err := compile(ctx, program, zctx, reader, cfg)
 	if err != nil {
 		return err
 	}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -20,6 +20,9 @@ type Driver interface {
 }
 
 func Run(ctx context.Context, d Driver, program ast.Proc, zctx *resolver.Context, reader zbuf.Reader, cfg Config) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	mux, err := compileMux(ctx, program, zctx, reader, cfg)
 	if err != nil {
 		return err

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -27,28 +27,27 @@ func TestMuxDriver(t *testing.T) {
 #0:record[_path:string,ts:time]
 0:[conn;1425565514.419939;]`
 
-	zctx := resolver.NewContext()
 	query, err := zql.ParseProc("(tail 1; tail 1)")
 	assert.NoError(t, err)
 
 	t.Run("muxed into one writer", func(t *testing.T) {
+		zctx := resolver.NewContext()
 		reader := tzngio.NewReader(strings.NewReader(input), zctx)
-		flowgraph, err := Compile(context.Background(), query, zctx, reader, Config{})
 		assert.NoError(t, err)
 		c := counter{}
 		d := NewCLI(&c)
-		err = Run(flowgraph, d, nil)
+		err = Run(context.Background(), d, query, zctx, reader, Config{})
 		assert.NoError(t, err)
 		assert.Equal(t, 2, c.n)
 	})
 
 	t.Run("muxed into individual writers", func(t *testing.T) {
+		zctx := resolver.NewContext()
 		reader := tzngio.NewReader(strings.NewReader(input), zctx)
-		flowgraph, err := Compile(context.Background(), query, zctx, reader, Config{})
 		assert.NoError(t, err)
 		cs := []zbuf.Writer{&counter{}, &counter{}}
 		d := NewCLI(cs...)
-		err = Run(flowgraph, d, nil)
+		err = Run(context.Background(), d, query, zctx, reader, Config{})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, cs[0].(*counter).n)
 		assert.Equal(t, 1, cs[1].(*counter).n)

--- a/pkg/test/internal.go
+++ b/pkg/test/internal.go
@@ -56,16 +56,12 @@ func (i *Internal) Run() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	mux, err := driver.Compile(context.Background(), program, zctx, reader, driver.Config{})
-	if err != nil {
-		return "", err
-	}
 	output, err := newEmitter(i.OutputFormat)
 	if err != nil {
 		return "", err
 	}
 	d := driver.NewCLI(output)
-	if err := driver.Run(mux, d, nil); err != nil {
+	if err := driver.Run(context.Background(), d, program, zctx, reader, driver.Config{}); err != nil {
 		return "", err
 	}
 	return string(output.Bytes()), nil

--- a/proc/groupby_test.go
+++ b/proc/groupby_test.go
@@ -494,10 +494,6 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 		zctx := resolver.NewContext()
 		zr := tzngio.NewReader(strings.NewReader(strings.Join(data, "\n")), zctx)
 		cr := &countReader{r: zr}
-		muxOutput, err := driver.Compile(context.Background(), proc, zctx, cr, driver.Config{
-			ReaderSortKey: inputSortKey,
-		})
-		assert.NoError(t, err)
 		var outbuf bytes.Buffer
 		zw := detector.LookupWriter(&nopCloser{&outbuf}, &zio.WriterFlags{})
 		d := &testGroupByDriver{
@@ -510,7 +506,9 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 				}
 			},
 		}
-		err = driver.Run(muxOutput, d, nil)
+		err = driver.Run(context.Background(), d, proc, zctx, cr, driver.Config{
+			ReaderSortKey: inputSortKey,
+		})
 		require.NoError(t, err)
 		outData := strings.Split(outbuf.String(), "\n")
 		sort.Strings(outData)

--- a/python/src/zqext.go
+++ b/python/src/zqext.go
@@ -74,13 +74,8 @@ func doZqlFileEval(inquery, inpath, informat, outpath, outformat string) (err er
 		}
 	}()
 
-	fg, err := driver.Compile(context.Background(), query, zctx, rc, driver.Config{})
-	if err != nil {
-		return err
-	}
 	d := driver.NewCLI(w)
-
-	return driver.Run(fg, d, nil)
+	return driver.Run(context.Background(), d, query, zctx, rc, driver.Config{})
 }
 
 func main() {}

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -91,14 +91,13 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 	defer cancel()
 
-	srch, err := search.NewSearchOp(ctx, s.Storage(), req)
+	srch, err := search.NewSearchOp(req)
 	if err != nil {
 		// XXX This always returns bad request but should return status codes
 		// that reflect the nature of the returned error.
 		respondError(c, w, r, err)
 		return
 	}
-	defer srch.Close()
 
 	out, err := getSearchOutput(w, r)
 	if err != nil {
@@ -107,7 +106,7 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", out.ContentType())
-	if err := srch.Run(out); err != nil {
+	if err := srch.Run(ctx, s.Storage(), out); err != nil {
 		c.requestLogger(r).Warn("Error writing response", zap.Error(err))
 	}
 }

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -81,15 +81,12 @@ func (s *SearchOp) Run(ctx context.Context, store SearchStore, output Output) (e
 	}
 	defer rc.Close()
 
-	if err := driver.Run(ctx, d, s.query.Proc, zctx, rc, driver.Config{
+	return driver.Run(ctx, d, s.query.Proc, zctx, rc, driver.Config{
 		ReaderSortKey:     "ts",
 		ReaderSortReverse: true,
 		Span:              s.query.Span,
 		StatsTick:         statsTicker.C,
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 // A Query is the internal representation of search query describing a source

--- a/zqd/storage/filestore/filestore.go
+++ b/zqd/storage/filestore/filestore.go
@@ -135,12 +135,8 @@ func (s *Storage) Rewrite(ctx context.Context, zctx *resolver.Context, zr zbuf.R
 }
 
 func (s *Storage) write(ctx context.Context, zw zbuf.Writer, zctx *resolver.Context, zr zbuf.Reader) error {
-	out, err := driver.Compile(ctx, zngWriteProc, zctx, zr, driver.Config{})
-	if err != nil {
-		return err
-	}
 	d := &zngdriver{zw}
-	return driver.Run(out, d, nil)
+	return driver.Run(ctx, d, zngWriteProc, zctx, zr, driver.Config{})
 }
 
 // Clear wipes all data from storage. Will wait for any ongoing write operations

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -588,10 +588,6 @@ func runzq(path, ZQL, outputFormat, outputFlags string, inputs ...string) (out s
 		outputFormat = "null"
 		zctx.SetLogger(&emitter.TypeLogger{WriteCloser: &nopCloser{&outbuf}})
 	}
-	muxOutput, err := driver.Compile(context.Background(), proc, zctx, rc, driver.Config{})
-	if err != nil {
-		return "", err.Error(), err
-	}
 	var zflags zio.WriterFlags
 	var flags flag.FlagSet
 	zflags.SetFlags(&flags)
@@ -605,7 +601,7 @@ func runzq(path, ZQL, outputFormat, outputFlags string, inputs ...string) (out s
 	}
 	d := driver.NewCLI(zw)
 	d.SetWarningsWriter(&errbuf)
-	err = driver.Run(muxOutput, d, nil)
+	err = driver.Run(context.Background(), d, proc, zctx, rc, driver.Config{})
 	if err2 := zw.Flush(); err == nil {
 		err = err2
 	}


### PR DESCRIPTION
Combine the existing driver.Compile and driver.Run calls into driver.Run, and stop exporting the mux related names. I did this mostly because I wanted to add the extra `context.WithCancel` call into the new driver.Run, so that any resources needed for executing the ZQL (like the parallel scanner setup in #1074) would be released as soon as possible.

There was only one user of MuxOutput, the search api handler in zqd. It sent the stats after a successful search query. I maintained that behavior (and verified that Brim tests still work) by sending the stats at the end of a successful run, if a stats timer had been configured.

