### PR TITLE
zqd listen: add -loglevel flag

### DIFF
--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -38,22 +38,6 @@ The listen command launches a process to listen on the provided interface and
 	New: New,
 }
 
-// defaultLogger ignores output from the access logger.
-var defaultLogger = &logger.Config{
-	Type: logger.TypeWaterfall,
-	Children: []logger.Config{
-		{
-			Name:  "http.access",
-			Path:  "/dev/null",
-			Level: zap.InfoLevel,
-		},
-		{
-			Path:  "stderr",
-			Level: zap.InfoLevel,
-		},
-	},
-}
-
 func init() {
 	root.Zqd.Add(Listen)
 }
@@ -81,7 +65,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	f.BoolVar(&c.pprof, "pprof", false, "add pprof routes to api")
 	f.BoolVar(&c.prom, "prometheus", false, "add prometheus metrics routes to api")
 	f.StringVar(&c.configfile, "config", "", "path to a zqd config file")
-	f.Var(&c.logLevel, "loglevel", "level for log output")
+	f.Var(&c.logLevel, "loglevel", "level for log output (defaults to info)")
 	f.BoolVar(&c.devMode, "dev", false, "runs zqd in development mode")
 	f.StringVar(&c.portFile, "portfile", "", "write port of http listener to file")
 	return c, nil
@@ -211,12 +195,27 @@ func (c *Command) initZeek() error {
 	return nil
 }
 
+// defaultLogger ignores output from the access logger.
+func (c *Command) defaultLogger() *logger.Config {
+	return &logger.Config{
+		Type: logger.TypeWaterfall,
+		Children: []logger.Config{
+			{
+				Name:  "http.access",
+				Path:  "/dev/null",
+				Level: c.logLevel,
+			},
+			{
+				Path:  "stderr",
+				Level: c.logLevel,
+			},
+		},
+	}
+}
+
 func (c *Command) initLogger() error {
 	if c.loggerConf == nil {
-		c.loggerConf = defaultLogger
-		for i := range c.loggerConf.Children {
-			c.loggerConf.Children[i].Level = c.logLevel
-		}
+		c.loggerConf = c.defaultLogger()
 	}
 	core, err := logger.NewCore(*c.loggerConf)
 	if err != nil {

--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -81,7 +81,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	f.BoolVar(&c.pprof, "pprof", false, "add pprof routes to api")
 	f.BoolVar(&c.prom, "prometheus", false, "add prometheus metrics routes to api")
 	f.StringVar(&c.configfile, "config", "", "path to a zqd config file")
-	f.Var(&c.logLevel, "loglevel", "level for log output (defaults to info)")
+	f.Var(&c.logLevel, "loglevel", "level for log output")
 	f.BoolVar(&c.devMode, "dev", false, "runs zqd in development mode")
 	f.StringVar(&c.portFile, "portfile", "", "write port of http listener to file")
 	return c, nil

--- a/tests/suite/zqd/services.sh
+++ b/tests/suite/zqd/services.sh
@@ -33,7 +33,7 @@ export AWS_ACCESS_KEY_ID=minioadmin
 export AWS_SECRET_ACCESS_KEY=minioadmin
 export AWS_S3_ENDPOINT=http://localhost:$(cat $portdir/minio)
 
-zqd listen -l=localhost:0 -portfile="$portdir/zqd" -data="$zqdroot" 2> zqd.error &
+zqd listen -l=localhost:0 -portfile="$portdir/zqd" -data="$zqdroot" -loglevel=warn &
 zqdpid=$!
 trap "rm -rf $portdir; kill -9 $miniopid $zqdpid" EXIT
 


### PR DESCRIPTION
Add -loglevel flag to set the level of printed logs. If logging
is specified in the passed zqd config, this flag will be ignored.