### PR TITLE
simplify zbuf.Array

### DIFF
--- a/archive/proc.go
+++ b/archive/proc.go
@@ -78,7 +78,7 @@ func (f *FieldCutter) Pull() (zbuf.Batch, error) {
 		}
 		batch.Unref()
 		if len(recs) > 0 {
-			return zbuf.NewArray(recs), nil
+			return zbuf.Array(recs), nil
 		}
 	}
 }
@@ -135,7 +135,7 @@ func (t *TypeSplitter) Pull() (zbuf.Batch, error) {
 		}
 		batch.Unref()
 		if len(recs) > 0 {
-			return zbuf.NewArray(recs), nil
+			return zbuf.Array(recs), nil
 		}
 	}
 }

--- a/proc/cut/cut.go
+++ b/proc/cut/cut.go
@@ -90,7 +90,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 		}
 		batch.Unref()
 		if len(recs) > 0 {
-			return zbuf.NewArray(recs), nil
+			return zbuf.Array(recs), nil
 		}
 	}
 }

--- a/proc/filter/filter.go
+++ b/proc/filter/filter.go
@@ -33,7 +33,7 @@ func (f *Proc) Pull() (zbuf.Batch, error) {
 			out = append(out, r.Keep())
 		}
 	}
-	return zbuf.NewArray(out), nil
+	return zbuf.Array(out), nil
 }
 
 func (p *Proc) Done() {

--- a/proc/groupby/groupby.go
+++ b/proc/groupby/groupby.go
@@ -523,7 +523,7 @@ func (a *Aggregator) readSpills(eof bool) (zbuf.Batch, error) {
 	if len(recs) == 0 {
 		return nil, nil
 	}
-	return zbuf.NewArray(recs), nil
+	return zbuf.Array(recs), nil
 }
 
 func (a *Aggregator) nextResultFromSpills() (*zng.Record, error) {
@@ -632,7 +632,7 @@ func (a *Aggregator) readTable(flush, decompose bool) (zbuf.Batch, error) {
 	if len(recs) == 0 {
 		return nil, nil
 	}
-	return zbuf.NewArray(recs), nil
+	return zbuf.Array(recs), nil
 }
 
 func (a *Aggregator) lookupRowType(row *Row, decompose bool) (*zng.TypeRecord, error) {

--- a/proc/head/head.go
+++ b/proc/head/head.go
@@ -44,7 +44,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 	}
 	p.count = p.limit
 	p.Done()
-	return zbuf.NewArray(recs), nil
+	return zbuf.Array(recs), nil
 }
 
 func (p *Proc) Done() {

--- a/proc/proctest/utils.go
+++ b/proc/proctest/utils.go
@@ -35,7 +35,7 @@ func (r *RecordPuller) Pull() (zbuf.Batch, error) {
 		if rec == nil || err != nil {
 			return nil, err
 		}
-		return zbuf.Array([]*zng.Record{rec}), nil
+		return zbuf.Array{rec}, nil
 	}
 }
 

--- a/proc/proctest/utils.go
+++ b/proc/proctest/utils.go
@@ -35,7 +35,7 @@ func (r *RecordPuller) Pull() (zbuf.Batch, error) {
 		if rec == nil || err != nil {
 			return nil, err
 		}
-		return zbuf.NewArray([]*zng.Record{rec}), nil
+		return zbuf.Array([]*zng.Record{rec}), nil
 	}
 }
 
@@ -215,7 +215,7 @@ func (p *ProcTest) Finish() error {
 	}
 }
 
-func ParseTestTzng(zctx *resolver.Context, src string) (*zbuf.Array, error) {
+func ParseTestTzng(zctx *resolver.Context, src string) (zbuf.Array, error) {
 	reader := tzngio.NewReader(strings.NewReader(src), zctx)
 	records := make([]*zng.Record, 0)
 	for {
@@ -229,7 +229,7 @@ func ParseTestTzng(zctx *resolver.Context, src string) (*zbuf.Array, error) {
 		records = append(records, rec)
 	}
 
-	return zbuf.NewArray(records), nil
+	return zbuf.Array(records), nil
 }
 
 // TestOneProcWithWarnings runs one test of a proc by compiling cmd as a proc,

--- a/proc/put/put.go
+++ b/proc/put/put.go
@@ -217,7 +217,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 		recs = append(recs, p.put(in).Keep())
 	}
 	batch.Unref()
-	return zbuf.NewArray(recs), nil
+	return zbuf.Array(recs), nil
 }
 
 func (p *Proc) Done() {

--- a/proc/rename/rename.go
+++ b/proc/rename/rename.go
@@ -115,7 +115,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 		recs = append(recs, out)
 	}
 	batch.Unref()
