### PR TITLE
add readdir equivalent to iosrc

### DIFF
--- a/cmd/zar/ls/command.go
+++ b/cmd/zar/ls/command.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 
 	"github.com/brimsec/zq/archive"
 	"github.com/brimsec/zq/cmd/zar/root"
@@ -93,12 +92,13 @@ func (c *Command) printDir(root, dir iosrc.URI, pattern string) {
 			files = lsfs(dir.Filepath())
 		case "s3":
 			var err error
-			if files, err = s3io.ListObjects(context.TODO(), dir.String(), nil); err != nil {
+			entries, err := s3io.List(context.TODO(), dir.String(), nil)
+			if err != nil {
 				fmt.Fprintf(os.Stderr, "error listing s3 objects: %v", err)
 				return
 			}
-			for i := range files {
-				_, files[i] = path.Split(files[i])
+			for _, e := range entries {
+				files = append(files, e.Name)
 			}
 		default:
 			fmt.Fprintf(os.Stderr, "long form flag unsupported for scheme %q", dir.Scheme)

--- a/cmd/zar/ls/command.go
+++ b/cmd/zar/ls/command.go
@@ -5,13 +5,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/brimsec/zq/archive"
 	"github.com/brimsec/zq/cmd/zar/root"
 	"github.com/brimsec/zq/pkg/iosrc"
-	"github.com/brimsec/zq/pkg/s3io"
 	"github.com/mccanne/charm"
 )
 
@@ -86,26 +84,13 @@ func (c *Command) printDir(root, dir iosrc.URI, pattern string) {
 	}
 	fmt.Println(c.printable(root, dir))
 	if c.lflag {
-		var files []string
-		switch dir.Scheme {
-		case "file":
-			files = lsfs(dir.Filepath())
-		case "s3":
-			var err error
-			entries, err := s3io.List(context.TODO(), dir.String(), nil)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "error listing s3 objects: %v", err)
-				return
-			}
-			for _, e := range entries {
-				files = append(files, e.Name)
-			}
-		default:
-			fmt.Fprintf(os.Stderr, "long form flag unsupported for scheme %q", dir.Scheme)
+		entries, err := iosrc.ReadDir(context.TODO(), dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error listing directory: %v", err)
 			return
 		}
-		for _, f := range files {
-			fmt.Printf("\t%s\n", f)
+		for _, e := range entries {
+			fmt.Printf("\t%s\n", e.Name())
 		}
 	}
 }
@@ -115,20 +100,4 @@ func (c *Command) printable(root, path iosrc.URI) string {
 		return root.RelPath(path)
 	}
 	return path.String()
-}
-
-func lsfs(dir string) []string {
-	var out []string
-	infos, err := ioutil.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-	for _, info := range infos {
-		name := info.Name()
-		if info.IsDir() {
-			name += "/"
-		}
-		out = append(out, name)
-	}
-	return out
 }

--- a/pkg/iosrc/file.go
+++ b/pkg/iosrc/file.go
@@ -73,6 +73,18 @@ func (s *FileSource) NewReplacer(_ context.Context, uri URI) (io.WriteCloser, er
 	return fs.NewFileReplacer(uri.Filepath(), s.Perm)
 }
 
