### PR TITLE
create zst format

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -9,6 +9,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/zstio"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -24,9 +25,8 @@ func (f *Flags) Options() zio.WriterOpts {
 	return f.WriterOpts
 }
 
-func (f *Flags) SetFlags(fs *flag.FlagSet) {
+func (f *Flags) setFlags(fs *flag.FlagSet) {
 	// zio stuff
-	fs.StringVar(&f.Format, "f", "zng", "format for output data [zng,ndjson,table,text,csv,zeek,zjson,tzng]")
 	fs.BoolVar(&f.UTF8, "U", false, "display zeek strings as UTF-8")
 	fs.BoolVar(&f.Text.ShowTypes, "T", false, "display field types in text output")
 	fs.BoolVar(&f.Text.ShowFields, "F", false, "display field names in text output")
@@ -34,11 +34,27 @@ func (f *Flags) SetFlags(fs *flag.FlagSet) {
 	fs.IntVar(&f.Zng.StreamRecordsMax, "b", 0, "limit for number of records in each ZNG stream (0 for no limit)")
 	fs.IntVar(&f.Zng.LZ4BlockSize, "znglz4blocksize", zngio.DefaultLZ4BlockSize,
 		"LZ4 block size in bytes for ZNG compression (nonpositive to disable)")
+	f.Zst.ColumnThresh = zstio.DefaultColumnThresh
+	fs.Var(&f.Zst.ColumnThresh, "coltresh", "minimum frame size (MiB) used for zst columns")
+	f.Zst.SkewThresh = zstio.DefaultSkewThresh
+	fs.Var(&f.Zst.SkewThresh, "skewtresh", "minimum skew size (MiB) used to group zst columns")
+
 	// emitter stuff
 	fs.StringVar(&f.dir, "d", "", "directory for output data files")
 	fs.StringVar(&f.outputFile, "o", "", "write data to output file")
-	fs.BoolVar(&f.textShortcut, "t", false, "use format tzng independent of -f option")
 	fs.BoolVar(&f.forceBinary, "B", false, "allow binary zng be sent to a terminal output")
+
+}
+
+func (f *Flags) SetFlags(fs *flag.FlagSet) {
+	f.setFlags(fs)
+	fs.StringVar(&f.Format, "f", "zng", "format for output data [zng,ndjson,table,text,csv,zeek,zjson,tzng]")
+	fs.BoolVar(&f.textShortcut, "t", false, "use format tzng independent of -f option")
+}
+
+func (f *Flags) SetFlagsWithFormat(fs *flag.FlagSet, format string) {
+	f.setFlags(fs)
+	f.Format = format
 }
 
 func (f *Flags) Init() error {
@@ -48,6 +64,16 @@ func (f *Flags) Init() error {
 		}
 		f.Format = "tzng"
 	}
+	if f.outputFile == "-" {
+		f.outputFile = ""
+	}
+	if f.outputFile == "" && f.Format == "zng" && IsTerminal(os.Stdout) && !f.forceBinary {
+		return errors.New("writing binary zng data to terminal; override with -B or use -t for text.")
+	}
+	return nil
+}
+
+func (f *Flags) InitWithFormat(format string) error {
 	if f.outputFile == "-" {
 		f.outputFile = ""
 	}

--- a/cmd/zst/create/command.go
+++ b/cmd/zst/create/command.go
@@ -1,0 +1,100 @@
+package create
+
+import (
+	"errors"
+	"flag"
+
+	"github.com/brimsec/zq/cli"
+	"github.com/brimsec/zq/cmd/zst/root"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zst"
+	"github.com/mccanne/charm"
+)
+
+var Create = &charm.Spec{
+	Name:  "create",
+	Usage: "create [-coltresh thresh] [-skewthresh thesh] -o file files...",
+	Short: "create a zst columnar object from a zng file or stream",
+	Long: `
+The create command generates a columnar zst object from a zng input stream,
+which may be stdin or one or more zng storage objects (local files or s3 objects).
+The output can be a local file or an s3 URI.
+
+The -colthresh flag specifies the byte threshold (in MiB) at which chunks
+of column data are written to disk.
+
+The -skewthresh flag specifies a rough byte threshold (in MiB) that controls
+how much column data is collectively buffered in memory before being entirely
+flushed to disk.  This parameter controls the amount of buffering "skew" required
+keep rows in alignment so that a reader should not have to use more than
+this (approximate) memory footprint.
+
+Unlike parquet, zst column data may be laid out any way a client so chooses
+and is not constrained to the "row group" concept.  Thus, care should be 
+taken here to control the amount of row skew that can arise.`,
+	New: newCommand,
+}
+
+func init() {
+	root.Zst.Add(Create)
+}
+
+type Command struct {
+	*root.Command
+	colThresh   float64
+	skewThresh  float64
+	outputFile  string
+	readerFlags zio.ReaderFlags
+}
+
+func MibToBytes(mib float64) int {
+	return int(mib * 1024 * 1024)
+}
+
+func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{
+		Command: parent.(*root.Command),
+	}
+	f.Float64Var(&c.colThresh, "coltresh", 5, "minimum frame size (MiB) used for zst columns")
+	f.Float64Var(&c.skewThresh, "skewtresh", 25, "minimum skew size (MiB) used to group zst columns")
+	f.StringVar(&c.outputFile, "o", "", "name of zst output file")
+	c.readerFlags.SetFlags(f)
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	defer c.Cleanup()
+	if ok, err := c.Init(); !ok {
+		return err
+	}
+	if len(args) == 0 {
+		return errors.New("must specify one or more input files")
+	}
+	if err := c.readerFlags.Init(); err != nil {
+		return err
+	}
+	if c.outputFile == "" {
+		return errors.New("must specify an output file with -o")
+	}
+	zctx := resolver.NewContext()
+	readers, err := cli.OpenInputs(zctx, c.readerFlags.Options(), args, true)
+	if err != nil {
+		return err
+	}
+	reader := zbuf.NewCombiner(readers, zbuf.CmpTimeForward)
+	defer reader.Close()
+
+	skewThresh := MibToBytes(c.skewThresh)
+	colThresh := MibToBytes(c.colThresh)
+	writer, err := zst.NewWriterFromPath(c.outputFile, skewThresh, colThresh)
+	if err != nil {
+		return err
+	}
+	if err := zbuf.Copy(writer, reader); err != nil {
+		writer.Abort()
+		return err
+	}
+	return writer.Close()
+}

--- a/cmd/zst/create/command.go
+++ b/cmd/zst/create/command.go
@@ -32,7 +32,7 @@ keep rows in alignment so that a reader should not have to use more than
 this (approximate) memory footprint.
 
 Unlike parquet, zst column data may be laid out any way a client so chooses
-and is not constrained to the "row group" concept.  Thus, care should be 
+and is not constrained to the "row group" concept.  Thus, care should be
 taken here to control the amount of row skew that can arise.`,
 	New: newCommand,
 }

--- a/cmd/zst/cut/command.go
+++ b/cmd/zst/cut/command.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"strings"
@@ -69,8 +70,10 @@ func (c *Command) Run(args []string) error {
 	if err := c.output.Init(&writerOpts); err != nil {
 		return err
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	path := args[0]
-	cutter, err := zst.NewCutterFromPath(resolver.NewContext(), path, fields)
+	cutter, err := zst.NewCutterFromPath(ctx, resolver.NewContext(), path, fields)
 	if err != nil {
 		return err
 	}

--- a/cmd/zst/inspect/command.go
+++ b/cmd/zst/inspect/command.go
@@ -1,0 +1,95 @@
+package inspect
+
+import (
+	"errors"
+	"flag"
+
+	"github.com/brimsec/zq/cli"
+	"github.com/brimsec/zq/cmd/zst/root"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zst"
+	"github.com/mccanne/charm"
+)
+
+var Inspect = &charm.Spec{
+	Name:  "inspect",
+	Usage: "inspect [flags] file",
+	Short: "look at info in a zst file",
+	Long: `
+The inspect command extracts information from a zst file.
+This is mostly useful for test and debug, though there may be interesting
+uses as the zst format becomes richer with pruning information and other internal
+aggregations about the columns and so forth.
+
+The -R option (on by default) sends the reassembly records to the output while
+the -trailer option (off by defaulut) indicates that the trailer should be included.
+`,
+	New: newCommand,
+}
+
+func init() {
+	root.Zst.Add(Inspect)
+}
+
+type Command struct {
+	*root.Command
+	writerFlags zio.WriterFlags
+	output      cli.OutputFlags
+	trailer     bool
+	reassembly  bool
+}
+
+func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	f.BoolVar(&c.trailer, "trailer", false, "include the zst trailer in the output")
+	f.BoolVar(&c.reassembly, "R", true, "include the zst reassembly section in the output")
+	c.writerFlags.SetFlags(f)
+	c.output.SetFlags(f)
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	defer c.Cleanup()
+	if ok, err := c.Init(); !ok {
+		return err
+	}
+	if len(args) != 1 {
+		return errors.New("zst inspect: must be run with a single file argument")
+	}
+	path := args[0]
+	reader, err := zst.NewReaderFromPath(resolver.NewContext(), path)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	writerOpts := c.writerFlags.Options()
+	if err := c.output.Init(&writerOpts); err != nil {
+		return err
+	}
+	writer, err := c.output.Open(writerOpts)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if writer != nil {
+			writer.Close()
+		}
+	}()
+	if c.reassembly {
+		r := reader.NewReassemblyReader()
+		if err := zbuf.Copy(writer, r); err != nil {
+			return err
+		}
+	}
+	if c.trailer {
+		r := reader.NewTrailerReader()
+		if err := zbuf.Copy(writer, r); err != nil {
+			return err
+		}
+	}
+	err = writer.Close()
+	writer = nil
+	return err
+}

--- a/cmd/zst/inspect/command.go
+++ b/cmd/zst/inspect/command.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"errors"
 	"flag"
 
@@ -58,8 +59,10 @@ func (c *Command) Run(args []string) error {
 	if len(args) != 1 {
 		return errors.New("zst inspect: must be run with a single file argument")
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	path := args[0]
-	reader, err := zst.NewReaderFromPath(resolver.NewContext(), path)
+	reader, err := zst.NewReaderFromPath(ctx, resolver.NewContext(), path)
 	if err != nil {
 		return err
 	}

--- a/cmd/zst/main.go
+++ b/cmd/zst/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	_ "github.com/brimsec/zq/cmd/zst/create"
+	_ "github.com/brimsec/zq/cmd/zst/cut"
+	_ "github.com/brimsec/zq/cmd/zst/inspect"
+	_ "github.com/brimsec/zq/cmd/zst/read"
+	"github.com/brimsec/zq/cmd/zst/root"
+)
+
+func main() {
+	_, err := root.Zst.ExecRoot(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/zst/read/command.go
+++ b/cmd/zst/read/command.go
@@ -1,0 +1,81 @@
+package inspect
+
+import (
+	"errors"
+	"flag"
+	"os"
+
+	"github.com/brimsec/zq/cli"
+	"github.com/brimsec/zq/cmd/zst/root"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zst"
+	"github.com/mccanne/charm"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var Read = &charm.Spec{
+	Name:  "read",
+	Usage: "read [flags] path",
+	Short: "read a zst file and output as zng",
+	Long: `
+The read command reads columnar zst from
+a zst storage objects (local files or s3 objects) and outputs
+the reconstructed zng row data in the format of choice.
+
+This command is most useful for test, debug, and demo as you can also
+read zst objects with zq.
+`,
+	New: newCommand,
+}
+
+func init() {
+	root.Zst.Add(Read)
+}
+
+type Command struct {
+	*root.Command
+	writerFlags zio.WriterFlags
+	output      cli.OutputFlags
+}
+
+func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	c.writerFlags.SetFlags(f)
+	c.output.SetFlags(f)
+	return c, nil
+}
+
+func isTerminal(f *os.File) bool {
+	return terminal.IsTerminal(int(f.Fd()))
+}
+
+func (c *Command) Run(args []string) error {
+	defer c.Cleanup()
+	if ok, err := c.Init(); !ok {
+		return err
+	}
+	if len(args) != 1 {
+		return errors.New("zst read: must be run with a single path argument")
+	}
+	path := args[0]
+	reader, err := zst.NewReaderFromPath(resolver.NewContext(), path)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	writerOpts := c.writerFlags.Options()
+	if err := c.output.Init(&writerOpts); err != nil {
+		return err
+	}
+	writer, err := c.output.Open(writerOpts)
+	if err != nil {
+		return err
+	}
+	if err := zbuf.Copy(writer, reader); err != nil {
+		writer.Close()
+		return err
+	}
+	return writer.Close()
+}

--- a/cmd/zst/read/command.go
+++ b/cmd/zst/read/command.go
@@ -6,10 +6,9 @@ import (
 	"flag"
 	"os"
 
-	"github.com/brimsec/zq/cli"
+	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zst/root"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zst"
 	"github.com/mccanne/charm"
@@ -37,14 +36,12 @@ func init() {
 
 type Command struct {
 	*root.Command
-	writerFlags zio.WriterFlags
-	output      cli.OutputFlags
+	outputFlags outputflags.Flags
 }
 
 func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
-	c.writerFlags.SetFlags(f)
-	c.output.SetFlags(f)
+	c.outputFlags.SetFlags(f)
 	return c, nil
 }
 
@@ -68,11 +65,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer reader.Close()
-	writerOpts := c.writerFlags.Options()
-	if err := c.output.Init(&writerOpts); err != nil {
-		return err
-	}
-	writer, err := c.output.Open(writerOpts)
+	writer, err := c.outputFlags.Open()
 	if err != nil {
 		return err
 	}

--- a/cmd/zst/read/command.go
+++ b/cmd/zst/read/command.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"os"
@@ -59,8 +60,10 @@ func (c *Command) Run(args []string) error {
 	if len(args) != 1 {
 		return errors.New("zst read: must be run with a single path argument")
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	path := args[0]
-	reader, err := zst.NewReaderFromPath(resolver.NewContext(), path)
+	reader, err := zst.NewReaderFromPath(ctx, resolver.NewContext(), path)
 	if err != nil {
 		return err
 	}

--- a/cmd/zst/root/command.go
+++ b/cmd/zst/root/command.go
@@ -1,0 +1,47 @@
+package root
+
+import (
+	"flag"
+
+	"github.com/brimsec/zq/cli"
+	"github.com/mccanne/charm"
+)
+
+var Zst = &charm.Spec{
+	Name:  "zst",
+	Usage: "zst <command> [options] [arguments...]",
+	Short: "create and manipulate zst columnar objects",
+	Long: `
+zst is a command-line tool for creating and manipulating zst columnar objects.`,
+	New: New,
+}
+
+func init() {
+	Zst.Add(charm.Help)
+}
+
+type Command struct {
+	charm.Command
+	cli cli.Flags
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{}
+	c.cli.SetFlags(f)
+	return c, nil
+}
+
+func (c *Command) Cleanup() {
+	c.cli.Cleanup()
+}
+
+func (c *Command) Init() (bool, error) {
+	return c.cli.Init()
+}
+
+func (c *Command) Run(args []string) error {
+	if len(args) == 0 {
+		return Zst.Exec(c, []string{"help"})
+	}
+	return charm.ErrNoRun
+}

--- a/cmd/zst/root/command.go
+++ b/cmd/zst/root/command.go
@@ -35,8 +35,8 @@ func (c *Command) Cleanup() {
 	c.cli.Cleanup()
 }
 
-func (c *Command) Init() (bool, error) {
-	return c.cli.Init()
+func (c *Command) Init(all ...cli.Initializer) (bool, error) {
+	return c.cli.Init(all...)
 }
 
 func (c *Command) Run(args []string) error {

--- a/emitter/bytes.go
+++ b/emitter/bytes.go
@@ -19,9 +19,10 @@ func (b *Bytes) Bytes() []byte {
 
 func NewBytes(opts zio.WriterOpts) (*Bytes, error) {
 	b := &Bytes{}
-	b.Writer = detector.LookupWriter(zio.NopCloser(&b.buf), opts)
-	if b.Writer == nil {
-		return nil, unknownFormat(opts.Format)
+	w, err := detector.LookupWriter(zio.NopCloser(&b.buf), opts)
+	if err != nil {
+		return nil, err
 	}
+	b.Writer = w
 	return b, nil
 }

--- a/emitter/dir.go
+++ b/emitter/dir.go
@@ -32,10 +32,6 @@ type Dir struct {
 	source  iosrc.Source
 }
 
-func unknownFormat(format string) error {
-	return fmt.Errorf("unknown output format: %s", format)
-}
-
 func NewDir(dir, prefix string, stderr io.Writer, opts zio.WriterOpts) (*Dir, error) {
 	uri, err := iosrc.ParseURI(dir)
 	if err != nil {
@@ -56,7 +52,7 @@ func NewDirWithSource(dir iosrc.URI, prefix string, stderr io.Writer, opts zio.W
 	}
 	e := zio.Extension(opts.Format)
 	if e == "" {
-		return nil, unknownFormat(opts.Format)
+		return nil, fmt.Errorf("unknown format: %s", opts.Format)
 	}
 	return &Dir{
 		dir:     dir,

--- a/emitter/file.go
+++ b/emitter/file.go
@@ -58,9 +58,9 @@ func NewFileWithSource(path iosrc.URI, opts zio.WriterOpts, source iosrc.Source)
 	// On close, zbuf.WriteCloser.Close() will close and flush the
 	// downstream writer, which will flush the bufwriter here and,
 	// in turn, close its underlying writer.
-	w := detector.LookupWriter(wc, opts)
-	if w == nil {
-		return nil, unknownFormat(opts.Format)
+	w, err := detector.LookupWriter(wc, opts)
+	if err != nil {
+		return nil, err
 	}
 	return w, nil
 }

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -496,7 +496,7 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 		zr := tzngio.NewReader(strings.NewReader(strings.Join(data, "\n")), zctx)
 		cr := &countReader{r: zr}
 		var outbuf bytes.Buffer
-		zw := detector.LookupWriter(&nopCloser{&outbuf}, zio.WriterOpts{})
+		zw, _ := detector.LookupWriter(&nopCloser{&outbuf}, zio.WriterOpts{})
 		d := &testGroupByDriver{
 			writer: zw,
 			cb: func(n int) {

--- a/tests/suite/zst/array.yaml
+++ b/tests/suite/zst/array.yaml
@@ -1,0 +1,19 @@
+script: |
+  zst create -o out.zst in.tzng
+  zq -i zst -t out.zst
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[a:string,b:array[record[a:string,b:string]]]
+      0:[hello;[[a;b;][c;d;][e;f;]]]
+      0:[world;-;]
+      0:[goodnight;[[a;b;][c;-;][e;f;]]]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[a:string,b:array[record[a:string,b:string]]]
+      0:[hello;[[a;b;][c;d;][e;f;]]]
+      0:[world;-;]
+      0:[goodnight;[[a;b;][c;-;][e;f;]]]

--- a/tests/suite/zst/create.yaml
+++ b/tests/suite/zst/create.yaml
@@ -1,0 +1,17 @@
+script: |
+  zst create -o out.zst in.tzng
+  zq -i zst -t out.zst
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[a:string,b:int32]
+      0:[hello;1;]
+      0:[world;2;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[a:string,b:int32]
+      0:[hello;1;]
+      0:[world;2;]

--- a/tests/suite/zst/cut.yaml
+++ b/tests/suite/zst/cut.yaml
@@ -1,0 +1,41 @@
+script: |
+  #zq -i zst -t out.zst
+  #zq  -t in.tzng
+  zst create -o out.zst in.tzng
+  zst cut -t -k a out.zst
+  echo ===
+  zst cut -t -k b out.zst
+  echo ===
+  zst cut -t -k b.c out.zst
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[a:string,b:record[c:int32,d:int32]]
+      0:[hello;[1;2;]]
+      0:[world;[3;4;]]
+      #1:record[junk:string]
+      1:[trick;]
+      0:[goodnight;[5;6;]]
+      0:[gracie;[7;8;]]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[a:string]
+      0:[hello;]
+      0:[world;]
+      0:[goodnight;]
+      0:[gracie;]
+      ===
+      #0:record[b:record[c:int32,d:int32]]
+      0:[[1;2;]]
+      0:[[3;4;]]
+      0:[[5;6;]]
+      0:[[7;8;]]
+      ===
+      #0:record[b:record[c:int32]]
+      0:[[1;]]
+      0:[[3;]]
+      0:[[5;]]
+      0:[[7;]]

--- a/tests/suite/zst/cut.yaml
+++ b/tests/suite/zst/cut.yaml
@@ -1,6 +1,4 @@
 script: |
-  #zq -i zst -t out.zst
-  #zq  -t in.tzng
   zst create -o out.zst in.tzng
   zst cut -t -k a out.zst
   echo ===

--- a/tests/suite/zst/empty-file.yaml
+++ b/tests/suite/zst/empty-file.yaml
@@ -1,6 +1,5 @@
 script: |
-  echo -n "" > empty.zst
-  zq -t -i zst empty.zst
+  zq -t -i zst /dev/null
 
 outputs:
   - name: stderr

--- a/tests/suite/zst/empty-file.yaml
+++ b/tests/suite/zst/empty-file.yaml
@@ -1,0 +1,8 @@
+script: |
+  echo -n "" > empty.zst
+  zq -t -i zst empty.zst
+
+outputs:
+  - name: stderr
+    regexp: |
+      .*: zst trailer not found

--- a/tests/suite/zst/presence.yaml
+++ b/tests/suite/zst/presence.yaml
@@ -1,0 +1,105 @@
+script: |
+  zst create -o o1.zst p1.tzng
+  zq -i zst -t -o o1.tzng o1.zst
+  zst create -o o2.zst p2.tzng
+  zq -i zst -t -o o2.tzng o2.zst
+  zst create -o o3.zst p3.tzng
+  zq -i zst -t -o o3.tzng o3.zst
+  zst create -o o4.zst p4.tzng
+  zq -i zst -t -o o4.tzng o4.zst
+
+inputs:
+  - name: p1.tzng
+    data: |
+        #0:record[s:string]
+        0:[-;]
+  - name: p2.tzng
+    data: |
+        #0:record[s:string]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[x;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+  - name: p3.tzng
+    data: |
+        #0:record[s:string]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[x;]
+  - name: p4.tzng
+    data: |
+        #0:record[s:string]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[-;]
+
+outputs:
+  - name: o1.tzng
+    data: |
+        #0:record[s:string]
+        0:[-;]
+  - name: o2.tzng
+    data: |
+        #0:record[s:string]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[x;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+  - name: o3.tzng
+    data: |
+        #0:record[s:string]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[-;]
+        0:[x;]
+  - name: o4.tzng
+    data: |
+        #0:record[s:string]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[x;]
+        0:[-;]

--- a/tests/suite/zst/union.yaml
+++ b/tests/suite/zst/union.yaml
@@ -1,0 +1,17 @@
+script: |
+  zst create -o out.zst in.tzng
+  zq -i zst -t out.zst
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[a:string,b:union[string,float64]]
+      0:[hello;0:foo;]
+      0:[world;1:1;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[a:string,b:union[string,float64]]
+      0:[hello;0:foo;]
+      0:[world;1:1;]

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -83,7 +83,10 @@ func OpenParquet(zctx *resolver.Context, path string, opts zio.ReaderOpts) (*zbu
 
 func OpenFromNamedReadCloser(zctx *resolver.Context, rc io.ReadCloser, path string, opts zio.ReaderOpts) (*zbuf.File, error) {
 	var err error
-	r := GzipReader(rc)
+	r := io.Reader(rc)
+	if opts.Format != "zst" {
+		r = GzipReader(rc)
+	}
 	var zr zbuf.Reader
 	if opts.Format == "" || opts.Format == "auto" {
 		zr, err = NewReaderWithOpts(r, zctx, path, opts)

--- a/zio/detector/lookup.go
+++ b/zio/detector/lookup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/brimsec/zq/zio/zeekio"
 	"github.com/brimsec/zq/zio/zjsonio"
 	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/zstio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 )
@@ -47,6 +48,8 @@ func LookupWriter(w io.WriteCloser, opts zio.WriterOpts) zbuf.WriteCloser {
 		return ndjsonio.NewWriter(w)
 	case "zjson":
 		return zjsonio.NewWriter(w)
+	case "zst":
+		return zstio.NewWriter(w, opts.Zst)
 	case "text":
 		return textio.NewWriter(w, opts.UTF8, opts.Text, opts.EpochDates)
 	case "table":
@@ -68,6 +71,8 @@ func lookupReader(r io.Reader, zctx *resolver.Context, path string, opts zio.Rea
 		return zjsonio.NewReader(r, zctx), nil
 	case "zng":
 		return zngio.NewReaderWithOpts(r, zctx, opts.Zng), nil
+	case "zst":
+		return zstio.NewReader(r, zctx)
 	}
 	return nil, fmt.Errorf("no such format: \"%s\"", opts.Format)
 }

--- a/zio/detector/lookup.go
+++ b/zio/detector/lookup.go
@@ -29,33 +29,33 @@ func (*nullWriter) Close() error {
 	return nil
 }
 
-func LookupWriter(w io.WriteCloser, opts zio.WriterOpts) zbuf.WriteCloser {
+func LookupWriter(w io.WriteCloser, opts zio.WriterOpts) (zbuf.WriteCloser, error) {
 	if opts.Format == "" {
 		opts.Format = "tzng"
 	}
 	switch opts.Format {
 	default:
-		return nil
+		return nil, fmt.Errorf("unknown format: %s", opts.Format)
 	case "null":
-		return &nullWriter{}
+		return &nullWriter{}, nil
 	case "tzng":
-		return tzngio.NewWriter(w)
+		return tzngio.NewWriter(w), nil
 	case "zng":
-		return zngio.NewWriter(w, opts.Zng)
+		return zngio.NewWriter(w, opts.Zng), nil
 	case "zeek":
-		return zeekio.NewWriter(w, opts.UTF8)
+		return zeekio.NewWriter(w, opts.UTF8), nil
 	case "ndjson":
-		return ndjsonio.NewWriter(w)
+		return ndjsonio.NewWriter(w), nil
 	case "zjson":
-		return zjsonio.NewWriter(w)
+		return zjsonio.NewWriter(w), nil
 	case "zst":
 		return zstio.NewWriter(w, opts.Zst)
 	case "text":
-		return textio.NewWriter(w, opts.UTF8, opts.Text, opts.EpochDates)
+		return textio.NewWriter(w, opts.UTF8, opts.Text, opts.EpochDates), nil
 	case "table":
-		return tableio.NewWriter(w, opts.UTF8)
+		return tableio.NewWriter(w, opts.UTF8), nil
 	case "csv":
-		return csvio.NewWriter(w, opts.UTF8, opts.EpochDates)
+		return csvio.NewWriter(w, opts.UTF8, opts.EpochDates), nil
 	}
 }
 

--- a/zio/detector/reader.go
+++ b/zio/detector/reader.go
@@ -59,7 +59,8 @@ func NewReaderWithOpts(r io.Reader, zctx *resolver.Context, path string, opts zi
 		return zngio.NewReaderWithOpts(recorder, zctx, opts.Zng), nil
 	}
 	parquetErr := errors.New("parquet: auto-detection not supported")
-	return nil, joinErrs([]error{tzngErr, zeekErr, ndjsonErr, zjsonErr, zngErr, parquetErr})
+	zstErr := errors.New("zst: auto-detection not supported")
+	return nil, joinErrs([]error{tzngErr, zeekErr, ndjsonErr, zjsonErr, zngErr, parquetErr, zstErr})
 }
 
 func NewReader(r io.Reader, zctx *resolver.Context) (zbuf.Reader, error) {

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -18,12 +18,12 @@ type ReaderOpts struct {
 }
 
 type WriterOpts struct {
-	Format string
-	UTF8   bool
+	Format     string
+	UTF8       bool
 	EpochDates bool
-	Text   textio.WriterOpts
-	Zng    zngio.WriterOpts
-	Zst    zstio.WriterOpts
+	Text       textio.WriterOpts
+	Zng        zngio.WriterOpts
+	Zst        zstio.WriterOpts
 }
 
 func Extension(format string) string {

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -7,6 +7,7 @@ import (
 	"github.com/brimsec/zq/zio/ndjsonio"
 	"github.com/brimsec/zq/zio/textio"
 	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zio/zstio"
 )
 
 type ReaderOpts struct {
@@ -17,11 +18,12 @@ type ReaderOpts struct {
 }
 
 type WriterOpts struct {
-	Format     string
-	UTF8       bool
-	Text       textio.WriterOpts
-	Zng        zngio.WriterOpts
+	Format string
+	UTF8   bool
 	EpochDates bool
+	Text   textio.WriterOpts
+	Zng    zngio.WriterOpts
+	Zst    zstio.WriterOpts
 }
 
 func Extension(format string) string {
@@ -42,6 +44,8 @@ func Extension(format string) string {
 		return ".zng"
 	case "csv":
 		return ".csv"
+	case "zst":
+		return ".zst"
 	default:
 		return ""
 	}

--- a/zio/zstio/reader.go
+++ b/zio/zstio/reader.go
@@ -1,0 +1,25 @@
+package zstio
+
+import (
+	"errors"
+	"io"
+
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zst"
+)
+
+type Reader struct {
+	zst.Reader
+}
+
+func NewReader(r io.Reader, zctx *resolver.Context) (*Reader, error) {
+	seeker, ok := r.(zst.Seeker)
+	if !ok {
+		return nil, errors.New("zst must be used with a seekable input")
+	}
+	reader, err := zst.NewReaderFromSeeker(zctx, seeker)
+	if err != nil {
+		return nil, err
+	}
+	return &Reader{*reader}, nil
+}

--- a/zio/zstio/reader.go
+++ b/zio/zstio/reader.go
@@ -8,18 +8,10 @@ import (
 	"github.com/brimsec/zq/zst"
 )
 
-type Reader struct {
-	zst.Reader
-}
-
-func NewReader(r io.Reader, zctx *resolver.Context) (*Reader, error) {
+func NewReader(r io.Reader, zctx *resolver.Context) (*zst.Reader, error) {
 	seeker, ok := r.(zst.Seeker)
 	if !ok {
 		return nil, errors.New("zst must be used with a seekable input")
 	}
-	reader, err := zst.NewReaderFromSeeker(zctx, seeker)
-	if err != nil {
-		return nil, err
-	}
-	return &Reader{*reader}, nil
+	return zst.NewReaderFromSeeker(zctx, seeker)
 }

--- a/zio/zstio/writer.go
+++ b/zio/zstio/writer.go
@@ -11,10 +11,6 @@ const (
 	DefaultSkewThresh   = 25 * 1024 * 1024
 )
 
-type Writer struct {
-	zst.Writer
-}
-
 type WriterOpts struct {
 	ColumnThresh float64
 	SkewThresh   float64
@@ -24,15 +20,8 @@ func MibToBytes(mib float64) int {
 	return int(mib * 1024 * 1024)
 }
 
-func NewWriter(w io.WriteCloser, opts WriterOpts) (*Writer, error) {
+func NewWriter(w io.WriteCloser, opts WriterOpts) (*zst.Writer, error) {
 	skewthresh := MibToBytes(opts.SkewThresh)
 	colthresh := MibToBytes(opts.ColumnThresh)
-	//XXX should handle error, but zio API doesn't have this yet...
-	// this is just checking bounds on the threshholds so maybe we
-	// do this from above?
-	writer, err := zst.NewWriter(w, skewthresh, colthresh)
-	if err != nil {
-		return nil, err
-	}
-	return &Writer{*writer}, nil
+	return zst.NewWriter(w, skewthresh, colthresh)
 }

--- a/zio/zstio/writer.go
+++ b/zio/zstio/writer.go
@@ -1,0 +1,35 @@
+package zstio
+
+import (
+	"io"
+
+	"github.com/brimsec/zq/zst"
+)
+
+const (
+	DefaultColumnThresh = 5 * 1024 * 1024
+	DefaultSkewThresh   = 25 * 1024 * 1024
+)
+
+type Writer struct {
+	zst.Writer
+}
+
+type WriterOpts struct {
+	ColumnThresh float64
+	SkewThresh   float64
+}
+
+func MibToBytes(mib float64) int {
+	return int(mib * 1024 * 1024)
+}
+
+func NewWriter(w io.WriteCloser, opts WriterOpts) *Writer {
+	skewthresh := MibToBytes(opts.SkewThresh)
+	colthresh := MibToBytes(opts.ColumnThresh)
+	//XXX should handle error, but zio API doesn't have this yet...
+	// this is just checking bounds on the threshholds so maybe we
+	// do this from above?
+	writer, _ := zst.NewWriter(w, skewthresh, colthresh)
+	return &Writer{*writer}
+}

--- a/zio/zstio/writer.go
+++ b/zio/zstio/writer.go
@@ -24,12 +24,15 @@ func MibToBytes(mib float64) int {
 	return int(mib * 1024 * 1024)
 }
 
-func NewWriter(w io.WriteCloser, opts WriterOpts) *Writer {
+func NewWriter(w io.WriteCloser, opts WriterOpts) (*Writer, error) {
 	skewthresh := MibToBytes(opts.SkewThresh)
 	colthresh := MibToBytes(opts.ColumnThresh)
 	//XXX should handle error, but zio API doesn't have this yet...
 	// this is just checking bounds on the threshholds so maybe we
 	// do this from above?
-	writer, _ := zst.NewWriter(w, skewthresh, colthresh)
-	return &Writer{*writer}
+	writer, err := zst.NewWriter(w, skewthresh, colthresh)
+	if err != nil {
+		return nil, err
+	}
+	return &Writer{*writer}, nil
 }

--- a/zio/zstio/writer.go
+++ b/zio/zstio/writer.go
@@ -3,6 +3,7 @@ package zstio
 import (
 	"io"
 
+	"github.com/brimsec/zq/pkg/units"
 	"github.com/brimsec/zq/zst"
 )
 
@@ -12,16 +13,10 @@ const (
 )
 
 type WriterOpts struct {
-	ColumnThresh float64
-	SkewThresh   float64
-}
-
-func MibToBytes(mib float64) int {
-	return int(mib * 1024 * 1024)
+	ColumnThresh units.Bytes
+	SkewThresh   units.Bytes
 }
 
 func NewWriter(w io.WriteCloser, opts WriterOpts) (*zst.Writer, error) {
-	skewthresh := MibToBytes(opts.SkewThresh)
-	colthresh := MibToBytes(opts.ColumnThresh)
-	return zst.NewWriter(w, skewthresh, colthresh)
+	return zst.NewWriter(w, int(opts.SkewThresh), int(opts.ColumnThresh))
 }

--- a/zst/README.md
+++ b/zst/README.md
@@ -1,0 +1,552 @@
+# Zst - *z*ng-*st*acked format
+
+Zst, pronounced "zest", is a format for columnar data based on
+[zng](https://github.com/brimsec/zq/blob/master/zng/docs/spec.md).
+Zst is the "stacked" version of zng, where the fields from a stream of
+zng records are stacked into vectors that form columns.
+
+You can convert a zng stream to zst and back to zng,
+and the input and output will match exactly.
+
+Zst is much inspired by [parquet](https://github.com/apache/parquet-format).
+We thought long and hard about using
+parquet directly with zng but felt a new format was warranted and important
+(as is justified elsewhere).
+
+> TBD: add a link to the "justified elsewhere" document.
+
+> TBD: check that zng aliases "just work" as alias bindings should be emitted
+> when any data of using a type alias is decoded and written/transmitted
+
+> TBD: add support for multi-file zst objects.
+
+> TBD: test support for zng set types.
+
+> TBD: add support for more efficient seekability (compared to brute force
+> parsing of all the root ids).  However we do this, it will probably be the
+> right opportunity to add arbitrary zng meta data for pruning (e.g., numeric
+> min,max,sum,small-set summaries,cardinality).  We also probably need to add
+> column counts and byte sizes in various places to optimize things and provide
+> for scanning stats.  Also, being able to do push-down with multiple, parallel
+> queries could be useful when the app wants to assemble a splash page or
+> run about of complex, interrelated queries to populate sophisticated views etc.
+
+> TBD: add more examples.
+
+## The Zng Data Model
+
+The zng data model is an unbounded sequence of zng streams, where
+each stream comprises a finite sequence of "rows", and each row conforms to
+an arbitrary schema.  In this way, you can think of a zng stream as a diverse
+collection of sql-like tables where the rows from each table are interspersed
+amongst each other in a deterministic order.
+
+> In the [zq implementation](https://github.com/brimsec/zq), a zng row is a
+> [zng.Record](https://github.com/brimsec/zq/blob/42103ef6a15b3ee53fbcd980604e75c42ea3308d/zng/recordval.go#L39)
+> and a schema is a
+> [zng.TypeRecord](https://github.com/brimsec/zq/blob/42103ef6a15b3ee53fbcd980604e75c42ea3308d/zng/record.go#L10).
+
+Each zng stream has its own, embedded "type context" that defines the schema
+of each row value. A zng stream is fully self-contained and self describing.
+There is no need for external schema definitions or for accesses to a
+centralized schema registry to decode a zng stream.
+
+Zng streams can represent data at rest on a storage system, data in memory
+for online-analytics processing, or data in flight,
+e.g., as the foundation of a data communication layer.  Like
+[FlexBuffers](https://google.github.io/flatbuffers/flexbuffers.html),
+the zng format was designed so that serialized form of the data is the same
+as the in-memory form of the data so there is no need to unmarshal zng data
+into native programming data structures.  Thus, analytics may be carried out
+directly on the zng data types.  We call this "in-place analytics".
+
+Unlike parquet, which presumes the out-of-band definition of schemas with
+optional fields, the zng data model is self-describing and presumes there is
+often no good way ahead of time to know which fields may or may not be optional.
+Thus, the encoding here is a bit different and new, as any field in any zng row can
+always be optional.  You don't need to say ahead of times what things are optional.
+For many important use cases, you can't know this anyway.
+
+> Ad an example: zeek script change that adds a new column (maybe this discussion
+> belongs elsewhere).
+
+A value that is not present in a field is called "unset".
+
+> An "unset" field should not be confused with a value that is present
+> but is null/empty/undefined/nil/etc.
+
+## Zst
+
+Zst (pronounced "zest") is a storage object format that represents a fixed-size
+zng stream.  Its purpose is to provide for efficient analytics and search over
+snapshots of zng row data that is stored in columnar form.
+
+While a zst object can be built on the fly from a stream of zng records,
+it generally cannot be read or queried until the final end-of-stream
+is received on the stream of zng records that are to be treated as a
+zst object and everything about the zst object is flushed to storage.
+
+A zst object can be stored entirely as one seekable object (e.g., an s3 object)
+or split into separate seekable objects (e.g., unix files) that are treated
+together as a single zst entity.  While the zst format provides much flexibility
+for how data is laid out, it's up to implementations to layout data
+in intelligent ways for efficient sequential read access in spite of occasional
+seeks.
+
+## The "Column Stream" Abstraction
+
+The zst data abstraction is built around a collection of "column streams".
+
+There is one column stream for each field of zng record type definition
+that appears collectively throughout the zng input data including records
+embedded within records.
+
+For example, a field that is an array of records containing other fields would
+have a column stream for the top-level array field as well as column a stream
+for each field inside of the array values.
+
+Each column stream represents a sequence of values (inclusive of unset values)
+comprising each occurrence where that value appears with respect to its context.
+
+Records are reconstructed one by one from the column streams by picking values
+from each appropriate column stream based on the type structure of the record and
+its relationship to the various column streams.  For hierarchical records
+(i.e., records inside of records, or records inside of arrays inside of records, etc),
+the reconstruction process is recursive (as described below).
+
+## The Physical Layout
+
+Given the above logical design of zst column streams, we now describe how
+zng rows are physically laid out across zst columns as a storage
+data structure.
+
+The overall layout of a zst object is comprised of the following sections,
+in this order:
+* the data section,
+* the reassembly section,
+* and the trailer.
+
+This layout is designed so that an implementation can buffer metadata in
+memory while writing column data in a natural order to the
+data section (based on the volume statistics of each column),
+then write the metadata into the reassembly section along with the trailer
+at the end.  This allows a zng stream to be converted to a zst object
+in a single pass.
+
+> That said, the layout is
+> flexible enough that an implementation may optimize the data layout with
+> additional passes or by writing the output to multiple files then then
+> merging them together (or even leaving the zst object as separate files
+> that can be collectively read and scanned by a zst implementation).
+
+### The Data Section
+
+The data section contains raw data values organized into "segments",
+where a segment is simply a seek offset and byte length relative to the
+data section.  Each segment contains a sequence of
+[primitive-type zng values](https://github.com/brimsec/zq/blob/zst/zng/docs/spec.md#5-primitive-types),
+encoded as counted-length byte sequences where the counted-length is
+variable-length encoded as in the zng spec.
+
+There is no information in the data section for how segments relate
+to one another or how they are reconstructed into columns.  They are just
+blobs of zng data.
+
+> Unlike parquet, there is no explicit arrangement the column chunks into
+> row groups but rather they are allowed to grow at different rates so a
+> high-volume column might be comprised of many segments while a low-volume
+> column must just one or several.  This allows scans of low-volume record types
+> (the "mice") to perform well amongst high-volume record types (the "elephants"),
+> i.e., there are not a bunch of seeks with tiny reads of mice data interspersed
+> throughout the elephants.
+
+> TBD: The mice/elephants model creates an interesting and challenging layout
+> problem.  If you let the row indexes get too far apart (call this "skew"), then
+> you have to buffer very large amounts of data to keep the column data aligned.
+> This is the point of row groups in parquet, but the model here is to leave it
+> up to the implementation to do layout as it sees fit.  You can also fall back
+> to doing lots of seeks and that might work perfectly fine when using SSDs but
+> this also creates interesting optimization problems when sequential reads work
+> a lot better.  There could be a scan optimizer that lays out how the data is
+> read that lives under the column stream reader.  Also, you can make tradeoffs:
+> if you use lots of buffering on ingest, you can write the mice in front of the
+> elephants so the read path requires less buffering to align columns.  Or you can
+> do two passes where you store segments in separate files them merge them at close
+> according to an optimization plan.
+
+Segments are sub-divided into frames where each frame is compressed
+independently of each other, similar to zng compression framing.
+
+> TBD: use the
+> [same compression format](https://github.com/brimsec/zq/blob/master/zng/docs/spec.md#313-compressed-value-message-block)
+> exactly?
+
+> The intent here is that segments are sized so that sequential read access
+> performs well (e.g., 5MB) while frames are comparatively smaller (say 32KB)
+> so that they can be decompressed and processed in a multi-threaded fashion where
+> search and analytics can be performed on the decompressed buffer by the same
+> thread that decompressed the frame enhancing read-locality and L1/L2 cache
+> performance.
+
+### The Reassembly Section
+
+The reassembly section provides the information needed to reconstruct
+column streams from segments, and in turn, to reconstruct the original zng rows
+from column streams, i.e., to map columns back to rows.
+
+> Of course, the reassembly section also provides the ability to extract just subsets of columns
+> to be read and searched efficiently without ever needing to reconstruct
+> the original rows.  How performant this is all done is up to any particular
+> zst implementation.
+
+> Also, the reassembly section is in generally vastly smaller than the data section
+> so the goal here isn't to express information in cute and obscure compact forms
+> but rather to represent data in easy-to-digest, programmer-friendly form that
+> leverages zng.
+
+The reassembly section is a zng stream.  Unlike parquet,
+which uses an externally described schema
+(via [Thrift](https://thrift.apache.org/)) to describe
+analogous data structures, we simply reuse zng here.
+
+> So, we are using zng to encode zng in column format.  Yo dawg.
+
+#### The Schema Definitions
+
+This reassembly zng stream encodes 2*N+1 zng records, where N is equal to the number
+of top-level zng record types that are present in the encoded input.
+To simply terminology, we call a top-level zng record type a "schema",
+e.g., there are N unique schemas encoded in the zst object.
+
+Each of these N schemas gets defined as a record value, comprised
+of unset fields appearing in the same order
+as they were encountered in the original zng stream.
+In this way, a fresh zng type context can be created to read these N records and
+that type context will have precisely the same structure as the type context
+from the original zng stream.  This is guaranteed by the deterministic nature
+of embedded zng type definitions.
+
+The next N+1 records contain reassembly information for each of the N schemas
+where each record is used to create column streams to reconstruct the original
+zng records.  The schemas do not overlap as columns from a record from any one
+schema are not intermixed with columns of another.
+
+#### Segment Maps
+
+The foundation of column reconstruction is based on segment maps, which is simply
+a list of the segments from the data area that are concatenated to form the
+data for a column stream.
+
+Each segment map that appears within the reassembly records is represented
+with a zng array of records that represent seek ranges, i.e., specifically
+this zng type:
+```
+array[record[offset:uint64,length:uint32]]
+```
+In the rest this document, we will refer to this type as `<segmap>` for
+shorthand and refer to the concept as a "segmap".
+
+> We use the type name "segmap" to emphasize that this information represents
+> a set of seek ranges where data stored and must be read from *rather than*
+> the data itself.
+
+#### The Root Reassembly Record
+
+The first of the N+1 reassembly records defines the "root column", where this column
+represents the sequence of schemas of each original zng record, i.e., indicating
+which schema's column stream to select from to pull column values to form the zng row.
+The sequence of schemas is defined by each row's small-integer positional index,
+0 to N-1, within the N schemas.
+
+The root column stream is encoded as zng int32 values.
+While there are a large number entries in the root column (one for each original row),
+the cardinality of the set of root identifiers is small in practice so this column
+will compress very significantly, e.g., in the special case that all the
+rows have the same schema, this column will compress to practically nothing.
+
+The type of the reassembly record for the root column stream is simply:
+```
+record[root:<segmap>]
+```
+
+#### The Row Reassembly Records
+
+The remaining N records in the reassembly stream define the reassembly
+maps for each schema.
+
+Each such row reassembly record is record of type `<record_column>`, as defined below,
+where each row assembly record appears in the same sequence as the original N schemas.
+This simple top-level arrangement, along with the definition of
+the `<record_column>` type below, is all that is needed to reconstruct all of the
+original data.
+
+In other words, these root reassembly record combined with the N row reassembly
+records collectively define the original zng row structure.
+Taken in pieces, the reassembly records allow efficient access to sub-ranges of the
+rows, to subset of columns of the rows, to sub-ranges of columns of the rows, and so forth.
+
+> Note that each row reassembly record has its own layout of columnar
+> values and there is no attempt made to store like-typed columns from different
+> schemas in the same physical column.
+
+A `<record_column>` is defined recusively in terms of other `<record_column>'s`
+and other type that represent arrays, unions, or primitive types, which will
+be referred to as follows:
+* `<array_column>`,
+* `<union_column>`, or
+* `<primitive_column>`.
+
+In addition,the notation `<any_column>` refers to any instance of the four
+column types:
+* `<record_column>`,
+* `<array_column>`,
+* `<union_column>`, or
+* `<primitive_column>`.
+
+#### Record Column
+
+The `<record_column>` type has the form:
+```
+record[
+        <fld1>:record[column:<any_column>,presence:<segmap>],
+        <fld2>:record[column:<any_column>,presence:<segmap>],
+        ...
+        <fldn>:record[column:<any_column>,presence:<segmap>]
+]        
+```
+where
+* `<fld1>` through `<fldn>` are the names of the top-level fields of the
+original row record,
+* the `column` fields are column stream definitions for each field, and
+* the `presence` columns are int32 zng column streams comprised of a
+run-length encoding the locations of column values in their respective rows,
+when there are unset values (as described below).
+
+If there are no unset values, then the `presence` field contains an empty `<segmap>`.
+If all of the values are unset, then then `column` field is unset (and the `presence`
+both contain empty `<segmap>'s`).  For empty `<segmap>'s`, there is no
+corresponding data stored in the data section.  Since a `<segmap>` is a zng
+array, an empty `<segmap>` is simply the empty array value `[]`.
+
+> Note that the only place a value can be "unset" is in the context of
+> a field of a record.  Hence, the only place presence columns are needed
+> is on the context of a record field.
+
+#### Array Column
+
+An `<array_column>` has the form:
+```
+record[values:<any_column>,lengths:<segmap>]
+```
+where
+* `values` represents a continuous sequence of values of the array elements  
+that are sliced into array values based on the length information, and
+* `lengths` encodes a zng int32 sequence of values that represent the length
+ of each array value.
+
+#### Union Columns
+
+A `<union_column>` has the form:
+```
+record[c0:<any_column>,c1:<any_column>,...,selector:<segmap>]
+```
+where
+* `c0`, `c1` etc, up to the number of types in the union, are column values for
+each the type ordered by the implied type in the union type, and
+* `selector` is a column of int32 where each subsequent value indicates which
+of the union types is to be used for each respective column.
+
+The number of times each value of `selector` appears must equal the number of values
+in each respective column.
+
+#### Primitive Column
+
+A `<primitive_column>` is just a `<segmap>` that defines a column stream of
+primitive values.  There is no need to encode the primitive type here
+as it can be obtained from the corresponding schema.
+
+> Note that when locating a column, all type information is known
+> from the root type context of the record in question so there is no need
+> to encode the type information redundantly here.  An implementation would
+> typically pass down the appropriate types from the root type context recursively
+> when landing at a primitive_column type encoded in the local type context.
+
+#### Presence Columns
+
+The presence column is logically a sequence of booleans, one for each position
+in the original column, indicating whether a value is unset or present.
+The number of values in the encoded column is equal to the number of values
+present so that unset values are not encoded.
+
+Instead the presence column is encoded as a sequence of alternating runs.
+First, the number of values present is encoded, then the number of values not present,
+then the number of values present, and so forth.   These runs are the stored
+as zng int32 values in the presence column (which may be subject to further
+compression based on segment framing).
+
+### The Trailer
+
+After the reassembly section is a zng stream with a single record defining
+the "trailer" of the zst object.  The trailer provides a magic field
+indicating the "zst" format, a version number,
+the size of the segment threshold for decomposing segments into frames,
+the size of the skew threshold for flushing all segments to storage when
+the memory footprint roughly exceeds this threshold,
+and an array of sizes in bytes of the sections of the zst object.
+
+This type of this record has the format
+```
+record[magic:string,version:int32,skew_thresh:int32,segment_thresh:int32,sections:array[int64]]
+```
+The trailer can be efficiently found by scanning backward from the end of the
+zst object to the find a valid zng stream containing a single record value
+conforming to the above type.
+
+## Decoding
+
+To decode a entire zst object into rows, the trailer is read to find the sizes
+of the sections, then the zng stream of the reassembly section is read,
+typically in its entirety.
+
+Since this data structure is relatively small compared to all of the columnar
+data in the zst object,
+it will typically fit comfortably in memory and it can be very fast to scan the
+xentire reassembly structure for any purpose.
+
+> For example, for a given query, a "scan planner" could traverse all the
+> reassembly records to figure out which segments will be needed, then construct
+> an intelligent plan for reading the needed segments and attempt to read them
+> in mostly sequential order, which could serve as
+> an optimizing intermediary between any underlying storage API and the
+> zst decoding logic.
+
+To decode the "next" row, its schema index is read from the root reassembly
+column stream.
+
+This schema index then determines which reassembly record to fetch
+column values from.
+
+The top-level reassembly fetches column values as a `<record_column>`.
+
+For any `<record_column>`, a value from each field is read from each field's column,
+accounting for the presence column indicating nil,
+and the results are encoded into the corresponding zng record value using
+zng type information from the corresponding schema.
+
+For a `<primitive_column>` a value is determined by reading the next
+value from its segmap.
+
+For an `<array_column>`, a length is read from its `lengths` segmap as an int32
+and that many values are read from its the `values` sub-column,
+encoding the result as a zng array value.
+
+For an `<union_column>`, a value is read from its `selector` segmap
+and that value is used to the select to corresponding column stream
+`c0`, `c1`, etc.  The value read is then encoded as a zng union value
+using the same selector value within the union value.
+
+## Examples
+
+### Hello, world
+
+```
+#0:record[a:string,b:string]
+0:[hello;world;]
+0:[goodnight;gracie;]
+```
+
+Segments would be laid out like this:
+```
+=== column for a
+hello
+goodnight
+=== column for b
+world
+gracie
+=== column for schema IDs
+0
+0
+===
+```
+First, the schemas are defined (just one here):
+```
+#0:record[a:string,b:string]
+0:[-;-;]
+```
+
+Then, root reassembly record:
+```
+#1:record[root:array[record[offset:int64,length:int32]]]
+1:[[[29;2;]]]
+```
+Next comes the column reassembly records (again, only schema in this
+example, so only one such record):
+```
+#2:record[a:record[column:array[record[offset:int64,length:int32]],presence:array[record[offset:int64,length:int32]]],b:record[column:array[record[offset:int64,length:int32]],presence:array[record[offset:int64,length:int32]]]]
+2:[[[[0;16;]][]][[[16;13;]][]]]
+```
+And finally, the trailer as a new zng stream:
+```
+#0:record[magic:string,version:int32,skew_thresh:int32,segment_thresh:int32,sections:array[int64]]
+0:[zst;1;26214400;5242880;[31;94;]]
+```
+
+All of this can be viewed a bit more easily in json...
+For example, you can use the zst command like this:
+```
+zst inspect -t -trailer hello.zst
+```
+to get the output above, but it's all a bit more easily viewed as json,
+so you can do this too...
+```
+zst inspect -f ndjson -trailer hello.zst | jq
+```
+to view it all a bit more easily (with loss of information due to json):
+```
+{
+  "a": null,
+  "b": null
+}
+{
+  "root": [
+    {
+      "length": 2,
+      "offset": 29
+    }
+  ]
+}
+{
+  "a": {
+    "column": [
+      {
+        "length": 16,
+        "offset": 0
+      }
+    ],
+    "presence": []
+  },
+  "b": {
+    "column": [
+      {
+        "length": 13,
+        "offset": 16
+      }
+    ],
+    "presence": []
+  }
+}
+{
+  "magic": "zst",
+  "sections": [
+    31,
+    94
+  ],
+  "segment_thresh": 5242880,
+  "skew_thresh": 26214400,
+  "version": 1
+}
+```
+
+> Note finally, if there were 10MB of zng row data here, the reassembly section
+> would be basically the same size, with perhaps a few segmaps.  This emphasizes
+> just how small this data structure is compared to the data section.

--- a/zst/README.md
+++ b/zst/README.md
@@ -102,7 +102,7 @@ that appears collectively throughout the zng input data including records
 embedded within records.
 
 For example, a field that is an array of records containing other fields would
-have a column stream for the top-level array field as well as a column a stream
+have a column stream for the top-level array field as well as a column
 for each field inside of the array values.
 
 Each column stream represents a sequence of values (inclusive of unset values)
@@ -155,7 +155,7 @@ blobs of zng data.
 > Unlike parquet, there is no explicit arrangement the column chunks into
 > row groups but rather they are allowed to grow at different rates so a
 > high-volume column might be comprised of many segments while a low-volume
-> column must just one or several.  This allows scans of low-volume record types
+> column must just be one or several.  This allows scans of low-volume record types
 > (the "mice") to perform well amongst high-volume record types (the "elephants"),
 > i.e., there are not a bunch of seeks with tiny reads of mice data interspersed
 > throughout the elephants.
@@ -411,7 +411,7 @@ typically in its entirety.
 Since this data structure is relatively small compared to all of the columnar
 data in the zst object,
 it will typically fit comfortably in memory and it can be very fast to scan the
-xentire reassembly structure for any purpose.
+entire reassembly structure for any purpose.
 
 > For example, for a given query, a "scan planner" could traverse all the
 > reassembly records to figure out which segments will be needed, then construct

--- a/zst/README.md
+++ b/zst/README.md
@@ -97,12 +97,12 @@ seeks.
 
 The zst data abstraction is built around a collection of "column streams".
 
-There is one column stream for each field of zng record type definition
+There is one column stream for each field of a zng record type definition
 that appears collectively throughout the zng input data including records
 embedded within records.
 
 For example, a field that is an array of records containing other fields would
-have a column stream for the top-level array field as well as column a stream
+have a column stream for the top-level array field as well as a column a stream
 for each field inside of the array values.
 
 Each column stream represents a sequence of values (inclusive of unset values)
@@ -215,7 +215,7 @@ analogous data structures, we simply reuse zng here.
 
 This reassembly zng stream encodes 2*N+1 zng records, where N is equal to the number
 of top-level zng record types that are present in the encoded input.
-To simply terminology, we call a top-level zng record type a "schema",
+To simplify terminology, we call a top-level zng record type a "schema",
 e.g., there are N unique schemas encoded in the zst object.
 
 Each of these N schemas gets defined as a record value, comprised

--- a/zst/assembler.go
+++ b/zst/assembler.go
@@ -1,0 +1,79 @@
+package zst
+
+import (
+	"errors"
+	"io"
+
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zst/column"
+)
+
+var ErrBadSchemaID = errors.New("bad schema id in root reassembly column")
+
+type Assembly struct {
+	root    zng.Value
+	schemas []*zng.TypeRecord
+	columns []*zng.Record
+}
+
+func NewAssembler(a *Assembly, seeker Seeker) (*Assembler, error) {
+	assembler := &Assembler{
+		root:    &column.Int{},
+		schemas: a.schemas,
+	}
+	if err := assembler.root.UnmarshalZNG(a.root, seeker); err != nil {
+		return nil, err
+	}
+	assembler.columns = make([]*column.Record, len(a.schemas))
+	for k := 0; k < len(a.schemas); k++ {
+		rec := a.columns[k]
+		zv := zng.Value{rec.Type, rec.Raw}
+		record_col := &column.Record{}
+		if err := record_col.UnmarshalZNG(a.schemas[k], zv, seeker); err != nil {
+			return nil, err
+		}
+		assembler.columns[k] = record_col
+	}
+	return assembler, nil
+}
+
+// Assembler implements the zbuf.Reader and io.Closer.  It reads a columnar
+// zst object to generate a stream of zng.Records.  It also has methods
+// to read metainformation for test and debugging.
+type Assembler struct {
+	root    *column.Int
+	columns []*column.Record
+	schemas []*zng.TypeRecord
+	builder zcode.Builder
+	err     error
+}
+
+func (a *Assembler) Read() (*zng.Record, error) {
+	a.builder.Reset()
+	schemaID, err := a.root.Read()
+	if err == io.EOF {
+		return nil, nil
+	}
+	if schemaID < 0 || int(schemaID) >= len(a.columns) {
+		return nil, ErrBadSchemaID
+	}
+	col := a.columns[schemaID]
+	if col == nil {
+		return nil, ErrBadSchemaID
+	}
+	err = a.columns[schemaID].Read(&a.builder)
+	if err != nil {
+		return nil, err
+	}
+	body, err := a.builder.Bytes().ContainerBody()
+	if err != nil {
+		return nil, err
+	}
+	rec := zng.NewRecord(a.schemas[schemaID], body)
+	//XXX if we had a buffer pool where records could be built back to
+	// back in batches, then we could get rid of this extra allocation
+	// and copy on every record
+	rec.Keep()
+	return rec, nil
+}

--- a/zst/assembler.go
+++ b/zst/assembler.go
@@ -62,7 +62,7 @@ func (a *Assembler) Read() (*zng.Record, error) {
 	if col == nil {
 		return nil, ErrBadSchemaID
 	}
-	err = a.columns[schemaID].Read(&a.builder)
+	err = col.Read(&a.builder)
 	if err != nil {
 		return nil, err
 	}

--- a/zst/column/array.go
+++ b/zst/column/array.go
@@ -1,0 +1,107 @@
+package column
+
+import (
+	"errors"
+	"io"
+
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type ArrayWriter struct {
+	typ     zng.Type
+	values  Writer
+	lengths *IntWriter
+}
+
+func NewArrayWriter(inner zng.Type, spiller *Spiller) *ArrayWriter {
+	return &ArrayWriter{
+		typ:     inner,
+		values:  NewWriter(inner, spiller),
+		lengths: NewIntWriter(spiller),
+	}
+}
+
+func (a *ArrayWriter) Write(body zcode.Bytes) error {
+	it := zcode.Iter(body)
+	var len int32
+	for !it.Done() {
+		body, _, err := it.Next()
+		if err != nil {
+			return err
+		}
+		if err := a.values.Write(body); err != nil {
+			return err
+		}
+		len++
+	}
+	return a.lengths.Write(len)
+}
+
+func (a *ArrayWriter) Flush(eof bool) error {
+	if err := a.lengths.Flush(eof); err != nil {
+		return err
+	}
+	return a.values.Flush(eof)
+}
+
+func (a *ArrayWriter) MarshalZNG(zctx *resolver.Context, b *zcode.Builder) (zng.Type, error) {
+	b.BeginContainer()
+	valType, err := a.values.MarshalZNG(zctx, b)
+	if err != nil {
+		return nil, err
+	}
+	lenType, err := a.lengths.MarshalZNG(zctx, b)
+	if err != nil {
+		return nil, err
+	}
+	b.EndContainer()
+	cols := []zng.Column{
+		{"values", valType},
+		{"lengths", lenType},
+	}
+	return zctx.LookupTypeRecord(cols)
+}
+
+type Array struct {
+	values  Interface
+	lengths *Int
+}
+
+func (a *Array) UnmarshalZNG(inner zng.Type, in zng.Value, r io.ReaderAt) error {
+	typ, ok := in.Type.(*zng.TypeRecord)
+	if !ok {
+		return errors.New("zst object array_column not a record")
+	}
+	rec := zng.NewRecord(typ, in.Bytes)
+	zv, err := rec.Access("values")
+	if err != nil {
+		return err
+	}
+	a.values, err = Unmarshal(inner, zv, r)
+	if err != nil {
+		return err
+	}
+	zv, err = rec.Access("lengths")
+	if err != nil {
+		return err
+	}
+	a.lengths = &Int{}
+	return a.lengths.UnmarshalZNG(zv, r)
+}
+
+func (a *Array) Read(b *zcode.Builder) error {
+	len, err := a.lengths.Read()
+	if err != nil {
+		return err
+	}
+	b.BeginContainer()
+	for k := 0; k < int(len); k++ {
+		if err := a.values.Read(b); err != nil {
+			return err
+		}
+	}
+	b.EndContainer()
+	return nil
+}

--- a/zst/column/column.go
+++ b/zst/column/column.go
@@ -1,5 +1,5 @@
-// Package column implements the organization of columns on storage for the
-// zst colunar storage object.
+// Package column implements the organization of columns on storage for a
+// zst columnar storage object.
 //
 // A zst object is created by allocating a RecordWriter for a top-level zng row type
 // (i.e., "schema") via NewRecordWriter.  The object to be written to is wrapped

--- a/zst/column/column.go
+++ b/zst/column/column.go
@@ -1,0 +1,107 @@
+// Package column implements the organization of columns on storage for the
+// zst colunar storage object.
+//
+// A zst object is created by allocating a RecordWriter for a top-level zng row type
+// (i.e., "schema") via NewRecordWriter.  The object to be written to is wrapped
+// in a Spiller with a column threshold.  Output is streamed to the underlying spiller
+// in a single pass.  (In the future, we may implement multiple passes to optimize
+// the storage layout of column data or spread a given zst object across multiple
+//
+// NewRecordWriter recursively decends the record type, allocating a column Writer
+// for each node in the type tree.  The top-level record body is written via a call
+// to Write and all of the columns are called with their respetive values represented
+// as a zcode.Bytes.  The columns buffer data in memorry until they reach their
+// byte threshold or until Flush is called.
+//
+// After all of the zng data is written, a reassembly record may be formed for
+// the RecordColumn by calling its MarshalZNG method, which builds the record
+// value in place using zcode.Builder and returns the zng.TypeRecord (i.e., schema)
+// of that record column.
+//
+// Data is read from a zst file by scanning the reassembly records then unmarshaling
+// a zng.Record body into an empty Record by calling Record.UnmarshalZNG, which
+// recusirvely builds an assembly structure.  An io.ReaderAt is passed to unmarshal
+// so each column reader can access the underlying storage object and read its
+// column data effciently in largish column chunks.
+//
+// Once an assembly is built, the recontructed zng row data can be read from the
+// assembly by calling the Read method on the top-level Record and passing in
+// a zcode.Builder to reconstruct the record body in place.  The assembly does not
+// need any type information as the structure of values is entirely self describing
+// in the zng data format.
+package column
+
+import (
+	"io"
+
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+const MaxSegmentThresh = 20 * 1024 * 1024
+
+type Writer interface {
+	// Write encodes the given value into memory.  When the column exceeds
+	// a threshold, it is automatically flushed.  Flush may also be called
+	// explicitly to push columns to storage and thus avoid too much row skew
+	// between columns.
+	Write(zcode.Bytes) error
+	// Push all in-memory column data to the storage layer.
+	Flush(bool) error
+	// MarshalZNG is called after all data is flushed to build the reassembly
+	// record for this column.
+	MarshalZNG(*resolver.Context, *zcode.Builder) (zng.Type, error)
+}
+
+func NewWriter(typ zng.Type, spiller *Spiller) Writer {
+	switch typ := typ.(type) {
+	case *zng.TypeAlias:
+		return NewWriter(typ.Type, spiller)
+	case *zng.TypeRecord:
+		return NewRecordWriter(typ, spiller)
+	case *zng.TypeArray:
+		return NewArrayWriter(typ.Type, spiller)
+	case *zng.TypeSet:
+		// Sets encode the same way as arrays but behave
+		// differently semantically, and we don't care here.
+		return NewArrayWriter(typ.InnerType, spiller)
+	case *zng.TypeUnion:
+		return NewUnionWriter(typ, spiller)
+	default:
+		return NewPrimitiveWriter(spiller)
+	}
+}
+
+type Interface interface {
+	Read(*zcode.Builder) error
+}
+
+func Unmarshal(typ zng.Type, in zng.Value, r io.ReaderAt) (Interface, error) {
+	switch typ := typ.(type) {
+	case *zng.TypeAlias:
+		return Unmarshal(typ.Type, in, r)
+	case *zng.TypeRecord:
+		record := &Record{}
+		err := record.UnmarshalZNG(typ, in, r)
+		return record, err
+	case *zng.TypeArray:
+		a := &Array{}
+		err := a.UnmarshalZNG(typ.Type, in, r)
+		return a, err
+	case *zng.TypeSet:
+		// Sets encode the same way as arrays but behave
+		// differently semantically, and we don't care here.
+		a := &Array{}
+		err := a.UnmarshalZNG(typ.InnerType, in, r)
+		return a, err
+	case *zng.TypeUnion:
+		u := &Union{}
+		err := u.UnmarshalZNG(typ, in, r)
+		return u, err
+	default:
+		p := &Primitive{}
+		err := p.UnmarshalZNG(in, r)
+		return p, err
+	}
+}

--- a/zst/column/field.go
+++ b/zst/column/field.go
@@ -28,7 +28,7 @@ func (f *FieldWriter) write(body zcode.Bytes) error {
 	return f.column.Write(body)
 }
 
-func (f *FieldWriter) encode(zctx *resolver.Context, b *zcode.Builder) (zng.Type, error) {
+func (f *FieldWriter) MarshalZNG(zctx *resolver.Context, b *zcode.Builder) (zng.Type, error) {
 	b.BeginContainer()
 	var colType zng.Type
 	if f.vcnt == 0 {

--- a/zst/column/field.go
+++ b/zst/column/field.go
@@ -1,0 +1,140 @@
+package column
+
+import (
+	"errors"
+	"io"
+
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type FieldWriter struct {
+	name     string
+	column   Writer
+	presence *PresenceWriter
+	vcnt     int
+	ucnt     int
+}
+
+func (f *FieldWriter) write(body zcode.Bytes) error {
+	if body == nil {
+		f.ucnt++
+		f.presence.TouchUnset()
+		return nil
+	}
+	f.vcnt++
+	f.presence.TouchValue()
+	return f.column.Write(body)
+}
+
+func (f *FieldWriter) encode(zctx *resolver.Context, b *zcode.Builder) (zng.Type, error) {
+	b.BeginContainer()
+	var colType zng.Type
+	if f.vcnt == 0 {
+		colType = zng.TypeNull
+		b.AppendPrimitive(nil)
+	} else {
+		var err error
+		colType, err = f.column.MarshalZNG(zctx, b)
+		if err != nil {
+			return nil, err
+		}
+	}
+	presenceType, err := f.presence.MarshalZNG(zctx, b)
+	if err != nil {
+		return nil, err
+	}
+	b.EndContainer()
+	cols := []zng.Column{
+		{"column", colType},
+		{"presence", presenceType},
+	}
+	return zctx.LookupTypeRecord(cols)
+}
+
+func (f *FieldWriter) Flush(eof bool) error {
+	if f.column != nil {
+		if err := f.column.Flush(eof); err != nil {
+			return err
+		}
+	}
+	if eof {
+		// For now, we only flush presence vectors at the end.
+		// They will flush on their own outside of the skew window
+		// if they get too big.  But they are very small in practice so
+		// this is a feature not a bug, since these vectors will
+		// almost always be small and they can all be read efficiently
+		// toward the end of the file in preparatoin for a scan.
+		// XXX TODO: measure how big they get in practice to see if they
+		// will cause seek traffic.
+		f.presence.Finish()
+		if f.vcnt != 0 && f.ucnt != 0 {
+			// If this colummn is not either all values or all unsets,
+			// then flush and write out the presence vector.
+			// Otherwise, there will be no values in the presence
+			// column and an empty segmap will be encoded for it.
+			if err := f.presence.Flush(eof); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+type Field struct {
+	isContainer bool
+	column      Interface
+	presence    *Presence
+}
+
+func (f *Field) UnmarshalZNG(typ zng.Type, in zng.Value, r io.ReaderAt) error {
+	rtype, ok := in.Type.(*zng.TypeRecord)
+	if !ok {
+		return errors.New("zst object array_column not a record")
+	}
+	rec := zng.NewRecord(rtype, in.Bytes)
+	zv, err := rec.Access("column")
+	if err != nil {
+		return err
+	}
+	if zv.Bytes != nil {
+		f.column, err = Unmarshal(typ, zv, r)
+		if err != nil {
+			return err
+		}
+	}
+	zv, err = rec.Access("presence")
+	if err != nil {
+		return err
+	}
+	f.isContainer = zng.IsContainerType(typ)
+	f.presence = NewPresence()
+	if err := f.presence.UnmarshalZNG(zv, r); err != nil {
+		return err
+	}
+	if f.presence.IsEmpty() {
+		f.presence = nil
+	}
+	return nil
+}
+
+func (f *Field) Read(b *zcode.Builder) error {
+	isval := true
+	if f.presence != nil {
+		var err error
+		isval, err = f.presence.Read()
+		if err != nil {
+			return err
+		}
+	}
+	if isval && f.column != nil {
+		return f.column.Read(b)
+	}
+	if f.isContainer {
+		b.AppendContainer(nil)
+	} else {
+		b.AppendPrimitive(nil)
+	}
+	return nil
+}

--- a/zst/column/int.go
+++ b/zst/column/int.go
@@ -1,0 +1,30 @@
+package column
+
+import (
+	"github.com/brimsec/zq/zng"
+)
+
+type IntWriter struct {
+	PrimitiveWriter
+}
+
+func NewIntWriter(spiller *Spiller) *IntWriter {
+	return &IntWriter{*NewPrimitiveWriter(spiller)}
+}
+
+func (p *IntWriter) Write(v int32) error {
+	return p.PrimitiveWriter.Write(zng.EncodeInt(int64(v)))
+}
+
+type Int struct {
+	Primitive
+}
+
+func (p *Int) Read() (int32, error) {
+	zv, err := p.read()
+	if err != nil {
+		return 0, err
+	}
+	v, err := zng.DecodeInt(zv)
+	return int32(v), err
+}

--- a/zst/column/presence.go
+++ b/zst/column/presence.go
@@ -1,0 +1,67 @@
+package column
+
+type PresenceWriter struct {
+	IntWriter
+	run   int32
+	unset bool
+}
+
+func NewPresenceWriter(spiller *Spiller) *PresenceWriter {
+	return &PresenceWriter{
+		IntWriter: *NewIntWriter(spiller),
+	}
+}
+
+func (p *PresenceWriter) TouchValue() {
+	if !p.unset {
+		p.run++
+	} else {
+		p.Write(p.run)
+		p.run = 1
+		p.unset = false
+	}
+}
+
+func (p *PresenceWriter) TouchUnset() {
+	if p.unset {
+		p.run++
+	} else {
+		p.Write(p.run)
+		p.run = 1
+		p.unset = true
+	}
+}
+
+func (p *PresenceWriter) Finish() {
+	p.Write(p.run)
+}
+
+type Presence struct {
+	Int
+	unset bool
+	run   int
+}
+
+func NewPresence() *Presence {
+	// We start out with unset true so it is immediately flipped to
+	// false on the first call to Read.
+	return &Presence{unset: true}
+}
+
+func (p *Presence) IsEmpty() bool {
+	return len(p.segmap) == 0
+}
+
+func (p *Presence) Read() (bool, error) {
+	run := p.run
+	for run == 0 {
+		p.unset = !p.unset
+		v, err := p.Int.Read()
+		if err != nil {
+			return false, err
+		}
+		run = int(v)
+	}
+	p.run = run - 1
+	return !p.unset, nil
+}

--- a/zst/column/primitive.go
+++ b/zst/column/primitive.go
@@ -1,0 +1,106 @@
+package column
+
+import (
+	"errors"
+	"io"
+
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type PrimitiveWriter struct {
+	bytes    zcode.Bytes
+	spiller  *Spiller
+	segments []Segment
+}
+
+func NewPrimitiveWriter(spiller *Spiller) *PrimitiveWriter {
+	return &PrimitiveWriter{
+		spiller: spiller,
+	}
+}
+
+func (p *PrimitiveWriter) Write(body zcode.Bytes) error {
+	p.bytes = zcode.AppendPrimitive(p.bytes, body)
+	var err error
+	if len(p.bytes) >= p.spiller.Thresh {
+		err = p.Flush(false)
+	}
+	return err
+}
+
+func (p *PrimitiveWriter) Flush(eof bool) error {
+	var err error
+	if len(p.bytes) > 0 {
+		p.segments, err = p.spiller.Write(p.segments, p.bytes)
+		p.bytes = p.bytes[:0]
+	}
+	return err
+}
+
+func (p *PrimitiveWriter) MarshalZNG(zctx *resolver.Context, b *zcode.Builder) (zng.Type, error) {
+	b.BeginContainer()
+	for _, segment := range p.segments {
+		// Add a segmap record to the array for each segment.
+		b.BeginContainer()
+		b.AppendPrimitive(zng.EncodeInt(segment.Offset))
+		b.AppendPrimitive(zng.EncodeInt(segment.Length))
+		b.EndContainer()
+	}
+	b.EndContainer()
+	return zctx.LookupByName(SegmapTypeString)
+}
+
+type Primitive struct {
+	iter   zcode.Iter
+	segmap []Segment
+	reader io.ReaderAt
+}
+
+func (p *Primitive) UnmarshalZNG(in zng.Value, reader io.ReaderAt) error {
+	p.reader = reader
+	return UnmarshalSegmap(in, &p.segmap)
+}
+
+func (p *Primitive) Read(b *zcode.Builder) error {
+	zv, err := p.read()
+	if err == nil {
+		b.AppendPrimitive(zv)
+	}
+	return err
+}
+
+func (p *Primitive) read() (zcode.Bytes, error) {
+	if p.iter == nil || p.iter.Done() {
+		if len(p.segmap) == 0 {
+			return nil, io.EOF
+		}
+		if err := p.next(); err != nil {
+			return nil, err
+		}
+	}
+	zv, _, err := p.iter.Next()
+	return zv, err
+}
+
+func (p *Primitive) next() error {
+	segment := p.segmap[0]
+	p.segmap = p.segmap[1:]
+	if segment.Length > 2*MaxSegmentThresh {
+		return errors.New("segment too big")
+	}
+	b := make([]byte, segment.Length)
+	//XXX this where lots of seeks can happen until we put intelligent
+	// scheduling in a layer below this informed by the reassembly maps
+	// and the query that is going to run.
+	n, err := p.reader.ReadAt(b, segment.Offset)
+	if err != nil {
+		return err
+	}
+	if n < int(segment.Length) {
+		return errors.New("truncated read of zst column")
+	}
+	p.iter = zcode.Iter(b)
+	return nil
+}

--- a/zst/column/record.go
+++ b/zst/column/record.go
@@ -1,0 +1,131 @@
+package column
+
+import (
+	"errors"
+	"io"
+
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+var ErrColumnMismatch = errors.New("zng record value doesn't match column writer")
+
+type RecordWriter []*FieldWriter
+
+func NewRecordWriter(typ *zng.TypeRecord, spiller *Spiller) RecordWriter {
+	var r RecordWriter
+	for _, col := range typ.Columns {
+		fw := &FieldWriter{
+			name:     col.Name,
+			column:   NewWriter(col.Type, spiller),
+			presence: NewPresenceWriter(spiller),
+		}
+		r = append(r, fw)
+	}
+	return r
+}
+
+func (r RecordWriter) Write(body zcode.Bytes) error {
+	it := body.Iter()
+	for _, f := range r {
+		if it.Done() {
+			return ErrColumnMismatch
+		}
+		body, _, err := it.Next()
+		if err != nil {
+			return err
+		}
+		if err := f.write(body); err != nil {
+			return err
+		}
+	}
+	if !it.Done() {
+		return ErrColumnMismatch
+	}
+	return nil
+}
+
+func (r RecordWriter) Flush(eof bool) error {
+	// XXX we might want to arrange these flushes differently for locality
+	for _, f := range r {
+		if err := f.Flush(eof); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r RecordWriter) MarshalZNG(zctx *resolver.Context, b *zcode.Builder) (zng.Type, error) {
+	var columns []zng.Column
+	b.BeginContainer()
+	for _, f := range r {
+		fieldType, err := f.encode(zctx, b)
+		if err != nil {
+			return nil, err
+		}
+		columns = append(columns, zng.Column{f.name, fieldType})
+	}
+	b.EndContainer()
+	return zctx.LookupTypeRecord(columns)
+}
+
+type Record []*Field
+
+func (r *Record) UnmarshalZNG(typ *zng.TypeRecord, in zng.Value, reader io.ReaderAt) error {
+	rtype, ok := in.Type.(*zng.TypeRecord)
+	if !ok {
+		return errors.New("corrupt zst object: record_column is not a record")
+	}
+	k := 0
+	for it := zcode.Iter(in.Bytes); !it.Done(); k++ {
+		zv, _, err := it.Next()
+		if err != nil {
+			return err
+		}
+		if k >= len(typ.Columns) {
+			return errors.New("mismatch between record type and record_column") //XXX
+		}
+		fieldType := typ.Columns[k].Type
+		f := &Field{}
+		if err = f.UnmarshalZNG(fieldType, zng.Value{rtype.Columns[k].Type, zv}, reader); err != nil {
+			return err
+		}
+		*r = append(*r, f)
+	}
+	return nil
+}
+
+func (r Record) Read(b *zcode.Builder) error {
+	b.BeginContainer()
+	for _, f := range r {
+		if err := f.Read(b); err != nil {
+			return err
+		}
+	}
+	b.EndContainer()
+	return nil
+}
+
+var ErrNonRecordAccess = errors.New("attempting to access a field in a non-record value")
+
+func (r Record) Lookup(typ *zng.TypeRecord, fields []string) (zng.Type, Interface, error) {
+	if len(fields) == 0 {
+		panic("column.Record.Lookup cannot be called with an empty fields argument")
+	}
+	k, ok := typ.ColumnOfField(fields[0])
+	if !ok {
+		return nil, nil, zng.ErrNoSuchField
+	}
+	t := typ.Columns[k].Type
+	if len(fields) == 1 {
+		return t, r[k], nil
+	}
+	typ, ok = t.(*zng.TypeRecord)
+	if !ok {
+		// This condition can happen when you are cutting id.foo and there
+		// is a field "id" that isn't a record so cut should ignore it.
+		return nil, nil, ErrNonRecordAccess
+	}
+	return r[k].column.(*Record).Lookup(typ, fields[1:])
+}

--- a/zst/column/record.go
+++ b/zst/column/record.go
@@ -60,7 +60,7 @@ func (r RecordWriter) MarshalZNG(zctx *resolver.Context, b *zcode.Builder) (zng.
 	var columns []zng.Column
 	b.BeginContainer()
 	for _, f := range r {
-		fieldType, err := f.encode(zctx, b)
+		fieldType, err := f.MarshalZNG(zctx, b)
 		if err != nil {
 			return nil, err
 		}

--- a/zst/column/segment.go
+++ b/zst/column/segment.go
@@ -1,0 +1,82 @@
+package column
+
+import (
+	"errors"
+	"io"
+
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+)
+
+const SegmapTypeString = "array[record[offset:int64,length:int32]]"
+
+type Segment struct {
+	Offset int64
+	Length int64
+}
+
+func (s Segment) NewSectionReader(r io.ReaderAt) io.Reader {
+	return io.NewSectionReader(r, s.Offset, s.Length)
+}
+
+var ErrCorruptSegment = errors.New("segmap value corrupt")
+
+func UnmarshalSegment(zv zcode.Bytes, s *Segment) error {
+	it := zcode.Iter(zv)
+	zv, isContainer, err := it.Next()
+	if err != nil {
+		return err
+	}
+	if isContainer {
+		return ErrCorruptSegment
+	}
+	v, err := zng.DecodeInt(zv)
+	if err != nil {
+		return err
+	}
+	s.Offset = v
+	zv, isContainer, err = it.Next()
+	if err != nil {
+		return err
+	}
+	if isContainer {
+		return ErrCorruptSegment
+	}
+	s.Length, err = zng.DecodeInt(zv)
+	return err
+}
+
+func checkSegType(col zng.Column, which string, typ zng.Type) bool {
+	return col.Name == which && col.Type == typ
+}
+
+func UnmarshalSegmap(in zng.Value, s *[]Segment) error {
+	typ, ok := in.Type.(*zng.TypeArray)
+	if !ok {
+		return errors.New("zst object segmap not an array")
+	}
+	segType, ok := typ.Type.(*zng.TypeRecord)
+	if !ok {
+		return errors.New("zst object segmap element not a record")
+	}
+	if len(segType.Columns) != 2 || !checkSegType(segType.Columns[0], "offset", zng.TypeInt64) || !checkSegType(segType.Columns[1], "length", zng.TypeInt32) {
+		return errors.New("zst object segmap element not a record[offset:int64,length:int32]")
+	}
+	*s = make([]Segment, 0)
+	it := zcode.Iter(in.Bytes)
+	for !it.Done() {
+		zv, isContainer, err := it.Next()
+		if err != nil {
+			return err
+		}
+		if !isContainer {
+			return ErrCorruptSegment
+		}
+		var segment Segment
+		if err := UnmarshalSegment(zv, &segment); err != nil {
+			return err
+		}
+		*s = append(*s, segment)
+	}
+	return nil
+}

--- a/zst/column/spiller.go
+++ b/zst/column/spiller.go
@@ -1,0 +1,34 @@
+package column
+
+import (
+	"io"
+
+	"github.com/brimsec/zq/zcode"
+)
+
+type Spiller struct {
+	writer io.Writer
+	off    int64
+	Thresh int
+}
+
+func NewSpiller(w io.Writer, thresh int) *Spiller {
+	return &Spiller{
+		writer: w,
+		Thresh: thresh,
+	}
+}
+
+func (s *Spiller) Position() int64 {
+	return s.off
+}
+
+func (s *Spiller) Write(segments []Segment, b zcode.Bytes) ([]Segment, error) {
+	n, err := s.writer.Write(b)
+	if err != nil {
+		return segments, err
+	}
+	segment := Segment{s.off, int64(n)}
+	s.off += int64(n)
+	return append(segments, segment), nil
+}

--- a/zst/column/union.go
+++ b/zst/column/union.go
@@ -1,0 +1,123 @@
+package column
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type UnionWriter struct {
+	typ      *zng.TypeUnion
+	values   []Writer
+	selector *IntWriter
+}
+
+func NewUnionWriter(typ *zng.TypeUnion, spiller *Spiller) *UnionWriter {
+	var values []Writer
+	for _, typ := range typ.Types {
+		values = append(values, NewWriter(typ, spiller))
+	}
+	return &UnionWriter{
+		typ:      typ,
+		values:   values,
+		selector: NewIntWriter(spiller),
+	}
+}
+
+func (u *UnionWriter) Write(body zcode.Bytes) error {
+	_, selector, zv, err := u.typ.SplitZng(body)
+	if err != nil {
+		return err
+	}
+	if int(selector) >= len(u.values) || selector < 0 {
+		return fmt.Errorf("bad selector in column.UnionWriter: %d", selector)
+	}
+	if err := u.selector.Write(int32(selector)); err != nil {
+		return err
+	}
+	return u.values[selector].Write(zv)
+}
+
+func (u *UnionWriter) Flush(eof bool) error {
+	if err := u.selector.Flush(eof); err != nil {
+		return err
+	}
+	for _, value := range u.values {
+		if err := value.Flush(eof); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (u *UnionWriter) MarshalZNG(zctx *resolver.Context, b *zcode.Builder) (zng.Type, error) {
+	var cols []zng.Column
+	b.BeginContainer()
+	for k, value := range u.values {
+		typ, err := value.MarshalZNG(zctx, b)
+		if err != nil {
+			return nil, err
+		}
+		// Field name is based on integer position in the column.
+		name := fmt.Sprintf("c%d", k)
+		cols = append(cols, zng.Column{name, typ})
+	}
+	typ, err := u.selector.MarshalZNG(zctx, b)
+	if err != nil {
+		return nil, err
+	}
+	cols = append(cols, zng.Column{"selector", typ})
+	b.EndContainer()
+	return zctx.LookupTypeRecord(cols)
+}
+
+type Union struct {
+	values   []Interface
+	selector *Int
+}
+
+func (u *Union) UnmarshalZNG(typ *zng.TypeUnion, in zng.Value, r io.ReaderAt) error {
+	rtype, ok := in.Type.(*zng.TypeRecord)
+	if !ok {
+		return errors.New("zst object union_column not a record")
+	}
+	rec := zng.NewRecord(rtype, in.Bytes)
+	for k := 0; k < len(typ.Types); k++ {
+		zv, err := rec.Access(fmt.Sprintf("c%d", k))
+		if err != nil {
+			return err
+		}
+		valueCol, err := Unmarshal(typ.Types[k], zv, r)
+		if err != nil {
+			return err
+		}
+		u.values = append(u.values, valueCol)
+	}
+	zv, err := rec.Access("selector")
+	if err != nil {
+		return err
+	}
+	u.selector = &Int{}
+	return u.selector.UnmarshalZNG(zv, r)
+}
+
+func (u *Union) Read(b *zcode.Builder) error {
+	selector, err := u.selector.Read()
+	if err != nil {
+		return err
+	}
+	if selector < 0 || int(selector) >= len(u.values) {
+		return errors.New("bad selector in zst union reader") //XXX
+	}
+	b.BeginContainer()
+	b.AppendPrimitive(zng.EncodeInt(int64(selector)))
+	if err := u.values[selector].Read(b); err != nil {
+		return err
+	}
+	b.EndContainer()
+	return nil
+}

--- a/zst/cutter.go
+++ b/zst/cutter.go
@@ -1,0 +1,153 @@
+package zst
+
+import (
+	"errors"
+	"io"
+
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zst/column"
+)
+
+func NewCutter(object *Object, fields []string) (*Reader, error) {
+	assembler, err := NewCutAssembler(object.zctx, fields, object)
+	if err != nil {
+		return nil, err
+	}
+	return &Reader{
+		Object: object,
+		Reader: assembler,
+	}, nil
+
+}
+
+func NewCutterFromPath(zctx *resolver.Context, path string, fields []string) (*Reader, error) {
+	object, err := NewObjectFromPath(zctx, path)
+	if err != nil {
+		return nil, err
+	}
+	reader, err := NewCutter(object, fields)
+	if err != nil {
+		object.Close()
+		return nil, err
+	}
+	return reader, nil
+}
+
+type CutAssembler struct {
+	zctx    *resolver.Context
+	root    *column.Int
+	schemas []*zng.TypeRecord
+	columns []column.Interface
+	types   []*zng.TypeRecord
+	nwrap   []int
+	builder zcode.Builder
+	leaf    string
+}
+
+func NewCutAssembler(zctx *resolver.Context, fields []string, object *Object) (*CutAssembler, error) {
+	a := object.assembly
+	n := len(a.columns)
+	ca := &CutAssembler{
+		zctx:    zctx,
+		root:    &column.Int{},
+		schemas: a.schemas,
+		columns: make([]column.Interface, n),
+		types:   make([]*zng.TypeRecord, n),
+		nwrap:   make([]int, n),
+		leaf:    fields[len(fields)-1],
+	}
+	if err := ca.root.UnmarshalZNG(a.root, object.seeker); err != nil {
+		return nil, err
+	}
+	cnt := 0
+	for k, schema := range a.schemas {
+		var err error
+		rec := a.columns[k]
+		zv := zng.Value{rec.Type, rec.Raw}
+		topcol := &column.Record{}
+		if err := topcol.UnmarshalZNG(a.schemas[k], zv, object.seeker); err != nil {
+			return nil, err
+		}
+		_, ca.columns[k], err = topcol.Lookup(schema, fields)
+		if err == zng.ErrNoSuchField || err == column.ErrNonRecordAccess {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		ca.types[k], ca.nwrap[k], err = cutType(zctx, schema, fields)
+		if err != nil {
+			return nil, err
+		}
+		cnt++
+	}
+	if cnt == 0 {
+		return nil, zng.ErrNoSuchField
+	}
+	return ca, nil
+}
+
+func cutType(zctx *resolver.Context, typ *zng.TypeRecord, fields []string) (*zng.TypeRecord, int, error) {
+	if len(fields) == 0 {
+		panic("zst.cutType cannot be called with an empty fields argument")
+	}
+	k, ok := typ.ColumnOfField(fields[0])
+	if !ok {
+		return nil, 0, zng.ErrNoSuchField
+	}
+	if len(fields) == 1 {
+		col := []zng.Column{typ.Columns[k]}
+		recType, err := zctx.LookupTypeRecord(col)
+		return recType, 0, err
+	}
+	fieldName := typ.Columns[k].Name
+	typ, ok = typ.Columns[k].Type.(*zng.TypeRecord)
+	if !ok {
+		return nil, 0, column.ErrNonRecordAccess
+	}
+	typ, nwrap, err := cutType(zctx, typ, fields[1:])
+	if err != nil {
+		return nil, 0, err
+	}
+	col := []zng.Column{{fieldName, typ}}
+	wrapType, err := zctx.LookupTypeRecord(col)
+	return wrapType, nwrap + 1, err
+}
+
+func (a *CutAssembler) Read() (*zng.Record, error) {
+	a.builder.Reset()
+	for {
+		schemaID, err := a.root.Read()
+		if err == io.EOF {
+			return nil, nil
+		}
+		if schemaID < 0 || int(schemaID) >= len(a.columns) {
+			return nil, errors.New("bad schema id in root reassembly column")
+		}
+		col := a.columns[schemaID]
+		if col == nil {
+			// Skip records that don't have the field we're cutting.
+			continue
+		}
+		nwrap := a.nwrap[schemaID]
+		for n := nwrap; n > 0; n-- {
+			a.builder.BeginContainer()
+		}
+		err = col.Read(&a.builder)
+		if err != nil {
+			return nil, err
+		}
+		for n := nwrap; n > 0; n-- {
+			a.builder.EndContainer()
+		}
+		recType := a.types[schemaID]
+		rec := zng.NewRecord(recType, a.builder.Bytes())
+		//XXX if we had a buffer pool where records could be built back to
+		// back in batches, then we could get rid of this extra allocation
+		// and copy on every record
+		rec.Keep()
+		return rec, nil
+	}
+}

--- a/zst/cutter.go
+++ b/zst/cutter.go
@@ -1,6 +1,7 @@
 package zst
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -22,8 +23,8 @@ func NewCutter(object *Object, fields []string) (*Reader, error) {
 
 }
 
-func NewCutterFromPath(zctx *resolver.Context, path string, fields []string) (*Reader, error) {
-	object, err := NewObjectFromPath(zctx, path)
+func NewCutterFromPath(ctx context.Context, zctx *resolver.Context, path string, fields []string) (*Reader, error) {
+	object, err := NewObjectFromPath(ctx, zctx, path)
 	if err != nil {
 		return nil, err
 	}

--- a/zst/object.go
+++ b/zst/object.go
@@ -26,6 +26,7 @@
 package zst
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -86,16 +87,16 @@ func NewObjectFromSeeker(zctx *resolver.Context, s Seeker) (*Object, error) {
 	return NewObject(zctx, s, size)
 }
 
-func NewObjectFromPath(zctx *resolver.Context, path string) (*Object, error) {
+func NewObjectFromPath(ctx context.Context, zctx *resolver.Context, path string) (*Object, error) {
 	uri, err := iosrc.ParseURI(path)
 	if err != nil {
 		return nil, err
 	}
-	r, err := iosrc.NewReader(uri)
+	r, err := iosrc.NewReader(ctx, uri)
 	if err != nil {
 		return nil, err
 	}
-	si, err := iosrc.Stat(uri)
+	si, err := iosrc.Stat(ctx, uri)
 	if err != nil {
 		return nil, err
 	}

--- a/zst/object.go
+++ b/zst/object.go
@@ -1,0 +1,195 @@
+// Package zst implements reading and writing zst storage objects
+// to and from zng row format.  The zst storage format consists of
+// a section of column data stored in zng values followed by a section
+// containing a zng record stream comprised of N zng "reassembly records"
+// (one for each zng.TypeRecord or "schema") stored in the zst object, plus
+// an N+1st zng record describing the list of schemas IDs of the original
+// zng rows that were encoded into the zst object.
+//
+// A zst storage object must be seekable (e.g., a local file or s3 object),
+// so, unlike zng, streaming of zst objects is not supported.
+//
+// The zst/column package handles reading and writing row data to columns,
+// while the zst package comprises the API used to read and write zst objects.
+//
+// An Object provides the interface to the underlying storage object.
+// To generate rows or cuts (and in the future more sophisticated traversals
+// and introspection), an Assembly is created from the Object then zng records
+// are read from the assembly, which implements zbuf.Reader.  The Assembly
+// keeps track of where each column is, which is why you need a separate
+// Assembly per scan.
+//
+// You can have multiple Assembly's referring to one Object as once an
+// object is created, it's state never changes.  That said, each assembly
+// will issue reads to the underlying storage object and the read pattern
+// may create performance issues.
+package zst
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zst/column"
+)
+
+type Seeker interface {
+	io.Reader
+	io.ReaderAt
+	io.Seeker
+}
+
+type Object struct {
+	seeker   Seeker
+	closer   io.Closer
+	zctx     *resolver.Context
+	assembly *Assembly
+	trailer  *Trailer
+	size     int64
+	builder  zcode.Builder
+	err      error
+}
+
+func NewObject(zctx *resolver.Context, s Seeker, size int64) (*Object, error) {
+	trailer, err := readTrailer(s, size)
+	if err != nil {
+		return nil, err
+	}
+	if trailer.SkewThresh > MaxSkewThresh {
+		return nil, fmt.Errorf("skew threshold too large (%d)", trailer.SkewThresh)
+	}
+	if trailer.SegmentThresh > MaxSegmentThresh {
+		return nil, fmt.Errorf("column threshold too large (%d)", trailer.SegmentThresh)
+	}
+	o := &Object{
+		seeker:  s,
+		zctx:    zctx,
+		size:    size,
+		trailer: trailer,
+	}
+	o.assembly, err = o.readAssembly()
+	return o, err
+}
+
+func NewObjectFromSeeker(zctx *resolver.Context, s Seeker) (*Object, error) {
+	// We can't get the size from a stat, so get it by seeking.
+	size, err := s.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, err
+	}
+	return NewObject(zctx, s, size)
+}
+
+func NewObjectFromPath(zctx *resolver.Context, path string) (*Object, error) {
+	uri, err := iosrc.ParseURI(path)
+	if err != nil {
+		return nil, err
+	}
+	r, err := iosrc.NewReader(uri)
+	if err != nil {
+		return nil, err
+	}
+	si, err := iosrc.Stat(uri)
+	if err != nil {
+		return nil, err
+	}
+	o, err := NewObject(zctx, r, si.Size())
+	if err == nil {
+		o.closer = r
+	}
+	return o, err
+}
+
+func (o *Object) Close() error {
+	if o.closer != nil {
+		return o.closer.Close()
+	}
+	return nil
+}
+
+func (o *Object) IsEmpty() bool {
+	if o.trailer == nil {
+		panic("IsEmpty called on a Reader with an error")
+	}
+	return o.trailer.Sections == nil
+}
+
+func (o *Object) readAssembly() (*Assembly, error) {
+	reader := o.NewReassemblyReader()
+	assembly := &Assembly{}
+	var rec *zng.Record
+	for {
+		var err error
+		rec, err = reader.Read()
+		if err != nil {
+			return nil, err
+		}
+		if rec == nil {
+			return nil, errors.New("no reassembly records found in zst file")
+		}
+		zv := rec.Value(0)
+		if zv.Bytes != nil {
+			break
+		}
+		assembly.schemas = append(assembly.schemas, rec.Type)
+	}
+	var err error
+	assembly.root, err = rec.Access("root")
+	if err != nil {
+		return nil, err
+	}
+	expectedType, err := o.zctx.LookupByName(column.SegmapTypeString)
+	if err != nil {
+		return nil, err
+	}
+	if assembly.root.Type != expectedType {
+		return nil, fmt.Errorf("zst root reassembly value has wrong type: %s; should be %s", assembly.root.Type, expectedType)
+	}
+
+	for k := 0; k < len(assembly.schemas); k++ {
+		rec, err := reader.Read()
+		if err != nil {
+			return nil, err
+		}
+		assembly.columns = append(assembly.columns, rec)
+	}
+	rec, _ = reader.Read()
+	if rec != nil {
+		return nil, errors.New("extra records in reassembly section")
+	}
+	return assembly, nil
+}
+
+//XXX this should be a common method on Trailer and shared with microindexes
+func (o *Object) section(level int) (int64, int64) {
+	off := int64(0)
+	for k := 0; k < level; k++ {
+		off += o.trailer.Sections[k]
+	}
+	return off, o.trailer.Sections[level]
+}
+
+func (o *Object) newSectionReader(level int, sectionOff int64) zbuf.Reader {
+	off, len := o.section(level)
+	off += sectionOff
+	len -= sectionOff
+	reader := io.NewSectionReader(o.seeker, off, len)
+	return zngio.NewReader(reader, o.zctx)
+}
+
+func (o *Object) NewReassemblyReader() zbuf.Reader {
+	return o.newSectionReader(1, 0)
+}
+
+func (o *Object) NewTrailerReader() zbuf.Reader {
+	len := o.trailer.Length
+	off := o.size - int64(len)
+	reader := io.NewSectionReader(o.seeker, off, int64(len))
+	return zngio.NewReaderWithOpts(reader, o.zctx, zngio.ReaderOpts{Size: len})
+}

--- a/zst/reader.go
+++ b/zst/reader.go
@@ -1,6 +1,8 @@
 package zst
 
 import (
+	"context"
+
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 )
@@ -27,8 +29,8 @@ func NewReader(object *Object) (*Reader, error) {
 
 }
 
-func NewReaderFromPath(zctx *resolver.Context, path string) (*Reader, error) {
-	object, err := NewObjectFromPath(zctx, path)
+func NewReaderFromPath(ctx context.Context, zctx *resolver.Context, path string) (*Reader, error) {
+	object, err := NewObjectFromPath(ctx, zctx, path)
 	if err != nil {
 		return nil, err
 	}

--- a/zst/reader.go
+++ b/zst/reader.go
@@ -1,0 +1,54 @@
+package zst
+
+import (
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+// Reader implements the zbuf.Reader and io.Closer.  It reads a columnar
+// zst object to generate a stream of zng.Records.  It also has methods
+// to read metainformation for test and debugging.
+type Reader struct {
+	*Object
+	zbuf.Reader
+}
+
+// NewReader returns a Reader ready to read a zst object as zng.Records.
+// Close() should be called when done.  This embeds a zst.Object.
+func NewReader(object *Object) (*Reader, error) {
+	assembler, err := NewAssembler(object.assembly, object.seeker)
+	if err != nil {
+		return nil, err
+	}
+	return &Reader{
+		Object: object,
+		Reader: assembler,
+	}, nil
+
+}
+
+func NewReaderFromPath(zctx *resolver.Context, path string) (*Reader, error) {
+	object, err := NewObjectFromPath(zctx, path)
+	if err != nil {
+		return nil, err
+	}
+	reader, err := NewReader(object)
+	if err != nil {
+		object.Close()
+		return nil, err
+	}
+	return reader, nil
+}
+
+func NewReaderFromSeeker(zctx *resolver.Context, seeker Seeker) (*Reader, error) {
+	object, err := NewObjectFromSeeker(zctx, seeker)
+	if err != nil {
+		return nil, err
+	}
+	reader, err := NewReader(object)
+	if err != nil {
+		// don't close object as we didn't open the seeker
+		return nil, err
+	}
+	return reader, nil
+}

--- a/zst/trailer.go
+++ b/zst/trailer.go
@@ -1,0 +1,177 @@
+package zst
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+const (
+	MagicField         = "magic"
+	VersionField       = "version"
+	SkewThreshField    = "skew_thresh"
+	SegmentThreshField = "segment_thresh"
+	SectionsField      = "sections"
+
+	MagicVal   = "zst"
+	VersionVal = 1
+
+	TrailerMaxSize = 4096
+)
+
+// XXX we should make generic trailer package and share between microindex and zst
+
+type Trailer struct {
+	Length        int
+	Magic         string
+	Version       int
+	SkewThresh    int
+	SegmentThresh int
+	Sections      []int64
+}
+
+var ErrNotZst = errors.New("not a zst object")
+
+func newTrailerRecord(zctx *resolver.Context, skewThresh, segmentThresh int, sections []int64) (*zng.Record, error) {
+	sectionsType := zctx.LookupTypeArray(zng.TypeInt64)
+	cols := []zng.Column{
+		{MagicField, zng.TypeString},
+		{VersionField, zng.TypeInt32},
+		{SkewThreshField, zng.TypeInt32},
+		{SegmentThreshField, zng.TypeInt32},
+		{SectionsField, sectionsType},
+	}
+	typ, err := zctx.LookupTypeRecord(cols)
+	if err != nil {
+		return nil, err
+	}
+	builder := zng.NewBuilder(typ)
+	return builder.Build(
+		zng.EncodeString(MagicVal),
+		zng.EncodeInt(VersionVal),
+		zng.EncodeInt(int64(skewThresh)),
+		zng.EncodeInt(int64(segmentThresh)),
+		encodeSections(sections)), nil
+}
+
+func encodeSections(sections []int64) zcode.Bytes {
+	var b zcode.Builder
+	for _, s := range sections {
+		b.AppendPrimitive(zng.EncodeInt(s))
+	}
+	return b.Bytes()
+}
+
+func readTrailer(r io.ReadSeeker, n int64) (*Trailer, error) {
+	if n > TrailerMaxSize {
+		n = TrailerMaxSize
+	}
+	if _, err := r.Seek(-n, io.SeekEnd); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, n)
+	cc, err := r.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	if int64(cc) != n {
+		// This shouldn't happen but maybe could occur under a corner case
+		// or I/O problems.
+		return nil, fmt.Errorf("couldn't read trailer: expected %d bytes but read %d", n, cc)
+	}
+	for off := int(n) - 3; off >= 0; off-- {
+		// Look for end of stream followed by an array[int64] typedef then
+		// a record typedef indicating the possible presence of the trailer,
+		// which we then try to decode.
+		if bytes.Equal(buf[off:(off+3)], []byte{zng.TypeDefArray, zng.IdInt64, zng.TypeDefRecord}) {
+			if off > 0 && buf[off-1] != zng.CtrlEOS {
+				// If this isn't right after an end-of-stream
+				// (and we're not at the start of index), then
+				// we skip because it can't be a valid trailer.
+				continue
+			}
+			r := bytes.NewReader(buf[off:n])
+			rec, _ := zngio.NewReader(r, resolver.NewContext()).Read()
+			if rec == nil {
+				continue
+			}
+			_, err := trailerVersion(rec)
+			if err != nil {
+				return nil, err
+			}
+			trailer, _ := recordToTrailer(rec)
+			if trailer != nil {
+				trailer.Length = int(n) - off
+				return trailer, nil
+			}
+		}
+	}
+	return nil, errors.New("zst trailer not found")
+}
+
+func trailerVersion(rec *zng.Record) (int, error) {
+	version, err := rec.AccessInt(VersionField)
+	if err != nil {
+		return -1, errors.New("zst version field is not a valid int32")
+	}
+	if version != VersionVal {
+		return -1, fmt.Errorf("zst version %d found while expecting version %d", version, VersionVal)
+	}
+	return int(version), nil
+}
+
+func recordToTrailer(rec *zng.Record) (*Trailer, error) {
+	var trailer Trailer
+	var err error
+	trailer.Magic, err = rec.AccessString(MagicField)
+	if err != nil || trailer.Magic != MagicVal {
+		return nil, ErrNotZst
+	}
+	trailer.Version, err = trailerVersion(rec)
+	if err != nil {
+		return nil, err
+	}
+
+	trailer.Sections, err = decodeSections(rec)
+	if err != nil {
+		return nil, err
+	}
+	return &trailer, nil
+}
+
+func decodeSections(rec *zng.Record) ([]int64, error) {
+	v, err := rec.Access(SectionsField)
+	if err != nil {
+		return nil, err
+	}
+	arrayType, ok := v.Type.(*zng.TypeArray)
+	if !ok {
+		return nil, fmt.Errorf("%s field in zst trailer is not an arrray", SectionsField)
+	}
+	if v.Bytes == nil {
+		// This is an empty index.  Just return nil/success.
+		return nil, nil
+	}
+	zvals, err := arrayType.Decode(v.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	var sizes []int64
+	for _, zv := range zvals {
+		if zv.Type != zng.TypeInt64 {
+			return nil, errors.New("section element is not an int64")
+		}
+		size, err := zng.DecodeInt(zv.Bytes)
+		if err != nil {
+			return nil, errors.New("int64 section element could not be decoded")
+		}
+		sizes = append(sizes, size)
+	}
+	return sizes, nil
+}

--- a/zst/writer.go
+++ b/zst/writer.go
@@ -1,6 +1,7 @@
 package zst
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -70,12 +71,12 @@ type WriterURI struct {
 	uri iosrc.URI
 }
 
-func NewWriterFromPath(path string, skewThresh, segThresh int) (*WriterURI, error) {
+func NewWriterFromPath(ctx context.Context, path string, skewThresh, segThresh int) (*WriterURI, error) {
 	uri, err := iosrc.ParseURI(path)
 	if err != nil {
 		return nil, err
 	}
-	w, err := iosrc.NewWriter(uri)
+	w, err := iosrc.NewWriter(ctx, uri)
 	if err != nil {
 		return nil, err
 	}
@@ -126,9 +127,9 @@ func (w *Writer) Write(rec *zng.Record) error {
 
 // Abort closes this writer, deleting any and all objects and/or files associated
 // with it.
-func (w *WriterURI) Abort() error {
+func (w *WriterURI) Abort(ctx context.Context) error {
 	firstErr := w.writer.Close()
-	if err := iosrc.Remove(w.uri); firstErr == nil {
+	if err := iosrc.Remove(ctx, w.uri); firstErr == nil {
 		firstErr = err
 	}
 	return firstErr

--- a/zst/writer.go
+++ b/zst/writer.go
@@ -1,0 +1,235 @@
+package zst
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/brimsec/zq/pkg/bufwriter"
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zst/column"
+)
+
+const (
+	MaxSegmentThresh = column.MaxSegmentThresh
+	MaxSkewThresh    = 512 * 1024 * 1024
+)
+
+// Writer implements the zbuf.Writer interface. A Writer creates a columnar
+// zst object from a stream of zng.Records.
+type Writer struct {
+	zctx       *resolver.Context
+	writer     io.WriteCloser
+	spiller    *column.Spiller
+	schemaMap  map[int]int
+	schemas    []column.RecordWriter
+	types      []*zng.TypeRecord
+	skewThresh int
+	segThresh  int
+	// We keep track of the size of rows we've encoded into in-memory
+	// data structures.  This is roughtly propertional to the amount of
+	// memory used and the max amount of skew between rows that will be
+	// needed for reader-side buffering.  So when the memory footprint
+	// exceeds the confired skew theshhold, we flush the columns to storage.
+	footprint int
+	root      *column.IntWriter
+}
+
+func NewWriter(w io.WriteCloser, skewThresh, segThresh int) (*Writer, error) {
+	if err := checkThresh("skew", MaxSkewThresh, skewThresh); err != nil {
+		return nil, err
+	}
+	if err := checkThresh("column", MaxSegmentThresh, segThresh); err != nil {
+		return nil, err
+	}
+	spiller := column.NewSpiller(w, segThresh)
+	return &Writer{
+		zctx:       resolver.NewContext(),
+		spiller:    spiller,
+		writer:     w,
+		schemaMap:  make(map[int]int),
+		skewThresh: skewThresh,
+		segThresh:  segThresh,
+		root:       column.NewIntWriter(spiller),
+	}, nil
+}
+
+func (w *Writer) Close() error {
+	firstErr := w.finalize()
+	if err := w.writer.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+type WriterURI struct {
+	Writer
+	uri iosrc.URI
+}
+
+func NewWriterFromPath(path string, skewThresh, segThresh int) (*WriterURI, error) {
+	uri, err := iosrc.ParseURI(path)
+	if err != nil {
+		return nil, err
+	}
+	w, err := iosrc.NewWriter(uri)
+	if err != nil {
+		return nil, err
+	}
+	writer, err := NewWriter(bufwriter.New(w), skewThresh, segThresh)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", uri, err)
+	}
+	return &WriterURI{*writer, uri}, nil
+}
+
+func checkThresh(which string, max, thresh int) error {
+	if thresh == 0 {
+		return fmt.Errorf("zst %s threshold cannot be zero", which)
+	}
+	if thresh > max {
+		return fmt.Errorf("zst %s threshold too large (%d)", which, thresh)
+	}
+	return nil
+}
+
+func (w *Writer) Write(rec *zng.Record) error {
+	inputID := rec.Type.ID()
+	schemaID, ok := w.schemaMap[inputID]
+	if !ok {
+		recType, err := w.zctx.TranslateTypeRecord(rec.Type)
+		if err != nil {
+			return err
+		}
+		schemaID = len(w.schemas)
+		w.schemaMap[inputID] = schemaID
+		rw := column.NewRecordWriter(recType, w.spiller)
+		w.schemas = append(w.schemas, rw)
+		w.types = append(w.types, recType)
+	}
+	if err := w.root.Write(int32(schemaID)); err != nil {
+		return err
+	}
+	if err := w.schemas[schemaID].Write(rec.Raw); err != nil {
+		return err
+	}
+	w.footprint += len(rec.Raw)
+	if w.footprint >= w.skewThresh {
+		w.footprint = 0
+		return w.flush(false)
+	}
+	return nil
+}
+
+// Abort closes this writer, deleting any and all objects and/or files associated
+// with it.
+func (w *WriterURI) Abort() error {
+	firstErr := w.writer.Close()
+	if err := iosrc.Remove(w.uri); firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+func (w *WriterURI) Close() error {
+	if err := w.finalize(); err != nil {
+		w.writer.Close()
+		return err
+	}
+	return w.writer.Close()
+}
+
+func (w *Writer) flush(eof bool) error {
+	for _, col := range w.schemas {
+		if err := col.Flush(eof); err != nil {
+			return err
+		}
+	}
+	return w.root.Flush(eof)
+}
+
+func (w *Writer) finalize() error {
+	if err := w.flush(true); err != nil {
+		return err
+	}
+	// At this point all the column data has been written out
+	// to the underlying spiller, so we start writing zng at this point.
+	zw := zngio.NewWriter(w.writer, zngio.WriterOpts{})
+	dataSize := w.spiller.Position()
+	var b zcode.Builder
+	// First, write out empty records for each schemas.  Since these types
+	// are all put here first, in the orde they were originally encountered
+	// in the zng input, when they are read fresh by the zst reader, the
+	// reconstructued type context will exactly match the original context
+	// and the resulting zng output will be byte-equivalent to the original
+	// input.
+	for _, schema := range w.types {
+		b.Reset()
+		for _, col := range schema.Columns {
+			if zng.IsContainerType(col.Type) {
+				b.AppendContainer(nil)
+			} else {
+				b.AppendPrimitive(nil)
+			}
+		}
+		rec := zng.NewRecord(schema, b.Bytes())
+		if err := zw.Write(rec); err != nil {
+			return err
+		}
+	}
+	// Next, write the root reassembly record.
+	b.Reset()
+	typ, err := w.root.MarshalZNG(w.zctx, &b)
+	if err != nil {
+		return err
+	}
+	rootType, err := w.zctx.LookupTypeRecord([]zng.Column{{"root", typ}})
+	if err != nil {
+		return err
+	}
+	rec := zng.NewRecord(rootType, b.Bytes())
+	if err := zw.Write(rec); err != nil {
+		return err
+	}
+	// Now, write out the reassembly record for each schema.  Each record
+	// is highly nested and encodes all of the segmaps for every column stream
+	// needed to reconstruct all of the records of that schema.
+	for _, schema := range w.schemas {
+		b.Reset()
+		typ, err := schema.MarshalZNG(w.zctx, &b)
+		if err != nil {
+			return err
+		}
+		body, err := b.Bytes().ContainerBody()
+		if err != nil {
+			return err
+		}
+		rec := zng.NewRecord(typ.(*zng.TypeRecord), body)
+		if err := zw.Write(rec); err != nil {
+			return err
+		}
+	}
+	zw.EndStream()
+	columnSize := zw.Position()
+	sizes := []int64{dataSize, columnSize}
+	return writeTrailer(zw, w.zctx, w.skewThresh, w.segThresh, sizes)
+}
+
+func (w *Writer) writeEmptyTrailer() error {
+	zw := zngio.NewWriter(w.writer, zngio.WriterOpts{})
+	return writeTrailer(zw, w.zctx, w.skewThresh, w.segThresh, nil)
+}
+
+func writeTrailer(w *zngio.Writer, zctx *resolver.Context, skewThresh, segThresh int, sizes []int64) error {
+	rec, err := newTrailerRecord(zctx, skewThresh, segThresh, sizes)
+	if err != nil {
+		return err
+	}
+	if err := w.Write(rec); err != nil {
+		return err
+	}
+	return w.EndStream()
+}

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -590,9 +590,9 @@ func runzq(path, ZQL, outputFormat, outputFlags string, inputs ...string) (out s
 		return "", "", err
 	}
 	zflags.Format = outputFormat
-	zw := detector.LookupWriter(&nopCloser{&outbuf}, zflags.Options())
-	if zw == nil {
-		return "", "", fmt.Errorf("%s: unknown output format", outputFormat)
+	zw, err := detector.LookupWriter(&nopCloser{&outbuf}, zflags.Options())
+	if err != nil {
+		return "", "", err
 	}
 	d := driver.NewCLI(zw)
 	d.SetWarningsWriter(&errbuf)


### PR DESCRIPTION
This commit introduces the zst columnar format to zq.  Package zst
provides the core new functionality.  Package zstio is a zio wrapper
for zst to wire it into the zq pipeline.  A new CLI command "zst"
provides a tool for test, debug, and demo.

There is much more work to be done for columnar format but this
should serve as a good foundation to start from.

Fixes #1219 