### PR TITLE
pcap: Add pcap info command

### DIFF
--- a/cmd/pcap/info/command.go
+++ b/cmd/pcap/info/command.go
@@ -1,0 +1,133 @@
+package info
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/brimsec/zq/cmd/pcap/root"
+	"github.com/brimsec/zq/pcap/pcapio"
+	"github.com/brimsec/zq/pkg/fs"
+	"github.com/mccanne/charm"
+)
+
+var Info = &charm.Spec{
+	Name:  "info",
+	Usage: "info <input_pcap>",
+	Short: "prints info about a pcap",
+	Long: `
+The info command reads through the entire pcap file and prints useful
+information about the pcap's contents.
+`,
+	New: New,
+}
+
+func init() {
+	root.Pcap.Add(Info)
+}
+
+type Command struct {
+	*root.Command
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
+	if len(args) != 1 {
+		return errors.New("pcap info takes a single file as input")
+	}
+	in, err := fs.Open(args[0])
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	reader, err := pcapio.NewReader(in)
+	if err != nil {
+		return err
+	}
+	out := os.Stdout
+	if pr, ok := reader.(*pcapio.PcapReader); ok {
+		return readPcap(pr, out)
+	}
+	return readNgPcap(reader.(*pcapio.NgReader), out)
+}
+
+func readPcap(reader *pcapio.PcapReader, out io.Writer) error {
+	w := tabwriter.NewWriter(out, 0, 0, 1, ' ', 0)
+	var pcnt int
+	fmt.Fprintf(w, "Pcap type:\tpcap\n")
+	fmt.Fprintf(w, "Pcap version:\t%s\n", reader.Version())
+	fmt.Fprintf(w, "Link type:\t%s\n", reader.LinkType.String())
+	fmt.Fprintf(w, "Packet size limit:\t%d\n", reader.Snaplen())
+	for {
+		block, typ, err := reader.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		if block == nil {
+			break
+		}
+		if typ == pcapio.TypePacket {
+			pcnt++
+		}
+	}
+	fmt.Fprintf(w, "Number of packets:\t%d\n", pcnt)
+	return w.Flush()
+}
+
+func readNgPcap(reader *pcapio.NgReader, out io.Writer) error {
+	var intfCounter, pcnt int
+	buf := bytes.NewBuffer(nil)
+	w := tabwriter.NewWriter(out, 4, 0, 1, ' ', 0)
+	fmt.Fprintf(w, "Pcap type:\tpcapng\n")
+	for {
+		block, typ, err := reader.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		if block == nil {
+			break
+		}
+		switch typ {
+		case pcapio.TypeSection:
+			intfCounter = 0
+			section := reader.SectionHeader(block)
+			fmt.Fprintf(w, "Pcap Version:\t%s\n", section.Version())
+		case pcapio.TypeInterface:
+			intf, err := reader.InterfaceDescriptor(block)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(buf, "Interface %d:\n", intfCounter)
+			intfCounter++
+			fmt.Fprintf(buf, "\tDescription:\t%s\n", intf.Description)
+			fmt.Fprintf(buf, "\tLink type:\t%s\n", intf.LinkType)
+			fmt.Fprintf(buf, "\tTime resolution:\t%s\n", intf.Resolution().String())
+			fmt.Fprintf(buf, "\tPacket size limit:\t%d\n", intf.SnapLength)
+		case pcapio.TypePacket:
+			pcnt++
+		}
+	}
+	fmt.Fprintf(w, "Number of packets:\t%d\n", pcnt)
+	if _, err := io.Copy(w, buf); err != nil {
+		return err
+	}
+	return w.Flush()
+}

--- a/cmd/pcap/main.go
+++ b/cmd/pcap/main.go
@@ -6,6 +6,7 @@ import (
 
 	_ "github.com/brimsec/zq/cmd/pcap/cut"
 	_ "github.com/brimsec/zq/cmd/pcap/index"
+	_ "github.com/brimsec/zq/cmd/pcap/info"
 	"github.com/brimsec/zq/cmd/pcap/root"
 	_ "github.com/brimsec/zq/cmd/pcap/slice"
 	_ "github.com/brimsec/zq/cmd/pcap/ts"

--- a/pcap/pcapio/pcapng.go
+++ b/pcap/pcapio/pcapng.go
@@ -11,6 +11,7 @@
 package pcapio
 
 import (
+	"fmt"
 	"math"
 	"time"
 
@@ -173,6 +174,8 @@ func (i NgInterface) Resolution() gopacket.TimestampResolution {
 
 // NgSectionInfo contains additional information of a pcapng section
 type NgSectionInfo struct {
+	MajorVersion uint16
+	MinorVersion uint16
 	// Hardware is the hardware this file was generated on. This value might be empty if this option is missing.
 	Hardware string
 	// OS is the operating system this file was generated on. This value might be empty if this option is missing.
@@ -181,4 +184,8 @@ type NgSectionInfo struct {
 	Application string
 	// Comment can be an arbitrary comment. This value might be empty if this option is missing.
 	Comment string
+}
+
+func (n NgSectionInfo) Version() string {
+	return fmt.Sprintf("%d.%d", n.MajorVersion, n.MinorVersion)
 }

--- a/tests/suite/pcap/info-ng.yaml
+++ b/tests/suite/pcap/info-ng.yaml
@@ -1,0 +1,32 @@
+script: |
+  pcap info ng-interfaces.pcapng
+
+inputs:
+  - name: ng-interfaces.pcapng
+
+outputs:
+  - name: stdout
+    data: |
+      Pcap type:         pcapng
+      Pcap Version:      1.0
+      Number of packets: 2
+      Interface 0:
+          Description:       [arista7120]
+          Link type:         Ethernet
+          Time resolution:   10^-9
+          Packet size limit: 4294967295
+      Interface 1:
+          Description:       [metamux]
+          Link type:         Ethernet
+          Time resolution:   10^-9
+          Packet size limit: 4294967295
+      Interface 2:
+          Description:       [noswitchstamp]
+          Link type:         Ethernet
+          Time resolution:   10^-9
+          Packet size limit: 4294967295
+      Interface 3:
+          Description:       [arista7260]
+          Link type:         Ethernet
+          Time resolution:   10^-9
+          Packet size limit: 4294967295

--- a/tests/suite/pcap/info.yaml
+++ b/tests/suite/pcap/info.yaml
@@ -1,0 +1,14 @@
+script: |
+  pcap info in.pcap
+
+inputs:
+  - name: in.pcap
+
+outputs:
+  - name: stdout
+    data: |
+      Pcap type:         pcap
+      Pcap version:      2.4
+      Link type:         Ethernet
+      Packet size limit: 65535
+      Number of packets: 9


### PR DESCRIPTION
zq#1341 fixed a bug with how pcapio was parsing interface descriptors
for pcapng files. This follow up as an info command along with tests
to ensure the pcap command is correctly gathering pcap info.

This is a simple first pass, not an attempt to exhaustively parse and
display all information available in the pcap|ng file formats.