### PR TITLE
simplify spill.MergeSort

### DIFF
--- a/proc/spill/peeker.go
+++ b/proc/spill/peeker.go
@@ -8,9 +8,10 @@ import (
 type peeker struct {
 	*File
 	nextRecord *zng.Record
+	ordinal    int
 }
 
-func newPeeker(filename string, recs []*zng.Record, zctx *resolver.Context) (*peeker, error) {
+func newPeeker(filename string, ordinal int, recs []*zng.Record, zctx *resolver.Context) (*peeker, error) {
 	f, err := NewFileWithPath(filename, zctx)
 	if err != nil {
 		return nil, err
@@ -30,7 +31,7 @@ func newPeeker(filename string, recs []*zng.Record, zctx *resolver.Context) (*pe
 		f.closeAndRemove()
 		return nil, err
 	}
-	return &peeker{f, first}, nil
+	return &peeker{f, first, ordinal}, nil
 }
 
 // read is like Read but returns eof at the last record so a MergeSort can


### PR DESCRIPTION
This commit simplifies spill.MergeSort by removing the map that
tracked temp file name with the position of the file in the overall
spill.  This same information can be tracked more simply by storing
this ordinal position in the peeker.