### PR TITLE
Run Zeek system tests in Windows CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
       - run: mkdir dist -ea 0
       - run: go build -o dist ./cmd/...
       - run: go test -v -tags=system ./tests
+      - run: make test-zeek
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I found myself wanting this as I work on suricata integration and make changes to launchers/process management. 