### PR TITLE
add ndjson option to search endpoint

### DIFF
--- a/tests/suite/zqd/ndjson.yaml
+++ b/tests/suite/zqd/ndjson.yaml
@@ -1,0 +1,20 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new test
+  zapi -h $ZQD_HOST -s test post in.tzng
+  zapi -h $ZQD_HOST -s test get -e ndjson > out.ndjson
+
+inputs:
+  - name: services.sh
+    source: services.sh
+  - name: in.tzng
+    data: |
+      #0:record[a:string,b:string]
+      0:[hello;world;]
+      0:[goodnight;gracie;]
+
+outputs:
+  - name: out.ndjson
+    data: |
+      {"a":"hello","b":"world"}
+      {"a":"goodnight","b":"gracie"}

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -120,7 +120,9 @@ func getSearchOutput(w http.ResponseWriter, r *http.Request) (search.Output, err
 	switch format {
 	case "csv":
 		return search.NewCSVOutput(w, ctrl), nil
-	case "zjson", "ndjson":
+	case "ndjson":
+		return search.NewNDJSONOutput(w), nil
+	case "zjson":
 		return search.NewJSONOutput(w, search.DefaultMTU, ctrl), nil
 	case "zng":
 		return search.NewZngOutput(w, ctrl), nil

--- a/zqd/search/ndjson.go
+++ b/zqd/search/ndjson.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NDJSONOutput implements the Output inteface and writes NDJSON encoded-output
-// directly to the client as text/NDJSON.
+// directly to the client as application/x-ndjson..
 type NDJSONOutput struct {
 	response http.ResponseWriter
 	writer   *ndjsonio.Writer

--- a/zqd/search/ndjson.go
+++ b/zqd/search/ndjson.go
@@ -1,0 +1,65 @@
+package search
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/brimsec/zq/pkg/bufwriter"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/ndjsonio"
+)
+
+// NDJSONOutput implements the Output inteface and writes NDJSON encoded-output
+// directly to the client as text/NDJSON.
+type NDJSONOutput struct {
+	response http.ResponseWriter
+	writer   *ndjsonio.Writer
+	buffer   *bufwriter.Writer
+}
+
+func NewNDJSONOutput(response http.ResponseWriter) *NDJSONOutput {
+	return &NDJSONOutput{
+		response: response,
+		writer:   ndjsonio.NewWriter(zio.NopCloser(response)),
+	}
+}
+
+func (n *NDJSONOutput) flush() {
+	n.response.(http.Flusher).Flush()
+}
+
+func (*NDJSONOutput) Collect() interface{} {
+	return "TBD" //XXX
+}
+
+func (n *NDJSONOutput) SendBatch(cid int, batch zbuf.Batch) error {
+	for _, rec := range batch.Records() {
+		if err := n.writer.Write(rec); err != nil {
+			// Embed an error in the NDJSON output.  We can't report
+			// an http error because we already started successfully
+			// streaming records.
+			msg := fmt.Sprintf("query error: %s\n", err)
+			n.response.Write([]byte(msg))
+			return err
+		}
+	}
+	batch.Unref()
+	n.flush()
+	return nil
+}
+
+func (n *NDJSONOutput) End(ctrl interface{}) error {
+	if err := n.writer.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *NDJSONOutput) SendControl(ctrl interface{}) error {
+	return nil
+}
+
+func (r *NDJSONOutput) ContentType() string {
+	return MimeTypeNDJSON
+}


### PR DESCRIPTION
This commit adds an ndjson option to the search endpoint enabled by
setting the "format" query parameter on the search to "ndjson".

Fixes #1275 