### PR TITLE
JSON types: remove "_path must be first column" check

### DIFF
--- a/zio/ndjsonio/config.go
+++ b/zio/ndjsonio/config.go
@@ -52,10 +52,6 @@ func (conf TypeConfig) Validate() error {
 				return fmt.Errorf("descriptor %s has field ts with wrong type %s", name, col["type"])
 			}
 		}
-		col := desc[0].(map[string]interface{})
-		if col["name"] != "_path" {
-			return fmt.Errorf("descriptor %s does not have _path as first column", name)
-		}
 	}
 	return nil
 }

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -334,7 +334,7 @@ func TestNDJSONTypeErrors(t *testing.T) {
 		},
 		{
 			name:    "Missing _path",
-			result:  typeStats{MissingPath: 1, FirstBadLine: 1},
+			result:  typeStats{DescriptorNotFound: 1, FirstBadLine: 1},
 			input:   `{"ts":"2017-03-24T19:59:23.306076Z","uid":"CXY9a54W2dLZwzPXf1","id.orig_h":"10.10.7.65"}` + "\n",
 			success: false,
 		},

--- a/zio/ndjsonio/typeparser.go
+++ b/zio/ndjsonio/typeparser.go
@@ -20,7 +20,6 @@ type typeStats struct {
 	FirstBadLine         int
 	DescriptorNotFound   int
 	IncompleteDescriptor int
-	MissingPath          int
 }
 
 type typeParser struct {
@@ -34,7 +33,6 @@ type typeParser struct {
 
 var (
 	ErrDescriptorNotFound   = errors.New("descriptor not found")
-	ErrMissingPath          = errors.New("missing path field")
 	ErrIncompleteDescriptor = errors.New("incomplete descriptor")
 )
 
@@ -255,9 +253,6 @@ func (p *typeParser) findTypeInfo(zctx *resolver.Context, jobj []byte, tr typeRu
 			return ti, nil
 		}
 	}
-	if path == "" {
-		return nil, ErrMissingPath
-	}
 	return nil, ErrDescriptorNotFound
 }
 
@@ -275,8 +270,6 @@ func (p *typeParser) parseObject(b []byte) (zng.Value, error) {
 		switch err {
 		case ErrDescriptorNotFound:
 			incr(&p.stats.DescriptorNotFound)
-		case ErrMissingPath:
-			incr(&p.stats.MissingPath)
 		default:
 			panic("unhandled error")
 		}


### PR DESCRIPTION
This commit removes the validation check that ensured that _path was
present as the first field of descriptors. This check is a reflection of our
zeek-onlyness back when this feature was first introduced. Now with the
impending arrival of Suricata and other data types, this hardcoded
check no longer belongs.

If we find ourselves needing such a validation, we can re-introduce
something more general once we have a few more ingest types under our
belt.