### PR TITLE
Add signal-canceled context to commands that call driver.Run

### DIFF
--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -47,7 +47,7 @@ func indexArchiveSpace(t *testing.T, datapath string, ruledef string) {
 	ark, err := OpenArchive(datapath, nil)
 	require.NoError(t, err)
 
-	err = IndexDirTree(ark, []Rule{*rule}, "_", nil)
+	err = IndexDirTree(context.Background(), ark, []Rule{*rule}, "_", nil)
 	require.NoError(t, err)
 }
 

--- a/archive/indexer.go
+++ b/archive/indexer.go
@@ -28,10 +28,10 @@ func fieldZdxName(fieldname string) string {
 	return "zdx-field-" + fieldname
 }
 
-func IndexDirTree(ark *Archive, rules []Rule, path string, progress chan<- string) error {
+func IndexDirTree(ctx context.Context, ark *Archive, rules []Rule, path string, progress chan<- string) error {
 	err := Walk(ark, func(zardir iosrc.URI) error {
 		logPath := Localize(zardir, path)
-		return run(zardir, rules, logPath, progress)
+		return run(ctx, zardir, rules, logPath, progress)
 	})
 	if err != nil {
 		return err
@@ -43,7 +43,7 @@ func IndexDirTree(ark *Archive, rules []Rule, path string, progress chan<- strin
 	return ark.AddIndexes(infos)
 }
 
-func runOne(zardir iosrc.URI, rule Rule, inputPath iosrc.URI, progress chan<- string) error {
+func runOne(ctx context.Context, zardir iosrc.URI, rule Rule, inputPath iosrc.URI, progress chan<- string) error {
 	rc, err := iosrc.NewReader(inputPath)
 	if err != nil {
 		return err
@@ -59,14 +59,14 @@ func runOne(zardir iosrc.URI, rule Rule, inputPath iosrc.URI, progress chan<- st
 	if progress != nil {
 		progress <- fmt.Sprintf("%s: creating index %s", inputPath, rule.Path(zardir))
 	}
-	return driver.Run(context.TODO(), fgi, rule.proc, zctx, r, driver.Config{
+	return driver.Run(ctx, fgi, rule.proc, zctx, r, driver.Config{
 		Custom: &compiler{},
 	})
 }
 
-func run(zardir iosrc.URI, rules []Rule, logPath iosrc.URI, progress chan<- string) error {
+func run(ctx context.Context, zardir iosrc.URI, rules []Rule, logPath iosrc.URI, progress chan<- string) error {
 	for _, rule := range rules {
-		if err := runOne(zardir, rule, logPath, progress); err != nil {
+		if err := runOne(ctx, zardir, rule, logPath, progress); err != nil {
 			return err
 		}
 	}

--- a/cmd/zar/import/command.go
+++ b/cmd/zar/import/command.go
@@ -1,7 +1,6 @@
 package zarimport
 
 import (
-	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -10,6 +9,7 @@ import (
 	"github.com/alecthomas/units"
 	"github.com/brimsec/zq/archive"
 	"github.com/brimsec/zq/cmd/zar/root"
+	"github.com/brimsec/zq/pkg/signalctx"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
@@ -93,5 +93,8 @@ func (c *Command) Run(args []string) error {
 	}
 	defer reader.Close()
 
-	return archive.Import(context.TODO(), ark, zctx, reader)
+	ctx, cancel := signalctx.New(os.Interrupt)
+	defer cancel()
+
+	return archive.Import(ctx, ark, zctx, reader)
 }

--- a/cmd/zar/index/command.go
+++ b/cmd/zar/index/command.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/brimsec/zq/archive"
 	"github.com/brimsec/zq/cmd/zar/root"
+	"github.com/brimsec/zq/pkg/signalctx"
 	"github.com/mccanne/charm"
 )
 
@@ -110,7 +111,9 @@ func (c *Command) Run(args []string) error {
 			wg.Done()
 		}()
 	}
-	err = archive.IndexDirTree(ark, rules, c.inputFile, progress)
+	ctx, cancel := signalctx.New(os.Interrupt)
+	defer cancel()
+	err = archive.IndexDirTree(ctx, ark, rules, c.inputFile, progress)
 	if progress != nil {
 		close(progress)
 		wg.Wait()

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -17,6 +16,7 @@ import (
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
 	"github.com/brimsec/zq/pkg/s3io"
+	"github.com/brimsec/zq/pkg/signalctx"
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
@@ -250,7 +250,9 @@ func (c *Command) Run(args []string) error {
 	if !c.quiet {
 		d.SetWarningsWriter(os.Stderr)
 	}
-	if err := driver.Run(context.Background(), d, query, c.zctx, reader, driver.Config{
+	ctx, cancel := signalctx.New(os.Interrupt)
+	defer cancel()
+	if err := driver.Run(ctx, d, query, c.zctx, reader, driver.Config{
 		Warnings: wch,
 	}); err != nil {
 		writer.Close()

--- a/pkg/signalctx/signalctx.go
+++ b/pkg/signalctx/signalctx.go
@@ -1,0 +1,57 @@
+// Package signalctx provides a context.Context that can be canceled by an
+// operating system signal.
+package signalctx
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+)
+
+// New returns a context whose Done channel is closed when a provided signal (or
+// any signal if none are provided) is received or when the returned cancel
+// function is called, whichever happens first.
+//
+// Canceling this context releases resources associated with it, so code should
+// call cancel as soon as the operations running in this context complete.
+func New(sigs ...os.Signal) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	sctx := &signalCtx{Context: ctx}
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, sigs...)
+	go func() {
+		select {
+		case sig := <-ch:
+			sctx.setErr(fmt.Errorf("%s signal", sig))
+			cancel()
+		case <-ctx.Done():
+		}
+		signal.Stop(ch)
+	}()
+	return sctx, func() {
+		sctx.setErr(context.Canceled)
+		cancel()
+	}
+}
+
+type signalCtx struct {
+	context.Context
+	errMu sync.Mutex
+	err   error
+}
+
+func (s *signalCtx) Err() error {
+	s.errMu.Lock()
+	defer s.errMu.Unlock()
+	return s.err
+}
+
+func (s *signalCtx) setErr(err error) {
+	s.errMu.Lock()
+	if s.err == nil {
+		s.err = err
+	}
+	s.errMu.Unlock()
+}

--- a/pkg/signalctx/signalctx_notwindows_test.go
+++ b/pkg/signalctx/signalctx_notwindows_test.go
@@ -1,0 +1,53 @@
+// +build !windows
+
+package signalctx
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallCancelFuncThenSendSignal(t *testing.T) {
+	ctx, cancel := New(syscall.SIGHUP)
+
+	cancel()
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("expected Done channel to be closed")
+	}
+
+	p, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, p.Signal(syscall.SIGHUP))
+	// Signals are asynchronous.
+	time.Sleep(100 * time.Millisecond)
+
+	require.EqualError(t, ctx.Err(), "context canceled")
+}
+
+func TestSendSignalThenCallCancelFunc(t *testing.T) {
+	ctx, cancel := New(syscall.SIGHUP)
+
+	p, err := os.FindProcess(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, p.Signal(syscall.SIGHUP))
+	// Signals are asynchronous.
+	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("expected Done channel to be closed")
+	}
+
+	cancel()
+
+	assert.EqualError(t, ctx.Err(), "hangup signal")
+}

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -734,7 +734,7 @@ func indexArchiveSpace(t *testing.T, datapath string, ruledef string) {
 	ark, err := archive.OpenArchive(datapath, nil)
 	require.NoError(t, err)
 
-	err = archive.IndexDirTree(ark, []archive.Rule{*rule}, "_", nil)
+	err = archive.IndexDirTree(context.Background(), ark, []archive.Rule{*rule}, "_", nil)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
proc.GroupBy and proc.Sort rely on context cancelation for cleanup of
temporary files created by proc.runManager.  Add a signal-canceled
context in pkg/signalctx and use it in commands that call driver.Run
(and thus might create a proc.GroupBy or proc.Sort) to ensure that
cleanup happens.

This in combination with #1093, this should address #970.