### PR TITLE
add csv option to search endpoint

### DIFF
--- a/tests/suite/zqd/csv-error.yaml
+++ b/tests/suite/zqd/csv-error.yaml
@@ -1,0 +1,20 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new test
+  zapi -h $ZQD_HOST -s test post in.tzng
+  zapi -h $ZQD_HOST -s test get -e csv > out.csv
+
+inputs:
+  - name: services.sh
+    source: services.sh
+  - name: in.tzng
+    data: |
+      #0:record[a:string]
+      0:[hello;]
+      #1:record[b:int32]
+      1:[123;]
+
+outputs:
+  - name: out.csv
+    regexp: |
+      .*query error: csv output requires uniform records.*

--- a/tests/suite/zqd/csv.yaml
+++ b/tests/suite/zqd/csv.yaml
@@ -1,0 +1,19 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new test
+  zapi -h $ZQD_HOST -s test post in.tzng
+  zapi -h $ZQD_HOST -s test get -e csv > out.csv
+
+inputs:
+  - name: services.sh
+    source: services.sh
+  - name: in.tzng
+    data: |
+      #0:record[a:string,b:record[c:string,d:string]]
+      0:[hello;[world;goodbye;]]
+
+outputs:
+  - name: out.csv
+    data: |
+      a,b.c,b.d
+      hello,world,goodbye

--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -43,7 +43,7 @@ func (w *Writer) Close() error {
 
 func (w *Writer) Flush() error {
 	w.encoder.Flush()
-	return nil
+	return w.encoder.Error()
 }
 
 func (w *Writer) Write(rec *zng.Record) error {

--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -41,6 +41,11 @@ func (w *Writer) Close() error {
 	return w.writer.Close()
 }
 
+func (w *Writer) Flush() error {
+	w.encoder.Flush()
+	return nil
+}
+
 func (w *Writer) Write(rec *zng.Record) error {
 	rec, err := w.flattener.Flatten(rec)
 	if err != nil {

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -118,6 +118,8 @@ func getSearchOutput(w http.ResponseWriter, r *http.Request) (search.Output, err
 	}
 	format := r.URL.Query().Get("format")
 	switch format {
+	case "csv":
+		return search.NewCSVOutput(w, ctrl), nil
 	case "zjson", "ndjson":
 		return search.NewJSONOutput(w, search.DefaultMTU, ctrl), nil
 	case "zng":

--- a/zqd/search/csv.go
+++ b/zqd/search/csv.go
@@ -1,0 +1,62 @@
+package search
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/csvio"
+)
+
+// CSVOutput implements the Output inteface and writes csv encoded-output
+// directly to the client as text/csv.
+type CSVOutput struct {
+	response http.ResponseWriter
+	writer   *csvio.Writer
+}
+
+func NewCSVOutput(response http.ResponseWriter, ctrl bool) *CSVOutput {
+	o := &CSVOutput{
+		response: response,
+		writer:   csvio.NewWriter(zio.NopCloser(response), true, false),
+	}
+	return o
+}
+
+func (r *CSVOutput) flush() {
+	r.writer.Flush()
+	r.response.(http.Flusher).Flush()
+}
+
+func (r *CSVOutput) Collect() interface{} {
+	return "TBD" //XXX
+}
+
+func (r *CSVOutput) SendBatch(cid int, batch zbuf.Batch) error {
+	for _, rec := range batch.Records() {
+		if err := r.writer.Write(rec); err != nil {
+			// Embed an error in the csv output.  We can't report
+			// an http error because we already started successfully
+			// streaming records.
+			msg := fmt.Sprintf("query error: %s\n", err)
+			r.response.Write([]byte(msg))
+			return err
+		}
+	}
+	batch.Unref()
+	r.flush()
+	return nil
+}
+
+func (r *CSVOutput) End(ctrl interface{}) error {
+	return nil
+}
+
+func (r *CSVOutput) SendControl(ctrl interface{}) error {
+	return nil
+}
+
+func (r *CSVOutput) ContentType() string {
+	return MimeTypeCSV
+}

--- a/zqd/search/csv.go
+++ b/zqd/search/csv.go
@@ -17,11 +17,10 @@ type CSVOutput struct {
 }
 
 func NewCSVOutput(response http.ResponseWriter, ctrl bool) *CSVOutput {
-	o := &CSVOutput{
+	return &CSVOutput{
 		response: response,
 		writer:   csvio.NewWriter(zio.NopCloser(response), true, false),
 	}
-	return o
 }
 
 func (r *CSVOutput) flush() {

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -27,6 +27,7 @@ const DefaultMTU = 100
 const StatsInterval = time.Millisecond * 500
 
 const (
+	MimeTypeCSV    = "text/csv"
 	MimeTypeNDJSON = "application/x-ndjson"
 	MimeTypeZNG    = "application/x-zng"
 )


### PR DESCRIPTION
This commit adds a csv option to the search endpoint enabled by
setting the "format" query parameter on the search to "csv".

We also fixed a small problem in "zapi get" so that "-e csv"
will work properly.