### PR TITLE
don't issue empty batches from reduce

### DIFF
--- a/proc/reduce.go
+++ b/proc/reduce.go
@@ -12,46 +12,42 @@ type ReduceParams struct {
 
 type Reduce struct {
 	Base
-	n       int
-	columns compile.Row
+	params ReduceParams
 }
 
 func NewReduce(c *Context, parent Proc, params ReduceParams) Proc {
 	return &Reduce{
-		Base:    Base{Context: c, Parent: parent},
-		columns: compile.NewRow(params.reducers),
+		Base:   Base{Context: c, Parent: parent},
+		params: params,
 	}
 }
 
-func (r *Reduce) output() (*zbuf.Array, error) {
-	rec, err := r.columns.Result(r.Context.TypeContext)
+func (r *Reduce) Pull() (zbuf.Batch, error) {
+	var columns compile.Row
+	var consumed bool
+	for {
+		batch, err := r.Get()
+		if err != nil {
+			return nil, err
+		}
+		if batch == nil {
+			break
+		}
+		if !consumed {
+			consumed = true
+			columns = compile.NewRow(r.params.reducers)
+		}
+		for k := 0; k < batch.Length(); k++ {
+			columns.Consume(batch.Index(k))
+		}
+		batch.Unref()
+	}
+	if !consumed {
+		return nil, nil
+	}
+	rec, err := columns.Result(r.Context.TypeContext)
 	if err != nil {
 		return nil, err
 	}
 	return zbuf.NewArray([]*zng.Record{rec}), nil
-}
-
-func (r *Reduce) Pull() (zbuf.Batch, error) {
-	batch, err := r.Get()
-	if err != nil {
-		return nil, err
-	}
-	if batch == nil {
-		//XXX why does this crash if we take out this test?
-		if r.n == 0 {
-			return nil, nil
-		}
-		r.n = 0
-		return r.output()
-	}
-	for k := 0; k < batch.Length(); k++ {
-		r.consume(batch.Index(k))
-	}
-	batch.Unref()
-	return zbuf.NewArray([]*zng.Record{}), nil
-}
-
-func (r *Reduce) consume(rec *zng.Record) {
-	r.n++
-	r.columns.Consume(rec)
 }


### PR DESCRIPTION
I noticed this while debugging a separate issue: reduce's Pull would respond with a batch for each Get() it made, even if it responded with an empty batch. I'm not aware of problems due to empty batches, but it seems more efficienct to loop over Get until end of stream & generate a single non-empty batch, as I see other Procs do.
