### PR TITLE
zqd: Gracefully handle moved/delete pcap in spaces

### DIFF
--- a/tests/suite/zqd/pcap-deleted.yaml
+++ b/tests/suite/zqd/pcap-deleted.yaml
@@ -1,0 +1,43 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST -s testsp pcappost -f ng.pcap >/dev/null
+  echo ===
+  zapi -h $ZQD_HOST -s testsp info | egrep -v 'data_path|id|pcap_path|size'
+  echo ===
+  rm ng.pcap
+  zapi -h $ZQD_HOST -s testsp info | egrep -v 'data_path|id|pcap_path|size'
+  echo ===
+  zapi -h $ZQD_HOST ls
+  echo ===
+  zapi -h $ZQD_HOST -s testsp get -f tzng "_path=conn | count()"
+  echo ===
+  zapi -h $ZQD_HOST rm testsp
+
+inputs:
+  - name: ng.pcap
+    source: ../pcap/ng.pcap
+  - name: services.sh
+    source: services.sh
+
+outputs:
+  - name: stdout
+    data: |
+      ===
+      testsp
+        name:         testsp
+        storage_kind: filestore
+        span:         2015-03-05T14:50:47Z+30m45.933045001s
+        pcap_support: true
+      ===
+      testsp
+        name:         testsp
+        storage_kind: filestore
+        span:         2015-03-05T14:50:47Z+30m45.933045001s
+        pcap_support: false
+      ===
+      testsp
+      ===
+      #0:record[count:uint64]
+      0:[5;]
+      ===
+      testsp: space removed

--- a/zqd/pcapstorage/pcapstorage.go
+++ b/zqd/pcapstorage/pcapstorage.go
@@ -127,6 +127,12 @@ func (s *Store) Info() (Info, error) {
 	}, nil
 }
 
+func (s *Store) PcapURI() iosrc.URI {
+	s.metaMu.Lock()
+	defer s.metaMu.Unlock()
+	return s.meta.PcapURI
+}
+
 func (s *Store) Delete() error {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()

--- a/zqd/space/archivespace.go
+++ b/zqd/space/archivespace.go
@@ -9,6 +9,7 @@ import (
 	"github.com/brimsec/zq/zqd/storage"
 	"github.com/brimsec/zq/zqd/storage/archivestore"
 	"github.com/brimsec/zq/zqe"
+	"go.uber.org/zap"
 )
 
 type archiveSpace struct {
@@ -98,8 +99,9 @@ func (s *archiveSpace) CreateSubspace(req api.SubspacePostRequest) (*archiveSubs
 		return nil, err
 	}
 
+	logger := s.logger.With(zap.String("space_id", string(subcfg.ID)))
 	return &archiveSubspace{
-		spaceBase: spaceBase{subcfg.ID, substore, nil, newGuard()},
+		spaceBase: spaceBase{subcfg.ID, substore, nil, newGuard(), logger},
 		parent:    s,
 	}, nil
 }

--- a/zqd/space/manager.go
+++ b/zqd/space/manager.go
@@ -52,7 +52,7 @@ func NewManager(root iosrc.URI, logger *zap.Logger) (*Manager, error) {
 			continue
 		}
 
-		spaces, err := loadSpaces(dir, config)
+		spaces, err := loadSpaces(dir, config, mgr.logger)
 		if err != nil {
 			return nil, err
 		}
@@ -146,7 +146,7 @@ func (m *Manager) Create(req api.SpacePostRequest) (Space, error) {
 		iosrc.RemoveAll(path)
 		return nil, err
 	}
-	spaces, err := loadSpaces(path, conf)
+	spaces, err := loadSpaces(path, conf, m.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -236,6 +236,12 @@ func (m *Manager) List(ctx context.Context) ([]api.SpaceInfo, error) {
 		sp := m.spaces[id]
 		info, err := sp.Info(ctx)
 		if err != nil {
+			// XXX should add ability to derive request id from context if it
+			// exists for current ctx.
+			m.logger.Warn("Could not get space info",
+				zap.String("space_id", string(id)),
+				zap.Error(err),
+			)
 			return nil, err
 		}
 		result = append(result, info)


### PR DESCRIPTION
Currently a space that references a moved or delete pcap causes
the list spaces endpoint to fail with 404.

If a pcapspace references a no longer existing pcap make it so:
- list spaces still works
- info request on the space returns pcap_support false
- searches on the space still works

Closes #1195