### PR TITLE
update zapi to package zq/cli and other minor changes

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -107,6 +107,10 @@ func (f *OutputFlags) Init(opts *zio.WriterOpts) error {
 	return nil
 }
 
+func (f *OutputFlags) FileName() string {
+	return f.outputFile
+}
+
 func (o *OutputFlags) Open(opts zio.WriterOpts) (zbuf.WriteCloser, error) {
 	if o.dir != "" {
 		d, err := emitter.NewDir(o.dir, o.outputFile, os.Stderr, opts)

--- a/cmd/zapi/cmd/cli.go
+++ b/cmd/zapi/cmd/cli.go
@@ -25,7 +25,17 @@ var CLI = &charm.Spec{
 	Name:  "zapi",
 	Usage: "zapi [global options] command [options] [arguments...]",
 	Short: "use zapi to talk to a zqd server",
-	Long:  "",
+	Long: `
+The zapi command-line tool is used to talk to a zq analytics service.
+This service could be zqd running on your laptop or a zqd running in the cloud.
+
+Zapi is prounounced "zappy".
+
+With zapi you can create spaces, list spaces, post data to spaces, and run queries.
+
+The brim application and the zapi client use the same REST API
+for interacting with a zq analytics service.
+`,
 	New: func(parent charm.Command, flags *flag.FlagSet) (charm.Command, error) {
 		return New(flags)
 	},

--- a/cmd/zapi/cmd/cli.go
+++ b/cmd/zapi/cmd/cli.go
@@ -27,13 +27,13 @@ var CLI = &charm.Spec{
 	Short: "use zapi to talk to a zqd server",
 	Long: `
 The zapi command-line tool is used to talk to a zq analytics service.
-This service could be zqd running on your laptop or a zqd running in the cloud.
+This service could be zqd running on your laptop or in the cloud.
 
 Zapi is prounounced "zappy".
 
 With zapi you can create spaces, list spaces, post data to spaces, and run queries.
 
-The brim application and the zapi client use the same REST API
+The Brim application and the zapi client use the same REST API
 for interacting with a zq analytics service.
 `,
 	New: func(parent charm.Command, flags *flag.FlagSet) (charm.Command, error) {

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/brimsec/zq/cli"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/emitter"
 	"github.com/brimsec/zq/pkg/fs"
@@ -25,8 +26,30 @@ var Get = &charm.Spec{
 	Name:  "get",
 	Usage: "get [options] <search>",
 	Short: "perform zql searches",
-	Long:  "TODO",
-	New:   New,
+	Long: `
+zapi get issues search requests to the zqd search service.
+
+The -from and -to options specify a time range.  If not provided, the entire
+space is searched.
+
+By default, the service streams results in native zng and the zapi client
+converts the results to the format specified by -f.
+
+Alternatively, the -e option can specify a different encoding to be used by
+the server, in which case, the output is not converted by -f.  These two options
+cannot be used together.
+
+Statistics and warnings can be displayed on stderr, which can be useful
+for long running jobs.
+
+Everything is flow-controlled end to end, so if the client host, network,
+or disk becomes a bottleneck, the service will naturally clock itself
+at the rate determined by the client.
+
+The -debug option can be useful for debugging.  In this case, the server
+response is written unmodified in its entirety to the output.
+`,
+	New: New,
 }
 
 func init() {
@@ -37,14 +60,14 @@ func init() {
 type Command struct {
 	*cmd.Command
 	writerFlags zio.WriterFlags
-	protocol    string
+	output      cli.OutputFlags
+	encoding    string
 	from        tsflag
 	to          tsflag
 	dir         string
-	outputFile  string
 	stats       bool
 	warnings    bool
-	wire        bool
+	debug       bool
 	final       *api.SearchStats
 }
 
@@ -54,24 +77,17 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 		to:      tsflag(nano.MaxTs),
 	}
 	c.writerFlags.SetFlags(f)
-	f.StringVar(&c.protocol, "p", "zng", "protocol to use for search request [ndjson,zjson,zng]")
-	f.StringVar(&c.dir, "d", "", "directory for output data files")
-	f.StringVar(&c.outputFile, "o", "", "write data to output file")
+	f.StringVar(&c.encoding, "e", "zng", "server encoding to use for search results [ndjson,zjson,zng]")
 	f.BoolVar(&c.stats, "S", false, "display search stats on stderr")
 	f.BoolVar(&c.warnings, "W", true, "display warnings on stderr")
-	f.BoolVar(&c.wire, "w", false, "dump what's on the wire")
+	f.BoolVar(&c.debug, "debug", false, "dump raw http response straight to output")
 	f.Var(&c.from, "from", "search from timestamp in RFC3339Nano format (e.g. 2006-01-02T15:04:05.999999999Z07:00)")
 	f.Var(&c.to, "to", "search to timestamp in RFC3339Nano format (e.g. 2006-01-02T15:04:05.999999999Z07:00)")
+	c.output.SetFlags(f)
 	return c, nil
 }
 
 func (c *Command) Run(args []string) error {
-	// XXX For now only allow non-wire searches to run with zng response
-	// encoding. It shouldn't be difficult to allow this for all supported
-	// response encodings but KISS for now.
-	if !c.wire && c.protocol != "zng" {
-		return errors.New("only zng protocol allowed for non-wire searches")
-	}
 	expr := "*"
 	if len(args) > 0 {
 		expr = strings.Join(args, " ")
@@ -86,16 +102,23 @@ func (c *Command) Run(args []string) error {
 		return fmt.Errorf("parse error: %s", err)
 	}
 	req.Span = nano.NewSpanTs(nano.Ts(c.from), nano.Ts(c.to))
-	params := map[string]string{"format": c.protocol}
+	params := map[string]string{"format": c.encoding}
 	r, err := client.SearchRaw(c.Context(), *req, params)
 	if err != nil {
 		return fmt.Errorf("search error: %w", err)
 	}
 	defer r.Close()
-	if c.wire {
-		return c.runWireSearch(r)
+	if c.debug {
+		return c.runDebugSearch(r)
 	}
-	writer, err := openOutput(c.dir, c.outputFile, c.writerFlags.Options())
+	writerOpts := c.writerFlags.Options()
+	if err := c.output.Init(&writerOpts); err != nil {
+		return err
+	}
+	if writerOpts.Format != "zng" && c.encoding != "zng" {
+		return errors.New("-e cannot be used with -f")
+	}
+	writer, err := c.output.Open(writerOpts)
 	if err != nil {
 		return err
 	}
@@ -143,12 +166,13 @@ func (c *Command) handleControl(ctrl interface{}) {
 	}
 }
 
-func (c *Command) runWireSearch(r io.Reader) error {
+func (c *Command) runDebugSearch(r io.Reader) error {
 	w := os.Stdout
-	if c.outputFile != "" {
+	filename := c.output.FileName()
+	if filename != "" {
 		var err error
 		flags := os.O_WRONLY | os.O_CREATE | os.O_TRUNC
-		file, err := fs.OpenFile(c.outputFile, flags, 0600)
+		file, err := fs.OpenFile(filename, flags, 0600)
 		if err != nil {
 			return err
 		}

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -36,7 +36,7 @@ By default, the service streams results in native zng and the zapi client
 converts the results to the format specified by -f.
 
 Alternatively, the -e option can specify a different encoding to be used by
-the server, in which case, the output is not converted by -f.  These two options
+the server, in which case the output is not converted by -f.  These two options
 cannot be used together.
 
 Statistics and warnings can be displayed on stderr, which can be useful
@@ -80,7 +80,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	f.StringVar(&c.encoding, "e", "zng", "server encoding to use for search results [ndjson,zjson,zng]")
 	f.BoolVar(&c.stats, "S", false, "display search stats on stderr")
 	f.BoolVar(&c.warnings, "W", true, "display warnings on stderr")
-	f.BoolVar(&c.debug, "debug", false, "dump raw http response straight to output")
+	f.BoolVar(&c.debug, "debug", false, "dump raw HTTP response straight to output")
 	f.Var(&c.from, "from", "search from timestamp in RFC3339Nano format (e.g. 2006-01-02T15:04:05.999999999Z07:00)")
 	f.Var(&c.to, "to", "search to timestamp in RFC3339Nano format (e.g. 2006-01-02T15:04:05.999999999Z07:00)")
 	c.output.SetFlags(f)


### PR DESCRIPTION
This commit updates "zapi get" to use the output flags options
in package zq/cli.  It also changes the "protocol" option to
"encoding" representing the server format encoding of the http
response.  This sets up "zapi get" to handle the vanilla ndjson
and csv support that is coming soon to the zqd search end point.

We also updated the online help a bit.
