### PR TITLE
remove an unncessary waitgroup in log ingester

### DIFF
--- a/zqd/ingest/log.go
+++ b/zqd/ingest/log.go
@@ -155,7 +155,7 @@ func (p *LogOp) Status() <-chan string {
 }
 
 // Error indicates what if any error occurred during import, after the
-// Status channel is closed.
+// Status channel is closed.  The result is undefined while Status is open.
 func (p *LogOp) Error() error {
 	return p.err
 }


### PR DESCRIPTION
This commit removes an unncessary waitgroup from the log ingester
since synchronous was already being provided by the closure of
the warnings channel.  We also added comments for clarification.
This follows more closely the pattern of context.Context.