### PR TITLE
use space migration to convert alpha zng files

### DIFF
--- a/ppl/zqd/pcapstorage/pcapstorage.go
+++ b/ppl/zqd/pcapstorage/pcapstorage.go
@@ -175,7 +175,7 @@ func (s *Store) NewSearch(ctx context.Context, req api.PcapSearch) (*Search, err
 
 const metaFileV0 = "packets.idx.json"
 
-func MigrateV3(u iosrc.URI, pcapuri iosrc.URI) error {
+func MigrateV3(ctx context.Context, u iosrc.URI, pcapuri iosrc.URI) error {
 	b, err := iosrc.ReadFile(context.Background(), u.AppendPath(metaFileV0))
 	if err != nil {
 		return err
@@ -193,8 +193,8 @@ func MigrateV3(u iosrc.URI, pcapuri iosrc.URI) error {
 	if err != nil {
 		return err
 	}
-	if err := iosrc.WriteFile(context.Background(), u.AppendPath(MetaFile), out); err != nil {
+	if err := iosrc.WriteFile(ctx, u.AppendPath(MetaFile), out); err != nil {
 		return err
 	}
-	return iosrc.Remove(context.Background(), u.AppendPath(metaFileV0))
+	return iosrc.Remove(ctx, u.AppendPath(metaFileV0))
 }

--- a/ppl/zqd/storage/filestore/filestore.go
+++ b/ppl/zqd/storage/filestore/filestore.go
@@ -78,17 +78,8 @@ func (s *Storage) Open(_ context.Context, zctx *resolver.Context, span nano.Span
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
-
-		// Couldn't read all.zng, check for an old space with all.bzng
-		bzngFile := strings.TrimSuffix(allZngFile, filepath.Ext(allZngFile)) + ".bzng"
-		f, err = fs.Open(s.join(bzngFile))
-		if err != nil {
-			if !os.IsNotExist(err) {
-				return nil, err
-			}
-			r := zngio.NewReader(strings.NewReader(""), zctx)
-			return zbuf.NopReadCloser(r), nil
-		}
+		r := zngio.NewReader(strings.NewReader(""), zctx)
+		return zbuf.NopReadCloser(r), nil
 	}
 	return s.index.NewReader(f, zctx, span)
 }


### PR DESCRIPTION
This uses the in-tree alpha zng reader to convert the all.zng file from alpha zng binary to post-alpha zng. In a separate branch, I combined this with the `eval` branch in #1375 to test. That uncovered an issue with the alpha zng reader, which @mccanne is working on. That also verified the replacer code changes for aborting the replacement operation and leaving the original file intact.

I'll file this as a draft, as this should go in after #1375 .

closes #1376 