### PR TITLE
Allow for singular "week" like we do for other time units

### DIFF
--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -817,110 +817,111 @@ function peg$parse(input, options) {
       peg$c320 = function(num) { return {"type": "Duration", "seconds": num*3600} },
       peg$c321 = function() { return {"type": "Duration", "seconds": 3600*24} },
       peg$c322 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c323 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c324 = function(a) { return text() },
-      peg$c325 = function(a, b) {
+      peg$c323 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c324 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c325 = function(a) { return text() },
+      peg$c326 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c326 = "::",
-      peg$c327 = peg$literalExpectation("::", false),
-      peg$c328 = function(a, b, d, e) {
+      peg$c327 = "::",
+      peg$c328 = peg$literalExpectation("::", false),
+      peg$c329 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c329 = function(a, b) {
+      peg$c330 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c330 = function(a, b) {
+      peg$c331 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c331 = function() {
+      peg$c332 = function() {
             return "::"
           },
-      peg$c332 = function(v) { return ":" + v },
-      peg$c333 = function(v) { return v + ":" },
-      peg$c334 = function(a, m) {
+      peg$c333 = function(v) { return ":" + v },
+      peg$c334 = function(v) { return v + ":" },
+      peg$c335 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c335 = function(a, m) {
+      peg$c336 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c336 = function(s) { return parseInt(s) },
-      peg$c337 = /^[+\-]/,
-      peg$c338 = peg$classExpectation(["+", "-"], false, false),
-      peg$c340 = function() {
+      peg$c337 = function(s) { return parseInt(s) },
+      peg$c338 = /^[+\-]/,
+      peg$c339 = peg$classExpectation(["+", "-"], false, false),
+      peg$c341 = function() {
             return text()
           },
-      peg$c341 = "0",
-      peg$c342 = peg$literalExpectation("0", false),
-      peg$c343 = /^[1-9]/,
-      peg$c344 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c345 = "e",
-      peg$c346 = peg$literalExpectation("e", true),
-      peg$c347 = function(chars) { return text() },
-      peg$c348 = /^[0-9a-fA-F]/,
-      peg$c349 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c350 = function(chars) { return joinChars(chars) },
-      peg$c351 = "\\",
-      peg$c352 = peg$literalExpectation("\\", false),
-      peg$c353 = /^[\0-\x1F\\(),!><="|';]/,
-      peg$c354 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
-      peg$c355 = peg$anyExpectation(),
-      peg$c356 = "\"",
-      peg$c357 = peg$literalExpectation("\"", false),
-      peg$c358 = function(v) { return joinChars(v) },
-      peg$c359 = "'",
-      peg$c360 = peg$literalExpectation("'", false),
-      peg$c361 = "x",
-      peg$c362 = peg$literalExpectation("x", false),
-      peg$c363 = function() { return "\\" + text() },
-      peg$c364 = "b",
-      peg$c365 = peg$literalExpectation("b", false),
-      peg$c366 = function() { return "\b" },
-      peg$c367 = "f",
-      peg$c368 = peg$literalExpectation("f", false),
-      peg$c369 = function() { return "\f" },
-      peg$c370 = "n",
-      peg$c371 = peg$literalExpectation("n", false),
-      peg$c372 = function() { return "\n" },
-      peg$c373 = "r",
-      peg$c374 = peg$literalExpectation("r", false),
-      peg$c375 = function() { return "\r" },
-      peg$c376 = "t",
-      peg$c377 = peg$literalExpectation("t", false),
-      peg$c378 = function() { return "\t" },
-      peg$c379 = "v",
-      peg$c380 = peg$literalExpectation("v", false),
-      peg$c381 = function() { return "\v" },
-      peg$c382 = function() { return "=" },
-      peg$c383 = function() { return "\\*" },
-      peg$c384 = "u",
-      peg$c385 = peg$literalExpectation("u", false),
-      peg$c386 = function(chars) {
+      peg$c342 = "0",
+      peg$c343 = peg$literalExpectation("0", false),
+      peg$c344 = /^[1-9]/,
+      peg$c345 = peg$classExpectation([["1", "9"]], false, false),
+      peg$c346 = "e",
+      peg$c347 = peg$literalExpectation("e", true),
+      peg$c348 = function(chars) { return text() },
+      peg$c349 = /^[0-9a-fA-F]/,
+      peg$c350 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c351 = function(chars) { return joinChars(chars) },
+      peg$c352 = "\\",
+      peg$c353 = peg$literalExpectation("\\", false),
+      peg$c354 = /^[\0-\x1F\\(),!><="|';]/,
+      peg$c355 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
+      peg$c356 = peg$anyExpectation(),
+      peg$c357 = "\"",
+      peg$c358 = peg$literalExpectation("\"", false),
+      peg$c359 = function(v) { return joinChars(v) },
+      peg$c360 = "'",
+      peg$c361 = peg$literalExpectation("'", false),
+      peg$c362 = "x",
+      peg$c363 = peg$literalExpectation("x", false),
+      peg$c364 = function() { return "\\" + text() },
+      peg$c365 = "b",
+      peg$c366 = peg$literalExpectation("b", false),
+      peg$c367 = function() { return "\b" },
+      peg$c368 = "f",
+      peg$c369 = peg$literalExpectation("f", false),
+      peg$c370 = function() { return "\f" },
+      peg$c371 = "n",
+      peg$c372 = peg$literalExpectation("n", false),
+      peg$c373 = function() { return "\n" },
+      peg$c374 = "r",
+      peg$c375 = peg$literalExpectation("r", false),
+      peg$c376 = function() { return "\r" },
+      peg$c377 = "t",
+      peg$c378 = peg$literalExpectation("t", false),
+      peg$c379 = function() { return "\t" },
+      peg$c380 = "v",
+      peg$c381 = peg$literalExpectation("v", false),
+      peg$c382 = function() { return "\v" },
+      peg$c383 = function() { return "=" },
+      peg$c384 = function() { return "\\*" },
+      peg$c385 = "u",
+      peg$c386 = peg$literalExpectation("u", false),
+      peg$c387 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c387 = "{",
-      peg$c388 = peg$literalExpectation("{", false),
-      peg$c389 = "}",
-      peg$c390 = peg$literalExpectation("}", false),
-      peg$c391 = /^[^\/\\]/,
-      peg$c392 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c393 = "\\/",
-      peg$c394 = peg$literalExpectation("\\/", false),
-      peg$c395 = /^[\0-\x1F\\]/,
-      peg$c396 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c397 = "\t",
-      peg$c398 = peg$literalExpectation("\t", false),
-      peg$c399 = "\x0B",
-      peg$c400 = peg$literalExpectation("\x0B", false),
-      peg$c401 = "\f",
-      peg$c402 = peg$literalExpectation("\f", false),
-      peg$c403 = " ",
-      peg$c404 = peg$literalExpectation(" ", false),
-      peg$c405 = "\xA0",
-      peg$c406 = peg$literalExpectation("\xA0", false),
-      peg$c407 = "\uFEFF",
-      peg$c408 = peg$literalExpectation("\uFEFF", false),
-      peg$c409 = peg$otherExpectation("whitespace"),
+      peg$c388 = "{",
+      peg$c389 = peg$literalExpectation("{", false),
+      peg$c390 = "}",
+      peg$c391 = peg$literalExpectation("}", false),
+      peg$c392 = /^[^\/\\]/,
+      peg$c393 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c394 = "\\/",
+      peg$c395 = peg$literalExpectation("\\/", false),
+      peg$c396 = /^[\0-\x1F\\]/,
+      peg$c397 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c398 = "\t",
+      peg$c399 = peg$literalExpectation("\t", false),
+      peg$c400 = "\x0B",
+      peg$c401 = peg$literalExpectation("\x0B", false),
+      peg$c402 = "\f",
+      peg$c403 = peg$literalExpectation("\f", false),
+      peg$c404 = " ",
+      peg$c405 = peg$literalExpectation(" ", false),
+      peg$c406 = "\xA0",
+      peg$c407 = peg$literalExpectation("\xA0", false),
+      peg$c408 = "\uFEFF",
+      peg$c409 = peg$literalExpectation("\uFEFF", false),
+      peg$c410 = peg$otherExpectation("whitespace"),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -6704,18 +6705,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseunsignedInteger();
+    if (input.substr(peg$currPos, 4) === peg$c307) {
+      s1 = peg$c307;
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c308); }
+    }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseweek_abbrev();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c323(s1);
-          s0 = s1;
+      peg$savedPos = s0;
+      s1 = peg$c323();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseunsignedInteger();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse_();
+        if (s2 === peg$FAILED) {
+          s2 = null;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseweek_abbrev();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c324(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -6724,9 +6743,6 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
     }
 
     return s0;
@@ -6801,7 +6817,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c324();
+      s1 = peg$c325();
     }
     s0 = s1;
 
@@ -6855,7 +6871,7 @@ function peg$parse(input, options) {
       s2 = peg$parseip6tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c325(s1, s2);
+        s1 = peg$c326(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6876,12 +6892,12 @@ function peg$parse(input, options) {
           s3 = peg$parseh_append();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c326) {
-            s3 = peg$c326;
+          if (input.substr(peg$currPos, 2) === peg$c327) {
+            s3 = peg$c327;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c327); }
+            if (peg$silentFails === 0) { peg$fail(peg$c328); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6894,7 +6910,7 @@ function peg$parse(input, options) {
               s5 = peg$parseip6tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c328(s1, s2, s4, s5);
+                s1 = peg$c329(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6918,12 +6934,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c326) {
-          s1 = peg$c326;
+        if (input.substr(peg$currPos, 2) === peg$c327) {
+          s1 = peg$c327;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c327); }
+          if (peg$silentFails === 0) { peg$fail(peg$c328); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6936,7 +6952,7 @@ function peg$parse(input, options) {
             s3 = peg$parseip6tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c329(s2, s3);
+              s1 = peg$c330(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6961,16 +6977,16 @@ function peg$parse(input, options) {
               s3 = peg$parseh_append();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c326) {
-                s3 = peg$c326;
+              if (input.substr(peg$currPos, 2) === peg$c327) {
+                s3 = peg$c327;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c327); }
+                if (peg$silentFails === 0) { peg$fail(peg$c328); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c330(s1, s2);
+                s1 = peg$c331(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6986,16 +7002,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c326) {
-              s1 = peg$c326;
+            if (input.substr(peg$currPos, 2) === peg$c327) {
+              s1 = peg$c327;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c327); }
+              if (peg$silentFails === 0) { peg$fail(peg$c328); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c331();
+              s1 = peg$c332();
             }
             s0 = s1;
           }
@@ -7032,7 +7048,7 @@ function peg$parse(input, options) {
       s2 = peg$parseh16();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c332(s2);
+        s1 = peg$c333(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7061,7 +7077,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c333(s1);
+        s1 = peg$c334(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7092,7 +7108,7 @@ function peg$parse(input, options) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c334(s1, s3);
+          s1 = peg$c335(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7127,7 +7143,7 @@ function peg$parse(input, options) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c335(s1, s3);
+          s1 = peg$c336(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7152,7 +7168,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesuint();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c336(s1);
+      s1 = peg$c337(s1);
     }
     s0 = s1;
 
@@ -7198,12 +7214,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c337.test(input.charAt(peg$currPos))) {
+    if (peg$c338.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c339); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -7277,7 +7293,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c340();
+              s1 = peg$c341();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7337,7 +7353,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c340();
+              s1 = peg$c341();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7364,20 +7380,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     if (input.charCodeAt(peg$currPos) === 48) {
-      s0 = peg$c341;
+      s0 = peg$c342;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c342); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$c343.test(input.charAt(peg$currPos))) {
+      if (peg$c344.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c344); }
+        if (peg$silentFails === 0) { peg$fail(peg$c345); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7432,12 +7448,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c345) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c346) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c346); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesinteger();
@@ -7472,7 +7488,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c347();
+      s1 = peg$c348();
     }
     s0 = s1;
 
@@ -7482,12 +7498,12 @@ function peg$parse(input, options) {
   function peg$parsehexdigit() {
     var s0;
 
-    if (peg$c348.test(input.charAt(peg$currPos))) {
+    if (peg$c349.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c349); }
+      if (peg$silentFails === 0) { peg$fail(peg$c350); }
     }
 
     return s0;
@@ -7509,7 +7525,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c350(s1);
+      s1 = peg$c351(s1);
     }
     s0 = s1;
 
@@ -7521,11 +7537,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c351;
+      s1 = peg$c352;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c352); }
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseescapeSequence();
@@ -7548,12 +7564,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c353.test(input.charAt(peg$currPos))) {
+      if (peg$c354.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c354); }
+        if (peg$silentFails === 0) { peg$fail(peg$c355); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parsews();
@@ -7571,7 +7587,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c355); }
+          if (peg$silentFails === 0) { peg$fail(peg$c356); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -7595,11 +7611,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c356;
+      s1 = peg$c357;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c357); }
+      if (peg$silentFails === 0) { peg$fail(peg$c358); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -7610,15 +7626,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c356;
+          s3 = peg$c357;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c357); }
+          if (peg$silentFails === 0) { peg$fail(peg$c358); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c358(s2);
+          s1 = peg$c359(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7635,11 +7651,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c359;
+        s1 = peg$c360;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c360); }
+        if (peg$silentFails === 0) { peg$fail(peg$c361); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7650,15 +7666,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c359;
+            s3 = peg$c360;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c360); }
+            if (peg$silentFails === 0) { peg$fail(peg$c361); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c358(s2);
+            s1 = peg$c359(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7684,11 +7700,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c356;
+      s2 = peg$c357;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c357); }
+      if (peg$silentFails === 0) { peg$fail(peg$c358); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -7706,7 +7722,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c355); }
+        if (peg$silentFails === 0) { peg$fail(peg$c356); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -7723,11 +7739,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c351;
+        s1 = peg$c352;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c352); }
+        if (peg$silentFails === 0) { peg$fail(peg$c353); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -7755,11 +7771,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c359;
+      s2 = peg$c360;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+      if (peg$silentFails === 0) { peg$fail(peg$c361); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -7777,7 +7793,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c355); }
+        if (peg$silentFails === 0) { peg$fail(peg$c356); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -7794,11 +7810,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c351;
+        s1 = peg$c352;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c352); }
+        if (peg$silentFails === 0) { peg$fail(peg$c353); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -7824,11 +7840,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c361;
+      s1 = peg$c362;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c362); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsehexdigit();
@@ -7836,7 +7852,7 @@ function peg$parse(input, options) {
         s3 = peg$parsehexdigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c363();
+          s1 = peg$c364();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7864,110 +7880,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c359;
+      s0 = peg$c360;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+      if (peg$silentFails === 0) { peg$fail(peg$c361); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c356;
+        s0 = peg$c357;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c357); }
+        if (peg$silentFails === 0) { peg$fail(peg$c358); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c351;
+          s0 = peg$c352;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c352); }
+          if (peg$silentFails === 0) { peg$fail(peg$c353); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c364;
+            s1 = peg$c365;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c365); }
+            if (peg$silentFails === 0) { peg$fail(peg$c366); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c366();
+            s1 = peg$c367();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c367;
+              s1 = peg$c368;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c368); }
+              if (peg$silentFails === 0) { peg$fail(peg$c369); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c369();
+              s1 = peg$c370();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c370;
+                s1 = peg$c371;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c371); }
+                if (peg$silentFails === 0) { peg$fail(peg$c372); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c372();
+                s1 = peg$c373();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c373;
+                  s1 = peg$c374;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c374); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c375); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c375();
+                  s1 = peg$c376();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c376;
+                    s1 = peg$c377;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c377); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c378); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c378();
+                    s1 = peg$c379();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c379;
+                      s1 = peg$c380;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c380); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c381); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c381();
+                      s1 = peg$c382();
                     }
                     s0 = s1;
                   }
