### PR TITLE
add a scanner that combines multiple readers

### DIFF
--- a/scanner/combiner.go
+++ b/scanner/combiner.go
@@ -1,0 +1,54 @@
+package scanner
+
+import (
+	"context"
+
+	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/filter"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng"
+)
+
+type combinerScanner struct {
+	combiner zbuf.Reader
+	scanners []Scanner
+}
+
+// NewCombinerScanner returns a Scanner that combines the records scanned from
+// a set of filtered readers.
+func NewCombinerScanner(ctx context.Context, readers []zbuf.Reader, spans []nano.Span, cmp zbuf.RecordCmpFn, f filter.Filter, filterExpr ast.BooleanExpr) (Scanner, error) {
+	if len(readers) != len(spans) {
+		panic("length mismatch between readers and spans")
+	}
+	scanners := make([]Scanner, len(readers))
+	scanReaders := make([]zbuf.Reader, len(readers))
+	for i, r := range readers {
+		s, err := NewScanner(ctx, r, f, filterExpr, spans[i])
+		if err != nil {
+			return nil, err
+		}
+		scanners[i] = s
+		scanReaders[i] = zbuf.PullerReader(s)
+	}
+	return &combinerScanner{
+		combiner: zbuf.NewCombiner(scanReaders, cmp),
+		scanners: scanners,
+	}, nil
+}
+
+func (c *combinerScanner) Pull() (zbuf.Batch, error) {
+	return zbuf.ReadBatch(c, BatchSize)
+}
+
+func (c *combinerScanner) Read() (*zng.Record, error) {
+	return c.combiner.Read()
+}
+
+func (c *combinerScanner) Stats() *ScannerStats {
+	var ss ScannerStats
+	for _, s := range c.scanners {
+		ss.Accumulate(s.Stats())
+	}
+	return &ss
+}

--- a/zbuf/batch.go
+++ b/zbuf/batch.go
@@ -72,3 +72,32 @@ func CopyPuller(w Writer, p Puller) error {
 		b.Unref()
 	}
 }
+
+func PullerReader(p Puller) Reader {
+	return &pullerReader{p: p}
+}
+
+type pullerReader struct {
+	p     Puller
+	batch Batch
+	idx   int
+}
+
+var _ Reader = (*pullerReader)(nil)
+
+func (r *pullerReader) Read() (*zng.Record, error) {
+	if r.batch == nil {
+		batch, err := r.p.Pull()
+		if err != nil || batch == nil {
+			return nil, err
+		}
+		r.batch = batch
+		r.idx = 0
+	}
+	rec := r.batch.Index(r.idx)
+	r.idx++
+	if r.idx == r.batch.Length() {
+		r.batch = nil
+	}
+	return rec, nil
+}

--- a/zbuf/batch.go
+++ b/zbuf/batch.go
@@ -83,16 +83,20 @@ type pullerReader struct {
 	idx   int
 }
 
-var _ Reader = (*pullerReader)(nil)
-
 func (r *pullerReader) Read() (*zng.Record, error) {
 	if r.batch == nil {
-		batch, err := r.p.Pull()
-		if err != nil || batch == nil {
-			return nil, err
+		for {
+			batch, err := r.p.Pull()
+			if err != nil || batch == nil {
+				return nil, err
+			}
+			if batch.Length() == 0 {
+				continue
+			}
+			r.batch = batch
+			r.idx = 0
+			break
 		}
-		r.batch = batch
-		r.idx = 0
 	}
 	rec := r.batch.Index(r.idx)
 	r.idx++


### PR DESCRIPTION
This is a subset of work for #1263 ; this will be used when scanning/reading from overlapping files in a zar archive.


