### PR TITLE
Return context errors from proc.GroupBy.Pull and proc.Sort.Pull

### DIFF
--- a/proc/groupby.go
+++ b/proc/groupby.go
@@ -235,8 +235,10 @@ func NewGroupBy(c *Context, parent Proc, params GroupByParams) *GroupBy {
 
 func (g *GroupBy) Pull() (zbuf.Batch, error) {
 	g.once.Do(func() { go g.run() })
-	r := <-g.resultCh
-	return r.Batch, r.Err
+	if r, ok := <-g.resultCh; ok {
+		return r.Batch, r.Err
+	}
+	return nil, g.Context.Err()
 }
 
 func (g *GroupBy) run() {

--- a/proc/sort.go
+++ b/proc/sort.go
@@ -56,8 +56,10 @@ func CompileSortProc(c *Context, parent Proc, node *ast.SortProc) (*Sort, error)
 
 func (s *Sort) Pull() (zbuf.Batch, error) {
 	s.once.Do(func() { go s.sortLoop() })
-	r := <-s.resultCh
-	return r.Batch, r.Err
+	if r, ok := <-s.resultCh; ok {
+		return r.Batch, r.Err
+	}
+	return nil, s.Context.Err()
 }
 
 func (s *Sort) sortLoop() {


### PR DESCRIPTION
This is part of fixing #970.