### PR TITLE
zar readme updates

### DIFF
--- a/cmd/zar/README.md
+++ b/cmd/zar/README.md
@@ -47,7 +47,7 @@ its input into chunk files of approximately equal size.
 
 Zar import expects its input to be
 in the zng format so we'll use zq to take all the zng logs, gunzip them,
-and feed them to chop, which here expects its data on stdin.  We'll chop them
+and feed them to `zar import`, which here expects its data on stdin.  We'll chop them
 into chunks of 25MB, which is very small, but in this example the data set is
 fairly small (175MB) and you can always try it out on larger data sets:
 ```
@@ -163,7 +163,7 @@ zar ls -l
 You will see all the indexes left behind. They are just zng files.
 If you want to see one, just look at it with zq, e.g.
 ```
-zq -t $ZAR_ROOT/logs/20180324/1521911772.980384.zng/zdx-type-ip.zng
+zq -t $ZAR_ROOT/20180324/1521912990.158766.zng.zar/zdx-type-ip.zng
 ```
 Now if you run "zar find", it will efficiently look through all the index files
 instead of the logs and run much faster...

--- a/cmd/zar/README.md
+++ b/cmd/zar/README.md
@@ -265,7 +265,7 @@ zq -f table $ZAR_ROOT/20180324/1521911772.980384.zng.zar/custom.zng | head -10
 ```
 You can see the IPs, counts, and _path strings.
 
-At the bottom you'll also find a record describing the microindex layout. To
+At the bottom you'll also find a record describing the micro-index layout. To
 see it:
 
 ```
@@ -353,7 +353,7 @@ key, and so forth, and efficient lookups are carried out by traversing the
 b-tree index structure of these sorted keys.  But remember,
 everything is a zng file, so you can do a brute-force search on the base-layer
 of the index, e.g., to look for all the instances of a value in the secondary
-key position (ignoring the primary key) by using "zar zq" instead of "zar find".
+key position (ignoring the primary key) by using "zar map" instead of "zar find".
 
 So, let's say we wanted
 a count of all bytes received by 10.47.6.173 as the originator, which is the


### PR DESCRIPTION
#1110, #1050, #1138, #1148, and #1150 all caused changes to the inputs/outputs shown in the [`zar` README](https://github.com/brimsec/zq/blob/master/cmd/zar/README.md). This PR catches the README up with those changes.