### PR TITLE
Record past allocations in zq memory profile

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -330,6 +330,6 @@ func (c *Command) runMemProfile() {
 		log.Fatal(err)
 	}
 	runtime.GC()
-	pprof.WriteHeapProfile(f)
+	pprof.Lookup("allocs").WriteTo(f, 0)
 	f.Close()
 }


### PR DESCRIPTION
The -memprofile flag to zq records a sampling of allocations for live
objects upon exit, but that isn't particularly useful.  Record a
sampling of all past allocations instead.