### PR TITLE
Use pctx name for *proc.Context

### DIFF
--- a/proc/cut/cut_test.go
+++ b/proc/cut/cut_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/proc/proctest"
-	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,14 +80,10 @@ func TestCutComplement(t *testing.T) {
 	proctest.TestOneProc(t, fooAndBarAndBlar, fooOnly, "cut -c bar,blar")
 }
 
-func ctx() *proc.Context {
-	return &proc.Context{TypeContext: resolver.NewContext()}
-}
-
 // Test that illegal cut operations fail at compile time with a
 // reasonable error message.
 func testNonAdjacentFields(t *testing.T, zql string) {
-	_, err := proctest.CompileTestProc(zql, ctx(), nil)
+	_, err := proctest.CompileTestProc(zql, proctest.NewTestContext(nil), nil)
 	require.Error(t, err, "cut with non-adjacent records did not fail")
 	ok := errors.Is(err, proc.ErrNonAdjacent)
 	require.True(t, ok, "cut with non-adjacent records failed with the wrong error")
@@ -104,7 +99,7 @@ func TestNotAdjacentErrors(t *testing.T) {
 // Test that illegal cut operations fail at compile time with a
 // reasonable error message.
 func testDuplicateFields(t *testing.T, zql string) {
-	_, err := proctest.CompileTestProc(zql, ctx(), nil)
+	_, err := proctest.CompileTestProc(zql, proctest.NewTestContext(nil), nil)
 	require.Error(t, err, "cut with duplicate records did not fail")
 	ok := errors.Is(err, proc.ErrDuplicateFields)
 	require.True(t, ok, "cut with duplicate records failed with wrong error")
@@ -116,10 +111,10 @@ func TestDuplicateFieldErrors(t *testing.T) {
 	testDuplicateFields(t, "cut rec.sub,rec.sub.sub")
 	testDuplicateFields(t, "cut rec.sub.sub,rec.sub")
 
-	_, err := proctest.CompileTestProc("cut a,ab", ctx(), nil)
+	_, err := proctest.CompileTestProc("cut a,ab", proctest.NewTestContext(nil), nil)
 	require.NoError(t, err)
 
-	_, err = proctest.CompileTestProc("cut ab,a", ctx(), nil)
+	_, err = proctest.CompileTestProc("cut ab,a", proctest.NewTestContext(nil), nil)
 	require.NoError(t, err)
 }
 

--- a/proc/rename/rename.go
+++ b/proc/rename/rename.go
@@ -16,14 +16,14 @@ import (
 // applied left to right; each rename observes the effect of all
 // renames that preceded it.
 type Proc struct {
-	ctx        *proc.Context
+	pctx       *proc.Context
 	parent     proc.Interface
 	fieldnames []string
 	targets    []string
 	typeMap    map[int]*zng.TypeRecord
 }
 
-func New(ctx *proc.Context, parent proc.Interface, node *ast.RenameProc) (*Proc, error) {
+func New(pctx *proc.Context, parent proc.Interface, node *ast.RenameProc) (*Proc, error) {
 	var fieldnames, targets []string
 	for _, fa := range node.Fields {
 		ts := strings.Split(fa.Target, ".")
@@ -40,7 +40,7 @@ func New(ctx *proc.Context, parent proc.Interface, node *ast.RenameProc) (*Proc,
 		fieldnames = append(fieldnames, fa.Source)
 	}
 	return &Proc{
-		ctx:        ctx,
+		pctx:       pctx,
 		parent:     parent,
 		fieldnames: fieldnames,
 		targets:    targets,
@@ -74,7 +74,7 @@ func (p *Proc) renamedType(typ *zng.TypeRecord, fields []string, target string) 
 	newcols := make([]zng.Column, len(typ.Columns))
 	copy(newcols, typ.Columns)
 	newcols[c] = zng.Column{Name: name, Type: innerType}
-	return p.ctx.TypeContext.LookupTypeRecord(newcols)
+	return p.pctx.TypeContext.LookupTypeRecord(newcols)
 }
 
 func (p *Proc) computeType(typ *zng.TypeRecord) (*zng.TypeRecord, error) {

--- a/proc/sort/sort.go
+++ b/proc/sort/sort.go
@@ -16,7 +16,7 @@ import (
 var MemMaxBytes = 128 * 1024 * 1024
 
 type Proc struct {
-	ctx        *proc.Context
+	pctx       *proc.Context
 	parent     proc.Interface
 	dir        int
 	nullsFirst bool
@@ -29,13 +29,13 @@ type Proc struct {
 	unseenFieldTracker *unseenFieldTracker
 }
 
-func New(ctx *proc.Context, parent proc.Interface, node *ast.SortProc) (*Proc, error) {
+func New(pctx *proc.Context, parent proc.Interface, node *ast.SortProc) (*Proc, error) {
 	fieldResolvers, err := expr.CompileFieldExprs(node.Fields)
 	if err != nil {
 		return nil, err
 	}
 	return &Proc{
-		ctx:                ctx,
+		pctx:               pctx,
 		parent:             parent,
 		dir:                node.SortDir,
 		nullsFirst:         node.NullsFirst,
@@ -51,7 +51,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 	if r, ok := <-p.resultCh; ok {
 		return r.Batch, r.Err
 	}
-	return nil, p.ctx.Err()
+	return nil, p.pctx.Err()
 }
 
 func (p *Proc) Done() {
@@ -82,7 +82,7 @@ func (p *Proc) sortLoop() {
 	}
 	defer runManager.Cleanup()
 	p.warnAboutUnseenFields()
-	for p.ctx.Err() == nil {
+	for p.pctx.Err() == nil {
 		// Reading from runManager merges the runs.
 		b, err := zbuf.ReadBatch(runManager, 100)
 		p.sendResult(b, err)
@@ -95,7 +95,7 @@ func (p *Proc) sortLoop() {
 func (p *Proc) sendResult(b zbuf.Batch, err error) {
 	select {
 	case p.resultCh <- proc.Result{Batch: b, Err: err}:
-	case <-p.ctx.Done():
+	case <-p.pctx.Done():
 	}
 }
 
@@ -154,7 +154,7 @@ func (p *Proc) createRuns(firstRunRecs []*zng.Record) (*RunManager, error) {
 
 func (p *Proc) warnAboutUnseenFields() {
 	for _, f := range p.unseenFieldTracker.unseen() {
-		p.ctx.Warnings <- fmt.Sprintf("Sort field %s not present in input", expr.FieldExprToString(f))
+		p.pctx.Warnings <- fmt.Sprintf("Sort field %s not present in input", expr.FieldExprToString(f))
 	}
 }
 

--- a/proc/uniq/uniq.go
+++ b/proc/uniq/uniq.go
@@ -10,17 +10,17 @@ import (
 )
 
 type Proc struct {
+	pctx   *proc.Context
 	parent proc.Interface
-	ctx    *proc.Context
 	cflag  bool
 	count  uint64
 	last   *zng.Record
 }
 
-func New(ctx *proc.Context, parent proc.Interface, cflag bool) *Proc {
+func New(pctx *proc.Context, parent proc.Interface, cflag bool) *Proc {
 	return &Proc{
+		pctx:   pctx,
 		parent: parent,
-		ctx:    ctx,
 		cflag:  cflag,
 	}
 }
@@ -29,9 +29,9 @@ func (p *Proc) wrap(t *zng.Record) *zng.Record {
 	if p.cflag {
 		cols := []zng.Column{zng.NewColumn("_uniq", zng.TypeUint64)}
 		vals := []zng.Value{zng.NewUint64(p.count)}
-		newR, err := p.ctx.TypeContext.AddColumns(t, cols, vals)
+		newR, err := p.pctx.TypeContext.AddColumns(t, cols, vals)
 		if err != nil {
-			p.ctx.Logger.Error("AddColumns failed", zap.Error(err))
+			p.pctx.Logger.Error("AddColumns failed", zap.Error(err))
 			return t
 		}
 		return newR


### PR DESCRIPTION
Conventionally, the ctx name is used for a context.Context.  Reserve it
for that purpose by changing the name of *proc.Context fields and
variables to pctx.