@@ -7995,7 +8011,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c382();
+      s1 = peg$c383();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -8009,7 +8025,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c383();
+        s1 = peg$c384();
       }
       s0 = s1;
     }
@@ -8022,11 +8038,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c384;
+      s1 = peg$c385;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c385); }
+      if (peg$silentFails === 0) { peg$fail(peg$c386); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8058,7 +8074,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c386(s2);
+        s1 = peg$c387(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8071,19 +8087,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c384;
+        s1 = peg$c385;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c385); }
+        if (peg$silentFails === 0) { peg$fail(peg$c386); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c387;
+          s2 = peg$c388;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c388); }
+          if (peg$silentFails === 0) { peg$fail(peg$c389); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -8142,15 +8158,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c389;
+              s4 = peg$c390;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c390); }
+              if (peg$silentFails === 0) { peg$fail(peg$c391); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c386(s3);
+              s1 = peg$c387(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8219,39 +8235,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c391.test(input.charAt(peg$currPos))) {
+    if (peg$c392.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c392); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c393) {
-        s2 = peg$c393;
+      if (input.substr(peg$currPos, 2) === peg$c394) {
+        s2 = peg$c394;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c394); }
+        if (peg$silentFails === 0) { peg$fail(peg$c395); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c391.test(input.charAt(peg$currPos))) {
+        if (peg$c392.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c392); }
+          if (peg$silentFails === 0) { peg$fail(peg$c393); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c393) {
-            s2 = peg$c393;
+          if (input.substr(peg$currPos, 2) === peg$c394) {
+            s2 = peg$c394;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c394); }
+            if (peg$silentFails === 0) { peg$fail(peg$c395); }
           }
         }
       }
@@ -8270,12 +8286,12 @@ function peg$parse(input, options) {
   function peg$parseescapedChar() {
     var s0;
 
-    if (peg$c395.test(input.charAt(peg$currPos))) {
+    if (peg$c396.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c396); }
+      if (peg$silentFails === 0) { peg$fail(peg$c397); }
     }
 
     return s0;
@@ -8285,51 +8301,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c397;
+      s0 = peg$c398;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c398); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c399;
+        s0 = peg$c400;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c400); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c401;
+          s0 = peg$c402;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c402); }
+          if (peg$silentFails === 0) { peg$fail(peg$c403); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c403;
+            s0 = peg$c404;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c404); }
+            if (peg$silentFails === 0) { peg$fail(peg$c405); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c405;
+              s0 = peg$c406;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c406); }
+              if (peg$silentFails === 0) { peg$fail(peg$c407); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c407;
+                s0 = peg$c408;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c408); }
+                if (peg$silentFails === 0) { peg$fail(peg$c409); }
               }
             }
           }
@@ -8357,7 +8373,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
+      if (peg$silentFails === 0) { peg$fail(peg$c410); }
     }
 
     return s0;
@@ -8386,7 +8402,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c355); }
+      if (peg$silentFails === 0) { peg$fail(peg$c356); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -4644,30 +4644,44 @@ var g = &grammar{
 		{
 			name: "weeks",
 			pos:  position{line: 634, col: 1, offset: 18629},
-			expr: &actionExpr{
+			expr: &choiceExpr{
 				pos: position{line: 635, col: 5, offset: 18639},
-				run: (*parser).callonweeks1,
-				expr: &seqExpr{
-					pos: position{line: 635, col: 5, offset: 18639},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 635, col: 5, offset: 18639},
-							label: "num",
-							expr: &ruleRefExpr{
-								pos:  position{line: 635, col: 9, offset: 18643},
-								name: "number",
-							},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 635, col: 5, offset: 18639},
+						run: (*parser).callonweeks2,
+						expr: &litMatcher{
+							pos:        position{line: 635, col: 5, offset: 18639},
+							val:        "week",
+							ignoreCase: false,
 						},
-						&zeroOrOneExpr{
-							pos: position{line: 635, col: 16, offset: 18650},
-							expr: &ruleRefExpr{
-								pos:  position{line: 635, col: 16, offset: 18650},
-								name: "_",
+					},
+					&actionExpr{
+						pos: position{line: 636, col: 5, offset: 18731},
+						run: (*parser).callonweeks4,
+						expr: &seqExpr{
+							pos: position{line: 636, col: 5, offset: 18731},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 636, col: 5, offset: 18731},
+									label: "num",
+									expr: &ruleRefExpr{
+										pos:  position{line: 636, col: 9, offset: 18735},
+										name: "number",
+									},
+								},
+								&zeroOrOneExpr{
+									pos: position{line: 636, col: 16, offset: 18742},
+									expr: &ruleRefExpr{
+										pos:  position{line: 636, col: 16, offset: 18742},
+										name: "_",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 636, col: 19, offset: 18745},
+									name: "week_abbrev",
+								},
 							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 635, col: 19, offset: 18653},
-							name: "week_abbrev",
 						},
 					},
 				},
@@ -4675,53 +4689,53 @@ var g = &grammar{
 		},
 		{
 			name: "number",
-			pos:  position{line: 637, col: 1, offset: 18757},
+			pos:  position{line: 638, col: 1, offset: 18849},
 			expr: &ruleRefExpr{
-				pos:  position{line: 637, col: 10, offset: 18766},
+				pos:  position{line: 638, col: 10, offset: 18858},
 				name: "unsignedInteger",
 			},
 		},
 		{
 			name: "addr",
-			pos:  position{line: 641, col: 1, offset: 18812},
+			pos:  position{line: 642, col: 1, offset: 18904},
 			expr: &actionExpr{
-				pos: position{line: 642, col: 5, offset: 18821},
+				pos: position{line: 643, col: 5, offset: 18913},
 				run: (*parser).callonaddr1,
 				expr: &labeledExpr{
-					pos:   position{line: 642, col: 5, offset: 18821},
+					pos:   position{line: 643, col: 5, offset: 18913},
 					label: "a",
 					expr: &seqExpr{
-						pos: position{line: 642, col: 8, offset: 18824},
+						pos: position{line: 643, col: 8, offset: 18916},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 642, col: 8, offset: 18824},
+								pos:  position{line: 643, col: 8, offset: 18916},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 642, col: 24, offset: 18840},
+								pos:        position{line: 643, col: 24, offset: 18932},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 642, col: 28, offset: 18844},
+								pos:  position{line: 643, col: 28, offset: 18936},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 642, col: 44, offset: 18860},
+								pos:        position{line: 643, col: 44, offset: 18952},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 642, col: 48, offset: 18864},
+								pos:  position{line: 643, col: 48, offset: 18956},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 642, col: 64, offset: 18880},
+								pos:        position{line: 643, col: 64, offset: 18972},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 642, col: 68, offset: 18884},
+								pos:  position{line: 643, col: 68, offset: 18976},
 								name: "unsignedInteger",
 							},
 						},
