### PR TITLE
choose memory defaults using reported system memory

### DIFF
--- a/cli/procflags/procflags.go
+++ b/cli/procflags/procflags.go
@@ -3,33 +3,84 @@ package procflags
 import (
 	"errors"
 	"flag"
+	"fmt"
 
-	"github.com/brimsec/zq/pkg/units"
+	"github.com/alecthomas/units"
 	"github.com/brimsec/zq/proc/fuse"
 	"github.com/brimsec/zq/proc/sort"
+	"github.com/pbnjay/memory"
 )
+
+// defaultMemMaxBytes returns approximately 1/8 of total system memory,
+// in bytes, bounded between 128MiB and 1GiB.
+func defaultMemMaxBytes() uint64 {
+	tm := memory.TotalMemory()
+	const gig = 1024 * 1024 * 1024
+	switch {
+	case tm <= 1*gig:
+		return 128 * 1024 * 1024
+	case tm <= 2*gig:
+		return 256 * 1024 * 1024
+	case tm <= 4*gig:
+		return 512 * 1024 * 1024
+	default:
+		return 1 * gig
+	}
+}
+
+type AutoBytes struct {
+	defStr string
+	bytes  units.Base2Bytes
+}
+
+func (b AutoBytes) String() string {
+	if b.defStr != "" {
+		return b.defStr
+	}
+	return b.bytes.String()
+}
+
+func (b *AutoBytes) Set(s string) error {
+	b.defStr = ""
+	b.bytes = 0
+	bytes, err := units.ParseStrictBytes(s)
+	if err != nil {
+		return err
+	}
+	b.bytes = units.Base2Bytes(bytes)
+	return nil
+}
+
+func newAutoBytes(def uint64) AutoBytes {
+	bytes := units.Base2Bytes(def)
+	return AutoBytes{
+		defStr: fmt.Sprintf("auto(%s)", bytes),
+		bytes:  bytes,
+	}
+}
 
 type Flags struct {
 	// these memory limits should be based on a shared resource model
-	sortMemMax units.Bytes
-	fuseMemMax units.Bytes
+	sortMemMax AutoBytes
+	fuseMemMax AutoBytes
 }
 
 func (f *Flags) SetFlags(fs *flag.FlagSet) {
-	f.sortMemMax = units.Bytes(sort.MemMaxBytes)
+	def := defaultMemMaxBytes()
+	f.sortMemMax = newAutoBytes(def)
 	fs.Var(&f.sortMemMax, "sortmem", "maximum memory used by sort in MiB, MB, etc")
-	f.fuseMemMax = units.Bytes(fuse.MemMaxBytes)
+	f.fuseMemMax = newAutoBytes(def)
 	fs.Var(&f.fuseMemMax, "fusemem", "maximum memory used by fuse in MiB, MB, etc")
 }
 
 func (f *Flags) Init() error {
-	if f.sortMemMax <= 0 {
+	if f.sortMemMax.bytes <= 0 {
 		return errors.New("sortmem value must be greater than zero")
 	}
-	sort.MemMaxBytes = int(f.sortMemMax)
-	if f.fuseMemMax <= 0 {
+	sort.MemMaxBytes = int(f.sortMemMax.bytes)
+	if f.fuseMemMax.bytes <= 0 {
 		return errors.New("fusemem value must be greater than zero")
 	}
-	fuse.MemMaxBytes = int(f.fuseMemMax)
+	fuse.MemMaxBytes = int(f.fuseMemMax.bytes)
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mccanne/charm v0.0.3-0.20191224190439-b05e1b7b1be3
 	github.com/mitchellh/mapstructure v1.3.3
+	github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4
 	github.com/peterh/liner v1.1.0
 	github.com/pierrec/lz4/v4 v4.0.2
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
+github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4 h1:MfIUBZ1bz7TgvQLVa/yPJZOGeKEgs6eTKUjz3zB4B+U=
+github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4/go.mod h1:RMU2gJXhratVxBDTFeOdNhd540tG57lt9FIUV0YLvIQ=
 github.com/pborman/getopt v0.0.0-20180729010549-6fdd0a2c7117/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/peterh/liner v1.1.0 h1:f+aAedNJA6uk7+6rXsYBnhdo4Xux7ESLe+kcuVUF5os=
 github.com/peterh/liner v1.1.0/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=


### PR DESCRIPTION
This chooses the default memory limits for sort & fuse based on the amount of system memory. It uses a small go package that looks up total system memory (with a sysctl syscall on linux & macos, and a similar syscall on windows), and then assigns 1/8 of that to the sort & fuse max mem bytes, bounded between 128MiB and 1GiB.

To display that the value will be used, I made a change to the cli flag variable; the help output looks like this on my laptop, which has 32GiB of memory:

```
    -sortmem maximum memory used by sort in MiB, MB, etc (default "auto(1GiB)")
```

The value in the parentheses is the size that will be used, as selected by looking at the total system memory.
