### PR TITLE
Update github.com/pierrec/lz4/v4 to v4.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mccanne/joe v0.0.0-20200731213236-7c7845acf98b
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/peterh/liner v1.1.0
-	github.com/pierrec/lz4/v4 v4.0.1
+	github.com/pierrec/lz4/v4 v4.0.2
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.7.1
 	github.com/segmentio/ksuid v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/pborman/getopt v0.0.0-20180729010549-6fdd0a2c7117/go.mod h1:85jBQOZwp
 github.com/peterh/liner v1.1.0 h1:f+aAedNJA6uk7+6rXsYBnhdo4Xux7ESLe+kcuVUF5os=
 github.com/peterh/liner v1.1.0/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/pierrec/cmdflag v0.0.2/go.mod h1:a3zKGZ3cdQUfxjd0RGMLZr8xI3nvpJOB+m6o/1X5BmU=
-github.com/pierrec/lz4/v4 v4.0.1 h1:HiTUn/JqhQQrNlPxvuXmpcyqpl+lvAM0meyTDvlVOaI=
-github.com/pierrec/lz4/v4 v4.0.1/go.mod h1:vvUajMAuienWCEdMnA5Zb5mp0VIa9M8VvKcVEOkoAh8=
+github.com/pierrec/lz4/v4 v4.0.2 h1:fD8xxs2iTE+tzWpQGKOiqn102qVH00ZT/STpuaN2eH0=
+github.com/pierrec/lz4/v4 v4.0.2/go.mod h1:vvUajMAuienWCEdMnA5Zb5mp0VIa9M8VvKcVEOkoAh8=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
This version eliminates a memory allocation on each call to
lz4.ComrpessBlock with a nil hash table.