### PR TITLE
zapi index create|find commands

### DIFF
--- a/cmd/zapi/cmd/index/create.go
+++ b/cmd/zapi/cmd/index/create.go
@@ -24,7 +24,7 @@ A pattern is either a field name or a ":" followed by a zng type name.
 For example, to index the all fields of type port and the field id.orig_h,
 you would run:
 
-	zapi index create id.orig_h:port
+	zapi index create id.orig_h :port
 
 Each pattern results in a separate microindex file for each log file found.
 

--- a/cmd/zapi/cmd/index/create.go
+++ b/cmd/zapi/cmd/index/create.go
@@ -26,7 +26,7 @@ you would run:
 
 	zapi index create id.orig_h :port
 
-Each pattern results in a separate microindex file for each log file found.
+Each pattern results in a separate, single-key microindex file for each log file found.
 
 For custom indexes, zql can be used instead of a pattern. This
 requires specifying the key and output file name. For example:

--- a/cmd/zapi/cmd/index/create.go
+++ b/cmd/zapi/cmd/index/create.go
@@ -1,0 +1,97 @@
+package idx
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"strings"
+
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/zqd/api"
+	"github.com/brimsec/zq/zql"
+	"github.com/mccanne/charm"
+)
+
+var Create = &charm.Spec{
+	Name:  "create",
+	Usage: "create [options] [-z zql] [ pattern [ pattern ...]]",
+	Short: "create index on a space",
+	Long: `
+"zapi index create" creates index files in a zar archive using one or more indexing
+rules.
+
+A pattern is either a field name or a ":" followed by a zng type name.
+For example, to index the all fields of type port and the field id.orig_h,
+you would run:
+
+	zapi index create id.orig_h:port
+
+Each pattern results in a separate microindex file for each log file found.
+
+For custom indexes, zql can be used instead of a pattern. This
+requires specifying the key and output file name. For example:
+
+    zapi index create -k id.orig_h -o custom -z "count() by _path, id.orig_h | sort id.orig_h"
+`,
+	New: NewCreate,
+}
+
+func init() {
+	cmd.CLI.Add(Create)
+}
+
+type CreateCmd struct {
+	*cmd.Command
+	root       string
+	inputFile  string
+	outputFile string
+	keys       arrayFlag
+	zql        string
+}
+
+func NewCreate(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &CreateCmd{Command: parent.(*IndexCmd).Command}
+	f.Var(&c.keys, "k", "key fields (can be specified multiple times)")
+	f.StringVar(&c.inputFile, "i", "", "input file relative to each zar directory ('' means archive log file in the parent of the zar directory)")
+	f.StringVar(&c.outputFile, "o", "index.zng", "name of microindex output file (for custom indexes)")
+	f.StringVar(&c.zql, "z", "", "zql for custom indexes")
+	return c, nil
+}
+
+func (c *CreateCmd) Run(args []string) error {
+	if len(args) == 0 && c.zql == "" {
+		return errors.New("zapi index create: one or more indexing patterns must be specified")
+	}
+	id, err := c.SpaceID()
+	if err != nil {
+		return err
+	}
+	req := api.IndexPostRequest{
+		Patterns:   args,
+		InputFile:  c.inputFile,
+		OutputFile: c.outputFile,
+	}
+	if c.zql != "" {
+		proc, err := zql.ParseProc(c.zql)
+		if err != nil {
+			return err
+		}
+		req.AST, err = json.Marshal(proc)
+		if err != nil {
+			return err
+		}
+		req.Keys = c.keys
+	}
+	return c.Client().IndexPost(c.Context(), id, req)
+}
+
+type arrayFlag []string
+
+func (i *arrayFlag) String() string {
+	return strings.Join(*i, ", ")
+}
+
+func (i *arrayFlag) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}