@@ -4731,23 +4745,23 @@ var g = &grammar{
 		},
 		{
 			name: "port",
-			pos:  position{line: 644, col: 1, offset: 18933},
+			pos:  position{line: 645, col: 1, offset: 19025},
 			expr: &actionExpr{
-				pos: position{line: 645, col: 5, offset: 18942},
+				pos: position{line: 646, col: 5, offset: 19034},
 				run: (*parser).callonport1,
 				expr: &seqExpr{
-					pos: position{line: 645, col: 5, offset: 18942},
+					pos: position{line: 646, col: 5, offset: 19034},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 645, col: 5, offset: 18942},
+							pos:        position{line: 646, col: 5, offset: 19034},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 645, col: 9, offset: 18946},
+							pos:   position{line: 646, col: 9, offset: 19038},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 645, col: 11, offset: 18948},
+								pos:  position{line: 646, col: 11, offset: 19040},
 								name: "suint",
 							},
 						},
@@ -4757,32 +4771,32 @@ var g = &grammar{
 		},
 		{
 			name: "ip6addr",
-			pos:  position{line: 649, col: 1, offset: 19104},
+			pos:  position{line: 650, col: 1, offset: 19196},
 			expr: &choiceExpr{
-				pos: position{line: 650, col: 5, offset: 19116},
+				pos: position{line: 651, col: 5, offset: 19208},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 650, col: 5, offset: 19116},
+						pos: position{line: 651, col: 5, offset: 19208},
 						run: (*parser).callonip6addr2,
 						expr: &seqExpr{
-							pos: position{line: 650, col: 5, offset: 19116},
+							pos: position{line: 651, col: 5, offset: 19208},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 650, col: 5, offset: 19116},
+									pos:   position{line: 651, col: 5, offset: 19208},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 650, col: 7, offset: 19118},
+										pos: position{line: 651, col: 7, offset: 19210},
 										expr: &ruleRefExpr{
-											pos:  position{line: 650, col: 8, offset: 19119},
+											pos:  position{line: 651, col: 8, offset: 19211},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 650, col: 20, offset: 19131},
+									pos:   position{line: 651, col: 20, offset: 19223},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 650, col: 22, offset: 19133},
+										pos:  position{line: 651, col: 22, offset: 19225},
 										name: "ip6tail",
 									},
 								},
@@ -4790,51 +4804,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 653, col: 5, offset: 19197},
+						pos: position{line: 654, col: 5, offset: 19289},
 						run: (*parser).callonip6addr9,
 						expr: &seqExpr{
-							pos: position{line: 653, col: 5, offset: 19197},
+							pos: position{line: 654, col: 5, offset: 19289},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 653, col: 5, offset: 19197},
+									pos:   position{line: 654, col: 5, offset: 19289},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 653, col: 7, offset: 19199},
+										pos:  position{line: 654, col: 7, offset: 19291},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 653, col: 11, offset: 19203},
+									pos:   position{line: 654, col: 11, offset: 19295},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 653, col: 13, offset: 19205},
+										pos: position{line: 654, col: 13, offset: 19297},
 										expr: &ruleRefExpr{
-											pos:  position{line: 653, col: 14, offset: 19206},
+											pos:  position{line: 654, col: 14, offset: 19298},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 653, col: 25, offset: 19217},
+									pos:        position{line: 654, col: 25, offset: 19309},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 653, col: 30, offset: 19222},
+									pos:   position{line: 654, col: 30, offset: 19314},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 653, col: 32, offset: 19224},
+										pos: position{line: 654, col: 32, offset: 19316},
 										expr: &ruleRefExpr{
-											pos:  position{line: 653, col: 33, offset: 19225},
+											pos:  position{line: 654, col: 33, offset: 19317},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 653, col: 45, offset: 19237},
+									pos:   position{line: 654, col: 45, offset: 19329},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 653, col: 47, offset: 19239},
+										pos:  position{line: 654, col: 47, offset: 19331},
 										name: "ip6tail",
 									},
 								},
@@ -4842,32 +4856,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 656, col: 5, offset: 19338},
+						pos: position{line: 657, col: 5, offset: 19430},
 						run: (*parser).callonip6addr22,
 						expr: &seqExpr{
-							pos: position{line: 656, col: 5, offset: 19338},
+							pos: position{line: 657, col: 5, offset: 19430},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 656, col: 5, offset: 19338},
+									pos:        position{line: 657, col: 5, offset: 19430},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 656, col: 10, offset: 19343},
+									pos:   position{line: 657, col: 10, offset: 19435},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 656, col: 12, offset: 19345},
+										pos: position{line: 657, col: 12, offset: 19437},
 										expr: &ruleRefExpr{
-											pos:  position{line: 656, col: 13, offset: 19346},
+											pos:  position{line: 657, col: 13, offset: 19438},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 656, col: 25, offset: 19358},
+									pos:   position{line: 657, col: 25, offset: 19450},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 656, col: 27, offset: 19360},
+										pos:  position{line: 657, col: 27, offset: 19452},
 										name: "ip6tail",
 									},
 								},
@@ -4875,32 +4889,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 19431},
+						pos: position{line: 660, col: 5, offset: 19523},
 						run: (*parser).callonip6addr30,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 19431},
+							pos: position{line: 660, col: 5, offset: 19523},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 659, col: 5, offset: 19431},
+									pos:   position{line: 660, col: 5, offset: 19523},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 659, col: 7, offset: 19433},
+										pos:  position{line: 660, col: 7, offset: 19525},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 659, col: 11, offset: 19437},
+									pos:   position{line: 660, col: 11, offset: 19529},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 659, col: 13, offset: 19439},
+										pos: position{line: 660, col: 13, offset: 19531},
 										expr: &ruleRefExpr{
-											pos:  position{line: 659, col: 14, offset: 19440},
+											pos:  position{line: 660, col: 14, offset: 19532},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 659, col: 25, offset: 19451},
+									pos:        position{line: 660, col: 25, offset: 19543},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -4908,10 +4922,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 662, col: 5, offset: 19519},
+						pos: position{line: 663, col: 5, offset: 19611},
 						run: (*parser).callonip6addr38,
 						expr: &litMatcher{
-							pos:        position{line: 662, col: 5, offset: 19519},
+							pos:        position{line: 663, col: 5, offset: 19611},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -4921,16 +4935,16 @@ var g = &grammar{
 		},
 		{
 			name: "ip6tail",
-			pos:  position{line: 666, col: 1, offset: 19556},
+			pos:  position{line: 667, col: 1, offset: 19648},
 			expr: &choiceExpr{
-				pos: position{line: 667, col: 5, offset: 19568},
+				pos: position{line: 668, col: 5, offset: 19660},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 667, col: 5, offset: 19568},
+						pos:  position{line: 668, col: 5, offset: 19660},
 						name: "addr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 668, col: 5, offset: 19577},
+						pos:  position{line: 669, col: 5, offset: 19669},
 						name: "h16",
 					},
 				},
@@ -4938,23 +4952,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_append",
-			pos:  position{line: 670, col: 1, offset: 19582},
+			pos:  position{line: 671, col: 1, offset: 19674},
 			expr: &actionExpr{
-				pos: position{line: 670, col: 12, offset: 19593},
+				pos: position{line: 671, col: 12, offset: 19685},
 				run: (*parser).callonh_append1,
 				expr: &seqExpr{
-					pos: position{line: 670, col: 12, offset: 19593},
+					pos: position{line: 671, col: 12, offset: 19685},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 670, col: 12, offset: 19593},
+							pos:        position{line: 671, col: 12, offset: 19685},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 670, col: 16, offset: 19597},
+							pos:   position{line: 671, col: 16, offset: 19689},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 670, col: 18, offset: 19599},
+								pos:  position{line: 671, col: 18, offset: 19691},
 								name: "h16",
 							},
 						},
@@ -4964,23 +4978,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_prepend",
-			pos:  position{line: 671, col: 1, offset: 19636},
+			pos:  position{line: 672, col: 1, offset: 19728},
 			expr: &actionExpr{
-				pos: position{line: 671, col: 13, offset: 19648},
+				pos: position{line: 672, col: 13, offset: 19740},
 				run: (*parser).callonh_prepend1,
 				expr: &seqExpr{
-					pos: position{line: 671, col: 13, offset: 19648},
+					pos: position{line: 672, col: 13, offset: 19740},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 671, col: 13, offset: 19648},
+							pos:   position{line: 672, col: 13, offset: 19740},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 671, col: 15, offset: 19650},
+								pos:  position{line: 672, col: 15, offset: 19742},
 								name: "h16",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 671, col: 19, offset: 19654},
+							pos:        position{line: 672, col: 19, offset: 19746},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -4990,31 +5004,31 @@ var g = &grammar{
 		},
 		{
 			name: "subnet",
-			pos:  position{line: 673, col: 1, offset: 19692},
+			pos:  position{line: 674, col: 1, offset: 19784},
 			expr: &actionExpr{
-				pos: position{line: 674, col: 5, offset: 19703},
+				pos: position{line: 675, col: 5, offset: 19795},
 				run: (*parser).callonsubnet1,
 				expr: &seqExpr{
-					pos: position{line: 674, col: 5, offset: 19703},
+					pos: position{line: 675, col: 5, offset: 19795},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 674, col: 5, offset: 19703},
+							pos:   position{line: 675, col: 5, offset: 19795},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 674, col: 7, offset: 19705},
+								pos:  position{line: 675, col: 7, offset: 19797},
 								name: "addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 674, col: 12, offset: 19710},
+							pos:        position{line: 675, col: 12, offset: 19802},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 674, col: 16, offset: 19714},
+							pos:   position{line: 675, col: 16, offset: 19806},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 674, col: 18, offset: 19716},
+								pos:  position{line: 675, col: 18, offset: 19808},
 								name: "unsignedInteger",
 							},
 						},
