### PR TITLE
add version check to zdx module

### DIFF
--- a/tests/suite/zar/stat.yaml
+++ b/tests/suite/zar/stat.yaml
@@ -22,20 +22,20 @@ outputs:
       TYPE  LOG_ID                          START                DURATION       SIZE
       chunk 20200422/1587518620.0622373.zng 1587509477.064505280 9142.997732021 32205
       TYPE  LOG_ID                          INDEX_ID            INDEX_TYPE SIZE  KEYS.KEY
-      index 20200422/1587518620.0622373.zng zdx-field-v.zng     field      2986  int64
-      index 20200422/1587518620.0622373.zng zdx-type-string.zng type       23748 string
+      index 20200422/1587518620.0622373.zng zdx-field-v.zng     field      2984  int64
+      index 20200422/1587518620.0622373.zng zdx-type-string.zng type       23746 string
       TYPE  LOG_ID                           START                DURATION      SIZE
       chunk 20200421/1587509477.06313454.zng 1587508830.068523240 646.994611301 2133
       TYPE  LOG_ID                           INDEX_ID            INDEX_TYPE SIZE KEYS.KEY
-      index 20200421/1587509477.06313454.zng zdx-field-v.zng     field      495  int64
-      index 20200421/1587509477.06313454.zng zdx-type-string.zng type       1647 string
+      index 20200421/1587509477.06313454.zng zdx-field-v.zng     field      493  int64
+      index 20200421/1587509477.06313454.zng zdx-type-string.zng type       1645 string
       ===
       #0:record[type:string,log_id:string,start:time,duration:duration,size:uint64]
       0:[chunk;20200422/1587518620.0622373.zng;1587509477.06450528;9142.997732021;32205;]
       #1:record[type:string,log_id:string,index_id:string,index_type:string,size:uint64,keys:record[key:string]]
-      1:[index;20200422/1587518620.0622373.zng;zdx-field-v.zng;field;2986;[int64;]]
-      1:[index;20200422/1587518620.0622373.zng;zdx-type-string.zng;type;23748;[string;]]
+      1:[index;20200422/1587518620.0622373.zng;zdx-field-v.zng;field;2984;[int64;]]
+      1:[index;20200422/1587518620.0622373.zng;zdx-type-string.zng;type;23746;[string;]]
       0:[chunk;20200421/1587509477.06313454.zng;1587508830.06852324;646.994611301;2133;]
-      1:[index;20200421/1587509477.06313454.zng;zdx-field-v.zng;field;495;[int64;]]
-      1:[index;20200421/1587509477.06313454.zng;zdx-type-string.zng;type;1647;[string;]]
+      1:[index;20200421/1587509477.06313454.zng;zdx-field-v.zng;field;493;[int64;]]
+      1:[index;20200421/1587509477.06313454.zng;zdx-type-string.zng;type;1645;[string;]]
       ===

--- a/tests/suite/zdx/bad-version.yaml
+++ b/tests/suite/zdx/bad-version.yaml
@@ -1,0 +1,21 @@
+script: |
+  # cat together the index and trailer so we get an eos before the trailer
+  zq -o in1.zng in.tzng
+  zq -o trailer.zng trailer.tzng
+  cat in1.zng trailer.zng > index.zng
+  zdx lookup -t -k hello index.zng
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[key:string]
+      0:[hello;]
+  - name: trailer.tzng
+    data: |
+      #1:record[magic:string,version:int32,child_field:string,frame_thresh:int32,sections:array[int64],keys:record[key:string]]
+      1:[microindex;0;_child;32768;[16;]-;]
+
+outputs:
+  - name: stderr
+    regexp: |
+      .*: microindex version 0 found while expecting version 1

--- a/tests/suite/zdx/btree-clash.yaml
+++ b/tests/suite/zdx/btree-clash.yaml
@@ -17,5 +17,5 @@ outputs:
     data: ''
   - name: stdout
     data: |
-      #0:record[magic:string,version:string,child_field:string,frame_thresh:int32,sections:array[int64],keys:record[_child:int64]]
-      0:[microindex;0.3;_child_0;50;[33;]-;]
+      #0:record[magic:string,version:int32,child_field:string,frame_thresh:int32,sections:array[int64],keys:record[_child:int64]]
+      0:[microindex;1;_child_0;50;[33;]-;]

