### PR TITLE
Point to permanent link for joining public Slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for contributing to `zq`!
 Per [common practice](https://www.thinkful.com/learn/github-pull-request-tutorial/Feel-Free-to-Ask#Feel-Free-to-Ask),
 please [open an issue](https://github.com/brimsec/zq/issues) before sending a pull request.  If you
 think your ideas might benefit from some refinement via Q&A, come talk to us on
-[Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg) as well.
+[Slack](https://www.brimsecurity.com/join-slack/) as well.
 
 `zq` is early in its life cycle and will be expanding quickly.  Please star and/or
 watch the repo so you can follow and track our progress.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See the [contributing guide](CONTRIBUTING.md) on how you can help improve `zq`!
 
 ## Join the Community
 
-Join our [Public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg) workspace for announcements, Q&A, and to trade tips!
+Join our [Public Slack](https://www.brimsecurity.com/join-slack/) workspace for announcements, Q&A, and to trade tips!
 
 [doc-img]: https://godoc.org/github.com/brimsec/zq?status.svg
 [doc]: https://godoc.org/github.com/brimsec/zq

--- a/zeek/README.md
+++ b/zeek/README.md
@@ -34,7 +34,7 @@ can be tricky. We have ideas for ways we might improve it, but we'll have a
 better sense of priority and how to go about it if we've heard from those
 who have tried it. Whether you've used this feature and it "just worked" or if
 you hit challenges and need help, please join our
-[public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg)
+[public Slack](https://www.brimsecurity.com/join-slack/)
 and tell us about it, or
 [open an issue](https://github.com/brimsec/zq/issues/new/choose). Thanks!
 
@@ -438,5 +438,5 @@ the additional fields and logs included in the type definition.
 
 # Need help? Have feedback?
 
-Once again, please do join our [public Slack](https://join.slack.com/t/brimsec/shared_invite/zt-cy34xoxg-hZiTKUT~1KdGjlaBIuUUdg)
+Once again, please do join our [public Slack](https://www.brimsecurity.com/join-slack/)
 and let us know your experience (good or bad) so we can improve it. Thanks!


### PR DESCRIPTION
We recently added a redirect layer on the https://www.brimsecurity.com/ web site such that the `#` icon for joining Slack is attached to a permanent URL https://www.brimsecurity.com/join-slack/ which, in turn, redirects to the current "invite yourself" URL, which might change after 2000 users invite themselves or Slack expires it due to some glitch (it's happened before). Here I change all the Slack URL pointers such that if the "invite yourself" URL changes again in the future, we only have to update it in that one place on the web site.