@@ -5024,31 +5038,31 @@ var g = &grammar{
 		},
 		{
 			name: "ip6subnet",
-			pos:  position{line: 678, col: 1, offset: 19800},
+			pos:  position{line: 679, col: 1, offset: 19892},
 			expr: &actionExpr{
-				pos: position{line: 679, col: 5, offset: 19814},
+				pos: position{line: 680, col: 5, offset: 19906},
 				run: (*parser).callonip6subnet1,
 				expr: &seqExpr{
-					pos: position{line: 679, col: 5, offset: 19814},
+					pos: position{line: 680, col: 5, offset: 19906},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 679, col: 5, offset: 19814},
+							pos:   position{line: 680, col: 5, offset: 19906},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 679, col: 7, offset: 19816},
+								pos:  position{line: 680, col: 7, offset: 19908},
 								name: "ip6addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 679, col: 15, offset: 19824},
+							pos:        position{line: 680, col: 15, offset: 19916},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 679, col: 19, offset: 19828},
+							pos:   position{line: 680, col: 19, offset: 19920},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 679, col: 21, offset: 19830},
+								pos:  position{line: 680, col: 21, offset: 19922},
 								name: "unsignedInteger",
 							},
 						},
@@ -5058,15 +5072,15 @@ var g = &grammar{
 		},
 		{
 			name: "unsignedInteger",
-			pos:  position{line: 683, col: 1, offset: 19904},
+			pos:  position{line: 684, col: 1, offset: 19996},
 			expr: &actionExpr{
-				pos: position{line: 684, col: 5, offset: 19924},
+				pos: position{line: 685, col: 5, offset: 20016},
 				run: (*parser).callonunsignedInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 684, col: 5, offset: 19924},
+					pos:   position{line: 685, col: 5, offset: 20016},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 684, col: 7, offset: 19926},
+						pos:  position{line: 685, col: 7, offset: 20018},
 						name: "suint",
 					},
 				},
@@ -5074,14 +5088,14 @@ var g = &grammar{
 		},
 		{
 			name: "suint",
-			pos:  position{line: 686, col: 1, offset: 19961},
+			pos:  position{line: 687, col: 1, offset: 20053},
 			expr: &actionExpr{
-				pos: position{line: 687, col: 5, offset: 19971},
+				pos: position{line: 688, col: 5, offset: 20063},
 				run: (*parser).callonsuint1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 687, col: 5, offset: 19971},
+					pos: position{line: 688, col: 5, offset: 20063},
 					expr: &charClassMatcher{
-						pos:        position{line: 687, col: 5, offset: 19971},
+						pos:        position{line: 688, col: 5, offset: 20063},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -5092,15 +5106,15 @@ var g = &grammar{
 		},
 		{
 			name: "integer",
-			pos:  position{line: 689, col: 1, offset: 20010},
+			pos:  position{line: 690, col: 1, offset: 20102},
 			expr: &actionExpr{
-				pos: position{line: 690, col: 5, offset: 20022},
+				pos: position{line: 691, col: 5, offset: 20114},
 				run: (*parser).calloninteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 690, col: 5, offset: 20022},
+					pos:   position{line: 691, col: 5, offset: 20114},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 690, col: 7, offset: 20024},
+						pos:  position{line: 691, col: 7, offset: 20116},
 						name: "sinteger",
 					},
 				},
@@ -5108,17 +5122,17 @@ var g = &grammar{
 		},
 		{
 			name: "sinteger",
-			pos:  position{line: 692, col: 1, offset: 20062},
+			pos:  position{line: 693, col: 1, offset: 20154},
 			expr: &actionExpr{
-				pos: position{line: 693, col: 5, offset: 20075},
+				pos: position{line: 694, col: 5, offset: 20167},
 				run: (*parser).callonsinteger1,
 				expr: &seqExpr{
-					pos: position{line: 693, col: 5, offset: 20075},
+					pos: position{line: 694, col: 5, offset: 20167},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 693, col: 5, offset: 20075},
+							pos: position{line: 694, col: 5, offset: 20167},
 							expr: &charClassMatcher{
-								pos:        position{line: 693, col: 5, offset: 20075},
+								pos:        position{line: 694, col: 5, offset: 20167},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -5126,7 +5140,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 693, col: 11, offset: 20081},
+							pos:  position{line: 694, col: 11, offset: 20173},
 							name: "suint",
 						},
 					},
@@ -5135,15 +5149,15 @@ var g = &grammar{
 		},
 		{
 			name: "double",
-			pos:  position{line: 695, col: 1, offset: 20119},
+			pos:  position{line: 696, col: 1, offset: 20211},
 			expr: &actionExpr{
-				pos: position{line: 696, col: 5, offset: 20130},
+				pos: position{line: 697, col: 5, offset: 20222},
 				run: (*parser).callondouble1,
 				expr: &labeledExpr{
-					pos:   position{line: 696, col: 5, offset: 20130},
+					pos:   position{line: 697, col: 5, offset: 20222},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 696, col: 7, offset: 20132},
+						pos:  position{line: 697, col: 7, offset: 20224},
 						name: "sdouble",
 					},
 				},
@@ -5151,47 +5165,47 @@ var g = &grammar{
 		},
 		{
 			name: "sdouble",
-			pos:  position{line: 700, col: 1, offset: 20179},
+			pos:  position{line: 701, col: 1, offset: 20271},
 			expr: &choiceExpr{
-				pos: position{line: 701, col: 5, offset: 20191},
+				pos: position{line: 702, col: 5, offset: 20283},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 701, col: 5, offset: 20191},
+						pos: position{line: 702, col: 5, offset: 20283},
 						run: (*parser).callonsdouble2,
 						expr: &seqExpr{
-							pos: position{line: 701, col: 5, offset: 20191},
+							pos: position{line: 702, col: 5, offset: 20283},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 701, col: 5, offset: 20191},
+									pos: position{line: 702, col: 5, offset: 20283},
 									expr: &litMatcher{
-										pos:        position{line: 701, col: 5, offset: 20191},
+										pos:        position{line: 702, col: 5, offset: 20283},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 701, col: 10, offset: 20196},
+									pos: position{line: 702, col: 10, offset: 20288},
 									expr: &ruleRefExpr{
-										pos:  position{line: 701, col: 10, offset: 20196},
+										pos:  position{line: 702, col: 10, offset: 20288},
 										name: "doubleInteger",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 701, col: 25, offset: 20211},
+									pos:        position{line: 702, col: 25, offset: 20303},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 701, col: 29, offset: 20215},
+									pos: position{line: 702, col: 29, offset: 20307},
 									expr: &ruleRefExpr{
-										pos:  position{line: 701, col: 29, offset: 20215},
+										pos:  position{line: 702, col: 29, offset: 20307},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 701, col: 42, offset: 20228},
+									pos: position{line: 702, col: 42, offset: 20320},
 									expr: &ruleRefExpr{
-										pos:  position{line: 701, col: 42, offset: 20228},
+										pos:  position{line: 702, col: 42, offset: 20320},
 										name: "exponentPart",
 									},
 								},
@@ -5199,35 +5213,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 704, col: 5, offset: 20287},
+						pos: position{line: 705, col: 5, offset: 20379},
 						run: (*parser).callonsdouble13,
 						expr: &seqExpr{
-							pos: position{line: 704, col: 5, offset: 20287},
+							pos: position{line: 705, col: 5, offset: 20379},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 704, col: 5, offset: 20287},
+									pos: position{line: 705, col: 5, offset: 20379},
 									expr: &litMatcher{
-										pos:        position{line: 704, col: 5, offset: 20287},
+										pos:        position{line: 705, col: 5, offset: 20379},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 704, col: 10, offset: 20292},
+									pos:        position{line: 705, col: 10, offset: 20384},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 704, col: 14, offset: 20296},
+									pos: position{line: 705, col: 14, offset: 20388},
 									expr: &ruleRefExpr{
-										pos:  position{line: 704, col: 14, offset: 20296},
+										pos:  position{line: 705, col: 14, offset: 20388},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 704, col: 27, offset: 20309},
+									pos: position{line: 705, col: 27, offset: 20401},
 									expr: &ruleRefExpr{
-										pos:  position{line: 704, col: 27, offset: 20309},
+										pos:  position{line: 705, col: 27, offset: 20401},
 										name: "exponentPart",
 									},
 								},
@@ -5239,29 +5253,29 @@ var g = &grammar{
 		},
 		{
 			name: "doubleInteger",
-			pos:  position{line: 708, col: 1, offset: 20365},
+			pos:  position{line: 709, col: 1, offset: 20457},
 			expr: &choiceExpr{
-				pos: position{line: 709, col: 5, offset: 20383},
+				pos: position{line: 710, col: 5, offset: 20475},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 709, col: 5, offset: 20383},
+						pos:        position{line: 710, col: 5, offset: 20475},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 710, col: 5, offset: 20391},
+						pos: position{line: 711, col: 5, offset: 20483},
 						exprs: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 710, col: 5, offset: 20391},
+								pos:        position{line: 711, col: 5, offset: 20483},
 								val:        "[1-9]",
 								ranges:     []rune{'1', '9'},
 								ignoreCase: false,
 								inverted:   false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 710, col: 11, offset: 20397},
