### PR TITLE
import joe and make it better

### DIFF
--- a/ast/unpack.go
+++ b/ast/unpack.go
@@ -5,38 +5,50 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/mccanne/joe"
+	"github.com/brimsec/zq/pkg/joe"
 	"github.com/mitchellh/mapstructure"
 )
 
 type Unpacker interface {
-	Unpack(string, joe.JSON) (Proc, error)
+	Unpack(string, joe.Interface) (Proc, error)
 }
 
-func unpackProcs(custom Unpacker, node joe.JSON) ([]Proc, error) {
-	procList := node.Get("procs")
-	if procList == joe.Undefined {
+func unpackProcs(custom Unpacker, node joe.Interface) ([]Proc, error) {
+	procList, err := node.Get("procs")
+	if err != nil {
 		return nil, fmt.Errorf("procs field is missing")
 	}
-	if !procList.IsArray() {
+	a, ok := procList.(joe.Array)
+	if !ok {
 		return nil, fmt.Errorf("procs field is not an array")
 	}
-	n := procList.Len()
-	procs := make([]Proc, n)
-	for k := 0; k < n; k++ {
-		var err error
-		procs[k], err = unpackProc(custom, procList.Index(k))
+	procs := make([]Proc, 0, len(a))
+	for _, item := range a {
+		proc, err := unpackProc(custom, item)
 		if err != nil {
 			return nil, err
 		}
+		procs = append(procs, proc)
 	}
 	return procs, nil
 }
 
-func unpackProc(custom Unpacker, node joe.JSON) (Proc, error) {
-	op, ok := node.Get("op").String()
-	if !ok {
-		return nil, fmt.Errorf("AST is missing op field: %s", node)
+func getString(node joe.Interface, field string) (string, error) {
+	item, err := node.Get(field)
+	if err != nil {
+		return "", fmt.Errorf("AST is missing %s field: %s", node, field)
+	}
+	s, err := item.String()
+	if err != nil {
+		return "", fmt.Errorf("AST field %s of %s is not a string", field, node)
+	}
+	return s, nil
+}
+
+func unpackProc(custom Unpacker, node joe.Interface) (Proc, error) {
+	op, err := getString(node, "op")
+	if err != nil {
+		return nil, err
 	}
 	if custom != nil {
 		p, err := custom.Unpack(op, node)
@@ -62,7 +74,8 @@ func unpackProc(custom Unpacker, node joe.JSON) (Proc, error) {
 		}
 		return &ParallelProc{Procs: procs}, nil
 	case "SortProc":
-		fields, err := unpackFieldExprArray(node.Get("fields"))
+		a, _ := node.Get("fields")
+		fields, err := unpackFieldExprArray(a)
 		if err != nil {
 			return nil, err
 		}
@@ -80,7 +93,8 @@ func unpackProc(custom Unpacker, node joe.JSON) (Proc, error) {
 		}
 		return &FilterProc{Filter: filter}, nil
 	case "PutProc":
-		clauses, err := unpackExpressionAssignments(node.Get("clauses"))
+		a, _ := node.Get("clauses")
+		clauses, err := unpackExpressionAssignments(a)
 		if err != nil {
 			return nil, err
 		}
@@ -90,17 +104,20 @@ func unpackProc(custom Unpacker, node joe.JSON) (Proc, error) {
 	case "UniqProc":
 		return &UniqProc{}, nil
 	case "GroupByProc":
-		keys, err := unpackExpressionAssignments(node.Get("keys"))
+		a, _ := node.Get("keys")
+		keys, err := unpackExpressionAssignments(a)
 		if err != nil {
 			return nil, err
 		}
-		reducers, err := unpackReducers(node.Get("reducers"))
+		a, _ = node.Get("reducers")
+		reducers, err := unpackReducers(a)
 		if err != nil {
 			return nil, err
 		}
 		return &GroupByProc{Reducers: reducers, Keys: keys}, nil
 	case "TopProc":
-		fields, err := unpackFieldExprArray(node.Get("fields"))
+		a, _ := node.Get("fields")
+		fields, err := unpackFieldExprArray(a)
 		if err != nil {
 			return nil, err
 		}
@@ -112,9 +129,9 @@ func unpackProc(custom Unpacker, node joe.JSON) (Proc, error) {
 	}
 }
 
-func unpackExpressionAssignment(node joe.JSON) (ExpressionAssignment, error) {
-	exprNode := node.Get("expression")
-	if exprNode == joe.Undefined {
+func unpackExpressionAssignment(node joe.Interface) (ExpressionAssignment, error) {
+	exprNode, err := node.Get("expression")
+	if err != nil {
 		return ExpressionAssignment{}, errors.New("ExpressionAssignment missing expression")
 	}
 	expr, err := UnpackExpression(exprNode)
@@ -124,35 +141,34 @@ func unpackExpressionAssignment(node joe.JSON) (ExpressionAssignment, error) {
 	return ExpressionAssignment{Expr: expr}, nil
 }
 
-func unpackExpressionAssignments(node joe.JSON) ([]ExpressionAssignment, error) {
-	if node == joe.Undefined {
+func unpackExpressionAssignments(node joe.Interface) ([]ExpressionAssignment, error) {
+	if node == nil {
 		return nil, nil
 	}
-	if !node.IsArray() {
+	a, ok := node.(joe.Array)
+	if !ok {
 		return nil, errors.New("assignments should be an array")
 	}
-	n := node.Len()
-	keys := make([]ExpressionAssignment, n)
-	for k := 0; k < n; k++ {
-		assi, err := unpackExpressionAssignment(node.Index(k))
+	keys := make([]ExpressionAssignment, 0, len(a))
+	for _, item := range a {
+		assi, err := unpackExpressionAssignment(item)
 		if err != nil {
 			return nil, err
 		}
-		keys[k] = assi
+		keys = append(keys, assi)
 	}
 	return keys, nil
 }
 
-func UnpackExpression(node joe.JSON) (Expression, error) {
-	op, ok := node.Get("op").String()
-	if !ok {
-		return nil, errors.New("Expression node missing op field")
+func UnpackExpression(node joe.Interface) (Expression, error) {
+	op, err := getString(node, "op")
+	if err != nil {
+		return nil, err
 	}
-
 	switch op {
 	case "UnaryExpr":
-		operandNode := node.Get("operand")
-		if operandNode == joe.Undefined {
+		operandNode, err := node.Get("operand")
+		if err != nil {
 			return nil, errors.New("UnaryExpression missing operand")
 		}
 		operand, err := UnpackExpression(operandNode)
@@ -161,8 +177,8 @@ func UnpackExpression(node joe.JSON) (Expression, error) {
 		}
 		return &UnaryExpression{Operand: operand}, nil
 	case "BinaryExpr":
-		lhsNode := node.Get("lhs")
-		if lhsNode == joe.Undefined {
+		lhsNode, err := node.Get("lhs")
+		if err != nil {
 			return nil, errors.New("BinaryExpression missing lhs")
 		}
 		lhs, err := UnpackExpression(lhsNode)
@@ -170,8 +186,8 @@ func UnpackExpression(node joe.JSON) (Expression, error) {
 			return nil, err
 		}
 
-		rhsNode := node.Get("rhs")
-		if rhsNode == joe.Undefined {
+		rhsNode, err := node.Get("rhs")
+		if err != nil {
 			return nil, errors.New("BinaryExpression missing rhs")
 		}
 		rhs, err := UnpackExpression(rhsNode)
@@ -181,8 +197,8 @@ func UnpackExpression(node joe.JSON) (Expression, error) {
 
 		return &BinaryExpression{LHS: lhs, RHS: rhs}, nil
 	case "ConditionalExpr":
-		conditionNode := node.Get("condition")
-		if conditionNode == joe.Undefined {
+		conditionNode, err := node.Get("condition")
+		if err != nil {
 			return nil, errors.New("ConditionalExpr missing condition")
 		}
 		condition, err := UnpackExpression(conditionNode)
@@ -190,8 +206,8 @@ func UnpackExpression(node joe.JSON) (Expression, error) {
 			return nil, err
 		}
 
-		thenNode := node.Get("then")
-		if thenNode == joe.Undefined {
+		thenNode, err := node.Get("then")
+		if err != nil {
 			return nil, errors.New("ConditionalExpr missing then")
 		}
 		thenClause, err := UnpackExpression(thenNode)
@@ -199,8 +215,8 @@ func UnpackExpression(node joe.JSON) (Expression, error) {
 			return nil, err
 		}
 
-		elseNode := node.Get("else")
-		if elseNode == joe.Undefined {
+		elseNode, err := node.Get("else")
+		if err != nil {
 			return nil, errors.New("ConditionalExpr missing else")
 		}
 		elseClause, err := UnpackExpression(elseNode)
@@ -213,26 +229,27 @@ func UnpackExpression(node joe.JSON) (Expression, error) {
 			Else:      elseClause,
 		}, nil
 	case "FunctionCall":
-		argsNode := node.Get("args")
-		if argsNode == joe.Undefined {
+		argsNode, err := node.Get("args")
+		if err != nil {
 			return nil, errors.New("FunctionCall missing args")
 		}
-		if !argsNode.IsArray() {
+		a, ok := argsNode.(joe.Array)
+		if !ok {
 			return nil, errors.New("FunctionCall args property must be an array")
 		}
-		n := argsNode.Len()
+		n := len(a)
 		args := make([]Expression, n)
 		for i := 0; i < n; i++ {
 			var err error
-			args[i], err = UnpackExpression(argsNode.Index(i))
+			args[i], err = UnpackExpression(a[i])
 			if err != nil {
 				return nil, err
 			}
 		}
 		return &FunctionCall{Args: args}, nil
 	case "CastExpr":
-		exprNode := node.Get("expr")
-		if exprNode == joe.Undefined {
+		exprNode, err := node.Get("expr")
+		if err != nil {
 			return nil, errors.New("CastExpr missing expr")
 		}
 		expr, err := UnpackExpression(exprNode)
@@ -245,8 +262,8 @@ func UnpackExpression(node joe.JSON) (Expression, error) {
 	case "FieldRead":
 		return &FieldRead{}, nil
 	case "FieldCall":
-		child := node.Get("field")
-		if child == joe.Undefined {
+		child, err := node.Get("field")
+		if err != nil {
 			return nil, errors.New("FieldCall missing field property")
 		}
 		field, err := unpackFieldExpr(child)
@@ -259,15 +276,15 @@ func UnpackExpression(node joe.JSON) (Expression, error) {
 	}
 }
 
-func UnpackChild(node joe.JSON, field string) (BooleanExpr, error) {
-	child := node.Get(field)
-	if child == joe.Undefined {
+func UnpackChild(node joe.Interface, field string) (BooleanExpr, error) {
+	child, err := node.Get(field)
+	if err != nil {
 		return nil, fmt.Errorf("%s field is missing", field)
 	}
 	return unpackBooleanExpr(child)
 }
 
-func unpackChildren(node joe.JSON) (BooleanExpr, BooleanExpr, error) {
+func unpackChildren(node joe.Interface) (BooleanExpr, BooleanExpr, error) {
 	left, err := UnpackChild(node, "left")
 	if err != nil {
 		return nil, nil, err
@@ -279,9 +296,9 @@ func unpackChildren(node joe.JSON) (BooleanExpr, BooleanExpr, error) {
 	return left, right, nil
 }
 
-func unpackBooleanExpr(node joe.JSON) (BooleanExpr, error) {
-	op, ok := node.Get("op").String()
-	if !ok {
+func unpackBooleanExpr(node joe.Interface) (BooleanExpr, error) {
+	op, err := getString(node, "op")
+	if err != nil {
 		return nil, fmt.Errorf("AST is missing op field")
 	}
 	switch op {
@@ -310,8 +327,8 @@ func unpackBooleanExpr(node joe.JSON) (BooleanExpr, error) {
 	case "CompareAny":
 		return &CompareAny{}, nil
 	case "CompareField":
-		child := node.Get("field")
-		if child == joe.Undefined {
+		child, err := node.Get("field")
+		if err != nil {
 			return nil, errors.New("CompareField missing field property")
 		}
 		field, err := unpackFieldExpr(child)
@@ -325,34 +342,34 @@ func unpackBooleanExpr(node joe.JSON) (BooleanExpr, error) {
 	}
 }
 
-func unpackFieldExprArray(node joe.JSON) ([]FieldExpr, error) {
-	if node == joe.Undefined {
+func unpackFieldExprArray(node joe.Interface) ([]FieldExpr, error) {
+	if node == nil {
 		return nil, nil
 	}
-	if !node.IsArray() {
+	a, ok := node.(joe.Array)
+	if !ok {
 		return nil, errors.New("fields property should be an array")
 	}
-	n := node.Len()
-	fields := make([]FieldExpr, n)
-	for k := 0; k < n; k++ {
-		var err error
-		fields[k], err = unpackFieldExpr(node.Index(k))
+	fields := make([]FieldExpr, 0, len(a))
+	for _, item := range a {
+		field, err := unpackFieldExpr(item)
 		if err != nil {
 			return nil, err
 		}
+		fields = append(fields, field)
 	}
 	return fields, nil
 }
 
-func unpackFieldExpr(node joe.JSON) (FieldExpr, error) {
-	op, ok := node.Get("op").String()
-	if !ok {
+func unpackFieldExpr(node joe.Interface) (FieldExpr, error) {
+	op, err := getString(node, "op")
+	if err != nil {
 		return nil, errors.New("AST is missing op field")
 	}
 	switch op {
 	case "FieldCall":
-		child := node.Get("field")
-		if child == joe.Undefined {
+		child, err := node.Get("field")
+		if err != nil {
 			return nil, errors.New("FieldCall missing field property")
 		}
 		field, err := unpackFieldExpr(child)
@@ -367,21 +384,20 @@ func unpackFieldExpr(node joe.JSON) (FieldExpr, error) {
 	}
 }
 
-func unpackReducers(node joe.JSON) ([]Reducer, error) {
-	if node == joe.Undefined {
+func unpackReducers(node joe.Interface) ([]Reducer, error) {
+	if node == nil {
 		return nil, nil
 	}
-	if !node.IsArray() {
+	a, ok := node.(joe.Array)
+	if !ok {
 		return nil, errors.New("reducers property should be an array")
 	}
-	n := node.Len()
-	reducers := make([]Reducer, n)
-	for k := 0; k < n; k++ {
-		fld := node.Index(k).Get("field")
-		if fld == joe.Undefined {
+	reducers := make([]Reducer, len(a))
+	for k, item := range a {
+		fld, err := item.Get("field")
+		if err != nil {
 			continue
 		}
-		var err error
 		reducers[k].Field, err = unpackFieldExpr(fld)
 		if err != nil {
 			return nil, err
@@ -391,7 +407,7 @@ func unpackReducers(node joe.JSON) ([]Reducer, error) {
 }
 
 func UnpackMap(custom Unpacker, m interface{}) (Proc, error) {
-	obj := joe.Interface(m)
+	obj := joe.Convert(m)
 	proc, err := unpackProc(custom, obj)
 	if err != nil {
 		return nil, err
@@ -410,7 +426,7 @@ func UnpackMap(custom Unpacker, m interface{}) (Proc, error) {
 
 // UnpackJSON transforms a JSON representation of a proc into an ast.Proc.
 func UnpackJSON(custom Unpacker, buf []byte) (Proc, error) {
-	obj, err := joe.Parse(buf)
+	obj, err := joe.Unmarshal(buf)
 	if err != nil {
 		return nil, err
 	}

--- a/ast/unpack.go
+++ b/ast/unpack.go
@@ -237,9 +237,8 @@ func UnpackExpression(node joe.Interface) (Expression, error) {
 		if !ok {
 			return nil, errors.New("FunctionCall args property must be an array")
 		}
-		n := len(a)
-		args := make([]Expression, n)
-		for i := 0; i < n; i++ {
+		args := make([]Expression, len(a))
+		for i := range args {
 			var err error
 			args[i], err = UnpackExpression(a[i])
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.10.3 // indirect
 	github.com/mccanne/charm v0.0.3-0.20191224190439-b05e1b7b1be3
-	github.com/mccanne/joe v0.0.0-20200731213236-7c7845acf98b
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/peterh/liner v1.1.0
 	github.com/pierrec/lz4/v4 v4.0.2

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mccanne/charm v0.0.3-0.20191224190439-b05e1b7b1be3 h1:Sj9zugMeJDXrKpOZgiQXhm0Z87vPF2QfUMWE41lwcRQ=
 github.com/mccanne/charm v0.0.3-0.20191224190439-b05e1b7b1be3/go.mod h1:R47PUgWIRA4UrwFWKI6vgAEWHXPYWUg3iAtyXB8yKNU=
-github.com/mccanne/joe v0.0.0-20200731213236-7c7845acf98b h1:ixbbGEmeKfQ0UWUUuNv5hxkkR1aO/Sy//vFLNrdCXQQ=
-github.com/mccanne/joe v0.0.0-20200731213236-7c7845acf98b/go.mod h1:ws78j95WzGWyQqUJksJu3Dly2hyMI1II7HVcY7DoHFg=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/mapstructure v1.3.3 h1:SzB1nHZ2Xi+17FP0zVQBHIZqvwRN9408fJO8h+eeNA8=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=

--- a/pkg/joe/joe.go
+++ b/pkg/joe/joe.go
@@ -1,7 +1,7 @@
-// Package joe provides helper types and methods for encoding and decoding json.
+// Package joe provides helper types and methods for encoding and decoding JSON.
 //
 // joe provides a simple API to access unstructured and ad hoc JSON objects
-// that is parsed generically by json.Unmarshal.  When JSON inputs are
+// that is parsed generically by json.Unmarshal.  When a inputs are
 // unstructured, it can be difficult to define Go structs that map cleanly
 // onto the JSON input.
 package joe

--- a/pkg/joe/joe.go
+++ b/pkg/joe/joe.go
@@ -1,0 +1,236 @@
+// Package joe provides help types and methods for encoding and decoding json.
+//
+// joe provides a simple API to access unstructured and ad hoc JSON objects
+// that is parsed generically by json.Unmarshal.  When JSON inputs are
+// unstructured, it can be difficult to define Go structs that map cleanly
+// onto the JSON input.
+package joe
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type Object map[string]Interface
+type Array []Interface
+type String string
+type Number float64
+type Bool bool
+
+type Interface interface {
+	Get(string) (Interface, error)
+	Index(int) (Interface, error)
+	Number() (float64, error)
+	String() (string, error)
+	Bool() (bool, error)
+}
+
+func NewObject() Object {
+	return make(map[string]Interface)
+}
+
+func (o Object) Get(field string) (Interface, error) {
+	v, ok := o[field]
+	if ok {
+		return v, nil
+	}
+	return nil, fmt.Errorf("object has no such field: '%s'", field)
+}
+
+func (Object) Index(k int) (Interface, error) {
+	return nil, errors.New("object is not an array")
+}
+
+func (Object) Number() (float64, error) {
+	return 0, fmt.Errorf("array is not a number")
+}
+
+func (Object) String() (string, error) {
+	return "", fmt.Errorf("array is not a string")
+}
+
+func (Object) Bool() (bool, error) {
+	return false, fmt.Errorf("array is not a bool")
+}
+
+func (o Object) GetObject(field string) (Object, error) {
+	v, ok := o[field]
+	if !ok {
+		return nil, fmt.Errorf("field '%s' does not exist", field)
+	}
+	if object, ok := v.(Object); ok {
+		return object, nil
+	}
+	return nil, fmt.Errorf("field '%s' is not an object", field)
+}
+
+func (o Object) GetArray(field string) (Array, error) {
+	v, ok := o[field]
+	if !ok {
+		return nil, fmt.Errorf("field '%s' does not exist", field)
+	}
+	if array, ok := v.(Array); ok {
+		return array, nil
+	}
+	return nil, fmt.Errorf("field '%s' is not an array", field)
+}
+
+func (o Object) GetString(field string) (string, error) {
+	v, ok := o[field]
+	if !ok {
+		return "", fmt.Errorf("field '%s' does not exist", field)
+	}
+	return v.String()
+}
+
+func (o Object) GetNumber(field string) (float64, error) {
+	v, ok := o[field]
+	if !ok {
+		return 0, fmt.Errorf("field '%s' does not exist", field)
+	}
+	return v.Number()
+}
+
+func (o Object) GetBool(field string) (bool, error) {
+	v, ok := o[field]
+	if !ok {
+		return false, fmt.Errorf("field '%s' does not exist", field)
+	}
+	return v.Bool()
+}
+
+func (Array) Get(field string) (Interface, error) {
+	return nil, fmt.Errorf("cannot access field '%s' in an array", field)
+}
+
+func (a Array) Index(k int) (Interface, error) {
+	if k < 0 || k >= len(a) {
+		return nil, fmt.Errorf("array index (%d) out of range of [0,%d]", k, len(a)-1)
+	}
+	return a[k], nil
+}
+
+func (Array) Number() (float64, error) {
+	return 0, fmt.Errorf("array is not a number")
+}
+
+func (Array) String() (string, error) {
+	return "", fmt.Errorf("array is not a string")
+}
+
+func (Array) Bool() (bool, error) {
+	return false, fmt.Errorf("array is not a bool")
+}
+
+func (Number) Get(field string) (Interface, error) {
+	return nil, fmt.Errorf("cannot access field '%s' in a number", field)
+}
+
+func (Number) Index(k int) (Interface, error) {
+	return nil, fmt.Errorf("number is not an array")
+}
+
+func (n Number) Number() (float64, error) {
+	return float64(n), nil
+}
+
+func (Number) String() (string, error) {
+	return "", fmt.Errorf("number is not a string")
+}
+
+func (Number) Bool() (bool, error) {
+	return false, fmt.Errorf("number is not a bool")
+}
+
+func (String) Get(field string) (Interface, error) {
+	return nil, fmt.Errorf("cannot access field '%s' in a string", field)
+}
+
+func (String) Index(k int) (Interface, error) {
+	return nil, fmt.Errorf("string is not an array")
+}
+
+func (String) Number() (float64, error) {
+	return 0, fmt.Errorf("string is not a number")
+}
+
+func (s String) String() (string, error) {
+	return string(s), nil
+}
+
+func (String) Bool() (bool, error) {
+	return false, fmt.Errorf("string is not a bool")
+}
+
+func (Bool) Get(field string) (Interface, error) {
+	return nil, fmt.Errorf("cannot access field '%s' in a bool", field)
+}
+
+func (Bool) Index(k int) (Interface, error) {
+	return nil, fmt.Errorf("bool is not an array")
+}
+
+func (Bool) Number() (float64, error) {
+	return 0, fmt.Errorf("bool is not a number")
+}
+
+func (Bool) String() (string, error) {
+	return "", fmt.Errorf("bool is not a string")
+}
+
+func (b Bool) Bool() (bool, error) {
+	return bool(b), nil
+}
+
+func Convert(v interface{}) Interface {
+	if v == nil {
+		return nil
+	}
+	switch v := v.(type) {
+	case string:
+		return String(v)
+	case float64:
+		return Number(v)
+	case int:
+		return Number(v)
+	case bool:
+		return Bool(v)
+	case []interface{}:
+		var elements []Interface
+		for _, elem := range v {
+			elements = append(elements, Convert(elem))
+		}
+		return Array(elements)
+	case map[string]interface{}:
+		object := make(map[string]Interface)
+		for key, val := range v {
+			object[key] = Convert(val)
+		}
+		return Object(object)
+	default:
+		panic(fmt.Sprintf("unknown type in joe.Convert(): %v", v))
+	}
+}
+
+func Unmarshal(in []byte) (Interface, error) {
+	var v interface{}
+	err := json.Unmarshal(in, &v)
+	if err != nil {
+		return nil, err
+	}
+	return Convert(v), nil
+}
+
+func (o *Object) UnmarshalJSON(b []byte) error {
+	v, err := Unmarshal(b)
+	if err != nil {
+		return err
+	}
+	object, ok := v.(Object)
+	if !ok {
+		return errors.New("not a joe.Object")
+	}
+	*o = object
+	return nil
+}

--- a/pkg/joe/joe.go
+++ b/pkg/joe/joe.go
@@ -1,4 +1,4 @@
-// Package joe provides help types and methods for encoding and decoding json.
+// Package joe provides helper types and methods for encoding and decoding json.
 //
 // joe provides a simple API to access unstructured and ad hoc JSON objects
 // that is parsed generically by json.Unmarshal.  When JSON inputs are
@@ -43,15 +43,15 @@ func (Object) Index(k int) (Interface, error) {
 }
 
 func (Object) Number() (float64, error) {
-	return 0, fmt.Errorf("array is not a number")
+	return 0, errors.New("array is not a number")
 }
 
 func (Object) String() (string, error) {
-	return "", fmt.Errorf("array is not a string")
+	return "", errors.New("array is not a string")
 }
 
 func (Object) Bool() (bool, error) {
-	return false, fmt.Errorf("array is not a bool")
+	return false, errors.New("array is not a bool")
 }
 
 func (o Object) GetObject(field string) (Object, error) {
@@ -112,15 +112,15 @@ func (a Array) Index(k int) (Interface, error) {
 }
 
 func (Array) Number() (float64, error) {
-	return 0, fmt.Errorf("array is not a number")
+	return 0, errors.New("array is not a number")
 }
 
 func (Array) String() (string, error) {
-	return "", fmt.Errorf("array is not a string")
+	return "", errors.New("array is not a string")
 }
 
 func (Array) Bool() (bool, error) {
-	return false, fmt.Errorf("array is not a bool")
+	return false, errors.New("array is not a bool")
 }
 
 func (Number) Get(field string) (Interface, error) {
@@ -128,7 +128,7 @@ func (Number) Get(field string) (Interface, error) {
 }
 
 func (Number) Index(k int) (Interface, error) {
-	return nil, fmt.Errorf("number is not an array")
+	return nil, errors.New("number is not an array")
 }
 
 func (n Number) Number() (float64, error) {
@@ -136,11 +136,11 @@ func (n Number) Number() (float64, error) {
 }
 
 func (Number) String() (string, error) {
-	return "", fmt.Errorf("number is not a string")
+	return "", errors.New("number is not a string")
 }
 
 func (Number) Bool() (bool, error) {
-	return false, fmt.Errorf("number is not a bool")
+	return false, errors.New("number is not a bool")
 }
 
 func (String) Get(field string) (Interface, error) {
@@ -148,11 +148,11 @@ func (String) Get(field string) (Interface, error) {
 }
 
 func (String) Index(k int) (Interface, error) {
-	return nil, fmt.Errorf("string is not an array")
+	return nil, errors.New("string is not an array")
 }
 
 func (String) Number() (float64, error) {
-	return 0, fmt.Errorf("string is not a number")
+	return 0, errors.New("string is not a number")
 }
 
 func (s String) String() (string, error) {
@@ -160,7 +160,7 @@ func (s String) String() (string, error) {
 }
 
 func (String) Bool() (bool, error) {
-	return false, fmt.Errorf("string is not a bool")
+	return false, errors.New("string is not a bool")
 }
 
 func (Bool) Get(field string) (Interface, error) {
@@ -168,15 +168,15 @@ func (Bool) Get(field string) (Interface, error) {
 }
 
 func (Bool) Index(k int) (Interface, error) {
-	return nil, fmt.Errorf("bool is not an array")
+	return nil, errors.New("bool is not an array")
 }
 
 func (Bool) Number() (float64, error) {
-	return 0, fmt.Errorf("bool is not a number")
+	return 0, errors.New("bool is not a number")
 }
 
 func (Bool) String() (string, error) {
-	return "", fmt.Errorf("bool is not a string")
+	return "", errors.New("bool is not a string")
 }
 
 func (b Bool) Bool() (bool, error) {
@@ -184,10 +184,9 @@ func (b Bool) Bool() (bool, error) {
 }
 
 func Convert(v interface{}) Interface {
-	if v == nil {
-		return nil
-	}
 	switch v := v.(type) {
+	case nil:
+		return nil
 	case string:
 		return String(v)
 	case float64:
@@ -215,8 +214,7 @@ func Convert(v interface{}) Interface {
 
 func Unmarshal(in []byte) (Interface, error) {
 	var v interface{}
-	err := json.Unmarshal(in, &v)
-	if err != nil {
+	if err := json.Unmarshal(in, &v); err != nil {
 		return nil, err
 	}
 	return Convert(v), nil

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/brimsec/zq/ast"
-	"github.com/mccanne/joe"
+	"github.com/brimsec/zq/pkg/joe"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -26,7 +26,7 @@ func ParseExpression(expr string) (ast.Expression, error) {
 	if err != nil {
 		return nil, err
 	}
-	node := joe.Interface(m)
+	node := joe.Convert(m)
 	ex, err := ast.UnpackExpression(node)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit rewrites joe to be more go-like and better.

Many have complained about joe, me included, but I still think
it's easier to maintain code written with this thin API compared
to seeing []interface{} and map[string]interface{} all over
the place.

p.s. I was using the old joe for the zjson changes and got frustrated 
so I did this and it felt better.