### PR TITLE
proc.CompileProc: add support for multiple parents

### DIFF
--- a/driver/compile.go
+++ b/driver/compile.go
@@ -61,7 +61,7 @@ func compile(ctx context.Context, program ast.Proc, zctx *resolver.Context, msrc
 		return nil, err
 	}
 
-	leaves, err := proc.CompileProc(mcfg.Custom, program, pctx, mergeProc)
+	leaves, err := proc.CompileProc(mcfg.Custom, program, pctx, []proc.Proc{mergeProc})
 	if err != nil {
 		return nil, err
 	}

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -193,7 +193,7 @@ func createParallelGroup(pctx *proc.Context, pgn *pgSetup, msrc MultiSource, mcf
 	chains := make([]proc.Proc, mcfg.Parallelism)
 	for i := range chains {
 		head := &parallelHead{Base: proc.Base{Context: pctx}, pg: pg}
-		p, err := proc.CompileProc(mcfg.Custom, pgn.chain, pctx, head)
+		p, err := proc.CompileProc(mcfg.Custom, pgn.chain, pctx, []proc.Proc{head})
 		if err != nil {
 			return nil, nil, err
 		}

--- a/proc/compile_test.go
+++ b/proc/compile_test.go
@@ -1,0 +1,70 @@
+package proc_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/pkg/test"
+	"github.com/brimsec/zq/proc"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/tzngio"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileParents(t *testing.T) {
+	input := `
+#0:record[ts:time]
+0:[1;]
+`
+	exp := `
+#0:record[ts:time]
+0:[1;]
+0:[1;]
+`
+	zctx := resolver.NewContext()
+	pctx := &proc.Context{Context: context.Background(), TypeContext: zctx}
+	var sources []proc.Proc
+	for i := 0; i < 2; i++ {
+		r := tzngio.NewReader(bytes.NewReader([]byte(input)), zctx)
+		sources = append(sources, &recordPuller{Base: proc.Base{Context: pctx}, r: r})
+	}
+	t.Run("read two sources", func(t *testing.T) {
+		query, err := zql.ParseProc("(filter *; filter *) | filter *")
+		require.NoError(t, err)
+
+		// Remove the "filter *" that is pre-pended during parsing
+		// if the proc started with a parallel graph.
+		query.(*ast.SequentialProc).Procs = query.(*ast.SequentialProc).Procs[1:]
+
+		leaves, err := proc.CompileProc(nil, query, pctx, sources)
+		require.NoError(t, err)
+
+		var sb strings.Builder
+		err = zbuf.CopyPuller(tzngio.NewWriter(&sb), leaves[0])
+		require.NoError(t, err)
+		assert.Equal(t, test.Trim(exp), sb.String())
+	})
+
+	t.Run("too few parents", func(t *testing.T) {
+		query, err := zql.ParseProc("(filter *; filter *; filter *) | filter *")
+		require.NoError(t, err)
+
+		query.(*ast.SequentialProc).Procs = query.(*ast.SequentialProc).Procs[1:]
+
+		_, err = proc.CompileProc(nil, query, pctx, sources)
+		require.Error(t, err)
+	})
+
+	t.Run("too many parents", func(t *testing.T) {
+		query, err := zql.ParseProc("* | (filter *; filter *) | filter *")
+		require.NoError(t, err)
+		_, err = proc.CompileProc(nil, query, pctx, sources)
+		require.Error(t, err)
+	})
+}

--- a/proc/utils.go
+++ b/proc/utils.go
@@ -44,7 +44,7 @@ func CompileTestProc(code string, ctx *Context, parent Proc) (Proc, error) {
 }
 
 func CompileTestProcAST(proc ast.Proc, ctx *Context, parent Proc) (Proc, error) {
-	procs, err := CompileProc(nil, proc, ctx, parent)
+	procs, err := CompileProc(nil, proc, ctx, []Proc{parent})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Extend proc.CompileProc to support compiling with multiple parents. This will allow passing in multiple parallel scanners into a flowgraph that is suitably shaped (namely, that starts with a parallel proc).

part of #1155 