### PR TITLE
Add context.Context args interface iosrc.Source

### DIFF
--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -124,24 +124,24 @@ func TestImportWhileOpen(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify initial update count.
-	update1, err := ark1.UpdateCheck()
+	update1, err := ark1.UpdateCheck(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, update1)
 
 	importTestFile(t, ark1, "testdata/td1.zng")
 
 	// Ensure UpdateCheck has incremented.
-	update2, err := ark1.UpdateCheck()
+	update2, err := ark1.UpdateCheck(context.Background())
 	require.NoError(t, err)
 	if !assert.Equal(t, 3, update2) {
-		if fi, err := iosrc.Stat(ark1.mdURI()); err == nil {
+		if fi, err := iosrc.Stat(context.Background(), ark1.mdURI()); err == nil {
 			fmt.Fprintf(os.Stderr, "metadata mtime: %v, mdModTime %v", fi.ModTime(), ark1.mdModTime)
 		}
 	}
 
 	// Verify data & that a span walk now does not increment the update counter.
 	var initialSpans []SpanInfo
-	err = SpanWalk(ark1, func(si SpanInfo, _ iosrc.URI) error {
+	err = SpanWalk(context.Background(), ark1, func(si SpanInfo, _ iosrc.URI) error {
 		initialSpans = append(initialSpans, si)
 		return nil
 	})
@@ -162,7 +162,7 @@ func TestImportWhileOpen(t *testing.T) {
 
 	// Verify that the data appears to the earlier opened handle
 	var postSpans []SpanInfo
-	err = SpanWalk(ark1, func(si SpanInfo, _ iosrc.URI) error {
+	err = SpanWalk(context.Background(), ark1, func(si SpanInfo, _ iosrc.URI) error {
 		postSpans = append(postSpans, si)
 		return nil
 	})
@@ -180,7 +180,7 @@ func TestImportWhileOpen(t *testing.T) {
 	assert.Equal(t, exp, postSpans)
 
 	if !assert.Equal(t, 4, ark1.mdUpdateCount) {
-		if fi, err := iosrc.Stat(ark1.mdURI()); err == nil {
+		if fi, err := iosrc.Stat(context.Background(), ark1.mdURI()); err == nil {
 			fmt.Fprintf(os.Stderr, "metadata mtime: %v, ark1.mdModTime %v, ark2.mdModTime %v", fi.ModTime(), ark1.mdModTime, ark2.mdModTime)
 		}
 	}
@@ -194,8 +194,8 @@ func TestRemoteSourceImport(t *testing.T) {
 	defer ctrl.Finish()
 	src := iosrcmock.NewMockSource(ctrl)
 	var recvuri iosrc.URI
-	src.EXPECT().NewWriter(gomock.Any()).
-		DoAndReturn(func(uri iosrc.URI) (io.WriteCloser, error) {
+	src.EXPECT().NewWriter(context.Background(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, uri iosrc.URI) (io.WriteCloser, error) {
 			recvuri = uri
 			return &nopWriteCloser{}, nil
 		})

--- a/archive/finder.go
+++ b/archive/finder.go
@@ -87,7 +87,7 @@ func Find(ctx context.Context, zctx *resolver.Context, ark *Archive, query Index
 			return err
 		}
 	}
-	if _, err := ark.UpdateCheck(); err != nil {
+	if _, err := ark.UpdateCheck(ctx); err != nil {
 		return err
 	}
 	ark.mu.RLock()
@@ -96,7 +96,7 @@ func Find(ctx context.Context, zctx *resolver.Context, ark *Archive, query Index
 	if !ok {
 		return zqe.E(zqe.NotFound)
 	}
-	return SpanWalk(ark, func(si SpanInfo, zardir iosrc.URI) error {
+	return SpanWalk(ctx, ark, func(si SpanInfo, zardir iosrc.URI) error {
 		searchHits := make(chan *zng.Record)
 		var searchErr error
 		go func() {
@@ -127,7 +127,7 @@ func Find(ctx context.Context, zctx *resolver.Context, ark *Archive, query Index
 
 func search(ctx context.Context, zctx *resolver.Context, hits chan<- *zng.Record, uri iosrc.URI, patterns []string) error {
 	finder := microindex.NewFinder(zctx, uri)
-	if err := finder.Open(); err != nil {
+	if err := finder.Open(ctx); err != nil {
 		return fmt.Errorf("%s: %w", finder.Path(), err)
 	}
 	defer finder.Close()

--- a/archive/import.go
+++ b/archive/import.go
@@ -23,6 +23,7 @@ func tsDir(ts nano.Ts) string {
 
 type importDriver struct {
 	ark *Archive
+	ctx context.Context
 	zw  *zngio.Writer
 
 	span   nano.Span
@@ -52,7 +53,7 @@ func (d *importDriver) writeOne(rec *zng.Record) error {
 		//XXX for now just truncate any existing file.
 		// a future PR will do a split/merge.
 		fpath := dpath.AppendPath(fname)
-		out, err := d.ark.dataSrc.NewWriter(fpath)
+		out, err := d.ark.dataSrc.NewWriter(d.ctx, fpath)
 		if err != nil {
 			return err
 		}
@@ -124,7 +125,7 @@ func Import(ctx context.Context, ark *Archive, zctx *resolver.Context, r zbuf.Re
 		return err
 	}
 
-	id := &importDriver{ark: ark}
+	id := &importDriver{ark: ark, ctx: ctx}
 	if err := driver.Run(ctx, id, proc, zctx, r, driver.Config{}); err != nil {
 		return fmt.Errorf("archive.Import: run failed: %w", err)
 	}

--- a/archive/stat.go
+++ b/archive/stat.go
@@ -45,7 +45,7 @@ func (s *statReadCloser) Close() error {
 }
 
 func (s *statReadCloser) chunkRecord(si SpanInfo, zardir iosrc.URI) error {
-	fi, err := iosrc.Stat(ZarDirToLog(zardir))
+	fi, err := iosrc.Stat(s.ctx, ZarDirToLog(zardir))
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (s *statReadCloser) chunkRecord(si SpanInfo, zardir iosrc.URI) error {
 }
 
 func (s *statReadCloser) indexRecord(si SpanInfo, zardir iosrc.URI, indexPath string) error {
-	info, err := microindex.Stat(zardir.AppendPath(indexPath))
+	info, err := microindex.Stat(s.ctx, zardir.AppendPath(indexPath))
 	if err != nil {
 		if errors.Is(err, zqe.E(zqe.NotFound)) {
 			return nil
@@ -138,7 +138,7 @@ func (s *statReadCloser) indexRecord(si SpanInfo, zardir iosrc.URI, indexPath st
 func (s *statReadCloser) run() {
 	defer close(s.recs)
 
-	if _, err := s.ark.UpdateCheck(); err != nil {
+	if _, err := s.ark.UpdateCheck(s.ctx); err != nil {
 		s.err = err
 		return
 	}
@@ -150,7 +150,7 @@ func (s *statReadCloser) run() {
 	s.ark.mu.RUnlock()
 	sort.Strings(indexPaths)
 
-	s.err = SpanWalk(s.ark, func(si SpanInfo, zardir iosrc.URI) error {
+	s.err = SpanWalk(s.ctx, s.ark, func(si SpanInfo, zardir iosrc.URI) error {
 		if err := s.chunkRecord(si, zardir); err != nil {
 			return err
 		}

--- a/cmd/microindex/lookup/command.go
+++ b/cmd/microindex/lookup/command.go
@@ -74,7 +74,7 @@ func (c *LookupCommand) Run(args []string) error {
 		return err
 	}
 	finder := microindex.NewFinder(resolver.NewContext(), uri)
-	if err := finder.Open(); err != nil {
+	if err := finder.Open(context.TODO()); err != nil {
 		return err
 	}
 	defer finder.Close()

--- a/cmd/zar/ls/command.go
+++ b/cmd/zar/ls/command.go
@@ -1,6 +1,7 @@
 package ls
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -59,14 +60,14 @@ func (c *Command) Run(args []string) error {
 	if len(args) == 1 {
 		pattern = args[0]
 	}
-	return archive.Walk(ark, func(zardir iosrc.URI) error {
+	return archive.Walk(context.TODO(), ark, func(zardir iosrc.URI) error {
 		c.printDir(ark.DataPath, zardir, pattern)
 		return nil
 	})
 }
 
 func fileExists(path iosrc.URI) bool {
-	info, err := iosrc.Stat(path)
+	info, err := iosrc.Stat(context.TODO(), path)
 	if err != nil {
 		return false
 	}
@@ -92,7 +93,7 @@ func (c *Command) printDir(root, dir iosrc.URI, pattern string) {
 			files = lsfs(dir.Filepath())
 		case "s3":
 			var err error
-			if files, err = s3io.ListObjects(dir.String(), nil); err != nil {
+			if files, err = s3io.ListObjects(context.TODO(), dir.String(), nil); err != nil {
 				fmt.Fprintf(os.Stderr, "error listing s3 objects: %v", err)
 				return
 			}

--- a/cmd/zar/map/command.go
+++ b/cmd/zar/map/command.go
@@ -102,14 +102,14 @@ func (c *Command) Run(args []string) error {
 	ctx, cancel := signalctx.New(os.Interrupt)
 	defer cancel()
 
-	ark, err := archive.OpenArchive(c.root, nil)
+	ark, err := archive.OpenArchiveWithContext(ctx, c.root, nil)
 	if err != nil {
 		return err
 	}
 
 	// XXX this is parallelizable except for writing to stdout when
 	// concatenating results
-	return archive.Walk(ark, func(zardir iosrc.URI) error {
+	return archive.Walk(ctx, ark, func(zardir iosrc.URI) error {
 		var paths []string
 		for _, input := range inputs {
 			p := archive.Localize(zardir, input)

--- a/cmd/zar/rm/command.go
+++ b/cmd/zar/rm/command.go
@@ -1,6 +1,7 @@
 package rm
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -54,10 +55,10 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 
-	return archive.Walk(ark, func(zardir iosrc.URI) error {
+	return archive.Walk(context.TODO(), ark, func(zardir iosrc.URI) error {
 		for _, name := range args {
 			path := zardir.AppendPath(name)
-			if err := iosrc.Remove(path); err != nil {
+			if err := iosrc.Remove(context.TODO(), path); err != nil {
 				var zerr *zqe.Error
 				if errors.As(err, &zerr) && zerr.Kind == zqe.NotFound {
 					fmt.Printf("%s: not found\n", c.printable(ark.DataPath, path))

--- a/cmd/zar/rmdirs/command.go
+++ b/cmd/zar/rmdirs/command.go
@@ -1,6 +1,7 @@
 package rmdirs
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -42,5 +43,5 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	return archive.RmDirs(ark)
+	return archive.RmDirs(context.TODO(), ark)
 }

--- a/emitter/dir_test.go
+++ b/emitter/dir_test.go
@@ -2,6 +2,7 @@ package emitter
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -29,9 +30,9 @@ func TestDirS3Source(t *testing.T) {
 	defer ctrl.Finish()
 	src := iosrcmock.NewMockSource(ctrl)
 
-	src.EXPECT().NewWriter(uri.AppendPath("conn.tzng")).
+	src.EXPECT().NewWriter(context.Background(), uri.AppendPath("conn.tzng")).
 		Return(&nopCloser{bytes.NewBuffer(nil)}, nil)
-	src.EXPECT().NewWriter(uri.AppendPath("http.tzng")).
+	src.EXPECT().NewWriter(context.Background(), uri.AppendPath("http.tzng")).
 		Return(&nopCloser{bytes.NewBuffer(nil)}, nil)
 
 	r := tzngio.NewReader(strings.NewReader(tzng), resolver.NewContext())

--- a/emitter/file.go
+++ b/emitter/file.go
@@ -1,6 +1,7 @@
 package emitter
 
 import (
+	"context"
 	"io"
 	"os"
 
@@ -37,7 +38,7 @@ func IsTerminal(w io.Writer) bool {
 }
 
 func NewFileWithSource(path iosrc.URI, opts zio.WriterOpts, source iosrc.Source) (zbuf.WriteCloser, error) {
-	f, err := source.NewWriter(path)
+	f, err := source.NewWriter(context.Background(), path) // XXX pass context?
 	if err != nil {
 		return nil, err
 	}

--- a/microindex/finder.go
+++ b/microindex/finder.go
@@ -35,8 +35,8 @@ func NewFinder(zctx *resolver.Context, uri iosrc.URI) *Finder {
 // exist, or its microindex trailer is invalid.  If the microindex exists
 // but is empty, zero values are returned for any lookups.  If the microindex
 // does not exist, os.ErrNotExist is returned.
-func (f *Finder) Open() error {
-	reader, err := NewReaderFromURI(f.zctx, f.uri)
+func (f *Finder) Open(ctx context.Context) error {
+	reader, err := NewReaderFromURI(ctx, f.zctx, f.uri)
 	f.Reader = reader
 	return err
 }

--- a/microindex/microindex_test.go
+++ b/microindex/microindex_test.go
@@ -2,6 +2,7 @@ package microindex_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -98,7 +99,7 @@ func TestSearch(t *testing.T) {
 	require.NoError(t, err)
 	zctx := resolver.NewContext()
 	finder := microindex.NewFinder(zctx, uri)
-	require.NoError(t, finder.Open())
+	require.NoError(t, finder.Open(context.Background()))
 	keyRec, err := zng.NewBuilder(finder.Keys()).Parse("key2")
 	require.NoError(t, err)
 	rec, err := finder.Lookup(keyRec)

--- a/microindex/reader.go
+++ b/microindex/reader.go
@@ -1,6 +1,7 @@
 package microindex
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -39,11 +40,19 @@ func NewReader(zctx *resolver.Context, path string) (*Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewReaderFromURI(zctx, uri)
+	return NewReaderFromURI(context.Background(), zctx, uri)
 }
 
-func NewReaderFromURI(zctx *resolver.Context, uri iosrc.URI) (*Reader, error) {
-	r, err := iosrc.NewReader(uri)
+func NewReaderWithContext(ctx context.Context, zctx *resolver.Context, path string) (*Reader, error) {
+	uri, err := iosrc.ParseURI(path)
+	if err != nil {
+		return nil, err
+	}
+	return NewReaderFromURI(ctx, zctx, uri)
+}
+
+func NewReaderFromURI(ctx context.Context, zctx *resolver.Context, uri iosrc.URI) (*Reader, error) {
+	r, err := iosrc.NewReader(ctx, uri)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +61,7 @@ func NewReaderFromURI(zctx *resolver.Context, uri iosrc.URI) (*Reader, error) {
 	// in the inner loop of a microindex scan, so we might want to do this
 	// in parallel with the open either by extending the iosrc interface
 	// or running this call here in its own goroutine (before the open)
-	si, err := iosrc.Stat(uri)
+	si, err := iosrc.Stat(ctx, uri)
 	if err != nil {
 		return nil, err
 	}

--- a/microindex/stat.go
+++ b/microindex/stat.go
@@ -1,6 +1,8 @@
 package microindex
 
 import (
+	"context"
+
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zng/resolver"
 )
@@ -16,13 +18,13 @@ type Info struct {
 }
 
 // Stat returns summary information about the microindex at uri.
-func Stat(uri iosrc.URI) (*Info, error) {
-	si, err := iosrc.Stat(uri)
+func Stat(ctx context.Context, uri iosrc.URI) (*Info, error) {
+	si, err := iosrc.Stat(ctx, uri)
 	if err != nil {
 		return nil, err
 	}
 	size := si.Size()
-	r, err := NewReaderFromURI(resolver.NewContext(), uri)
+	r, err := NewReaderFromURI(ctx, resolver.NewContext(), uri)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/iosrc/iosrc.go
+++ b/pkg/iosrc/iosrc.go
@@ -3,6 +3,7 @@
 package iosrc
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -25,16 +26,16 @@ type Reader interface {
 }
 
 type Source interface {
-	NewReader(URI) (Reader, error)
-	NewWriter(URI) (io.WriteCloser, error)
-	ReadFile(URI) ([]byte, error)
-	WriteFile([]byte, URI) error
-	Remove(URI) error
-	RemoveAll(URI) error
+	NewReader(context.Context, URI) (Reader, error)
+	NewWriter(context.Context, URI) (io.WriteCloser, error)
+	ReadFile(context.Context, URI) ([]byte, error)
+	WriteFile(context.Context, []byte, URI) error
+	Remove(context.Context, URI) error
+	RemoveAll(context.Context, URI) error
 	// Exists returns true if the specified uri exists and an error is there
 	// was an error finding this information.
-	Exists(URI) (bool, error)
-	Stat(URI) (Info, error)
+	Exists(context.Context, URI) (bool, error)
+	Stat(context.Context, URI) (Info, error)
 }
 
 type Info interface {
@@ -48,63 +49,71 @@ type DirMaker interface {
 
 // A ReplacerAble source supports atomic updates to a URI.
 type ReplacerAble interface {
-	NewReplacer(URI) (io.WriteCloser, error)
+	NewReplacer(context.Context, URI) (io.WriteCloser, error)
 }
 
-func NewReader(uri URI) (Reader, error) {
+func NewReader(ctx context.Context, uri URI) (Reader, error) {
 	source, err := GetSource(uri)
 	if err != nil {
 		return nil, err
 	}
-	return source.NewReader(uri)
+	return source.NewReader(ctx, uri)
 }
 
-func NewWriter(uri URI) (io.WriteCloser, error) {
+func NewWriter(ctx context.Context, uri URI) (io.WriteCloser, error) {
 	source, err := GetSource(uri)
 	if err != nil {
 		return nil, err
 	}
-	return source.NewWriter(uri)
+	return source.NewWriter(ctx, uri)
 }
 
-func ReadFile(uri URI) ([]byte, error) {
+func ReadFile(ctx context.Context, uri URI) ([]byte, error) {
 	source, err := GetSource(uri)
 	if err != nil {
 		return nil, err
 	}
-	return source.ReadFile(uri)
+	return source.ReadFile(ctx, uri)
 }
 
-func WriteFile(uri URI, d []byte) error {
+func WriteFile(ctx context.Context, uri URI, d []byte) error {
 	source, err := GetSource(uri)
 	if err != nil {
 		return err
 	}
-	return source.WriteFile(d, uri)
+	return source.WriteFile(ctx, d, uri)
 }
 
-func Exists(uri URI) (bool, error) {
+func Exists(ctx context.Context, uri URI) (bool, error) {
 	source, err := GetSource(uri)
 	if err != nil {
 		return false, err
 	}
-	return source.Exists(uri)
+	return source.Exists(ctx, uri)
 }
 
-func Remove(uri URI) error {
+func Remove(ctx context.Context, uri URI) error {
 	source, err := GetSource(uri)
 	if err != nil {
 		return err
 	}
-	return source.Remove(uri)
+	return source.Remove(ctx, uri)
 }
 
-func RemoveAll(uri URI) error {
+func RemoveAll(ctx context.Context, uri URI) error {
 	source, err := GetSource(uri)
 	if err != nil {
 		return err
 	}
-	return source.RemoveAll(uri)
+	return source.RemoveAll(ctx, uri)
+}
+
+func Stat(ctx context.Context, uri URI) (Info, error) {
+	source, err := GetSource(uri)
+	if err != nil {
+		return nil, err
+	}
+	return source.Stat(ctx, uri)
 }
 
 func GetSource(uri URI) (Source, error) {
@@ -114,14 +123,6 @@ func GetSource(uri URI) (Source, error) {
 		return nil, fmt.Errorf("unknown scheme: %q", scheme)
 	}
 	return source, nil
-}
-
-func Stat(uri URI) (Info, error) {
-	source, err := GetSource(uri)
-	if err != nil {
-		return nil, err
-	}
-	return source.Stat(uri)
 }
 
 func getScheme(uri URI) string {

--- a/pkg/iosrc/mock/mock_source.go
+++ b/pkg/iosrc/mock/mock_source.go
@@ -5,6 +5,7 @@
 package mock
 
 import (
+	context "context"
 	iosrc "github.com/brimsec/zq/pkg/iosrc"
 	gomock "github.com/golang/mock/gomock"
 	io "io"
@@ -35,118 +36,118 @@ func (m *MockSource) EXPECT() *MockSourceMockRecorder {
 }
 
 // Exists mocks base method
-func (m *MockSource) Exists(arg0 iosrc.URI) (bool, error) {
+func (m *MockSource) Exists(arg0 context.Context, arg1 iosrc.URI) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exists", arg0)
+	ret := m.ctrl.Call(m, "Exists", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Exists indicates an expected call of Exists
-func (mr *MockSourceMockRecorder) Exists(arg0 interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) Exists(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockSource)(nil).Exists), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockSource)(nil).Exists), arg0, arg1)
 }
 
 // NewReader mocks base method
-func (m *MockSource) NewReader(arg0 iosrc.URI) (iosrc.Reader, error) {
+func (m *MockSource) NewReader(arg0 context.Context, arg1 iosrc.URI) (iosrc.Reader, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewReader", arg0)
+	ret := m.ctrl.Call(m, "NewReader", arg0, arg1)
 	ret0, _ := ret[0].(iosrc.Reader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewReader indicates an expected call of NewReader
-func (mr *MockSourceMockRecorder) NewReader(arg0 interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) NewReader(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReader", reflect.TypeOf((*MockSource)(nil).NewReader), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReader", reflect.TypeOf((*MockSource)(nil).NewReader), arg0, arg1)
 }
 
 // NewWriter mocks base method
-func (m *MockSource) NewWriter(arg0 iosrc.URI) (io.WriteCloser, error) {
+func (m *MockSource) NewWriter(arg0 context.Context, arg1 iosrc.URI) (io.WriteCloser, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewWriter", arg0)
+	ret := m.ctrl.Call(m, "NewWriter", arg0, arg1)
 	ret0, _ := ret[0].(io.WriteCloser)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewWriter indicates an expected call of NewWriter
-func (mr *MockSourceMockRecorder) NewWriter(arg0 interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) NewWriter(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewWriter", reflect.TypeOf((*MockSource)(nil).NewWriter), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewWriter", reflect.TypeOf((*MockSource)(nil).NewWriter), arg0, arg1)
 }
 
 // ReadFile mocks base method
-func (m *MockSource) ReadFile(arg0 iosrc.URI) ([]byte, error) {
+func (m *MockSource) ReadFile(arg0 context.Context, arg1 iosrc.URI) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadFile", arg0)
+	ret := m.ctrl.Call(m, "ReadFile", arg0, arg1)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadFile indicates an expected call of ReadFile
-func (mr *MockSourceMockRecorder) ReadFile(arg0 interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) ReadFile(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockSource)(nil).ReadFile), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockSource)(nil).ReadFile), arg0, arg1)
 }
 
 // Remove mocks base method
-func (m *MockSource) Remove(arg0 iosrc.URI) error {
+func (m *MockSource) Remove(arg0 context.Context, arg1 iosrc.URI) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Remove", arg0)
+	ret := m.ctrl.Call(m, "Remove", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Remove indicates an expected call of Remove
-func (mr *MockSourceMockRecorder) Remove(arg0 interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) Remove(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockSource)(nil).Remove), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockSource)(nil).Remove), arg0, arg1)
 }
 
 // RemoveAll mocks base method
-func (m *MockSource) RemoveAll(arg0 iosrc.URI) error {
+func (m *MockSource) RemoveAll(arg0 context.Context, arg1 iosrc.URI) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveAll", arg0)
+	ret := m.ctrl.Call(m, "RemoveAll", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveAll indicates an expected call of RemoveAll
-func (mr *MockSourceMockRecorder) RemoveAll(arg0 interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) RemoveAll(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockSource)(nil).RemoveAll), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveAll", reflect.TypeOf((*MockSource)(nil).RemoveAll), arg0, arg1)
 }
 
 // Stat mocks base method
-func (m *MockSource) Stat(arg0 iosrc.URI) (iosrc.Info, error) {
+func (m *MockSource) Stat(arg0 context.Context, arg1 iosrc.URI) (iosrc.Info, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Stat", arg0)
+	ret := m.ctrl.Call(m, "Stat", arg0, arg1)
 	ret0, _ := ret[0].(iosrc.Info)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Stat indicates an expected call of Stat
-func (mr *MockSourceMockRecorder) Stat(arg0 interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) Stat(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockSource)(nil).Stat), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stat", reflect.TypeOf((*MockSource)(nil).Stat), arg0, arg1)
 }
 
 // WriteFile mocks base method
-func (m *MockSource) WriteFile(arg0 []byte, arg1 iosrc.URI) error {
+func (m *MockSource) WriteFile(arg0 context.Context, arg1 []byte, arg2 iosrc.URI) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteFile", arg0, arg1)
+	ret := m.ctrl.Call(m, "WriteFile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteFile indicates an expected call of WriteFile
-func (mr *MockSourceMockRecorder) WriteFile(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSourceMockRecorder) WriteFile(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockSource)(nil).WriteFile), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockSource)(nil).WriteFile), arg0, arg1, arg2)
 }

--- a/pkg/iosrc/s3.go
+++ b/pkg/iosrc/s3.go
@@ -1,6 +1,7 @@
 package iosrc
 
 import (
+	"context"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -16,23 +17,24 @@ import (
 
 var defaultS3Source = &s3Source{}
 var _ Source = defaultS3Source
+var _ ReplacerAble = defaultS3Source
 
 type s3Source struct {
 	Config *aws.Config
 }
 
-func (s *s3Source) NewWriter(u URI) (io.WriteCloser, error) {
-	w, err := s3io.NewWriter(u.String(), s.Config)
+func (s *s3Source) NewWriter(ctx context.Context, u URI) (io.WriteCloser, error) {
+	w, err := s3io.NewWriter(ctx, u.String(), s.Config)
 	return w, wrapErr(err)
 }
 
-func (s *s3Source) NewReader(u URI) (Reader, error) {
-	r, err := s3io.NewReader(u.String(), s.Config)
+func (s *s3Source) NewReader(ctx context.Context, u URI) (Reader, error) {
+	r, err := s3io.NewReader(ctx, u.String(), s.Config)
 	return r, wrapErr(err)
 }
 
-func (s *s3Source) ReadFile(u URI) ([]byte, error) {
-	r, err := NewReader(u)
+func (s *s3Source) ReadFile(ctx context.Context, u URI) ([]byte, error) {
+	r, err := NewReader(ctx, u)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +42,8 @@ func (s *s3Source) ReadFile(u URI) ([]byte, error) {
 	return ioutil.ReadAll(r)
 }
 
-func (s *s3Source) WriteFile(d []byte, u URI) error {
-	w, err := NewWriter(u)
+func (s *s3Source) WriteFile(ctx context.Context, d []byte, u URI) error {
+	w, err := NewWriter(ctx, u)
 	if err != nil {
 		return err
 	}
@@ -52,16 +54,16 @@ func (s *s3Source) WriteFile(d []byte, u URI) error {
 	return err
 }
 
-func (s *s3Source) Remove(u URI) error {
-	return wrapErr(s3io.Remove(u.String(), s.Config))
+func (s *s3Source) Remove(ctx context.Context, u URI) error {
+	return wrapErr(s3io.Remove(ctx, u.String(), s.Config))
 }
 
-func (s *s3Source) RemoveAll(u URI) error {
-	return wrapErr(s3io.RemoveAll(u.String(), s.Config))
+func (s *s3Source) RemoveAll(ctx context.Context, u URI) error {
+	return wrapErr(s3io.RemoveAll(ctx, u.String(), s.Config))
 }
 
-func (s *s3Source) Exists(u URI) (bool, error) {
-	ok, err := s3io.Exists(u.String(), s.Config)
+func (s *s3Source) Exists(ctx context.Context, u URI) (bool, error) {
+	ok, err := s3io.Exists(ctx, u.String(), s.Config)
 	return ok, wrapErr(err)
 }
 
@@ -70,17 +72,17 @@ type info s3.HeadObjectOutput
 func (i info) Size() int64        { return *i.ContentLength }
 func (i info) ModTime() time.Time { return *i.LastModified }
 
-func (s *s3Source) Stat(u URI) (Info, error) {
-	out, err := s3io.Stat(u.String(), s.Config)
+func (s *s3Source) Stat(ctx context.Context, u URI) (Info, error) {
+	out, err := s3io.Stat(ctx, u.String(), s.Config)
 	if err != nil {
 		return nil, wrapErr(err)
 	}
 	return info(*out), nil
 }
 
-func (s *s3Source) NewReplacer(uri URI) (io.WriteCloser, error) {
+func (s *s3Source) NewReplacer(ctx context.Context, uri URI) (io.WriteCloser, error) {
 	// Updates to S3 objects are atomic.
-	return s.NewWriter(uri)
+	return s.NewWriter(ctx, uri)
 }
 
 func wrapErr(err error) error {

--- a/pkg/iosrc/stdio.go
+++ b/pkg/iosrc/stdio.go
@@ -1,6 +1,7 @@
 package iosrc
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -13,35 +14,35 @@ var defaultStdioSource = &StdioSource{}
 
 type StdioSource struct{}
 
-func (f *StdioSource) NewReader(uri URI) (Reader, error) {
+func (f *StdioSource) NewReader(_ context.Context, uri URI) (Reader, error) {
 	return getStdioSource(uri)
 }
 
-func (s *StdioSource) NewWriter(uri URI) (io.WriteCloser, error) {
+func (s *StdioSource) NewWriter(_ context.Context, uri URI) (io.WriteCloser, error) {
 	return getStdioSource(uri)
 }
 
-func (s *StdioSource) ReadFile(uri URI) ([]byte, error) {
+func (s *StdioSource) ReadFile(_ context.Context, uri URI) ([]byte, error) {
 	return nil, errStdioNotSupport
 }
 
-func (s *StdioSource) WriteFile(_ []byte, _ URI) error {
+func (s *StdioSource) WriteFile(_ context.Context, _ []byte, _ URI) error {
 	return errStdioNotSupport
 }
 
-func (s *StdioSource) Remove(uri URI) error {
+func (s *StdioSource) Remove(_ context.Context, uri URI) error {
 	return errStdioNotSupport
 }
 
-func (s *StdioSource) RemoveAll(uri URI) error {
+func (s *StdioSource) RemoveAll(_ context.Context, uri URI) error {
 	return errStdioNotSupport
 }
 
-func (s *StdioSource) Stat(uri URI) (Info, error) {
+func (s *StdioSource) Stat(_ context.Context, uri URI) (Info, error) {
 	return nil, errStdioNotSupport
 }
 
-func (s *StdioSource) Exists(uri URI) (bool, error) {
+func (s *StdioSource) Exists(_ context.Context, uri URI) (bool, error) {
 	if _, err := getStdioSource(uri); err != nil {
 		return false, err
 	}

--- a/pkg/s3io/reader.go
+++ b/pkg/s3io/reader.go
@@ -1,6 +1,7 @@
 package s3io
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 
 type Reader struct {
 	client *s3.S3
+	ctx    context.Context
 	bucket string
 	key    string
 	size   int64
@@ -19,8 +21,8 @@ type Reader struct {
 	body   io.ReadCloser
 }
 
-func NewReader(path string, cfg *aws.Config) (*Reader, error) {
-	info, err := Stat(path, cfg)
+func NewReader(ctx context.Context, path string, cfg *aws.Config) (*Reader, error) {
+	info, err := Stat(ctx, path, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -30,6 +32,7 @@ func NewReader(path string, cfg *aws.Config) (*Reader, error) {
 	}
 	return &Reader{
 		client: newClient(cfg),
+		ctx:    ctx,
 		bucket: bucket,
 		key:    key,
 		size:   *info.ContentLength,
@@ -115,7 +118,7 @@ func (r *Reader) makeRequest(off int64, count int64) (io.ReadCloser, error) {
 		Key:    aws.String(r.key),
 		Range:  aws.String(fmt.Sprintf("bytes=%d-%d", off, off+count-1)),
 	}
-	res, err := r.client.GetObject(input)
+	res, err := r.client.GetObjectWithContext(r.ctx, input)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/s3io/s3io.go
+++ b/pkg/s3io/s3io.go
@@ -1,6 +1,7 @@
 package s3io
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -21,7 +22,7 @@ var ErrInvalidS3Path = errors.New("path is not a valid s3 location")
 // uploader is an interface wrapper for s3manager.Uploader. This is only here
 // for unit testing purposes.
 type uploader interface {
-	Upload(*s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
+	UploadWithContext(context.Context, *s3manager.UploadInput, ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 }
 
 func IsS3Path(path string) bool {
@@ -45,6 +46,7 @@ func parsePath(path string) (bucket, key string, err error) {
 type Writer struct {
 	writer   *io.PipeWriter
 	reader   *io.PipeReader
+	ctx      context.Context
 	uploader uploader
 	bucket   string
 	key      string
@@ -53,7 +55,7 @@ type Writer struct {
 	err      error
 }
 
-func NewWriter(path string, cfg *aws.Config, options ...func(*s3manager.Uploader)) (*Writer, error) {
+func NewWriter(ctx context.Context, path string, cfg *aws.Config, options ...func(*s3manager.Uploader)) (*Writer, error) {
 	bucket, key, err := parsePath(path)
 	if err != nil {
 		return nil, err
@@ -62,18 +64,19 @@ func NewWriter(path string, cfg *aws.Config, options ...func(*s3manager.Uploader
 	uploader := s3manager.NewUploaderWithClient(client, options...)
 	pr, pw := io.Pipe()
 	return &Writer{
-		bucket:   bucket,
-		key:      key,
 		writer:   pw,
 		reader:   pr,
+		ctx:      ctx,
 		uploader: uploader,
+		bucket:   bucket,
+		key:      key,
 	}, nil
 }
 
 func (w *Writer) init() {
 	w.done.Add(1)
 	go func() {
-		_, err := w.uploader.Upload(&s3manager.UploadInput{
+		_, err := w.uploader.UploadWithContext(w.ctx, &s3manager.UploadInput{
 			Bucket: aws.String(w.bucket),
 			Key:    aws.String(w.key),
 			Body:   w.reader,
@@ -98,7 +101,7 @@ func (w *Writer) Close() error {
 	return w.err
 }
 
-func RemoveAll(path string, cfg *aws.Config) error {
+func RemoveAll(ctx context.Context, path string, cfg *aws.Config) error {
 	bucket, key, err := parsePath(path)
 	if err != nil {
 		return err
@@ -109,7 +112,7 @@ func RemoveAll(path string, cfg *aws.Config) error {
 		Bucket: aws.String(bucket),
 		Prefix: aws.String(key),
 	})
-	if err := deleter.Delete(aws.BackgroundContext(), it); err != nil {
+	if err := deleter.Delete(ctx, it); err != nil {
 		return err
 	}
 	for it.Next() {
@@ -121,44 +124,44 @@ func RemoveAll(path string, cfg *aws.Config) error {
 	return nil
 }
 
-func Remove(path string, cfg *aws.Config) error {
+func Remove(ctx context.Context, path string, cfg *aws.Config) error {
 	bucket, key, err := parsePath(path)
 	if err != nil {
 		return err
 	}
-	if _, err := head(bucket, key, cfg); err != nil {
+	if _, err := head(ctx, bucket, key, cfg); err != nil {
 		return err
 	}
-	_, err = newClient(cfg).DeleteObject(&s3.DeleteObjectInput{
+	_, err = newClient(cfg).DeleteObjectWithContext(ctx, &s3.DeleteObjectInput{
 		Key:    &key,
 		Bucket: &bucket,
 	})
 	return err
 }
 
-func Stat(path string, cfg *aws.Config) (*s3.HeadObjectOutput, error) {
+func Stat(ctx context.Context, path string, cfg *aws.Config) (*s3.HeadObjectOutput, error) {
 	bucket, key, err := parsePath(path)
 	if err != nil {
 		return nil, err
 	}
-	return head(bucket, key, cfg)
+	return head(ctx, bucket, key, cfg)
 }
 
-func head(bucket, key string, cfg *aws.Config) (*s3.HeadObjectOutput, error) {
-	return newClient(cfg).HeadObject(&s3.HeadObjectInput{
+func head(ctx context.Context, bucket, key string, cfg *aws.Config) (*s3.HeadObjectOutput, error) {
+	return newClient(cfg).HeadObjectWithContext(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})
 }
 
-func ListObjects(path string, cfg *aws.Config) ([]string, error) {
+func ListObjects(ctx context.Context, path string, cfg *aws.Config) ([]string, error) {
 	bucket, key, err := parsePath(path)
 	if err != nil {
 		return nil, err
 	}
 	client := newClient(cfg)
 	var keys []string
-	return keys, ls(client, bucket, key, func(out *s3.ListObjectsV2Output, lastPage bool) bool {
+	return keys, ls(ctx, client, bucket, key, func(out *s3.ListObjectsV2Output, lastPage bool) bool {
 		for _, obj := range out.Contents {
 			keys = append(keys, *obj.Key)
 		}
@@ -166,7 +169,7 @@ func ListObjects(path string, cfg *aws.Config) ([]string, error) {
 	})
 }
 
-func ListCommonPrefixes(path string, cfg *aws.Config) ([]string, error) {
+func ListCommonPrefixes(ctx context.Context, path string, cfg *aws.Config) ([]string, error) {
 	bucket, key, err := parsePath(path)
 	if err != nil {
 		return nil, err
@@ -190,16 +193,16 @@ func ListCommonPrefixes(path string, cfg *aws.Config) ([]string, error) {
 	return prefixes, err
 }
 
-func ls(client *s3.S3, bucket, key string, cb func(*s3.ListObjectsV2Output, bool) bool) error {
+func ls(ctx context.Context, client *s3.S3, bucket, key string, cb func(*s3.ListObjectsV2Output, bool) bool) error {
 	input := &s3.ListObjectsV2Input{
 		Prefix: aws.String(key),
 		Bucket: aws.String(bucket),
 	}
-	return client.ListObjectsV2Pages(input, cb)
+	return client.ListObjectsV2PagesWithContext(ctx, input, cb)
 }
 
-func Exists(path string, cfg *aws.Config) (bool, error) {
-	_, err := Stat(path, cfg)
+func Exists(ctx context.Context, path string, cfg *aws.Config) (bool, error) {
+	_, err := Stat(ctx, path, cfg)
 	if err != nil {
 		var reqerr awserr.RequestFailure
 		if errors.As(err, &reqerr) && reqerr.StatusCode() == http.StatusNotFound {

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -213,7 +213,7 @@ func handleSpacePost(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sp, err := c.spaces.Create(req)
+	sp, err := c.spaces.Create(r.Context(), req)
 	if err != nil {
 		respondError(c, w, r, err)
 		return
@@ -245,7 +245,7 @@ func handleSubspacePost(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sp, err := c.spaces.CreateSubspace(s, req)
+	sp, err := c.spaces.CreateSubspace(ctx, s, req)
 	if err != nil {
 		respondError(c, w, r, err)
 		return
@@ -291,7 +291,7 @@ func handleSpaceDelete(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := c.spaces.Delete(api.SpaceID(id)); err != nil {
+	if err := c.spaces.Delete(r.Context(), api.SpaceID(id)); err != nil {
 		respondError(c, w, r, err)
 		return
 	}

--- a/zqd/ingest/pcap.go
+++ b/zqd/ingest/pcap.go
@@ -50,13 +50,13 @@ func NewPcapOp(ctx context.Context, pcapstore *pcapstorage.Store, store Clearabl
 	if err != nil {
 		return nil, nil, err
 	}
-	info, err := iosrc.Stat(pcapuri)
+	info, err := iosrc.Stat(ctx, pcapuri)
 	if err != nil {
 		return nil, nil, err
 	}
 	warn := make(chan string)
 	go func() {
-		err = pcapstore.Update(pcapuri, warn)
+		err = pcapstore.Update(ctx, pcapuri, warn)
 		close(warn)
 	}()
 	var warnings []string
@@ -101,7 +101,7 @@ func (p *PcapOp) run(ctx context.Context) error {
 		os.RemoveAll(p.logdir)
 		// Don't want to use passed context here because a cancelled context
 		// would cause storage not to be cleared.
-		p.pcapstore.Delete()
+		p.pcapstore.Delete(context.Background())
 		p.store.Clear(context.Background())
 	}
 
@@ -144,7 +144,7 @@ outer:
 }
 
 func (p *PcapOp) runZeek(ctx context.Context) error {
-	pcapfile, err := iosrc.NewReader(p.pcapuri)
+	pcapfile, err := iosrc.NewReader(ctx, p.pcapuri)
 	if err != nil {
 		return err
 	}
@@ -198,7 +198,7 @@ func (p *PcapOp) createSnapshot(ctx context.Context) error {
 	}
 	// convert logs into sorted zng
 	zctx := resolver.NewContext()
-	zr, err := detector.OpenFiles(zctx, zbuf.RecordCompare(p.store.NativeDirection()), files...)
+	zr, err := detector.OpenFiles(ctx, zctx, zbuf.RecordCompare(p.store.NativeDirection()), files...)
 	if err != nil {
 		return err
 	}

--- a/zqd/pcapstorage/pcapstorage.go
+++ b/zqd/pcapstorage/pcapstorage.go
@@ -42,9 +42,9 @@ func New(root iosrc.URI) *Store {
 	return &Store{root: root}
 }
 
-func Load(u iosrc.URI) (*Store, error) {
+func Load(ctx context.Context, u iosrc.URI) (*Store, error) {
 	metauri := u.AppendPath(MetaFile)
-	b, err := iosrc.ReadFile(metauri)
+	b, err := iosrc.ReadFile(ctx, metauri)
 	if os.IsNotExist(err) {
 		return nil, zqe.E(zqe.NotFound, "%s: pcap store not found", metauri)
 	}
@@ -61,10 +61,10 @@ func Load(u iosrc.URI) (*Store, error) {
 	}, nil
 }
 
-func (s *Store) Update(pcapuri iosrc.URI, warningCh chan<- string) error {
+func (s *Store) Update(ctx context.Context, pcapuri iosrc.URI, warningCh chan<- string) error {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()
-	pcapfile, err := iosrc.NewReader(pcapuri)
+	pcapfile, err := iosrc.NewReader(ctx, pcapuri)
 	if err != nil {
 		return err
 	}
@@ -89,9 +89,9 @@ func (s *Store) Update(pcapuri iosrc.URI, warningCh chan<- string) error {
 	metauri := s.root.AppendPath(MetaFile)
 	var w io.WriteCloser
 	if replace, ok := src.(iosrc.ReplacerAble); ok {
-		w, err = replace.NewReplacer(metauri)
+		w, err = replace.NewReplacer(ctx, metauri)
 	} else {
-		w, err = src.NewWriter(metauri)
+		w, err = src.NewWriter(ctx, metauri)
 	}
 	if err != nil {
 		return err
@@ -113,10 +113,10 @@ func (s *Store) Empty() bool {
 	return s.meta.PcapURI.IsZero()
 }
 
-func (s *Store) Info() (Info, error) {
+func (s *Store) Info(ctx context.Context) (Info, error) {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()
-	fi, err := iosrc.Stat(s.meta.PcapURI)
+	fi, err := iosrc.Stat(ctx, s.meta.PcapURI)
 	if err != nil {
 		return Info{}, err
 	}
@@ -133,11 +133,11 @@ func (s *Store) PcapURI() iosrc.URI {
 	return s.meta.PcapURI
 }
 
-func (s *Store) Delete() error {
+func (s *Store) Delete(ctx context.Context) error {
 	s.metaMu.Lock()
 	defer s.metaMu.Unlock()
 	s.meta = meta{}
-	return iosrc.Remove(s.root.AppendPath(MetaFile))
+	return iosrc.Remove(ctx, s.root.AppendPath(MetaFile))
 }
 
 type Search struct {
@@ -170,7 +170,7 @@ func (s *Store) NewSearch(ctx context.Context, req api.PcapSearch) (*Search, err
 	default:
 		return nil, fmt.Errorf("unsupported proto type: %s", req.Proto)
 	}
-	f, err := iosrc.NewReader(s.meta.PcapURI)
+	f, err := iosrc.NewReader(ctx, s.meta.PcapURI)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func (s *Store) NewSearch(ctx context.Context, req api.PcapSearch) (*Search, err
 const metaFileV0 = "packets.idx.json"
 
 func MigrateV3(u iosrc.URI, pcapuri iosrc.URI) error {
-	b, err := iosrc.ReadFile(u.AppendPath(metaFileV0))
+	b, err := iosrc.ReadFile(context.Background(), u.AppendPath(metaFileV0))
 	if err != nil {
 		return err
 	}
@@ -212,8 +212,8 @@ func MigrateV3(u iosrc.URI, pcapuri iosrc.URI) error {
 	if err != nil {
 		return err
 	}
-	if err := iosrc.WriteFile(u.AppendPath(MetaFile), out); err != nil {
+	if err := iosrc.WriteFile(context.Background(), u.AppendPath(MetaFile), out); err != nil {
 		return err
 	}
-	return iosrc.Remove(u.AppendPath(metaFileV0))
+	return iosrc.Remove(context.Background(), u.AppendPath(metaFileV0))
 }

--- a/zqd/space/archivespace.go
+++ b/zqd/space/archivespace.go
@@ -60,7 +60,7 @@ func (s *archiveSpace) updateConfigWithLock(conf config) error {
 	return nil
 }
 
-func (s *archiveSpace) delete() error {
+func (s *archiveSpace) delete(ctx context.Context) error {
 	s.confMu.Lock()
 	defer s.confMu.Unlock()
 
@@ -71,17 +71,17 @@ func (s *archiveSpace) delete() error {
 	if err := s.sg.acquireForDelete(); err != nil {
 		return err
 	}
-	if err := iosrc.RemoveAll(s.path); err != nil {
+	if err := iosrc.RemoveAll(ctx, s.path); err != nil {
 		return err
 	}
-	return iosrc.RemoveAll(s.conf.DataURI)
+	return iosrc.RemoveAll(ctx, s.conf.DataURI)
 }
 
-func (s *archiveSpace) CreateSubspace(req api.SubspacePostRequest) (*archiveSubspace, error) {
+func (s *archiveSpace) CreateSubspace(ctx context.Context, req api.SubspacePostRequest) (*archiveSubspace, error) {
 	s.confMu.Lock()
 	defer s.confMu.Unlock()
 
-	substore, err := archivestore.Load(s.conf.DataURI, &storage.ArchiveConfig{
+	substore, err := archivestore.Load(ctx, s.conf.DataURI, &storage.ArchiveConfig{
 		OpenOptions: &req.OpenOptions,
 	})
 	if err != nil {

--- a/zqd/space/archivesubspace.go
+++ b/zqd/space/archivesubspace.go
@@ -49,7 +49,7 @@ func (s *archiveSubspace) update(req api.SpacePutRequest) error {
 	})
 }
 
-func (s *archiveSubspace) delete() error {
+func (s *archiveSubspace) delete(_ context.Context) error {
 	if err := s.sg.acquireForDelete(); err != nil {
 		return err
 	}

--- a/zqd/space/config.go
+++ b/zqd/space/config.go
@@ -1,6 +1,7 @@
 package space
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -82,10 +83,10 @@ func (c config) subspaceIndex(id api.SpaceID) int {
 }
 
 // loadConfig loads the contents of config.json in a space's path.
-func (m *Manager) loadConfig(spaceURI iosrc.URI) (config, error) {
+func (m *Manager) loadConfig(ctx context.Context, spaceURI iosrc.URI) (config, error) {
 	var c config
 	p := spaceURI.AppendPath(configFile)
-	r, err := iosrc.NewReader(p)
+	r, err := iosrc.NewReader(ctx, p)
 	if err != nil {
 		return c, err
 	}
@@ -221,9 +222,9 @@ func writeConfig(spaceURI iosrc.URI, c config) error {
 	uri := spaceURI.AppendPath(configFile)
 	var w io.WriteCloser
 	if replacer, ok := src.(iosrc.ReplacerAble); ok {
-		w, err = replacer.NewReplacer(uri)
+		w, err = replacer.NewReplacer(context.TODO(), uri)
 	} else {
-		w, err = src.NewWriter(uri)
+		w, err = src.NewWriter(context.TODO(), uri)
 	}
 	if err != nil {
 		return err

--- a/zqd/space/filespace.go
+++ b/zqd/space/filespace.go
@@ -67,14 +67,14 @@ func (s *fileSpace) updateConfigWithLock(conf config) error {
 	return nil
 }
 
-func (s *fileSpace) delete() error {
+func (s *fileSpace) delete(ctx context.Context) error {
 	if err := s.sg.acquireForDelete(); err != nil {
 		return err
 	}
-	if err := iosrc.RemoveAll(s.path); err != nil {
+	if err := iosrc.RemoveAll(ctx, s.path); err != nil {
 		return err
 	}
-	return iosrc.RemoveAll(s.conf.DataURI)
+	return iosrc.RemoveAll(ctx, s.conf.DataURI)
 }
 
 func filesize(path string) (int64, error) {

--- a/zqd/space/manager_test.go
+++ b/zqd/space/manager_test.go
@@ -27,7 +27,7 @@ func TestConfigCurrentVersion(t *testing.T) {
 	require.NoError(t, err)
 	m, err := NewManager(u, zap.NewNop())
 	require.NoError(t, err)
-	s, err := m.Create(api.SpacePostRequest{Name: "test"})
+	s, err := m.Create(context.Background(), api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	id := s.ID()
 	versionConfig := struct {
@@ -73,7 +73,7 @@ func TestV3MigrationPcap(t *testing.T) {
 			Kind: storage.FileStore,
 		},
 	})
-	err := iosrc.WriteFile(pcapuri, nil)
+	err := iosrc.WriteFile(context.Background(), pcapuri, nil)
 	require.NoError(t, err)
 	tm.writeSpaceJSONFile(id, "packets.idx.json", pcap.Index{})
 
@@ -99,7 +99,7 @@ func TestV2Migration(t *testing.T) {
 			Kind: storage.FileStore,
 		},
 	})
-	err := iosrc.WriteFile(pcapuri, nil)
+	err := iosrc.WriteFile(context.Background(), pcapuri, nil)
 	require.NoError(t, err)
 	tm.writeSpaceJSONFile(id, "packets.idx.json", pcap.Index{})
 


### PR DESCRIPTION
Currently this change only applies to the s3 Source.

Adjust the various public methods of s3io to require a Context in
the first argument.

Closes #1108