### PR TITLE
update help text for zar commands

### DIFF
--- a/cmd/zar/find/command.go
+++ b/cmd/zar/find/command.go
@@ -20,7 +20,7 @@ var Find = &charm.Spec{
 	Usage: "find [options] pattern [pattern...]",
 	Short: "look through zar index files and displays matches",
 	Long: `
-"zar find" descends the directory given by the -R option (or ZAR_ROOT)
+"zar find" searches a zar archive
 looking for zng files that have been indexed and performs a search on
 each such index file in accordance with the specified search pattern.
 Indexes are created by "zar index".
@@ -71,7 +71,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
 	f.BoolVar(&c.skipMissing, "Q", false, "skip errors caused by missing index files ")
 	f.StringVar(&c.indexFile, "x", "", "name of zdx index for custom index searches")
 	f.StringVar(&c.outputFile, "o", "", "write data to output file")

--- a/cmd/zar/import/command.go
+++ b/cmd/zar/import/command.go
@@ -18,14 +18,16 @@ import (
 
 var Import = &charm.Spec{
 	Name:  "import",
-	Usage: "import [options] file",
+	Usage: "import [-R root] [options] [file|S3-object|-]",
 	Short: "import log files into pieces",
 	Long: `
-The import command provides a way to create a new zar archive with data.
-It takes as input zng data and cuts the stream
-into chunks where each chunk is created when the size threshold is exceeded,
-either in bytes (-b) or megabytes (-s).  The path of each chunk is a subdirectory
-in the specified directory (-R or ZAR_ROOT) where the subdirectory name is derived from the
+The import command provides a way to create a new zar archive with ZNG data
+from an existing file, S3 location, or stdin.
+
+The input data is sorted and paritioned by time into chunks. Each chunk is
+created when the size threshold is exceeded, either in bytes (-b) or megabytes
+(-s).  The path of each chunk is a subdirectory in the specified root
+(-R or ZAR_ROOT) where the subdirectory name is derived from the
 timestamp of the first zng record in that chunk.
 `,
 	New: New,
@@ -46,8 +48,8 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
-	f.StringVar(&c.dataPath, "data", "", "location for storing data files (defaults to root directory)")
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.StringVar(&c.dataPath, "data", "", "location for storing data files (defaults to root)")
 	f.StringVar(&c.thresh, "s", units.Base2Bytes(archive.DefaultLogSizeThreshold).String(), "target size of chopped files, as '10MB' or '4GiB', etc.")
 	f.BoolVar(&c.empty, "empty", false, "create an archive without initial data")
 	c.ReaderFlags.SetFlags(f)

--- a/cmd/zar/import/command.go
+++ b/cmd/zar/import/command.go
@@ -24,11 +24,10 @@ var Import = &charm.Spec{
 The import command provides a way to create a new zar archive with ZNG data
 from an existing file, S3 location, or stdin.
 
-The input data is sorted and paritioned by time into chunks. Each chunk is
-created when the size threshold is exceeded, either in bytes (-b) or megabytes
-(-s).  The path of each chunk is a subdirectory in the specified root
-(-R or ZAR_ROOT) where the subdirectory name is derived from the
-timestamp of the first zng record in that chunk.
+The input data is sorted and partitioned by time into approximately equal
+sized ZNG files, called "chunks". The path of each chunk is a subdirectory in
+the specified root location (-R or ZAR_ROOT), where the subdirectory name is
+derived from the timestamp of the first zng record in that chunk.
 `,
 	New: New,
 }
@@ -50,7 +49,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
 	f.StringVar(&c.dataPath, "data", "", "location for storing data files (defaults to root)")
-	f.StringVar(&c.thresh, "s", units.Base2Bytes(archive.DefaultLogSizeThreshold).String(), "target size of chopped files, as '10MB' or '4GiB', etc.")
+	f.StringVar(&c.thresh, "s", units.Base2Bytes(archive.DefaultLogSizeThreshold).String(), "target size of chunk files, as '10MB' or '4GiB', etc.")
 	f.BoolVar(&c.empty, "empty", false, "create an archive without initial data")
 	c.ReaderFlags.SetFlags(f)
 	return c, nil