--- a/cmd/zapi/cmd/index/create.go
+++ b/cmd/zapi/cmd/index/create.go
@@ -33,6 +33,10 @@ requires specifying the key and output file name. For example:
 
     zapi index create -k id.orig_h -o custom -z "count() by _path, id.orig_h | sort id.orig_h"
 `,
+Multiple keys may be specified with multiple -k arguments, in which case the first key is the primary search key, the second key is the secondary search key, and so forth.  For example,
+
+zapi index create -k id.orig_h -k count -o custom -z "count() by _path, id.orig_h | sort id.orig_h,count"
+
 	New: NewCreate,
 }
 

--- a/cmd/zapi/cmd/index/create.go
+++ b/cmd/zapi/cmd/index/create.go
@@ -32,11 +32,10 @@ For custom indexes, zql can be used instead of a pattern. This
 requires specifying the key and output file name. For example:
 
     zapi index create -k id.orig_h -o custom -z "count() by _path, id.orig_h | sort id.orig_h"
-`,
 Multiple keys may be specified with multiple -k arguments, in which case the first key is the primary search key, the second key is the secondary search key, and so forth.  For example,
 
 zapi index create -k id.orig_h -k count -o custom -z "count() by _path, id.orig_h | sort id.orig_h,count"
-
+`,
 	New: NewCreate,
 }
 

--- a/cmd/zapi/cmd/index/find.go
+++ b/cmd/zapi/cmd/index/find.go
@@ -30,7 +30,7 @@ indexed then the IP 10.0.1.2 can be searched by saying
 
 Or if the field "uri" has been indexed, you might say
 
-	zapi iindex uri=/x/y/z
+	zapi index uri=/x/y/z
 
 For custom indexes, the name of index is given by the -x option,
 and the "pattern" argument(s) comprise one or more values that

--- a/cmd/zapi/cmd/index/find.go
+++ b/cmd/zapi/cmd/index/find.go
@@ -1,0 +1,97 @@
+package idx
+
+import (
+	"flag"
+
+	"github.com/brimsec/zq/archive"
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/emitter"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zqd/api"
+	"github.com/mccanne/charm"
+)
+
+var Find = &charm.Spec{
+	Name:  "find",
+	Usage: "find [options] pattern [pattern...]",
+	Short: "look through zar index files and displays matches",
+	Long: `
+"zapi index find" searches an archive-backed space 
+looking for zng files that have been indexed and performs a search on
+each such index file in accordance with the specified search pattern.
+Indexes are created by "zapi index create".
+
+For standard indexes, "pattern" argument has the form "field=value" (for field searches)
+or ":type=value" (for type searches).  For example, if type "ip" has been
+indexed then the IP 10.0.1.2 can be searched by saying
+
+	zapi index find :ip=10.0.1.2
+
+Or if the field "uri" has been indexed, you might say
+
+	zapi iindex uri=/x/y/z
+
+For custom indexes, the name of index is given by the -x option,
+and the "pattern" argument(s) comprise one or more values that
+are parseable in accordance with the zng type of the corresponding
+search keys.  For example, an index with custom keys of the form
+
+	record[a:record[x:int64,y:ip],b:string]
+
+could be queried using syntax like this
+
+	zapi idx find -x custom 99 10.0.0.1 hello
+
+The results of a search is either a list of the paths of each
+zng log that matches the pattern (the default), or a zng stream of the
+records of the base layer of the index file (-z)
+`,
+	New: NewFind,
+}
+
+func init() {
+	cmd.CLI.Add(Find)
+}
+
+type FindCmd struct {
+	*cmd.Command
+	indexFile     string
+	outputFile    string
+	pathField     string
+	relativePaths bool
+	zng           bool
+	writerFlags   zio.WriterFlags
+}
+
+func NewFind(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &FindCmd{Command: parent.(*IndexCmd).Command}
+	f.StringVar(&c.indexFile, "x", "", "name of microindex for custom index searches")
+	f.StringVar(&c.outputFile, "o", "", "write data to output file")
+	f.StringVar(&c.pathField, "l", archive.DefaultAddPathField, "zng field name for path name of log file")
+	f.BoolVar(&c.relativePaths, "relative", false, "display paths relative to root")
+	f.BoolVar(&c.zng, "z", false, "write results as zng stream rather than list of files")
+
+	// Flags added for writers are -f, -T, -F, -E, -U, and -b
+	c.writerFlags.SetFlags(f)
+
+	return c, nil
+}
+
+func (c *FindCmd) Run(args []string) error {
+	req := api.IndexSearchRequest{IndexName: c.indexFile, Patterns: args}
+	id, err := c.SpaceID()
+	if err != nil {
+		return err
+	}
+	stream, err := c.Client().IndexSearch(c.Context(), id, req, nil)
+	if err != nil {
+		return err
+	}
+	writer, err := emitter.NewFile(c.outputFile, c.writerFlags.Options())
+	if err != nil {
+		return err
+	}
+	defer writer.Close()
+	return zbuf.Copy(writer, stream)
+}

--- a/cmd/zapi/cmd/index/index.go
+++ b/cmd/zapi/cmd/index/index.go
@@ -1,0 +1,34 @@
+package idx
+
+import (
+	"flag"
+
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/mccanne/charm"
+)
+
+var Index = &charm.Spec{
+	Name:  "index",
+	Usage: "index [find|create]",
+	Short: "query and create search indexes",
+	Long:  "",
+	New:   New,
+}
+
+func init() {
+	cmd.CLI.Add(Index)
+	Index.Add(Find)
+	Index.Add(Create)
+}
+
+type IndexCmd struct {
+	*cmd.Command
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	return &IndexCmd{Command: parent.(*cmd.Command)}, nil
+}
+
+func (c *IndexCmd) Run(args []string) error {
+	return charm.ErrNoRun
+}

--- a/cmd/zapi/main.go
+++ b/cmd/zapi/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	_ "github.com/brimsec/zq/cmd/zapi/cmd/get"
+	_ "github.com/brimsec/zq/cmd/zapi/cmd/index"
 	_ "github.com/brimsec/zq/cmd/zapi/cmd/info"
 	_ "github.com/brimsec/zq/cmd/zapi/cmd/new"
 	_ "github.com/brimsec/zq/cmd/zapi/cmd/newsubspace"

--- a/tests/suite/zqd/index-custom.yaml
+++ b/tests/suite/zqd/index-custom.yaml
@@ -1,0 +1,19 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new -k archivestore testsp >/dev/null
+  zapi -h $ZQD_HOST -s testsp post babble.tzng >/dev/null
+  zapi -h $ZQD_HOST -s testsp index create -k key -o index.zng -z "sum(v) by s | put key=s | sort key"
+  zapi -h $ZQD_HOST -s testsp index find -f tzng -x index.zng glycerite-oligoprothesy
+
+inputs:
+  - name: services.sh
+    source: services.sh
+  - name: babble.tzng
+    source: ../data/babble.tzng
+
+outputs:
+  - name: stdout
+    data: |
+      #zfile=string
+      #0:record[s:string,sum:int64,key:string,_log:zfile]
+      0:[glycerite-oligoprothesy;407;glycerite-oligoprothesy;20200422/1587518620.0622373.zng;]

--- a/tests/suite/zqd/index-type.yaml
+++ b/tests/suite/zqd/index-type.yaml
@@ -1,0 +1,28 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new -k archivestore -thresh 1B testsp >/dev/null
+  zapi -h $ZQD_HOST -s testsp post data.tzng >/dev/null
+  zapi -h $ZQD_HOST -s testsp index create :ip
+  zapi -h $ZQD_HOST -s testsp index find -f tzng :ip=192.168.1.102
+  echo ===
+  zapi -h $ZQD_HOST -s testsp index find -f tzng :ip=192.168.1.103
+
+inputs:
+  - name: services.sh
+    source: services.sh
+  - name: data.tzng
+    data: |
+      #0:record[_path:string,ts:time,orig_h:ip]
+      0:[test;1.0;192.168.1.102;]
+      0:[test;2;192.168.1.103;]
+
+outputs:
+  - name: stdout
+    data: |
+      #zfile=string
+      #0:record[key:ip,count:uint64,_log:zfile]
+      0:[192.168.1.102;1;19700101/1.zng;]
+      ===
+      #zfile=string
+      #0:record[key:ip,count:uint64,_log:zfile]
+      0:[192.168.1.103;1;19700101/2.zng;]


### PR DESCRIPTION
Add zar index related commands, allowing users to create and query
indices in archive backed spaces.

Closes #882