### PR TITLE
zqd handler test cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - run: make test-generate
       - run: make test-unit
       - run: make test-system
-      - run: make test-zeek
+      - run: make test-pcap-ingest
       - run: make test-heavy
   test-windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - run: make test-generate
       - run: make test-unit
       - run: make test-system
-      - run: make test-pcap-ingest
+      - run: make test-pcapingest
       - run: make test-heavy
   test-windows:
     runs-on: windows-latest
@@ -37,7 +37,7 @@ jobs:
       - run: mkdir dist -ea 0
       - run: go build -o dist ./cmd/...
       - run: go test -v ./tests
-      - run: make test-zeek
+      - run: make test-pcapingest
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     - run: make test-generate
     - run: make test-unit
     - run: make test-system
-    - run: make test-pcap-ingest
+    - run: make test-pcapingest
     - run: make test-heavy
     - run: make create-release-assets
     - name: upload release assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     - run: make test-generate
     - run: make test-unit
     - run: make test-system
-    - run: make test-zeek
+    - run: make test-pcap-ingest
     - run: make test-heavy
     - run: make create-release-assets
     - name: upload release assets

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ test-run: build bin/minio bin/$(ZEEKPATH) bin/$(SURICATAPATH)
 test-heavy: build $(SAMPLEDATA)
 	@go test -v -tags=heavy ./tests
 
-test-pcap-ingest: bin/$(ZEEKPATH)
+test-pcapingest: bin/$(ZEEKPATH)
 	@ZEEK=$(CURDIR)/bin/$(ZEEKPATH)/zeekrunner go test -v -run=PcapPost -tags=pcapingest ./zqd
 
 perf-compare: build $(SAMPLEDATA)

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ test-run: build bin/minio bin/$(ZEEKPATH) bin/$(SURICATAPATH)
 test-heavy: build $(SAMPLEDATA)
 	@go test -v -tags=heavy ./tests
 
-test-zeek: bin/$(ZEEKPATH)
-	@ZEEK=$(CURDIR)/bin/$(ZEEKPATH)/zeekrunner go test -v -run=PcapPost -tags=zeek ./zqd
+test-pcap-ingest: bin/$(ZEEKPATH)
+	@ZEEK=$(CURDIR)/bin/$(ZEEKPATH)/zeekrunner go test -v -run=PcapPost -tags=pcapingest ./zqd
 
 perf-compare: build $(SAMPLEDATA)
 	scripts/comparison-test.sh

