### PR TITLE
fix bug where bad record type allowed through

### DIFF
--- a/tests/suite/errors/extra-bracket.yaml
+++ b/tests/suite/errors/extra-bracket.yaml
@@ -1,0 +1,14 @@
+# extra bracket in record type should cause an errror
+script: |
+  zq -t -i tzng in.tzng
+
+inputs:
+  - name: in.tzng
+    data: |
+        #0:record[s:string]]
+        0:[-;]
+
+outputs:
+  - name: stderr
+    regexp: |
+         .*: line 1: syntax error parsing type string

--- a/tests/suite/errors/hanging-bracket.yaml
+++ b/tests/suite/errors/hanging-bracket.yaml
@@ -1,0 +1,14 @@
+# missing bracket in record type (with missing field name) should cause an error
+script: |
+  zq -t -i tzng in.tzng
+
+inputs:
+  - name: in.tzng
+    data: |
+        #0:record[record[s:string]
+        0:[-;]
+
+outputs:
+  - name: stderr
+    regexp: |
+         .*: line 1: syntax error parsing type string


### PR DESCRIPTION
This commit fixes a bug where a field name discovered by
searching for a colon could have illegal characters in it,
which should result in a syntax error but happened to be
interpreted as a valid type.

The fix is to check that field names discovered by the colon
search conform with the type syntax.  A better fix would be
to use peg or write a proper recursive descent parse for
the zng type system  Maybe later.

While we were at it, we noticed there was a problem where extra
text after the end of a valid type would be ignored instead of
flagging an error.

Fixes #1222 