--- a/cmd/zar/index/command.go
+++ b/cmd/zar/index/command.go
@@ -15,13 +15,11 @@ import (
 
 var Index = &charm.Spec{
 	Name:  "index",
-	Usage: "index [-R dir] [options] [-z zql] [ pattern [ pattern ...]]",
+	Usage: "index [-R root] [options] [-z zql] [ pattern [ pattern ...]]",
 	Short: "create index files for zng files",
 	Long: `
-zar index descends the directory argument starting at dir and looks
-for files with zar directories.  Each such file found is indexed according
-to the one or more indexing rules provided, and the resulting indexes
-are written to that file's zar directory.
+"zar index" creates index files in a zar archive using one or more indexing
+rules.
 
 A pattern is either a field name or a ":" followed by a zng type name.
 For example, to index the all fields of type port and the field id.orig_h,
@@ -35,9 +33,6 @@ For custom indexes, zql can be used instead of a pattern. This
 requires specifying the key and output file name. For example:
 
        zar index -k id.orig_h -o custom -z "count() by _path, id.orig_h | sort id.orig_h"
-
-The root directory must be specified either by the ZAR_ROOT environemnt
-variable or the -R option.
 `,
 	New: New,
 }
@@ -59,7 +54,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
 	f.StringVar(&c.keys, "k", "key", "one or more comma-separated key fields")
 	f.IntVar(&c.framesize, "f", 32*1024, "minimum frame size used in zdx file")
 	f.StringVar(&c.inputFile, "i", "_", "input file relative to each zar directory ('_' means archive log file in the parent of the zar directory)")

--- a/cmd/zar/ls/command.go
+++ b/cmd/zar/ls/command.go
@@ -17,13 +17,11 @@ import (
 
 var Ls = &charm.Spec{
 	Name:  "ls",
-	Usage: "ls [options] [pattern]",
+	Usage: "ls [-R root] [options] [pattern]",
 	Short: "list the zar directories in an archive",
 	Long: `
 "zar ls" walks an archive's directories and prints out
 the path of each zar directory contained with those top-level directories.
-TBD: In the future, this command could
-display a detailed summary of the context each zar directory.
 `,
 	New: New,
 }
@@ -41,7 +39,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
 	f.BoolVar(&c.lflag, "l", false, "long form")
 	f.BoolVar(&c.relativePaths, "relative", false, "display paths relative to root")
 	return c, nil

--- a/cmd/zar/rm/command.go
+++ b/cmd/zar/rm/command.go
@@ -15,7 +15,7 @@ import (
 
 var Rm = &charm.Spec{
 	Name:  "rm",
-	Usage: "rm file",
+	Usage: "rm [-R root] file",
 	Short: "remove files from zar directories in an archive",
 	Long: `
 "zar rm" walks a zar achive and removes the file with the given name from
@@ -36,7 +36,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
 	f.BoolVar(&c.relativePaths, "relative", false, "display paths relative to root")
 	return c, nil
 }

--- a/cmd/zar/rmdirs/command.go
+++ b/cmd/zar/rmdirs/command.go
@@ -11,7 +11,7 @@ import (
 
 var RmDirs = &charm.Spec{
 	Name:  "rmdirs",
-	Usage: "rmdirs [-R archive]",
+	Usage: "rmdirs [-R root]",
 	Short: "walk a directory tree and remove zar directories",
 	Long: `
 "zar rmdirs" descends the provided directory looking for
@@ -33,7 +33,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
 	return c, nil
 }
 

--- a/cmd/zar/root/command.go
+++ b/cmd/zar/root/command.go
@@ -11,7 +11,20 @@ var Zar = &charm.Spec{
 	Usage: "zar [global options] command [options] [arguments...]",
 	Short: "create and search zng archives",
 	Long: `
-zar creates and searches index files for zng files.
+zar operates on collections of ZNG files partitioned by time and stored either
+on a filesystem or an S3 compatible object store. An individual
+item of data (a file or object) is called a chunk, and each chunk may have
+other named ZNG files associated with it, stored "near" to the chunk. For 
+filesystem archives, the associated files are stored in a directory next
+to the chunk file.
+
+An example of a chunk associated file is a micro-index: a ZNG file that holds
+keyed records and supports very fast lookup of keys. When the key represents
+a value in the associated chunk file, micro-indexes can be used to to make
+searching an archive very fast.
+
+See the zar README in the zq github repo for more information:
+https://github.com/brimsec/zq/blob/master/cmd/zar/README.md
 `,
 	New: New,
 }

--- a/cmd/zar/stat/command.go
+++ b/cmd/zar/stat/command.go
@@ -17,7 +17,7 @@ import (
 
 var Stat = &charm.Spec{
 	Name:  "stat",
-	Usage: "stat [options]",
+	Usage: "stat [-R root] [options]",
 	Short: "archive component statistics",
 	Long: `
 "zar stat" generates a ZNG stream with information about the chunks in
@@ -38,7 +38,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
 	f.StringVar(&c.format, "f", "table", "format for output data [zng,ndjson,table,text,zeek,zjson,tzng] (default \"table\")")
 	return c, nil
 }

--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -22,17 +22,12 @@ import (
 
 var Zq = &charm.Spec{
 	Name:  "zq",
-	Usage: "zq [-R dir] [options] [zql] file [file...]",
+	Usage: "zq [-R root] [options] [zql] file [file...]",
 	Short: "walk an archive and run zql queries",
 	Long: `
-"zar zq" descends the directory given by the -R option (or ZAR_ROOT env) looking for
-logs with zar directories and for each such directory found, it runs
-the zq logic relative to that directory and emits the results in zng format.
-The file names here are relative to that directory and the special name "_" refers
-to the actual log file in the parent of the zar directory.
-
-If the root directory is not specified by either the ZAR_ROOT environemnt
-variable or the -R option, then the current directory is assumed.
+"zar zq" executes a ZQL query against each chunk or associated file in an 
+archive. The special name "_" refers to chunk file itelf, and other names
+are interpreted relative to the chunk's associated file directory.
 `,
 	New: New,
 }
@@ -51,7 +46,7 @@ type Command struct {
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
 	f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
 	f.StringVar(&c.outputFile, "o", "", "write data to output file")
 	f.BoolVar(&c.stopErr, "e", true, "stop upon input errors")


### PR DESCRIPTION
We've added support for S3 root's since #1031 was filed, so I thought I'd add some text both for `zar import` and the higher level `zar help` that mentioned S3. I also tried to make a few other improvements, like consistent language about a "chunk" as the main log file, and the use of a "root" location instead of just directory for the `-R`/`$ZAR_ROOT` configs.

Closes #1031 