### PR TITLE
Fix godoc URLs

### DIFF
--- a/zql/docs/processors/README.md
+++ b/zql/docs/processors/README.md
@@ -27,7 +27,7 @@ The following available processors are documented in detail below:
 | **Syntax**                | `cut [-c] <field-list>`                                     |
 | **Required<br>arguments** | `<field-list>`<br>One or more comma-separated field names or assignments.  |
 | **Optional<br>arguments** | `[-c]`<br>If specified, print all fields _other than_ those specified. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc#Cut            |
+| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/cut            |
 
 #### Example #1:
 
@@ -121,7 +121,7 @@ TIME              UID
 | **Syntax**                | `filter <search-expression>`                                          |
 | **Required<br>arguments** | `<search-expression>`<br>Any valid expression in ZQL [search syntax](../search-syntax/README.md) |
 | **Optional<br>arguments** | None                                                                  |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc#Filter                   |
+| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/filter                   |
 
 #### Example #1:
 
@@ -162,7 +162,7 @@ ssl   1521912240.189735 CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85.83.215 44
 | **Syntax**                | `head [N]`                                                            |
 | **Required<br>arguments** | None. If no arguments are specified, only the first event is returned.| 
 | **Optional<br>arguments** | `[N]`<br>An integer specifying the number of results to return. If not specified, defaults to `1`. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc#Head                     |
+| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/head                     |
 
 #### Example #1:
 
@@ -207,7 +207,7 @@ conn  1521911720.607695 CpjMvj2Cvj048u6bF1 10.164.94.120 39169     10.47.3.200 8
 | **Required arguments**    | `<field>`<br>Field into which the computed value will be stored.<br><br>`<expression>`<br>A valid ZQL [expression](../expressions/README.md). If evaluation of any expression fails, a warning is emitted and the original record is passed through unchanged. |
 | **Optional arguments**    | None |
 | **Limitations**           | If multiple fields are written in a single `put`, all the new field values are computed first and then they are all written simultaneously.  As a result, a computed value cannot be referenced in another expression.  If you need to re-use a computed result, this can be done by chaining multiple `put` processors.  For example, this will not work:<br>`put N=len(somelist), isbig=N>10`<br>But it could be written instead as:<br>`put N=len(somelist) \| put isbig=N>10` |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc#Put |
+| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/put |
 
 #### Example #1:
 
@@ -243,7 +243,7 @@ ID.ORIG_H     ID.ORIG_P ID.RESP_H       ID.RESP_P ORIG_BYTES RESP_BYTES TOTAL_BY
 | **Required arguments**    | One or more field assignment expressions. Renames are applied left to right; each rename observes the effect of all renames that preceded it. |
 | **Optional arguments**    | None |
 | **Limitations**           | A field can only be renamed within its own record. For example `id.orig_h` can be renamed to `id.src`, but it cannot be renamed to `src`. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc#Rename |
+| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/rename |
 
 
 #### Example:
@@ -274,7 +274,7 @@ conn  1521911722.690601 CuKFds250kxFgkhh8f 10.47.25.80    50813            10.12
 | **Syntax**                | `sort [-r] [-nulls first\|last] [field-list]`                 |
 | **Required<br>arguments** | None                                                                      |
 | **Optional<br>arguments** | `[-r]`<br>If specified, results will be sorted in reverse order.<br><br>`[-nulls first\|last]`<br>Specifies where null values (i.e., values that are unset or that are not present at all in an incoming record) should be placed in the output.<br><br>`[field-list]`<br>One or more comma-separated field names by which to sort. Results will be sorted based on the values of the first field named in the list, then based on values in the second field named in the list, and so on.<br><br>If no field list is provided, sort will automatically pick a field by which to sort. The pick is done by examining the first result returned and finding the first field in left-to-right that is of one of the integer ZNG [data types](../data-types/README.md) (`int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`) and if no integer fields are found, the first `float64` field is used. If no fields of these numeric types are found, sorting will be performed on the first field found in left-to-right order that is _not_ of the `time` data type. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc#Sort                         |
+| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/sort                         |
 
 #### Example #1:
 
@@ -370,7 +370,7 @@ wwonka       1
 | **Syntax**                | `tail [N]`                                                            |
 | **Required<br>arguments** | None. If no arguments are specified, only the last event is returned. | 
 | **Optional<br>arguments** | `[N]`<br>An integer specifying the number of results to return. If not specified, defaults to `1`. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc#Tail                     |
+| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/tail                     |
 
 #### Example #1:
 
@@ -414,7 +414,7 @@ conn  1521912988.752765 COICgc1FXHKteyFy67 10.0.0.227     61314     10.47.5.58  
 | **Syntax**                | `uniq [-c]`                                                           |
 | **Required<br>arguments** | None                                                                  | 
 | **Optional<br>arguments** | `[-c]`<br>For each unique value shown, include a numeric count of how many times it appeared. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc#Uniq                     |
+| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/uniq                     |
 
 #### Example:
 


### PR DESCRIPTION
When sitting down to write a doc for the new `fuse` processor,I noticed the godoc links recently became incorrect, surely due to some code reorg. The broken link checker didn't notice because the non-matching `#` anchors just landed the user at the base page, i.e. `https://godoc.org/github.com/brimsec/zq/proc`.