### PR TITLE
fix merge behavior on eos

### DIFF
--- a/proc/merge.go
+++ b/proc/merge.go
@@ -84,8 +84,10 @@ func (m *Merge) Pull() (zbuf.Batch, error) {
 			go m.run()
 		}
 	})
-
 	for {
+		if m.nparents == 0 {
+			return nil, nil
+		}
 		res, ok := <-m.ch
 		if !ok {
 			return nil, nil
@@ -100,9 +102,6 @@ func (m *Merge) Pull() (zbuf.Batch, error) {
 		}
 
 		m.nparents--
-		if m.nparents == 0 {
-			return nil, nil
-		}
 	}
 }
 


### PR DESCRIPTION
Found while working on #1074  : merge would block forever after all of its upstreams reported eos, it returns a nil batch from Pull, and then a subsequent Pull occurred again. That branch will use Merge, and this issue was visible with many tests locking up, hence I'm not adding explicit tests here.
