### PR TITLE
enable shared config for aws sessions

### DIFF
--- a/pkg/s3io/s3io.go
+++ b/pkg/s3io/s3io.go
@@ -220,6 +220,17 @@ func newClient(cfg *aws.Config) *s3.S3 {
 		cfg.Endpoint = aws.String(endpoint)
 		cfg.S3ForcePathStyle = aws.Bool(true) // https://github.com/minio/minio/tree/master/docs/config#domain
 	}
-	sess := session.Must(session.NewSession(cfg))
+
+	// Unless the user has a environment setting for shared config, enable it
+	// so that region & other info is automatically picked up from the
+	// .aws/config file.
+	scs := session.SharedConfigEnable
+	if v := os.Getenv("AWS_SDK_LOAD_CONFIG"); v != "" {
+		scs = session.SharedConfigStateFromEnv
+	}
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		Config:            *cfg,
+		SharedConfigState: scs,
+	}))
 	return s3.New(sess)
 }

--- a/pkg/s3io/s3io.go
+++ b/pkg/s3io/s3io.go
@@ -225,7 +225,7 @@ func newClient(cfg *aws.Config) *s3.S3 {
 	// so that region & other info is automatically picked up from the
 	// .aws/config file.
 	scs := session.SharedConfigEnable
-	if v := os.Getenv("AWS_SDK_LOAD_CONFIG"); v != "" {
+	if os.Getenv("AWS_SDK_LOAD_CONFIG") != "" {
 		scs = session.SharedConfigStateFromEnv
 	}
 	sess := session.Must(session.NewSessionWithOptions(session.Options{


### PR DESCRIPTION
Unless a user has explicitly set an environment variable to control whether config from their shared config file (`~/.aws/config`) is loaded, do so automatically, so that users don't need the AWS_SDK_LOAD_CONFIG=1 setting in their setup.

Related to #904. This won't close that issue, as it doesn't improve the error if a user still doesn't have their config in place, but should help avoid users running into it the first time they try to use S3 objects.