--- a/cmd/zapi/cmd/post/pcap.go
+++ b/cmd/zapi/cmd/post/pcap.go
@@ -72,7 +72,7 @@ func (c *PcapCommand) Run(args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	stream, err := client.PcapPost(c.Context(), id, api.PcapPostRequest{Path: file})
+	stream, err := client.PcapPostStream(c.Context(), id, api.PcapPostRequest{Path: file})
 	if err != nil {
 		return err
 	}

--- a/pkg/iosrc/uri.go
+++ b/pkg/iosrc/uri.go
@@ -35,6 +35,14 @@ func ParseURI(path string) (URI, error) {
 	return URI(*u), nil
 }
 
+func MustParseURI(path string) URI {
+	u, err := ParseURI(path)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
 func stdio(path string) (URI, bool) {
 	switch path {
 	case "stdin":

--- a/zqd/api/connection.go
+++ b/zqd/api/connection.go
@@ -269,7 +269,7 @@ func (c *Connection) ArchiveStat(ctx context.Context, space SpaceID, params map[
 	return NewZngSearch(r), nil
 }
 
-func (c *Connection) PcapPost(ctx context.Context, space SpaceID, payload PcapPostRequest) (*Stream, error) {
+func (c *Connection) PcapPostStream(ctx context.Context, space SpaceID, payload PcapPostRequest) (*Stream, error) {
 	req := c.Request(ctx).
 		SetBody(payload)
 	req.Method = http.MethodPost
@@ -280,6 +280,18 @@ func (c *Connection) PcapPost(ctx context.Context, space SpaceID, payload PcapPo
 	}
 	jsonpipe := NewJSONPipeScanner(r)
 	return NewStream(jsonpipe), nil
+}
+
+func (c *Connection) PcapPost(ctx context.Context, space SpaceID, payload PcapPostRequest) (Payloads, error) {
+	stream, err := c.PcapPostStream(ctx, space, payload)
+	if err != nil {
+		return nil, err
+	}
+	payloads, err := stream.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	return payloads, payloads.Error()
 }
 
 func (c *Connection) PcapSearch(ctx context.Context, space SpaceID, payload PcapSearch) (*PcapReadCloser, error) {
@@ -324,8 +336,11 @@ func (c *Connection) LogPost(ctx context.Context, space SpaceID, payload LogPost
 	if err != nil {
 		return err
 	}
-	_, err = stream.ReadAll()
-	return err
+	payloads, err := stream.ReadAll()
+	if err != nil {
+		return err
+	}
+	return payloads.Error()
 }
 
 type ErrorResponse struct {

--- a/zqd/api/stream.go
+++ b/zqd/api/stream.go
@@ -15,10 +15,7 @@ type Payloads []interface{}
 func (p Payloads) Error() error {
 	last := p[len(p)-1]
 	if te, ok := last.(*TaskEnd); ok {
-		if te.Error != nil {
-			return te.Error
-		}
-		return nil
+		return te.Error
 	}
 	return errors.New("expected last payload to be of type *TaskEnd")
 }

--- a/zqd/api/stream.go
+++ b/zqd/api/stream.go
@@ -15,7 +15,10 @@ type Payloads []interface{}
 func (p Payloads) Error() error {
 	last := p[len(p)-1]
 	if te, ok := last.(*TaskEnd); ok {
-		return te.Error
+		if te.Error != nil {
+			return te.Error
+		}
+		return nil
 	}
 	return errors.New("expected last payload to be of type *TaskEnd")
 }

--- a/zqd/handlers_pcap_test.go
+++ b/zqd/handlers_pcap_test.go
@@ -135,7 +135,7 @@ func TestPcapPostPcapNgWithExtraBytes(t *testing.T) {
 }
 
 func TestPcapPostInvalidPcap(t *testing.T) {
-	p := pcapPostTest(t, "./testdata/invalid.pcap", testLauncher(nil, nil))
+	p := pcapPostTest(t, "testdata/invalid.pcap", testLauncher(nil, nil))
 	t.Run("ErrorResponse", func(t *testing.T) {
 		require.Error(t, p.err)
 		var reserr *api.ErrorResponse

--- a/zqd/handlers_pcap_test.go
+++ b/zqd/handlers_pcap_test.go
@@ -88,7 +88,7 @@ func TestPcapPostSearch(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping test for windows")
 	}
-	pcapfile := "testdata/valid.pcap"
+	const pcapfile = "testdata/valid.pcap"
 	p := pcapPostTest(t, pcapfile, launcherFromEnv(t, "ZEEK"))
 	t.Run("Success", func(t *testing.T) {
 		req := api.PcapSearch{

--- a/zqd/handlers_pcap_test.go
+++ b/zqd/handlers_pcap_test.go
@@ -161,7 +161,7 @@ func TestPcapPostInvalidPcap(t *testing.T) {
 func TestPcapPostZeekFailImmediate(t *testing.T) {
 	expectedErr := errors.New("zeek error: failed to start")
 	startFn := func(*testPcapProcess) error { return expectedErr }
-	p := pcapPostTest(t, "./testdata/valid.pcap", testLauncher(startFn, nil))
+	p := pcapPostTest(t, "testdata/valid.pcap", testLauncher(startFn, nil))
 	t.Run("TaskEndError", func(t *testing.T) {
 		expected := &api.TaskEnd{
 			Type:   "TaskEnd",

--- a/zqd/handlers_pcap_test.go
+++ b/zqd/handlers_pcap_test.go
@@ -126,7 +126,7 @@ func TestPcapPostSearch(t *testing.T) {
 }
 
 func TestPcapPostPcapNgWithExtraBytes(t *testing.T) {
-	p := pcapPostTest(t, "./testdata/extra.pcapng", testLauncher(nil, nil))
+	p := pcapPostTest(t, "testdata/extra.pcapng", testLauncher(nil, nil))
 	t.Run("PcapNgExtra", func(t *testing.T) {
 		require.NoError(t, p.err)
 		warning := p.payloads[1].(*api.PcapPostWarning)

--- a/zqd/handlers_pcap_test.go
+++ b/zqd/handlers_pcap_test.go
@@ -1,14 +1,12 @@
-// +build zeek
+// +build pcapingest
 
 package zqd_test
 
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"runtime"
 	"testing"
@@ -23,9 +21,6 @@ import (
 	"github.com/brimsec/zq/zqd/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 )
 
 var testZeekLogs = []string{
@@ -39,12 +34,8 @@ func TestPcapPostSuccess(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping test for windows")
 	}
-	pcapuri, err := iosrc.ParseURI("testdata/valid.pcap")
-	require.NoError(t, err)
-	ln, err := pcapanalyzer.LauncherFromPath(os.Getenv("ZEEK"))
-	require.NoError(t, err)
-	p := pcapPost(t, pcapuri.Filepath(), ln)
-	defer p.cleanup()
+	pcapfile := "testdata/valid.pcap"
+	p := pcapPostTest(t, pcapfile, launcherFromEnv(t, "ZEEK"))
 	t.Run("DataReverseSorted", func(t *testing.T) {
 		expected := `
 #0:record[ts:time]
@@ -59,14 +50,14 @@ func TestPcapPostSuccess(t *testing.T) {
 	t.Run("SpaceInfo", func(t *testing.T) {
 		info, err := p.client.SpaceInfo(context.Background(), p.space.ID)
 		assert.NoError(t, err)
-		assert.Equal(t, p.space.ID, info.ID)
+		assert.Equal(t, info.ID, p.space.ID)
 		assert.Equal(t, nano.NewSpanTs(nano.Unix(1501770877, 471635000), nano.Unix(1501770880, 988247001)), *info.Span)
 		// Must use InDelta here because zeek randomly generates uids that
 		// vary in size.
 		assert.InDelta(t, 1561, info.Size, 10)
 		assert.Equal(t, int64(4224), info.PcapSize)
 		assert.True(t, info.PcapSupport)
-		assert.Equal(t, pcapuri, info.PcapPath)
+		assert.Equal(t, iosrc.MustParseURI(pcapfile), info.PcapPath)
 	})
 	t.Run("PcapIndexExists", func(t *testing.T) {
 		require.FileExists(t, p.core.Root.AppendPath(string(p.space.ID), pcapstorage.MetaFile).Filepath())
@@ -76,7 +67,7 @@ func TestPcapPostSuccess(t *testing.T) {
 		assert.Equal(t, status.Type, "TaskStart")
 	})
 	t.Run("StatusMessage", func(t *testing.T) {
-		info, err := os.Stat(p.pcapfile)
+		info, err := os.Stat(pcapfile)
 		require.NoError(t, err)
 		plen := len(p.payloads)
 		status := p.payloads[plen-2].(*api.PcapPostStatus)
@@ -97,10 +88,8 @@ func TestPcapPostSearch(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping test for windows")
 	}
-	ln, err := pcapanalyzer.LauncherFromPath(os.Getenv("ZEEK"))
-	require.NoError(t, err)
-	p := pcapPost(t, "./testdata/valid.pcap", ln)
-	defer p.cleanup()
+	pcapfile := "testdata/valid.pcap"
+	p := pcapPostTest(t, pcapfile, launcherFromEnv(t, "ZEEK"))
 	t.Run("Success", func(t *testing.T) {
 		req := api.PcapSearch{
 			Span:    nano.Span{Ts: 1501770877471635000, Dur: 3485852000},
@@ -136,19 +125,8 @@ func TestPcapPostSearch(t *testing.T) {
 	})
 }
 
-func TestPcapSearchNotFound(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test for windows")
-	}
-	ln, err := pcapanalyzer.LauncherFromPath(os.Getenv("ZEEK"))
-	require.NoError(t, err)
-	p := pcapPost(t, "./testdata/valid.pcap", ln)
-	defer p.cleanup()
-}
-
 func TestPcapPostPcapNgWithExtraBytes(t *testing.T) {
-	p := pcapPost(t, "./testdata/extra.pcapng", testZeekLauncher(nil, nil))
-	defer p.cleanup()
+	p := pcapPostTest(t, "./testdata/extra.pcapng", testLauncher(nil, nil))
 	t.Run("PcapNgExtra", func(t *testing.T) {
 		require.NoError(t, p.err)
 		warning := p.payloads[1].(*api.PcapPostWarning)
@@ -157,8 +135,7 @@ func TestPcapPostPcapNgWithExtraBytes(t *testing.T) {
 }
 
 func TestPcapPostInvalidPcap(t *testing.T) {
-	p := pcapPost(t, "./testdata/invalid.pcap", testZeekLauncher(nil, nil))
-	defer p.cleanup()
+	p := pcapPostTest(t, "./testdata/invalid.pcap", testLauncher(nil, nil))
 	t.Run("ErrorResponse", func(t *testing.T) {
 		require.Error(t, p.err)
 		var reserr *api.ErrorResponse
@@ -183,9 +160,8 @@ func TestPcapPostInvalidPcap(t *testing.T) {
 
 func TestPcapPostZeekFailImmediate(t *testing.T) {
 	expectedErr := errors.New("zeek error: failed to start")
-	startFn := func(*testZeekProcess) error { return expectedErr }
-	p := pcapPost(t, "./testdata/valid.pcap", testZeekLauncher(startFn, nil))
-	defer p.cleanup()
+	startFn := func(*testPcapProcess) error { return expectedErr }
+	p := pcapPostTest(t, "./testdata/valid.pcap", testLauncher(startFn, nil))
 	t.Run("TaskEndError", func(t *testing.T) {
 		expected := &api.TaskEnd{
 			Type:   "TaskEnd",
@@ -202,14 +178,13 @@ func TestPcapPostZeekFailImmediate(t *testing.T) {
 
 func TestPcapPostZeekFailAfterWrite(t *testing.T) {
 	expectedErr := errors.New("zeek exited after write")
-	write := func(p *testZeekProcess) error {
+	write := func(p *testPcapProcess) error {
 		if err := writeLogsFn(testZeekLogs)(p); err != nil {
 			return err
 		}
 		return expectedErr
 	}
-	p := pcapPost(t, "./testdata/valid.pcap", testZeekLauncher(nil, write))
-	defer p.cleanup()
+	p := pcapPostTest(t, "./testdata/valid.pcap", testLauncher(nil, write))
 	t.Run("TaskEndError", func(t *testing.T) {
 		expected := &api.TaskEnd{
 			Type:   "TaskEnd",
@@ -235,75 +210,35 @@ func TestPcapPostZeekFailAfterWrite(t *testing.T) {
 	})
 }
 
-func pcapPost(t *testing.T, pcapfile string, l pcapanalyzer.Launcher) pcapPostResult {
-	return pcapPostWithConfig(t, zqd.Config{Zeek: l}, pcapfile)
-}
-
-func pcapPostWithConfig(t *testing.T, conf zqd.Config, pcapfile string) pcapPostResult {
-	if conf.Logger == nil {
-		conf.Logger = zaptest.NewLogger(t, zaptest.Level(zapcore.WarnLevel))
-	}
-	c := setCoreRoot(t, conf)
-	ts := httptest.NewServer(zqd.NewHandler(c, conf.Logger))
-	client := api.NewConnectionTo(ts.URL)
-	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
+func launcherFromEnv(t *testing.T, env string) pcapanalyzer.Launcher {
+	ln, err := pcapanalyzer.LauncherFromPath(os.Getenv(env))
 	require.NoError(t, err)
-	res := pcapPostResult{
-		core:     c,
-		srv:      ts,
-		client:   client,
-		space:    *sp,
-		pcapfile: pcapfile,
-	}
-	res.postPcap(t, pcapfile)
-	return res
+	return ln
 }
 
-func setCoreRoot(t *testing.T, c zqd.Config) *zqd.Core {
-	if c.Root == "" {
-		dir, err := ioutil.TempDir("", "PcapPostTest")
-		require.NoError(t, err)
-		c.Root = dir
-	}
-	if c.Logger == nil {
-		c.Logger = zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel))
-	}
-	core, err := zqd.NewCore(c)
-	require.NoError(t, err)
-	return core
-}
-
-type pcapPostResult struct {
-	core     *zqd.Core
+type pcapPostTestResult struct {
 	client   *api.Connection
-	srv      *httptest.Server
+	core     *zqd.Core
 	space    api.SpaceInfo
-	pcapfile string
-	body     []byte
 	err      error
-	payloads []interface{}
+	payloads api.Payloads
 }
 
-func (r *pcapPostResult) postPcap(t *testing.T, file string) {
-	var stream *api.Stream
-	stream, r.err = r.client.PcapPost(context.Background(), r.space.ID, api.PcapPostRequest{r.pcapfile})
-	if r.err == nil {
-		r.readPayloads(t, stream)
+func pcapPostTest(t *testing.T, pcapfile string, zeek pcapanalyzer.Launcher) pcapPostTestResult {
+	return testPcapPostWithConfig(t, zqd.Config{Zeek: zeek}, pcapfile)
+}
+
+func testPcapPostWithConfig(t *testing.T, conf zqd.Config, pcapfile string) pcapPostTestResult {
+	ctx := context.Background()
+	c, client := newCoreWithConfig(t, conf)
+	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
+	require.NoError(t, err)
+	payloads, perr := client.PcapPost(ctx, sp.ID, api.PcapPostRequest{pcapfile})
+	return pcapPostTestResult{
+		err:      perr,
+		payloads: payloads,
+		space:    *sp,
+		core:     c,
+		client:   client,
 	}
-}
-
-func (r *pcapPostResult) readPayloads(t *testing.T, stream *api.Stream) {
-	for {
-		i, err := stream.Next()
-		require.NoError(t, err)
-		if i == nil {
-			break
-		}
-		r.payloads = append(r.payloads, i)
-	}
-}
-
-func (r *pcapPostResult) cleanup() {
-	os.RemoveAll(r.core.Root.Filepath())
-	r.srv.Close()
 }

--- a/zqd/handlers_pcap_test.go
+++ b/zqd/handlers_pcap_test.go
@@ -184,7 +184,7 @@ func TestPcapPostZeekFailAfterWrite(t *testing.T) {
 		}
 		return expectedErr
 	}
-	p := pcapPostTest(t, "./testdata/valid.pcap", testLauncher(nil, write))
+	p := pcapPostTest(t, "testdata/valid.pcap", testLauncher(nil, write))
 	t.Run("TaskEndError", func(t *testing.T) {
 		expected := &api.TaskEnd{
 			Type:   "TaskEnd",

--- a/zqd/handlers_pcap_test.go
+++ b/zqd/handlers_pcap_test.go
@@ -210,8 +210,8 @@ func TestPcapPostZeekFailAfterWrite(t *testing.T) {
 	})
 }
 
-func launcherFromEnv(t *testing.T, env string) pcapanalyzer.Launcher {
-	ln, err := pcapanalyzer.LauncherFromPath(os.Getenv(env))
+func launcherFromEnv(t *testing.T, key string) pcapanalyzer.Launcher {
+	ln, err := pcapanalyzer.LauncherFromPath(os.Getenv(key))
 	require.NoError(t, err)
 	return ln
 }

--- a/zqd/handlers_pcap_test.go
+++ b/zqd/handlers_pcap_test.go
@@ -34,7 +34,7 @@ func TestPcapPostSuccess(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping test for windows")
 	}
-	pcapfile := "testdata/valid.pcap"
+	const pcapfile = "testdata/valid.pcap"
 	p := pcapPostTest(t, pcapfile, launcherFromEnv(t, "ZEEK"))
 	t.Run("DataReverseSorted", func(t *testing.T) {
 		expected := `

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -1095,8 +1095,7 @@ func newCoreWithConfig(t *testing.T, conf zqd.Config) (*zqd.Core, *api.Connectio
 	}
 	core, err := zqd.NewCore(conf)
 	require.NoError(t, err)
-	h := zqd.NewHandler(core, conf.Logger)
-	srv := httptest.NewServer(h)
+	srv := httptest.NewServer(zqd.NewHandler(core, conf.Logger))
 	t.Cleanup(srv.Close)
 	return core, api.NewConnectionTo(srv.URL)
 }

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -1083,8 +1083,7 @@ func newCore(t *testing.T) (*zqd.Core, *api.Connection) {
 func newCoreAtDir(t *testing.T, dir string) (*zqd.Core, *api.Connection) {
 	require.NoError(t, os.MkdirAll(dir, 0755))
 	t.Cleanup(func() { os.RemoveAll(dir) })
-	conf := zqd.Config{Root: dir}
-	return newCoreWithConfig(t, conf)
+	return newCoreWithConfig(t, zqd.Config{Root: dir})
 }
 
 func newCoreWithConfig(t *testing.T, conf zqd.Config) (*zqd.Core, *api.Connection) {

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -47,8 +47,7 @@ func TestSearch(t *testing.T) {
 0:[conn;1521911723.205187;CBrzd94qfowOqJwCHa;]
 0:[conn;1521911721.255387;C8Tful1TvM3Zf5x8fl;]
 `
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	_ = postSpaceLogs(t, client, sp.ID, nil, src)
@@ -62,8 +61,7 @@ func TestSearchNoCtrl(t *testing.T) {
 0:[conn;1521911723.205187;CBrzd94qfowOqJwCHa;]
 0:[conn;1521911721.255387;C8Tful1TvM3Zf5x8fl;]
 `
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	_ = postSpaceLogs(t, client, sp.ID, nil, src)
@@ -97,8 +95,7 @@ func TestSearchStats(t *testing.T) {
 0:[a;1;]
 0:[b;1;]
 `
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	_ = postSpaceLogs(t, client, sp.ID, nil, src)
@@ -132,8 +129,7 @@ func TestGroupByReverse(t *testing.T) {
 0:[2;1;]
 0:[1;2;]
 `
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	_ = postSpaceLogs(t, client, sp.ID, nil, src)
@@ -143,8 +139,7 @@ func TestGroupByReverse(t *testing.T) {
 
 func TestSearchEmptySpace(t *testing.T) {
 	ctx := context.Background()
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	res := searchTzng(t, client, sp.ID, "*")
@@ -157,8 +152,7 @@ func TestSearchError(t *testing.T) {
 0:[conn;1521911723.205187;CBrzd94qfowOqJwCHa;]
 0:[conn;1521911721.255387;C8Tful1TvM3Zf5x8fl;]
 `
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	_ = postSpaceLogs(t, client, sp.ID, nil, src)
@@ -200,10 +194,8 @@ func TestSpaceList(t *testing.T) {
 	var expected []api.SpaceInfo
 
 	ctx := context.Background()
-	c, client, done := newCore(t)
+	c, client := newCore(t)
 	{
-		defer done()
-
 		for _, n := range names {
 			sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: n})
 			require.NoError(t, err)
@@ -226,8 +218,7 @@ func TestSpaceList(t *testing.T) {
 	require.NoError(t, os.RemoveAll(filepath.Join(c.Root.Filepath(), string(expected[2].ID))))
 	expected = append(expected[:2], expected[3:]...)
 
-	_, client, done = newCoreAtDir(t, c.Root.Filepath())
-	defer done()
+	_, client = newCoreAtDir(t, c.Root.Filepath())
 
 	list, err := client.SpaceList(ctx)
 	require.NoError(t, err)
@@ -241,8 +232,7 @@ func TestSpaceInfo(t *testing.T) {
 0:[conn;1;CBrzd94qfowOqJwCHa;]
 0:[conn;2;C8Tful1TvM3Zf5x8fl;]`
 	ctx := context.Background()
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	_ = postSpaceLogs(t, client, sp.ID, nil, src)
@@ -263,8 +253,7 @@ func TestSpaceInfo(t *testing.T) {
 
 func TestSpaceInfoNoData(t *testing.T) {
 	ctx := context.Background()
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	info, err := client.SpaceInfo(ctx, sp.ID)
@@ -282,8 +271,7 @@ func TestSpaceInfoNoData(t *testing.T) {
 
 func TestSpacePostNameOnly(t *testing.T) {
 	ctx := context.Background()
-	c, client, done := newCore(t)
-	defer done()
+	c, client := newCore(t)
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	assert.Equal(t, "test", sp.Name)
@@ -293,8 +281,7 @@ func TestSpacePostNameOnly(t *testing.T) {
 
 func TestSpacePostDuplicateName(t *testing.T) {
 	ctx := context.Background()
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	_, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	_, err = client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
@@ -303,8 +290,7 @@ func TestSpacePostDuplicateName(t *testing.T) {
 
 func TestSpaceInvalidName(t *testing.T) {
 	ctx := context.Background()
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	t.Run("Post", func(t *testing.T) {
 		_, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "𝚭𝚴𝚪 is.good"})
 		require.NoError(t, err)
@@ -321,8 +307,7 @@ func TestSpaceInvalidName(t *testing.T) {
 
 func TestSpacePutDuplicateName(t *testing.T) {
 	ctx := context.Background()
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	_, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test1"})
@@ -335,8 +320,7 @@ func TestSpacePostDataPath(t *testing.T) {
 	ctx := context.Background()
 	tmp := createTempDir(t)
 	datapath := filepath.Join(tmp, "mypcap.brim")
-	_, client, done := newCoreAtDir(t, filepath.Join(tmp, "spaces"))
-	defer done()
+	_, client := newCoreAtDir(t, filepath.Join(tmp, "spaces"))
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{DataPath: datapath})
 	require.NoError(t, err)
 	assert.Equal(t, "mypcap.brim", sp.Name)
@@ -345,8 +329,7 @@ func TestSpacePostDataPath(t *testing.T) {
 
 func TestSpacePut(t *testing.T) {
 	ctx := context.Background()
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	err = client.SpacePut(ctx, sp.ID, api.SpacePutRequest{Name: "new_name"})
@@ -358,8 +341,7 @@ func TestSpacePut(t *testing.T) {
 
 func TestSpaceDelete(t *testing.T) {
 	ctx := context.Background()
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	err = client.SpaceDelete(ctx, sp.ID)
@@ -372,8 +354,7 @@ func TestSpaceDelete(t *testing.T) {
 func TestSpaceDeleteDataDir(t *testing.T) {
 	ctx := context.Background()
 	tmp := createTempDir(t)
-	_, client, done := newCoreAtDir(t, filepath.Join(tmp, "spaces"))
-	defer done()
+	_, client := newCoreAtDir(t, filepath.Join(tmp, "spaces"))
 	datadir := filepath.Join(tmp, "mypcap.brim")
 	sp, err := client.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
@@ -389,8 +370,7 @@ func TestSpaceDeleteDataDir(t *testing.T) {
 }
 
 func TestNoEndSlashSupport(t *testing.T) {
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	_, err := client.Do(context.Background(), "GET", "/space/", nil)
 	require.Error(t, err)
 	require.Equal(t, 404, err.(*api.ErrorResponse).StatusCode())
@@ -399,8 +379,7 @@ func TestNoEndSlashSupport(t *testing.T) {
 func TestRequestID(t *testing.T) {
 	ctx := context.Background()
 	t.Run("GeneratesUniqueID", func(t *testing.T) {
-		_, client, done := newCore(t)
-		defer done()
+		_, client := newCore(t)
 		res1, err := client.Do(ctx, "GET", "/space", nil)
 		require.NoError(t, err)
 		res2, err := client.Do(ctx, "GET", "/space", nil)
@@ -409,8 +388,7 @@ func TestRequestID(t *testing.T) {
 		assert.Equal(t, "2", res2.Header().Get("X-Request-ID"))
 	})
 	t.Run("PropagatesID", func(t *testing.T) {
-		_, client, done := newCore(t)
-		defer done()
+		_, client := newCore(t)
 		requestID := "random-request-ID"
 		req := client.Request(context.Background())
 		req.SetHeader("X-Request-ID", requestID)
@@ -429,8 +407,7 @@ func TestPostZngLogs(t *testing.T) {
 		"#0:record[_path:string,ts:time,uid:bstring]",
 		"0:[conn;2;CBrzd94qfowOqJwCHa;]",
 	}
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 
@@ -472,8 +449,7 @@ func TestPostZngLogWarning(t *testing.T) {
 		"0:[conn;1;CBrzd94qfowOqJwCHa;]",
 		"detectablebutbadline",
 	}
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 
@@ -522,8 +498,7 @@ func TestPostNDJSONLogs(t *testing.T) {
 	}
 
 	test := func(input string) {
-		_, client, done := newCore(t)
-		defer done()
+		_, client := newCore(t)
 
 		sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
 		require.NoError(t, err)
@@ -584,8 +559,7 @@ func TestPostNDJSONLogWarning(t *testing.T) {
 			ndjsonio.Rule{"_path", "http", "http_log"},
 		},
 	}
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 
@@ -613,8 +587,7 @@ func TestPostLogStopErr(t *testing.T) {
 0:[conn;1;CBrzd94qfowOqJwCHa;]`
 	logfile := writeTempFile(t, src)
 	defer os.Remove(logfile)
-	_, client, done := newCore(t)
-	defer done()
+	_, client := newCore(t)
 
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
@@ -625,28 +598,27 @@ func TestPostLogStopErr(t *testing.T) {
 }
 
 func TestDeleteDuringPcapPost(t *testing.T) {
-	c, client, done := newCore(t)
-	defer done()
+	c, client := newCore(t)
 
 	pcapfile := "./testdata/valid.pcap"
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{Name: "deleteDuringPacketPost"})
 	require.NoError(t, err)
 	var zeekClosed int32
 
-	waitFn := func(tzp *testZeekProcess) error {
+	waitFn := func(tzp *testPcapProcess) error {
 		<-tzp.ctx.Done()
 		atomic.StoreInt32(&zeekClosed, 1)
 		return errors.New("zeek exited with error code: -1")
 	}
 
-	c.Zeek = testZeekLauncher(nil, waitFn)
+	c.Zeek = testLauncher(nil, waitFn)
 
 	var wg sync.WaitGroup
 	pcapPostErr := make(chan error)
 
 	wg.Add(1)
 	doPost := func() error {
-		stream, err := client.PcapPost(context.Background(), sp.ID, api.PcapPostRequest{pcapfile})
+		stream, err := client.PcapPostStream(context.Background(), sp.ID, api.PcapPostRequest{pcapfile})
 		wg.Done()
 		if err != nil {
 			return err
@@ -692,8 +664,7 @@ func TestSpaceDataDir(t *testing.T) {
 	root := createTempDir(t)
 	datapath := createTempDir(t)
 
-	_, client1, done1 := newCoreAtDir(t, root)
-	defer done1()
+	_, client1 := newCoreAtDir(t, root)
 
 	// Verify space creation request uses datapath.
 	sp, err := client1.SpacePost(context.Background(), api.SpacePostRequest{
@@ -709,8 +680,7 @@ func TestSpaceDataDir(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify space load on startup uses datapath.
-	_, client2, done2 := newCoreAtDir(t, root)
-	defer done2()
+	_, client2 := newCoreAtDir(t, root)
 
 	res = searchTzng(t, client2, sp.ID, "*")
 	require.Equal(t, test.Trim(src), res)
@@ -720,10 +690,9 @@ func TestCreateArchiveSpace(t *testing.T) {
 	thresh := int64(1000)
 	root := createTempDir(t)
 
-	c, client, done := newCoreAtDir(t, root)
-	defer done()
+	c, client := newCoreAtDir(t, root)
 
-	c.Zeek = testZeekLauncher(func(tzp *testZeekProcess) error {
+	c.Zeek = testLauncher(func(tzp *testPcapProcess) error {
 		const s = "unexpected attempt to run zeek"
 		t.Error(s)
 		return errors.New(s)
@@ -766,7 +735,7 @@ func TestCreateArchiveSpace(t *testing.T) {
 	require.Equal(t, test.Trim(exptzng), res)
 
 	// Verify pcap post not supported
-	_, err = client.PcapPost(context.Background(), sp.ID, api.PcapPostRequest{"foo"})
+	_, err = client.PcapPostStream(context.Background(), sp.ID, api.PcapPostRequest{"foo"})
 	require.Error(t, err)
 	assert.Regexp(t, "space does not support pcap import", err.Error())
 }
@@ -783,8 +752,7 @@ func TestBlankNameSpace(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(root, testdirname, "config.json"), []byte(oldconfig), 0600)
 	require.NoError(t, err)
 
-	_, client, done := newCoreAtDir(t, root)
-	defer done()
+	_, client := newCoreAtDir(t, root)
 
 	si, err := client.SpaceInfo(context.Background(), api.SpaceID(testdirname))
 	require.NoError(t, err)
@@ -795,8 +763,7 @@ func TestIndexSearch(t *testing.T) {
 	thresh := int64(1000)
 	root := createTempDir(t)
 
-	_, client, done := newCoreAtDir(t, root)
-	defer done()
+	_, client := newCoreAtDir(t, root)
 
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{
 		Name: "TestIndexSearch",
@@ -836,8 +803,7 @@ func TestSubspaceCreate(t *testing.T) {
 
 	// Create server & the parent space
 	root := createTempDir(t)
-	_, client, done := newCoreAtDir(t, root)
-	defer done()
+	_, client := newCoreAtDir(t, root)
 
 	sp1, err := client.SpacePost(context.Background(), api.SpacePostRequest{
 		Name: "TestSubspaceCreate",
@@ -914,8 +880,7 @@ func TestSubspacePersist(t *testing.T) {
 
 	// Create server & the parent space
 	root := createTempDir(t)
-	_, client1, done1 := newCoreAtDir(t, root)
-	defer done1()
+	_, client1 := newCoreAtDir(t, root)
 
 	sp1, err := client1.SpacePost(context.Background(), api.SpacePostRequest{
 		Name: "TestSubspaceCreate",
@@ -969,8 +934,7 @@ func TestSubspacePersist(t *testing.T) {
 	assert.Equal(t, "newname", si.Name)
 
 	// Verify subspace is present & has new name with new server
-	_, client2, done2 := newCoreAtDir(t, root)
-	defer done2()
+	_, client2 := newCoreAtDir(t, root)
 
 	si, err = client2.SpaceInfo(context.Background(), sp2.ID)
 	require.NoError(t, err)
@@ -987,8 +951,7 @@ func TestSubspacePersist(t *testing.T) {
 	assert.Regexp(t, "not found", err.Error())
 
 	// Verify subspace gone with new server
-	_, client3, done3 := newCoreAtDir(t, root)
-	defer done3()
+	_, client3 := newCoreAtDir(t, root)
 
 	si, err = client3.SpaceInfo(context.Background(), sp2.ID)
 	require.Error(t, err)
@@ -998,8 +961,7 @@ func TestSubspacePersist(t *testing.T) {
 func TestArchiveStat(t *testing.T) {
 	thresh := int64(20 * 1024)
 	root := createTempDir(t)
-	_, client, done := newCoreAtDir(t, root)
-	defer done()
+	_, client := newCoreAtDir(t, root)
 
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{
 		Name: "TestArchiveStat",
@@ -1113,22 +1075,31 @@ func createTempDir(t *testing.T) string {
 	return dir
 }
 
-func newCore(t *testing.T) (*zqd.Core, *api.Connection, func()) {
+func newCore(t *testing.T) (*zqd.Core, *api.Connection) {
 	root := createTempDir(t)
 	return newCoreAtDir(t, root)
 }
 
-func newCoreAtDir(t *testing.T, dir string) (*zqd.Core, *api.Connection, func()) {
-	conf := zqd.Config{
-		Root:   dir,
-		Logger: zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel)),
-	}
+func newCoreAtDir(t *testing.T, dir string) (*zqd.Core, *api.Connection) {
 	require.NoError(t, os.MkdirAll(dir, 0755))
-	c, err := zqd.NewCore(conf)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	conf := zqd.Config{Root: dir}
+	return newCoreWithConfig(t, conf)
+}
+
+func newCoreWithConfig(t *testing.T, conf zqd.Config) (*zqd.Core, *api.Connection) {
+	if conf.Root == "" {
+		conf.Root = createTempDir(t)
+	}
+	if conf.Logger == nil {
+		conf.Logger = zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel))
+	}
+	core, err := zqd.NewCore(conf)
 	require.NoError(t, err)
-	h := zqd.NewHandler(c, conf.Logger)
-	ts := httptest.NewServer(h)
-	return c, api.NewConnectionTo(ts.URL), ts.Close
+	h := zqd.NewHandler(core, conf.Logger)
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return core, api.NewConnectionTo(srv.URL)
 }
 
 func writeTempFile(t *testing.T, contents string) string {
@@ -1177,9 +1148,9 @@ func postSpaceLogs(t *testing.T, c *api.Connection, spaceID api.SpaceID, tc *ndj
 	return payloads
 }
 
-func testZeekLauncher(start, wait procFn) pcapanalyzer.Launcher {
+func testLauncher(start, wait procFn) pcapanalyzer.Launcher {
 	return func(ctx context.Context, r io.Reader, dir string) (pcapanalyzer.ProcessWaiter, error) {
-		p := &testZeekProcess{
+		p := &testPcapProcess{
 			ctx:    ctx,
 			reader: r,
 			wd:     dir,
@@ -1190,9 +1161,9 @@ func testZeekLauncher(start, wait procFn) pcapanalyzer.Launcher {
 	}
 }
 
-type procFn func(t *testZeekProcess) error
+type procFn func(t *testPcapProcess) error
 
-type testZeekProcess struct {
+type testPcapProcess struct {
 	ctx    context.Context
 	reader io.Reader
 	wd     string
@@ -1200,14 +1171,14 @@ type testZeekProcess struct {
 	wait   procFn
 }
 
-func (p *testZeekProcess) Start() error {
+func (p *testPcapProcess) Start() error {
 	if p.start != nil {
 		return p.start(p)
 	}
 	return nil
 }
 
-func (p *testZeekProcess) Wait() error {
+func (p *testPcapProcess) Wait() error {
 	if p.wait != nil {
 		return p.wait(p)
 	}
@@ -1215,7 +1186,7 @@ func (p *testZeekProcess) Wait() error {
 }
 
 func writeLogsFn(logs []string) procFn {
-	return func(t *testZeekProcess) error {
+	return func(p *testPcapProcess) error {
 		for _, log := range logs {
 			r, err := fs.Open(log)
 			if err != nil {
@@ -1223,7 +1194,7 @@ func writeLogsFn(logs []string) procFn {
 			}
 			defer r.Close()
 			base := filepath.Base(r.Name())
-			w, err := os.Create(filepath.Join(t.wd, base))
+			w, err := os.Create(filepath.Join(p.wd, base))
 			if err != nil {
 				return err
 			}
@@ -1233,7 +1204,7 @@ func writeLogsFn(logs []string) procFn {
 			}
 		}
 		// drain the reader
-		_, err := io.Copy(ioutil.Discard, t.reader)
+		_, err := io.Copy(ioutil.Discard, p.reader)
 		return err
 	}
 }


### PR DESCRIPTION
Some tidying of the zqd handler tests:
- Use testing.T.Cleanup more liberally
- Rename handlers_zeek_test.go -> handlers_pcap_test.go to more
accurately reflect the updated nature the pcap ingest pathway (i.e.
the addition of suricata logs to zeek logs).
- Increase ergonomics of running pcap ingest tests- including a
non-streaming variant of client.PcapPost.