+								pos: position{line: 711, col: 11, offset: 20489},
 								expr: &charClassMatcher{
-									pos:        position{line: 710, col: 11, offset: 20397},
+									pos:        position{line: 711, col: 11, offset: 20489},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -5275,9 +5289,9 @@ var g = &grammar{
 		},
 		{
 			name: "doubleDigit",
-			pos:  position{line: 712, col: 1, offset: 20405},
+			pos:  position{line: 713, col: 1, offset: 20497},
 			expr: &charClassMatcher{
-				pos:        position{line: 712, col: 15, offset: 20419},
+				pos:        position{line: 713, col: 15, offset: 20511},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -5286,17 +5300,17 @@ var g = &grammar{
 		},
 		{
 			name: "exponentPart",
-			pos:  position{line: 714, col: 1, offset: 20426},
+			pos:  position{line: 715, col: 1, offset: 20518},
 			expr: &seqExpr{
-				pos: position{line: 714, col: 16, offset: 20441},
+				pos: position{line: 715, col: 16, offset: 20533},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 714, col: 16, offset: 20441},
+						pos:        position{line: 715, col: 16, offset: 20533},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 714, col: 21, offset: 20446},
+						pos:  position{line: 715, col: 21, offset: 20538},
 						name: "sinteger",
 					},
 				},
@@ -5304,17 +5318,17 @@ var g = &grammar{
 		},
 		{
 			name: "h16",
-			pos:  position{line: 716, col: 1, offset: 20456},
+			pos:  position{line: 717, col: 1, offset: 20548},
 			expr: &actionExpr{
-				pos: position{line: 716, col: 7, offset: 20462},
+				pos: position{line: 717, col: 7, offset: 20554},
 				run: (*parser).callonh161,
 				expr: &labeledExpr{
-					pos:   position{line: 716, col: 7, offset: 20462},
+					pos:   position{line: 717, col: 7, offset: 20554},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 716, col: 13, offset: 20468},
+						pos: position{line: 717, col: 13, offset: 20560},
 						expr: &ruleRefExpr{
-							pos:  position{line: 716, col: 13, offset: 20468},
+							pos:  position{line: 717, col: 13, offset: 20560},
 							name: "hexdigit",
 						},
 					},
@@ -5323,9 +5337,9 @@ var g = &grammar{
 		},
 		{
 			name: "hexdigit",
-			pos:  position{line: 718, col: 1, offset: 20510},
+			pos:  position{line: 719, col: 1, offset: 20602},
 			expr: &charClassMatcher{
-				pos:        position{line: 718, col: 12, offset: 20521},
+				pos:        position{line: 719, col: 12, offset: 20613},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -5334,17 +5348,17 @@ var g = &grammar{
 		},
 		{
 			name: "searchWord",
-			pos:  position{line: 720, col: 1, offset: 20534},
+			pos:  position{line: 721, col: 1, offset: 20626},
 			expr: &actionExpr{
-				pos: position{line: 721, col: 5, offset: 20549},
+				pos: position{line: 722, col: 5, offset: 20641},
 				run: (*parser).callonsearchWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 721, col: 5, offset: 20549},
+					pos:   position{line: 722, col: 5, offset: 20641},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 721, col: 11, offset: 20555},
+						pos: position{line: 722, col: 11, offset: 20647},
 						expr: &ruleRefExpr{
-							pos:  position{line: 721, col: 11, offset: 20555},
+							pos:  position{line: 722, col: 11, offset: 20647},
 							name: "searchWordPart",
 						},
 					},
@@ -5353,33 +5367,33 @@ var g = &grammar{
 		},
 		{
 			name: "searchWordPart",
-			pos:  position{line: 723, col: 1, offset: 20605},
+			pos:  position{line: 724, col: 1, offset: 20697},
 			expr: &choiceExpr{
-				pos: position{line: 724, col: 5, offset: 20624},
+				pos: position{line: 725, col: 5, offset: 20716},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 724, col: 5, offset: 20624},
+						pos: position{line: 725, col: 5, offset: 20716},
 						run: (*parser).callonsearchWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 724, col: 5, offset: 20624},
+							pos: position{line: 725, col: 5, offset: 20716},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 724, col: 5, offset: 20624},
+									pos:        position{line: 725, col: 5, offset: 20716},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 724, col: 10, offset: 20629},
+									pos:   position{line: 725, col: 10, offset: 20721},
 									label: "s",
 									expr: &choiceExpr{
-										pos: position{line: 724, col: 13, offset: 20632},
+										pos: position{line: 725, col: 13, offset: 20724},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 724, col: 13, offset: 20632},
+												pos:  position{line: 725, col: 13, offset: 20724},
 												name: "escapeSequence",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 724, col: 30, offset: 20649},
+												pos:  position{line: 725, col: 30, offset: 20741},
 												name: "searchEscape",
 											},
 										},
@@ -5389,18 +5403,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 725, col: 5, offset: 20686},
+						pos: position{line: 726, col: 5, offset: 20778},
 						run: (*parser).callonsearchWordPart9,
 						expr: &seqExpr{
-							pos: position{line: 725, col: 5, offset: 20686},
+							pos: position{line: 726, col: 5, offset: 20778},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 725, col: 5, offset: 20686},
+									pos: position{line: 726, col: 5, offset: 20778},
 									expr: &choiceExpr{
-										pos: position{line: 725, col: 7, offset: 20688},
+										pos: position{line: 726, col: 7, offset: 20780},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 725, col: 7, offset: 20688},
+												pos:        position{line: 726, col: 7, offset: 20780},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -5408,14 +5422,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 725, col: 42, offset: 20723},
+												pos:  position{line: 726, col: 42, offset: 20815},
 												name: "ws",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 725, col: 46, offset: 20727,
+									line: 726, col: 46, offset: 20819,
 								},
 							},
 						},
@@ -5425,34 +5439,34 @@ var g = &grammar{
 		},
 		{
 			name: "quotedString",
-			pos:  position{line: 727, col: 1, offset: 20761},
+			pos:  position{line: 728, col: 1, offset: 20853},
 			expr: &choiceExpr{
-				pos: position{line: 728, col: 5, offset: 20778},
+				pos: position{line: 729, col: 5, offset: 20870},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 728, col: 5, offset: 20778},
+						pos: position{line: 729, col: 5, offset: 20870},
 						run: (*parser).callonquotedString2,
 						expr: &seqExpr{
-							pos: position{line: 728, col: 5, offset: 20778},
+							pos: position{line: 729, col: 5, offset: 20870},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 728, col: 5, offset: 20778},
+									pos:        position{line: 729, col: 5, offset: 20870},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 728, col: 9, offset: 20782},
+									pos:   position{line: 729, col: 9, offset: 20874},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 728, col: 11, offset: 20784},
+										pos: position{line: 729, col: 11, offset: 20876},
 										expr: &ruleRefExpr{
-											pos:  position{line: 728, col: 11, offset: 20784},
+											pos:  position{line: 729, col: 11, offset: 20876},
 											name: "doubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 728, col: 29, offset: 20802},
+									pos:        position{line: 729, col: 29, offset: 20894},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5460,29 +5474,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 729, col: 5, offset: 20839},
+						pos: position{line: 730, col: 5, offset: 20931},
 						run: (*parser).callonquotedString9,
 						expr: &seqExpr{
-							pos: position{line: 729, col: 5, offset: 20839},
+							pos: position{line: 730, col: 5, offset: 20931},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 729, col: 5, offset: 20839},
+									pos:        position{line: 730, col: 5, offset: 20931},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 729, col: 9, offset: 20843},
+									pos:   position{line: 730, col: 9, offset: 20935},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 729, col: 11, offset: 20845},
+										pos: position{line: 730, col: 11, offset: 20937},
 										expr: &ruleRefExpr{
-											pos:  position{line: 729, col: 11, offset: 20845},
+											pos:  position{line: 730, col: 11, offset: 20937},
 											name: "singleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 729, col: 29, offset: 20863},
+									pos:        position{line: 730, col: 29, offset: 20955},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5494,55 +5508,55 @@ var g = &grammar{
 		},
 		{
 			name: "doubleQuotedChar",
-			pos:  position{line: 731, col: 1, offset: 20897},
+			pos:  position{line: 732, col: 1, offset: 20989},
 			expr: &choiceExpr{
-				pos: position{line: 732, col: 5, offset: 20918},
+				pos: position{line: 733, col: 5, offset: 21010},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 732, col: 5, offset: 20918},
+						pos: position{line: 733, col: 5, offset: 21010},
 						run: (*parser).callondoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 732, col: 5, offset: 20918},
+							pos: position{line: 733, col: 5, offset: 21010},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 732, col: 5, offset: 20918},
+									pos: position{line: 733, col: 5, offset: 21010},
 									expr: &choiceExpr{
-										pos: position{line: 732, col: 7, offset: 20920},
+										pos: position{line: 733, col: 7, offset: 21012},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 732, col: 7, offset: 20920},
+												pos:        position{line: 733, col: 7, offset: 21012},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 732, col: 13, offset: 20926},
+												pos:  position{line: 733, col: 13, offset: 21018},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 732, col: 26, offset: 20939,
+									line: 733, col: 26, offset: 21031,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 733, col: 5, offset: 20976},
+						pos: position{line: 734, col: 5, offset: 21068},
 						run: (*parser).callondoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 733, col: 5, offset: 20976},
+							pos: position{line: 734, col: 5, offset: 21068},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 733, col: 5, offset: 20976},
+									pos:        position{line: 734, col: 5, offset: 21068},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 733, col: 10, offset: 20981},
+									pos:   position{line: 734, col: 10, offset: 21073},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 733, col: 12, offset: 20983},
+										pos:  position{line: 734, col: 12, offset: 21075},
 										name: "escapeSequence",
 									},
 								},
@@ -5554,55 +5568,55 @@ var g = &grammar{
 		},
 		{
 			name: "singleQuotedChar",
-			pos:  position{line: 735, col: 1, offset: 21017},
+			pos:  position{line: 736, col: 1, offset: 21109},
 			expr: &choiceExpr{
-				pos: position{line: 736, col: 5, offset: 21038},
+				pos: position{line: 737, col: 5, offset: 21130},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 736, col: 5, offset: 21038},
+						pos: position{line: 737, col: 5, offset: 21130},
 						run: (*parser).callonsingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 736, col: 5, offset: 21038},
+							pos: position{line: 737, col: 5, offset: 21130},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 736, col: 5, offset: 21038},
+									pos: position{line: 737, col: 5, offset: 21130},
 									expr: &choiceExpr{
-										pos: position{line: 736, col: 7, offset: 21040},
+										pos: position{line: 737, col: 7, offset: 21132},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 736, col: 7, offset: 21040},
+												pos:        position{line: 737, col: 7, offset: 21132},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 736, col: 13, offset: 21046},
+												pos:  position{line: 737, col: 13, offset: 21138},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 736, col: 26, offset: 21059,
+									line: 737, col: 26, offset: 21151,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 737, col: 5, offset: 21096},
+						pos: position{line: 738, col: 5, offset: 21188},
 						run: (*parser).callonsingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 737, col: 5, offset: 21096},
+							pos: position{line: 738, col: 5, offset: 21188},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 737, col: 5, offset: 21096},
+									pos:        position{line: 738, col: 5, offset: 21188},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 737, col: 10, offset: 21101},
+									pos:   position{line: 738, col: 10, offset: 21193},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 737, col: 12, offset: 21103},
+										pos:  position{line: 738, col: 12, offset: 21195},
 										name: "escapeSequence",
 									},
 								},
@@ -5614,38 +5628,38 @@ var g = &grammar{
 		},
 		{
 			name: "escapeSequence",
-			pos:  position{line: 739, col: 1, offset: 21137},
+			pos:  position{line: 740, col: 1, offset: 21229},
 			expr: &choiceExpr{
-				pos: position{line: 740, col: 5, offset: 21156},
+				pos: position{line: 741, col: 5, offset: 21248},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 740, col: 5, offset: 21156},
+						pos: position{line: 741, col: 5, offset: 21248},
 						run: (*parser).callonescapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 740, col: 5, offset: 21156},
+							pos: position{line: 741, col: 5, offset: 21248},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 740, col: 5, offset: 21156},
+									pos:        position{line: 741, col: 5, offset: 21248},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 740, col: 9, offset: 21160},
+									pos:  position{line: 741, col: 9, offset: 21252},
 									name: "hexdigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 740, col: 18, offset: 21169},
+									pos:  position{line: 741, col: 18, offset: 21261},
 									name: "hexdigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 741, col: 5, offset: 21220},
+						pos:  position{line: 742, col: 5, offset: 21312},
 						name: "singleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 742, col: 5, offset: 21241},
