### PR TITLE
replace *zio.Writer with zbuf.WriteCloser

### DIFF
--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -58,7 +58,7 @@ func indexQuery(t *testing.T, ark *Archive, query IndexQuery, opts ...FindOption
 	defer rc.Close()
 
 	var buf bytes.Buffer
-	w := tzngio.NewWriter(&zio.NoCloser{&buf})
+	w := tzngio.NewWriter(zio.NopCloser(&buf))
 	require.NoError(t, zbuf.Copy(w, rc))
 
 	return buf.String()

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/pkg/test"
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
@@ -57,7 +58,7 @@ func indexQuery(t *testing.T, ark *Archive, query IndexQuery, opts ...FindOption
 	defer rc.Close()
 
 	var buf bytes.Buffer
-	w := tzngio.NewWriter(&buf)
+	w := tzngio.NewWriter(&zio.NoCloser{&buf})
 	require.NoError(t, zbuf.Copy(w, rc))
 
 	return buf.String()

--- a/cmd/zar/find/command.go
+++ b/cmd/zar/find/command.go
@@ -9,6 +9,7 @@ import (
 	"github.com/brimsec/zq/archive"
 	"github.com/brimsec/zq/cmd/zar/root"
 	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
@@ -108,7 +109,7 @@ func (c *Command) Run(args []string) error {
 	if c.outputFile == "-" {
 		c.outputFile = ""
 	}
-	var writer *zio.Writer
+	var writer zbuf.WriteCloser
 	if c.zng {
 		var err error
 		writer, err = emitter.NewFile(c.outputFile, &c.WriterFlags)

--- a/driver/parallel_test.go
+++ b/driver/parallel_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
@@ -82,7 +83,7 @@ func TestParallelOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	d := NewCLI(tzngio.NewWriter(&buf))
+	d := NewCLI(tzngio.NewWriter(&zio.NoCloser{&buf}))
 	zctx := resolver.NewContext()
 	err = MultiRun(context.Background(), d, query, zctx, &orderedmsrc{}, MultiConfig{
 		Parallelism: len(parallelTestInputs),
@@ -146,7 +147,7 @@ func TestScannerClose(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	d := NewCLI(tzngio.NewWriter(&buf))
+	d := NewCLI(tzngio.NewWriter(&zio.NoCloser{&buf}))
 	zctx := resolver.NewContext()
 	ms := &scannerCloseMS{
 		input: `

--- a/driver/parallel_test.go
+++ b/driver/parallel_test.go
@@ -83,7 +83,7 @@ func TestParallelOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	d := NewCLI(tzngio.NewWriter(&zio.NoCloser{&buf}))
+	d := NewCLI(tzngio.NewWriter(zio.NopCloser(&buf)))
 	zctx := resolver.NewContext()
 	err = MultiRun(context.Background(), d, query, zctx, &orderedmsrc{}, MultiConfig{
 		Parallelism: len(parallelTestInputs),
@@ -147,7 +147,7 @@ func TestScannerClose(t *testing.T) {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	d := NewCLI(tzngio.NewWriter(&zio.NoCloser{&buf}))
+	d := NewCLI(tzngio.NewWriter(zio.NopCloser(&buf)))
 	zctx := resolver.NewContext()
 	ms := &scannerCloseMS{
 		input: `

--- a/emitter/bytes.go
+++ b/emitter/bytes.go
@@ -19,7 +19,7 @@ func (b *Bytes) Bytes() []byte {
 
 func NewBytes(flags *zio.WriterFlags) (*Bytes, error) {
 	b := &Bytes{}
-	b.Writer = detector.LookupWriter(&zio.NoCloser{&b.buf}, flags)
+	b.Writer = detector.LookupWriter(zio.NopCloser(&b.buf), flags)
 	if b.Writer == nil {
 		return nil, unknownFormat(flags.Format)
 	}

--- a/emitter/bytes.go
+++ b/emitter/bytes.go
@@ -3,12 +3,13 @@ package emitter
 import (
 	"bytes"
 
+	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
 )
 
 type Bytes struct {
-	*zio.Writer
+	zbuf.Writer
 	buf bytes.Buffer
 }
 
@@ -18,7 +19,7 @@ func (b *Bytes) Bytes() []byte {
 
 func NewBytes(flags *zio.WriterFlags) (*Bytes, error) {
 	b := &Bytes{}
-	b.Writer = detector.LookupWriter(&noClose{&b.buf}, flags)
+	b.Writer = detector.LookupWriter(&zio.NoCloser{&b.buf}, flags)
 	if b.Writer == nil {
 		return nil, unknownFormat(flags.Format)
 	}

--- a/emitter/file.go
+++ b/emitter/file.go
@@ -46,7 +46,7 @@ func NewFileWithSource(path iosrc.URI, flags *zio.WriterFlags, source iosrc.Sour
 	if path.Scheme == "stdio" {
 		// Don't close stdio in case we live inside something
 		// that has multiple stdio users.
-		wc = &zio.NoCloser{f}
+		wc = zio.NopCloser(f)
 		// Don't buffer terminal output.
 		if !IsTerminal(f) {
 			wc = bufwriter.New(wc)

--- a/emitter/file.go
+++ b/emitter/file.go
@@ -6,20 +6,13 @@ import (
 
 	"github.com/brimsec/zq/pkg/bufwriter"
 	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-type noClose struct {
-	io.Writer
-}
-
-func (*noClose) Close() error {
-	return nil
-}
-
-func NewFile(path string, flags *zio.WriterFlags) (*zio.Writer, error) {
+func NewFile(path string, flags *zio.WriterFlags) (zbuf.WriteCloser, error) {
 	if path == "" {
 		path = "stdout"
 	}
@@ -43,7 +36,7 @@ func IsTerminal(w io.Writer) bool {
 	return false
 }
 
-func NewFileWithSource(path iosrc.URI, flags *zio.WriterFlags, source iosrc.Source) (*zio.Writer, error) {
+func NewFileWithSource(path iosrc.URI, flags *zio.WriterFlags, source iosrc.Source) (zbuf.WriteCloser, error) {
 	f, err := source.NewWriter(path)
 	if err != nil {
 		return nil, err
@@ -53,7 +46,7 @@ func NewFileWithSource(path iosrc.URI, flags *zio.WriterFlags, source iosrc.Sour
 	if path.Scheme == "stdio" {
 		// Don't close stdio in case we live inside something
 		// that has multiple stdio users.
-		wc = &noClose{f}
+		wc = &zio.NoCloser{f}
 		// Don't buffer terminal output.
 		if !IsTerminal(f) {
 			wc = bufwriter.New(wc)
@@ -61,9 +54,9 @@ func NewFileWithSource(path iosrc.URI, flags *zio.WriterFlags, source iosrc.Sour
 	} else {
 		wc = bufwriter.New(f)
 	}
-	// On close, zio.Writer.Close(), the zng WriteFlusher will be flushed
-	// then the bufwriter will closed (which will flush it's internal buffer
-	// then close the file)
+	// On close, zbuf.WriteCloser.Close() will close and flush the
+	// downstream writer, which will flush the bufwriter here and,
+	// in turn, close its underlying writer.
 	w := detector.LookupWriter(wc, flags)
 	if w == nil {
 		return nil, unknownFormat(flags.Format)

--- a/emitter/types.go
+++ b/emitter/types.go
@@ -22,7 +22,7 @@ func NewTypeLogger(path string, verbose bool) (*TypeLogger, error) {
 	if path == "" {
 		// Don't close stdout in case we live inside something
 		// here that runs multiple instances of this to stdout.
-		f = &zio.NoCloser{os.Stdout}
+		f = zio.NopCloser(os.Stdout)
 	} else {
 		var err error
 		flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC

--- a/emitter/types.go
+++ b/emitter/types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/brimsec/zq/pkg/bufwriter"
 	"github.com/brimsec/zq/pkg/fs"
+	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zng"
 )
 
@@ -21,7 +22,7 @@ func NewTypeLogger(path string, verbose bool) (*TypeLogger, error) {
 	if path == "" {
 		// Don't close stdout in case we live inside something
 		// here that runs multiple instances of this to stdout.
-		f = &noClose{os.Stdout}
+		f = &zio.NoCloser{os.Stdout}
 	} else {
 		var err error
 		flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC

--- a/proc/compiler/compiler_test.go
+++ b/proc/compiler/compiler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/brimsec/zq/proc/compiler"
 	"github.com/brimsec/zq/proc/proctest"
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
@@ -48,7 +49,7 @@ func TestCompileParents(t *testing.T) {
 		require.NoError(t, err)
 
 		var sb strings.Builder
-		err = zbuf.CopyPuller(tzngio.NewWriter(&sb), leaves[0])
+		err = zbuf.CopyPuller(tzngio.NewWriter(&zio.NoCloser{&sb}), leaves[0])
 		require.NoError(t, err)
 		assert.Equal(t, test.Trim(exp), sb.String())
 	})

--- a/proc/compiler/compiler_test.go
+++ b/proc/compiler/compiler_test.go
@@ -49,7 +49,7 @@ func TestCompileParents(t *testing.T) {
 		require.NoError(t, err)
 
 		var sb strings.Builder
-		err = zbuf.CopyPuller(tzngio.NewWriter(&zio.NoCloser{&sb}), leaves[0])
+		err = zbuf.CopyPuller(tzngio.NewWriter(zio.NopCloser(&sb)), leaves[0])
 		require.NoError(t, err)
 		assert.Equal(t, test.Trim(exp), sb.String())
 	})

--- a/proc/orderedmerge/orderedmerge_test.go
+++ b/proc/orderedmerge/orderedmerge_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/brimsec/zq/proc/orderedmerge"
 	"github.com/brimsec/zq/proc/proctest"
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/assert"
@@ -109,7 +110,7 @@ func TestParallelOrder(t *testing.T) {
 			om := orderedmerge.New(pctx, parents, c.field, c.reversed)
 
 			var sb strings.Builder
-			err := zbuf.CopyPuller(tzngio.NewWriter(&sb), om)
+			err := zbuf.CopyPuller(tzngio.NewWriter(&zio.NoCloser{&sb}), om)
 			require.NoError(t, err)
 			assert.Equal(t, test.Trim(c.exp), sb.String())
 		})

--- a/proc/orderedmerge/orderedmerge_test.go
+++ b/proc/orderedmerge/orderedmerge_test.go
@@ -110,7 +110,7 @@ func TestParallelOrder(t *testing.T) {
 			om := orderedmerge.New(pctx, parents, c.field, c.reversed)
 
 			var sb strings.Builder
-			err := zbuf.CopyPuller(tzngio.NewWriter(&zio.NoCloser{&sb}), om)
+			err := zbuf.CopyPuller(tzngio.NewWriter(zio.NopCloser(&sb)), om)
 			require.NoError(t, err)
 			assert.Equal(t, test.Trim(c.exp), sb.String())
 		})

--- a/proc/sort/spill.go
+++ b/proc/sort/spill.go
@@ -71,7 +71,7 @@ func (r *runFile) read() (*zng.Record, bool, error) {
 
 // writeZng writes records to w as a zng stream.
 func writeZng(w io.Writer, records []*zng.Record) error {
-	zw := zngio.NewWriter(bufwriter.New(&zio.NoCloser{w}), zio.WriterFlags{})
+	zw := zngio.NewWriter(bufwriter.New(zio.NopCloser(w)), zio.WriterFlags{})
 	for _, rec := range records {
 		if err := zw.Write(rec); err != nil {
 			return err

--- a/proc/sort/spill.go
+++ b/proc/sort/spill.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/brimsec/zq/pkg/bufwriter"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
@@ -70,15 +71,11 @@ func (r *runFile) read() (*zng.Record, bool, error) {
 
 // writeZng writes records to w as a zng stream.
 func writeZng(w io.Writer, records []*zng.Record) error {
-	bw := bufio.NewWriter(w)
-	zw := zngio.NewWriter(bw, zio.WriterFlags{})
+	zw := zngio.NewWriter(bufwriter.New(&zio.NoCloser{w}), zio.WriterFlags{})
 	for _, rec := range records {
 		if err := zw.Write(rec); err != nil {
 			return err
 		}
 	}
-	if err := zw.Flush(); err != nil {
-		return nil
-	}
-	return bw.Flush()
+	return zw.Close()
 }

--- a/zbuf/zbuf.go
+++ b/zbuf/zbuf.go
@@ -32,23 +32,6 @@ type WriteCloser interface {
 	io.Closer
 }
 
-type WriteFlusher interface {
-	Writer
-	Flush() error
-}
-
-type nopFlusher struct {
-	Writer
-}
-
-func (nopFlusher) Flush() error { return nil }
-
-// NopFlusher returns a WriteFlusher with a no-op Flush method wrapping
-// the provided Writer w.
-func NopFlusher(w Writer) WriteFlusher {
-	return nopFlusher{w}
-}
-
 type nopReadCloser struct {
 	Reader
 }

--- a/zio/detector/file_test.go
+++ b/zio/detector/file_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/stretchr/testify/assert"
@@ -65,7 +66,7 @@ func TestMultiFileScanner(t *testing.T) {
 	assert.True(t, ok)
 
 	var sb strings.Builder
-	err = zbuf.CopyPuller(tzngio.NewWriter(&sb), sn)
+	err = zbuf.CopyPuller(tzngio.NewWriter(&zio.NoCloser{&sb}), sn)
 	require.NoError(t, err)
 	require.Equal(t, trim(exp), trim(sb.String()))
 

--- a/zio/detector/file_test.go
+++ b/zio/detector/file_test.go
@@ -66,7 +66,7 @@ func TestMultiFileScanner(t *testing.T) {
 	assert.True(t, ok)
 
 	var sb strings.Builder
-	err = zbuf.CopyPuller(tzngio.NewWriter(&zio.NoCloser{&sb}), sn)
+	err = zbuf.CopyPuller(tzngio.NewWriter(zio.NopCloser(&sb)), sn)
 	require.NoError(t, err)
 	require.Equal(t, trim(exp), trim(sb.String()))
 

--- a/zio/detector/lookup.go
+++ b/zio/detector/lookup.go
@@ -23,35 +23,34 @@ func (*nullWriter) Write(*zng.Record) error {
 	return nil
 }
 
-func LookupWriter(w io.WriteCloser, wflags *zio.WriterFlags) *zio.Writer {
+func (*nullWriter) Close() error {
+	return nil
+}
+
+func LookupWriter(w io.WriteCloser, wflags *zio.WriterFlags) zbuf.WriteCloser {
 	flags := *wflags
 	if flags.Format == "" {
 		flags.Format = "tzng"
 	}
-	var f zbuf.WriteFlusher
 	switch flags.Format {
 	default:
 		return nil
 	case "null":
-		f = zbuf.NopFlusher(&nullWriter{})
+		return &nullWriter{}
 	case "tzng":
-		f = zbuf.NopFlusher(tzngio.NewWriter(w))
+		return tzngio.NewWriter(w)
 	case "zng":
-		f = zngio.NewWriter(w, flags)
+		return zngio.NewWriter(w, flags)
 	case "zeek":
-		f = zbuf.NopFlusher(zeekio.NewWriter(w, flags))
+		return zeekio.NewWriter(w, flags)
 	case "ndjson":
-		f = zbuf.NopFlusher(ndjsonio.NewWriter(w))
+		return ndjsonio.NewWriter(w)
 	case "zjson":
-		f = zbuf.NopFlusher(zjsonio.NewWriter(w))
+		return zjsonio.NewWriter(w)
 	case "text":
-		f = zbuf.NopFlusher(textio.NewWriter(w, flags))
+		return textio.NewWriter(w, flags)
 	case "table":
-		f = tableio.NewWriter(w, flags)
-	}
-	return &zio.Writer{
-		WriteFlusher: f,
-		Closer:       w,
+		return tableio.NewWriter(w, flags)
 	}
 }
 

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -52,7 +52,7 @@ func TestNDJSONWriter(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			var out bytes.Buffer
-			w := NewWriter(&zio.NoCloser{&out})
+			w := NewWriter(zio.NopCloser(&out))
 			r := tzngio.NewReader(strings.NewReader(c.input), resolver.NewContext())
 			require.NoError(t, zbuf.Copy(w, r))
 			NDJSONEq(t, c.output, out.String())
@@ -132,7 +132,7 @@ func TestNDJSON(t *testing.T) {
 
 func runtestcase(t *testing.T, input, output string) {
 	var out bytes.Buffer
-	w := NewWriter(&zio.NoCloser{&out})
+	w := NewWriter(zio.NopCloser(&out))
 	r, err := NewReader(strings.NewReader(input), resolver.NewContext(), nil, "", "")
 	require.NoError(t, err)
 	require.NoError(t, zbuf.Copy(w, r))
@@ -351,7 +351,7 @@ func TestNDJSONTypeErrors(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			var out bytes.Buffer
-			w := NewWriter(&zio.NoCloser{&out})
+			w := NewWriter(zio.NopCloser(&out))
 			r, err := NewReader(strings.NewReader(c.input), resolver.NewContext(), nil, "", "")
 			require.NoError(t, err)
 			err = r.configureTypes(typeConfig, c.defaultPath)

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
@@ -51,7 +52,7 @@ func TestNDJSONWriter(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			var out bytes.Buffer
-			w := NewWriter(&out)
+			w := NewWriter(&zio.NoCloser{&out})
 			r := tzngio.NewReader(strings.NewReader(c.input), resolver.NewContext())
 			require.NoError(t, zbuf.Copy(w, r))
 			NDJSONEq(t, c.output, out.String())
@@ -131,7 +132,7 @@ func TestNDJSON(t *testing.T) {
 
 func runtestcase(t *testing.T, input, output string) {
 	var out bytes.Buffer
-	w := NewWriter(&out)
+	w := NewWriter(&zio.NoCloser{&out})
 	r, err := NewReader(strings.NewReader(input), resolver.NewContext(), nil, "", "")
 	require.NoError(t, err)
 	require.NoError(t, zbuf.Copy(w, r))
@@ -350,7 +351,7 @@ func TestNDJSONTypeErrors(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			var out bytes.Buffer
-			w := NewWriter(&out)
+			w := NewWriter(&zio.NoCloser{&out})
 			r, err := NewReader(strings.NewReader(c.input), resolver.NewContext(), nil, "", "")
 			require.NoError(t, err)
 			err = r.configureTypes(typeConfig, c.defaultPath)

--- a/zio/ndjsonio/writer.go
+++ b/zio/ndjsonio/writer.go
@@ -9,15 +9,19 @@ import (
 
 // Writer implements a Formatter for ndjson
 type Writer struct {
-	io.Writer
+	writer  io.WriteCloser
 	encoder *json.Encoder
 }
 
-func NewWriter(w io.Writer) *Writer {
+func NewWriter(w io.WriteCloser) *Writer {
 	return &Writer{
-		Writer:  w,
+		writer:  w,
 		encoder: json.NewEncoder(w),
 	}
+}
+
+func (w *Writer) Close() error {
+	return w.writer.Close()
 }
 
 func (w *Writer) Write(rec *zng.Record) error {

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -12,8 +12,8 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-type Table struct {
-	io.Writer
+type Writer struct {
+	writer    io.WriteCloser
 	flattener *zeekio.Flattener
 	table     *tabwriter.Writer
 	typ       *zng.TypeRecord
@@ -23,66 +23,74 @@ type Table struct {
 	format    zng.OutFmt
 }
 
-func NewWriter(w io.Writer, flags zio.WriterFlags) *Table {
-	writer := tabwriter.NewWriter(w, 0, 8, 1, ' ', 0)
+func NewWriter(w io.WriteCloser, flags zio.WriterFlags) *Writer {
+	table := tabwriter.NewWriter(w, 0, 8, 1, ' ', 0)
 	var format zng.OutFmt
 	if flags.UTF8 {
 		format = zng.OutFormatZeek
 	} else {
 		format = zng.OutFormatZeekAscii
 	}
-	return &Table{
-		Writer:    w,
+	return &Writer{
+		writer:    w,
 		flattener: zeekio.NewFlattener(resolver.NewContext()),
-		table:     writer,
+		table:     table,
 		limit:     1000,
 		precision: 6,
 		format:    format,
 	}
 }
 
-func (t *Table) writeHeader(typ *zng.TypeRecord) {
+func (w *Writer) writeHeader(typ *zng.TypeRecord) {
 	// write out descriptor headers
 	columnNames := []string{}
 	for _, col := range typ.Columns {
 		//XXX not sure about ToUpper here...
 		columnNames = append(columnNames, strings.ToUpper(col.Name))
 	}
-	fmt.Fprintln(t.table, strings.Join(columnNames, "\t"))
+	fmt.Fprintln(w.table, strings.Join(columnNames, "\t"))
 }
 
-func (t *Table) Write(r *zng.Record) error {
-	r, err := t.flattener.Flatten(r)
+func (w *Writer) Write(r *zng.Record) error {
+	r, err := w.flattener.Flatten(r)
 	if err != nil {
 		return err
 	}
-	if r.Type != t.typ {
-		if t.typ != nil {
-			t.Flush()
-			t.nline = 0
+	if r.Type != w.typ {
+		if w.typ != nil {
+			w.flush()
+			w.nline = 0
 		}
 		// First time, or new descriptor, print header
-		t.writeHeader(r.Type)
-		t.typ = r.Type
+		w.writeHeader(r.Type)
+		w.typ = r.Type
 	}
-	if t.nline >= t.limit {
-		t.Flush()
-		t.writeHeader(t.typ)
-		t.nline = 0
+	if w.nline >= w.limit {
+		w.flush()
+		w.writeHeader(w.typ)
+		w.nline = 0
 	}
 	//XXX only works for zeek-oriented records right now (won't work for NDJSON nested records)
-	ss, changePrecision, err := zeekio.ZeekStrings(r, t.precision, t.format)
+	ss, changePrecision, err := zeekio.ZeekStrings(r, w.precision, w.format)
 	if err != nil {
 		return err
 	}
 	if changePrecision {
-		t.precision = 9
+		w.precision = 9
 	}
-	t.nline++
-	_, err = fmt.Fprintf(t.table, "%s\n", strings.Join(ss, "\t"))
+	w.nline++
+	_, err = fmt.Fprintf(w.table, "%s\n", strings.Join(ss, "\t"))
 	return err
 }
 
-func (t *Table) Flush() error {
-	return t.table.Flush()
+func (w *Writer) flush() error {
+	return w.table.Flush()
+}
+
+func (w *Writer) Close() error {
+	firstErr := w.flush()
+	if err := w.writer.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
 }

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -89,7 +89,7 @@ func (w *Writer) flush() error {
 
 func (w *Writer) Close() error {
 	err := w.flush()
-	if closeErr := w.writer.Close(); closeErr != nil && err == nil {
+	if closeErr := w.writer.Close(); err == nil {
 		err = closeErr
 	}
 	return err

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -88,9 +88,9 @@ func (w *Writer) flush() error {
 }
 
 func (w *Writer) Close() error {
-	firstErr := w.flush()
-	if err := w.writer.Close(); err != nil && firstErr == nil {
-		firstErr = err
+	err := w.flush()
+	if closeErr := w.writer.Close(); closeErr != nil && err == nil {
+		err = closeErr
 	}
-	return firstErr
+	return err
 }

--- a/zio/zeekio/writer_test.go
+++ b/zio/zeekio/writer_test.go
@@ -51,7 +51,7 @@ func runcase(t *testing.T, tzng, expected string) {
 	r := tzngio.NewReader(strings.NewReader(tzng), resolver.NewContext())
 	rec, err := r.Read()
 	require.NoError(t, err)
-	w := zeekio.NewWriter(out, zio.WriterFlags{})
+	w := zeekio.NewWriter(&zio.NoCloser{out}, zio.WriterFlags{})
 	require.NoError(t, w.Write(rec))
 	require.Equal(t, expected, out.String())
 }

--- a/zio/zeekio/writer_test.go
+++ b/zio/zeekio/writer_test.go
@@ -51,7 +51,7 @@ func runcase(t *testing.T, tzng, expected string) {
 	r := tzngio.NewReader(strings.NewReader(tzng), resolver.NewContext())
 	rec, err := r.Read()
 	require.NoError(t, err)
-	w := zeekio.NewWriter(&zio.NoCloser{out}, zio.WriterFlags{})
+	w := zeekio.NewWriter(zio.NopCloser(out), zio.WriterFlags{})
 	require.NoError(t, w.Write(rec))
 	require.Equal(t, expected, out.String())
 }

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -65,6 +65,14 @@ func Extension(format string) string {
 	}
 }
 
-type NoCloser struct{ io.Writer }
+type nopCloser struct {
+	io.Writer
+}
 
-func (_ *NoCloser) Close() error { return nil }
+func (nopCloser) Close() error { return nil }
+
+// NopCloser returns a WriteCloser with a no-op Close method wrapping
+// the provided Writer w.
+func NopCloser(w io.Writer) io.WriteCloser {
+	return nopCloser{w}
+}

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -3,8 +3,6 @@ package zio
 import (
 	"flag"
 	"io"
-
-	"github.com/brimsec/zq/zbuf"
 )
 
 // ReaderFlags has the union of all the flags accepted by the different
@@ -46,27 +44,6 @@ func (f *WriterFlags) SetFlags(fs *flag.FlagSet) {
 		"LZ4 block size in bytes for ZNG compression (nonpositive to disable)")
 }
 
-type Writer struct {
-	zbuf.WriteFlusher
-	io.Closer
-}
-
-func NewWriter(writer zbuf.WriteFlusher, closer io.Closer) *Writer {
-	return &Writer{
-		WriteFlusher: writer,
-		Closer:       closer,
-	}
-}
-
-func (w *Writer) Close() error {
-	err := w.Flush()
-	cerr := w.Closer.Close()
-	if err == nil {
-		err = cerr
-	}
-	return err
-}
-
 func Extension(format string) string {
 	switch format {
 	case "tzng":
@@ -87,3 +64,7 @@ func Extension(format string) string {
 		return ""
 	}
 }
+
+type NoCloser struct{ io.Writer }
+
+func (_ *NoCloser) Close() error { return nil }

--- a/zio/zjsonio/writer.go
+++ b/zio/zjsonio/writer.go
@@ -25,15 +25,19 @@ type Record struct {
 }
 
 type Writer struct {
-	io.Writer
+	writer io.WriteCloser
 	stream *Stream
 }
 
-func NewWriter(w io.Writer) *Writer {
+func NewWriter(w io.WriteCloser) *Writer {
 	return &Writer{
-		Writer: w,
+		writer: w,
 		stream: NewStream(),
 	}
+}
+
+func (w *Writer) Close() error {
+	return w.writer.Close()
 }
 
 func (w *Writer) Write(r *zng.Record) error {
@@ -45,7 +49,7 @@ func (w *Writer) Write(r *zng.Record) error {
 	if err != nil {
 		return err
 	}
-	_, err = w.Writer.Write(b)
+	_, err = w.writer.Write(b)
 	if err != nil {
 		return err
 	}
@@ -53,6 +57,6 @@ func (w *Writer) Write(r *zng.Record) error {
 }
 
 func (w *Writer) write(s string) error {
-	_, err := w.Writer.Write([]byte(s))
+	_, err := w.writer.Write([]byte(s))
 	return err
 }

--- a/zio/zng_test.go
+++ b/zio/zng_test.go
@@ -48,7 +48,7 @@ func boomerang(t *testing.T, logs string, compress bool) {
 	}
 	rawDst := zngio.NewWriter(&rawzng, zio.WriterFlags{ZngLZ4BlockSize: zngLZ4BlockSize})
 	require.NoError(t, zbuf.Copy(rawDst, tzngSrc))
-	require.NoError(t, rawDst.Flush())
+	require.NoError(t, rawDst.Close())
 
 	var out Output
 	rawSrc := zngio.NewReader(bytes.NewReader(rawzng.Bytes()), resolver.NewContext())

--- a/zio/zngio/writer.go
+++ b/zio/zngio/writer.go
@@ -38,11 +38,11 @@ func NewWriter(w io.WriteCloser, flags zio.WriterFlags) *Writer {
 }
 
 func (w *Writer) Close() error {
-	firstErr := w.flush()
-	if err := w.closer.Close(); err != nil && firstErr == nil {
-		return firstErr
+	err := w.flush()
+	if closeErr := w.closer.Close(); closeErr != nil && err == nil {
+		err = closeErr
 	}
-	return firstErr
+	return err
 }
 
 func (w *Writer) write(p []byte) error {

--- a/zio/zngio/writer.go
+++ b/zio/zngio/writer.go
@@ -39,7 +39,7 @@ func NewWriter(w io.WriteCloser, flags zio.WriterFlags) *Writer {
 
 func (w *Writer) Close() error {
 	err := w.flush()
-	if closeErr := w.closer.Close(); closeErr != nil && err == nil {
+	if closeErr := w.closer.Close(); err == nil {
 		err = closeErr
 	}
 	return err

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -81,7 +81,7 @@ func TestSearchNoCtrl(t *testing.T) {
 		msgs = append(msgs, i)
 	})
 	buf := bytes.NewBuffer(nil)
-	w := tzngio.NewWriter(&zio.NoCloser{buf})
+	w := tzngio.NewWriter(zio.NopCloser(buf))
 	require.NoError(t, zbuf.Copy(w, r))
 	require.Equal(t, test.Trim(src), buf.String())
 	require.Equal(t, 0, len(msgs))
@@ -1028,7 +1028,7 @@ func archiveStat(t *testing.T, client *api.Connection, space api.SpaceID) string
 	r, err := client.ArchiveStat(context.Background(), space, nil)
 	require.NoError(t, err)
 	buf := bytes.NewBuffer(nil)
-	w := tzngio.NewWriter(&zio.NoCloser{buf})
+	w := tzngio.NewWriter(zio.NopCloser(buf))
 	require.NoError(t, zbuf.Copy(w, r))
 	return buf.String()
 }
@@ -1041,7 +1041,7 @@ func indexSearch(t *testing.T, client *api.Connection, space api.SpaceID, indexN
 	r, err := client.IndexSearch(context.Background(), space, req, nil)
 	require.NoError(t, err)
 	buf := bytes.NewBuffer(nil)
-	w := tzngio.NewWriter(&zio.NoCloser{buf})
+	w := tzngio.NewWriter(zio.NopCloser(buf))
 	var msgs []interface{}
 	r.SetOnCtrl(func(i interface{}) {
 		msgs = append(msgs, i)
@@ -1067,7 +1067,7 @@ func search(t *testing.T, client *api.Connection, space api.SpaceID, prog string
 	r, err := client.Search(context.Background(), req, nil)
 	require.NoError(t, err)
 	buf := bytes.NewBuffer(nil)
-	w := tzngio.NewWriter(&zio.NoCloser{buf})
+	w := tzngio.NewWriter(zio.NopCloser(buf))
 	var msgs []interface{}
 	r.SetOnCtrl(func(i interface{}) {
 		msgs = append(msgs, i)

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/pkg/test"
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/ndjsonio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zqd"
@@ -80,7 +81,7 @@ func TestSearchNoCtrl(t *testing.T) {
 		msgs = append(msgs, i)
 	})
 	buf := bytes.NewBuffer(nil)
-	w := tzngio.NewWriter(buf)
+	w := tzngio.NewWriter(&zio.NoCloser{buf})
 	require.NoError(t, zbuf.Copy(w, r))
 	require.Equal(t, test.Trim(src), buf.String())
 	require.Equal(t, 0, len(msgs))
@@ -1027,7 +1028,7 @@ func archiveStat(t *testing.T, client *api.Connection, space api.SpaceID) string
 	r, err := client.ArchiveStat(context.Background(), space, nil)
 	require.NoError(t, err)
 	buf := bytes.NewBuffer(nil)
-	w := tzngio.NewWriter(buf)
+	w := tzngio.NewWriter(&zio.NoCloser{buf})
 	require.NoError(t, zbuf.Copy(w, r))
 	return buf.String()
 }
@@ -1040,7 +1041,7 @@ func indexSearch(t *testing.T, client *api.Connection, space api.SpaceID, indexN
 	r, err := client.IndexSearch(context.Background(), space, req, nil)
 	require.NoError(t, err)
 	buf := bytes.NewBuffer(nil)
-	w := tzngio.NewWriter(buf)
+	w := tzngio.NewWriter(&zio.NoCloser{buf})
 	var msgs []interface{}
 	r.SetOnCtrl(func(i interface{}) {
 		msgs = append(msgs, i)
@@ -1066,7 +1067,7 @@ func search(t *testing.T, client *api.Connection, space api.SpaceID, prog string
 	r, err := client.Search(context.Background(), req, nil)
 	require.NoError(t, err)
 	buf := bytes.NewBuffer(nil)
-	w := tzngio.NewWriter(buf)
+	w := tzngio.NewWriter(&zio.NoCloser{buf})
 	var msgs []interface{}
 	r.SetOnCtrl(func(i interface{}) {
 		msgs = append(msgs, i)

--- a/zqd/search/zng.go
+++ b/zqd/search/zng.go
@@ -23,7 +23,7 @@ type ZngOutput struct {
 func NewZngOutput(response http.ResponseWriter, ctrl bool) *ZngOutput {
 	o := &ZngOutput{
 		response: response,
-		writer:   zngio.NewWriter(response, zio.WriterFlags{}),
+		writer:   zngio.NewWriter(&zio.NoCloser{response}, zio.WriterFlags{}),
 		ctrl:     ctrl,
 	}
 	return o

--- a/zqd/search/zng.go
+++ b/zqd/search/zng.go
@@ -23,7 +23,7 @@ type ZngOutput struct {
 func NewZngOutput(response http.ResponseWriter, ctrl bool) *ZngOutput {
 	o := &ZngOutput{
 		response: response,
-		writer:   zngio.NewWriter(&zio.NoCloser{response}, zio.WriterFlags{}),
+		writer:   zngio.NewWriter(zio.NopCloser(response), zio.WriterFlags{}),
 		ctrl:     ctrl,
 	}
 	return o

--- a/zqd/storage/filestore/filestore.go
+++ b/zqd/storage/filestore/filestore.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/brimsec/zq/driver"
+	"github.com/brimsec/zq/pkg/bufwriter"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
@@ -119,7 +120,7 @@ func (s *Storage) Write(ctx context.Context, zctx *resolver.Context, zr zbuf.Rea
 
 	spanWriter := &spanWriter{}
 	if err := fs.ReplaceFile(s.join(allZngFile), 0600, func(w io.Writer) error {
-		fileWriter := zngio.NewWriter(w, zio.WriterFlags{
+		fileWriter := zngio.NewWriter(bufwriter.New(&zio.NoCloser{w}), zio.WriterFlags{
 			StreamRecordsMax: s.streamsize,
 			ZngLZ4BlockSize:  zio.DefaultZngLZ4BlockSize,
 		})
@@ -127,7 +128,7 @@ func (s *Storage) Write(ctx context.Context, zctx *resolver.Context, zr zbuf.Rea
 		if err := s.write(ctx, zw, zctx, zr); err != nil {
 			return err
 		}
-		return fileWriter.Flush()
+		return fileWriter.Close()
 	}); err != nil {
 		return err
 	}

--- a/zqd/storage/filestore/filestore.go
+++ b/zqd/storage/filestore/filestore.go
@@ -120,7 +120,7 @@ func (s *Storage) Write(ctx context.Context, zctx *resolver.Context, zr zbuf.Rea
 
 	spanWriter := &spanWriter{}
 	if err := fs.ReplaceFile(s.join(allZngFile), 0600, func(w io.Writer) error {
-		fileWriter := zngio.NewWriter(bufwriter.New(&zio.NoCloser{w}), zio.WriterFlags{
+		fileWriter := zngio.NewWriter(bufwriter.New(zio.NopCloser(w)), zio.WriterFlags{
 			StreamRecordsMax: s.streamsize,
 			ZngLZ4BlockSize:  zio.DefaultZngLZ4BlockSize,
 		})

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -602,7 +602,7 @@ func runzq(path, ZQL, outputFormat, outputFlags string, inputs ...string) (out s
 	d := driver.NewCLI(zw)
 	d.SetWarningsWriter(&errbuf)
 	err = driver.Run(context.Background(), d, proc, zctx, rc, driver.Config{})
-	if err2 := zw.Flush(); err == nil {
+	if err2 := zw.Close(); err == nil {
 		err = err2
 	}
 	if err != nil {


### PR DESCRIPTION
This commit cleans up the zio design pattern to allow generic
writers to be closed instead of doing a flush followed by reaching
around the writer to close the underlyinig object.

This will make integrating the zst writer easier because it needs
to be closed to finish up writing metadata and a trailer.  I was
fighting with the existing pattern to wire it all up and this change
will make it all straightforward.

The previous flush-based approach had merits but this seems
easier to understand and work with, albeit we had to add Close
stubs to all of the zio writers.

We also mooved zbuf/zng.go to zbuf/zbuf.go as the previous
name was historical and no longer accurate, and deleted
zbuf.WriteFlusher as it is no longer used.

Finally, this refactoring exposed a problem in the fs.ReplaceFile
call in storage filestore, which was doing a storage copy without
any write buffering, so this is fixed.

Fixed #1235 