### PR TITLE
zqe: Add syntactic sugar methods

### DIFF
--- a/cmd/zar/rm/command.go
+++ b/cmd/zar/rm/command.go
@@ -59,8 +59,7 @@ func (c *Command) Run(args []string) error {
 		for _, name := range args {
 			path := zardir.AppendPath(name)
 			if err := iosrc.Remove(context.TODO(), path); err != nil {
-				var zerr *zqe.Error
-				if errors.As(err, &zerr) && zerr.Kind == zqe.NotFound {
+				if zqe.IsNotFound(err) {
 					fmt.Printf("%s: not found\n", c.printable(ark.DataPath, path))
 					continue
 				}

--- a/pkg/iosrc/s3.go
+++ b/pkg/iosrc/s3.go
@@ -88,7 +88,7 @@ func (s *s3Source) NewReplacer(ctx context.Context, uri URI) (io.WriteCloser, er
 func wrapErr(err error) error {
 	var reqerr awserr.RequestFailure
 	if errors.As(err, &reqerr) && reqerr.StatusCode() == http.StatusNotFound {
-		return zqe.E(zqe.NotFound)
+		return zqe.ErrNotFound()
 	}
 	return err
 }

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -174,7 +174,7 @@ func loadSpaces(ctx context.Context, p iosrc.URI, conf config, logger *zap.Logge
 func loadPcapStore(ctx context.Context, u iosrc.URI) (*pcapstorage.Store, error) {
 	pcapstore, err := pcapstorage.Load(ctx, u)
 	if err != nil {
-		if zqe.IsKind(err, zqe.NotFound) {
+		if zqe.IsNotFound(err) {
 			return pcapstorage.New(u), nil
 		}
 		return nil, err

--- a/zqd/space/space.go
+++ b/zqd/space/space.go
@@ -2,7 +2,6 @@ package space
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path"
 	"sync"
@@ -175,8 +174,7 @@ func loadSpaces(ctx context.Context, p iosrc.URI, conf config, logger *zap.Logge
 func loadPcapStore(ctx context.Context, u iosrc.URI) (*pcapstorage.Store, error) {
 	pcapstore, err := pcapstorage.Load(ctx, u)
 	if err != nil {
-		var zerr *zqe.Error
-		if errors.As(err, &zerr) && zerr.Kind == zqe.NotFound {
+		if zqe.IsKind(err, zqe.NotFound) {
 			return pcapstorage.New(u), nil
 		}
 		return nil, err
@@ -219,8 +217,7 @@ func (s *spaceBase) Info(ctx context.Context) (api.SpaceInfo, error) {
 	if s.pcapstore != nil && !s.pcapstore.Empty() {
 		pcapinfo, err := s.pcapstore.Info(ctx)
 		if err != nil {
-			var ze *zqe.Error
-			if !errors.As(err, &ze) || ze.Kind != zqe.NotFound {
+			if !zqe.IsNotFound(err) {
 				s.logger.Error("Error getting pcap store summary", zap.Error(err))
 				return api.SpaceInfo{}, err
 			}

--- a/zqe/error.go
+++ b/zqe/error.go
@@ -125,6 +125,30 @@ func E(args ...interface{}) error {
 	return e
 }
 
+// IsKind returns true if the provided error can be unwrapped as a *Error and if
+// *Error.Kind matches the provided Kind
+func IsKind(err error, k Kind) bool {
+	var zerr *Error
+	return errors.As(err, &zerr) && zerr.Kind == k
+}
+
+func IsOther(err error) bool    { return IsKind(err, Other) }
+func IsConflict(err error) bool { return IsKind(err, Conflict) }
+func IsExists(err error) bool   { return IsKind(err, Exists) }
+func IsInvalid(err error) bool  { return IsKind(err, Invalid) }
+func IsNotFound(err error) bool { return IsKind(err, NotFound) }
+
+func ErrOther(args ...interface{}) error    { return errKind(Other, args) }
+func ErrConflict(args ...interface{}) error { return errKind(Conflict, args) }
+func ErrExists(args ...interface{}) error   { return errKind(Exists, args) }
+func ErrInvalid(args ...interface{}) error  { return errKind(Invalid, args) }
+func ErrNotFound(args ...interface{}) error { return errKind(NotFound, args) }
+
+func errKind(k Kind, args []interface{}) error {
+	args = append([]interface{}{k}, args...)
+	return E(args...)
+}
+
 func RecoverError(r interface{}) error {
 	return E("panic: %+v\n%s\n", r, string(debug.Stack()))
 }


### PR DESCRIPTION
Add some syntactic sugar methods to zqe that make it a little easier
to create error types and introspect errors.