### PR TITLE
Fix LDFLAGS in npm-installed zq build

### DIFF
--- a/npm/build/index.js
+++ b/npm/build/index.js
@@ -14,7 +14,7 @@ const getVersion = () => {
   return cmdOut.toString().trim()
 }
 
-const getLdflags = (version) => `-s -X main.version=${version}`
+const getLdflags = (version) => `-s -X github.com/brimsec/zq/cli.Version=${version}`
 
 const getBuildCommand = (options) =>
   // Double-quotes work both in Windows and *nix shells


### PR DESCRIPTION
NPM-installed `zq` started life in #712. Recent overhaul to reporting `zq` versions in #1249 and further refined in #1256 still left versioning broken in the NPM-built artifacts. Shout out to @mikesbrown who left us the helpful reminder back in #712 [😄 ]:

```
# If VERSION or LDFLAGS change, please also change
# npm/build.
```

I've tested the fix in this branch via:

```
$ git clone https://github.com/brimsec/brim.git
$ cd brim
$ npm install https://github.com/brimsec/zq#5c1d5adc0482b26e321500455477984eb4593a4e
$ npm install
$ zdeps/zq -version
Version: 5c1d5ad
$ npm start
...
```

Then in another shell:

```
$ curl http://localhost:9867/version
{"version":"5c1d5ad"}
```

Fixes #1295.
