### PR TITLE
Handle nested records with nonadjacent fields in zeekio.Parser

### DIFF
--- a/tests/formats/zeek/nested-record-with-nonadjacent-fields.yaml
+++ b/tests/formats/zeek/nested-record-with-nonadjacent-fields.yaml
@@ -1,0 +1,17 @@
+zql: '*'
+
+input: |
+  #separator \x09
+  #set_separator	,
+  #empty_field	(empty)
+  #unset_field	-
+  #path	conn
+  #open	2020-08-24-00-25-01
+  #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	proto	service	duration	orig_bytes	resp_bytes	conn_state	local_orig	local_resp	missed_bytes	history	orig_pkts	orig_ip_bytes	resp_pkts	resp_ip_bytes	tunnel_parents	orig_cc	resp_cc	id.orig_h_name.src	id.orig_h_name.vals	id.resp_h_name.src	id.resp_h_name.vals
+  #types	time	string	addr	port	addr	port	enum	string	interval	count	count	string	bool	bool	count	string	count	count	count	count	set[string]	string	string	string	set[string]	string	set[string]
+  1598243094.015046	CWjxkd3jpmxuvN21uj	10.124.2.117	61927	10.70.70.70	8080	tcp	-	0.002716	0	77	SF	F	F	0	FdfR	3	120	2	157	-	-	-	-	-	SSL_SNI	oneclient.sfx.ms,bats.video.yahoo.com,ctldl.windowsupdate.com,tapestry.tapad.com,www.gstatic.com,www.google.com:443,c.clicktale.net,eb2.3lift.com:443,13-237-209-96.expertcity.com:443,pr-bh.ybp.yahoo.com:443,clientservices.googleapis.com:443,js-sec.indexww.com:443,collect.tealiumiq.com,www.pacast.com,oneclient.sfx.ms:443,clientservices.googleapis.com,bats.video.yahoo.com:443,www.youtube.com
+
+output: |
+  #zenum=string
+  #0:record[_path:string,ts:time,uid:bstring,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port,orig_h_name:record[src:bstring,vals:set[bstring]],resp_h_name:record[src:bstring,vals:set[bstring]]],proto:zenum,service:bstring,duration:duration,orig_bytes:uint64,resp_bytes:uint64,conn_state:bstring,local_orig:bool,local_resp:bool,missed_bytes:uint64,history:bstring,orig_pkts:uint64,orig_ip_bytes:uint64,resp_pkts:uint64,resp_ip_bytes:uint64,tunnel_parents:set[bstring],orig_cc:bstring,resp_cc:bstring]
+  0:[conn;1598243094.015046;CWjxkd3jpmxuvN21uj;[10.124.2.117;61927;10.70.70.70;8080;[-;-;][SSL_SNI;[www.pacast.com;c.clicktale.net;www.gstatic.com;www.youtube.com;oneclient.sfx.ms;eb2.3lift.com:443;tapestry.tapad.com;www.google.com:443;bats.video.yahoo.com;oneclient.sfx.ms:443;collect.tealiumiq.com;js-sec.indexww.com:443;ctldl.windowsupdate.com;pr-bh.ybp.yahoo.com:443;bats.video.yahoo.com:443;clientservices.googleapis.com;13-237-209-96.expertcity.com:443;clientservices.googleapis.com:443;]]]tcp;-;0.002716;0;77;SF;F;F;0;FdfR;3;120;2;157;-;-;-;]

--- a/zio/zeekio/builder.go
+++ b/zio/zeekio/builder.go
@@ -8,7 +8,7 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
-func buildRecordFromZeekTSV(builder *zcode.Builder, typ *zng.TypeRecord, path []byte, data []byte) (zcode.Bytes, error) {
+func buildRecordFromZeekTSV(builder *zcode.Builder, typ *zng.TypeRecord, sourceFields []int, path []byte, data []byte) (zcode.Bytes, error) {
 	columns := typ.Columns
 	if path != nil {
 		if columns[0].Name != "_path" {
@@ -29,8 +29,14 @@ func buildRecordFromZeekTSV(builder *zcode.Builder, typ *zng.TypeRecord, path []
 		}
 	}
 	fields = append(fields, data[start:])
-
-	fields, err := appendRecordFromZeekTSV(builder, columns, fields)
+	if len(fields) > len(sourceFields) {
+		return nil, errors.New("too many values")
+	}
+	var fields2 [][]byte
+	for _, s := range sourceFields {
+		fields2 = append(fields2, fields[s])
+	}
+	fields, err := appendRecordFromZeekTSV(builder, columns, fields2)
 	if err != nil {
 		return nil, err
 	}

--- a/zio/zeekio/parser.go
+++ b/zio/zeekio/parser.go
@@ -168,7 +168,7 @@ func (p *Parser) ParseDirective(line []byte) error {
 // already present. The columns are returned as a slice along with a
 // bool indicating if a _path column was added.
 // Note that according to the zng spec, all the fields for a nested
-// record must be adjacent.
+// record must be adjacent which simplifies the logic here.
 func Unflatten(zctx *resolver.Context, columns []zng.Column, addPath bool) ([]zng.Column, bool, error) {
 	hasPath := false
 	for _, col := range columns {


### PR DESCRIPTION
zeekio.Parser assumes the fields of a nested record are adjacent.  Relax
that requirement.

I find this hard to love but couldn't come up with anything nicer.

Should close #1217.