### PR TITLE
rename reducer/compile as reducer/compiler

### DIFF
--- a/driver/compile.go
+++ b/driver/compile.go
@@ -13,7 +13,7 @@ import (
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/proc/compiler"
 	"github.com/brimsec/zq/reducer"
-	rcompile "github.com/brimsec/zq/reducer/compile"
+	rcompiler "github.com/brimsec/zq/reducer/compiler"
 	"github.com/brimsec/zq/zng/resolver"
 	"go.uber.org/zap"
 )
@@ -424,7 +424,7 @@ func buildSplitFlowgraph(branch, tail []ast.Proc, mergeField string, reverse boo
 
 func decomposable(rs []ast.Reducer) bool {
 	for _, r := range rs {
-		cr, err := rcompile.Compile(r)
+		cr, err := rcompiler.Compile(r)
 		if err != nil {
 			return false
 		}

--- a/reducer/compiler/compile.go
+++ b/reducer/compiler/compile.go
@@ -1,4 +1,4 @@
-package compile
+package compiler
 
 import (
 	"errors"

--- a/reducer/compiler/row.go
+++ b/reducer/compiler/row.go
@@ -1,4 +1,4 @@
-package compile
+package compiler
 
 import (
 	"errors"

--- a/reducer/reducer_test.go
+++ b/reducer/reducer_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/reducer"
-	"github.com/brimsec/zq/reducer/compile"
+	"github.com/brimsec/zq/reducer/compiler"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
@@ -31,7 +31,7 @@ func parse(zctx *resolver.Context, src string) (*zbuf.Array, error) {
 	return zbuf.NewArray(records), nil
 }
 
-func runOne(t *testing.T, zctx *resolver.Context, cred compile.CompiledReducer, i int, recs []*zng.Record) zng.Value {
+func runOne(t *testing.T, zctx *resolver.Context, cred compiler.CompiledReducer, i int, recs []*zng.Record) zng.Value {
 	red := cred.Instantiate().(reducer.Decomposable)
 	for _, rec := range recs[:i] {
 		red.Consume(rec)
@@ -59,8 +59,8 @@ func TestDecomposableReducers(t *testing.T) {
 	require.NoError(t, err)
 	recs := b.Records()
 
-	makeReducer := func(op, field string) compile.CompiledReducer {
-		cred, err := compile.Compile(ast.Reducer{
+	makeReducer := func(op, field string) compiler.CompiledReducer {
+		cred, err := compiler.Compile(ast.Reducer{
 			Node: ast.Node{Op: op},
 			Var:  strings.ToLower(op),
 			Field: &ast.FieldRead{


### PR DESCRIPTION
This commit renames reducer/compile as "compiler" to have consistent
naming convention for compiler abstractons in the zq code base.

Fixes #1162 