### PR TITLE
create skeleton concept for package z

### DIFF
--- a/z/z.go
+++ b/z/z.go
@@ -6,7 +6,7 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-type Context struct {
+type Container struct {
 	*resolver.Context
 }
 
@@ -14,10 +14,6 @@ type Field struct {
 	zng.Column
 	zcode.Bytes
 	fields []Field
-}
-
-func NewContext() Context {
-	return Context{resolver.NewContext()}
 }
 
 func Int64(key string, val int64) Field {
@@ -35,14 +31,14 @@ func Stringv(val string) Field {
 	return String("", val)
 }
 
-func (c *Context) zctx() *resolver.Context {
+func (c *Container) zctx() *resolver.Context {
 	if c.Context == nil {
 		c.Context = resolver.NewContext()
 	}
 	return c.Context
 }
 
-func (c *Context) recType(fields ...Field) *zng.TypeRecord {
+func (c *Container) recType(fields ...Field) *zng.TypeRecord {
 	cols := make([]zng.Column, len(fields))
 	for k := range fields {
 		cols[k] = fields[k].Column
@@ -54,21 +50,21 @@ func (c *Context) recType(fields ...Field) *zng.TypeRecord {
 	return typ
 }
 
-func (c *Context) arrayType(fields ...Field) *zng.TypeArray {
+func (c *Container) arrayType(fields ...Field) *zng.TypeArray {
 	// XXX we should check the types of all the fields and
 	// convert to a union if the types are mixed
 	return c.zctx().LookupTypeArray(fields[0].Column.Type)
 }
 
-func (c *Context) Record(key string, fields ...Field) Field {
+func (c *Container) Record(key string, fields ...Field) Field {
 	return Field{zng.Column{key, c.recType(fields...)}, nil, fields}
 }
 
-func (c *Context) Array(key string, fields ...Field) Field {
+func (c *Container) Array(key string, fields ...Field) Field {
 	return Field{zng.Column{key, c.arrayType(fields...)}, nil, fields}
 }
 
-func (c *Context) NewRecord(fields ...Field) *zng.Record {
+func (c *Container) NewRecord(fields ...Field) *zng.Record {
 	typ := c.recType(fields...)
 	var b zcode.Builder
 	c.build(&b, fields...)
@@ -76,7 +72,7 @@ func (c *Context) NewRecord(fields ...Field) *zng.Record {
 	return zng.NewRecord(typ, body)
 }
 
-func (c *Context) build(b *zcode.Builder, fields ...Field) {
+func (c *Container) build(b *zcode.Builder, fields ...Field) {
 	b.BeginContainer()
 	for _, f := range fields {
 		if f.Bytes != nil {

--- a/z/z.go
+++ b/z/z.go
@@ -1,0 +1,78 @@
+package z
+
+import (
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type Context struct {
+	*resolver.Context
+}
+
+type Field struct {
+	zng.Column
+	zcode.Bytes
+	fields []Field
+}
+
+func NewContext() Context {
+	return Context{resolver.NewContext()}
+}
+
+func Int64(key string, val int64) Field {
+	return Field{zng.Column{key, zng.TypeInt64}, zng.EncodeInt(val), nil}
+}
+
+func String(key string, val string) Field {
+	return Field{zng.Column{key, zng.TypeString}, zng.EncodeString(val), nil}
+}
+
+func (c *Context) zctx() *resolver.Context {
+	if c.Context == nil {
+		c.Context = resolver.NewContext()
+	}
+	return c.Context
+}
+
+func (c *Context) recType(fields ...Field) *zng.TypeRecord {
+	cols := make([]zng.Column, len(fields))
+	for k := range fields {
+		cols[k] = fields[k].Column
+	}
+	typ, err := c.zctx().LookupTypeRecord(cols)
+	if err != nil {
+		panic(err.Error())
+	}
+	return typ
+}
+
+func (c *Context) RecordField(key string, fields ...Field) Field {
+	return Field{zng.Column{key, c.recType(fields...)}, nil, fields}
+}
+
+func (c *Context) Record(fields ...Field) *zng.Record {
+	typ := c.recType(fields...)
+	var b zcode.Builder
+	c.build(&b, fields...)
+	body, _ := b.Bytes().ContainerBody()
+	return zng.NewRecord(typ, body)
+}
+
+func (c *Context) build(b *zcode.Builder, fields ...Field) {
+	b.BeginContainer()
+	for _, f := range fields {
+		if f.Bytes != nil {
+			b.AppendPrimitive(f.Bytes)
+			continue
+		}
+		switch typ := f.Column.Type.(type) {
+		case *zng.TypeRecord:
+			c.build(b, f.fields...)
+		default:
+			panic("not implemented: " + typ.String())
+		}
+
+	}
+	b.EndContainer()
+}

--- a/z/z_test.go
+++ b/z/z_test.go
@@ -1,0 +1,20 @@
+package z_test
+
+import (
+	"testing"
+
+	"github.com/brimsec/zq/z"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZ(t *testing.T) {
+	var zc z.Context
+	rec := zc.Record(
+		z.Int64("cnt", 12),
+		z.String("s", "hello"),
+		zc.RecordField("rec",
+			z.String("a", "foo"),
+			z.String("b", "bar")))
+
+	assert.Equal(t, rec.String(), "record[12,hello,record[foo,bar]]")
+}

--- a/z/z_test.go
+++ b/z/z_test.go
@@ -9,12 +9,14 @@ import (
 
 func TestZ(t *testing.T) {
 	var zc z.Context
-	rec := zc.Record(
+	rec := zc.NewRecord(
 		z.Int64("cnt", 12),
+		zc.Array("a", z.Int64v(1), z.Int64v(2), z.Int64v(3)),
 		z.String("s", "hello"),
-		zc.RecordField("rec",
+		zc.Record("r",
 			z.String("a", "foo"),
 			z.String("b", "bar")))
 
-	assert.Equal(t, rec.String(), "record[12,hello,record[foo,bar]]")
+	assert.Equal(t, rec.Type.String(), "record[cnt:int64,a:array[int64],s:string,r:record[a:string,b:string]]")
+	assert.Equal(t, rec.String(), "record[12,array[1,2,3],hello,record[foo,bar]]")
 }

--- a/z/z_test.go
+++ b/z/z_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestZ(t *testing.T) {
-	var zc z.Context
+	var zc z.Container
 	rec := zc.NewRecord(
 		z.Int64("cnt", 12),
 		zc.Array("a", z.Int64v(1), z.Int64v(2), z.Int64v(3)),


### PR DESCRIPTION
Any thoughts on this draft?  I always pull my hair out creating zng.Records from native Go types.  Even programmers don't want to create their schemas ahead of time!

This is inspired by zapper and if we finished it up, it would make it easy to do a zapzng core extension to zapper.

Also, this could be helpful when we get to zng.Marshal(interface{}).

