### PR TITLE
fix batch.Unref() bug

### DIFF
--- a/archive/indexer.go
+++ b/archive/indexer.go
@@ -96,6 +96,7 @@ func NewFlowgraphIndexer(zctx *resolver.Context, uri iosrc.URI, keys []string, f
 }
 
 func (f *FlowgraphIndexer) Write(_ int, batch zbuf.Batch) error {
+	defer batch.Unref()
 	for i := 0; i < batch.Length(); i++ {
 		rec := batch.Index(i)
 		key, err := f.cutter.Cut(rec)
@@ -112,7 +113,6 @@ func (f *FlowgraphIndexer) Write(_ int, batch zbuf.Batch) error {
 			return err
 		}
 	}
-	batch.Unref()
 	return nil
 }
 


### PR DESCRIPTION
This commit fixes a bug in archive.FlowgraphIndexer.Write() where
the incoming batch was not unreferenced in an error condition.

This is not that big a deal since not-unref'd stuff would be picked up by GC 
and this only happens here on an error, but this is more consistent with the
Unref protocol.
