### PR TITLE
Configurable merge

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -197,7 +197,12 @@ type (
 	// a stream of records from their parent.
 	ParallelProc struct {
 		Node
-		Procs []Proc `json:"procs"`
+		// If non-zero, MergeOrderField contains the field name on
+		// which the branches of this parallel proc should be
+		// merged in the order indicated by MergeOrderReverse.
+		MergeOrderField   string `json:"merge_order_field"`
+		MergeOrderReverse bool   `json:"merge_order_reverse"`
+		Procs             []Proc `json:"procs"`
 	}
 	// A SortProc node represents a proc that sorts records.
 	SortProc struct {

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -207,9 +207,5 @@ func createParallelGroup(pctx *proc.Context, pgn *pgSetup, msrc MultiSource, mcf
 	if sortField == "" {
 		return proc.NewMerge(pctx, chains), pg, nil
 	}
-	cmp, err := newCompareFn(sortField, reversed)
-	if err != nil {
-		return nil, nil, err
-	}
-	return proc.NewOrderedMerge(pctx, chains, cmp), pg, nil
+	return proc.NewOrderedMerge(pctx, chains, sortField, reversed), pg, nil
 }

--- a/proc/orderedmerge_test.go
+++ b/proc/orderedmerge_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brimsec/zq/ast"
-	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/pkg/test"
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/zbuf"
@@ -51,21 +49,6 @@ func readProcToTzng(p proc.Proc) (string, error) {
 		}
 		b.Unref()
 	}
-}
-
-func fieldReadCompare(field string) (zbuf.RecordCmpFn, error) {
-	fieldRead := &ast.FieldRead{
-		Node:  ast.Node{Op: "FieldRead"},
-		Field: field,
-	}
-	res, err := expr.CompileFieldExpr(fieldRead)
-	if err != nil {
-		return nil, err
-	}
-	cmp := expr.NewCompareFn(true, res)
-	return func(a, b *zng.Record) bool {
-		return cmp(a, b) < 0
-	}, nil
 }
 
 var omTestInputs = []string{

--- a/proc/orderedmerge_test.go
+++ b/proc/orderedmerge_test.go
@@ -82,15 +82,14 @@ var omTestInputs = []string{
 }
 
 func TestParallelOrder(t *testing.T) {
-	fieldV, err := fieldReadCompare("v")
-	require.NoError(t, err)
-
 	cases := []struct {
-		cmp zbuf.RecordCmpFn
-		exp string
+		field    string
+		reversed bool
+		exp      string
 	}{
 		{
-			cmp: zbuf.CmpTimeForward,
+			field:    "ts",
+			reversed: false,
 			exp: `
 #0:record[v:int32,ts:time]
 0:[10;1;]
@@ -102,7 +101,8 @@ func TestParallelOrder(t *testing.T) {
 `,
 		},
 		{
-			cmp: fieldV,
+			field:    "v",
+			reversed: false,
 			exp: `
 #0:record[v:int32,ts:time]
 0:[10;1;]
@@ -124,7 +124,7 @@ func TestParallelOrder(t *testing.T) {
 				r := tzngio.NewReader(bytes.NewReader([]byte(s)), zctx)
 				parents = append(parents, &recordPuller{Base: proc.Base{Context: pctx}, r: r})
 			}
-			om := proc.NewOrderedMerge(pctx, parents, c.cmp)
+			om := proc.NewOrderedMerge(pctx, parents, c.field, c.reversed)
 
 			res, err := readProcToTzng(om)
 			require.NoError(t, err)

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -186,6 +186,11 @@ func CompileProc(custom Compiler, node ast.Proc, c *Context, parent Proc) ([]Pro
 			// in which case the output layer will mux
 			// into channels.
 			if len(parents) > 1 && k < n-1 {
+				p := v.Procs[k].(*ast.ParallelProc)
+				if p.MergeOrderField != "" {
+					parent = NewOrderedMerge(c, parents, p.MergeOrderField, p.MergeOrderReverse)
+					return []Proc{parent}, nil
+				}
 				parent = NewMerge(c, parents)
 			} else {
 				parent = parents[0]

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -189,12 +189,12 @@ func CompileProc(custom Compiler, node ast.Proc, c *Context, parent Proc) ([]Pro
 				p := v.Procs[k].(*ast.ParallelProc)
 				if p.MergeOrderField != "" {
 					parent = NewOrderedMerge(c, parents, p.MergeOrderField, p.MergeOrderReverse)
-					return []Proc{parent}, nil
+				} else {
+					parent = NewMerge(c, parents)
 				}
-				parent = NewMerge(c, parents)
-			} else {
-				parent = parents[0]
+				continue
 			}
+			parent = parents[0]
 		}
 		return parents, nil
 


### PR DESCRIPTION
Add two fields to ParallelProc to specify ordering behavior when merging branches. 

If `ParallelProc.MergeOrderField` is zero-valued, then the existing (unordered) `proc.Merge` proc is used. Otherwise, a `proc.OrderedMerge` proc is used, configured with the ordering field name and direction indicated in the new AST fields.

These new fields are not currently exposed in ZQL syntax but could be at a later point if needed.

closes #1036 
