### PR TITLE
add spilling to fuse proc

### DIFF
--- a/cli/procflags/procflags.go
+++ b/cli/procflags/procflags.go
@@ -5,17 +5,21 @@ import (
 	"flag"
 
 	"github.com/brimsec/zq/pkg/units"
+	"github.com/brimsec/zq/proc/fuse"
 	"github.com/brimsec/zq/proc/sort"
 )
 
 type Flags struct {
+	// these memory limits should be based on a shared resource model
 	sortMemMax units.Bytes
-	// fuse, groupby etc memory limits coming soon
+	fuseMemMax units.Bytes
 }
 
 func (f *Flags) SetFlags(fs *flag.FlagSet) {
 	f.sortMemMax = units.Bytes(sort.MemMaxBytes)
 	fs.Var(&f.sortMemMax, "sortmem", "maximum memory used by sort in MiB, MB, etc")
+	f.fuseMemMax = units.Bytes(fuse.MemMaxBytes)
+	fs.Var(&f.fuseMemMax, "fusemem", "maximum memory used by sort in MiB, MB, etc")
 }
 
 func (f *Flags) Init() error {
@@ -23,5 +27,9 @@ func (f *Flags) Init() error {
 		return errors.New("sortmem value must be greater than zero")
 	}
 	sort.MemMaxBytes = int(f.sortMemMax)
+	if f.fuseMemMax <= 0 {
+		return errors.New("fusemem value must be greater than zero")
+	}
+	fuse.MemMaxBytes = int(f.fuseMemMax)
 	return nil
 }

--- a/proc/fuse/fuse.go
+++ b/proc/fuse/fuse.go
@@ -2,8 +2,10 @@ package fuse
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/brimsec/zq/proc"
+	"github.com/brimsec/zq/proc/spill"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zng"
@@ -11,56 +13,144 @@ import (
 )
 
 var MemMaxBytes = 128 * 1024 * 1024