+						pos:  position{line: 743, col: 5, offset: 21333},
 						name: "unicodeEscape",
 					},
 				},
@@ -5653,75 +5667,75 @@ var g = &grammar{
 		},
 		{
 			name: "singleCharEscape",
-			pos:  position{line: 744, col: 1, offset: 21256},
+			pos:  position{line: 745, col: 1, offset: 21348},
 			expr: &choiceExpr{
-				pos: position{line: 745, col: 5, offset: 21277},
+				pos: position{line: 746, col: 5, offset: 21369},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 745, col: 5, offset: 21277},
+						pos:        position{line: 746, col: 5, offset: 21369},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 746, col: 5, offset: 21285},
+						pos:        position{line: 747, col: 5, offset: 21377},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 747, col: 5, offset: 21293},
+						pos:        position{line: 748, col: 5, offset: 21385},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 748, col: 5, offset: 21302},
+						pos: position{line: 749, col: 5, offset: 21394},
 						run: (*parser).callonsingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 748, col: 5, offset: 21302},
+							pos:        position{line: 749, col: 5, offset: 21394},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 749, col: 5, offset: 21331},
+						pos: position{line: 750, col: 5, offset: 21423},
 						run: (*parser).callonsingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 749, col: 5, offset: 21331},
+							pos:        position{line: 750, col: 5, offset: 21423},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 750, col: 5, offset: 21360},
+						pos: position{line: 751, col: 5, offset: 21452},
 						run: (*parser).callonsingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 750, col: 5, offset: 21360},
+							pos:        position{line: 751, col: 5, offset: 21452},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 751, col: 5, offset: 21389},
+						pos: position{line: 752, col: 5, offset: 21481},
 						run: (*parser).callonsingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 751, col: 5, offset: 21389},
+							pos:        position{line: 752, col: 5, offset: 21481},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 752, col: 5, offset: 21418},
+						pos: position{line: 753, col: 5, offset: 21510},
 						run: (*parser).callonsingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 752, col: 5, offset: 21418},
+							pos:        position{line: 753, col: 5, offset: 21510},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 753, col: 5, offset: 21447},
+						pos: position{line: 754, col: 5, offset: 21539},
 						run: (*parser).callonsingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 753, col: 5, offset: 21447},
+							pos:        position{line: 754, col: 5, offset: 21539},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5731,24 +5745,24 @@ var g = &grammar{
 		},
 		{
 			name: "searchEscape",
-			pos:  position{line: 755, col: 1, offset: 21473},
+			pos:  position{line: 756, col: 1, offset: 21565},
 			expr: &choiceExpr{
-				pos: position{line: 756, col: 5, offset: 21490},
+				pos: position{line: 757, col: 5, offset: 21582},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 756, col: 5, offset: 21490},
+						pos: position{line: 757, col: 5, offset: 21582},
 						run: (*parser).callonsearchEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 756, col: 5, offset: 21490},
+							pos:        position{line: 757, col: 5, offset: 21582},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 757, col: 5, offset: 21518},
+						pos: position{line: 758, col: 5, offset: 21610},
 						run: (*parser).callonsearchEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 757, col: 5, offset: 21518},
+							pos:        position{line: 758, col: 5, offset: 21610},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -5758,41 +5772,41 @@ var g = &grammar{
 		},
 		{
 			name: "unicodeEscape",
-			pos:  position{line: 759, col: 1, offset: 21545},
+			pos:  position{line: 760, col: 1, offset: 21637},
 			expr: &choiceExpr{
-				pos: position{line: 760, col: 5, offset: 21563},
+				pos: position{line: 761, col: 5, offset: 21655},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 760, col: 5, offset: 21563},
+						pos: position{line: 761, col: 5, offset: 21655},
 						run: (*parser).callonunicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 760, col: 5, offset: 21563},
+							pos: position{line: 761, col: 5, offset: 21655},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 760, col: 5, offset: 21563},
+									pos:        position{line: 761, col: 5, offset: 21655},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 760, col: 9, offset: 21567},
+									pos:   position{line: 761, col: 9, offset: 21659},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 760, col: 16, offset: 21574},
+										pos: position{line: 761, col: 16, offset: 21666},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 760, col: 16, offset: 21574},
+												pos:  position{line: 761, col: 16, offset: 21666},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 760, col: 25, offset: 21583},
+												pos:  position{line: 761, col: 25, offset: 21675},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 760, col: 34, offset: 21592},
+												pos:  position{line: 761, col: 34, offset: 21684},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 760, col: 43, offset: 21601},
+												pos:  position{line: 761, col: 43, offset: 21693},
 												name: "hexdigit",
 											},
 										},
@@ -5802,63 +5816,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 763, col: 5, offset: 21664},
+						pos: position{line: 764, col: 5, offset: 21756},
 						run: (*parser).callonunicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 763, col: 5, offset: 21664},
+							pos: position{line: 764, col: 5, offset: 21756},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 763, col: 5, offset: 21664},
+									pos:        position{line: 764, col: 5, offset: 21756},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 763, col: 9, offset: 21668},
+									pos:        position{line: 764, col: 9, offset: 21760},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 763, col: 13, offset: 21672},
+									pos:   position{line: 764, col: 13, offset: 21764},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 763, col: 20, offset: 21679},
+										pos: position{line: 764, col: 20, offset: 21771},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 763, col: 20, offset: 21679},
+												pos:  position{line: 764, col: 20, offset: 21771},
 												name: "hexdigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 763, col: 29, offset: 21688},
+												pos: position{line: 764, col: 29, offset: 21780},
 												expr: &ruleRefExpr{
-													pos:  position{line: 763, col: 29, offset: 21688},
+													pos:  position{line: 764, col: 29, offset: 21780},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 763, col: 39, offset: 21698},
+												pos: position{line: 764, col: 39, offset: 21790},
 												expr: &ruleRefExpr{
-													pos:  position{line: 763, col: 39, offset: 21698},
+													pos:  position{line: 764, col: 39, offset: 21790},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 763, col: 49, offset: 21708},
+												pos: position{line: 764, col: 49, offset: 21800},
 												expr: &ruleRefExpr{
-													pos:  position{line: 763, col: 49, offset: 21708},
+													pos:  position{line: 764, col: 49, offset: 21800},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 763, col: 59, offset: 21718},
+												pos: position{line: 764, col: 59, offset: 21810},
 												expr: &ruleRefExpr{
-													pos:  position{line: 763, col: 59, offset: 21718},
+													pos:  position{line: 764, col: 59, offset: 21810},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 763, col: 69, offset: 21728},
+												pos: position{line: 764, col: 69, offset: 21820},
 												expr: &ruleRefExpr{
-													pos:  position{line: 763, col: 69, offset: 21728},
+													pos:  position{line: 764, col: 69, offset: 21820},
 													name: "hexdigit",
 												},
 											},
@@ -5866,7 +5880,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 763, col: 80, offset: 21739},
+									pos:        position{line: 764, col: 80, offset: 21831},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5878,28 +5892,28 @@ var g = &grammar{
 		},
 		{
 			name: "reString",
-			pos:  position{line: 767, col: 1, offset: 21793},
+			pos:  position{line: 768, col: 1, offset: 21885},
 			expr: &actionExpr{
-				pos: position{line: 768, col: 5, offset: 21806},
+				pos: position{line: 769, col: 5, offset: 21898},
 				run: (*parser).callonreString1,
 				expr: &seqExpr{
-					pos: position{line: 768, col: 5, offset: 21806},
+					pos: position{line: 769, col: 5, offset: 21898},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 768, col: 5, offset: 21806},
+							pos:        position{line: 769, col: 5, offset: 21898},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 768, col: 9, offset: 21810},
+							pos:   position{line: 769, col: 9, offset: 21902},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 768, col: 11, offset: 21812},
+								pos:  position{line: 769, col: 11, offset: 21904},
 								name: "reBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 768, col: 18, offset: 21819},
+							pos:        position{line: 769, col: 18, offset: 21911},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5909,24 +5923,24 @@ var g = &grammar{
 		},
 		{
 			name: "reBody",
-			pos:  position{line: 770, col: 1, offset: 21842},
+			pos:  position{line: 771, col: 1, offset: 21934},
 			expr: &actionExpr{
-				pos: position{line: 771, col: 5, offset: 21853},
+				pos: position{line: 772, col: 5, offset: 21945},
 				run: (*parser).callonreBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 771, col: 5, offset: 21853},
+					pos: position{line: 772, col: 5, offset: 21945},
 					expr: &choiceExpr{
-						pos: position{line: 771, col: 6, offset: 21854},
+						pos: position{line: 772, col: 6, offset: 21946},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 771, col: 6, offset: 21854},
+								pos:        position{line: 772, col: 6, offset: 21946},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 771, col: 13, offset: 21861},
+								pos:        position{line: 772, col: 13, offset: 21953},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -5937,9 +5951,9 @@ var g = &grammar{
 		},
 		{
 			name: "escapedChar",
-			pos:  position{line: 773, col: 1, offset: 21901},
+			pos:  position{line: 774, col: 1, offset: 21993},
 			expr: &charClassMatcher{
-				pos:        position{line: 774, col: 5, offset: 21917},
+				pos:        position{line: 775, col: 5, offset: 22009},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5949,37 +5963,37 @@ var g = &grammar{
 		},
 		{
 			name: "ws",
-			pos:  position{line: 776, col: 1, offset: 21932},
+			pos:  position{line: 777, col: 1, offset: 22024},
 			expr: &choiceExpr{
-				pos: position{line: 777, col: 5, offset: 21939},
+				pos: position{line: 778, col: 5, offset: 22031},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 777, col: 5, offset: 21939},
+						pos:        position{line: 778, col: 5, offset: 22031},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 778, col: 5, offset: 21948},
+						pos:        position{line: 779, col: 5, offset: 22040},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 779, col: 5, offset: 21957},
+						pos:        position{line: 780, col: 5, offset: 22049},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 780, col: 5, offset: 21966},
+						pos:        position{line: 781, col: 5, offset: 22058},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 781, col: 5, offset: 21974},
+						pos:        position{line: 782, col: 5, offset: 22066},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 782, col: 5, offset: 21987},
+						pos:        position{line: 783, col: 5, offset: 22079},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5989,33 +6003,33 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 784, col: 1, offset: 21997},
+			pos:         position{line: 785, col: 1, offset: 22089},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 784, col: 18, offset: 22014},
+				pos: position{line: 785, col: 18, offset: 22106},
 				expr: &ruleRefExpr{
-					pos:  position{line: 784, col: 18, offset: 22014},
+					pos:  position{line: 785, col: 18, offset: 22106},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 785, col: 1, offset: 22018},
+			pos:  position{line: 786, col: 1, offset: 22110},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 785, col: 6, offset: 22023},
+				pos: position{line: 786, col: 6, offset: 22115},
 				expr: &ruleRefExpr{
-					pos:  position{line: 785, col: 6, offset: 22023},
+					pos:  position{line: 786, col: 6, offset: 22115},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 787, col: 1, offset: 22028},
+			pos:  position{line: 788, col: 1, offset: 22120},
 			expr: &notExpr{
-				pos: position{line: 787, col: 7, offset: 22034},
+				pos: position{line: 788, col: 7, offset: 22126},
 				expr: &anyMatcher{
-					line: 787, col: 8, offset: 22035,
+					line: 788, col: 8, offset: 22127,
 				},
 			},
 		},
