### PR TITLE
Fix wildcard field name example by introducing **

### DIFF
--- a/zql/docs/search-syntax/README.md
+++ b/zql/docs/search-syntax/README.md
@@ -372,7 +372,7 @@ dns   1521912892.637238 CN9X7Y36SH6faoh8t 10.47.8.10 58340     10.0.0.100 53    
 
 ### Wildcard Field Names
 
-It's possible to search for the typed value across _any_ field by entering a wildcard in place of the field name. Two wildcard operators are available depending on how broad you want your search to be. The `*` operator matches all top-level fields of the value's type, and the `**` operator additionally matches such values when they appear nested within records.
+It's possible to search across _all_ fields of the value's data type by entering a wildcard in place of the field name. Two wildcard operators are available depending on how broad you want your search to be. The `*` operator matches all top-level fields of the value's type, and the `**` operator additionally matches such values when they appear nested within records.
 
 For example, the following search matches many `ssl` and `conn` events that contain the value `10.150.0.85` in `addr`-type fields of the `id` record, such as `id.resp_h`. It also matches `notice` events where it appears in `id.resp_h` and also `dst`, a top-level field also of the `addr` type. Compare this with our [bare word](#bare-word) example where we also matched as a substring of the `string`-type field named `certificate.subject`.
 

--- a/zql/docs/search-syntax/README.md
+++ b/zql/docs/search-syntax/README.md
@@ -374,7 +374,7 @@ dns   1521912892.637238 CN9X7Y36SH6faoh8t 10.47.8.10 58340     10.0.0.100 53    
 
 It's possible to search across _all_ fields of the value's data type by entering a wildcard in place of the field name. Two wildcard operators are available depending on how broad you want your search to be. The `*` operator matches all top-level fields of the value's type, and the `**` operator additionally matches such values when they appear nested within records.
 
-For example, the following search matches many `ssl` and `conn` events that contain the value `10.150.0.85` in `addr`-type fields of the `id` record, such as `id.resp_h`. It also matches `notice` events where it appears in `id.resp_h` and also `dst`, a top-level field also of the `addr` type. Compare this with our [bare word](#bare-word) example where we also matched as a substring of the `string`-type field named `certificate.subject`.
+For example, the following search matches many `ssl` and `conn` events that contain the value `10.150.0.85` in `addr`-type fields of the `id` record, such as `id.resp_h`. It also matches `notice` events where it appears in `id.resp_h` and also `dst`, a top-level field also of the `addr` type. Compare this with our [bare word](#bare-word) example where we also matched as a substring of the `string`-type field named `certificate.subject`. This highlights how search matches both on typed values and their string representation, whereas field/value match is stricter, and considers typed values only.
 
 #### Example:
 ```zq-command

--- a/zql/docs/search-syntax/README.md
+++ b/zql/docs/search-syntax/README.md
@@ -374,7 +374,7 @@ dns   1521912892.637238 CN9X7Y36SH6faoh8t 10.47.8.10 58340     10.0.0.100 53    
 
 It's possible to search across _all_ fields of the value's data type by entering a wildcard in place of the field name. Two wildcard operators are available depending on how broad you want your search to be. The `*` operator matches all top-level fields of the value's type, and the `**` operator additionally matches such values when they appear nested within records.
 
-For example, the following search matches many `ssl` and `conn` events that contain the value `10.150.0.85` in `addr`-type fields of the `id` record, such as `id.resp_h`. It also matches `notice` events where it appears in `id.resp_h` and also `dst`, a top-level field also of the `addr` type. Compare this with our [bare word](#bare-word) example where we also matched as a substring of the `string`-type field named `certificate.subject`. This highlights how search matches both on typed values and their string representation, whereas field/value match is stricter, and considers typed values only.
+For example, the following search matches many `ssl` and `conn` events that contain the value `10.150.0.85` in `addr`-type fields of the `id` record, such as `id.resp_h`. It also matches `notice` events where it appears in `id.resp_h` and also `dst`, a top-level field also of the `addr` type. Compare this with our [bare word](#bare-word) example where we also matched as a substring of the `string`-type field named `certificate.subject`. This highlights how bare word searches match both on typed values and their string representation, whereas a field/value match is stricter, and considers typed values only.
 
 #### Example:
 ```zq-command

--- a/zql/docs/search-syntax/README.md
+++ b/zql/docs/search-syntax/README.md
@@ -372,7 +372,7 @@ dns   1521912892.637238 CN9X7Y36SH6faoh8t 10.47.8.10 58340     10.0.0.100 53    
 
 ### Wildcard Field Names
 
-Since the data type of the value is considered in field/value matches, it's possible to search for the value across any fields of the value's type by entering a wildcard in place of the field name. Two wildcard operators are available depending on how broad you want your search to be. The `*` operator matches all top-level fields of the value's type, and the `**` operator additionally matches such values when they appear nested within records.
+It's possible to search for the typed value across _any_ field by entering a wildcard in place of the field name. Two wildcard operators are available depending on how broad you want your search to be. The `*` operator matches all top-level fields of the value's type, and the `**` operator additionally matches such values when they appear nested within records.
 
 For example, the following search matches many `ssl` and `conn` events that contain the value `10.150.0.85` in `addr`-type fields of the `id` record, such as `id.resp_h`. It also matches `notice` events where it appears in `id.resp_h` and also `dst`, a top-level field also of the `addr` type. Compare this with our [bare word](#bare-word) example where we also matched as a substring of the `string`-type field named `certificate.subject`.
 


### PR DESCRIPTION
I was re-reading the docs with an eye to making improvements, but I stumbled onto this place where we regressed. The tl;dr is that this doc example stopped working with the changes in #59, but no one caught it because it pre-dated Michael Brown's automation that ensured docs examples stayed in sync with `zq` outputs against out sample data. Then in #330 where Michael introduced that automation, he pasted in updated `zq` output that made the test pass, but the output no longer made sense with the accompanying text. It's been that way ever since.

Figuring out how to fix it was a trip down memory lane. I'd forgotten how around the time of #59, Andrew changed the behavior of `*=` such that it only matched against _top-level_ fields, and then introduced `**=` that also targeted fields inside of nested records. I had a long 1-on-1 Slack thread going with Andrew at the time about how I didn't love this change, but I guess conditions were such that I never argued the prior behavior back into existence nor did `**=` end up being documented. So I do my best to reconcile all that here.

I admit that it's not the easiest thing to read, but I feel like that's a reflection of the underlying complexity of the operators. If looked at as a likely `jq` substitute, I respect that having operators that target "levels" of nesting is sometimes desirable. OTOH for the security-centric use cases that the Brim app has in mind (and these ZQL docs were written for an audience of those security users, which is why Zeek data is used in the examples) I have difficulty imagining real world examples where it matters. All that said, the text & example before this PR were confusing & wrong, so it seems I'd have to make a choice between fixing it or not mentioning `*=` / `**=` at all, and I've chosen to attempt the former. If there's a silver lining, no _users_ have complained about this doc, which says to me that this may be power user functionality that users aren't reaching for yet, so we probably don't need to overthink it regardless.

I know we have a high-level to-do to polish more corner cases in ZQL (#861), so perhaps this is one to consider during that exercise.