-	return zbuf.NewArray(recs), nil
+	return zbuf.Array(recs), nil
 }
 
 func (p *Proc) Done() {

--- a/proc/sort/sort.go
+++ b/proc/sort/sort.go
@@ -70,7 +70,7 @@ func (p *Proc) sortLoop() {
 		// Just one run so do an in-memory sort.
 		p.warnAboutUnseenFields()
 		expr.SortStable(firstRunRecs, p.compareFn)
-		array := zbuf.NewArray(firstRunRecs)
+		array := zbuf.Array(firstRunRecs)
 		p.sendResult(array, nil)
 		return
 	}

--- a/proc/tail/tail.go
+++ b/proc/tail/tail.go
@@ -37,7 +37,7 @@ func (p *Proc) tail() zbuf.Batch {
 	}
 	p.off = 0
 	p.count = 0
-	return zbuf.NewArray(out)
+	return zbuf.Array(out)
 
 }
 

--- a/proc/top/top.go
+++ b/proc/top/top.go
@@ -97,5 +97,5 @@ func (t *Proc) sorted() zbuf.Batch {
 	}
 	// clear records
 	t.records = nil
-	return zbuf.NewArray(out)
+	return zbuf.Array(out)
 }

--- a/proc/uniq/uniq.go
+++ b/proc/uniq/uniq.go
@@ -67,7 +67,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 		}
 		t := p.wrap(p.last)
 		p.last = nil
-		return zbuf.Array([]*zng.Record{t}), nil
+		return zbuf.Array{t}, nil
 	}
 	defer batch.Unref()
 	var out []*zng.Record

--- a/proc/uniq/uniq.go
+++ b/proc/uniq/uniq.go
@@ -67,14 +67,14 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 		}
 		t := p.wrap(p.last)
 		p.last = nil
-		return zbuf.NewArray([]*zng.Record{t}), nil
+		return zbuf.Array([]*zng.Record{t}), nil
 	}
 	defer batch.Unref()
 	var out []*zng.Record
 	for k := 0; k < batch.Length(); k++ {
 		out = p.appendUniq(out, batch.Index(k))
 	}
-	return zbuf.NewArray(out), nil
+	return zbuf.Array(out), nil
 }
 
 func (p *Proc) Done() {

--- a/reducer/reducer_test.go
+++ b/reducer/reducer_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func parse(zctx *resolver.Context, src string) (*zbuf.Array, error) {
+func parse(zctx *resolver.Context, src string) (zbuf.Array, error) {
 	reader := tzngio.NewReader(strings.NewReader(src), zctx)
 	records := make([]*zng.Record, 0)
 	for {
@@ -28,7 +28,7 @@ func parse(zctx *resolver.Context, src string) (*zbuf.Array, error) {
 		records = append(records, rec)
 	}
 
-	return zbuf.NewArray(records), nil
+	return zbuf.Array(records), nil
 }
 
 func runOne(t *testing.T, zctx *resolver.Context, cred compile.CompiledReducer, i int, recs []*zng.Record) zng.Value {

--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -5,41 +5,32 @@ import (
 )
 
 // Array is a slice of of records that implements the Batch interface.
-type Array struct {
-	records []*zng.Record
-}
+type Array []*zng.Record
 
-// NewArray returns an Array object holding the passed-in records.
-func NewArray(r []*zng.Record) *Array {
-	return &Array{
-		records: r,
-	}
-}
-
-func (a *Array) Ref() {
+func (a Array) Ref() {
 	// do nothing... let the GC reclaim it
 }
 
-func (a *Array) Unref() {
+func (a Array) Unref() {
 	// do nothing... let the GC reclaim it
 }
 
-func (a *Array) Length() int {
-	return len(a.records)
+func (a Array) Length() int {
+	return len(a)
 }
 
-func (a *Array) Records() []*zng.Record {
-	return a.records
+func (a Array) Records() []*zng.Record {
+	return a
 }
 
 //XXX should change this to Record()
-func (a *Array) Index(k int) *zng.Record {
-	if k < len(a.records) {
-		return a.records[k]
+func (a Array) Index(k int) *zng.Record {
+	if k < len(a) {
+		return a[k]
 	}
 	return nil
 }
 
 func (a *Array) Append(r *zng.Record) {
-	a.records = append(a.records, r)
+	*a = append(*a, r)
 }

--- a/zbuf/batch.go
+++ b/zbuf/batch.go
@@ -49,7 +49,7 @@ func ReadBatch(zr Reader, n int) (Batch, error) {
 	if len(recs) == 0 {
 		return nil, nil
 	}
-	return NewArray(recs), nil
+	return Array(recs), nil
 }
 
 // A Puller produces Batches of records, signaling end-of-stream by returning


### PR DESCRIPTION
No need to allocate a struct to hold a pointer when the zbuf.Array
type can be a slice and implement the zbuf.Batch interface.