### PR TITLE
Make release CI more like regular CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,18 @@ jobs:
       with:
         go-version: '1.14'
     - uses: actions/checkout@v1
+    - run: go mod download
+    - run: make fmt
+    - run: make tidy
+    - run: |
+          sudo apt-get update
+          sudo apt-get install -y zip libnet1 libjansson4
+    - run: make vet
+    - run: make test-generate
     - run: make test-unit
     - run: make test-system
     - run: make test-zeek
+    - run: make test-heavy
     - run: make create-release-assets
     - name: upload release assets
       uses: svenstaro/upload-release-action@1.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - suricata-in-release-ci
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - v*
+    branches:
+      - suricata-in-release-ci
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Even though zq CI has been running fine lately, I had failures today when trying to tag a new release. @alfred-landrum helped confirm that the failures were related to some recent Suricata-related changes. Closer inspection of the workflows revealed that the CI changes in #1294 needed to also be added to the `release.yml`, since there's some CI-style sanity tests run in there before building/uploading the release artifacts. While I was at it, I just copied over several other steps that were in `ci.yaml` but not yet in `release.yaml`. They may not be significant right now, but I assume any deltas may result in mysterious "hey it worked in one but not the other" problems later, so, might as well sync them up while it's top-of-mind.

https://github.com/brimsec/zq/actions/runs/273229142 was a run I triggered using this Workflow. I let it successfully get past the `make test-system` phase (that was failing previously) before I canceled it.