### PR TITLE
align zapi with rest of tools that print help with no args

### DIFF
--- a/cmd/zapi/cmd/cli.go
+++ b/cmd/zapi/cmd/cli.go
@@ -5,12 +5,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"syscall"
 
 	"github.com/brimsec/zq/cli"
-	"github.com/brimsec/zq/pkg/repl"
 	"github.com/brimsec/zq/zqd/api"
 	"github.com/kballard/go-shellquote"
 	"github.com/mccanne/charm"
@@ -110,19 +108,10 @@ func (c *Command) Run(args []string) error {
 	if err := c.Init(); err != nil {
 		return err
 	}
-	if len(args) > 0 {
-		return fmt.Errorf("unknown command: %s", args[0])
+	if len(args) == 0 {
+		return CLI.Exec(c, []string{"help"})
 	}
-	// do not enter repl if space is not selected
-	if _, err := c.SpaceID(); err != nil {
-		return err
-	}
-	err := repl.Run(c)
-	if err == io.EOF {
-		fmt.Println("")
-		err = nil
-	}
-	return err
+	return charm.ErrNoRun
 }
 
 func (c *Command) Consume(line string) (done bool) {

--- a/cmd/zapi/cmd/repl/repl.go
+++ b/cmd/zapi/cmd/repl/repl.go
@@ -41,7 +41,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(); !ok {
+	if err := c.Init(); err != nil {
 		return err
 	}
 	// do not enter repl if space is not selected

--- a/cmd/zapi/cmd/repl/repl.go
+++ b/cmd/zapi/cmd/repl/repl.go
@@ -1,0 +1,57 @@
+package repl
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/pkg/repl"
+	"github.com/brimsec/zq/pkg/units"
+	"github.com/brimsec/zq/zqd/storage"
+	"github.com/mccanne/charm"
+)
+
+var Repl = &charm.Spec{
+	Name:  "repl",
+	Usage: "repl [flags]",
+	Short: "enter read-eval-print loop",
+	Long: `The repl command takes a single argument and creates a new, empty space
+named as specified.`,
+	New: New,
+}
+
+func init() {
+	cmd.CLI.Add(Repl)
+}
+
+type Command struct {
+	*cmd.Command
+	kind     storage.Kind
+	datapath string
+	thresh   units.Bytes
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{
+		Command: parent.(*cmd.Command),
+	}
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	defer c.Cleanup()
+	if ok, err := c.Init(); !ok {
+		return err
+	}
+	// do not enter repl if space is not selected
+	if _, err := c.SpaceID(); err != nil {
+		return err
+	}
+	err := repl.Run(c)
+	if err == io.EOF {
+		fmt.Println("")
+		err = nil
+	}
+	return err
+}

--- a/cmd/zapi/main.go
+++ b/cmd/zapi/main.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/brimsec/zq/cmd/zapi/cmd/newsubspace"
 	_ "github.com/brimsec/zq/cmd/zapi/cmd/post"
 	_ "github.com/brimsec/zq/cmd/zapi/cmd/rename"
+	_ "github.com/brimsec/zq/cmd/zapi/cmd/repl"
 	_ "github.com/brimsec/zq/cmd/zapi/cmd/rm"
 	_ "github.com/brimsec/zq/cmd/zapi/cmd/version"
 )


### PR DESCRIPTION
This commit changes "zapi" to print help when run with no args.
The repl is now run with a new subcommand "zapi repl".

Fixes #1306 