### PR TITLE
zqd: prevent being orphaned by Brim (unix only)

### DIFF
--- a/cmd/mockbrim/main.go
+++ b/cmd/mockbrim/main.go
@@ -1,0 +1,66 @@
+// mockbrim is a command for testing purposes only. It is designed to simulate
+// the exact way brim launches then forks a separate zqd process. zqd must be
+// in $PATH for this to work.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+func die(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+var (
+	pidfile  string
+	portfile string
+	zqddata  string
+)
+
+func init() {
+	flag.StringVar(&portfile, "portfile", "", "location to write zqd port")
+	flag.StringVar(&pidfile, "pidfile", "", "location to write zqd pid")
+	flag.StringVar(&zqddata, "zqddata", "", "location to write zqd data")
+	flag.Parse()
+}
+
+func main() {
+	r, _, err := os.Pipe()
+	die(err)
+
+	if portfile == "" {
+		fmt.Fprintln(os.Stderr, "must provide -portfile arg")
+		os.Exit(1)
+	}
+	if pidfile == "" {
+		fmt.Fprintln(os.Stderr, "must provide -pidfile arg")
+		os.Exit(1)
+	}
+	args := []string{
+		"listen",
+		"-l=localhost:0",
+		"-loglevel=warn",
+		"-portfile=" + portfile,
+		"-data=" + zqddata,
+		fmt.Sprintf("-brimfd=%d", r.Fd()),
+	}
+	stderr := bytes.NewBuffer(nil)
+	cmd := exec.Command("zqd", args...)
+	cmd.Stderr = stderr
+	cmd.ExtraFiles = []*os.File{r}
+
+	err = cmd.Start()
+	die(err)
+	pid := fmt.Sprintf("%d", cmd.Process.Pid)
+	err = ioutil.WriteFile(pidfile, []byte(pid), 0644)
+	die(err)
+	cmd.Wait()
+}

--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -143,8 +143,7 @@ func (c *Command) watchBrimFd(ctx context.Context) (context.Context, error) {
 	}
 	f := os.NewFile(uintptr(c.brimfd), "brimfd")
 	c.logger.Info("Listening to brim process pipe", zap.String("fd", f.Name()))
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
 	go func() {
 		io.Copy(ioutil.Discard, f)
 		c.logger.Info("Brim fd closed, shutting down")

--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -137,13 +137,14 @@ func (c *Command) init() error {
 	return c.initZeek()
 }
 
-func (c *Command) watchBrimFd(p context.Context) (context.Context, error) {
+func (c *Command) watchBrimFd(ctx context.Context) (context.Context, error) {
 	if runtime.GOOS == "windows" {
 		return nil, errors.New("flag -brimfd not applicable to windows")
 	}
 	f := os.NewFile(uintptr(c.brimfd), "brimfd")
 	c.logger.Info("Listening to brim process pipe", zap.String("fd", f.Name()))
-	ctx, cancel := context.WithCancel(p)
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
 	go func() {
 		io.Copy(ioutil.Discard, f)
 		c.logger.Info("Brim fd closed, shutting down")

--- a/tests/suite/zqd/mockbrim.sh
+++ b/tests/suite/zqd/mockbrim.sh
@@ -29,12 +29,12 @@ function awaitfile {
   done
 }
 
-mkdir -p zqdroot
-zqdroot=zqdroot
+mkdir -p zqddata
+zqddata=zqddata
 tempdir=$(mktemp -d)
 
-mockbrim -zqddata="$zqdroot" -portfile="$tempdir/port" -pidfile="$tempdir/pid" &
-brimpid=$!
+mockbrim -zqddata="$zqddata" -portfile="$tempdir/port" -pidfile="$tempdir/pid" &
+mockbrimpid=$!
 
 # wait for zqd to start
 awaitfile $tempdir/port
@@ -42,7 +42,7 @@ awaitfile $tempdir/pid
 
 export ZQD_HOST=localhost:$(cat $tempdir/port)
 export ZQD_PID=$(cat $tempdir/pid)
-export BRIM_PID=$brimpid
+export MOCKBRIM_PID=$mockbrimpid
 
 # ensure that zqd process isn't leaked
 trap "kill -9 $ZQD_PID 2>/dev/null" EXIT

--- a/tests/suite/zqd/mockbrim.sh
+++ b/tests/suite/zqd/mockbrim.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# This file simulates a running version of brim desktop. It forks a zqd process
+# then sits forever on the main thread.
+
+function awaitdeadzqd {
+  i=0
+  function zqdalive { kill -0 $ZQD_PID 2> /dev/null; }
+  while zqdalive ; do
+    let i+=1
+    if [ $i -gt 5 ]; then
+      echo "timed out waiting for zqd to exit" 
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+function awaitfile {
+  file=$1
+  i=0
+  until [ -f $file ]; do
+    let i+=1
+    if [ $i -gt 5 ]; then
+      echo "timed out waiting for file \"$file\" to appear"
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+mkdir -p zqdroot
+zqdroot=zqdroot
+tempdir=$(mktemp -d)
+
+mockbrim -zqddata="$zqdroot" -portfile="$tempdir/port" -pidfile="$tempdir/pid" &
+brimpid=$!
+
+# wait for zqd to start
+awaitfile $tempdir/port
+awaitfile $tempdir/pid
+
+export ZQD_HOST=localhost:$(cat $tempdir/port)
+export ZQD_PID=$(cat $tempdir/pid)
+export BRIM_PID=$brimpid
+
+# ensure that zqd process isn't leaked
+trap "kill -9 $ZQD_PID 2>/dev/null" EXIT
+rm -rf $tempdir

--- a/tests/suite/zqd/orphaned-by-brim.yaml
+++ b/tests/suite/zqd/orphaned-by-brim.yaml
@@ -2,7 +2,7 @@ script: |
   source mockbrim.sh
   zapi -h $ZQD_HOST new testsp 
   echo "==="
-  kill -9 $BRIM_PID 2>/dev/null
+  kill -9 $MOCKBRIM_PID 2>/dev/null
   awaitdeadzqd
 
 inputs:

--- a/tests/suite/zqd/orphaned-by-brim.yaml
+++ b/tests/suite/zqd/orphaned-by-brim.yaml
@@ -1,0 +1,16 @@
+script: |
+  source mockbrim.sh
+  zapi -h $ZQD_HOST new testsp 
+  echo "==="
+  kill -9 $BRIM_PID 2>/dev/null
+  awaitdeadzqd
+
+inputs:
+  - name: mockbrim.sh
+    source: mockbrim.sh
+
+outputs:
+  - name: stdout
+    data: |
+      testsp: space created
+      ===


### PR DESCRIPTION
Add hidden -brimfd flag to zqd listen. Brim will use this option
to prevent zqd from being orphaned in the event that Brim is terminated
with a SIGKILL signal.

If set zqd with listen to the file descriptor and gracefully should
it be closed.

PART OF brimsec/brim#1018