### PR TITLE
Output format changes: Add "csv", remove "types"

### DIFF
--- a/zio/flags.go
+++ b/zio/flags.go
@@ -73,7 +73,7 @@ func (w *WriterFlags) Options() WriterOpts {
 }
 
 func (w *WriterFlags) SetFlags(fs *flag.FlagSet) {
-	fs.StringVar(&w.Format, "f", "zng", "format for output data [zng,ndjson,table,text,types,zeek,zjson,tzng]")
+	fs.StringVar(&w.Format, "f", "zng", "format for output data [zng,ndjson,table,text,csv,zeek,zjson,tzng]")
 	fs.BoolVar(&w.UTF8, "U", false, "display zeek strings as UTF-8")
 	fs.BoolVar(&w.Text.ShowTypes, "T", false, "display field types in text output")
 	fs.BoolVar(&w.Text.ShowFields, "F", false, "display field names in text output")


### PR DESCRIPTION
While verifying #1237, I noticed that CSV is not yet listed among the output formats. I wondered if maybe we were intentionally holding off on revealing it until we address #1271, but it seems useful enough in its present form that I'm proposing here that we reveal it now.

I'd also recalled seeing @mccanne mention recently that `types` was removed as an output format. Indeed, as of `zq` commit `4bce00d`:

```
$ zq -version
Version: v0.21.0-27-g4bce00d
```

Therefore I'm also taking that out while I'm at it.