### PR TITLE
fix record volatility bug introduced in commit 0382a0f

### DIFF
--- a/proc/spill/peeker.go
+++ b/proc/spill/peeker.go
@@ -37,6 +37,9 @@ func newPeeker(filename string, recs []*zng.Record, zctx *resolver.Context) (*pe
 // do its heap management a bit more easily.
 func (p *peeker) read() (*zng.Record, bool, error) {
 	rec := p.nextRecord
+	if rec != nil {
+		rec = rec.Keep()
+	}
 	var err error
 	p.nextRecord, err = p.Read()
 	eof := p.nextRecord == nil && err == nil


### PR DESCRIPTION
This commit fixes a bug that was introduced in commit 0382a0f,
where a rec.Keep() call was dropped in the spill/read path compared
to the old code.  This fix puts the call back in.

Fixes #1359 

