### PR TITLE
Remove fuse spill-to-disk limitation from ZQL docs

### DIFF
--- a/cli/procflags/procflags.go
+++ b/cli/procflags/procflags.go
@@ -19,7 +19,7 @@ func (f *Flags) SetFlags(fs *flag.FlagSet) {
 	f.sortMemMax = units.Bytes(sort.MemMaxBytes)
 	fs.Var(&f.sortMemMax, "sortmem", "maximum memory used by sort in MiB, MB, etc")
 	f.fuseMemMax = units.Bytes(fuse.MemMaxBytes)
-	fs.Var(&f.fuseMemMax, "fusemem", "maximum memory used by sort in MiB, MB, etc")
+	fs.Var(&f.fuseMemMax, "fusemem", "maximum memory used by fuse in MiB, MB, etc")
 }
 
 func (f *Flags) Init() error {

--- a/zql/docs/processors/README.md
+++ b/zql/docs/processors/README.md
@@ -165,7 +165,7 @@ ssl   1521912240.189735 CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85.83.215 44
 | **Syntax**                | `fuse`                                            |
 | **Required<br>arguments** | None                                              |
 | **Optional<br>arguments** | None                                              |
-| **Limitations**           | Because `fuse` must make a first pass through the data to assemble the unified schema, results from queries that use `fuse` will not begin streaming back immediately.<br><br>If the query result is too large, an error message `"fuse processor exceeded memory limit"` will be returned. Issue [zq/1320](https://github.com/brimsec/zq/issues/1320) tracks the removal of this limitation. |
+| **Limitations**           | Because `fuse` must make a first pass through the data to assemble the unified schema, results from queries that use `fuse` will not begin streaming back immediately. |
 | **Developer Docs**        | https://godoc.org/github.com/brimsec/zq/proc/fuse |
 
 #### Example:


### PR DESCRIPTION
Now that https://github.com/brimsec/zq/pull/1355 is merged, we can remove the caution in the ZQL doc about the limitation & error message.

While I'm at it, I also noticed some apparent copypasta in the help text from when `-fusemem` was created based on `-sortmem`, so I've also corrected that here.