### PR TITLE
Convert links from godoc.org to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [contributing guide](CONTRIBUTING.md) on how you can help improve `zq`!
 Join our [Public Slack](https://www.brimsecurity.com/join-slack/) workspace for announcements, Q&A, and to trade tips!
 
 [doc-img]: https://godoc.org/github.com/brimsec/zq?status.svg
-[doc]: https://godoc.org/github.com/brimsec/zq
+[doc]: https://pkg.go.dev/github.com/brimsec/zq
 [tests-img]: https://github.com/brimsec/zq/workflows/Tests/badge.svg
 [tests]: https://github.com/brimsec/zq/actions?query=workflow%3ATests
 

--- a/zql/docs/aggregate-functions/README.md
+++ b/zql/docs/aggregate-functions/README.md
@@ -74,7 +74,7 @@ QUICKEST LONGEST     TYPICAL
 | **Syntax**                | `avg(<field-name>)`                                            |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/reducer#Avg            |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Avg            |
 
 #### Example:
 
@@ -101,7 +101,7 @@ AVG
 | **Syntax**                | `count([field-name])`                                          |
 | **Required<br>arguments** | None                                                           |
 | **Optional<br>arguments** | `[field-name]`<br>The name a field. If specified, only events that contain this field will be counted. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/reducer#Count          |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Count          |
 
 #### Example #1:
 
@@ -144,7 +144,7 @@ ftp   93
 | **Required<br>arguments** | `<field-name>`<br>The name of a field containing values to be counted. |
 | **Optional<br>arguments** | None                                                           |
 | **Limitations**           | The potential inaccuracy of the calculated result is described in detail in the code and research linked from the [HyperLogLog repository](https://github.com/axiomhq/hyperloglog). |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/reducer#CountDistinct  |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#CountDistinct  |
 
 #### Example:
 
@@ -185,7 +185,7 @@ to perform this test, the ZQL using `countdistinct()` executed almost 3x faster.
 | **Syntax**                | `first(<field-name>)`                                          |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/reducer#First          |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#First          |
 
 #### Example:
 
@@ -211,7 +211,7 @@ TCP_ack_underflow_or_misorder
 | **Syntax**                | `last(<field-name>)`                                           |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/reducer#Last           |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Last           |
 
 #### Example:
 
@@ -237,7 +237,7 @@ talk.google.com
 | **Syntax**                | `max(<field-name>)`                                            |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/reducer/field#FieldReducer |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer/field#FieldReducer |
 
 #### Example:
 
@@ -264,7 +264,7 @@ MAX
 | **Syntax**                | `min(<field-name>)`                                            |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/reducer/field#FieldReducer |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer/field#FieldReducer |
 
 #### Example:
 
@@ -291,7 +291,7 @@ MIN
 | **Syntax**                | `sum(<field-name>)`                                            |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/reducer/field#FieldReducer |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer/field#FieldReducer |
 
 #### Example:
 

--- a/zql/docs/processors/README.md
+++ b/zql/docs/processors/README.md
@@ -30,7 +30,7 @@ The following available processors are documented in detail below:
 | **Syntax**                | `cut [-c] <field-list>`                                     |
 | **Required<br>arguments** | `<field-list>`<br>One or more comma-separated field names or assignments.  |
 | **Optional<br>arguments** | `[-c]`<br>If specified, print all fields _other than_ those specified. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/cut            |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/cut            |
 
 #### Example #1:
 
@@ -124,7 +124,7 @@ TIME              UID
 | **Syntax**                | `filter <search-expression>`                                          |
 | **Required<br>arguments** | `<search-expression>`<br>Any valid expression in ZQL [search syntax](../search-syntax/README.md) |
 | **Optional<br>arguments** | None                                                                  |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/filter                   |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/filter                   |
 
 #### Example #1:
 
@@ -166,7 +166,7 @@ ssl   1521912240.189735 CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85.83.215 44
 | **Required<br>arguments** | None                                              |
 | **Optional<br>arguments** | None                                              |
 | **Limitations**           | Because `fuse` must make a first pass through the data to assemble the unified schema, results from queries that use `fuse` will not begin streaming back immediately.<br><br>If the query result is too large, an error message `"fuse processor exceeded memory limit"` will be returned. Issue [zq/1320](https://github.com/brimsec/zq/issues/1320) tracks the removal of this limitation. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/fuse |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/fuse |
 
 #### Example:
 
@@ -228,7 +228,7 @@ Other output formats invoked via `zq -f` that benefit greatly from the use of `f
 | **Syntax**                | `head [N]`                                                            |
 | **Required<br>arguments** | None. If no arguments are specified, only the first event is returned.| 
 | **Optional<br>arguments** | `[N]`<br>An integer specifying the number of results to return. If not specified, defaults to `1`. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/head                     |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/head                     |
 
 #### Example #1:
 
@@ -273,7 +273,7 @@ conn  1521911720.607695 CpjMvj2Cvj048u6bF1 10.164.94.120 39169     10.47.3.200 8
 | **Required arguments**    | `<field>`<br>Field into which the computed value will be stored.<br><br>`<expression>`<br>A valid ZQL [expression](../expressions/README.md). If evaluation of any expression fails, a warning is emitted and the original record is passed through unchanged. |
 | **Optional arguments**    | None |
 | **Limitations**           | If multiple fields are written in a single `put`, all the new field values are computed first and then they are all written simultaneously.  As a result, a computed value cannot be referenced in another expression.  If you need to re-use a computed result, this can be done by chaining multiple `put` processors.  For example, this will not work:<br>`put N=len(somelist), isbig=N>10`<br>But it could be written instead as:<br>`put N=len(somelist) \| put isbig=N>10` |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/put |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/put |
 
 #### Example #1:
 
@@ -309,7 +309,7 @@ ID.ORIG_H     ID.ORIG_P ID.RESP_H       ID.RESP_P ORIG_BYTES RESP_BYTES TOTAL_BY
 | **Required arguments**    | One or more field assignment expressions. Renames are applied left to right; each rename observes the effect of all renames that preceded it. |
 | **Optional arguments**    | None |
 | **Limitations**           | A field can only be renamed within its own record. For example `id.orig_h` can be renamed to `id.src`, but it cannot be renamed to `src`. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/rename |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/rename |
 
 
 #### Example:
@@ -340,7 +340,7 @@ conn  1521911722.690601 CuKFds250kxFgkhh8f 10.47.25.80    50813            10.12
 | **Syntax**                | `sort [-r] [-nulls first\|last] [field-list]`                 |
 | **Required<br>arguments** | None                                                                      |
 | **Optional<br>arguments** | `[-r]`<br>If specified, results will be sorted in reverse order.<br><br>`[-nulls first\|last]`<br>Specifies where null values (i.e., values that are unset or that are not present at all in an incoming record) should be placed in the output.<br><br>`[field-list]`<br>One or more comma-separated field names by which to sort. Results will be sorted based on the values of the first field named in the list, then based on values in the second field named in the list, and so on.<br><br>If no field list is provided, sort will automatically pick a field by which to sort. The pick is done by examining the first result returned and finding the first field in left-to-right that is of one of the integer ZNG [data types](../data-types/README.md) (`int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`) and if no integer fields are found, the first `float64` field is used. If no fields of these numeric types are found, sorting will be performed on the first field found in left-to-right order that is _not_ of the `time` data type. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/sort                         |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/sort                         |
 
 #### Example #1:
 
@@ -436,7 +436,7 @@ wwonka       1
 | **Syntax**                | `tail [N]`                                                            |
 | **Required<br>arguments** | None. If no arguments are specified, only the last event is returned. | 
 | **Optional<br>arguments** | `[N]`<br>An integer specifying the number of results to return. If not specified, defaults to `1`. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/tail                     |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/tail                     |
 
 #### Example #1:
 
@@ -480,7 +480,7 @@ conn  1521912988.752765 COICgc1FXHKteyFy67 10.0.0.227     61314     10.47.5.58  
 | **Syntax**                | `uniq [-c]`                                                           |
 | **Required<br>arguments** | None                                                                  | 
 | **Optional<br>arguments** | `[-c]`<br>For each unique value shown, include a numeric count of how many times it appeared. |
-| **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/uniq                     |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/uniq                     |
 
 #### Example:
 


### PR DESCRIPTION
I recently noticed the text at the top of godoc.org:

![image](https://user-images.githubusercontent.com/5934157/94733865-431f6d00-031d-11eb-975e-24caee9f2a04.png)

I don't have a strong opinion on old vs. new, but since the message seems to imply an active transition, this PR includes the changes if we wanted to embrace it. The one link to godoc.org that it seems can't be changed is this one in the top-level README:

```
[doc-img]: https://godoc.org/github.com/brimsec/zq?status.svg
```

That link seems to go to the same destination page as https://pkg.go.dev/github.com/brimsec/zq, so I've left it as-is.