### PR TITLE
driver.parallelizeFlowgraph: put head/tail before and after merge

### DIFF
--- a/driver/compile.go
+++ b/driver/compile.go
@@ -519,7 +519,14 @@ func parallelizeFlowgraph(seq *ast.SequentialProc, N int, inputSortField string,
 			}
 		case *ast.ParallelProc:
 			return seq, false
-		case *ast.UniqProc, *ast.HeadProc, *ast.TailProc:
+		case *ast.HeadProc, *ast.TailProc:
+			if inputSortField == "" {
+				// Unknown order: we can't parallelize because we can't maintain this unknown order at the merge point.
+				return seq, false
+			}
+			// put one head/tail on each parallel branch and one after the merge.
+			return buildSplitFlowgraph(seq.Procs[0:i+1], seq.Procs[i:], inputSortField, inputSortReversed, N), true
+		case *ast.UniqProc:
 			if inputSortField == "" {
 				// Unknown order: we can't parallelize because we can't maintain this unknown order at the merge point.
 				return seq, false

--- a/driver/compile_test.go
+++ b/driver/compile_test.go
@@ -247,6 +247,12 @@ func TestParallelizeFlowgraph(t *testing.T) {
 			"(filter * | every 1h count() by y; filter * | every 1h count() by y) | every 1h count() by y",
 			"ts",
 		},
+		{
+			"* | put a=1 | tail",
+			"ts",
+			"(filter * | put a=1 | tail; filter * | put a=1 | tail) | tail",
+			"ts",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.zql, func(t *testing.T) {


### PR DESCRIPTION
`x | tail` was previously parallelized into `(x; x; ...) | tail`, which meant that all records had to be pulled through the ordered merge. It can instead be parallelized into `(x | tail; x | tail; ...) | tail` so that only the tails go through the ordered merge. The same is done for `head` for consistency, though the performance implications there are probably not significant.

This change takes `zar zq -t "* | tail"` from 98 seconds to 22 seconds on my laptop for an archive with ~82m conn records. (the speedup factor is further increased when removing the TypeCheck() call per #1181).

This is part of  #1034 (and came up while looking at #1172).
