### PR TITLE
workround pcap filtering problem with zeek's truncated timestamps

### DIFF
--- a/zqd/pcapstorage/pcapstorage.go
+++ b/zqd/pcapstorage/pcapstorage.go
@@ -155,7 +155,7 @@ func (s *Store) NewSearch(ctx context.Context, req api.PcapSearch) (*Search, err
 	// We add two microseconds to the end of the span as fudge to deal with the
 	// fact that zeek truncates timestamps to microseconds where pcap-ng
 	// timestamps have nanosecond precision.  We need two microseconds because
-	// both the base timestamp of a conn record as well as the durtion time
+	// both the base timestamp of a conn record as well as the duration time
 	// can be truncated downward.
 	span := nano.NewSpanTs(req.Span.Ts, req.Span.End()+2000)
 	switch req.Proto {


### PR DESCRIPTION
Zeek truncates packet timestamps to microseconds so packets
that have nanosecond-precison timestamps can fall outside of
the range of the the implied microsecond-precision time span
of a conn record.  This commit puts a hack in the pcap search
endpoint to round adjust the requested span to account for
the truncation of both the conn timestamp and its duration.

Fixes #1240 