+func (s *FileSource) ReadDir(_ context.Context, uri URI) ([]Info, error) {
+	entries, err := ioutil.ReadDir(uri.Filepath())
+	if err != nil {
+		return nil, err
+	}
+	infos := make([]Info, len(entries))
+	for i, e := range entries {
+		infos[i] = e
+	}
+	return infos, nil
+}
+
 func wrapfileError(uri URI, err error) error {
 	if os.IsNotExist(err) {
 		return zqe.E(zqe.NotFound, uri.String())

--- a/pkg/iosrc/iosrc.go
+++ b/pkg/iosrc/iosrc.go
@@ -36,11 +36,14 @@ type Source interface {
 	// was an error finding this information.
 	Exists(context.Context, URI) (bool, error)
 	Stat(context.Context, URI) (Info, error)
+	ReadDir(context.Context, URI) ([]Info, error)
 }
 
 type Info interface {
+	Name() string
 	Size() int64
 	ModTime() time.Time
+	IsDir() bool
 }
 
 type DirMaker interface {
@@ -114,6 +117,14 @@ func Stat(ctx context.Context, uri URI) (Info, error) {
 		return nil, err
 	}
 	return source.Stat(ctx, uri)
+}
+
+func ReadDir(ctx context.Context, uri URI) ([]Info, error) {
+	source, err := GetSource(uri)
+	if err != nil {
+		return nil, err
+	}
+	return source.ReadDir(ctx, uri)
 }
 
 func GetSource(uri URI) (Source, error) {

--- a/pkg/iosrc/mock/mock_source.go
+++ b/pkg/iosrc/mock/mock_source.go
@@ -80,6 +80,21 @@ func (mr *MockSourceMockRecorder) NewWriter(arg0, arg1 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewWriter", reflect.TypeOf((*MockSource)(nil).NewWriter), arg0, arg1)
 }
 
+// ReadDir mocks base method
+func (m *MockSource) ReadDir(arg0 context.Context, arg1 iosrc.URI) ([]iosrc.Info, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadDir", arg0, arg1)
+	ret0, _ := ret[0].([]iosrc.Info)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadDir indicates an expected call of ReadDir
+func (mr *MockSourceMockRecorder) ReadDir(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadDir", reflect.TypeOf((*MockSource)(nil).ReadDir), arg0, arg1)
+}
+
 // ReadFile mocks base method
 func (m *MockSource) ReadFile(arg0 context.Context, arg1 iosrc.URI) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/pkg/iosrc/s3.go
+++ b/pkg/iosrc/s3.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/brimsec/zq/pkg/s3io"
 	"github.com/brimsec/zq/zqe"
 )
@@ -67,22 +66,38 @@ func (s *s3Source) Exists(ctx context.Context, u URI) (bool, error) {
 	return ok, wrapErr(err)
 }
 
-type info s3.HeadObjectOutput
+type info struct {
+	s3io.Info
+}
 
-func (i info) Size() int64        { return *i.ContentLength }
-func (i info) ModTime() time.Time { return *i.LastModified }
+func (i info) Name() string       { return i.Info.Name }
+func (i info) Size() int64        { return i.Info.Size }
+func (i info) ModTime() time.Time { return i.Info.ModTime }
+func (i info) IsDir() bool        { return i.Info.IsDir }
 
 func (s *s3Source) Stat(ctx context.Context, u URI) (Info, error) {
-	out, err := s3io.Stat(ctx, u.String(), s.Config)
+	entry, err := s3io.Stat(ctx, u.String(), s.Config)
 	if err != nil {
 		return nil, wrapErr(err)
 	}
-	return info(*out), nil
+	return info{entry}, nil
 }
 
 func (s *s3Source) NewReplacer(ctx context.Context, uri URI) (io.WriteCloser, error) {
 	// Updates to S3 objects are atomic.
 	return s.NewWriter(ctx, uri)
+}
+
+func (s *s3Source) ReadDir(ctx context.Context, uri URI) ([]Info, error) {
+	entries, err := s3io.List(ctx, uri.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	infos := make([]Info, len(entries))
+	for i, e := range entries {
+		infos[i] = info{e}
+	}
+	return infos, nil
 }
 
 func wrapErr(err error) error {

--- a/pkg/iosrc/stdio.go
+++ b/pkg/iosrc/stdio.go
@@ -49,6 +49,10 @@ func (s *StdioSource) Exists(_ context.Context, uri URI) (bool, error) {
 	return true, nil
 }
 
+func (s *StdioSource) ReadDir(context.Context, URI) ([]Info, error) {
+	return nil, errStdioNotSupport
+}
+
 func getStdioSource(uri URI) (*os.File, error) {
 	if uri.Scheme != "stdio" {
 		return nil, fmt.Errorf("scheme of %q must stdio", uri)

--- a/pkg/s3io/reader.go
+++ b/pkg/s3io/reader.go
@@ -35,7 +35,7 @@ func NewReader(ctx context.Context, path string, cfg *aws.Config) (*Reader, erro
 		ctx:    ctx,
 		bucket: bucket,
 		key:    key,
-		size:   *info.ContentLength,
+		size:   info.Size,
 	}, nil
 }
 

--- a/zqd/space/manager.go
+++ b/zqd/space/manager.go
@@ -70,14 +70,14 @@ func NewManagerWithContext(ctx context.Context, root iosrc.URI, logger *zap.Logg
 }
 
 func s3spaces(ctx context.Context, root iosrc.URI) ([]iosrc.URI, error) {
-	prefixes, err := s3io.ListCommonPrefixes(ctx, root.String(), nil)
+	entries, err := s3io.List(ctx, root.String(), nil)
 	if err != nil {
 		return nil, err
 	}
 	var uris []iosrc.URI
-	for _, p := range prefixes {
+	for _, e := range entries {
 		u := root
-		u.Path = p
+		u.Path = e.Name
 		uris = append(uris, u)
 	}
 	return uris, nil

--- a/zqd/space/manager.go
+++ b/zqd/space/manager.go
@@ -2,13 +2,10 @@ package space
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
 	"path"
 	"sync"
 
 	"github.com/brimsec/zq/pkg/iosrc"
-	"github.com/brimsec/zq/pkg/s3io"
 	"github.com/brimsec/zq/zqd/api"
 	"github.com/brimsec/zq/zqd/storage"
 	"github.com/brimsec/zq/zqe"
@@ -34,22 +31,16 @@ func NewManagerWithContext(ctx context.Context, root iosrc.URI, logger *zap.Logg
 		names:    make(map[string]api.SpaceID),
 		logger:   logger,
 	}
-	var err error
-	var dirs []iosrc.URI
-	switch root.Scheme {
-	case "file":
-		if dirs, err = filespaces(root); err != nil {
-			return nil, err
-		}
-	case "s3":
-		if dirs, err = s3spaces(ctx, root); err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("%s: unsupported scheme", root.Scheme)
-	}
 
-	for _, dir := range dirs {
+	list, err := iosrc.ReadDir(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+	for _, l := range list {
+		if !l.IsDir() {
+			continue
+		}
+		dir := root.AppendPath(l.Name())
 		config, err := mgr.loadConfig(ctx, dir)
 		if err != nil {
 			logger.Error("Error loading config", zap.Error(err))
@@ -67,35 +58,6 @@ func NewManagerWithContext(ctx context.Context, root iosrc.URI, logger *zap.Logg
 	}
 
 	return mgr, nil
-}
-
-func s3spaces(ctx context.Context, root iosrc.URI) ([]iosrc.URI, error) {
-	entries, err := s3io.List(ctx, root.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	var uris []iosrc.URI
-	for _, e := range entries {
-		u := root
-		u.Path = e.Name
-		uris = append(uris, u)
-	}
-	return uris, nil
-}
-
-func filespaces(root iosrc.URI) ([]iosrc.URI, error) {
-	dirs, err := ioutil.ReadDir(root.Filepath())
-	if err != nil {
-		return nil, err
-	}
-	var uris []iosrc.URI
-	for _, dir := range dirs {
-		if !dir.IsDir() {
-			continue
-		}
-		uris = append(uris, root.AppendPath(dir.Name()))
-	}
-	return uris, nil
 }
 
 func (m *Manager) Create(ctx context.Context, req api.SpacePostRequest) (Space, error) {


### PR DESCRIPTION
This adds a ReadDir call to iosrc with implementations for file & s3 schemas. This will be used (and tested) in the zar changes coming in #1262 .
