### PR TITLE
impose limit on the number of levels in a microindex

### DIFF
--- a/tests/suite/zdx/maxlevels.yaml
+++ b/tests/suite/zdx/maxlevels.yaml
@@ -1,0 +1,10 @@
+script: |
+  zdx create -o index.zng -k s -f 20 babble.tzng
+
+inputs:
+  - name: babble.tzng
+
+outputs:
+  - name: stderr
+    regexp: |
+      .*too many levels.*

--- a/zdx/writer.go
+++ b/zdx/writer.go
@@ -42,6 +42,7 @@ type Writer struct {
 	keyType     *zng.TypeRecord
 	iow         io.WriteCloser
 	childField  string
+	nlevel      int
 }
 
 type indexWriter struct {
@@ -185,6 +186,10 @@ func (w *Writer) finalize() error {
 }
 
 func newIndexWriter(base *Writer, w io.WriteCloser, name string) (*indexWriter, error) {
+	base.nlevel++
+	if base.nlevel >= MaxLevels {
+		return nil, ErrTooManyLevels
+	}
 	writer := bufwriter.New(w)
 	return &indexWriter{
 		base:     base,

--- a/zdx/zdx.go
+++ b/zdx/zdx.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 )
 
+const MaxLevels = 20
+
 var (
-	ErrCorruptFile = errors.New("corrupt zdx file")
+	ErrTooManyLevels = errors.New("microindex has too many levels (a larger frame threshold is needed)")
 )


### PR DESCRIPTION
This commit adds a limit on the number of levels that comprise the
index-key tree in a microindex.  Since each node is relatively large
(e.g., 1000s of keys), this limit will only be hit if the frame threshold
is made small enough to limit the number of keys per level to 1.
Even with 2 keys per level, we can represent 2^MaxLevels keys in the
base layer, e.g., a million or so keys, but more typically with
say 512 keys per level, we'd be at 512^20 = 2^200.

Fixes #995 