@@ -7623,14 +7637,24 @@ func (p *parser) callondays4() (interface{}, error) {
 	return p.cur.ondays4(stack["num"])
 }
 
-func (c *current) onweeks1(num interface{}) (interface{}, error) {
+func (c *current) onweeks2() (interface{}, error) {
+	return map[string]interface{}{"type": "Duration", "seconds": 3600 * 24 * 7}, nil
+}
+
+func (p *parser) callonweeks2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onweeks2()
+}
+
+func (c *current) onweeks4(num interface{}) (interface{}, error) {
 	return map[string]interface{}{"type": "Duration", "seconds": num.(int) * 3600 * 24 * 7}, nil
 }
 
-func (p *parser) callonweeks1() (interface{}, error) {
+func (p *parser) callonweeks4() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onweeks1(stack["num"])
+	return p.cur.onweeks4(stack["num"])
 }
 
 func (c *current) onaddr1(a interface{}) (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -673,113 +673,114 @@ function peg$parse(input, options) {
       peg$c320 = function(num) { return {"type": "Duration", "seconds": num*3600} },
       peg$c321 = function() { return {"type": "Duration", "seconds": 3600*24} },
       peg$c322 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c323 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c324 = function(a) { return text() },
-      peg$c325 = function(a, b) {
+      peg$c323 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c324 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c325 = function(a) { return text() },
+      peg$c326 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c326 = "::",
-      peg$c327 = peg$literalExpectation("::", false),
-      peg$c328 = function(a, b, d, e) {
+      peg$c327 = "::",
+      peg$c328 = peg$literalExpectation("::", false),
+      peg$c329 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c329 = function(a, b) {
+      peg$c330 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c330 = function(a, b) {
+      peg$c331 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c331 = function() {
+      peg$c332 = function() {
             return "::"
           },
-      peg$c332 = function(v) { return ":" + v },
-      peg$c333 = function(v) { return v + ":" },
-      peg$c334 = function(a, m) {
+      peg$c333 = function(v) { return ":" + v },
+      peg$c334 = function(v) { return v + ":" },
+      peg$c335 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c335 = function(a, m) {
+      peg$c336 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c336 = function(s) { return parseInt(s) },
-      peg$c337 = /^[+\-]/,
-      peg$c338 = peg$classExpectation(["+", "-"], false, false),
-      peg$c339 = function(s) {
+      peg$c337 = function(s) { return parseInt(s) },
+      peg$c338 = /^[+\-]/,
+      peg$c339 = peg$classExpectation(["+", "-"], false, false),
+      peg$c340 = function(s) {
             return parseFloat(s)
         },
-      peg$c340 = function() {
+      peg$c341 = function() {
             return text()
           },
-      peg$c341 = "0",
-      peg$c342 = peg$literalExpectation("0", false),
-      peg$c343 = /^[1-9]/,
-      peg$c344 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c345 = "e",
-      peg$c346 = peg$literalExpectation("e", true),
-      peg$c347 = function(chars) { return text() },
-      peg$c348 = /^[0-9a-fA-F]/,
-      peg$c349 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c350 = function(chars) { return joinChars(chars) },
-      peg$c351 = "\\",
-      peg$c352 = peg$literalExpectation("\\", false),
-      peg$c353 = /^[\0-\x1F\\(),!><="|';]/,
-      peg$c354 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
-      peg$c355 = peg$anyExpectation(),
-      peg$c356 = "\"",
-      peg$c357 = peg$literalExpectation("\"", false),
-      peg$c358 = function(v) { return joinChars(v) },
-      peg$c359 = "'",
-      peg$c360 = peg$literalExpectation("'", false),
-      peg$c361 = "x",
-      peg$c362 = peg$literalExpectation("x", false),
-      peg$c363 = function() { return "\\" + text() },
-      peg$c364 = "b",
-      peg$c365 = peg$literalExpectation("b", false),
-      peg$c366 = function() { return "\b" },
-      peg$c367 = "f",
-      peg$c368 = peg$literalExpectation("f", false),
-      peg$c369 = function() { return "\f" },
-      peg$c370 = "n",
-      peg$c371 = peg$literalExpectation("n", false),
-      peg$c372 = function() { return "\n" },
-      peg$c373 = "r",
-      peg$c374 = peg$literalExpectation("r", false),
-      peg$c375 = function() { return "\r" },
-      peg$c376 = "t",
-      peg$c377 = peg$literalExpectation("t", false),
-      peg$c378 = function() { return "\t" },
-      peg$c379 = "v",
-      peg$c380 = peg$literalExpectation("v", false),
-      peg$c381 = function() { return "\v" },
-      peg$c382 = function() { return "=" },
-      peg$c383 = function() { return "\\*" },
-      peg$c384 = "u",
-      peg$c385 = peg$literalExpectation("u", false),
-      peg$c386 = function(chars) {
+      peg$c342 = "0",
+      peg$c343 = peg$literalExpectation("0", false),
+      peg$c344 = /^[1-9]/,
+      peg$c345 = peg$classExpectation([["1", "9"]], false, false),
+      peg$c346 = "e",
+      peg$c347 = peg$literalExpectation("e", true),
+      peg$c348 = function(chars) { return text() },
+      peg$c349 = /^[0-9a-fA-F]/,
+      peg$c350 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c351 = function(chars) { return joinChars(chars) },
+      peg$c352 = "\\",
+      peg$c353 = peg$literalExpectation("\\", false),
+      peg$c354 = /^[\0-\x1F\\(),!><="|';]/,
+      peg$c355 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";"], false, false),
+      peg$c356 = peg$anyExpectation(),
+      peg$c357 = "\"",
+      peg$c358 = peg$literalExpectation("\"", false),
+      peg$c359 = function(v) { return joinChars(v) },
+      peg$c360 = "'",
+      peg$c361 = peg$literalExpectation("'", false),
+      peg$c362 = "x",
+      peg$c363 = peg$literalExpectation("x", false),
+      peg$c364 = function() { return "\\" + text() },
+      peg$c365 = "b",
+      peg$c366 = peg$literalExpectation("b", false),
+      peg$c367 = function() { return "\b" },
+      peg$c368 = "f",
+      peg$c369 = peg$literalExpectation("f", false),
+      peg$c370 = function() { return "\f" },
+      peg$c371 = "n",
+      peg$c372 = peg$literalExpectation("n", false),
+      peg$c373 = function() { return "\n" },
+      peg$c374 = "r",
+      peg$c375 = peg$literalExpectation("r", false),
+      peg$c376 = function() { return "\r" },
+      peg$c377 = "t",
+      peg$c378 = peg$literalExpectation("t", false),
+      peg$c379 = function() { return "\t" },
+      peg$c380 = "v",
+      peg$c381 = peg$literalExpectation("v", false),
+      peg$c382 = function() { return "\v" },
+      peg$c383 = function() { return "=" },
+      peg$c384 = function() { return "\\*" },
+      peg$c385 = "u",
+      peg$c386 = peg$literalExpectation("u", false),
+      peg$c387 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c387 = "{",
-      peg$c388 = peg$literalExpectation("{", false),
-      peg$c389 = "}",
-      peg$c390 = peg$literalExpectation("}", false),
-      peg$c391 = /^[^\/\\]/,
-      peg$c392 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c393 = "\\/",
-      peg$c394 = peg$literalExpectation("\\/", false),
-      peg$c395 = /^[\0-\x1F\\]/,
-      peg$c396 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c397 = "\t",
-      peg$c398 = peg$literalExpectation("\t", false),
-      peg$c399 = "\x0B",
-      peg$c400 = peg$literalExpectation("\x0B", false),
-      peg$c401 = "\f",
-      peg$c402 = peg$literalExpectation("\f", false),
-      peg$c403 = " ",
-      peg$c404 = peg$literalExpectation(" ", false),
-      peg$c405 = "\xA0",
-      peg$c406 = peg$literalExpectation("\xA0", false),
-      peg$c407 = "\uFEFF",
-      peg$c408 = peg$literalExpectation("\uFEFF", false),
-      peg$c409 = peg$otherExpectation("whitespace"),
+      peg$c388 = "{",
+      peg$c389 = peg$literalExpectation("{", false),
+      peg$c390 = "}",
+      peg$c391 = peg$literalExpectation("}", false),
+      peg$c392 = /^[^\/\\]/,
+      peg$c393 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c394 = "\\/",
+      peg$c395 = peg$literalExpectation("\\/", false),
+      peg$c396 = /^[\0-\x1F\\]/,
+      peg$c397 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c398 = "\t",
+      peg$c399 = peg$literalExpectation("\t", false),
+      peg$c400 = "\x0B",
+      peg$c401 = peg$literalExpectation("\x0B", false),
+      peg$c402 = "\f",
+      peg$c403 = peg$literalExpectation("\f", false),
+      peg$c404 = " ",
+      peg$c405 = peg$literalExpectation(" ", false),
+      peg$c406 = "\xA0",
+      peg$c407 = peg$literalExpectation("\xA0", false),
+      peg$c408 = "\uFEFF",
+      peg$c409 = peg$literalExpectation("\uFEFF", false),
+      peg$c410 = peg$otherExpectation("whitespace"),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -6587,18 +6588,36 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseunsignedInteger();
+    if (input.substr(peg$currPos, 4) === peg$c307) {
+      s1 = peg$c307;
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c308); }
+    }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseweek_abbrev();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c323(s1);
-          s0 = s1;
+      peg$savedPos = s0;
+      s1 = peg$c323();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseunsignedInteger();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse_();
+        if (s2 === peg$FAILED) {
+          s2 = null;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseweek_abbrev();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c324(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -6607,9 +6626,6 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
     }
 
     return s0;
@@ -6684,7 +6700,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c324(s1);
+      s1 = peg$c325(s1);
     }
     s0 = s1;
 
@@ -6738,7 +6754,7 @@ function peg$parse(input, options) {
       s2 = peg$parseip6tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c325(s1, s2);
+        s1 = peg$c326(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6759,12 +6775,12 @@ function peg$parse(input, options) {
           s3 = peg$parseh_append();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c326) {
-            s3 = peg$c326;
+          if (input.substr(peg$currPos, 2) === peg$c327) {
+            s3 = peg$c327;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c327); }
+            if (peg$silentFails === 0) { peg$fail(peg$c328); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6777,7 +6793,7 @@ function peg$parse(input, options) {
               s5 = peg$parseip6tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c328(s1, s2, s4, s5);
+                s1 = peg$c329(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6801,12 +6817,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c326) {
-          s1 = peg$c326;
+        if (input.substr(peg$currPos, 2) === peg$c327) {
+          s1 = peg$c327;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c327); }
+          if (peg$silentFails === 0) { peg$fail(peg$c328); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6819,7 +6835,7 @@ function peg$parse(input, options) {
             s3 = peg$parseip6tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c329(s2, s3);
+              s1 = peg$c330(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6844,16 +6860,16 @@ function peg$parse(input, options) {
               s3 = peg$parseh_append();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c326) {
-                s3 = peg$c326;
+              if (input.substr(peg$currPos, 2) === peg$c327) {
+                s3 = peg$c327;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c327); }
+                if (peg$silentFails === 0) { peg$fail(peg$c328); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c330(s1, s2);
+                s1 = peg$c331(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6869,16 +6885,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c326) {
-              s1 = peg$c326;
+            if (input.substr(peg$currPos, 2) === peg$c327) {
+              s1 = peg$c327;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c327); }
+              if (peg$silentFails === 0) { peg$fail(peg$c328); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c331();
+              s1 = peg$c332();
             }
             s0 = s1;
           }
@@ -6915,7 +6931,7 @@ function peg$parse(input, options) {
       s2 = peg$parseh16();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c332(s2);
+        s1 = peg$c333(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6944,7 +6960,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c333(s1);
+        s1 = peg$c334(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6975,7 +6991,7 @@ function peg$parse(input, options) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c334(s1, s3);
+          s1 = peg$c335(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7010,7 +7026,7 @@ function peg$parse(input, options) {
         s3 = peg$parseunsignedInteger();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c335(s1, s3);
+          s1 = peg$c336(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7035,7 +7051,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesuint();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c336(s1);
+      s1 = peg$c337(s1);
     }
     s0 = s1;
 
@@ -7084,7 +7100,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesinteger();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c336(s1);
+      s1 = peg$c337(s1);
     }
     s0 = s1;
 
@@ -7095,12 +7111,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c337.test(input.charAt(peg$currPos))) {
+    if (peg$c338.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c339); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -7130,7 +7146,7 @@ function peg$parse(input, options) {
     s1 = peg$parsesdouble();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c339(s1);
+      s1 = peg$c340(s1);
     }
     s0 = s1;
 
@@ -7188,7 +7204,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c340();
+              s1 = peg$c341();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7248,7 +7264,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c340();
+              s1 = peg$c341();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7275,20 +7291,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     if (input.charCodeAt(peg$currPos) === 48) {
-      s0 = peg$c341;
+      s0 = peg$c342;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c342); }
+      if (peg$silentFails === 0) { peg$fail(peg$c343); }
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (peg$c343.test(input.charAt(peg$currPos))) {
+      if (peg$c344.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c344); }
+        if (peg$silentFails === 0) { peg$fail(peg$c345); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7343,12 +7359,12 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c345) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c346) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c346); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsesinteger();
@@ -7383,7 +7399,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c347(s1);
+      s1 = peg$c348(s1);
     }
     s0 = s1;
 
@@ -7393,12 +7409,12 @@ function peg$parse(input, options) {
   function peg$parsehexdigit() {
     var s0;
 
-    if (peg$c348.test(input.charAt(peg$currPos))) {
+    if (peg$c349.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c349); }
+      if (peg$silentFails === 0) { peg$fail(peg$c350); }
     }
 
     return s0;
@@ -7420,7 +7436,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c350(s1);
+      s1 = peg$c351(s1);
     }
     s0 = s1;
 
@@ -7432,11 +7448,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c351;
+      s1 = peg$c352;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c352); }
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseescapeSequence();
@@ -7459,12 +7475,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c353.test(input.charAt(peg$currPos))) {
+      if (peg$c354.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c354); }
+        if (peg$silentFails === 0) { peg$fail(peg$c355); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parsews();
@@ -7482,7 +7498,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c355); }
+          if (peg$silentFails === 0) { peg$fail(peg$c356); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -7506,11 +7522,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c356;
+      s1 = peg$c357;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c357); }
+      if (peg$silentFails === 0) { peg$fail(peg$c358); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -7521,15 +7537,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c356;
+          s3 = peg$c357;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c357); }
+          if (peg$silentFails === 0) { peg$fail(peg$c358); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c358(s2);
+          s1 = peg$c359(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7546,11 +7562,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c359;
+        s1 = peg$c360;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c360); }
+        if (peg$silentFails === 0) { peg$fail(peg$c361); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7561,15 +7577,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c359;
+            s3 = peg$c360;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c360); }
+            if (peg$silentFails === 0) { peg$fail(peg$c361); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c358(s2);
+            s1 = peg$c359(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7595,11 +7611,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c356;
+      s2 = peg$c357;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c357); }
+      if (peg$silentFails === 0) { peg$fail(peg$c358); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -7617,7 +7633,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c355); }
+        if (peg$silentFails === 0) { peg$fail(peg$c356); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -7634,11 +7650,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c351;
+        s1 = peg$c352;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c352); }
+        if (peg$silentFails === 0) { peg$fail(peg$c353); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -7666,11 +7682,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c359;
+      s2 = peg$c360;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+      if (peg$silentFails === 0) { peg$fail(peg$c361); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseescapedChar();
@@ -7688,7 +7704,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c355); }
+        if (peg$silentFails === 0) { peg$fail(peg$c356); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -7705,11 +7721,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c351;
+        s1 = peg$c352;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c352); }
+        if (peg$silentFails === 0) { peg$fail(peg$c353); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseescapeSequence();
@@ -7735,11 +7751,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c361;
+      s1 = peg$c362;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c362); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsehexdigit();
@@ -7747,7 +7763,7 @@ function peg$parse(input, options) {
         s3 = peg$parsehexdigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c363();
+          s1 = peg$c364();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7775,110 +7791,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c359;
+      s0 = peg$c360;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+      if (peg$silentFails === 0) { peg$fail(peg$c361); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c356;
+        s0 = peg$c357;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c357); }
+        if (peg$silentFails === 0) { peg$fail(peg$c358); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c351;
+          s0 = peg$c352;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c352); }
+          if (peg$silentFails === 0) { peg$fail(peg$c353); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c364;
+            s1 = peg$c365;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c365); }
+            if (peg$silentFails === 0) { peg$fail(peg$c366); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c366();
+            s1 = peg$c367();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c367;
+              s1 = peg$c368;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c368); }
+              if (peg$silentFails === 0) { peg$fail(peg$c369); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c369();
+              s1 = peg$c370();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c370;
+                s1 = peg$c371;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c371); }
+                if (peg$silentFails === 0) { peg$fail(peg$c372); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c372();
+                s1 = peg$c373();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c373;
+                  s1 = peg$c374;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c374); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c375); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c375();
+                  s1 = peg$c376();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c376;
+                    s1 = peg$c377;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c377); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c378); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c378();
+                    s1 = peg$c379();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c379;
+                      s1 = peg$c380;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c380); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c381); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c381();
+                      s1 = peg$c382();
                     }
                     s0 = s1;
                   }
