### PR TITLE
Return nonvolatile records from zngio.zngScanner.Pull

### DIFF
--- a/tests/fixedbugs/issue1087.yaml
+++ b/tests/fixedbugs/issue1087.yaml
@@ -1,0 +1,456 @@
+script: zq -t -
+
+inputs:
+  - name: stdin
+    data: !!binary |
+      gAwHdmVyc2lvbgcGc2VyaWFsCwdzdWJqZWN0CwZpc3N1ZXILEG5vdF92YWxpZF9iZWZvcm
+      UQD25vdF92YWxpZF9hZnRlchAHa2V5X2FsZwsHc2lnX2FsZwsIa2V5X3R5cGULCmtleV9s
+      ZW5ndGgHCGV4cG9uZW50CwVjdXJ2ZQuBC4ENgAQDZG5zGAN1cmkYBWVtYWlsGAJpcBmAAg
+      JjYQAIcGF0aF9sZW4HgAYFX3BhdGgJAnRzEAJpZAsLY2VydGlmaWNhdGUXA3NhbhoRYmFz
+      aWNfY29uc3RyYWludHMbhgDSfv4e818c3AIKeDUwORJwKIEL7Uk9KiRGb0M1Mlh3ZmdmT3
+      RJbGRNMY0EBANCMDE3RTQ1QTMxQUE1MEJDMzUwNTNCQzUwRjlCNjlCQUTKAUNOPSouc2Vy
+      dmljZXMubW96aWxsYS5jb20sT1U9Q2xvdWQgUx4AQixPPU0gAPZEIENvcnBvcmF0aW9uLE
+      w9TW91bnRhaW4gVmlldyxTVD1DYWxpZm9ybmlhLEM9VVNsQ049RGlnaUNlcnQgU0hBMiBT
+      ZWN1cmUgU2VydmVyIENBLE8hAPYnSW5jLEM9VVMSAMAUO3/60ykSAAA/AoMD0CsccnNhRW
+      5jcnlwdGlvbjBzaGEyNTZXaXRoUlNBGAD/Aghyc2EGAAgMNjU1MzcAY1su4AADIypz1wAI
+      9QCTAQEBCQQAABzdXwH/DAA1Ax/tST0qJkZNSmN3czJQbXVON2FBaUo5a2AB/ysTvGABQl
+      DgEFxgAfUxZnpaN1kxZHZlU0RpTlI0eWffAwQDQjBDQTlDNjQzNjFCRkM5MkE3OUIxREQ5
+      Q0ZCOUU0OEVDnAFDTj0qLmNkbsYBP25ldKkCX+/wENTuBikSAAAPQV6/3qkCIj1PRyTJAB
+      sgEAAEnwIEPwEzoPf9PwH/AkM0MkdsM1JTMzNiV2tiQXlhPwH/ChPePwFCACLiZj8B9Cd4
+      bW9UYzJFclpINllOY3BoNqcEBAMiNjNDQTBBODFGQUQ4OUFFNmBDTj0qLmZveGl0Y2xvdW
+      QnBfQWRG9tYWluIENvbnRyb2wgVmFsaWRhdGVkkAJDTj1HbyBEYWRkefQE9DlDZXJ0aWZp
+      Y2F0ZSBBdXRob3JpdHkgLSBHMixPVT1odHRwOi8vY2VydHMuZ29kYWRkeS5jb20vcmVwb3
+      NpdG9yeS8sTz1Hb0QaAPIPXCwgSW5jLixMPVNjb3R0c2RhbGUsU1Q9QXJpem9ugQX/AhIA
+      QGVLhZp6KRIAPIIh0X14ogIiPEtDIv4AGh4PAASgAhOcYQFC8O9LZ2EB8iZMdkw0bDJvZH
+      A5Yjh1WDNsYcUDBAMiNUI2QTM3RjM5QjM2QUY3RoQBQ049d3d3Lmdvb2dsZWABvz1Hb29n
+      bGUgSW5jbAYQNnpDTjEAZ3Rlcm5ldGcBJkczUABWVHJ1c3TdBgJzBv8QyDzLm6kzKhIAAI
+      lDci9nKh5pZC1lY1B1YmxpY0tleXQGBfoJDGVjZHNhBgABABZwcmltZTI1NnYxKSEezAAM
+      HwFC4LRObh8B/wJsZkg1aDJHRGFhZEpBVE9QOR8B6cLyBQp4NTA5EpAi7o0fAfMoaEM3M2
+      gxdzF3emZnak5GQziHBAQDQjBFMTFCQkQ3MEQ1NEI3MTBEMEM2RjU0MEI2QjUyQ0E0it0I
+      tHRhY2tleGNoYW5nUwJzU3RhY2sgRRUABkMD/QZOZXcgWW9yayxTVD1OWSxDPVVTpAG+CN
+      lIaWdoIEFzc3VyYW5jxgjjVT13d3cuZGlnaWNlcnRtAA/aCAHvfJ4nBqEoEgDAE8BXvnWP
+      AyJfkQeHByjfAAD0AyRzdGFja292ZXJmbG93LmNvbSYACBQA9w4cc3RhY2thdXRoLmNvbR
+      hzc3RhdGljLm5ldBwqLg4A8gIgc2VydmVyZmF1bHQuY29tJE4JBxIA+QIcc3VwZXJ1c2Vy
+      LmNvbSAqLhAAA2gA4nBwcy5jb20qb3BlbmlktQAEfQACsQAIogGNMioubWV0YS4ZAA8XAA
+      RVIm1hdGjeAGxuZXQmKi4TAKMcYXNrdWJ1bnR1pwAJEAAChACDc25pcHBldHNDAEVibG9n
+      VgBMY29tIhEACagACCoAEyyYAQUUAGplbWFpbCiaAVRlbWFpbBQEBPUCM3A/8fUC/wJjdT
+      hjMzIyQldFbVBOVW1lZvUC///BIqUJ6gVCgATFnvUC/x1vU0E2VzJ0RklBWWJla0llaMED
+      BAMiN0FFRTc3RDBBQTg3NEQzQYABQ049KiYIZ99MCE1PrDMqEgCwFzSOJggsWL0Osw4azA
+      D3CxwqLmFuZHJvaWQuY29tLiouYXBwZW5naW5lJQCHJiouY2xvdWQTALUqKi5kYjgzMzk1
+      MxYA9AluDiouZy5jbx4qLmdjcC5ndnQyLmNvbS5wAPQALWFuYWx5dGljcy5jb20YFwBELm
+      NhGCMARi5jbB4MAElvLmluDwApanAPADd1ayAtAEttLmFyEAAadRAAKmJyEAAqY28QACpt
+      eBAAG3QwACZ2brUAJmRlDAAmZXMMACZmcgwAJmh1DAAmaXQMACZubAwAGHAMACR0JsAAY2
+      FkYXBpcz0GAuMAAhEAJG4qEACDY29tbWVyY2UpBwIlANN2aWRlby5jb20aKi5nWQc3Y24c
+      DQCWb20WKi5ndnQxCwDoMi5jb20qKi5tZXRyaWMrAPMEGioudXJjaGluLmNvbSIqLnVybG
+      kAAy8C9QZ5b3V0dWJlLW5vY29va2llLmNvbRwXAAolAPUTZWR1Y2F0aW9uLmNvbRAqLnl0
+      LmJlGCoueXRpbWcuY29tNosCZ2xpZW50c9wBFRgbAMVvbThkZXZlbG9wZXK8AgSUACVuOh
+      wAHnMdANIKZy5jbw5nb28uZ2wqMwAKlAISFhUAUi5jb20mCwAIZQF+MnNvdXJjZXUAFhYk
+      ARMWhQvTLmdsEnlvdXR1LmJlGCUBUy5jb20qDAAJDAFkDHl0LmJlnQcTw9AMQlCDDaioBP
+      MuQzhoZ0QxOU5FaGJkNlU5NWT1AwQDQjAzMjM3QTc4QzRFMkU0M0VBOTdGQ0QwQkM2MkFC
+      M0IzsgFDTj1sb3MBD4ESAQdkE19Gb3VuZGMTTv8APN//aKApEgDA69+R/W4qYxMhP0c/PN
+      QACgRGAQTuBVLw+5QW7lUT/wFmS3doM1NJbmVHOG9Ka1c37gX/////dhOq7gVC0O+4I6gE
+      8xdRaWFobDNUczJiUTNoWXgwOLsDBAMiNkYyQUIzQzhEMTA0RUQ4N3AQOGFwaScHBnESD8
+      ESUld0AvfvqMESDzQZIT1PRyTHABsgEAAE1QUT9y0BQnAAE1AtAfgYRkVaNm8yMHpqeDAy
+      UHp1T2TJAwQDIjFEREVFOEM1RDNBRUYzMTSIwwsCSAkPLAFeX3xXHlCrxws0VNkBzwEi8w
+      kF0AAUKjgJFzYSAhMyvAuUZW5kcG9pbnRzLwAC0wsNFwASHk0CBCYABHoBIv8BPQ34VlBC
+      JrHuST0qJEZ0V2J2bTZLV09JdTJjdVY35wIEA0owNDNBNzdGNERFODk1M0YyNjg3MzcyNk
+      UzQzZBQUVDMjcyNUEkQ049aXNlLndyY2NkYy5vcmdmQ049TGV0J3MgRW5jcnlwRRVKWDMs
+      Tx0AAz0V/wCIvDHuWzMqEgBI1/vXlWp8AiQXJooAh2NwcC5lZHUeEwA0b3JnAgET3zQRUl
+      Bw6SjvRhryN0c4OGoxbk5XWEVEdUhjUzbPBAQDQjBBODAzOTQxOEI2RjJCRkRDODRBMkM5
+      MkQwMEJDMkNCtgFDTj1lbHEuc3ltYW50ZWOMAvMAVT1NYXJrZXRpbmcsTz1THAAP/BwcR8
+      ABQ048AGRsYXNzIDMMGAUAHYYgLSBHNCxPVSoAAp4Wf05ldHdvcmt/AAUCdwH/AMAMz0mQ
+      YCkSACzHWUY3UXcBIqyjBpkGLGRlbW8uCAEcIhEAbS5lbWFpbCgAjTJlbXBvd2VyGQBtLm
+      V2ZW50FwCNMmV4cGxvcmUZAI40aW5ub3ZhdBoAXSxrbm93FgBvMnByb3NweQAAMzRyZR8M
+      DGMAXi5zb2x2FwCtNnRyYW5zZm9ybWUAXi50cmlh9QASJhcACDgCAioASXdhcmVPAl8wd2
+      9uZKUAAF0sd29ya28ABOQDIvUD5ANCYJhGk+IC8il6WFo4eDJyQ1VwWmNaU2QxNOUGBANC
+      MEU1OThFQjU0QUY3OTc1REU4RUZENjM1NTZFQTRCMUbeA1kZWy1zZWN1mgD/JyxPVT1Db3
+      JwIE1rdGcgJiBDb21tcyAtIE9ubGluZSBFeHBlcmllbmNlICYgT3BlcmF0aW9uc5MCBQ+i
+      GQ/5HixzZXJpYWxOdW1iZXI9MjE1ODExMyxqdXJpc2RpY3Rpb25TVD1EZWxhd2FyZRgA/h
+      xDPVVTLGJ1c2luZXNzQ2F0ZWdvcnk9UHJpdmF0ZSBPcmdhbml6YXRpb26utReERXh0ZW5k
+      ZWSfGzZpb26AAw+6Fxj/ANTdNDQ2KhIAwPOaWPwwK20DIT87MzCMAQQN+AEznG+T2gT/AV
+      NUVzUyY243b3ZUSXZKV2j4Af/MIymX+AH/Ak1mejVGNFNBRVJqbEZGT0Vn+AH/wxO6RgtS
+      oA9Kl+/PJfImdkIxTDNpZDNwYkQ4a2Zw2QMEA0IwNTI0MjZGMUNENzE0NjEwNjI3MTZEMT
+      UwRDRGRUQ1RpbPJfIKZnJlc2hhZGRyZXNzLmJpeixPPUZyZXNoQRMACe8c/wV0b24sU1Q9
+      TWFzc2FjaHVzZXR0c7UlK+/QifdVXykSAMCDLVhdUyEFIj5TSybGABwiEQAELQUT2FgSQl
+      BE5ZklB/MoWVMyNzY0cEVINVlUYWNxaDOvBgQDQjA3Q0E3MDRGMUFGQUYxNzhGMkFEQjI4
+      OURFMzg1MUFBqCUHCbgHDx4HDw8KB+bvYhWnujsqEgDAdbB6Y4k7FCKZtQyrDCR3d3c0dA
+      EcIoUB8gIgd3d3LnNreWN1cmUuY29tKNMVDjUA+QNibHVlY29hdC5jb20mc2l0ZXMkAKku
+      c2l0ZXMtdWF0FwASLBcAKXFhFgASOBYAiWludGVybmFsHAD5AjxzZWN1cml0eXJlc3Bvbn
+      NlHgBJInNjbREAmSxwYXJ0bmVyc6EAEzAWACtuZY8ABxgAtm5vcnRvbi5jb204FgANwQAW
+      NDIAOC11YTYAFzoaAEl0ZW1wlwAIUwAqc2mFABc2HAALGQEaMhsABm0AF0IZAA83AQIfPi
+      EAAQZAADkgbXmgAD0obXnrADwmbXmQACkebdYAGyAZAjgeZ288AkkgZ2V0TAJaZm9ydW0o
+      AgQUAAiuAVQ+Y2RuLvcBAv8lCKwARSxidXmHAAIfAEhjb20iFgAFQyAIfwB7LGJjcG9ydE
+      UMDNsEM+Cd59sE/wJGd0MwMDFYbmpmWUZ2M3BWZdsE/////7EzUCDr2wT/AWVQWTZoMWs0
+      Y0l1a0ZTY0zbBP////+qE9eRDiKQvNsE/wMkRjU4TWxnbUpOcWdxd0M3dWnaBP////+pBG
+      sTM7BL9rUJ/wJPSkxHNDJjekptTlVWSkQzONsE/////5UAqBMCkhOQb20BAQEJBAAAhgCi
+      e+Io83Uc2AkKeDUwORKQwf+Z70k9KiZGem8zdmY0dUtWQ0RVa25HYTivBgQDQjA3Q0E3MD
+      RGMUFGQUYxNzhGMkFEQjI4OURFMzg1MUFBqANDTj13d3cuc3ltYW50ZWMuY29tLE9VPUNv
+      cnAgTWt0ZyAmIENvbW1zIC0gT25saW5lIEV4cCxPPVMxAPlNIENvcnBvcmF0aW9uLEw9TW
+      91bnRhaW4gVmlldyxTVD1DYWxpZm9ybmlhLEM9VVMsc2VyaWFsTnVtYmVyPTIxNTgxMTMs
+      anVyaXNkaWN0aW9uU1Q9RGVsYXdhcmUYAPJbQz1VUyxidXNpbmVzc0NhdGVnb3J5PVByaX
+      ZhdGUgT3JnYW5pemF0aW9urgFDTj1EaWdpQ2VydCBTSEEyIEV4dGVuZGVkIFZhbGlkYXRp
+      b24gU2VydmVyIENBLE9VPXd3dy5kaWdpY2VydAQBBkIA9idJbmMsQz1VUxIAwGIVp7o7Kh
+      IAwHWwemOJKhxyc2FFbmNyeXB0aW9uMHNoYTI1NldpdGhSU0EYAPkICHJzYQYACAw2NTUz
+      NwC1DKsMJHd3dzR0ARwihQH+CCB3d3cuc2t5Y3VyZS5jb20od3d3LmdvNQD5A2JsdWVjb2
+      F0LmNvbSZzaXRlc80BqS5zaXRlcy11YXQXABIsFwApcWEWABI4FgCJaW50ZXJuYWwcAPkC
+      PHNlY3VyaXR5cmVzcG9uc2UeAEkic2NtEQCZLHBhcnRuZXJzoQATMBYAK25ljwAHGAC2bm
+      9ydG9uLmNvbTgWAA3BABY0MgA4LXVhNgAXOhoASXRlbXCXAAhTACpzaYUAFzYcAAsZARoy
+      GwAGbQAXQhkADzcBAh8+IQABBkAAOSBteaAAPShteesAPCZteZAAKR5t1gAbIBkCOB5nbz
+      wCSSBnZXRMAlpmb3J1bSgCBBQACK4BVD5jZG4u9wFZY2xvdWR2AEUsYnV5EQACHwBIY29t
+      IhYAmC5jb20iYmxvZ38AlSxiY3BvcnRhbD0A8gkuY29tAQEBCQQAABy9Agp4NTA5EjAPQN
+      rbBPI2Zzc4a0M0emFPMkx0OWkyVWyHBAQDQjAyNjZCN0M1MDQ5MDBBOEE4NEZGNUM1MUUw
+      M0ZGQjY3xAFDTj0qLnQuZWxvcXVh1QP0ClU9T3JhY2xlIEVMT1FVQSBUT1JPTlRPLE8YAA
+      rOBM9SZWR3b29kIENpdHnNBAAdbGgEaFNlY3VyZVsED0cEAf8AADT5fEkeKhIAAMnlt6v+
+      RwQiOikhHt0ABEABE+5AAULgb3/4QAH/VzR5MjZFNFdxS3VhdFk0NVo4gQQEA0IwRUQ0RD
+      g5MjQ3MTk4MzAwQkRCNEIxNDZDOTFFMTE2NIQBQ049Ki5td2JzeXMuY29tLE89TWFsd2Fy
+      ZWJ5dGVzIEluYy4sTD1TYW4gSm9zZSABAC2kASEB2UhpZ2ggQXNzdXJhbmMpAQ+EBRX/AQ
+      AIn+ElGCoSAMCPT6h8ACw9ASFYjwGFARrcABYW5wCXKG1iYWMtZGV2HwCnKm1iYWMtcHJv
+      ZBUABHEBIp8DsQLzS1CttOryST0qJEZyY2Z5VnFZQllXVlJxTTFo8wMEA0IwNTM1OTVERE
+      M0ODhFM0JEMjE4NTMxNkM5RTAyNEE1N7ABQ049c2hhdmFyLnNlcnZpY2VzLm1vemlsbL0C
+      Ij1NDgAPcwccD6YCJf8BwNgbxUT7JxIAwA9sGuCeKmkBIV+BAvcBONUACP8FUnRyYWNraW
+      5nLXByb3RlY3Rpb27+AAIUPCkADx4AAhMuYwACogGUb3phd3MubmV0ogET3RMD/zfw0SIb
+      9Ek9KiZGS3U5c2kzZFJKczNGcHlqV2GNBAQDQjAxN0U0NUEzMUFBNTBCQzM1MDUzQkM1ME
+      Y5QjY5QkFEygFDTj0qggACsyxPVT1DbG91ZCBTvAEPsAFf/wAUO3/60ykSAAA/AoMD0Cuw
+      ASE/Y1su4AADHyoVAAEEYAETu2AB8jHAouYp9Ek9KiRGbmNuak1YOWc5dGRVcDBnZ98DBA
+      NCMENBOUM2NDM2MUJGQzkyQTc5QjFERDlDRkI5RTQ4RUOcXwE1Y2Ru+AI/bmV0SAFf7/AQ
+      1O4GKRIAAA9BXr/eSAEiPU9HJMkAGyAQAAQ+ARPDPgFCoMgmKp4C/zBqbVh2RzNOZFFVNV
+      lUOTJYNfUDBANCMDMyMzdBNzhDNEUyRTQzRUE5N0ZDRDBCQzYyQUIzQjOyAUNOPWxvY2FF
+      AwYHkwJCRm91bggLD7ULEA9CBCbvPN//aKApEgDA69+R/W4vCyI/Rz881AAKDEYBQnB2Iy
+      1GAf8CdTJPb3oyVGQ3ek1vbkN1NWFGAf8RE5vMBkKwYQZWRgH2Pml3c1F1M0pMeWpNYUVD
+      NUxrnQQEA0IwNDQxODYzQjgxRTZDNUJBQjA2MEIyMDMxRDFEMTExRdoBQ049dmVyc2lvbm
+      NoZWNrLmFkZG9u0QY/b3JnMwUKD6ACUv8BANjwCCQ7KRIAAGf1lAbrK+IGIV/NAcMBQOoA
+      DBhGIAA/LWJnDQEArzpibG9ja2xpc3QdAAAE5AIEngE08CspngH/AUpJUzExV0JHcUtxY3
+      JJZWieAf9pE67IBUJAa55bBgf1L3NPeUdyUEdzZVpTZENkejbnAwQDQjA3MTA4QjIwOUVE
+      MzQ1NkNFRTg4OTQ5MTQ0QzQ1NjBDpAFDTj1hdXM1BQcDLAMvSVTABV7v8K72F6QpEgDAdZ
+      0uIXUKByI8LSUizQAEzwITrDEB/wlQosVb9Ek9KiBGRnBJUVczZHZxZW9BeHAvAfwTvC8B
+      QrBTjMT+A/8Cd3Qxb3czamhXcnRSYXdBdmJnCf8KBD8BM4Bsnj8B/wJkZXFJWjFsbjBCWD
+      RDbGFxND8B/woTqT8BUjD7v0D13gTyFmlHdEsxQVIxNGxzMm1TVLsDBAMiNkYyQUIzQzhE
+      MTA0RUQ4N4rUC7NhcGlzLmdvb2dsZUsQr0dvb2dsZSBJbmOBChA2ekNOMQD2BHRlcm5ldC
+      BBdXRob3JpdHkgRzNQAFZUcnVzdIQNArcV/wF0AvfvqDMqEgAAiUNyL2cq6AchPU9HJMcA
+      GyAQAATZBBOlnhfyIiB0z0D1ST0qJkZuZnBvcjRpZms4bUkyeDJUbMEDBAMiN0FFRTc3RD
+      BBQTg3NEQzQYAtAQ8oAWb/EEwITU+sMyoSALAXNI4vZyoeaWQtZWNQdWJsaWNLZXngFgX4
+      CwxlY2RzYQYAAQAWcHJpbWUyNTZ2Mb0Osw4azAD3CxwqLmFuZHJvaWQuY29tLiouYXBwZW
+      5naW5lGQKHJiouY2xvdWQTALUqKi5kYjgzMzk1MxYA9AluDiouZy5jbx4qLmdjcC5ndnQy
+      LmNvbS5wAPQALWFuYWx5dGljcy5jb20YFwBELmNhGCMARi5jbB4MAElvLmluDwApanAPAD
+      d1ayAtAEttLmFyEAAadRAAKmJyEAAqY28QACpteBAAG3QwACZ2brUAJmRlDAAmZXMMACZm
+      cgwAJmh1DAAmaXQMACZubAwAGHAMACR0JsAApWFkYXBpcy5jb22TAAIRACRuKiMA1GNvbW
+      1lcmNlLmNvbSQVAPcIdmlkZW8uY29tGiouZ3N0YXRpYy5jbhwNAJZvbRYqLmd2dDELAOgy
+      LmNvbSoqLm1ldHJpYysA+AQaKi51cmNoaW4uY29tIioudXJscQH1CCoueW91dHViZS1ub2
+      Nvb2tpZS5jb20cFwADVAIDDgAzZWR1Bw/1CWNvbRAqLnl0LmJlGCoueXRpbWcuY29tNosC
+      Z2xpZW50c9wBFRgbAMVvbThkZXZlbG9wZXK8AgSUACVuOhwAHnMdANIKZy5jbw5nb28uZ2
+      wqMwAKlAISFhUAUi5jb20mCwAIZQF+MnNvdXJjZXUAFhYkARIWERrjby5nbBJ5b3V0dS5i
+      ZRgAAVMuY29tKgwACQwBbAx5dC5iZagEM6Cg0qgE/wJlYUFQUDJaMEp6WktvdU5CaqgE//
+      ///3YT3vgQQnB18oV8CvI1MUhTb3RpcDZYTVIzeWdKa6UGBANCMEFEOUIwMDgwMTcxODU1
+      Njc5MkNENUM2RkMxMjQyMUSeA0NOPWR1Y2tkdWNrZ28SHPQAPUR1Y2sgRHVjayBHb1ws1h
+      r1A1Bhb2xpLFNUPVBlbm5zeWx2YcIg+hZwb3N0YWxDb2RlPTE5MzAxLHN0cmVldD0yMCBQ
+      YW9saSBQaWtl6CB5NTAxOTMwM9AgD+ggiu9QMUCghikSAMBzVe2IbLkVIjpPRx5sAVomd3
+      d3Ln8BBIkGE7NdDEKAvHWSiQb7LTNxc2ViMWZqNUVYczI4NG410QMEA0IwODZDM0I0M0Uz
+      MTdDMzVFQjcwOEYzMTM4N0YzOEE2Qo4BQ049KmUAD+QBIA/xFibvBAE3T4opEgDArY5DfZ
+      84ASI8S0MiwgALSQEENgET+DYBQzAr2uE2AfNIbEZVSjFIVENFaU9qQ3ZGNu8EBAMaQ0M1
+      N0ZFNTQwMTFFmgN1bnN0cnVjdHVyZWROYW1lPTEzMTU2NTY5MDFcLDU2NGQ3NzYxNzI2NT
+      IwNDk2ZTYzMmUsWRjyJWxob3N0LmxvY2FsZG9tYWluLGVtYWlsQWRkcmVzcz1zc2wtY2Vy
+      dGlmaWNhdGVzQHZtd2G+IuQsT1U9Vk13YXJlIEVTWCAflkRlZmF1bHQgQzUAkixPPVZNd2
+      FyZYsDzyxMPVBhbG8gQWx0b2EeABQmLgD/DSBJbnN0YWxsZXISADgZTs17hCQSAHi6nznt
+      li7uDSE/Ny8s8QACDHsBQpBAKuV7Af8COTNpV3czdEhsNkM0cXVsVmd7Af9GE9r2AvMu4G
+      1NB/dJPSokRmJDZksxOWw2RlJrb0FmZWylBAQDIjAxRkJCRDAwMTcyRDlGNjReQ049Ki53
+      b3JkcHJlc9Eg9AFVPURvbWFpbiBDb250cm9sHyb0AGVkkAJDTj1HbyBEYWRkedchB6gCB3
+      8Q9CMtIEcyLE9VPWh0dHA6Ly9jZXJ0cy5nb2RhZGR5LmNvbS9yZXBvc2l0b3J5LyxPPUdv
+      RBoAAuQC8gkuLEw9U2NvdHRzZGFsZSxTVD1Bcml6b25vBv8CEgA05cY4EQMoEgB4nZ4oGr
+      tVBCI7Rz8g/QAZHA4ABNgCE9tdAVLAlk4H97oQ/wE2TDFRMklqRW9YbnhVU3NrXgH/KROR
+      XgFCMAIOy14B809DRVd3ZzNzOWNFRzZibXNYafcCBANKMDNCNTU0QjBFRTZGRTNCMjFBOT
+      YyODUzQzY4NDg5QkNFNDVENENOPW5pYmJsZXIud3JjY2RjLmNwcC5lZHVmQ049TGV0J3Mg
+      gygHrAJKWDMsTx0AA2UC/wG88wUPtR8qEgB8DtD47lYqNQUhP2FZLpIAA0Iob3duICYDqg
+      AHBRgU6xQB8jGLW5f6ST0qJkZxM05OcTNUNWZONG9mRWgxM9UEBANCNTIwNzg2RTBGQjU3
+      QzgxRDhGM0ExNEI4REZERTVEREK8PBNSaW50ZWzaCfsRVT1JbmZvcm1hdGlvbiBUZWNobm
+      9sb2d5LE89SW50ZWxHI79TYW50YSBDbGFyYWoGAEfAAUNO9CpkbGFzcyAzGAQFSiqGIC0g
+      RzQsT1UqAAKQFH9OZXR3b3JrNysFAoMB/wDAxq/ozropEgAsdba3f5uDASI3Ny8YBAEVFA
+      oABOADE+puAf8LEHyPl/pJPSokRmlFbVl6RnV1T3FWb2ZFdmZtAf85E+VtAVJwQHr2+u8D
+      9TswQTd5MUE4YjlaNWF1WkVnyQQEA0I2OTc3MjRGMkRFNzBGMkZFMDVBNDQ1MzlDREMyNU
+      M4ObABQ049c2FkbWluLmJyaWdodGNvdlcJ9QBFbmdpbmVlcmluZyxPPUIgAANbF/IHQm9z
+      dG9uLFNUPU1hc3NhY2h1c2V0dBoXD9UCUe82HeltmCkSACxpMoqJi70GIj83Lyz+AAIE1Q
+      IirgaBJ/M8ABWyCftJPSokRlJsamtMMjVDN0RhWmlVVWyxAwQDQjBDQ0MwMTIyNTYwNEZC
+      QkFFQzM1QTQ4Mjk5NjNCMjJGcENOPSoucXVhbHRyOhZELE89URAA/wVcLCBMTEMsTD1Qcm
+      92byxTVD1VVC0MKv8AAC43Zk4WKhIAwGFeOiyj8AMiW+EI1wggtQBuKCouYXUxFAAeehQA
+      K2NvFABdJioudXM7ADp1czIYAVsoKi51dDsAeioqLmFzaWEpAF0mKi5ldVAAK2NhPAD6AT
+      wqLnNpdGVpbnRlcmNlcHQyAHkMcWwudGMcWQB6KmIxLXBydikAPy4qLhcAAV80Ki5zMRoA
+      AmooKi5zdDNuAEsmZ292nwA+KiouFQATRhUAD7kACH0qKi5jb3JwpQAuczF3AP4FEioucT
+      AxLnVzDnEwMS51cyZpYWSHAA8VAABqZzEtaWFkKgA/LiouFwABBDEDE68xA1LAYLUJ+wsd
+      /wFvS1lEMmgySEZnZE1OR3gxMgP///4UzIIU8yWKwAv7ST0qJEZRcUROMk42YkNMQUc5RX
+      Y0xQMEAyIwRjY2M0E2QTM2NEMzNkJElAFDTj0qXRoKARoGsx4CqAcPOTUNDwMfLFc08lxa
+      q9sdD20GIVSJA/8CLv8bCs4A/wUoYXBwLW1lYXN1cmVtZW50LmNvbfgaAgMVAKJ0YWdtYW
+      5hZ2VytzRnZXJ2aWNlAhxPMnNzbDgBAgcCGxMyAhsNjgAHGQAKaQAEAQUTzc8BQjAh3g8B
+      Bf8CSUFMd1cxT3ZRaGJHVkRMejHQAf+bE95qC0IwJsIX0AHyIjEyWXpuMTZYbG5Pc2hJQW
+      VhpwQEAyI2M0NBMEE4MUZBRDg5QUU2YENOPSouZm94aXSgDgOrFA8WEpD/AUBlS4WaeikS
+      ADyCIdF9eCvRAyE8S0Mi/gAaHg8ABDEDBDIIQrAtjCVhAf8CWkRySjIyUld1Y2xLM3ZmMz
+      UyCP//6wCZDOBpY3MuY29tAQEBCQQAAIYAp3+vIvRQHK4GCng1MDkSYGK2JftJPSokRktp
+      M3JtNmVxYmpaajRSMGqxAwQDQjBDQ0MwMTIyNTYwNEZCQkFFQzM1QTQ4Mjk5NjNCMjJGcE
+      NOPSoucXVhbHRyaWNzLmNvbSxPPVEQAPYuXCwgTExDLEw9UHJvdm8sU1Q9VVQsQz1VU2xD
+      Tj1EaWdpQ2VydCBTSEEyIFNlY3VyZSBTZXJ2ZXIgQ0EsTyEA9idJbmMsQz1VUxIAAC43Zk
+      4WKhIAwGFeOiyjKhxyc2FFbmNyeXB0aW9uMHNoYTI1NldpdGhSU0EYAPsECHJzYQYACAw2
+      NTUzNwDhCNcIILUAbigqLmF1MRQAHnoUACtjbxQAXSYqLnVzOwA9dXMyYwArdXQ7AHoqKi
+      5hc2lhKQBdJiouZXVQACtjYTwA+gE8Ki5zaXRlaW50ZXJjZXB0MgB5DHFsLnRjHFkAeipi
+      MS1wcnYpAD8uKi4XAAFfNCouczEaAAJqKCouc3QzbgBLJmdvdp8APioqLhUAE0YVAA+5AA
+      h9KiouY29ycKUALnMxdwD+BRIqLnEwMS51cw5xMDEudXMmaWFkhwAPFQAAamcxLWlhZCoA
+      Py4qLhcAAZMBAQEJBAAAHK0xA/8KIMvJJftJPSoiRmltd3d3S3FibTZaMGc0eDAD///+E6
+      8wA/8MAOLNJftJPSomRm5jU04wMlJqYTJLYm90TlZmMgP///7C6wIKeDUwORIw9XgoMgP9
+      m0xNR291MWVzNFcxbWlNZ3Uy1QQEA0I1MjA3ODZFMEZCNTdDODFEOEYzQTE0QjhERkRFNU
+      REQrwBQ049Ki5pbnRlbC5jb20sT1U9SW5mb3JtYXRpb24gVGVjaG5vbG9neSxPPUludGVs
+      IENvcnBvcmF0aW9uLEw9U2FudGEgQ2xhcmEsU1Q9Q2FsaWZvcm5pYSxDPVVTwAFDTj1TeW
+      1hbnRlYyBDbGFzcyAzvwmGIC0gRzQsT1UqAPYAVHJ1c3QgTmV0d29yayxPGQAIfQAC5gn/
+      AMDGr+jOuikSACx1trd/m+YJIjc3LxgEARUUCgAE0AcT6m4BQgCmHi8BC/8BVUlPN0pQUz
+      g5N3JuOFE4bG0B/zkT9m0BQvAC2TZtAfQmeWhFQjlibklLdGNMZjRoNckDBAMiMURERUU4
+      QzVEM0FFRjMxNIgBQ049Ki5nb29nbGVhcGlgDP8LR29vZ2xlIEluYyxMPU1vdW50YWluIF
+      ZpZXewAgA2ekNOMQD2BHRlcm5ldCBBdXRob3JpdHkgRzNQAAKiAoNTZXJ2aWNlc4wC/xB8
+      Vx5QqzMqEgCwFzSOL2cqHmlkLWVjUHVibGljS2V5cwwF/QsMZWNkc2EGAAEAFnByaW1lMj
+      U2djHZAc8BItAA9BcqLmNsaWVudHM2Lmdvb2dsZS5jb20yKi5jbG91ZGVuZHBvaW50c/8A
+      DxcABBoeJQEE5gIT2HkBQqBYB6hUBPIhUTNOSjYxaGVtR3lvN016bjOpBAQDTjMzMDAwMD
+      AwQkQyMzY4RTdCRkMwOERGODlFGAACHAD0CogBQ049ZmUyLnVwZGF0ZS5taWNyb3NvZnRn
+      BHREU1AsTz1NFwD2CixMPVJlZG1vbmQsU1Q9V0EsQz1VU7wBQ04jAH0gVXBkYXRl/w1IID
+      IuMUsAC6MECFcAdWFzaGluZ3Q+BP8AOIJoWNQhKhIA+KRP5uN9PgQiPz01MugABQRbASL/
+      Aa8FQiCnY7TUAvNGOGxQYkswckxBM2d4cnlhbOcCBANKMDQzQTc3RjRERTg5NTNGMjY4Nz
+      M3MjZFM0M2QUFFQzI3MjVBJENOPWlzZS53cmNjZGMub3JnZkNOPUxldCdzIMYOB7MCSlgz
+      LE8dAAP5AP8AiLwx7lszKhIASNf715Vq+QAiN09HJooAimNwcC5lZHUenQAEAgEEXQL/Cz
+      BaNhn8ST0qJkY5alpwMTNLcWZva1g4czhRXQL/JyKnA10C8k1gHHM6/Ek9KiRGQ1dzMU5n
+      U0RmNVk0RGlQNZkEBANCMDhFRThDMDQzRkNCNEU2RTRFNzgyMzUwRkU0NTBFMDmcAUNOPX
+      FhLnNvY2tldHMuc3RhY2tleGNoYW5nZbUDgz1TdGFjayBFFQD2ElwsIEluYy4sTD1OZXcg
+      WW9yayxTVD1OWSxDPVVTpAFDTpYR+QNTSEEyIEhpZ2ggQXNzdXJhbmO/EdNVPXd3dy5kaW
+      dpY2VyIgQGPQAG0xH/AcCSS/UXpCgSAMBZLkoUaiu2AiFf6wHhATroAAlfPmNoYXQHAQd/
+      Qm1vYmlsZSgBB/QDJHN0YWNrc25pcHBldHMubmV0BQMTjKoB8z/QgfLt/Uk9KiZGREczQk
+      wzZ1l4R0ZJc3FYNWbFBAQDIjE1MURFRDc4RTVCMTMyMkV+Q049Ki53aWxkZmlyZS5wYWxv
+      YWx0b25ldHdvcmvqBvQYVT1Eb21haW4gQ29udHJvbCBWYWxpZGF0ZWSQAkNOPUdvIERhZG
+      R5PgW3Q2VydGlmaWNhdGUwBPQjLSBHMixPVT1odHRwOi8vY2VydHMuZ29kYWRkeS5jb20v
+      cmVwb3NpdG9yeS8sTz1Hb0QaAAYNAvIFU2NvdHRzZGFsZSxTVD1Bcml6b24PCv8DEgAgQw
+      5Mr0spEgCMlBY59QkswQEhT4cBf0AOAQwfPCwBCgSPARP5lgVCUJqf7o8B9CRBOEpySzIz
+      RTJSV0F2VVRGZ50DBAMiRjE3NTRCOUJBNDdENEE2Q3ZDTj1QYWxvIEFsdG+mCu9zIERldm
+      ljZSA0MTAsTyAAAI8sQz1VU3JDThsAAJ8gU1NMIENBIDE5AAf+AxIACJseogooKBIACF/M
+      xaQNMTsBPzUxMs8UDCQLAfwAIqQJNQT4IXCugiz+ST0qJEZJVTJPOUt4NmFseDAwd1hnwQ
+      MEAyI3QUVFNzdEMEFBODc0RDNBgGYJAxUEBTEJD2IJUF9MCE1PrGIJNFS9DrMOGmIJ9w8u
+      Y29tHCouYW5kcm9pZC5jb20uKi5hcHBlbmdpbmVtCRMmbQkHEwC1KiouZGI4MzM5NTMWAP
+      QEbg4qLmcuY28eKi5nY3AuZ3Z0MjkUw29vZ2xlLWFuYWx5dAgXFhiHABdhDAAmbB4YAElv
+      LmluDwApanAPADR1ayBcAIcuY29tLmFyIC4ASm0uYXUgABtiIAAqY28gACpteBAAG3QwAC
+      Z2bqkAJmRlDAAmZXMMACZmcgwAJmh1DAAmaXQMACZubAwAGHAMACR0JrAAJGFk0QoFkwAC
+      EQAkbioQANRjb21tZXJjZS5jb20kFQD3CHZpZGVvLmNvbRoqLmdzdGF0aWMuY24cDQCWb2
+      0WKi5ndnQxCwDoMi5jb20qKi5tZXRyaWMrAPgEGioudXJjaGluLmNvbSIqLnVybHEB9AIq
+      LnlvdXR1YmUtbm9jb29raVQCAxcAA1QCAw4A9RNlZHVjYXRpb24uY29tECoueXQuYmUYKi
+      55dGltZy5jb202iwJnbGllbnRzzAEVGBsAxW9tOGRldmVsb3BlcrwCBJQAJW46HAAecx0A
+      0gpnLmNvDmdvby5nbCozAAqUAhIWFQBSLmNvbSYLAAhlAX4yc291cmNldQAWFiQBUhZ3d3
+      cuYgCjEnlvdXR1LmJlGAABUy5jb20qDAAJDAFkDHl0LmJlpwQi7gynBPIiwKRzi/5JPSom
+      RmhacGkzMjQ4ellMc1lmSjdkqQMEAyIyRTFCNjNCM0NFRkNGMTAwjqgEWGMuZG9jOwEPrw
+      QdH2QRDgsaMlAAAlsL7yDKe+khNyoSACCi12izWwsjX+cV3RUowAAAUyoqLmExCwII3wLz
+      D2MuMm1kbi5uZXQ+Ki5jLmF1ZGlvYm9va3MucGxheTEA9AEuY29tOCouYy5iaWdjYWNo1w
+      QCTQPCb20oKi5jLmNoYXQu8AFTLmNvbVCFAKMtMC0wLXNqLnNqNQCzdXNlcmNvbnRlbnQy
+      A2RjLmRyaXZVAIMuY29tNCouYy8AVnN5bmRp8gIWKBoABccAoyoqLmMuaW5ib3g0AMMuY2
+      9tPCouYy5saDMTAAt2AIgoKi5jLm1haYkD+AE4Ki5jLm9mZmxpbmUubWFw/wGdKCouYy5w
+      YWNrFAAKJgFSKiouYy6ZAAJ4AIQuY29tICouY+QD3i5jb202Ki5jYWNoZTFnAggbAA+BAQ
+      AENgAMYgAXLjcAD2kAAB8yaQAHHzJpAAcfMssAAARpAB8y0gADHzNpAAcfM2kABx8zaQAI
+      HzNpAAMfNGkABx80aQAHHzRpAAgfNGkAAx81aQAHHzVpAAcfNWkACB81aQADHzZpAAcfNm
+      kABx82aQAIHzZpAAMfN2kABx83aQAHHzdpAAgfN2kAAx84aQAHHzhpAAcfOGkACBo4aQBj
+      LCouZGFpkgMCEwMPxgcCBf0Hd3ppcC5uZXS7ByQwKvIDEi3yAwPTB/8ILCoueG4tLW5nc3
+      RyLWxyYThqLmNvbSgUAAAEcQYTgKgQ/wxQ5C3UA0o9KiZGV3lQSWYyY2ZTUktWQ3g5OGur
+      Ec0EAwH/DDAOW08GSj0qJkZPd0VoMDRhd21sSWRVcWxsOAMBzRPeAwHyMcBamSgISj0qJk
+      YySllYcTNsa2Rmek53bGlYMacEBAMiNjNDQTBBODFGQUQ4OUFFNmBDTj0qLmZveGl0Y2xv
+      dWQiDQ+aD5L+AUBlS4WaeikSADyCIdF9eCtfDg8uIw88S0Mi/gAaHg8ABGcDE85hAUNgJc
+      upYQHyJ2ttRG0xY1pYYWxodlIwUmnrAwQDQjBBMTI5QUM3OUQxNTFDOEJGODUwNzJCMDU0
+      N0FBQ0Y0qOgJ+xB0ZWxlbWV0cnkubW96aWxsYS5vcmcsTz1Nb3ppbGxhERYPBhgND3EkJf
+      8BwNgbxUT7JxIAwA9sGuCeKkMBIT9nXzDPAAUPFgACDFEBM5Ds51EB/wFiMnhMYzQ4ZGE2
+      aHlidXN2UQH/Jv8L1ymqCEo9KiZGcW9oU1cxWWloMHpwczRBcmpRAf8kQoCwI6uiAv8Cdj
+      dvREQ0OTg0ekNqclRpRjVRAf8kMwCISVEB/wJ1R0U2QTRwdUE5VHBFRWdPOFEB/yQzMCxX
+      UQH/Am83bjRFMmpsenBFRVE5cG1oUQH/HBOlZRb/DBB66iAJSj0qJkZmMWdNSzNLUUdIUn
+      JINWxZamYW/////3YEqARCUOxWJagE/wJ0M3Y3cjFNa09ZaWV6NlV1NQ4b/////3YTnDYR
+      QqCNyvGoBPMcWEdHeWYxWVRGVUlMUHFOajPFAwQDIjVCNkEzN0YzOUIzNkFGN0aEAUNOPY
+      0bAzQoCrkaDxQRDw8aKSzfyDzLm6kzKhIAAIlDchopLDopIR7MAAQEEQVkJv8L13BWDEo9
+      KiZGemNac2Y0aDlzcXU5OWo2bWnBKP8mE5G6JPcNIP+elg1KPSomRkhDU3E4M1p0VUxqTE
+      JHSjI5zxwq8wQxMTBBN0QzODE0MkVGRDI5Mjc5GSpiMDAxMTC6thP+AHZvcnRleC13aW4u
+      ZGF0YSMqBh0qD94pE3pBLEM9VVOwNSoD8CQFLThPIDIwMS8qJf8A6PmsdqLdKRIAKHnacT
+      f24hMiAr8kD/wACh88HgAKBO8CBKgXQgDftJiUAf8CRXdpakQ0VzFwNW5CdUNkbGVWKs0E
+      AwH/DPCw1/gOSj0qJkZJWUxqZjNvdmR0Wm5zVThKbKsYzQRbLP8LYDjv+A5KPSokRmpxRV
+      RUM1NZY1VIWW1rNUIFAtVCoIk6+QUC/wJxVVl2djRXdkNUMk1NNU5jaQMBzQQFAkKQtUH5
+      BQL/AW5lZWxjM2xyNnh5djU3SmYCAc0ECgQzMC5vBQL/Anp2d3hLMVBCZ1ZhZ3lTN2QyAw
+      G5AHYvAQAwoG9yZwEBAQkEAACGAIhSxBv6cByAAgp4NTA5EmAl+R4QSj0qJkZCTGxEZTF3
+      dXd0d3VWejFmbOcCBANKMDQzQTc3RjRERTg5NTNGMjY4NzM3MjZFM0M2QUFFQzI3MjVBJE
+      NOPWlzZS53cmNjZGMub3JnZkNOPUxldCdzIEVuY3J5cHQgQXV0aG9yaXR5IFgzLE8dAPMM
+      LEM9VVMSAIi8Me5bMyoSAEjX+9eVaioccnNhPwDzAmlvbjBzaGEyNTZXaXRoUlNBVwD3BW
+      lvbghyc2EGAAgMNjU1MzcAT0cmigCHY3BwLmVkdR4TAPOsb3JnAQEBCQQAABySAwp4NTA5
+      EsAm38YRSj0qJkZsQ05YcjJ3TVhzOUd4UDVGZ+MEBANCNTBGRTlENjJDQzA3NjE0M0I4MT
+      dBQTk1NDYxODZEMTmuAUNOPXNzbDM2NTQyMi5jbG91ZGZsYXJlc3NsLmNvbSxPVT1Qb3Np
+      dGl2ZVNTTCBNdWx0aS1Eb21haW4sT1U9RG9tYWluIENvbnRyb2wgVmFsaWRhdGVk2AFDTj
+      1DT01PRE8gRUNDICgAAyAA9Alpb24gU2VjdXJlIFNlcnZlciBDQSAyLE8yAP9rQ0EgTGlt
+      aXRlZCxMPVNhbGZvcmQsU1Q9R3JlYXRlciBNYW5jaGVzdGVyLEM9R0ISAACMrbOQKioSAC
+      zHqNfLnyoeaWQtZWNQdWJsaWNLZXkkZWNkc2Etd2l0aC1TSEEyNTYMZWNkc2EGAAEAFnBy
+      aW1lMjU2djF3bzgLAQj3ABwqLmdpdC1zY20uY29tGAwABJUBBJgC/wyQi7lgE0o9KiZGMV
+      R3VUYxQm1NZE1rUUdkMTGYAs0TkZgCUnCPtAkYAwH0IWxtOVAzWkNHUHNBRFdWaWXPBAQD
+      TjMzMDAwMDAxMTBBN0QzODE0MkVGRDI5Mjc5MAEA9BQxMTC6AUNOPSoudm9ydGV4LXdpbi
+      5kYXRhLm1pY3Jvc29mdKICFE0RACYsTwwA9xYgQ29ycG9yYXRpb24sTD1SZWRtb25kLFNU
+      PVdBLEM9VVOwAUNOLwAOkQI/MDExUQAUk2FzaGluZ3Rvbg8E/wDo+ax2ot0pEgAoedpxN/
+      YPBCJPhwF/QPwADB88GgEKBJcCIv8BLAT/CzDdRvoYSj0qJEZDOVJDNlJFWEl6UzRZREw3
+      LgXNBJkDQsCUY/qWAv8CMzAybGs0Z3JYeTRBT1NGcGwDAc0T+AMB8mZA1YCAGUo9KiZGZ3
+      pxaFUzMGx2SmhDWFpiNTTvBAQDGkNDNTdGRTU0MDExRZoDdW5zdHJ1Y3R1cmVkTmFtZT0x
+      MzE1NjU2OTAxXCw1NjRkNzc2MTcyNjUyMDQ5NmU2MzJlLENOPWxvY2FsaG9zdC5sb2NhbG
+      QvBvQVZW1haWxBZGRyZXNzPXNzbC1jZXJ0aWZpY2F0ZXNAdm13YXJl0gOkVk13YXJlIEVT
+      WCIGlkRlZmF1bHQgQzUA9CAsTz1WTXdhcmVcLCBJbmMsTD1QYWxvIEFsdG8sU1Q9Q2FsaW
+      Zvcm5pYSxDPVVTJi4A/w0gSW5zdGFsbGVyEgA4GU7Ne4QkEgB4up857ZYuqQMhPzcvLPEA
+      AgSAAwR7AUIQH1iFewH/AnI4elRNMVJvVWNRdzFMN21newH/RhT3ewHyIetV4hpKPSomRk
+      ZrSVZKMnlobU9GUmdFaXVqyQMEAyIxRERFRThDNUQzQUVGMzE0iHkGomdvb2dsZWFwaXOY
+      AnM9R29vZ2xlbQLfTW91bnRhaW4gVmlld3ECADZ6Q04xAFh0ZXJuZUsKJkczUADjVHJ1c3
+      QgU2VydmljZXNEBvwAfFceUKszKhIAsBc0ji9n1AgPVAoFD9oIAl3ZAc8BItAA9BcqLmNs
+      aWVudHM2Lmdvb2dsZS5jb20yKi5jbG91ZGVuZHBvaW50c/8AAh0KDRcAGh4lAQT1AhOJCQ
+      jzPBCiZU0bSj0qJkZwZXBCUDJDVHc5Smw1OVE4Yr8EBAMiNjgxNDc5MEUwMUFCOUI5Q3hD
+      Tj11cGRhdGVzLnBhbG9hbHRvbmV0d29ya4UBD3UKB9SQAkNOPUdvIERhZGR50AcHMAQHfg
+      H0Iy0gRzIsT1U9aHR0cDovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvLE89R29E
+      GgACbATyCS4sTD1TY290dHNkYWxlLFNUPUFyaXpvbmsE/wISAFyBjYP3picSAACSym2VZh
+      AMIk+HAX86CwEJX0J3d3cuIQAJBIwBE4iMAf8LsAcQUhtKPSokRnF3Y045b3RuWFFOdFR0
+      NmmLAf9XBBcDQtA5BLYXA/8CZWVLVFIxUnVhWXMxTThHbmSMAf9XBBcDQmDqNcsXA/8BTD
+      BzU2ZmZGRQZ3RDSDd5a4sB/1cT3agH8jLwq6d5HUo9KiZGdXBJb280UFZpZDNyYmdFS2WN
+      BAQDQjAxN0U0NUEzMUFBNTBCQzM1MDUzQkM1MEY5QjY5QkFEyrgHE3NKB4QubW96aWxsYT
+      kGVkNsb3VkaAebTz1Nb3ppbGxhKw4P2QcN9AJsQ049RGlnaUNlcnQgU0hBMmwGBc0QJixP
+      IQAzSW5jJRL/AcAUO3/60ykSAAA/AoMD0CttCiE/Y1su4AADHyoVAAEEAgYTvGABQkBFFH
+      5gAfUxSWlZeHoxYjZxRTBnaFFTYWPfAwQDQjBDQTlDNjQzNjFCRkM5MkE3OUIxREQ5Q0ZC
+      OUU0OEVDnAFDTj0qLmNkblsBP25ldEkBX+/wENTuBikSAAAPQV6/3kkBIj1PRyTJABsgEA
+      AEPwETuz8B/wuQpzl+HUo9KiRGUW9GTTNXcDBYcXlmd0RrNT4B/xIzYAfSPgH/AUhhaEl5
+      Z09DV2tVcVdEd2U+Af8KIqUJvhHyIsAFL3ceSj0qJkZBNlhwRzFWaGxPTjJoeXM0YcEDBA
+      MiN0FFRTc3RDBBQTg3NEQzQYALBQKeCwIBBQ+/DFpfTAhNT6y/DDRYvQ6zDhrMAPcLHCou
+      YW5kcm9pZC5jb20uKi5hcHBlbmdpbmXKDBMmygwHEwC1KiouZGI4MzM5NTMWAPQJbg4qLm
+      cuY28eKi5nY3AuZ3Z0Mi5jb20ucAD0AC1hbmFseXRpY3MuY29tGBcARC5jYRgjAEYuY2we
+      DABJby5pbg8AKWpwDwA3dWsgLQBLbS5hchAAGnUQACpichAAKmNvEAAqbXgQABt0MAAmdm
+      61ACZkZQwAJmVzDAAmZnIMACZodQwAJml0DAAmbmwMABhwDAAkdCbAACRhZC4OBZMAAhEA
+      JG4qEADUY29tbWVyY2UuY29tJBUA9wh2aWRlby5jb20aKi5nc3RhdGljLmNuHA0Alm9tFi
+      ouZ3Z0MQsA6DIuY29tKioubWV0cmljKwD4BBoqLnVyY2hpbi5jb20iKi51cmxxAfUIKi55
+      b3V0dWJlLW5vY29va2llLmNvbRwXAANUAgMOAPUTZWR1Y2F0aW9uLmNvbRAqLnl0LmJlGC
+      oueXRpbWcuY29tNosCZ2xpZW50c9wBFRgbAMVvbThkZXZlbG9wZXK8AgSUACVuOhwAHnMd
+      ANIKZy5jbw5nb28uZ2wqMwAKlAISFhUAUi5jb20mCwAIZQF+MnNvdXJjZXUAFhYkAVIWd3
+      d3LmIAoxJ5b3V0dS5iZRgAAVMuY29tKgwACQwBZAx5dC5iZSQHBKgEQgDq+JKoBP8CMWk5
+      YVczaW5TcThHb0hVcmioBP////92E4CoBELQasqTqATyP0JKV3ZyMlY4TzFab2g5NGU34Q
+      QEA0IzODkyMjcyRUFEQ0VCRDIzNEMyRDlDRDg0RjM4OEYwRMgBQ049c2hhc3RhLWFycy5z
+      eW1hbnRlY2sJQlU9SVQWDnNpdHksTz1THgAPag4cR8ABQ048AGJsYXNzIDNYAAduDoYgLS
+      BHNCxPVSoAAlEWEk44FQ9/AAUClQ7/AQDUJ6Is7SkSAGwgUZp6ziqVDiH/FtMMyQwwU0hB
+      U1RBLUFSUy5TWU1BTlRFQy5DT01AUENUT09MUy0gAARPOE1BQxwABRMwYAEbbWABBBgAG3
+      IYAF84ZW50LRwABAyIABtSqABPOG5zczwABU84c21yHAAFxEhTVVBQT1JUVE9PTMgADVwA
+      P21pNUAABasycmF0aW5ncy13zQCEQHBjdG9vbHN5AAwgAE84YmFkPAAFTzhtYWM4AAY/bm
+      1zHAAFXzpuc2F0OQAGB14BDI0AE0ZRAPgIYXJzLXByb2QtbXVlMS5ucC5ub3J0b24jAB9t
+      IwAPH3IjAAcaTqcBD20ABRpOsgEPJwAGCpkBDycABRdIaAEPJAAFBAIBDyMACAQrCROqTx
+      BCQMsaloME+CFoRkFFQTNLbnhyMEg1WDI0NbsDBAMiNkYyQUIzQzhEMTA0RUQ4N4oBQ049
+      Ki5hcGlkCg/YDVz/AHQC9++oMyoSAACJQ3IvZzAEIj1PRyTHABsgEAAELQETiqYV/z1AUF
+      /CHko9KiRGN2ZMZmxLcDR6YWlMd3NCbIMFBANCNEVEMEE2MTQ1OTVCNEIzQ0ExMURDQjRF
+      RjU3NzA0ODHqAUNOPWRvd25sb2FkWxoHBUEeBD0FP3MsTxUAAAcFGq9hbnRhIENsYXJhAx
+      wAD8AFUP8AwFTnWlXAKRIAbJ6dVerYkAEiP0lBPhsBCwSNAROLjQFCkI9c27oC/wF0ejh0
+      QzFRYTlzT0xxMnMzjgH/SgAEHbAuY29tAQEBCQQAAIU=
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[_path:string,ts:time,id:bstring,certificate:record[version:uint64,serial:bstring,subject:bstring,issuer:bstring,not_valid_before:time,not_valid_after:time,key_alg:bstring,sig_alg:bstring,key_type:bstring,key_length:uint64,exponent:bstring,curve:bstring],san:record[dns:array[bstring],uri:array[bstring],email:array[bstring],ip:array[ip]],basic_constraints:record[ca:bool,path_len:uint64]]
+      0:[x509;1521835102.810707;FoC52XwfgfOtIldM1;[3;017E45A31AA50BC35053BC50F9B69BAD;CN=*.services.mozilla.com,OU=Cloud Services,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1507014000;1578513600;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.services.mozilla.com;services.mozilla.com;]-;-;-;][F;-;]]
+      0:[x509;1521835102.974352;FMJcws2PmuN7aAiJ9k;[3;017E45A31AA50BC35053BC50F9B69BAD;CN=*.services.mozilla.com,OU=Cloud Services,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1507014000;1578513600;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.services.mozilla.com;services.mozilla.com;]-;-;-;][F;-;]]
+      0:[x509;1521835103.486505;FfzZ7Y1dveSDiNR4yg;[3;0CA9C64361BFC92A79B1DD9CFB9E48EC;CN=*.cdn.mozilla.net,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1478156400;1580587200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.cdn.mozilla.net;cdn.mozilla.net;]-;-;-;][F;-;]]
+      0:[x509;1521835103.494274;FC42Gl3RS33bWkbAya;[3;0CA9C64361BFC92A79B1DD9CFB9E48EC;CN=*.cdn.mozilla.net,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1478156400;1580587200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.cdn.mozilla.net;cdn.mozilla.net;]-;-;-;][F;-;]]
+      0:[x509;1521835103.577248;FxmoTc2ErZH6YNcph6;[3;63CA0A81FAD89AE6;CN=*.foxitcloud.com,OU=Domain Control Validated;CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\\, Inc.,L=Scottsdale,ST=Arizona,C=US;1494435600;1566195939;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.foxitcloud.com;foxitcloud.com;]-;-;-;][F;-;]]
+      0:[x509;1521835103.580715;FLvL4l2odp9b8uX3la;[3;5B6A37F39B36AF7F;CN=www.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520480330;1527731520;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[www.google.com;]-;-;-;][F;-;]]
+      0:[x509;1521835103.639526;FlfH5h2GDaadJATOP9;[3;5B6A37F39B36AF7F;CN=www.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520480330;1527731520;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[www.google.com;]-;-;-;][F;-;]]
+      0:[x509;1521835103.904797;FhC73h1w1wzfgjNFC8;[3;0E11BBD70D54B710D0C6F540B6B52CA4;CN=*.stackexchange.com,O=Stack Exchange\\, Inc.,L=New York,ST=NY,C=US;CN=DigiCert SHA2 High Assurance Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1463814000;1565809200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.stackexchange.com;stackoverflow.com;*.stackoverflow.com;stackauth.com;sstatic.net;*.sstatic.net;serverfault.com;*.serverfault.com;superuser.com;*.superuser.com;stackapps.com;openid.stackauth.com;stackexchange.com;*.meta.stackexchange.com;meta.stackexchange.com;mathoverflow.net;*.mathoverflow.net;askubuntu.com;*.askubuntu.com;stacksnippets.net;*.blogoverflow.com;blogoverflow.com;*.meta.stackoverflow.com;*.stackoverflow.email;stackoverflow.email;]-;-;-;][F;-;]]
+      0:[x509;1521835103.904899;Fcu8c322BWEmPNUmef;[3;0E11BBD70D54B710D0C6F540B6B52CA4;CN=*.stackexchange.com,O=Stack Exchange\\, Inc.,L=New York,ST=NY,C=US;CN=DigiCert SHA2 High Assurance Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1463814000;1565809200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.stackexchange.com;stackoverflow.com;*.stackoverflow.com;stackauth.com;sstatic.net;*.sstatic.net;serverfault.com;*.serverfault.com;superuser.com;*.superuser.com;stackapps.com;openid.stackauth.com;stackexchange.com;*.meta.stackexchange.com;meta.stackexchange.com;mathoverflow.net;*.mathoverflow.net;askubuntu.com;*.askubuntu.com;stacksnippets.net;*.blogoverflow.com;blogoverflow.com;*.meta.stackoverflow.com;*.stackoverflow.email;stackoverflow.email;]-;-;-;][F;-;]]
+      0:[x509;1521835104.046056;FoSA6W2tFIAYbekIeh;[3;7AEE77D0AA874D3A;CN=*.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481815;1527731580;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[*.google.com;*.android.com;*.appengine.google.com;*.cloud.google.com;*.db833953.google.cn;*.g.co;*.gcp.gvt2.com;*.google-analytics.com;*.google.ca;*.google.cl;*.google.co.in;*.google.co.jp;*.google.co.uk;*.google.com.ar;*.google.com.au;*.google.com.br;*.google.com.co;*.google.com.mx;*.google.com.tr;*.google.com.vn;*.google.de;*.google.es;*.google.fr;*.google.hu;*.google.it;*.google.nl;*.google.pl;*.google.pt;*.googleadapis.com;*.googleapis.cn;*.googlecommerce.com;*.googlevideo.com;*.gstatic.cn;*.gstatic.com;*.gvt1.com;*.gvt2.com;*.metric.gstatic.com;*.urchin.com;*.url.google.com;*.youtube-nocookie.com;*.youtube.com;*.youtubeeducation.com;*.yt.be;*.ytimg.com;android.clients.google.com;android.com;developer.android.google.cn;developers.android.google.cn;g.co;goo.gl;google-analytics.com;google.com;googlecommerce.com;source.android.google.cn;urchin.com;www.goo.gl;youtu.be;youtube.com;youtubeeducation.com;yt.be;]-;-;-;][F;-;]]
+      0:[x509;1521835104.123929;FC8hgD19NEhbd6U95d;[3;03237A78C4E2E43EA97FCD0BC62AB3B3;CN=location.services.mozilla.com,O=Mozilla Foundation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1499756400;1528830000;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[location.services.mozilla.com;]-;-;-;][F;-;]]
+      0:[x509;1521835105.051115;FMfKwh3SIneG8oJkW7;[3;7AEE77D0AA874D3A;CN=*.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481815;1527731580;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[*.google.com;*.android.com;*.appengine.google.com;*.cloud.google.com;*.db833953.google.cn;*.g.co;*.gcp.gvt2.com;*.google-analytics.com;*.google.ca;*.google.cl;*.google.co.in;*.google.co.jp;*.google.co.uk;*.google.com.ar;*.google.com.au;*.google.com.br;*.google.com.co;*.google.com.mx;*.google.com.tr;*.google.com.vn;*.google.de;*.google.es;*.google.fr;*.google.hu;*.google.it;*.google.nl;*.google.pl;*.google.pt;*.googleadapis.com;*.googleapis.cn;*.googlecommerce.com;*.googlevideo.com;*.gstatic.cn;*.gstatic.com;*.gvt1.com;*.gvt2.com;*.metric.gstatic.com;*.urchin.com;*.url.google.com;*.youtube-nocookie.com;*.youtube.com;*.youtubeeducation.com;*.yt.be;*.ytimg.com;android.clients.google.com;android.com;developer.android.google.cn;developers.android.google.cn;g.co;goo.gl;google-analytics.com;google.com;googlecommerce.com;source.android.google.cn;urchin.com;www.goo.gl;youtu.be;youtube.com;youtubeeducation.com;yt.be;]-;-;-;][F;-;]]
+      0:[x509;1521835105.161345;FQiahl3Ts2bQ3hYx08;[3;6F2AB3C8D104ED87;CN=*.apis.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520479961;1527731520;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.apis.google.com;apis.google.com;]-;-;-;][F;-;]]
+      0:[x509;1521835105.533395;FFEZ6o20zjx02PzuOd;[3;1DDEE8C5D3AEF314;CN=*.googleapis.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481267;1527731580;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[*.googleapis.com;*.clients6.google.com;*.cloudendpointsapis.com;cloudendpointsapis.com;googleapis.com;]-;-;-;][F;-;]]
+      0:[x509;1521835106.347721;FtWbvm6KWOIu2cuV7;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835107.352361;FfG88j1nNWXEDuHcS6;[3;0A8039418B6F2BFDC84A2C92D00BC2CB;CN=elq.symantec.com,OU=Marketing,O=Symantec Corporation,L=Mountain View,ST=California,C=US;CN=Symantec Class 3 Secure Server CA - G4,OU=Symantec Trust Network,O=Symantec Corporation,C=US;1490770800;1524639599;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[demo.elq.symantec.com;elq.symantec.com;email.elq.symantec.com;empower.elq.symantec.com;event.elq.symantec.com;explore.elq.symantec.com;innovate.elq.symantec.com;know.elq.symantec.com;prosper.elq.symantec.com;resource.elq.symantec.com;solve.elq.symantec.com;transform.elq.symantec.com;trial.elq.symantec.com;trial.symantec.com;trialware.symantec.com;wonder.elq.symantec.com;work.elq.symantec.com;]-;-;-;][F;-;]]
+      0:[x509;1521835108.244606;FzXZ8x2rCUpZcZSd14;[3;0E598EB54AF7975DE8EFD63556EA4B1F;CN=www-secure.symantec.com,OU=Corp Mktg & Comms - Online Experience & Operations,O=Symantec Corporation,L=Mountain View,ST=California,C=US,serialNumber=2158113,jurisdictionST=Delaware,jurisdictionC=US,businessCategory=Private Organization;CN=DigiCert SHA2 Extended Validation Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1520838000;1556132400;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[www-secure.symantec.com;]-;-;-;][F;-;]]
+      0:[x509;1521835108.24595;FfSTW52cn7ovTIvJWh;[3;0E598EB54AF7975DE8EFD63556EA4B1F;CN=www-secure.symantec.com,OU=Corp Mktg & Comms - Online Experience & Operations,O=Symantec Corporation,L=Mountain View,ST=California,C=US,serialNumber=2158113,jurisdictionST=Delaware,jurisdictionC=US,businessCategory=Private Organization;CN=DigiCert SHA2 Extended Validation Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1520838000;1556132400;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[www-secure.symantec.com;]-;-;-;][F;-;]]
+      0:[x509;1521835108.247246;FMfz5F4SAERjlFFOEg;[3;0E598EB54AF7975DE8EFD63556EA4B1F;CN=www-secure.symantec.com,OU=Corp Mktg & Comms - Online Experience & Operations,O=Symantec Corporation,L=Mountain View,ST=California,C=US,serialNumber=2158113,jurisdictionST=Delaware,jurisdictionC=US,businessCategory=Private Organization;CN=DigiCert SHA2 Extended Validation Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1520838000;1556132400;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[www-secure.symantec.com;]-;-;-;][F;-;]]
+      0:[x509;1521835108.278274;FovB1L3id3pbD8kfp;[3;052426F1CD71461062716D150D4FED5F;CN=*.freshaddress.biz,O=FreshAddress\\, Inc.,L=Newton,ST=Massachusetts,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1490598000;1560970800;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.freshaddress.biz;freshaddress.biz;]-;-;-;][F;-;]]
+      0:[x509;1521835108.300137;FYS2764pEH5YTacqh3;[3;07CA704F1AFAF178F2ADB289DE3851AA;CN=www.symantec.com,OU=Corp Mktg & Comms - Online Exp,O=Symantec Corporation,L=Mountain View,ST=California,C=US,serialNumber=2158113,jurisdictionST=Delaware,jurisdictionC=US,businessCategory=Private Organization;CN=DigiCert SHA2 Extended Validation Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1521615600;1532545200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[www4.symantec.com;www.symantec.com;www.skycure.com;www.go.symantec.com;www.bluecoat.com;sites.symantec.com;sites-uat.symantec.com;sites-qa.symantec.com;sites-internal.symantec.com;securityresponse.symantec.com;scm.symantec.com;partners.bluecoat.com;partnernet.symantec.com;partnernet.norton.com;partnernet-uat.symantec.com;partnernet-uat.norton.com;partnernet-temp.symantec.com;partnernet-sit.symantec.com;partnernet-qa.symantec.com;partnernet-qa.norton.com;partnernet-internal.symantec.com;partnernet-internal.norton.com;my.symantec.com;my-uat.symantec.com;my-qa.symantec.com;m.symantec.com;go.symantec.com;go.skycure.com;get.skycure.com;forums.symantec.com;forums.bluecoat.com;cdn.securitycloud.symantec.com;buy.symanteccloud.com;buy.symantec.com;blog.skycure.com;bcportal.symantec.com;]-;-;-;][F;-;]]
+      0:[x509;1521835108.300214;FFwC001XnjfYFv3pVe;[3;07CA704F1AFAF178F2ADB289DE3851AA;CN=www.symantec.com,OU=Corp Mktg & Comms - Online Exp,O=Symantec Corporation,L=Mountain View,ST=California,C=US,serialNumber=2158113,jurisdictionST=Delaware,jurisdictionC=US,businessCategory=Private Organization;CN=DigiCert SHA2 Extended Validation Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1521615600;1532545200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[www4.symantec.com;www.symantec.com;www.skycure.com;www.go.symantec.com;www.bluecoat.com;sites.symantec.com;sites-uat.symantec.com;sites-qa.symantec.com;sites-internal.symantec.com;securityresponse.symantec.com;scm.symantec.com;partners.bluecoat.com;partnernet.symantec.com;partnernet.norton.com;partnernet-uat.symantec.com;partnernet-uat.norton.com;partnernet-temp.symantec.com;partnernet-sit.symantec.com;partnernet-qa.symantec.com;partnernet-qa.norton.com;partnernet-internal.symantec.com;partnernet-internal.norton.com;my.symantec.com;my-uat.symantec.com;my-qa.symantec.com;m.symantec.com;go.symantec.com;go.skycure.com;get.skycure.com;forums.symantec.com;forums.bluecoat.com;cdn.securitycloud.symantec.com;buy.symanteccloud.com;buy.symantec.com;blog.skycure.com;bcportal.symantec.com;]-;-;-;][F;-;]]
+      0:[x509;1521835108.300329;FePY6h1k4cIukFScLe;[3;07CA704F1AFAF178F2ADB289DE3851AA;CN=www.symantec.com,OU=Corp Mktg & Comms - Online Exp,O=Symantec Corporation,L=Mountain View,ST=California,C=US,serialNumber=2158113,jurisdictionST=Delaware,jurisdictionC=US,businessCategory=Private Organization;CN=DigiCert SHA2 Extended Validation Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1521615600;1532545200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[www4.symantec.com;www.symantec.com;www.skycure.com;www.go.symantec.com;www.bluecoat.com;sites.symantec.com;sites-uat.symantec.com;sites-qa.symantec.com;sites-internal.symantec.com;securityresponse.symantec.com;scm.symantec.com;partners.bluecoat.com;partnernet.symantec.com;partnernet.norton.com;partnernet-uat.symantec.com;partnernet-uat.norton.com;partnernet-temp.symantec.com;partnernet-sit.symantec.com;partnernet-qa.symantec.com;partnernet-qa.norton.com;partnernet-internal.symantec.com;partnernet-internal.norton.com;my.symantec.com;my-uat.symantec.com;my-qa.symantec.com;m.symantec.com;go.symantec.com;go.skycure.com;get.skycure.com;forums.symantec.com;forums.bluecoat.com;cdn.securitycloud.symantec.com;buy.symanteccloud.com;buy.symantec.com;blog.skycure.com;bcportal.symantec.com;]-;-;-;][F;-;]]
+      0:[x509;1521835108.300349;F58MlgmJNqgqwC7ui;[3;07CA704F1AFAF178F2ADB289DE3851AA;CN=www.symantec.com,OU=Corp Mktg & Comms - Online Exp,O=Symantec Corporation,L=Mountain View,ST=California,C=US,serialNumber=2158113,jurisdictionST=Delaware,jurisdictionC=US,businessCategory=Private Organization;CN=DigiCert SHA2 Extended Validation Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1521615600;1532545200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[www4.symantec.com;www.symantec.com;www.skycure.com;www.go.symantec.com;www.bluecoat.com;sites.symantec.com;sites-uat.symantec.com;sites-qa.symantec.com;sites-internal.symantec.com;securityresponse.symantec.com;scm.symantec.com;partners.bluecoat.com;partnernet.symantec.com;partnernet.norton.com;partnernet-uat.symantec.com;partnernet-uat.norton.com;partnernet-temp.symantec.com;partnernet-sit.symantec.com;partnernet-qa.symantec.com;partnernet-qa.norton.com;partnernet-internal.symantec.com;partnernet-internal.norton.com;my.symantec.com;my-uat.symantec.com;my-qa.symantec.com;m.symantec.com;go.symantec.com;go.skycure.com;get.skycure.com;forums.symantec.com;forums.bluecoat.com;cdn.securitycloud.symantec.com;buy.symanteccloud.com;buy.symantec.com;blog.skycure.com;bcportal.symantec.com;]-;-;-;][F;-;]]
+      0:[x509;1521835108.300695;FOJLG42czJmNUVJD38;[3;07CA704F1AFAF178F2ADB289DE3851AA;CN=www.symantec.com,OU=Corp Mktg & Comms - Online Exp,O=Symantec Corporation,L=Mountain View,ST=California,C=US,serialNumber=2158113,jurisdictionST=Delaware,jurisdictionC=US,businessCategory=Private Organization;CN=DigiCert SHA2 Extended Validation Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1521615600;1532545200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[www4.symantec.com;www.symantec.com;www.skycure.com;www.go.symantec.com;www.bluecoat.com;sites.symantec.com;sites-uat.symantec.com;sites-qa.symantec.com;sites-internal.symantec.com;securityresponse.symantec.com;scm.symantec.com;partners.bluecoat.com;partnernet.symantec.com;partnernet.norton.com;partnernet-uat.symantec.com;partnernet-uat.norton.com;partnernet-temp.symantec.com;partnernet-sit.symantec.com;partnernet-qa.symantec.com;partnernet-qa.norton.com;partnernet-internal.symantec.com;partnernet-internal.norton.com;my.symantec.com;my-uat.symantec.com;my-qa.symantec.com;m.symantec.com;go.symantec.com;go.skycure.com;get.skycure.com;forums.symantec.com;forums.bluecoat.com;cdn.securitycloud.symantec.com;buy.symanteccloud.com;buy.symantec.com;blog.skycure.com;bcportal.symantec.com;]-;-;-;][F;-;]]
+      0:[x509;1521835108.301005;Fzo3vf4uKVCDUknGa8;[3;07CA704F1AFAF178F2ADB289DE3851AA;CN=www.symantec.com,OU=Corp Mktg & Comms - Online Exp,O=Symantec Corporation,L=Mountain View,ST=California,C=US,serialNumber=2158113,jurisdictionST=Delaware,jurisdictionC=US,businessCategory=Private Organization;CN=DigiCert SHA2 Extended Validation Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1521615600;1532545200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[www4.symantec.com;www.symantec.com;www.skycure.com;www.go.symantec.com;www.bluecoat.com;sites.symantec.com;sites-uat.symantec.com;sites-qa.symantec.com;sites-internal.symantec.com;securityresponse.symantec.com;scm.symantec.com;partners.bluecoat.com;partnernet.symantec.com;partnernet.norton.com;partnernet-uat.symantec.com;partnernet-uat.norton.com;partnernet-temp.symantec.com;partnernet-sit.symantec.com;partnernet-qa.symantec.com;partnernet-qa.norton.com;partnernet-internal.symantec.com;partnernet-internal.norton.com;my.symantec.com;my-uat.symantec.com;my-qa.symantec.com;m.symantec.com;go.symantec.com;go.skycure.com;get.skycure.com;forums.symantec.com;forums.bluecoat.com;cdn.securitycloud.symantec.com;buy.symanteccloud.com;buy.symantec.com;blog.skycure.com;bcportal.symantec.com;]-;-;-;][F;-;]]
+      0:[x509;1521835108.839983;Fg78kC4zaO2Lt9i2Ul;[3;0266B7C504900A8A84FF5C51E03FFB67;CN=*.t.eloqua.com,OU=Oracle ELOQUA TORONTO,O=Oracle Corporation,L=Redwood City,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1517472000;1549051200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.t.eloqua.com;]-;-;-;][F;-;]]
+      0:[x509;1521835109.093718;F4y26E4WqKuatY45Z8;[3;0ED4D89247198300BDB4B146C91E1164;CN=*.mwbsys.com,O=Malwarebytes Inc.,L=San Jose,ST=California,C=US;CN=DigiCert SHA2 High Assurance Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1516608000;1585335600;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.mwbsys.com;mwbsys.com;mbac-dev.mwbsys.com;mbac-prod.mwbsys.com;]-;-;-;][F;-;]]
+      0:[x509;1521835115.420473;FrcfyVqYBYWVRqM1h;[3;053595DDC488E3BD2185316C9E024A57;CN=shavar.services.mozilla.com,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1440486000;1535569200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[shavar.services.mozilla.com;tracking-protection.services.mozilla.com;tracking.services.mozilla.com;shavar.prod.mozaws.net;]-;-;-;][F;-;]]
+      0:[x509;1521835117.974219;FKu9si3dRJs3FpyjWa;[3;017E45A31AA50BC35053BC50F9B69BAD;CN=*.services.mozilla.com,OU=Cloud Services,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1507014000;1578513600;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.services.mozilla.com;services.mozilla.com;]-;-;-;][F;-;]]
+      0:[x509;1521835118.098076;FncnjMX9g9tdUp0gg;[3;0CA9C64361BFC92A79B1DD9CFB9E48EC;CN=*.cdn.mozilla.net,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1478156400;1580587200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.cdn.mozilla.net;cdn.mozilla.net;]-;-;-;][F;-;]]
+      0:[x509;1521835118.100178;FjmXvG3NdQU5YT92X5;[3;03237A78C4E2E43EA97FCD0BC62AB3B3;CN=location.services.mozilla.com,O=Mozilla Foundation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1499756400;1528830000;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[location.services.mozilla.com;]-;-;-;][F;-;]]
+      0:[x509;1521835118.125235;Fu2Ooz2Td7zMonCu5a;[3;03237A78C4E2E43EA97FCD0BC62AB3B3;CN=location.services.mozilla.com,O=Mozilla Foundation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1499756400;1528830000;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[location.services.mozilla.com;]-;-;-;][F;-;]]
+      0:[x509;1521835118.468215;FiwsQu3JLyjMaEC5Lk;[3;0441863B81E6C5BAB060B2031D1D111E;CN=versioncheck.addons.mozilla.org,OU=Cloud Services,O=Mozilla Foundation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1485504000;1582315200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[versioncheck.addons.mozilla.org;versioncheck-bg.addons.mozilla.org;blocklist.addons.mozilla.org;]-;-;-;][F;-;]]
+      0:[x509;1521835118.469355;FiJIS11WBGqKqcrIeh;[3;0441863B81E6C5BAB060B2031D1D111E;CN=versioncheck.addons.mozilla.org,OU=Cloud Services,O=Mozilla Foundation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1485504000;1582315200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[versioncheck.addons.mozilla.org;versioncheck-bg.addons.mozilla.org;blocklist.addons.mozilla.org;]-;-;-;][F;-;]]
+      0:[x509;1521835118.51514;FsOyGrPGseZSdCdz6;[3;07108B209ED3456CEE88949144C4560C;CN=aus5.mozilla.org,OU=IT,O=Mozilla Foundation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1500274800;1565722800;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[aus5.mozilla.org;]-;-;-;][F;-;]]
+      0:[x509;1521835118.516425;FFpIQW3dvqeoAxp;[3;07108B209ED3456CEE88949144C4560C;CN=aus5.mozilla.org,OU=IT,O=Mozilla Foundation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1500274800;1565722800;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[aus5.mozilla.org;]-;-;-;][F;-;]]
+      0:[x509;1521835119.395351;Fwt1ow3jhWrtRawAvb;[3;0CA9C64361BFC92A79B1DD9CFB9E48EC;CN=*.cdn.mozilla.net,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1478156400;1580587200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.cdn.mozilla.net;cdn.mozilla.net;]-;-;-;][F;-;]]
+      0:[x509;1521835119.395944;FdeqIZ1ln0BX4Claq4;[3;0CA9C64361BFC92A79B1DD9CFB9E48EC;CN=*.cdn.mozilla.net,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1478156400;1580587200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.cdn.mozilla.net;cdn.mozilla.net;]-;-;-;][F;-;]]
+      0:[x509;1521835120.437231;FsiGtK1AR14ls2mST;[3;6F2AB3C8D104ED87;CN=*.apis.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520479961;1527731520;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.apis.google.com;apis.google.com;]-;-;-;][F;-;]]
+      0:[x509;1521835120.437738;Fnfpor4ifk8mI2x2Tl;[3;7AEE77D0AA874D3A;CN=*.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481815;1527731580;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[*.google.com;*.android.com;*.appengine.google.com;*.cloud.google.com;*.db833953.google.cn;*.g.co;*.gcp.gvt2.com;*.google-analytics.com;*.google.ca;*.google.cl;*.google.co.in;*.google.co.jp;*.google.co.uk;*.google.com.ar;*.google.com.au;*.google.com.br;*.google.com.co;*.google.com.mx;*.google.com.tr;*.google.com.vn;*.google.de;*.google.es;*.google.fr;*.google.hu;*.google.it;*.google.nl;*.google.pl;*.google.pt;*.googleadapis.com;*.googleapis.cn;*.googlecommerce.com;*.googlevideo.com;*.gstatic.cn;*.gstatic.com;*.gvt1.com;*.gvt2.com;*.metric.gstatic.com;*.urchin.com;*.url.google.com;*.youtube-nocookie.com;*.youtube.com;*.youtubeeducation.com;*.yt.be;*.ytimg.com;android.clients.google.com;android.com;developer.android.google.cn;developers.android.google.cn;g.co;goo.gl;google-analytics.com;google.com;googlecommerce.com;source.android.google.cn;urchin.com;www.goo.gl;youtu.be;youtube.com;youtubeeducation.com;yt.be;]-;-;-;][F;-;]]
+      0:[x509;1521835120.437842;FeaAPP2Z0JzZKouNBj;[3;7AEE77D0AA874D3A;CN=*.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481815;1527731580;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[*.google.com;*.android.com;*.appengine.google.com;*.cloud.google.com;*.db833953.google.cn;*.g.co;*.gcp.gvt2.com;*.google-analytics.com;*.google.ca;*.google.cl;*.google.co.in;*.google.co.jp;*.google.co.uk;*.google.com.ar;*.google.com.au;*.google.com.br;*.google.com.co;*.google.com.mx;*.google.com.tr;*.google.com.vn;*.google.de;*.google.es;*.google.fr;*.google.hu;*.google.it;*.google.nl;*.google.pl;*.google.pt;*.googleadapis.com;*.googleapis.cn;*.googlecommerce.com;*.googlevideo.com;*.gstatic.cn;*.gstatic.com;*.gvt1.com;*.gvt2.com;*.metric.gstatic.com;*.urchin.com;*.url.google.com;*.youtube-nocookie.com;*.youtube.com;*.youtubeeducation.com;*.yt.be;*.ytimg.com;android.clients.google.com;android.com;developer.android.google.cn;developers.android.google.cn;g.co;goo.gl;google-analytics.com;google.com;googlecommerce.com;source.android.google.cn;urchin.com;www.goo.gl;youtu.be;youtube.com;youtubeeducation.com;yt.be;]-;-;-;][F;-;]]
+      0:[x509;1521835121.017699;F1HSotip6XMR3ygJk;[3;0AD9B00801718556792CD5C6FC12421D;CN=duckduckgo.com,O=Duck Duck Go\\, Inc.,L=Paoli,ST=Pennsylvania,C=US,postalCode=19301,street=20 Paoli Pike,serialNumber=5019303,jurisdictionST=Delaware,jurisdictionC=US,businessCategory=Private Organization;CN=DigiCert SHA2 Extended Validation Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1496127600;1528484400;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[duckduckgo.com;www.duckduckgo.com;]-;-;-;][F;-;]]
+      0:[x509;1521835121.122664;F3qseb1fj5EXs284n5;[3;086C3B43E317C35EB708F31387F38A6B;CN=*.duckduckgo.com,O=Duck Duck Go\\, Inc.,L=Paoli,ST=Pennsylvania,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1496646000;1535655600;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.duckduckgo.com;duckduckgo.com;]-;-;-;][F;-;]]
+      0:[x509;1521835121.788655;F3lFUJ1HTCEiOjCvF6;[3;CC57FE54011E;unstructuredName=1315656901\\,564d7761726520496e632e,CN=localhost.localdomain,emailAddress=ssl-certificates@vmware.com,OU=VMware ESX Server Default Certificate,O=VMware\\, Inc,L=Palo Alto,ST=California,C=US;O=VMware Installer;1315682102;1678565702;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[localhost.localdomain;]-;-;-;][F;-;]]
+      0:[x509;1521835121.816445;F93iWw3tHl6C4qulVg;[3;CC57FE54011E;unstructuredName=1315656901\\,564d7761726520496e632e,CN=localhost.localdomain,emailAddress=ssl-certificates@vmware.com,OU=VMware ESX Server Default Certificate,O=VMware\\, Inc,L=Palo Alto,ST=California,C=US;O=VMware Installer;1315682102;1678565702;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[localhost.localdomain;]-;-;-;][F;-;]]
+      0:[x509;1521835124.250294;FbCfK19l6FRkoAfel;[3;01FBBD00172D9F64;CN=*.wordpress.com,OU=Domain Control Validated;CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\\, Inc.,L=Scottsdale,ST=Arizona,C=US;1441583561;1539541766;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.wordpress.com;wordpress.com;]-;-;-;][F;-;]]
+      0:[x509;1521835124.250332;Fn6L1Q2IjEoXnxUSsk;[3;01FBBD00172D9F64;CN=*.wordpress.com,OU=Domain Control Validated;CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\\, Inc.,L=Scottsdale,ST=Arizona,C=US;1441583561;1539541766;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.wordpress.com;wordpress.com;]-;-;-;][F;-;]]
+      0:[x509;1521835125.892383;FCEWwg3s9cEG6bmsXi;[3;03B554B0EE6FE3B21A962853C68489BCE45D;CN=nibbler.wrccdc.cpp.edu;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1517671875;1525444275;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[nibbler.wrccdc.cpp.edu;owncloud.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835131.901167;Fq3NNq3T5fN4ofEh13;[3;520786E0FB57C81D8F3A14B8DFDE5DDB;CN=*.intel.com,OU=Information Technology,O=Intel Corporation,L=Santa Clara,ST=California,C=US;CN=Symantec Class 3 Secure Server CA - G4,OU=Symantec Trust Network,O=Symantec Corporation,C=US;1503471600;1535093999;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.intel.com;intel.com;]-;-;-;][F;-;]]
+      0:[x509;1521835131.902869;FiEmYzFuuOqVofEvf;[3;520786E0FB57C81D8F3A14B8DFDE5DDB;CN=*.intel.com,OU=Information Technology,O=Intel Corporation,L=Santa Clara,ST=California,C=US;CN=Symantec Class 3 Secure Server CA - G4,OU=Symantec Trust Network,O=Symantec Corporation,C=US;1503471600;1535093999;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.intel.com;intel.com;]-;-;-;][F;-;]]
+      0:[x509;1521835132.699091;FC0A7y1A8b9Z5auZEg;[3;697724F2DE70F2FE05A44539CDC25C89;CN=sadmin.brightcove.com,OU=Engineering,O=Brightcove Inc,L=Boston,ST=Massachusetts,C=US;CN=Symantec Class 3 Secure Server CA - G4,OU=Symantec Trust Network,O=Symantec Corporation,C=US;1498633200;1532847599;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[sadmin.brightcove.com;]-;-;-;][F;-;]]
+      0:[x509;1521835132.860304;FRljkL25C7DaZiUUl;[3;0CCC01225604FBBAEC35A4829963B22F;CN=*.qualtrics.com,O=Qualtrics\\, LLC,L=Provo,ST=UT,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1516348800;1536174000;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.qualtrics.com;*.au1.qualtrics.com;*.az1.qualtrics.com;*.co1.qualtrics.com;*.us.qualtrics.com;*.us2.qualtrics.com;*.ut1.qualtrics.com;*.asia.qualtrics.com;*.eu.qualtrics.com;*.ca1.qualtrics.com;*.siteintercept.qualtrics.com;ql.tc;qualtrics.com;b1-prv.qualtrics.com;*.b1-prv.qualtrics.com;*.s1.b1-prv.qualtrics.com;*.st3.qualtrics.com;gov1.qualtrics.com;*.gov1.qualtrics.com;*.gov1.siteintercept.qualtrics.com;*.corp.qualtrics.com;*.s1.st3.qualtrics.com;*.q01.us;q01.us;iad1.qualtrics.com;*.iad1.qualtrics.com;g1-iad.qualtrics.com;*.g1-iad.qualtrics.com;]-;-;-;][F;-;]]
+      0:[x509;1521835132.860412;FdoKYD2h2HFgdMNGx1;[3;0CCC01225604FBBAEC35A4829963B22F;CN=*.qualtrics.com,O=Qualtrics\\, LLC,L=Provo,ST=UT,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1516348800;1536174000;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.qualtrics.com;*.au1.qualtrics.com;*.az1.qualtrics.com;*.co1.qualtrics.com;*.us.qualtrics.com;*.us2.qualtrics.com;*.ut1.qualtrics.com;*.asia.qualtrics.com;*.eu.qualtrics.com;*.ca1.qualtrics.com;*.siteintercept.qualtrics.com;ql.tc;qualtrics.com;b1-prv.qualtrics.com;*.b1-prv.qualtrics.com;*.s1.b1-prv.qualtrics.com;*.st3.qualtrics.com;gov1.qualtrics.com;*.gov1.qualtrics.com;*.gov1.siteintercept.qualtrics.com;*.corp.qualtrics.com;*.s1.st3.qualtrics.com;*.q01.us;q01.us;iad1.qualtrics.com;*.iad1.qualtrics.com;g1-iad.qualtrics.com;*.g1-iad.qualtrics.com;]-;-;-;][F;-;]]
+      0:[x509;1521835132.877555;FQqDN2N6bCLAG9Ev4;[3;0F663A6A364C36BD;CN=*.google-analytics.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481289;1527731580;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.google-analytics.com;app-measurement.com;google-analytics.com;googletagmanager.com;service.urchin.com;ssl.google-analytics.com;urchin.com;www.google-analytics.com;www.googletagmanager.com;]-;-;-;][F;-;]]
+      0:[x509;1521835132.912079;FIALwW1OvQhbGVDLz1;[3;0F663A6A364C36BD;CN=*.google-analytics.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481289;1527731580;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.google-analytics.com;app-measurement.com;google-analytics.com;googletagmanager.com;service.urchin.com;ssl.google-analytics.com;urchin.com;www.google-analytics.com;www.googletagmanager.com;]-;-;-;][F;-;]]
+      0:[x509;1521835132.978271;F12Yzn16XlnOshIAea;[3;63CA0A81FAD89AE6;CN=*.foxitcloud.com,OU=Domain Control Validated;CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\\, Inc.,L=Scottsdale,ST=Arizona,C=US;1494435600;1566195939;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.foxitcloud.com;foxitcloud.com;]-;-;-;][F;-;]]
+      0:[x509;1521835133.093943;FZDrJ22RWuclK3vf35;[3;0CCC01225604FBBAEC35A4829963B22F;CN=*.qualtrics.com,O=Qualtrics\\, LLC,L=Provo,ST=UT,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1516348800;1536174000;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.qualtrics.com;*.au1.qualtrics.com;*.az1.qualtrics.com;*.co1.qualtrics.com;*.us.qualtrics.com;*.us2.qualtrics.com;*.ut1.qualtrics.com;*.asia.qualtrics.com;*.eu.qualtrics.com;*.ca1.qualtrics.com;*.siteintercept.qualtrics.com;ql.tc;qualtrics.com;b1-prv.qualtrics.com;*.b1-prv.qualtrics.com;*.s1.b1-prv.qualtrics.com;*.st3.qualtrics.com;gov1.qualtrics.com;*.gov1.qualtrics.com;*.gov1.siteintercept.qualtrics.com;*.corp.qualtrics.com;*.s1.st3.qualtrics.com;*.q01.us;q01.us;iad1.qualtrics.com;*.iad1.qualtrics.com;g1-iad.qualtrics.com;*.g1-iad.qualtrics.com;]-;-;-;][F;-;]]
+      0:[x509;1521835133.095326;FKi3rm6eqbjZj4R0j;[3;0CCC01225604FBBAEC35A4829963B22F;CN=*.qualtrics.com,O=Qualtrics\\, LLC,L=Provo,ST=UT,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1516348800;1536174000;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.qualtrics.com;*.au1.qualtrics.com;*.az1.qualtrics.com;*.co1.qualtrics.com;*.us.qualtrics.com;*.us2.qualtrics.com;*.ut1.qualtrics.com;*.asia.qualtrics.com;*.eu.qualtrics.com;*.ca1.qualtrics.com;*.siteintercept.qualtrics.com;ql.tc;qualtrics.com;b1-prv.qualtrics.com;*.b1-prv.qualtrics.com;*.s1.b1-prv.qualtrics.com;*.st3.qualtrics.com;gov1.qualtrics.com;*.gov1.qualtrics.com;*.gov1.siteintercept.qualtrics.com;*.corp.qualtrics.com;*.s1.st3.qualtrics.com;*.q01.us;q01.us;iad1.qualtrics.com;*.iad1.qualtrics.com;g1-iad.qualtrics.com;*.g1-iad.qualtrics.com;]-;-;-;][F;-;]]
+      0:[x509;1521835133.095962;FimwwwKqbm6Z0g4x;[3;0CCC01225604FBBAEC35A4829963B22F;CN=*.qualtrics.com,O=Qualtrics\\, LLC,L=Provo,ST=UT,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1516348800;1536174000;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.qualtrics.com;*.au1.qualtrics.com;*.az1.qualtrics.com;*.co1.qualtrics.com;*.us.qualtrics.com;*.us2.qualtrics.com;*.ut1.qualtrics.com;*.asia.qualtrics.com;*.eu.qualtrics.com;*.ca1.qualtrics.com;*.siteintercept.qualtrics.com;ql.tc;qualtrics.com;b1-prv.qualtrics.com;*.b1-prv.qualtrics.com;*.s1.b1-prv.qualtrics.com;*.st3.qualtrics.com;gov1.qualtrics.com;*.gov1.qualtrics.com;*.gov1.siteintercept.qualtrics.com;*.corp.qualtrics.com;*.s1.st3.qualtrics.com;*.q01.us;q01.us;iad1.qualtrics.com;*.iad1.qualtrics.com;g1-iad.qualtrics.com;*.g1-iad.qualtrics.com;]-;-;-;][F;-;]]
+      0:[x509;1521835133.096096;FncSN02Rja2KbotNVf;[3;0CCC01225604FBBAEC35A4829963B22F;CN=*.qualtrics.com,O=Qualtrics\\, LLC,L=Provo,ST=UT,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1516348800;1536174000;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.qualtrics.com;*.au1.qualtrics.com;*.az1.qualtrics.com;*.co1.qualtrics.com;*.us.qualtrics.com;*.us2.qualtrics.com;*.ut1.qualtrics.com;*.asia.qualtrics.com;*.eu.qualtrics.com;*.ca1.qualtrics.com;*.siteintercept.qualtrics.com;ql.tc;qualtrics.com;b1-prv.qualtrics.com;*.b1-prv.qualtrics.com;*.s1.b1-prv.qualtrics.com;*.st3.qualtrics.com;gov1.qualtrics.com;*.gov1.qualtrics.com;*.gov1.siteintercept.qualtrics.com;*.corp.qualtrics.com;*.s1.st3.qualtrics.com;*.q01.us;q01.us;iad1.qualtrics.com;*.iad1.qualtrics.com;g1-iad.qualtrics.com;*.g1-iad.qualtrics.com;]-;-;-;][F;-;]]
+      0:[x509;1521835133.118479;FLMGou1es4W1miMgu2;[3;520786E0FB57C81D8F3A14B8DFDE5DDB;CN=*.intel.com,OU=Information Technology,O=Intel Corporation,L=Santa Clara,ST=California,C=US;CN=Symantec Class 3 Secure Server CA - G4,OU=Symantec Trust Network,O=Symantec Corporation,C=US;1503471600;1535093999;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.intel.com;intel.com;]-;-;-;][F;-;]]
+      0:[x509;1521835133.17424;FUIO7JPS897rn8Q8l;[3;520786E0FB57C81D8F3A14B8DFDE5DDB;CN=*.intel.com,OU=Information Technology,O=Intel Corporation,L=Santa Clara,ST=California,C=US;CN=Symantec Class 3 Secure Server CA - G4,OU=Symantec Trust Network,O=Symantec Corporation,C=US;1503471600;1535093999;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.intel.com;intel.com;]-;-;-;][F;-;]]
+      0:[x509;1521835133.239067;FyhEB9bnIKtcLf4h5;[3;1DDEE8C5D3AEF314;CN=*.googleapis.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481267;1527731580;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[*.googleapis.com;*.clients6.google.com;*.cloudendpointsapis.com;cloudendpointsapis.com;googleapis.com;]-;-;-;][F;-;]]
+      0:[x509;1521835134.188498;FQ3NJ61hemGyo7Mzn3;[3;33000000BD2368E7BFC08DF89E0000000000BD;CN=fe2.update.microsoft.com,OU=DSP,O=Microsoft,L=Redmond,ST=WA,C=US;CN=Microsoft Update Secure Server CA 2.1,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US;1517970550;1530926950;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[fe2.update.microsoft.com;]-;-;-;][F;-;]]
+      0:[x509;1521835134.292186;F8lPbK0rLA3gxryal;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835135.137951;F9jZp13KqfokX8s8Q3;[3;33000000BD2368E7BFC08DF89E0000000000BD;CN=fe2.update.microsoft.com,OU=DSP,O=Microsoft,L=Redmond,ST=WA,C=US;CN=Microsoft Update Secure Server CA 2.1,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US;1517970550;1530926950;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[fe2.update.microsoft.com;]-;-;-;][F;-;]]
+      0:[x509;1521835135.416766;FCWs1NgSDf5Y4DiP5;[3;08EE8C043FCB4E6E4E782350FE450E09;CN=qa.sockets.stackexchange.com,O=Stack Exchange\\, Inc.,L=New York,ST=NY,C=US;CN=DigiCert SHA2 High Assurance Server CA,OU=www.digicert.com,O=DigiCert Inc,C=US;1464246000;1564167600;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[qa.sockets.stackexchange.com;chat.sockets.stackexchange.com;mobile.sockets.stackexchange.com;stacksnippets.net;]-;-;-;][F;-;]]
+      0:[x509;1521835139.069985;FDG3BL3gYxGFIsqX5f;[3;151DED78E5B1322E;CN=*.wildfire.paloaltonetworks.com,OU=Domain Control Validated;CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\\, Inc.,L=Scottsdale,ST=Arizona,C=US;1487832360;1586668519;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.wildfire.paloaltonetworks.com;wildfire.paloaltonetworks.com;]-;-;-;][F;-;]]
+      0:[x509;1521835139.075657;FA8JrK23E2RWAvUTFg;[3;F1754B9BA47D4A6C;CN=Palo Alto Networks Device 410,O=Palo Alto Networks,C=US;CN=Palo Alto Networks SSL CA 1,O=Palo Alto Networks,C=US;1446787226;1767331226;rsaEncryption;sha512WithRSAEncryption;rsa;2048;65537;-;][-;-;-;-;][F;-;]]
+      0:[x509;1521835139.594803;FIU2O9Kx6alx00wXg;[3;7AEE77D0AA874D3A;CN=*.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481815;1527731580;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[*.google.com;*.android.com;*.appengine.google.com;*.cloud.google.com;*.db833953.google.cn;*.g.co;*.gcp.gvt2.com;*.google-analytics.com;*.google.ca;*.google.cl;*.google.co.in;*.google.co.jp;*.google.co.uk;*.google.com.ar;*.google.com.au;*.google.com.br;*.google.com.co;*.google.com.mx;*.google.com.tr;*.google.com.vn;*.google.de;*.google.es;*.google.fr;*.google.hu;*.google.it;*.google.nl;*.google.pl;*.google.pt;*.googleadapis.com;*.googleapis.cn;*.googlecommerce.com;*.googlevideo.com;*.gstatic.cn;*.gstatic.com;*.gvt1.com;*.gvt2.com;*.metric.gstatic.com;*.urchin.com;*.url.google.com;*.youtube-nocookie.com;*.youtube.com;*.youtubeeducation.com;*.yt.be;*.ytimg.com;android.clients.google.com;android.com;developer.android.google.cn;developers.android.google.cn;g.co;goo.gl;google-analytics.com;google.com;googlecommerce.com;source.android.google.cn;urchin.com;www.goo.gl;youtu.be;youtube.com;youtubeeducation.com;yt.be;]-;-;-;][F;-;]]
+      0:[x509;1521835140.391228;FhZpi3248zYLsYfJ7d;[3;2E1B63B3CEFCF100;CN=*.c.docs.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G2,O=Google Inc,C=US;1520968680;1528226280;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.c.docs.google.com;*.a1.googlevideo.com;*.c.2mdn.net;*.c.audiobooks.play.google.com;*.c.bigcache.googleapis.com;*.c.chat.google.com;*.c.doc-0-0-sj.sj.googleusercontent.com;*.c.drive.google.com;*.c.googlesyndication.com;*.c.googlevideo.com;*.c.inbox.google.com;*.c.lh3.googleusercontent.com;*.c.mail.google.com;*.c.offline.maps.google.com;*.c.pack.google.com;*.c.play.google.com;*.c.video.google.com;*.c.youtube.com;*.cache1.c.docs.google.com;*.cache1.c.play.google.com;*.cache1.c.video.google.com;*.cache1.c.youtube.com;*.cache2.c.docs.google.com;*.cache2.c.play.google.com;*.cache2.c.video.google.com;*.cache2.c.youtube.com;*.cache3.c.docs.google.com;*.cache3.c.play.google.com;*.cache3.c.video.google.com;*.cache3.c.youtube.com;*.cache4.c.docs.google.com;*.cache4.c.play.google.com;*.cache4.c.video.google.com;*.cache4.c.youtube.com;*.cache5.c.docs.google.com;*.cache5.c.play.google.com;*.cache5.c.video.google.com;*.cache5.c.youtube.com;*.cache6.c.docs.google.com;*.cache6.c.play.google.com;*.cache6.c.video.google.com;*.cache6.c.youtube.com;*.cache7.c.docs.google.com;*.cache7.c.play.google.com;*.cache7.c.video.google.com;*.cache7.c.youtube.com;*.cache8.c.docs.google.com;*.cache8.c.play.google.com;*.cache8.c.video.google.com;*.cache8.c.youtube.com;*.dai.googlevideo.com;*.googlevideo.com;*.googlezip.net;*.gvt1.com;*.offline-maps.gvt1.com;*.xn--ngstr-lra8j.com;xn--ngstr-lra8j.com;]-;-;-;][F;-;]]
+      0:[x509;1521835151.738729;FWyPIf2cfSRKVCx98k;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835157.066975;FOwEh04awmlIdUqll8;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835161.036828;F2JYXq3lkdfzNwliX1;[3;63CA0A81FAD89AE6;CN=*.foxitcloud.com,OU=Domain Control Validated;CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\\, Inc.,L=Scottsdale,ST=Arizona,C=US;1494435600;1566195939;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.foxitcloud.com;foxitcloud.com;]-;-;-;][F;-;]]
+      0:[x509;1521835162.12059;F2kmDm1cZXalhvR0Ri;[3;0A129AC79D151C8BF85072B0547AACF4;CN=*.telemetry.mozilla.org,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1440486000;1535569200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.telemetry.mozilla.org;telemetry.mozilla.org;]-;-;-;][F;-;]]
+      0:[x509;1521835162.121533;Fb2xLc48da6hybusvi;[3;0A129AC79D151C8BF85072B0547AACF4;CN=*.telemetry.mozilla.org,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1440486000;1535569200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.telemetry.mozilla.org;telemetry.mozilla.org;]-;-;-;][F;-;]]
+      0:[x509;1521835162.123693;FqohSW1Yih0zps4Arj;[3;0A129AC79D151C8BF85072B0547AACF4;CN=*.telemetry.mozilla.org,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1440486000;1535569200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.telemetry.mozilla.org;telemetry.mozilla.org;]-;-;-;][F;-;]]
+      0:[x509;1521835162.13188;Fv7oDD4984zCjrTiF5;[3;0A129AC79D151C8BF85072B0547AACF4;CN=*.telemetry.mozilla.org,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1440486000;1535569200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.telemetry.mozilla.org;telemetry.mozilla.org;]-;-;-;][F;-;]]
+      0:[x509;1521835162.13312;FuGE6A4puA9TpEEgO8;[3;0A129AC79D151C8BF85072B0547AACF4;CN=*.telemetry.mozilla.org,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1440486000;1535569200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.telemetry.mozilla.org;telemetry.mozilla.org;]-;-;-;][F;-;]]
+      0:[x509;1521835162.133567;Fo7n4E2jlzpEEQ9pmh;[3;0A129AC79D151C8BF85072B0547AACF4;CN=*.telemetry.mozilla.org,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1440486000;1535569200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.telemetry.mozilla.org;telemetry.mozilla.org;]-;-;-;][F;-;]]
+      0:[x509;1521835163.119861;Ff1gMK3KQGHRrH5lYj;[3;7AEE77D0AA874D3A;CN=*.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481815;1527731580;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[*.google.com;*.android.com;*.appengine.google.com;*.cloud.google.com;*.db833953.google.cn;*.g.co;*.gcp.gvt2.com;*.google-analytics.com;*.google.ca;*.google.cl;*.google.co.in;*.google.co.jp;*.google.co.uk;*.google.com.ar;*.google.com.au;*.google.com.br;*.google.com.co;*.google.com.mx;*.google.com.tr;*.google.com.vn;*.google.de;*.google.es;*.google.fr;*.google.hu;*.google.it;*.google.nl;*.google.pl;*.google.pt;*.googleadapis.com;*.googleapis.cn;*.googlecommerce.com;*.googlevideo.com;*.gstatic.cn;*.gstatic.com;*.gvt1.com;*.gvt2.com;*.metric.gstatic.com;*.urchin.com;*.url.google.com;*.youtube-nocookie.com;*.youtube.com;*.youtubeeducation.com;*.yt.be;*.ytimg.com;android.clients.google.com;android.com;developer.android.google.cn;developers.android.google.cn;g.co;goo.gl;google-analytics.com;google.com;googlecommerce.com;source.android.google.cn;urchin.com;www.goo.gl;youtu.be;youtube.com;youtubeeducation.com;yt.be;]-;-;-;][F;-;]]
+      0:[x509;1521835163.156969;Ft3v7r1MkOYiez6Uu5;[3;7AEE77D0AA874D3A;CN=*.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481815;1527731580;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[*.google.com;*.android.com;*.appengine.google.com;*.cloud.google.com;*.db833953.google.cn;*.g.co;*.gcp.gvt2.com;*.google-analytics.com;*.google.ca;*.google.cl;*.google.co.in;*.google.co.jp;*.google.co.uk;*.google.com.ar;*.google.com.au;*.google.com.br;*.google.com.co;*.google.com.mx;*.google.com.tr;*.google.com.vn;*.google.de;*.google.es;*.google.fr;*.google.hu;*.google.it;*.google.nl;*.google.pl;*.google.pt;*.googleadapis.com;*.googleapis.cn;*.googlecommerce.com;*.googlevideo.com;*.gstatic.cn;*.gstatic.com;*.gvt1.com;*.gvt2.com;*.metric.gstatic.com;*.urchin.com;*.url.google.com;*.youtube-nocookie.com;*.youtube.com;*.youtubeeducation.com;*.yt.be;*.ytimg.com;android.clients.google.com;android.com;developer.android.google.cn;developers.android.google.cn;g.co;goo.gl;google-analytics.com;google.com;googlecommerce.com;source.android.google.cn;urchin.com;www.goo.gl;youtu.be;youtube.com;youtubeeducation.com;yt.be;]-;-;-;][F;-;]]
+      0:[x509;1521835164.872034;FXGGyf1YTFUILPqNj3;[3;5B6A37F39B36AF7F;CN=www.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520480330;1527731520;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[www.google.com;]-;-;-;][F;-;]]
+      0:[x509;1521835170.011311;FzcZsf4h9squ99j6mi;[3;33000000BD2368E7BFC08DF89E0000000000BD;CN=fe2.update.microsoft.com,OU=DSP,O=Microsoft,L=Redmond,ST=WA,C=US;CN=Microsoft Update Secure Server CA 2.1,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US;1517970550;1530926950;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[fe2.update.microsoft.com;]-;-;-;][F;-;]]
+      0:[x509;1521835172.697178;FHCSq83ZtULjLBGJ29;[3;3300000110A7D38142EFD29279000000000110;CN=*.vortex-win.data.microsoft.com,OU=Microsoft,O=Microsoft Corporation,L=Redmond,ST=WA,C=US;CN=Microsoft Secure Server CA 2011,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US;1508372978;1547861378;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.vortex-win.data.microsoft.com;vortex-win.data.microsoft.com;]-;-;-;][F;-;]]
+      0:[x509;1521835172.714672;FEwijD4W1p5nBuCdle;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835175.668603;FIYLjf3ovdtZnsU8Jl;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835175.669374;FjqETT3SYcUHYmk5B;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835175.671842;FqUYvv4WvCT2MM5Nci;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835175.672077;Fneelc3lr6xyv57Jf;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835175.673567;FzvwxK1PBgVagyS7d2;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835178.13595;FBLlDe1wuwtwuVz1fl;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835181.691868;FlCNXr2wMXs9GxP5Fg;[3;50FE9D62CC076143B817AA9546186D19;CN=ssl365422.cloudflaressl.com,OU=PositiveSSL Multi-Domain,OU=Domain Control Validated;CN=COMODO ECC Domain Validation Secure Server CA 2,O=COMODO CA Limited,L=Salford,ST=Greater Manchester,C=GB;1519200000;1535698799;id-ecPublicKey;ecdsa-with-SHA256;ecdsa;256;-;prime256v1;][[ssl365422.cloudflaressl.com;*.git-scm.com;git-scm.com;]-;-;-;][F;-;]]
+      0:[x509;1521835185.129965;F1TwUF1BmMdMkQGd11;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835195.137411;F1lm9P3ZCGPsADWVie;[3;3300000110A7D38142EFD29279000000000110;CN=*.vortex-win.data.microsoft.com,OU=Microsoft,O=Microsoft Corporation,L=Redmond,ST=WA,C=US;CN=Microsoft Secure Server CA 2011,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US;1508372978;1547861378;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.vortex-win.data.microsoft.com;vortex-win.data.microsoft.com;]-;-;-;][F;-;]]
+      0:[x509;1521835197.155471;FC9RC6REXIzS4YDL7;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835197.156412;F302lk4grXy4AOSFpl;[3;043A77F4DE8953F26873726E3C6AAEC2725A;CN=ise.wrccdc.org;CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US;1520437626;1528210026;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[ise.wrccdc.cpp.edu;ise.wrccdc.org;]-;-;-;][F;-;]]
+      0:[x509;1521835198.281444;FgzqhU30lvJhCXZb54;[3;CC57FE54011E;unstructuredName=1315656901\\,564d7761726520496e632e,CN=localhost.localdomain,emailAddress=ssl-certificates@vmware.com,OU=VMware ESX Server Default Certificate,O=VMware\\, Inc,L=Palo Alto,ST=California,C=US;O=VMware Installer;1315682102;1678565702;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[localhost.localdomain;]-;-;-;][F;-;]]
+      0:[x509;1521835198.322053;Fr8zTM1RoUcQw1L7mg;[3;CC57FE54011E;unstructuredName=1315656901\\,564d7761726520496e632e,CN=localhost.localdomain,emailAddress=ssl-certificates@vmware.com,OU=VMware ESX Server Default Certificate,O=VMware\\, Inc,L=Palo Alto,ST=California,C=US;O=VMware Installer;1315682102;1678565702;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[localhost.localdomain;]-;-;-;][F;-;]]
+      0:[x509;1521835201.249605;FFkIVJ2yhmOFRgEiuj;[3;1DDEE8C5D3AEF314;CN=*.googleapis.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481267;1527731580;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[*.googleapis.com;*.clients6.google.com;*.cloudendpointsapis.com;cloudendpointsapis.com;googleapis.com;]-;-;-;][F;-;]]
+      0:[x509;1521835202.147701;FpepBP2CTw9Jl59Q8b;[3;6814790E01AB9B9C;CN=updates.paloaltonetworks.com,OU=Domain Control Validated;CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\\, Inc.,L=Scottsdale,ST=Arizona,C=US;1428621579;1527646848;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[updates.paloaltonetworks.com;www.updates.paloaltonetworks.com;]-;-;-;][F;-;]]
+      0:[x509;1521835202.186839;FqwcN9otnXQNtTt6i;[3;6814790E01AB9B9C;CN=updates.paloaltonetworks.com,OU=Domain Control Validated;CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\\, Inc.,L=Scottsdale,ST=Arizona,C=US;1428621579;1527646848;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[updates.paloaltonetworks.com;www.updates.paloaltonetworks.com;]-;-;-;][F;-;]]
+      0:[x509;1521835203.025313;FeeKTR1RuaYs1M8Gnd;[3;6814790E01AB9B9C;CN=updates.paloaltonetworks.com,OU=Domain Control Validated;CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\\, Inc.,L=Scottsdale,ST=Arizona,C=US;1428621579;1527646848;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[updates.paloaltonetworks.com;www.updates.paloaltonetworks.com;]-;-;-;][F;-;]]
+      0:[x509;1521835203.203102;FL0sSffddPgtCH7yk;[3;6814790E01AB9B9C;CN=updates.paloaltonetworks.com,OU=Domain Control Validated;CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\\, Inc.,L=Scottsdale,ST=Arizona,C=US;1428621579;1527646848;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[updates.paloaltonetworks.com;www.updates.paloaltonetworks.com;]-;-;-;][F;-;]]
+      0:[x509;1521835206.813931;FupIoo4PVid3rbgEKe;[3;017E45A31AA50BC35053BC50F9B69BAD;CN=*.services.mozilla.com,OU=Cloud Services,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1507014000;1578513600;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.services.mozilla.com;services.mozilla.com;]-;-;-;][F;-;]]
+      0:[x509;1521835206.851044;FIiYxz1b6qE0ghQSac;[3;0CA9C64361BFC92A79B1DD9CFB9E48EC;CN=*.cdn.mozilla.net,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1478156400;1580587200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.cdn.mozilla.net;cdn.mozilla.net;]-;-;-;][F;-;]]
+      0:[x509;1521835206.852269;FQoFM3Wp0XqyfwDk5;[3;0CA9C64361BFC92A79B1DD9CFB9E48EC;CN=*.cdn.mozilla.net,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1478156400;1580587200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.cdn.mozilla.net;cdn.mozilla.net;]-;-;-;][F;-;]]
+      0:[x509;1521835206.857262;FHahIygOCWkUqWDwe;[3;0CA9C64361BFC92A79B1DD9CFB9E48EC;CN=*.cdn.mozilla.net,O=Mozilla Corporation,L=Mountain View,ST=California,C=US;CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US;1478156400;1580587200;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.cdn.mozilla.net;cdn.mozilla.net;]-;-;-;][F;-;]]
+      0:[x509;1521835208.940684;FA6XpG1VhlON2hys4a;[3;7AEE77D0AA874D3A;CN=*.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481815;1527731580;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[*.google.com;*.android.com;*.appengine.google.com;*.cloud.google.com;*.db833953.google.cn;*.g.co;*.gcp.gvt2.com;*.google-analytics.com;*.google.ca;*.google.cl;*.google.co.in;*.google.co.jp;*.google.co.uk;*.google.com.ar;*.google.com.au;*.google.com.br;*.google.com.co;*.google.com.mx;*.google.com.tr;*.google.com.vn;*.google.de;*.google.es;*.google.fr;*.google.hu;*.google.it;*.google.nl;*.google.pl;*.google.pt;*.googleadapis.com;*.googleapis.cn;*.googlecommerce.com;*.googlevideo.com;*.gstatic.cn;*.gstatic.com;*.gvt1.com;*.gvt2.com;*.metric.gstatic.com;*.urchin.com;*.url.google.com;*.youtube-nocookie.com;*.youtube.com;*.youtubeeducation.com;*.yt.be;*.ytimg.com;android.clients.google.com;android.com;developer.android.google.cn;developers.android.google.cn;g.co;goo.gl;google-analytics.com;google.com;googlecommerce.com;source.android.google.cn;urchin.com;www.goo.gl;youtu.be;youtube.com;youtubeeducation.com;yt.be;]-;-;-;][F;-;]]
+      0:[x509;1521835209.173792;F1i9aW3inSq8GoHUrh;[3;7AEE77D0AA874D3A;CN=*.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520481815;1527731580;id-ecPublicKey;sha256WithRSAEncryption;ecdsa;256;-;prime256v1;][[*.google.com;*.android.com;*.appengine.google.com;*.cloud.google.com;*.db833953.google.cn;*.g.co;*.gcp.gvt2.com;*.google-analytics.com;*.google.ca;*.google.cl;*.google.co.in;*.google.co.jp;*.google.co.uk;*.google.com.ar;*.google.com.au;*.google.com.br;*.google.com.co;*.google.com.mx;*.google.com.tr;*.google.com.vn;*.google.de;*.google.es;*.google.fr;*.google.hu;*.google.it;*.google.nl;*.google.pl;*.google.pt;*.googleadapis.com;*.googleapis.cn;*.googlecommerce.com;*.googlevideo.com;*.gstatic.cn;*.gstatic.com;*.gvt1.com;*.gvt2.com;*.metric.gstatic.com;*.urchin.com;*.url.google.com;*.youtube-nocookie.com;*.youtube.com;*.youtubeeducation.com;*.yt.be;*.ytimg.com;android.clients.google.com;android.com;developer.android.google.cn;developers.android.google.cn;g.co;goo.gl;google-analytics.com;google.com;googlecommerce.com;source.android.google.cn;urchin.com;www.goo.gl;youtu.be;youtube.com;youtubeeducation.com;yt.be;]-;-;-;][F;-;]]
+      0:[x509;1521835209.180657;FBJWvr2V8O1Zoh94e7;[3;3892272EADCEBD234C2D9CD84F388F0D;CN=shasta-ars.symantec.com,OU=IT Security,O=Symantec Corporation,L=Mountain View,ST=California,C=US;CN=Symantec Class 3 Secure Server CA - G4,OU=Symantec Trust Network,O=Symantec Corporation,C=US;1510560000;1542268799;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[SHASTA-ARS.SYMANTEC.COM;PCTOOLS-SHASTA-ARS.SYMANTEC.COM;MAC-SHASTA-ARS.SYMANTEC.COM;shasta-mrs.symantec.com;shasta-rrs.symantec.com;ent-shasta-rrs.symantec.com;PCTOOLS-SHASTA-RRS.SYMANTEC.COM;nss-shasta-rrs.symantec.com;smr-shasta-rrs.symantec.com;SUPPORTTOOL-SHASTA-RRS.SYMANTEC.COM;mi5-shasta-rrs.symantec.com;ratings-wrs.symantec.com;pctools-shasta-wrs.symantec.com;badratings-wrs.symantec.com;mac-shasta-wrs.symantec.com;nms-shasta-wrs.symantec.com;nsat-shasta-wrs.symantec.com;ent-shasta-wrs.symantec.com;shasta-ars-prod-mue1.np.norton.com;shasta-mrs-prod-mue1.np.norton.com;shasta-rrs-prod-mue1.np.norton.com;nss-shasta-rrs-prod-mue1.np.norton.com;smr-shasta-rrs-prod-mue1.np.norton.com;mi5-shasta-rrs-prod-mue1.np.norton.com;ratings-wrs-prod-mue1.np.norton.com;shasta-wrs-prod-mue1.np.norton.com;]-;-;-;][F;-;]]
+      0:[x509;1521835209.200068;FhFAEA3Knxr0H5X245;[3;6F2AB3C8D104ED87;CN=*.apis.google.com,O=Google Inc,L=Mountain View,ST=California,C=US;CN=Google Internet Authority G3,O=Google Trust Services,C=US;1520479961;1527731520;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[*.apis.google.com;apis.google.com;]-;-;-;][F;-;]]
+      0:[x509;1521835209.571412;F7fLflKp4zaiLwsBl;[3;4ED0A614595B4B3CA11DCB4EF5770481;CN=downloads.paloaltonetworks.com,OU=Palo Alto Networks,O=Palo Alto Networks\\, Inc.,L=Santa Clara,ST=California,C=US;CN=Symantec Class 3 Secure Server CA - G4,OU=Symantec Trust Network,O=Symantec Corporation,C=US;1504249200;1543737599;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[downloads.paloaltonetworks.com;]-;-;-;][F;-;]]
+      0:[x509;1521835209.781037;Ftz8tC1Qa9sOLq2s3l;[3;4ED0A614595B4B3CA11DCB4EF5770481;CN=downloads.paloaltonetworks.com,OU=Palo Alto Networks,O=Palo Alto Networks\\, Inc.,L=Santa Clara,ST=California,C=US;CN=Symantec Class 3 Secure Server CA - G4,OU=Symantec Trust Network,O=Symantec Corporation,C=US;1504249200;1543737599;rsaEncryption;sha256WithRSAEncryption;rsa;2048;65537;-;][[downloads.paloaltonetworks.com;]-;-;-;][F;-;]]