+var BatchSize = 100
 
 type Proc struct {
-	pctx   *proc.Context
-	parent proc.Interface
-	recs   []*zng.Record
-	done   bool
+	pctx     *proc.Context
+	parent   proc.Interface
+	spiller  *spill.File
+	slotByID [][]int
+	slots    []slot
+	uberType *zng.TypeRecord
+	once     sync.Once
+	resultCh chan proc.Result
+	nbytes   int
+	recs     []*zng.Record
+	types    resolver.Slice
 }
 
 func New(pctx *proc.Context, parent proc.Interface) (*Proc, error) {
 	return &Proc{
-		pctx:   pctx,
-		parent: parent,
+		pctx:     pctx,
+		parent:   parent,
+		resultCh: make(chan proc.Result),
 	}, nil
 }
 
 func (p *Proc) Pull() (zbuf.Batch, error) {
-	if p.done {
-		return nil, nil
+	p.once.Do(func() { go p.run() })
+	if r, ok := <-p.resultCh; ok {
+		return r.Batch, r.Err
 	}
-	var nbytes int
-	var types resolver.Slice
+	return nil, p.pctx.Err()
+}
+
+func (p *Proc) run() {
+	if err := p.pullInput(); err != nil {
+		p.shutdown(err)
+		return
+	}
+	p.shutdown(p.pushOutput())
+}
+
+func (p *Proc) pullInput() error {
 	for {
+		if err := p.pctx.Err(); err != nil {
+			return err
+		}
 		batch, err := p.parent.Pull()
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if batch == nil {
-			p.done = true
-			return p.finish(types, p.recs)
+			return p.finish()
 		}
-		l := batch.Length()
-		for i := 0; i < l; i++ {
-			rec := batch.Index(i)
-			id := rec.Type.ID()
-			typ := types.Lookup(id)
-			if typ == nil {
-				types.Enter(id, rec.Type)
-			}
-			nbytes += len(rec.Raw)
-			// We're keeping records owned by batch so don't call Unref.
-			p.recs = append(p.recs, rec)
-		}
-		if nbytes >= MemMaxBytes {
-			return nil, errors.New("fuse processor exceeded memory limit")
+		if err := p.writeBatch(batch); err != nil {
+			return err
 		}
 	}
 }
 
+func (p *Proc) writeBatch(batch zbuf.Batch) error {
+	l := batch.Length()
+	for i := 0; i < l; i++ {
+		rec := batch.Index(i)
+		id := rec.Type.ID()
+		typ := p.types.Lookup(id)
+		if typ == nil {
+			p.types.Enter(id, rec.Type)
+		}
+		if p.spiller != nil {
+			if err := p.spiller.Write(rec); err != nil {
+				return err
+			}
+		} else {
+			if err := p.stash(rec); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (p *Proc) stash(rec *zng.Record) error {
+	p.nbytes += len(rec.Raw)
+	if p.nbytes >= MemMaxBytes {
+		var err error
+		p.spiller, err = spill.NewTempFile()
+		if err != nil {
+			return err
+		}
+		for _, rec := range p.recs {
+			if err := p.spiller.Write(rec); err != nil {
+				return err
+			}
+		}
+		p.recs = nil
+		return nil
+	}
+	p.recs = append(p.recs, rec)
+	return nil
+}
+
+func (p *Proc) pushOutput() error {
+	var reader zbuf.Reader
+	if p.spiller != nil {
+		if err := p.spiller.Rewind(p.pctx.TypeContext); err != nil {
+			return err
+		}
+		reader = p.spiller
+	} else {
+		reader = zbuf.Array(p.recs).NewReader()
+	}
+	for {
+		if err := p.pctx.Err(); err != nil {
+			return err
+		}
+		batch, err := p.nextBatch(reader)
+		if err != nil || batch == nil {
+			return err
+		}
+		p.sendResult(batch, nil)
+	}
+}
+
+func (p *Proc) sendResult(b zbuf.Batch, err error) {
+	select {
+	case p.resultCh <- proc.Result{Batch: b, Err: err}:
+	case <-p.pctx.Done():
+	}
+}
+
+func (p *Proc) shutdown(err error) {
+	if p.spiller != nil {
+		p.spiller.CloseAndRemove()
+	}
+	p.sendResult(nil, err)
+	close(p.resultCh)
+}
+
 func (p *Proc) Done() {
-	p.done = true
 	p.parent.Done()
 }
 
@@ -69,45 +159,60 @@ type slot struct {
 	container bool
 }
 
-func (p *Proc) finish(types resolver.Slice, recs []*zng.Record) (zbuf.Batch, error) {
+func (p *Proc) finish() error {
 	uber := newSchema()
 	// positionsByID provides a map from a type ID to a slice of integers
 	// that represent the column position in the uber schema for each column
 	// of the input record type.
-	positionsByID := make([][]int, len(types))
-	for _, typ := range types {
+	p.slotByID = make([][]int, len(p.types))
+	for _, typ := range p.types {
 		if typ != nil {
 			id := typ.ID()
-			positionsByID[id] = uber.mixin(typ)
+			p.slotByID[id] = uber.mixin(typ)
 		}
 	}
-	uberType, err := p.pctx.TypeContext.LookupTypeRecord(uber.columns)
+	var err error
+	p.uberType, err = p.pctx.TypeContext.LookupTypeRecord(uber.columns)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	slots := make([]slot, len(uberType.Columns))
-	for k := range slots {
-		slots[k].container = zng.IsContainerType(uberType.Columns[k].Type)
+	p.slots = make([]slot, len(p.uberType.Columns))
+	for k := range p.slots {
+		p.slots[k].container = zng.IsContainerType(p.uberType.Columns[k].Type)
 	}
+	return nil
+}
+
+func (p *Proc) nextBatch(reader zbuf.Reader) (zbuf.Batch, error) {
 	var out []*zng.Record
-	for _, rec := range recs {
-		for k := range slots {
-			slots[k].zv = nil
+	for len(out) < BatchSize {
+		rec, err := reader.Read()
+		if err != nil {
+			return nil, err
 		}
-		positions := positionsByID[rec.Type.ID()]
+		if rec == nil {
+			break
+		}
+		for k := range p.slots {
+			p.slots[k].zv = nil
+		}
+		slotList := p.slotByID[rec.Type.ID()]
 		it := zcode.Iter(rec.Raw)
-		for _, pos := range positions {
+		for _, slot := range slotList {
 			zv, _, err := it.Next()
 			if err != nil {
 				return nil, err
 			}
-			slots[pos].zv = zv
+			p.slots[slot].zv = zv
 		}
 		if !it.Done() {
 			return nil, errors.New("column mismatch in fuse processor")
 		}
-		uberRec := splice(uberType, slots)
+		uberRec := splice(p.uberType, p.slots)
 		out = append(out, uberRec)
+	}
+	if out == nil {
+		return nil, nil
 	}
 	return zbuf.Array(out), nil
 }

--- a/proc/fuse/fuse.go
+++ b/proc/fuse/fuse.go
@@ -98,7 +98,7 @@ func (p *Proc) stash(rec *zng.Record) error {
 	p.nbytes += len(rec.Raw)
 	if p.nbytes >= MemMaxBytes {
 		var err error
-		p.spiller, err = spill.NewTempFile()
+		p.spiller, err = spill.NewTempFile("")
 		if err != nil {
 			return err
 		}

--- a/proc/fuse/fuse.go
+++ b/proc/fuse/fuse.go
@@ -94,6 +94,7 @@ func (p *Proc) writeBatch(batch zbuf.Batch) error {
 }
 
 func (p *Proc) stash(rec *zng.Record) error {
+	p.recs = append(p.recs, rec)
 	p.nbytes += len(rec.Raw)
 	if p.nbytes >= MemMaxBytes {
 		var err error
@@ -109,7 +110,6 @@ func (p *Proc) stash(rec *zng.Record) error {
 		p.recs = nil
 		return nil
 	}
-	p.recs = append(p.recs, rec)
 	return nil
 }
 

--- a/proc/fuse/fuse.go
+++ b/proc/fuse/fuse.go
@@ -166,7 +166,7 @@ type slot struct {
 
 func (p *Proc) finish() error {
 	uber := newSchema()
-	// positionsByID provides a map from a type ID to a slice of integers
+	// slotByID provides a map from a type ID to a slice of integers
 	// that represent the column position in the uber schema for each column
 	// of the input record type.
 	p.slotByID = make([][]int, len(p.types))

--- a/proc/fuse/fuse.go
+++ b/proc/fuse/fuse.go
@@ -98,7 +98,7 @@ func (p *Proc) stash(rec *zng.Record) error {
 	p.nbytes += len(rec.Raw)
 	if p.nbytes >= MemMaxBytes {
 		var err error
-		p.spiller, err = spill.NewTempFile("")
+		p.spiller, err = spill.NewTempFile()
 		if err != nil {
 			return err
 		}

--- a/proc/spill/file.go
+++ b/proc/spill/file.go
@@ -32,8 +32,8 @@ func NewFile(f *os.File) *File {
 	}
 }
 
-func NewTempFile() (*File, error) {
-	f, err := TempFile()
+func NewTempFile(dir string) (*File, error) {
+	f, err := TempFile(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,6 @@ func (f *File) Rewind(zctx *resolver.Context) error {
 	}
 	f.Writer = nil
 	if _, err := f.file.Seek(0, 0); err != nil {
-		f.CloseAndRemove()
 		return err
 	}
 	f.Reader = zngio.NewReader(bufio.NewReader(f.file), zctx)

--- a/proc/spill/file.go
+++ b/proc/spill/file.go
@@ -56,16 +56,18 @@ func (f *File) Rewind(zctx *resolver.Context) error {
 	}
 	f.Writer = nil
 	if _, err := f.file.Seek(0, 0); err != nil {
-		f.closeAndRemove()
+		f.CloseAndRemove()
 		return err
 	}
 	f.Reader = zngio.NewReader(bufio.NewReader(f.file), zctx)
 	return nil
 }
 
-// closeAndRemove closes and removes the underlying file.
-// Errors are ignored.
-func (r *File) closeAndRemove() {
-	r.file.Close()
-	os.Remove(r.file.Name())
+// CloseAndRemove closes and removes the underlying file.
+func (r *File) CloseAndRemove() error {
+	err := r.file.Close()
+	if rmErr := os.Remove(r.file.Name()); err == nil {
+		err = rmErr
+	}
+	return err
 }

--- a/proc/spill/file.go
+++ b/proc/spill/file.go
@@ -32,8 +32,8 @@ func NewFile(f *os.File) *File {
 	}
 }
 
-func NewTempFile(dir string) (*File, error) {
-	f, err := TempFile(dir)
+func NewTempFile() (*File, error) {
+	f, err := TempFile()
 	if err != nil {
 		return nil, err
 	}

--- a/proc/spill/merge.go
+++ b/proc/spill/merge.go
@@ -4,8 +4,6 @@ import (
 	"container/heap"
 	"io/ioutil"
 	"os"
-	"path/filepath"
-	"strconv"
 
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/zng"
@@ -29,8 +27,8 @@ func TempDir() (string, error) {
 	return ioutil.TempDir("", TempPrefix)
 }
 
-func TempFile() (*os.File, error) {
-	return ioutil.TempFile("", TempPrefix)
+func TempFile(dir string) (*os.File, error) {
+	return ioutil.TempFile(dir, TempPrefix)
 }
 
 // NewMergeSort returns a MergeSort to implement external merge sorts of a large
@@ -96,7 +94,9 @@ func (r *MergeSort) Read() (*zng.Record, error) {
 			if err := r.runs[0].CloseAndRemove(); err != nil {
 				return nil, err
 			}
-			heap.Pop(r)
+			// XXX
+			//heap.Pop(r)
+			heap.Remove(r, 0)
 		} else {
 			heap.Fix(r, 0)
 		}

--- a/proc/spill/merge.go
+++ b/proc/spill/merge.go
@@ -4,6 +4,8 @@ import (
 	"container/heap"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strconv"
 
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/zng"
@@ -94,9 +96,7 @@ func (r *MergeSort) Read() (*zng.Record, error) {
 			if err := r.runs[0].CloseAndRemove(); err != nil {
 				return nil, err
 			}
-			// XXX
-			//heap.Pop(r)
-			heap.Remove(r, 0)
+			heap.Pop(r)
 		} else {
 			heap.Fix(r, 0)
 		}

--- a/proc/spill/merge.go
+++ b/proc/spill/merge.go
@@ -29,8 +29,8 @@ func TempDir() (string, error) {
 	return ioutil.TempDir("", TempPrefix)
 }
 
-func TempFile(dir string) (*os.File, error) {
-	return ioutil.TempFile(dir, TempPrefix)
+func TempFile() (*os.File, error) {
+	return ioutil.TempFile("", TempPrefix)
 }
 
 // NewMergeSort returns a MergeSort to implement external merge sorts of a large

--- a/proc/spill/merge.go
+++ b/proc/spill/merge.go
@@ -50,7 +50,7 @@ func NewMergeSort(compareFn expr.CompareFn) (*MergeSort, error) {
 
 func (r *MergeSort) Cleanup() {
 	for _, run := range r.runs {
-		run.closeAndRemove()
+		run.CloseAndRemove()
 	}
 	os.RemoveAll(r.tempDir)
 }
@@ -93,7 +93,9 @@ func (r *MergeSort) Read() (*zng.Record, error) {
 			return nil, err
 		}
 		if eof {
-			r.runs[0].closeAndRemove()
+			if err := r.runs[0].CloseAndRemove(); err != nil {
+				return nil, err
+			}
 			heap.Pop(r)
 		} else {
 			heap.Fix(r, 0)

--- a/proc/spill/peeker.go
+++ b/proc/spill/peeker.go
@@ -11,7 +11,11 @@ type peeker struct {
 	ordinal    int
 }
 
-func newPeeker(f *File, ordinal int, recs []*zng.Record, zctx *resolver.Context) (*peeker, error) {
+func newPeeker(filename string, ordinal int, recs []*zng.Record, zctx *resolver.Context) (*peeker, error) {
+	f, err := NewFileWithPath(filename, zctx)
+	if err != nil {
+		return nil, err
+	}
 	for _, rec := range recs {
 		if err := f.Write(rec); err != nil {
 			f.CloseAndRemove()

--- a/proc/spill/peeker.go
+++ b/proc/spill/peeker.go
@@ -18,17 +18,17 @@ func newPeeker(filename string, ordinal int, recs []*zng.Record, zctx *resolver.
 	}
 	for _, rec := range recs {
 		if err := f.Write(rec); err != nil {
-			f.closeAndRemove()
+			f.CloseAndRemove()
 			return nil, err
 		}
 	}
 	if err := f.Rewind(zctx); err != nil {
-		f.closeAndRemove()
+		f.CloseAndRemove()
 		return nil, err
 	}
 	first, err := f.Read()
 	if err != nil {
-		f.closeAndRemove()
+		f.CloseAndRemove()
 		return nil, err
 	}
 	return &peeker{f, first, ordinal}, nil

--- a/proc/spill/peeker.go
+++ b/proc/spill/peeker.go
@@ -11,11 +11,7 @@ type peeker struct {
 	ordinal    int
 }
 
-func newPeeker(filename string, ordinal int, recs []*zng.Record, zctx *resolver.Context) (*peeker, error) {
-	f, err := NewFileWithPath(filename, zctx)
-	if err != nil {
-		return nil, err
-	}
+func newPeeker(f *File, ordinal int, recs []*zng.Record, zctx *resolver.Context) (*peeker, error) {
 	for _, rec := range recs {
 		if err := f.Write(rec); err != nil {
 			f.CloseAndRemove()

--- a/tests/suite/fuse/spill.yaml
+++ b/tests/suite/fuse/spill.yaml
@@ -13,4 +13,5 @@ outputs:
   - name: stdout
     data: |
       #0:record[a:string,b:string,c:string]
+      0:[hello;world;-;]
       0:[-;goodnight;gracie;]

--- a/tests/suite/fuse/spill.yaml
+++ b/tests/suite/fuse/spill.yaml
@@ -1,0 +1,16 @@
+script: |
+  zq -t -fusemem 1B fuse in.tzng
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[a:string,b:string]
+      0:[hello;world;]
+      #1:record[b:string,c:string]
+      1:[goodnight;gracie;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[a:string,b:string,c:string]
+      0:[-;goodnight;gracie;]

--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -4,7 +4,8 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
-// Array is a slice of of records that implements the Batch interface.
+// Array is a slice of of records that implements the Batch and
+// the Reader interfaces.
 type Array []*zng.Record
 
 func (a Array) Ref() {
@@ -33,4 +34,19 @@ func (a Array) Index(k int) *zng.Record {
 
 func (a *Array) Append(r *zng.Record) {
 	*a = append(*a, r)
+}
+
+// Read returns removes the first element of the Array and returns it,
+// or it returns nil if the Array is empty.
+func (a *Array) Read() (*zng.Record, error) {
+	var rec *zng.Record
+	if len(*a) > 0 {
+		rec = (*a)[0]
+		*a = (*a)[1:]
+	}
+	return rec, nil
+}
+
+func (a Array) NewReader() Reader {
+	return &a
 }


### PR DESCRIPTION
This commit adds spill logic to the fuse proc triggered when its memory
footprint exceeds a threshold.  We changed the fuse proc implementation
to use a goroutine so it can cleanly teardown the spill file when
the proc context is canceled in addition to providing parallelism
between scanning and spilling.

The -fusemem proc flag option is analogous to -sortmem and controls
how much memory fuse will use before spilling.

We also added a Read method in zbuf.Array to implement zbuf.Reader,
which is handy for turning a slice of zng records into a reader.

Closes #1270 