@@ -7906,7 +7922,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c382();
+      s1 = peg$c383();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7920,7 +7936,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c383();
+        s1 = peg$c384();
       }
       s0 = s1;
     }
@@ -7933,11 +7949,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c384;
+      s1 = peg$c385;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c385); }
+      if (peg$silentFails === 0) { peg$fail(peg$c386); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7969,7 +7985,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c386(s2);
+        s1 = peg$c387(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7982,19 +7998,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c384;
+        s1 = peg$c385;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c385); }
+        if (peg$silentFails === 0) { peg$fail(peg$c386); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c387;
+          s2 = peg$c388;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c388); }
+          if (peg$silentFails === 0) { peg$fail(peg$c389); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -8053,15 +8069,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c389;
+              s4 = peg$c390;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c390); }
+              if (peg$silentFails === 0) { peg$fail(peg$c391); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c386(s3);
+              s1 = peg$c387(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8130,39 +8146,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c391.test(input.charAt(peg$currPos))) {
+    if (peg$c392.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c392); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c393) {
-        s2 = peg$c393;
+      if (input.substr(peg$currPos, 2) === peg$c394) {
+        s2 = peg$c394;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c394); }
+        if (peg$silentFails === 0) { peg$fail(peg$c395); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c391.test(input.charAt(peg$currPos))) {
+        if (peg$c392.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c392); }
+          if (peg$silentFails === 0) { peg$fail(peg$c393); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c393) {
-            s2 = peg$c393;
+          if (input.substr(peg$currPos, 2) === peg$c394) {
+            s2 = peg$c394;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c394); }
+            if (peg$silentFails === 0) { peg$fail(peg$c395); }
           }
         }
       }
@@ -8181,12 +8197,12 @@ function peg$parse(input, options) {
   function peg$parseescapedChar() {
     var s0;
 
-    if (peg$c395.test(input.charAt(peg$currPos))) {
+    if (peg$c396.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c396); }
+      if (peg$silentFails === 0) { peg$fail(peg$c397); }
     }
 
     return s0;
@@ -8196,51 +8212,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c397;
+      s0 = peg$c398;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c398); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c399;
+        s0 = peg$c400;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c400); }
+        if (peg$silentFails === 0) { peg$fail(peg$c401); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c401;
+          s0 = peg$c402;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c402); }
+          if (peg$silentFails === 0) { peg$fail(peg$c403); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c403;
+            s0 = peg$c404;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c404); }
+            if (peg$silentFails === 0) { peg$fail(peg$c405); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c405;
+              s0 = peg$c406;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c406); }
+              if (peg$silentFails === 0) { peg$fail(peg$c407); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c407;
+                s0 = peg$c408;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c408); }
+                if (peg$silentFails === 0) { peg$fail(peg$c409); }
               }
             }
           }
@@ -8268,7 +8284,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c409); }
+      if (peg$silentFails === 0) { peg$fail(peg$c410); }
     }
 
     return s0;
@@ -8297,7 +8313,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c355); }
+      if (peg$silentFails === 0) { peg$fail(peg$c356); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -672,7 +672,8 @@ days
   / num:number _? day_abbrev { RETURN(MAP("type": "Duration", "seconds": (ASSERT_INT(num)*3600*24))) }
 
 weeks
-  = num:number _? week_abbrev { RETURN(MAP("type": "Duration", "seconds": ASSERT_INT(num)*3600*24*7)) }
+  = "week" { RETURN(MAP("type": "Duration", "seconds": 3600*24*7)) }
+  / num:number _? week_abbrev { RETURN(MAP("type": "Duration", "seconds": ASSERT_INT(num)*3600*24*7)) }
 
 number = unsignedInteger
 


### PR DESCRIPTION
While documenting aggregate functions, I noticed that the singular `week` without a leading number was not available, though it is for all the other supported time units. I couldn't see a reason for leaving this out, so I've followed the existing pattern to make this consistent.