### PR TITLE
simplify resolver.Slice

### DIFF
--- a/zng/resolver/mapper.go
+++ b/zng/resolver/mapper.go
@@ -18,7 +18,7 @@ func NewMapper(out *Context) *Mapper {
 // the type mapping is unknown to it.  The output side is assumed to be shared
 // while the input side owned by one thread of control.
 func (m *Mapper) Map(td int) *zng.TypeRecord {
-	return m.lookup(td)
+	return m.Lookup(td)
 }
 
 //XXX Enter should allocate the td as it creates the new type in the output context
@@ -28,12 +28,12 @@ func (m *Mapper) Enter(id int, ext *zng.TypeRecord) (*zng.TypeRecord, error) {
 		return nil, err
 	}
 	if typ != nil {
-		m.enter(id, typ)
+		m.Slice.Enter(id, typ)
 		return typ, nil
 	}
 	return nil, nil
 }
 
 func (m *Mapper) EnterTypeRecord(td int, typ *zng.TypeRecord) {
-	m.enter(td, typ)
+	m.Slice.Enter(td, typ)
 }

--- a/zng/resolver/slice.go
+++ b/zng/resolver/slice.go
@@ -6,22 +6,20 @@ import (
 
 // Slice is a table of descriptors respresented as a slice and grown
 // on demand as small-in type descriptors are entered into the table.
-type Slice struct {
-	table []*zng.TypeRecord
-}
+type Slice []*zng.TypeRecord
 
-func (s *Slice) lookup(td int) *zng.TypeRecord {
-	if td >= 0 && td < len(s.table) {
-		return s.table[td]
+func (s Slice) Lookup(td int) *zng.TypeRecord {
+	if td >= 0 && td < len(s) {
+		return s[td]
 	}
 	return nil
 }
 
-func (s *Slice) enter(td int, d *zng.TypeRecord) {
-	if td >= len(s.table) {
+func (s *Slice) Enter(td int, d *zng.TypeRecord) {
+	if td >= len(*s) {
 		new := make([]*zng.TypeRecord, td+1)
-		copy(new, s.table)
-		s.table = new
+		copy(new, *s)
+		*s = new
 	}
-	s.table[td] = d
+	(*s)[td] = d
 }

--- a/zng/resolver/translator.go
+++ b/zng/resolver/translator.go
@@ -24,7 +24,7 @@ func NewTranslator(in, out *Context) *Translator {
 func (t *Translator) Lookup(id int) (*zng.TypeRecord, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	outputType := t.lookup(id)
+	outputType := t.Slice.Lookup(id)
 	var err error
 	if outputType == nil {
 		inputType := t.inputCtx.Lookup(id)
@@ -35,7 +35,7 @@ func (t *Translator) Lookup(id int) (*zng.TypeRecord, error) {
 		if err != nil {
 			return nil, err
 		}
-		t.enter(id, outputType)
+		t.Slice.Enter(id, outputType)
 	}
 	return outputType, nil
 }


### PR DESCRIPTION
This commit simplifies the resolver.Slice type so it's just a
slice of *zng.Records instead of an embedded struct.  This way
it can be transparently used as this type outside of the resolver
module.  The upcoming dataframe proc will use this.