--- a/tests/suite/zdx/create.yaml
+++ b/tests/suite/zdx/create.yaml
@@ -13,5 +13,5 @@ outputs:
     data: |
       #0:record[key:string]
       0:[hello;]
-      #1:record[magic:string,version:string,child_field:string,frame_thresh:int32,sections:array[int64],keys:record[key:string]]
-      1:[microindex;0.3;_child;32768;[16;]-;]
+      #1:record[magic:string,version:int32,child_field:string,frame_thresh:int32,sections:array[int64],keys:record[key:string]]
+      1:[microindex;1;_child;32768;[16;]-;]

--- a/tests/suite/zdx/levels.yaml
+++ b/tests/suite/zdx/levels.yaml
@@ -10,8 +10,8 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      #0:record[magic:string,version:string,child_field:string,frame_thresh:int32,sections:array[int64],keys:record[key:string]]
-      0:[microindex;0.3;_child;200;[24069;36;414;3192;]-;]
+      #0:record[magic:string,version:int32,child_field:string,frame_thresh:int32,sections:array[int64],keys:record[key:string]]
+      0:[microindex;1;_child;200;[24069;36;414;3192;]-;]
       ===
       #0:record[key:string,_child:int64]
       0:[Algedi-pigeonman;0;]

--- a/tests/suite/zdx/seek.yaml
+++ b/tests/suite/zdx/seek.yaml
@@ -24,5 +24,5 @@ outputs:
       0:[1002;34;]
       0:[1004;68;]
       0:[1006;102;]
-      #1:record[magic:string,version:string,child_field:string,frame_thresh:int32,sections:array[int64],keys:record[ts:time]]
-      1:[microindex;0.3;_child;100;[58;]-;]
+      #1:record[magic:string,version:int32,child_field:string,frame_thresh:int32,sections:array[int64],keys:record[ts:time]]
+      1:[microindex;1;_child;100;[58;]-;]

