### PR TITLE
Mention Go version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ To install `zq` or any other tool from this repo, you can either clone the repo
  [release](https://github.com/brimsec/zq/releases), available for Windows, macOS, and Linux.
 
 If you don't have Go installed, download and install it from the
-[Go downloads page](https://golang.org/dl/).
+[Go downloads page](https://golang.org/dl/). Go version 1.14 or later is
+required.
 
 To install the binaries in `$GOPATH/bin`, clone this repo and
 execute `make install`:


### PR DESCRIPTION
A couple times lately, I've advised community users to compile `master` of `zq` so they could work around a bug before the next GA release. The steps in the README for an install seem simple enough, but the fact that we don't mention the Go version might set them up for trouble if, say, they already have Go installed on their Linux distro and assume that whatever version is there will be adequate. I know we mention the "Go 1.14 or later" requirement in the CONTRIBUTING doc, but since ordinary users just compiling code may not look at that doc, I figure we should be redundant and mention this in the README as well.