### PR TITLE
unify log/pcap post logic and add warnings to pcap post

### DIFF
--- a/zqd/ingest/log.go
+++ b/zqd/ingest/log.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
 	"sync/atomic"
 
 	"github.com/brimsec/zq/pkg/fs"
@@ -33,7 +32,6 @@ type LogOp struct {
 	err          error
 
 	warningCh chan string
-	wg        sync.WaitGroup
 	zctx      *resolver.Context
 }
 
@@ -70,7 +68,6 @@ func NewLogOp(ctx context.Context, store storage.Storage, req api.LogPostRequest
 		p.readCounters = append(p.readCounters, rc)
 		p.readers = append(p.readers, zr)
 	}
-	p.wg.Add(1)
 	go p.start(ctx, store)
 	return p, nil
 }
@@ -143,7 +140,6 @@ func (p *LogOp) start(ctx context.Context, store storage.Storage) {
 		p.err = err
 	}
 	close(p.warningCh)
-	p.wg.Done()
 }
 
 func (p *LogOp) Stats() api.LogPostStatus {
@@ -158,7 +154,6 @@ func (p *LogOp) Status() <-chan string {
 	return p.warningCh
 }
 
-func (p *LogOp) Error() error {
-	p.wg.Wait()
+func (p *LogOp) Err() error {
 	return p.err
 }


### PR DESCRIPTION
This commits reworks the logic on the post-path for pcap files to
look more like the post-path for log files.  They now both use
the the closing of the warnings channel to indicate that the
posting goroutine is done.  This also extends pcap path to have
a warnings channel though it is not used yet (except for indicating
"done").  It will be used in a subsequent PR to send pcap-ng
parse warnings to the zqd client.