--- a/zdx/trailer.go
+++ b/zdx/trailer.go
@@ -91,8 +91,8 @@ func readTrailer(r io.ReadSeeker, n int64) (*Trailer, int, error) {
 		// look for end of stream followed by an array[int64] typedef then
 		// a record typedef indicating the possible presence of the trailer,
 		// which we then try to decode.
-		if buf[off] == 0x81 && buf[off+1] == 0x06 && buf[off+2] == 0x80 {
-			if off > 0 && buf[off-1] != 0x85 {
+		if bytes.Equal(buf[off:(off+3)], []byte{zng.TypeDefArray, zng.IdInt64, zng.TypeDefRecord}) {
+			if off > 0 && buf[off-1] != zng.CtrlEOS {
 				// If this isn't right after an end-of-stream
 				// (and we're not at the start of index), then
 				// we skip because it can't be a valid trailer.

--- a/zdx/trailer.go
+++ b/zdx/trailer.go
@@ -21,7 +21,7 @@ const (
 	KeysField        = "keys"
 
 	MagicVal      = "microindex"
-	VersionVal    = "0.3"
+	VersionVal    = 1
 	ChildFieldVal = "_child"
 
 	TrailerMaxSize = 4096
@@ -29,7 +29,7 @@ const (
 
 type Trailer struct {
 	Magic            string
-	Version          string
+	Version          int
 	ChildOffsetField string
 	FrameThresh      int
 	KeyType          *zng.TypeRecord
@@ -42,7 +42,7 @@ func newTrailerRecord(zctx *resolver.Context, childField string, frameThresh int
 	sectionsType := zctx.LookupTypeArray(zng.TypeInt64)
 	cols := []zng.Column{
 		{MagicField, zng.TypeString},
-		{VersionField, zng.TypeString},
+		{VersionField, zng.TypeInt32},
 		{ChildField, zng.TypeString},
 		{FrameThreshField, zng.TypeInt32},
 		{SectionsField, sectionsType},
@@ -55,7 +55,7 @@ func newTrailerRecord(zctx *resolver.Context, childField string, frameThresh int
 	builder := zng.NewBuilder(typ)
 	return builder.Build(
 		zng.EncodeString(MagicVal),
-		zng.EncodeString(VersionVal),
+		zng.EncodeInt(VersionVal),
 		zng.EncodeString(childField),
 		zng.EncodeInt(int64(frameThresh)),
 		encodeSections(sections),
@@ -87,24 +87,44 @@ func readTrailer(r io.ReadSeeker, n int64) (*Trailer, int, error) {
 		// or I/O problems XXX
 		return nil, 0, fmt.Errorf("couldn't read trailer: expected %d bytes but read %d", n, cc)
 	}
-	for off := int64(n) - 4; off >= 0; off-- {
+	for off := int(n) - 3; off >= 0; off-- {
 		// look for end of stream followed by an array[int64] typedef then
 		// a record typedef indicating the possible presence of the trailer,
 		// which we then try to decode.
-		if buf[off] == 0x85 && buf[off+1] == 0x81 && buf[off+2] == 0x06 && buf[off+3] == 0x80 {
-			attempt := buf[off+1 : n]
-			r := bytes.NewReader(attempt)
+		if buf[off] == 0x81 && buf[off+1] == 0x06 && buf[off+2] == 0x80 {
+			if off > 0 && buf[off-1] != 0x85 {
+				// If this isn't right after an end-of-stream
+				// (and we're not at the start of index), then
+				// we skip because it can't be a valid trailer.
+				continue
+			}
+			r := bytes.NewReader(buf[off:n])
 			rec, _ := zngio.NewReader(r, resolver.NewContext()).Read()
 			if rec == nil {
 				continue
 			}
+			_, err := trailerVersion(rec)
+			if err != nil {
+				return nil, 0, err
+			}
 			trailer, _ := recordToTrailer(rec)
 			if trailer != nil {
-				return trailer, len(attempt), nil
+				return trailer, int(n) - off, nil
 			}
 		}
 	}
 	return nil, 0, errors.New("microindex trailer not found")
+}
+
+func trailerVersion(rec *zng.Record) (int, error) {
+	version, err := rec.AccessInt(VersionField)
+	if err != nil {
+		return -1, errors.New("microindex version field is not a valid int32")
+	}
+	if version != VersionVal {
+		return -1, fmt.Errorf("microindex version %d found while expecting version %d", version, VersionVal)
+	}
+	return int(version), nil
 }
 
 func recordToTrailer(rec *zng.Record) (*Trailer, error) {
@@ -114,9 +134,9 @@ func recordToTrailer(rec *zng.Record) (*Trailer, error) {
 	if err != nil || trailer.Magic != MagicVal {
 		return nil, ErrNotIndex
 	}
-	version, err := rec.AccessString(VersionField)
-	if err != nil || version != VersionVal {
-		return nil, fmt.Errorf("microindex version %s not supported (by version %s)", version, VersionVal)
+	trailer.Version, err = trailerVersion(rec)
+	if err != nil {
+		return nil, err
 	}
 
 	trailer.ChildOffsetField, err = rec.AccessString(ChildField)

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -1017,9 +1017,9 @@ func TestArchiveStat(t *testing.T) {
 #0:record[type:string,log_id:string,start:time,duration:duration,size:uint64]
 0:[chunk;20200422/1587518620.0622373.zng;1587509477.06450528;9142.997732021;32205;]
 #1:record[type:string,log_id:string,index_id:string,index_type:string,size:uint64,keys:record[key:string]]
-1:[index;20200422/1587518620.0622373.zng;zdx-field-v.zng;field;2986;[int64;]]
+1:[index;20200422/1587518620.0622373.zng;zdx-field-v.zng;field;2984;[int64;]]
 0:[chunk;20200421/1587509477.06313454.zng;1587508830.06852324;646.994611301;2133;]
-1:[index;20200421/1587509477.06313454.zng;zdx-field-v.zng;field;495;[int64;]]`
+1:[index;20200421/1587509477.06313454.zng;zdx-field-v.zng;field;493;[int64;]]`
 	res := archiveStat(t, client, sp.ID)
 	assert.Equal(t, test.Trim(exp), res)
 }


### PR DESCRIPTION
This commit changes the microindex version type from a string to
an integer and adds a version check when opening a microindex
that currently fails if the version numbers do not match exactly.

Fixes #1116 