### PR TITLE
Fix zar import -zngcheck

### DIFF
--- a/cmd/zar/import/command.go
+++ b/cmd/zar/import/command.go
@@ -87,7 +87,7 @@ func (c *Command) Run(args []string) error {
 		Format: c.ReaderFlags.Format,
 		//JSONTypeConfig: c.jsonTypeConfig,
 		//JSONPathRegex:  c.jsonPathRegexp,
-		ZngCheck: true,
+		ZngCheck: c.ReaderFlags.ZngCheck,
 	}
 	reader, err := detector.OpenFile(zctx, path, cfg)
 	if err != nil {


### PR DESCRIPTION
Immediately after merging #1192, I realized that I had left the zar import zngcheck flag hard-coded to true.