### PR TITLE
cut -c: use descriptor to derive fields

### DIFF
--- a/proc/cut/cutter.go
+++ b/proc/cut/cutter.go
@@ -103,8 +103,7 @@ func (c *Cutter) complementBuilder(r *zng.Record) (*cutBuilder, error) {
 }
 
 // complementFields returns the slice of fields and associated types
-// that make up the complemente of the set of fields passed as first
-// argument.
+// that make up the complement of the set of fields in drops.
 func complementFields(drops []string, prefix string, typ *zng.TypeRecord) ([]string, []zng.Type) {
 	var fields []string
 	var types []zng.Type

--- a/proc/cut/cutter.go
+++ b/proc/cut/cutter.go
@@ -75,19 +75,16 @@ func (c *Cutter) FoundCut() bool {
 // complementBuilder creates a builder for the complement form of cut, where a
 // all fields not in a set are to be cut from a record and passed on.
 func (c *Cutter) complementBuilder(r *zng.Record) (*cutBuilder, error) {
-	var resolvers []expr.FieldExprResolver
-
 	fields, fieldTypes := complementFields(c.fieldnames, "", r.Type)
-
 	// if the set of cut -c fields is equal to the set of record
 	// fields, then there is no output for this input type.
 	if len(fieldTypes) == 0 {
 		return nil, nil
 	}
 
+	var resolvers []expr.FieldExprResolver
 	for _, f := range fields {
-		resolver := expr.CompileFieldAccess(f)
-		resolvers = append(resolvers, resolver)
+		resolvers = append(resolvers, expr.CompileFieldAccess(f))
 	}
 
 	builder, err := proc.NewColumnBuilder(c.zctx, fields)

--- a/tests/suite/cut/cut-c-unset-record.yaml
+++ b/tests/suite/cut/cut-c-unset-record.yaml
@@ -1,0 +1,9 @@
+zql: cut -c id
+
+input: |
+  #0:record[id:record[ip:ip],id2:record[ip:ip]]
+  0:[-;[1.1.1.1;]]
+
+output: |
+  #0:record[id2:record[ip:ip]]
+  0:[[1.1.1.1;]]


### PR DESCRIPTION
Previously, cut -c used a zng.fieldIter on the first record of a type
to compute which fields to extract. This leads to problems with unset
values: if an inner record is unset, fieldIter doesn't visit leaves,
and the cutter gets confused, as observed in https://github.com/brimsec/zq/issues/1226.

Instead, use the record's descriptor to figure out which fields to cut.

closes #1226