### PR TITLE
change union implementation to conform with zng spec

### DIFF
--- a/tests/formats/union/array-bzng.yaml
+++ b/tests/formats/union/array-bzng.yaml
@@ -1,6 +1,8 @@
 zql: '*'
 
-input: !!binary gwIGCYEXgAEBYRgZEiUZBAESYXNkZmFzZGYBCQIEyBkBAQ==
+input: !!binary |
+        IzA6cmVjb3JkW2E6YXJyYXlbdW5pb25baW50NjQsc3RyaW5nXV1dCjA6W1sxOm
+        FzZGZhc2RmOy07MDoxMDA7XV0KMDpbLTtdCg==
 
 output: |
   #0:record[a:array[union[int64,string]]]

--- a/tests/formats/union/nested-bzng.yaml
+++ b/tests/formats/union/nested-bzng.yaml
@@ -1,8 +1,9 @@
 zql: '*'
 
 input: !!binary |
-  gQaBCYMCCQaDBAkXGBmAAQFhGhsKFQIQImhlbGxvIhsIEQQBCwQCBAQbDBkEAhMIImEiCC
-  JiIhsIEQQDCwQBBPY=
+  IzA6cmVjb3JkW2E6dW5pb25bc3RyaW5nLGFycmF5W2ludDY0XSxhcnJheVtzdHJpbmddLH
+  VuaW9uW3N0cmluZyxpbnQ2NF1dXQowOlswOiJoZWxsbyI7XQowOlsxOlsxOzI7XV0KMDpb
+  MjpbImEiOyJiIjtdXQowOlszOjE6MTIzO10K
 
 output: |
   #0:record[a:union[string,array[int64],array[string],union[string,int64]]]

--- a/tests/formats/union/simple-bzng.yaml
+++ b/tests/formats/union/simple-bzng.yaml
@@ -1,6 +1,6 @@
 zql: '*'
 
-input: !!binary gwIGCYABAWEXGAwZBAESYXNkZmFzZGYYBAkCBAIYAQE=
+input: !!binary gwIGCYABAWEXGAwZBAISYXNkZmFzZGYYBAkCBAIYAQGF
 
 output: |
   #0:record[a:union[int64,string]]

--- a/zio/ndjsonio/inferparser.go
+++ b/zio/ndjsonio/inferparser.go
@@ -116,21 +116,19 @@ func (p *inferParser) unionType(vals []zng.Value) *zng.TypeUnion {
 }
 
 func encodeUnionArray(typ *zng.TypeUnion, vals []zng.Value) zcode.Bytes {
-	var a [8]byte
-	b := zcode.Bytes{}
+	var b zcode.Builder
 	for i := range vals {
-		ub := zcode.Bytes{}
+		b.BeginContainer()
 		index := typeIndex(typ.Types, vals[i].Type)
-		n := zcode.EncodeCountedUvarint(a[:], uint64(index))
-		ub = zcode.AppendPrimitive(ub, a[:n])
+		b.AppendPrimitive(zng.EncodeInt(int64(index)))
 		if zng.IsContainerType(vals[i].Type) {
-			ub = zcode.AppendContainer(ub, vals[i].Bytes)
+			b.AppendContainer(vals[i].Bytes)
 		} else {
-			ub = zcode.AppendPrimitive(ub, vals[i].Bytes)
+			b.AppendPrimitive(vals[i].Bytes)
 		}
-		b = zcode.AppendContainer(b, ub)
+		b.EndContainer()
 	}
-	return b
+	return b.Bytes()
 }
 
 func encodeContainer(vals []zng.Value) zcode.Bytes {

--- a/zio/tzngio/parser.go
+++ b/zio/tzngio/parser.go
@@ -108,9 +108,7 @@ func zngParseField(builder *zcode.Builder, typ zng.Type, b []byte) ([]byte, erro
 		}
 		builder.BeginContainer()
 		defer builder.EndContainer()
-		var a [8]byte
-		n := zcode.EncodeCountedUvarint(a[:], uint64(index))
-		builder.AppendPrimitive(a[:n])
+		builder.AppendPrimitive(zng.EncodeInt(int64(index)))
 		return zngParseField(builder, childType, b)
 	}
 	if b[0] == leftbracket {

--- a/zio/zjsonio/reader.go
+++ b/zio/zjsonio/reader.go
@@ -188,9 +188,7 @@ func decodeUnion(builder *zcode.Builder, typ *zng.TypeUnion, body interface{}) e
 	if err != nil {
 		return fmt.Errorf("bad type index for zjson union value: %w", err)
 	}
-	var a [8]byte
-	n := zcode.EncodeCountedUvarint(a[:], uint64(index))
-	builder.AppendPrimitive(a[:n])
+	builder.AppendPrimitive(zng.EncodeInt(int64(index)))
 	if utyp, ok := inner.(*zng.TypeUnion); ok {
 		if err := decodeUnion(builder, utyp, tuple[1]); err != nil {
 			return err

--- a/zng/union.go
+++ b/zng/union.go
@@ -57,7 +57,10 @@ func (t *TypeUnion) SplitZng(zv zcode.Bytes) (Type, int64, zcode.Bytes, error) {
 	if container {
 		return nil, -1, nil, ErrBadValue
 	}
-	index := zcode.DecodeCountedUvarint(v)
+	index, err := DecodeInt(v)
+	if err != nil {
+		return nil, -1, nil, err
+	}
 	inner, err := t.TypeIndex(int(index))
 	if err != nil {
 		return nil, -1, nil, err

--- a/zng/walk.go
+++ b/zng/walk.go
@@ -183,7 +183,10 @@ func walkUnion(typ *TypeUnion, body zcode.Bytes, rv RecordVisitor) error {
 	if container {
 		return ErrBadValue
 	}
-	index := zcode.DecodeCountedUvarint(v)
+	index, err := DecodeInt(v)
+	if err != nil {
+		return err
+	}
 	inner, err := typ.TypeIndex(int(index))
 	if err != nil {
 		return err


### PR DESCRIPTION
I noticed this problem when debugging the union column reader for zst.

Union values were being incorrectly encoded by double encoding the
length of the selector integer.  This commit changes things to
conform.

We also noticed a bug in the ndjson reader where the union array
values were being encoded as a sequence selector, value, selector,
value instead of sequence of containers of selector/value pairs.
This has been fixed.