### PR TITLE
one more time fixing CLI flags refactor

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -29,20 +29,24 @@ type Initializer interface {
 	Init() error
 }
 
-func (f *Flags) Init(all ...Initializer) (bool, error) {
+func (f *Flags) Init(all ...Initializer) error {
+	if f.showVersion {
+		fmt.Printf("Version: %s\n", Version)
+		os.Exit(0)
+	}
+	var err error
+	for _, flags := range all {
+		if initErr := flags.Init(); err == nil {
+			err = initErr
+		}
+	}
+	if err != nil {
+		return err
+	}
 	if f.cpuprofile != "" {
 		f.runCPUProfile(f.cpuprofile)
 	}
-	if f.showVersion {
-		fmt.Printf("Version: %s\n", Version)
-		return false, nil
-	}
-	for _, flags := range all {
-		if err := flags.Init(); err != nil {
-			return false, err
-		}
-	}
-	return true, nil
+	return nil
 }
 
 func (f *Flags) Cleanup() {

--- a/cmd/microindex/convert/command.go
+++ b/cmd/microindex/convert/command.go
@@ -56,7 +56,7 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(&c.inputFlags); !ok {
+	if err := c.Init(&c.inputFlags); err != nil {
 		return err
 	}
 	if c.keys == "" {

--- a/cmd/microindex/create/command.go
+++ b/cmd/microindex/create/command.go
@@ -57,7 +57,7 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(&c.inputFlags); !ok {
+	if err := c.Init(&c.inputFlags); err != nil {
 		return err
 	}
 	if c.keyField == "" {

--- a/cmd/microindex/lookup/command.go
+++ b/cmd/microindex/lookup/command.go
@@ -52,7 +52,7 @@ func newLookupCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, err
 
 func (c *LookupCommand) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(&c.outputFlags); !ok {
+	if err := c.Init(&c.outputFlags); err != nil {
 		return err
 	}
 	if len(args) != 1 {

--- a/cmd/microindex/root/command.go
+++ b/cmd/microindex/root/command.go
@@ -29,7 +29,7 @@ func (c *Command) Cleanup() {
 	c.cli.Cleanup()
 }
 
-func (c *Command) Init(all ...cli.Initializer) (bool, error) {
+func (c *Command) Init(all ...cli.Initializer) error {
 	return c.cli.Init(all...)
 }
 
@@ -41,11 +41,12 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.cli.Cleanup()
-	if ok, err := c.cli.Init(); !ok {
-		return err
-	}
+	err := c.cli.Init()
 	if len(args) == 0 {
 		return MicroIndex.Exec(c, []string{"help"})
+	}
+	if err != nil {
+		return err
 	}
 	return charm.ErrNoRun
 }

--- a/cmd/microindex/section/command.go
+++ b/cmd/microindex/section/command.go
@@ -53,7 +53,7 @@ func isTerminal(f *os.File) bool {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(&c.outputFlags); !ok {
+	if err := c.Init(&c.outputFlags); err != nil {
 		return err
 	}
 	if len(args) != 1 {

--- a/cmd/microindex/seek/command.go
+++ b/cmd/microindex/seek/command.go
@@ -58,7 +58,7 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(); !ok {
+	if err := c.Init(); err != nil {
 		return err
 	}
 	//XXX no reason to limit this... fix later

--- a/cmd/pcap/cut/command.go
+++ b/cmd/pcap/cut/command.go
@@ -98,7 +98,7 @@ func max(in []int) int {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(); !ok {
+	if err := c.Init(); err != nil {
 		return err
 	}
 	var cuts []int

--- a/cmd/pcap/index/command.go
+++ b/cmd/pcap/index/command.go
@@ -60,7 +60,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(); !ok {
+	if err := c.Init(); err != nil {
 		return err
 	}
 	if len(args) != 0 || c.inputFile == "" {

--- a/cmd/pcap/root/command.go
+++ b/cmd/pcap/root/command.go
@@ -44,13 +44,13 @@ func (c *Command) Cleanup() {
 	c.cli.Cleanup()
 }
 
-func (c *Command) Init() (bool, error) {
+func (c *Command) Init() error {
 	return c.cli.Init()
 }
 
 func (c *Command) Run(args []string) error {
 	defer c.cli.Cleanup()
-	if ok, err := c.cli.Init(); !ok {
+	if err := c.cli.Init(); err != nil {
 		return err
 	}
 	return Pcap.Exec(c, []string{"help"})

--- a/cmd/pcap/slice/command.go
+++ b/cmd/pcap/slice/command.go
@@ -98,7 +98,7 @@ func parseSpan(sfrom, sto string) (nano.Span, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(); !ok {
+	if err := c.Init(); err != nil {
 		return err
 	}
 	if c.indexFile != "" && c.inputFile == "-" {

--- a/cmd/pcap/ts/command.go
+++ b/cmd/pcap/ts/command.go
@@ -43,7 +43,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(); !ok {
+	if err := c.Init(); err != nil {
 		return err
 	}
 	if len(args) != 0 {

--- a/cmd/zapi/cmd/cli.go
+++ b/cmd/zapi/cmd/cli.go
@@ -99,7 +99,7 @@ func (c *Command) Cleanup() {
 	c.cli.Cleanup()
 }
 
-func (c *Command) Init(all ...cli.Initializer) (bool, error) {
+func (c *Command) Init(all ...cli.Initializer) error {
 	return c.cli.Init(all...)
 }
 
@@ -107,7 +107,7 @@ func (c *Command) Init(all ...cli.Initializer) (bool, error) {
 // zqd command line.
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(); !ok {
+	if err := c.Init(); err != nil {
 		return err
 	}
 	if len(args) > 0 {

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -87,7 +87,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(&c.outputFlags); !ok {
+	if err := c.Init(&c.outputFlags); err != nil {
 		return err
 	}
 	expr := "*"

--- a/cmd/zar/find/command.go
+++ b/cmd/zar/find/command.go
@@ -86,7 +86,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(); !ok {
+	if err := c.Init(); err != nil {
 		return err
 	}
 

--- a/cmd/zar/import/command.go
+++ b/cmd/zar/import/command.go
@@ -61,7 +61,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(&c.inputFlags, &c.procFlags); !ok {
+	if err := c.Init(&c.inputFlags, &c.procFlags); err != nil {
 		return err
 	}
 	if c.empty && len(args) > 0 {

--- a/cmd/zar/index/command.go
+++ b/cmd/zar/index/command.go
@@ -71,7 +71,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(&c.procFlags); !ok {
+	if err := c.Init(&c.procFlags); err != nil {
 		return err
 	}
 	if len(args) == 0 && c.zql == "" {

--- a/cmd/zar/map/command.go
+++ b/cmd/zar/map/command.go
@@ -63,7 +63,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 //XXX lots here copied from zq command... we should refactor into a tools package
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(&c.outputFlags, &c.procFlags); !ok {
+	if err := c.Init(&c.outputFlags, &c.procFlags); err != nil {
 		return err
 	}
 	if len(args) == 0 {

--- a/cmd/zar/root/command.go
+++ b/cmd/zar/root/command.go
@@ -49,13 +49,13 @@ func (c *Command) Cleanup() {
 	c.cli.Cleanup()
 }
 
-func (c *Command) Init(all ...cli.Initializer) (bool, error) {
+func (c *Command) Init(all ...cli.Initializer) error {
 	return c.cli.Init(all...)
 }
 
 func (c *Command) Run(args []string) error {
 	defer c.cli.Cleanup()
-	if ok, err := c.cli.Init(); !ok {
+	if err := c.cli.Init(); err != nil {
 		return err
 	}
 	return Zar.Exec(c, []string{"help"})

--- a/cmd/zar/zq/command.go
+++ b/cmd/zar/zq/command.go
@@ -55,7 +55,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(&c.outputFlags, &c.procFlags); !ok {
+	if err := c.Init(&c.outputFlags, &c.procFlags); err != nil {
 		return err
 	}
 

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -90,6 +90,7 @@ func New(f *flag.FlagSet) (charm.Command, error) {
 	c.inputFlags.SetFlags(f)
 
 	c.procFlags.SetFlags(f)
+
 	c.cli.SetFlags(f)
 
 	f.BoolVar(&c.verbose, "v", false, "show verbose details")
@@ -100,16 +101,16 @@ func New(f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) error {
+	defer c.cli.Cleanup()
+	err := c.cli.Init(&c.outputFlags, &c.inputFlags, &c.procFlags)
 	if len(args) == 0 {
 		return Zq.Exec(c, []string{"help"})
 	}
-	defer c.cli.Cleanup()
-	if ok, err := c.cli.Init(&c.outputFlags, &c.inputFlags, &c.procFlags); !ok {
+	if err != nil {
 		return err
 	}
 	paths := args
 	var query ast.Proc
-	var err error
 	if cli.FileExists(paths[0]) || s3io.IsS3Path(paths[0]) {
 		query, err = zql.ParseProc("*")
 		if err != nil {

--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -87,7 +87,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(); !ok {
+	if err := c.Init(); err != nil {
 		return err
 	}
 	if err := c.init(); err != nil {

--- a/cmd/zst/create/command.go
+++ b/cmd/zst/create/command.go
@@ -61,7 +61,7 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(&c.inputFlags, &c.outputFlags); !ok {
+	if err := c.Init(&c.inputFlags, &c.outputFlags); err != nil {
 		return err
 	}
 	if len(args) == 0 {

--- a/cmd/zst/cut/command.go
+++ b/cmd/zst/cut/command.go
@@ -53,7 +53,7 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(&c.outputFlags); !ok {
+	if err := c.Init(&c.outputFlags); err != nil {
 		return err
 	}
 	if len(args) != 1 {

--- a/cmd/zst/inspect/command.go
+++ b/cmd/zst/inspect/command.go
@@ -50,7 +50,7 @@ func newCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(&c.outputFlags); !ok {
+	if err := c.Init(&c.outputFlags); err != nil {
 		return err
 	}
 	if len(args) != 1 {

--- a/cmd/zst/read/command.go
+++ b/cmd/zst/read/command.go
@@ -51,7 +51,7 @@ func isTerminal(f *os.File) bool {
 
 func (c *Command) Run(args []string) error {
 	defer c.Cleanup()
-	if ok, err := c.Init(); !ok {
+	if err := c.Init(); err != nil {
 		return err
 	}
 	if len(args) != 1 {

--- a/cmd/zst/root/command.go
+++ b/cmd/zst/root/command.go
@@ -35,7 +35,7 @@ func (c *Command) Cleanup() {
 	c.cli.Cleanup()
 }
 
-func (c *Command) Init(all ...cli.Initializer) (bool, error) {
+func (c *Command) Init(all ...cli.Initializer) error {
 	return c.cli.Init(all...)
 }
 

--- a/tests/suite/zq/version.yaml
+++ b/tests/suite/zq/version.yaml
@@ -1,0 +1,7 @@
+script: |
+  zq -version
+
+outputs:
+  - name: stdout
+    regexp: |
+      Version: v[0-9]+\..*


### PR DESCRIPTION
The last refactor broke "zq -version".  The previous logic was a bit
fragile because cli.Flags.Init() would return a flag to stop
executing if -version was given.  But now, Init() can fail for
other reasons, e.g., writing binary data to stdout.  This would
block the help screen if Init was before the help check, but if we
put it after, then help would be displayed with -version.

The fix is to simplify the logic by cli.Init calling os.Exit if
"-version" is given and putting the error check after the subsequent
check for help.  This only applies to zq and not the other tools
because the other tools use subcommands and the issue does not
arise with the root command that does not have outputFlags checks.

We also added procFlags to zqd since they were missing in the last
refactor.  This gives "-sortmem" back to zqd.

Fixes #1333 