### PR TITLE
Fix anchor links

### DIFF
--- a/zql/docs/data-types/README.md
+++ b/zql/docs/data-types/README.md
@@ -3,8 +3,8 @@
 Comprehensive documentation for working with data types in ZQL is still a work
 in progress. In the meantime, here's a few tips to get started with.
 
-* Values read in by `zq` are stored internally and treated in expressions using one of the data types described in the [ZNG Value Messages](../../../zng/docs/spec.md#22-zng-value-messages) section of the ZNG spec.
-* See the [Zeek Type Mappings](../../../zng/docs/zeek-compat.md#zeek-type-mappings) table for details on which ZNG data types correspond to the [data types](https://docs.zeek.org/en/current/script-reference/types.html) that appear in Zeek logs.
+* Values read in by `zq` are stored internally and treated in expressions using one of the data types described in the [ZNG Value Messages](../../../zng/docs/spec.md#32-zng-value-messages) section of the ZNG spec.
+* See the [Equivalent Types](../../../zng/docs/zeek-compat.md#equivalent-types) table for details on which ZNG data types correspond to the [data types](https://docs.zeek.org/en/current/script-reference/types.html) that appear in Zeek logs.
 * ZQL provides a [type casting](https://en.wikipedia.org/wiki/Type_conversion) syntax using `:` followed by a ZNG data type.
 
 #### Example:

--- a/zql/docs/data-types/README.md
+++ b/zql/docs/data-types/README.md
@@ -3,7 +3,7 @@
 Comprehensive documentation for working with data types in ZQL is still a work
 in progress. In the meantime, here's a few tips to get started with.
 
-* Values read in by `zq` are stored internally and treated in expressions using one of the data types described in the [ZNG Value Messages](../../../zng/docs/spec.md#32-zng-value-messages) section of the ZNG spec.
+* Values read in by `zq` are stored internally and treated in expressions using one of the data types described in the [ZNG Value Messages](../../../zng/docs/spec.md#32-value-messages) section of the ZNG spec.
 * See the [Equivalent Types](../../../zng/docs/zeek-compat.md#equivalent-types) table for details on which ZNG data types correspond to the [data types](https://docs.zeek.org/en/current/script-reference/types.html) that appear in Zeek logs.
 * ZQL provides a [type casting](https://en.wikipedia.org/wiki/Type_conversion) syntax using `:` followed by a ZNG data type.
 

--- a/zql/docs/processors/README.md
+++ b/zql/docs/processors/README.md
@@ -139,7 +139,7 @@ TS                UID
 
 #### Example #2:
 
-An alternative syntax for our [`and` operator example](#../search-syntax/README.md#and):
+An alternative syntax for our [`and` operator example](../search-syntax/README.md#and):
 
 ```zq-command
 zq -f table 'filter www.*cdn*.com _path=ssl' *.log.gz


### PR DESCRIPTION
I found a couple more links containing anchors that no longer landed at their intended destinations. These weren't flagged as "broken" by automation because they land at a top-level page instead.