### PR TITLE
Fix some zbuf.Batch reference counting bugs

### DIFF
--- a/proc/put/put.go
+++ b/proc/put/put.go
@@ -170,7 +170,8 @@ func (p *Proc) put(in *zng.Record) *zng.Record {
 	var bytes zcode.Bytes
 	if rule.replace == nil {
 		// All fields are being appended.
-		bytes = in.Raw
+		bytes = make([]byte, len(in.Raw))
+		copy(bytes, in.Raw)
 	} else {
 		// We're overwriting one or more fields.  Travese the
 		// replacement vector to determine whether each value should
@@ -212,7 +213,8 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 	recs := make([]*zng.Record, 0, batch.Length())
 	for k := 0; k < batch.Length(); k++ {
 		in := batch.Index(k)
-		recs = append(recs, p.put(in))
+		// Keep is necessary because put can return its argument.
+		recs = append(recs, p.put(in).Keep())
 	}
 	batch.Unref()
 	return zbuf.NewArray(recs), nil

--- a/proc/sort/sort.go
+++ b/proc/sort/sort.go
@@ -113,12 +113,11 @@ func (p *Proc) recordsForOneRun() ([]*zng.Record, bool, error) {
 		l := batch.Length()
 		for i := 0; i < l; i++ {
 			rec := batch.Index(i)
-			rec.CopyBody()
 			p.unseenFieldTracker.update(rec)
 			nbytes += len(rec.Raw)
+			// We're keeping records owned by batch so don't call Unref.
 			recs = append(recs, rec)
 		}
-		batch.Unref()
 		if nbytes >= MemMaxBytes {
 			return recs, false, nil
 		}


### PR DESCRIPTION
A zbuf.Batch implementation that includes memory reuse will panic on tests without this.

Part of #1091.