### PR TITLE
add json option to search endpoint

### DIFF
--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -77,7 +77,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 		to:      tsflag(nano.MaxTs),
 	}
 	c.writerFlags.SetFlags(f)
-	f.StringVar(&c.encoding, "e", "zng", "server encoding to use for search results [csv,ndjson,zjson,zng]")
+	f.StringVar(&c.encoding, "e", "zng", "server encoding to use for search results [csv,json,ndjson,zjson,zng]")
 	f.BoolVar(&c.stats, "S", false, "display search stats on stderr")
 	f.BoolVar(&c.warnings, "W", true, "display warnings on stderr")
 	f.BoolVar(&c.debug, "debug", false, "dump raw HTTP response straight to output")

--- a/tests/suite/zqd/json.yaml
+++ b/tests/suite/zqd/json.yaml
@@ -1,0 +1,18 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new test
+  zapi -h $ZQD_HOST -s test post in.tzng
+  zapi -h $ZQD_HOST -s test get -e json > out.json
+
+inputs:
+  - name: services.sh
+    source: services.sh
+  - name: in.tzng
+    data: |
+      #0:record[a:string,b:record[c:string,d:string]]
+      0:[hello;[world;goodbye;]]
+
+outputs:
+  - name: out.json
+    regexp: |
+      .*"type":"TaskStart","task_id":0.*"type":\[\{"name":"a","type":"string"\}.*"values":\["hello",\["world".*

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -121,10 +121,12 @@ func getSearchOutput(w http.ResponseWriter, r *http.Request) (search.Output, err
 	switch format {
 	case "csv":
 		return search.NewCSVOutput(w, ctrl), nil
+	case "json":
+		return search.NewJSONOutput(w, search.DefaultMTU, ctrl), nil
 	case "ndjson":
 		return search.NewNDJSONOutput(w), nil
 	case "zjson":
-		return search.NewJSONOutput(w, search.DefaultMTU, ctrl), nil
+		return search.NewZJSONOutput(w, search.DefaultMTU, ctrl), nil
 	case "zng":
 		return search.NewZngOutput(w, ctrl), nil
 	default:

--- a/zqd/search/json.go
+++ b/zqd/search/json.go
@@ -1,52 +1,45 @@
 package search
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/zjsonio"
-	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zqd/api"
 )
 
+const MaxJSONRecords = 25000
+
 // JSON implements the Output interface.
 type JSON struct {
-	pipe   *api.JSONPipe
-	stream *zjsonio.Stream
-	mtu    int
-	ctrl   bool
+	stream   *zjsonio.Stream
+	response http.ResponseWriter
+	mtu      int
+	ctrl     bool
+	all      []interface{}
+	stat     interface{}
 }
 
 func NewJSONOutput(resp http.ResponseWriter, mtu int, ctrl bool) *JSON {
 	return &JSON{
-		pipe:   api.NewJSONPipe(resp),
-		stream: zjsonio.NewStream(),
-		mtu:    mtu,
-		ctrl:   ctrl,
+		stream:   zjsonio.NewStream(),
+		response: resp,
+		mtu:      mtu,
+		ctrl:     ctrl,
 	}
 }
 
-func (s *JSON) formatRecords(records []*zng.Record) ([]zjsonio.Record, error) {
-	var res = make([]zjsonio.Record, len(records))
-	for i, in := range records {
-		out, err := s.stream.Transform(in)
-		if err != nil {
-			return nil, err
-		}
-		res[i] = *out
-	}
-	return res, nil
-}
-
-func (s *JSON) SendBatch(cid int, set zbuf.Batch) error {
+func (j *JSON) SendBatch(cid int, set zbuf.Batch) error {
 	records := set.Records()
 	n := len(records)
 	for n > 0 {
 		frag := n
-		if frag > s.mtu {
-			frag = s.mtu
+		if frag > j.mtu {
+			frag = j.mtu
 		}
-		formatted, err := s.formatRecords(records[0:frag])
+		formatted, err := formatRecords(j.stream, records[0:frag])
 		if err != nil {
 			return err
 		}
@@ -55,7 +48,7 @@ func (s *JSON) SendBatch(cid int, set zbuf.Batch) error {
 			ChannelID: cid,
 			Records:   formatted,
 		}
-		if err := s.pipe.Send(v); err != nil {
+		if err := j.append(v); err != nil {
 			return err
 		}
 		records = records[frag:]
@@ -65,20 +58,39 @@ func (s *JSON) SendBatch(cid int, set zbuf.Batch) error {
 	return nil
 }
 
-func (s *JSON) SendControl(msg interface{}) error {
-	if !s.ctrl {
-		return nil
+func (j *JSON) append(msg interface{}) error {
+	j.all = append(j.all, msg)
+	if len(j.all) > MaxJSONRecords {
+		err := errors.New("memory limit exceeded for single JSON response")
+		http.Error(j.response, err.Error(), http.StatusBadRequest)
+		return err
 	}
-	return s.pipe.Send(msg)
+	return nil
 }
 
-func (s *JSON) End(msg interface{}) error {
-	if !s.ctrl {
+func (v *JSON) SendControl(msg interface{}) error {
+	if !v.ctrl {
+		return nil
+	}
+	if _, ok := msg.(*api.SearchStats); ok {
+		v.stat = msg
+		return nil
+	}
+	return v.append(msg)
+}
+
+func (j *JSON) End(msg interface{}) error {
+	if !j.ctrl {
 		msg = nil
 	}
-	return s.pipe.SendFinal(msg)
+	err := json.NewEncoder(j.response).Encode(j.all)
+	if err != nil {
+		http.Error(j.response, err.Error(), http.StatusInternalServerError)
+		return err
+	}
+	return nil
 }
 
 func (s *JSON) ContentType() string {
-	return MimeTypeNDJSON
+	return MimeTypeJSON
 }

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -28,7 +28,7 @@ const StatsInterval = time.Millisecond * 500
 
 const (
 	MimeTypeCSV    = "text/csv"
-	MimeTypeJSON   = "application/x-ndjson"
+	MimeTypeJSON   = "application/json"
 	MimeTypeNDJSON = "application/x-ndjson"
 	MimeTypeZJSON  = "application/x-zjson"
 	MimeTypeZNG    = "application/x-zng"

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -28,7 +28,9 @@ const StatsInterval = time.Millisecond * 500
 
 const (
 	MimeTypeCSV    = "text/csv"
+	MimeTypeJSON   = "application/x-ndjson"
 	MimeTypeNDJSON = "application/x-ndjson"
+	MimeTypeZJSON  = "application/x-zjson"
 	MimeTypeZNG    = "application/x-zng"
 )
 

--- a/zqd/search/zjson.go
+++ b/zqd/search/zjson.go
@@ -1,0 +1,84 @@
+package search
+
+import (
+	"net/http"
+
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/zjsonio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zqd/api"
+)
+
+// ZJSON implements the Output interface.
+type ZJSON struct {
+	pipe   *api.JSONPipe
+	stream *zjsonio.Stream
+	mtu    int
+	ctrl   bool
+}
+
+func NewZJSONOutput(resp http.ResponseWriter, mtu int, ctrl bool) *ZJSON {
+	return &ZJSON{
+		pipe:   api.NewJSONPipe(resp),
+		stream: zjsonio.NewStream(),
+		mtu:    mtu,
+		ctrl:   ctrl,
+	}
+}
+
+func formatRecords(stream *zjsonio.Stream, records []*zng.Record) ([]zjsonio.Record, error) {
+	var res = make([]zjsonio.Record, len(records))
+	for i, in := range records {
+		out, err := stream.Transform(in)
+		if err != nil {
+			return nil, err
+		}
+		res[i] = *out
+	}
+	return res, nil
+}
+
+func (s *ZJSON) SendBatch(cid int, set zbuf.Batch) error {
+	records := set.Records()
+	n := len(records)
+	for n > 0 {
+		frag := n
+		if frag > s.mtu {
+			frag = s.mtu
+		}
+		formatted, err := formatRecords(s.stream, records[0:frag])
+		if err != nil {
+			return err
+		}
+		v := &api.SearchRecords{
+			Type:      "SearchRecords",
+			ChannelID: cid,
+			Records:   formatted,
+		}
+		if err := s.pipe.Send(v); err != nil {
+			return err
+		}
+		records = records[frag:]
+		n -= frag
+	}
+	set.Unref()
+	return nil
+}
+
+func (s *ZJSON) SendControl(msg interface{}) error {
+	if !s.ctrl {
+		return nil
+	}
+	return s.pipe.Send(msg)
+}
+
+func (s *ZJSON) End(msg interface{}) error {
+	if !s.ctrl {
+		msg = nil
+	}
+	return s.pipe.SendFinal(msg)
+}
+
+func (s *ZJSON) ContentType() string {
+	return MimeTypeZJSON
+}


### PR DESCRIPTION
This commit renames the old json search endpoint "zjson" and adds
a new json format option that returns a valid, one-shot json
representation of query results.  This is enabled by
setting the "format" query parameter on the search to "json".

Fixes #1277 