### PR TITLE
Add support for timestamps with signed tz offsets

### DIFF
--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -194,7 +194,7 @@ func TestNewRawFromJSON(t *testing.T) {
 			json: `{"_path": "test", "ts":"2019-11-15T23:30:44.637486Z"}`,
 		},
 		{
-			name: "TsISO8601-0700",
+			name: "TsISO8601-0100",
 			tzng: `#0:record[_path:string,b:bool,i:int64,s:set[bool],ts:time,v:array[int64]]
 0:[test;-;-;-;1573864244.637486;-;]`,
 			json: `{"_path": "test", "ts":"2019-11-15T23:30:44.637486-0100"}`,

--- a/zio/ndjsonio/ndjson_test.go
+++ b/zio/ndjsonio/ndjson_test.go
@@ -194,6 +194,12 @@ func TestNewRawFromJSON(t *testing.T) {
 			json: `{"_path": "test", "ts":"2019-11-15T23:30:44.637486Z"}`,
 		},
 		{
+			name: "TsISO8601-0700",
+			tzng: `#0:record[_path:string,b:bool,i:int64,s:set[bool],ts:time,v:array[int64]]
+0:[test;-;-;-;1573864244.637486;-;]`,
+			json: `{"_path": "test", "ts":"2019-11-15T23:30:44.637486-0100"}`,
+		},
+		{
 			name: "TsEpoch",
 			tzng: `#0:record[_path:string,ts:time]
 0:[test;1573860644.637486;]`,


### PR DESCRIPTION
Suricata outputs timestamp like `2015-04-13T11:32:45.143323-0200`,
whereas Zeek does `2015-04-13T11:32:45.143323Z02:00`. This commit lets
us parse both.