### PR TITLE
move zng flattener from zeekio to zng/flattener

### DIFF
--- a/zio/ndjsonio/typeparser.go
+++ b/zio/ndjsonio/typeparser.go
@@ -9,8 +9,8 @@ import (
 	"github.com/brimsec/zq/pkg/byteconv"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zcode"
-	"github.com/brimsec/zq/zio/zeekio"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/flattener"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/buger/jsonparser"
 )
@@ -67,7 +67,7 @@ func getUnsafeDefault(data []byte, defaultValue string, key string) (string, err
 }
 
 func newTypeInfo(zctx *resolver.Context, desc *zng.TypeRecord, path string) (*typeInfo, error) {
-	flatCols := zeekio.FlattenColumns(desc.Columns)
+	flatCols := flattener.FlattenColumns(desc.Columns)
 	flatDesc, err := zctx.LookupTypeRecord(flatCols)
 	if err != nil {
 		return nil, err

--- a/zio/tableio/writer.go
+++ b/zio/tableio/writer.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/brimsec/zq/zio/zeekio"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/flattener"
 	"github.com/brimsec/zq/zng/resolver"
 )
 
 type Writer struct {
 	writer    io.WriteCloser
-	flattener *zeekio.Flattener
+	flattener *flattener.Flattener
 	table     *tabwriter.Writer
 	typ       *zng.TypeRecord
 	limit     int
@@ -32,7 +33,7 @@ func NewWriter(w io.WriteCloser, utf8 bool) *Writer {
 	}
 	return &Writer{
 		writer:    w,
-		flattener: zeekio.NewFlattener(resolver.NewContext()),
+		flattener: flattener.New(resolver.NewContext()),
 		table:     table,
 		limit:     1000,
 		precision: 6,

--- a/zio/textio/writer.go
+++ b/zio/textio/writer.go
@@ -9,13 +9,14 @@ import (
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zio/zeekio"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/flattener"
 	"github.com/brimsec/zq/zng/resolver"
 )
 
 type Writer struct {
 	WriterOpts
 	writer    io.WriteCloser
-	flattener *zeekio.Flattener
+	flattener *flattener.Flattener
 	precision int
 	format    zng.OutFmt
 }
@@ -36,7 +37,7 @@ func NewWriter(w io.WriteCloser, utf8 bool, opts WriterOpts) *Writer {
 	return &Writer{
 		WriterOpts: opts,
 		writer:     w,
-		flattener:  zeekio.NewFlattener(resolver.NewContext()),
+		flattener:  flattener.New(resolver.NewContext()),
 		precision:  6,
 		format:     format,
 	}

--- a/zio/zeekio/writer.go
+++ b/zio/zeekio/writer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/flattener"
 	"github.com/brimsec/zq/zng/resolver"
 )
 
@@ -16,7 +17,7 @@ var ErrDescriptorChanged = errors.New("descriptor changed")
 type Writer struct {
 	writer io.WriteCloser
 	header
-	flattener *Flattener
+	flattener *flattener.Flattener
 	typ       *zng.TypeRecord
 	precision int
 	format    zng.OutFmt
@@ -31,7 +32,7 @@ func NewWriter(w io.WriteCloser, utf8 bool) *Writer {
 	}
 	return &Writer{
 		writer:    w,
-		flattener: NewFlattener(resolver.NewContext()),
+		flattener: flattener.New(resolver.NewContext()),
 		precision: 6,
 		format:    format,
 	}

--- a/zng/flattener/flattener.go
+++ b/zng/flattener/flattener.go
@@ -1,4 +1,4 @@
-package zeekio
+package flattener
 
 import (
 	"fmt"
@@ -17,7 +17,7 @@ type Flattener struct {
 // records where the type context of the received records must match the
 // zctx parameter provided here.  Any new type descriptors that are created
 // to flatten types also use zctx.
-func NewFlattener(zctx *resolver.Context) *Flattener {
+func New(zctx *resolver.Context) *Flattener {
 	return &Flattener{
 		zctx: zctx,
 		// This mapper maps types back into the same context and gives

--- a/zng/flattener/flattener.go
+++ b/zng/flattener/flattener.go
@@ -13,7 +13,7 @@ type Flattener struct {
 	mapper *resolver.Mapper
 }
 
-// NewFlattener returns a flattener that transforms nested records to flattened
+// New returns a flattener that transforms nested records to flattened
 // records where the type context of the received records must match the
 // zctx parameter provided here.  Any new type descriptors that are created
 // to flatten types also use zctx.


### PR DESCRIPTION
This commit moves the flattening logic out of the zeekio package
and into its own package under zng since this operation is a
generic zng transformation and is not specific to zio.

This will be helpful also to the csv writer when we add it.