--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -78,6 +78,7 @@ func (s *zngScanner) scanUncompressed() ([]*zng.Record, error) {
 			return nil, err
 		}
 		if rec != nil {
+			rec.CopyBody()
 			recs = append(recs, rec)
 		}
 	}

--- a/zio/zngio/scanner.go
+++ b/zio/zngio/scanner.go
@@ -52,7 +52,6 @@ func (s *zngScanner) Pull() (zbuf.Batch, error) {
 			return nil, err
 		}
 		if rec != nil {
-			rec.CopyBody()
 			return zbuf.NewArray([]*zng.Record{rec}), nil
 		}
 	}
@@ -78,7 +77,6 @@ func (s *zngScanner) scanUncompressed() ([]*zng.Record, error) {
 			return nil, err
 		}
 		if rec != nil {
-			rec.CopyBody()
 			recs = append(recs, rec)
 		}
 	}
@@ -99,6 +97,7 @@ func (s *zngScanner) scanOne(id int, buf []byte) (*zng.Record, error) {
 	}
 	atomic.AddInt64(&s.stats.BytesMatched, int64(len(rec.Raw)))
 	atomic.AddInt64(&s.stats.RecordsMatched, 1)
+	rec.CopyBody()
 	return rec, nil
 }
 


### PR DESCRIPTION
zngio.zngScanner.Pull returns volatile records, but driver.mux.run sends
them to another goroutine to be read, presenting a potential data race.
Fix that by returning nonvolatile records from zngio.zngScanner.Pull.

Fixes #1087.