### PR TITLE
zqd: panic middleware request response

### DIFF
--- a/zqd/middleware.go
+++ b/zqd/middleware.go
@@ -76,10 +76,9 @@ func panicCatchMiddleware(logger *zap.Logger) mux.MiddlewareFunc {
 				if rec == nil {
 					return
 				}
-				err := zqe.RecoverError(rec)
 				logger.DPanic("Panic",
+					zap.Error(zqe.RecoverError(rec)),
 					zap.String("request_id", getRequestID(r.Context())),
-					zap.Error(err),
 					zap.Stack("stack"),
 				)
 			}()


### PR DESCRIPTION
Do not write panic message in http response body when a panic
occurs.

Also:
- Add stack trace and request_id to main logger in panic recovery
message

Closes #1098