### PR TITLE
zqd: Support pcap ingest for archive stores

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqd/api"
 )
@@ -146,4 +147,49 @@ func (d *transformDriver) ChannelEnd(cid int) error           { return nil }
 func Copy(ctx context.Context, w zbuf.Writer, prog ast.Proc, zctx *resolver.Context, r zbuf.Reader, cfg Config) error {
 	d := &transformDriver{w: w}
 	return Run(ctx, d, prog, zctx, r, cfg)
+}
+
+type muxReader struct {
+	*muxOutput
+	batch       zbuf.Batch
+	index       int
+	statsTickCh <-chan time.Time
+}
+
+func (mr *muxReader) Read() (*zng.Record, error) {
+read:
+	if mr.batch == nil {
+		chunk := mr.Pull(mr.statsTickCh)
+		if chunk.ID != 0 {
+			return nil, errors.New("transform proc with multiple tails")
+		}
+		if chunk.Batch != nil {
+			mr.batch = chunk.Batch
+		} else if chunk.Err != nil {
+			return nil, chunk.Err
+		} else if chunk.Warning != "" {
+			goto read
+		} else {
+			return nil, nil
+		}
+	}
+	if mr.index >= mr.batch.Length() {
+		mr.batch.Unref()
+		mr.batch, mr.index = nil, 0
+		goto read
+	}
+	rec := mr.batch.Index(mr.index)
+	mr.index++
+	return rec, nil
+}
+
+func NewReader(ctx context.Context, program ast.Proc, zctx *resolver.Context, reader zbuf.Reader) (zbuf.Reader, error) {
+	mux, err := compileSingle(ctx, program, zctx, reader, Config{})
+	if err != nil {
+		return nil, err
+	}
+	return &muxReader{
+		muxOutput:   mux,
+		statsTickCh: make(chan time.Time),
+	}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.30.19
 	github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f
 	github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-resty/resty/v2 v2.2.0
 	github.com/golang/mock v1.4.3
 	github.com/google/gopacket v1.1.17

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,7 @@ github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fp
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/pkg/fs/tail.go
+++ b/pkg/fs/tail.go
@@ -45,19 +45,17 @@ func TailFile(name string) (*TFile, error) {
 func (t *TFile) Read(b []byte) (int, error) {
 read:
 	n, err := t.f.Read(b)
-	if errors.Is(err, os.ErrClosed) {
-		err = io.EOF
-	}
-	// If there is data and EOF, change err to nil so data is read. Assuming
-	// no data is added to the file, the next Read call will initiate the wait.
-	if n > 0 && err == io.EOF {
-		err = nil
-	}
-	if n == 0 && err == io.EOF {
+	if err == io.EOF {
+		if n > 0 {
+			return n, nil
+		}
 		if err := t.waitWrite(); err != nil {
 			return 0, err
 		}
 		goto read
+	}
+	if errors.Is(err, os.ErrClosed) {
+		err = io.EOF
 	}
 	return n, err
 }

--- a/pkg/fs/tail.go
+++ b/pkg/fs/tail.go
@@ -128,8 +128,8 @@ func NewDirWatcher(dir string) (*DirWatcher, error) {
 		return nil, err
 	}
 	w := &DirWatcher{
-		dir:     dir,
 		Events:  make(chan FileEvent),
+		dir:     dir,
 		watched: make(map[string]struct{}),
 		watcher: watcher,
 	}
@@ -137,7 +137,7 @@ func NewDirWatcher(dir string) (*DirWatcher, error) {
 		return nil, err
 	}
 	go func() {
-		err := w.start()
+		err := w.run()
 		if errc := w.watcher.Close(); err == nil {
 			err = errc
 		}
@@ -149,7 +149,7 @@ func NewDirWatcher(dir string) (*DirWatcher, error) {
 	return w, nil
 }
 
-func (w *DirWatcher) start() error {
+func (w *DirWatcher) run() error {
 	if err := w.poll(); err != nil {
 		return err
 	}

--- a/pkg/fs/tail.go
+++ b/pkg/fs/tail.go
@@ -1,0 +1,175 @@
+package fs
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+var ErrIsDir = errors.New("path is a directory")
+
+type TFile struct {
+	f       *os.File
+	watcher *fsnotify.Watcher
+}
+
+func TailFile(name string) (*TFile, error) {
+	info, err := os.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, ErrIsDir
+	}
+	f, err := OpenFile(name, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	if err := watcher.Add(name); err != nil {
+		return nil, err
+	}
+	return &TFile{f, watcher}, nil
+}
+
+func (t *TFile) Read(b []byte) (int, error) {
+read:
+	n, err := t.f.Read(b)
+	if errors.Is(err, os.ErrClosed) {
+		err = io.EOF
+	}
+	if n == 0 && err == io.EOF {
+		if err := t.waitWrite(); err != nil {
+			return 0, err
+		}
+		goto read
+	}
+	return n, err
+}
+
+func (t *TFile) waitWrite() error {
+	for {
+		select {
+		case ev, ok := <-t.watcher.Events:
+			if !ok {
+				return io.EOF
+			}
+			if ev.Op == fsnotify.Write {
+				return nil
+			}
+		case err := <-t.watcher.Errors:
+			return err
+		}
+	}
+}
+
+func (t *TFile) Stop() error {
+	return t.watcher.Close()
+}
+
+func (t *TFile) Close() error {
+	return t.f.Close()
+}
+
+type FileOp int
+
+const (
+	FileOpCreated FileOp = iota
+	FileOpExisting
+	FileOpRemoved
+)
+
+func (o FileOp) Exists() bool {
+	return o == FileOpCreated || o == FileOpExisting
+}
+
+type FileEvent struct {
+	Name string
+	Op   FileOp
+	Err  error
+}
+
+// DirWatcher observes a directory and will emit events when files are added
+// or removed. When open for the first time this will emit an event for
+// every existing file.
+type DirWatcher struct {
+	dir     string
+	events  chan FileEvent
+	once    sync.Once
+	err     error
+	watcher *fsnotify.Watcher
+}
+
+func NewDirWatcher(dir string) (*DirWatcher, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, errors.New("provided path must be a directory")
+	}
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	return &DirWatcher{
+		dir:     dir,
+		events:  make(chan FileEvent, 5),
+		watcher: watcher,
+	}, err
+}
+
+func (w *DirWatcher) start() {
+	defer close(w.events)
+	defer w.watcher.Close()
+	if err := w.watcher.Add(w.dir); err != nil {
+		w.events <- FileEvent{Err: err}
+		return
+	}
+	if err := w.emitExisting(); err != nil {
+		w.events <- FileEvent{Err: err}
+		return
+	}
+	for ev := range w.watcher.Events {
+		switch ev.Op {
+		case fsnotify.Create:
+			w.events <- FileEvent{Name: ev.Name, Op: FileOpCreated}
+		case fsnotify.Remove:
+			w.events <- FileEvent{Name: ev.Name, Op: FileOpRemoved}
+		}
+	}
+}
+
+func (w *DirWatcher) emitExisting() error {
+	infos, err := ioutil.ReadDir(w.dir)
+	if err != nil {
+		return err
+	}
+	for _, info := range infos {
+		if info.IsDir() {
+			continue
+		}
+		w.events <- FileEvent{
+			Name: filepath.Join(w.dir, info.Name()),
+			Op:   FileOpExisting,
+		}
+	}
+	return nil
+}
+
+func (w *DirWatcher) Events() <-chan FileEvent {
+	w.once.Do(func() { go w.start() })
+	return w.events
+}
+
+func (w *DirWatcher) Stop() error {
+	return w.watcher.Close()
+}

--- a/pkg/fs/tail_test.go
+++ b/pkg/fs/tail_test.go
@@ -1,0 +1,65 @@
+package fs
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTailFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "tailfile.log")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	tf, err := TailFile(f.Name())
+	require.NoError(t, err)
+	buf := make([]byte, 100)
+
+	for i := 0; i < 10; i++ {
+		str := fmt.Sprintf("line #%d\n", i)
+		_, err := f.WriteString(str)
+		require.NoError(t, err)
+		n, err := tf.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, str, string(buf[:n]))
+	}
+	go require.NoError(t, tf.Stop())
+	n, err := tf.Read(buf)
+	assert.Equal(t, 0, n)
+	assert.Error(t, io.EOF, err)
+}
+
+func TestTailFileReadToEOF(t *testing.T) {
+	expected := `line #0
+line #1
+line #2
+line #3
+line #4
+line #5
+line #6
+line #7
+line #8
+line #9
+`
+	f, err := ioutil.TempFile("", "tailfile.log")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	tf, err := TailFile(f.Name())
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		str := fmt.Sprintf("line #%d\n", i)
+		_, err := f.WriteString(str)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tf.Stop())
+	buf := bytes.NewBuffer(nil)
+	_, err = io.Copy(buf, tf)
+	require.NoError(t, err)
+	assert.Equal(t, expected, buf.String())
+}

--- a/pkg/fs/tail_test.go
+++ b/pkg/fs/tail_test.go
@@ -15,7 +15,7 @@ import (
 func TestTailFile(t *testing.T) {
 	f, err := ioutil.TempFile("", "tailfile.log")
 	require.NoError(t, err)
-	defer os.Remove(f.Name())
+	t.Cleanup(func() { os.Remove(f.Name()) })
 	tf, err := TailFile(f.Name())
 	require.NoError(t, err)
 	buf := make([]byte, 100)

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -166,7 +166,9 @@ type PcapPostStatus struct {
 	UpdateTime    nano.Ts    `json:"update_time"`
 	PcapSize      int64      `json:"pcap_total_size" unit:"bytes"`
 	PcapReadSize  int64      `json:"pcap_read_size" unit:"bytes"`
-	SnapshotCount int        `json:"snapshot_count"`
+	RecordBytes   int64      `json:"record_bytes,omitempty" unit:"bytes"`
+	RecordCount   int64      `json:"record_count,omitempty"`
+	SnapshotCount int        `json:"snapshot_count,omitempty"`
 	Span          *nano.Span `json:"span,omitempty"`
 }
 

--- a/zqd/handlers_pcap_test.go
+++ b/zqd/handlers_pcap_test.go
@@ -71,9 +71,9 @@ func TestPcapPostSuccess(t *testing.T) {
 		require.NoError(t, err)
 		plen := len(p.payloads)
 		status := p.payloads[plen-2].(*api.PcapPostStatus)
-		assert.Equal(t, status.Type, "PcapPostStatus")
-		assert.Equal(t, status.PcapSize, info.Size())
-		assert.Equal(t, status.PcapReadSize, info.Size())
+		assert.Equal(t, "PcapPostStatus", status.Type)
+		assert.Equal(t, info.Size(), status.PcapSize)
+		assert.Equal(t, info.Size(), status.PcapReadSize)
 		assert.Equal(t, 1, status.SnapshotCount)
 		assert.Equal(t, nano.NewSpanTs(nano.Unix(1501770877, 471635000), nano.Unix(1501770880, 988247001)), *status.Span)
 	})
@@ -196,17 +196,6 @@ func TestPcapPostZeekFailAfterWrite(t *testing.T) {
 		}
 		last := p.payloads[len(p.payloads)-1]
 		require.Equal(t, expected, last)
-	})
-	t.Run("EmptySpaceInfo", func(t *testing.T) {
-		info, err := p.client.SpaceInfo(context.Background(), p.space.ID)
-		assert.NoError(t, err)
-		expected := api.SpaceInfo{
-			ID:          p.space.ID,
-			Name:        p.space.Name,
-			DataPath:    p.space.DataPath,
-			StorageKind: storage.FileStore,
-		}
-		require.Equal(t, &expected, info)
 	})
 }
 

--- a/zqd/handlers_test.go
+++ b/zqd/handlers_test.go
@@ -688,15 +688,7 @@ func TestSpaceDataDir(t *testing.T) {
 
 func TestCreateArchiveSpace(t *testing.T) {
 	thresh := int64(1000)
-	root := createTempDir(t)
-
-	c, client := newCoreAtDir(t, root)
-
-	c.Zeek = testLauncher(func(tzp *testPcapProcess) error {
-		const s = "unexpected attempt to run zeek"
-		t.Error(s)
-		return errors.New(s)
-	}, nil)
+	_, client := newCore(t)
 
 	sp, err := client.SpacePost(context.Background(), api.SpacePostRequest{
 		Name: "arktest",
@@ -733,11 +725,6 @@ func TestCreateArchiveSpace(t *testing.T) {
 `
 	res := searchTzng(t, client, sp.ID, "s=harefoot-raucous")
 	require.Equal(t, test.Trim(exptzng), res)
-
-	// Verify pcap post not supported
-	_, err = client.PcapPostStream(context.Background(), sp.ID, api.PcapPostRequest{"foo"})
-	require.Error(t, err)
-	assert.Regexp(t, "space does not support pcap import", err.Error())
 }
 
 func TestBlankNameSpace(t *testing.T) {

--- a/zqd/ingest/archivepcap.go
+++ b/zqd/ingest/archivepcap.go
@@ -198,9 +198,8 @@ type writeCounter struct {
 }
 
 func (w *writeCounter) Write(b []byte) (int, error) {
-	n, err := w.writer.Write(b)
-	atomic.AddInt64(&w.count, int64(n))
-	return n, err
+	atomic.AddInt64(&w.count, int64(len(b)))
+	return len(b), nil
 }
 
 func (w *writeCounter) Bytes() int64 {

--- a/zqd/ingest/archivepcap.go
+++ b/zqd/ingest/archivepcap.go
@@ -1,0 +1,245 @@
+package ingest
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"sync/atomic"
+
+	"github.com/brimsec/zq/driver"
+	"github.com/brimsec/zq/pkg/ctxio"
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/ndjsonio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zqd/api"
+	"github.com/brimsec/zq/zqd/pcapanalyzer"
+	"github.com/brimsec/zq/zqd/pcapstorage"
+	"github.com/brimsec/zq/zqd/storage"
+	"golang.org/x/sync/errgroup"
+)
+
+type archivePcapOp struct {
+	cleanupfns     []func()
+	err            error
+	done           chan struct{}
+	pcapuri        iosrc.URI
+	pcapstore      *pcapstorage.Store
+	store          storage.Storage
+	zeek, suricata pcapanalyzer.Launcher
+	zctx           *resolver.Context
+
+	// snap not used for archive store pcap ingest. Here for functional parity
+	// with legacyPcapOp. Can be removed once filestore has been deprecated
+	snap chan struct{}
+
+	// stat fields
+	startTime      nano.Ts
+	pcapBytesTotal int64
+	pcapBytesRead  int64
+	recordCounter  *recordCounter
+}
+
+func newArchivePcapOp(ctx context.Context, logstore storage.Storage, pcapstore *pcapstorage.Store, pcapuri iosrc.URI, suricata, zeek pcapanalyzer.Launcher) (PcapOp, []string, error) {
+	info, err := iosrc.Stat(ctx, pcapuri)
+	if err != nil {
+		return nil, nil, err
+	}
+	warn := make(chan string)
+	go func() {
+		err = pcapstore.Update(ctx, pcapuri, warn)
+		close(warn)
+	}()
+	var warnings []string
+	for w := range warn {
+		warnings = append(warnings, w)
+	}
+	if err != nil {
+		return nil, warnings, err
+	}
+	p := &archivePcapOp{
+		startTime:      nano.Now(),
+		pcapBytesTotal: info.Size(),
+		pcapstore:      pcapstore,
+		store:          logstore,
+		pcapuri:        pcapuri,
+		recordCounter:  &recordCounter{},
+		done:           make(chan struct{}),
+		snap:           make(chan struct{}),
+		suricata:       suricata,
+		zeek:           zeek,
+		zctx:           resolver.NewContext(),
+	}
+	go func() {
+		p.err = p.run(ctx)
+		for _, fn := range p.cleanupfns {
+			fn()
+		}
+		close(p.done)
+	}()
+	return p, warnings, nil
+}
+
+func (p *archivePcapOp) run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	pcapfile, err := iosrc.NewReader(ctx, p.pcapuri)
+	if err != nil {
+		return err
+	}
+	defer pcapfile.Close()
+	// Keeps track of bytes read from pcapfile.
+	r := io.TeeReader(pcapfile, p)
+
+	group, zreaders, err := p.runAnalyzers(ctx, r)
+	if err != nil {
+		return err
+	}
+	// track stats on records produced from analyzers.
+	p.recordCounter.reader = zbuf.NewCombiner(zreaders, zbuf.RecordCompare(p.store.NativeDirection()))
+
+	if err := p.store.Write(ctx, p.zctx, p.recordCounter); err != nil {
+		return err
+	}
+	return group.Wait()
+}
+
+func (p *archivePcapOp) runAnalyzers(ctx context.Context, pcapstream io.Reader) (*errgroup.Group, []zbuf.Reader, error) {
+	group, ctx := errgroup.WithContext(ctx)
+	var pipes []*io.PipeWriter
+	var zreaders []zbuf.Reader
+	if p.zeek != nil {
+		pw, dr, err := p.runAnalyzer(ctx, group, p.zeek)
+		if err != nil {
+			return nil, nil, err
+		}
+		pipes = append(pipes, pw)
+		zreaders = append(zreaders, dr)
+	}
+	if p.suricata != nil {
+		pw, dr, err := p.runAnalyzer(ctx, group, p.suricata)
+		if err != nil {
+			return nil, nil, err
+		}
+		pipes = append(pipes, pw)
+		// Suricata logs need flowgraph to rename timestamp fields into ts.
+		tr, err := driver.NewReader(ctx, suricataTransform, p.zctx, dr)
+		if err != nil {
+			return nil, nil, err
+		}
+		zreaders = append(zreaders, tr)
+	}
+	group.Go(func() error {
+		var writers []io.Writer
+		for _, p := range pipes {
+			writers = append(writers, p)
+		}
+		_, err := ctxio.Copy(ctx, io.MultiWriter(writers...), pcapstream)
+		// Once copy has completed, close pipe writers which will instruct the
+		// analyzer processes to exit.
+		for _, p := range pipes {
+			p.Close()
+		}
+		return err
+	})
+	return group, zreaders, nil
+}
+
+func (p *archivePcapOp) runAnalyzer(ctx context.Context, group *errgroup.Group, ln pcapanalyzer.Launcher) (*io.PipeWriter, zbuf.Reader, error) {
+	logdir, err := ioutil.TempDir("", "zqd-pcap-ingest-")
+	if err != nil {
+		return nil, nil, err
+	}
+	p.cleanup(func() { os.RemoveAll(logdir) })
+	pr, pw := io.Pipe()
+	waiter, err := ln(ctx, pr, logdir)
+	if err != nil {
+		return nil, nil, err
+	}
+	dr, err := newLogTailer(p.zctx, logdir, zio.ReaderOpts{
+		JSON: ndjsonio.ReaderOpts{TypeConfig: suricataTC},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	group.Go(func() error {
+		err := waiter.Wait()
+		// Analyzer has either encountered an error or recieved an EOF from the
+		// pcap stream. Tell DirReader to stop tail files, which will in turn
+		// cause an EOF on zbuf.Read stream when remaining data has been read.
+		if errs := dr.Stop(); err == nil {
+			err = errs
+		}
+		return err
+	})
+	return pw, dr, nil
+}
+
+func (p *archivePcapOp) Status() api.PcapPostStatus {
+	return api.PcapPostStatus{
+		Type:         "PcapPostStatus",
+		StartTime:    p.startTime,
+		UpdateTime:   nano.Now(),
+		PcapSize:     p.pcapBytesTotal,
+		PcapReadSize: atomic.LoadInt64(&p.pcapBytesRead),
+		RecordCount:  p.recordCounter.Records(),
+		RecordBytes:  p.recordCounter.Bytes(),
+	}
+}
+
+type recordCounter struct {
+	reader      zbuf.Reader
+	bytesRead   int64
+	recordsRead int64
+}
+
+func (r *recordCounter) Read() (*zng.Record, error) {
+	rec, err := r.reader.Read()
+	if rec != nil {
+		atomic.AddInt64(&r.bytesRead, int64(len(rec.Raw)))
+		atomic.AddInt64(&r.recordsRead, 1)
+	}
+	return rec, err
+}
+
+func (r *recordCounter) Bytes() int64 {
+	return atomic.LoadInt64(&r.bytesRead)
+}
+
+func (r *recordCounter) Records() int64 {
+	return atomic.LoadInt64(&r.recordsRead)
+}
+
+// Snap for archivePcapOp is functionally useless. It is only here to satisfy
+// the PcapOp interface. This will go away once filestore is deprecated.
+func (p *archivePcapOp) Snap() <-chan struct{} {
+	return p.snap
+}
+
+// Err returns the an error if an error occurred while the ingest process was
+// running. If the process is still running Err will wait for the process to
+// complete before returning.
+func (p *archivePcapOp) Err() error {
+	<-p.done
+	return p.err
+}
+
+func (p *archivePcapOp) cleanup(fn func()) {
+	p.cleanupfns = append(p.cleanupfns, fn)
+}
+
+// Done returns a chan that emits when the ingest process is complete.
+func (p *archivePcapOp) Done() <-chan struct{} {
+	return p.done
+}
+
+func (p *archivePcapOp) Write(b []byte) (int, error) {
+	n := len(b)
+	atomic.AddInt64(&p.pcapBytesRead, int64(n))
+	return n, nil
+}

--- a/zqd/ingest/archivepcap.go
+++ b/zqd/ingest/archivepcap.go
@@ -171,7 +171,7 @@ func (p *archivePcapOp) runAnalyzer(ctx context.Context, group *errgroup.Group, 
 	}
 	group.Go(func() error {
 		err := waiter.Wait()
-		// Analyzer has either encountered an error or recieved an EOF from the
+		// Analyzer has either encountered an error or received an EOF from the
 		// pcap stream. Tell DirReader to stop tail files, which will in turn
 		// cause an EOF on zbuf.Read stream when remaining data has been read.
 		if errs := dr.Stop(); err == nil {

--- a/zqd/ingest/archivepcap.go
+++ b/zqd/ingest/archivepcap.go
@@ -100,8 +100,10 @@ func (p *archivePcapOp) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	combiner := zbuf.NewCombiner(zreaders, zbuf.RecordCompare(p.store.NativeDirection()))
+	defer combiner.Close()
 	// track stats on records produced from analyzers.
-	p.recordCounter.reader = zbuf.NewCombiner(zreaders, zbuf.RecordCompare(p.store.NativeDirection()))
+	p.recordCounter.reader = combiner
 
 	if err := p.store.Write(ctx, p.zctx, p.recordCounter); err != nil {
 		return err

--- a/zqd/ingest/logtailer.go
+++ b/zqd/ingest/logtailer.go
@@ -1,0 +1,150 @@
+package ingest
+
+import (
+	"path/filepath"
+	"sync"
+
+	"github.com/brimsec/zq/pkg/fs"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/detector"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type result struct {
+	rec *zng.Record
+	err error
+}
+
+// logTailer is a zbuf.Reader that watches a specified directory and starts
+// tailing existing and new created files in the directory for new logs. Newly
+// written log data are transformed into *zng.Records and returned on a
+// first-come-first serve basis.
+type logTailer struct {
+	opts    zio.ReaderOpts
+	readers map[string]*fs.TFile
+	watcher *fs.DirWatcher
+	zctx    *resolver.Context
+
+	// synchronization primitives
+	results chan result
+	once    sync.Once
+	wg      sync.WaitGroup
+}
+
+func newLogTailer(zctx *resolver.Context, dir string, opts zio.ReaderOpts) (*logTailer, error) {
+	dir = filepath.Clean(dir)
+	watcher, err := fs.NewDirWatcher(dir)
+	if err != nil {
+		return nil, err
+	}
+	r := &logTailer{
+		opts:    opts,
+		readers: make(map[string]*fs.TFile),
+		results: make(chan result, 5),
+		watcher: watcher,
+		zctx:    zctx,
+	}
+	return r, nil
+}
+
+func (d *logTailer) start() {
+	var err error
+	for {
+		ev, ok := <-d.watcher.Events()
+		// Watcher closed. Enstruct all go routines to stop tailing files so
+		// they read remaining data then exit.
+		if !ok {
+			d.stopReaders(false)
+			break
+		}
+		if ev.Err != nil {
+			err = ev.Err
+			d.stopReaders(true)
+			break
+		}
+		if ev.Op.Exists() {
+			if terr := d.tailFile(ev.Name); terr != nil {
+				err = terr
+				d.stopReaders(true)
+				break
+			}
+		}
+	}
+	// Wait for all tail go routines to stop. We are about to close the results
+	// channel and do not want a write to closed channel panic.
+	d.wg.Wait()
+	// signfy EOS and close channel
+	d.results <- result{err: err}
+	close(d.results)
+}
+
+// stopReaders instructs all open TFile to stop tailing their respective files.
+// If close is set to false, the readers will read through the remaining data
+// in their files before emitting EOF. If close is set to true, the file
+// descriptors will be closed and no further data will be read.
+func (d *logTailer) stopReaders(close bool) {
+	for _, r := range d.readers {
+		if close {
+			r.Close()
+		}
+		r.Stop()
+	}
+}
+
+func (d *logTailer) tailFile(file string) error {
+	if _, ok := d.readers[file]; ok {
+		return nil
+	}
+	f, err := fs.TailFile(file)
+	if err == fs.ErrIsDir {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	d.readers[file] = f
+	d.wg.Add(1)
+	go func() {
+		zr, err := detector.OpenFromNamedReadCloser(d.zctx, f, file, d.opts)
+		if err != nil {
+			d.results <- result{err: err}
+			return
+		}
+		var res result
+		for {
+			res.rec, res.err = zr.Read()
+			if res.rec != nil || res.err != nil {
+				d.results <- res
+			}
+			if res.rec == nil || res.err != nil {
+				d.wg.Done()
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func (d *logTailer) Read() (*zng.Record, error) {
+	d.once.Do(func() { go d.start() })
+	res, ok := <-d.results
+	if !ok {
+		// already closed return EOS
+		return nil, nil
+	}
+	if res.err != nil {
+		d.watcher.Stop() // exits loop
+		// drain results
+		for range d.results {
+		}
+	}
+	return res.rec, res.err
+}
+
+// Stop instructs the directory watcher and indiviual file watchers to stop
+// watching for changes. Read() will emit EOS when the remaining unread data
+// in files has been read.
+func (d *logTailer) Stop() error {
+	return d.watcher.Stop()
+}

--- a/zqd/ingest/logtailer.go
+++ b/zqd/ingest/logtailer.go
@@ -51,7 +51,7 @@ func newLogTailer(zctx *resolver.Context, dir string, opts zio.ReaderOpts) (*log
 func (d *logTailer) start() {
 	var err error
 	for {
-		ev, ok := <-d.watcher.Events()
+		ev, ok := <-d.watcher.Events
 		// Watcher closed. Enstruct all go routines to stop tailing files so
 		// they read remaining data then exit.
 		if !ok {

--- a/zqd/ingest/logtailer.go
+++ b/zqd/ingest/logtailer.go
@@ -17,7 +17,7 @@ type result struct {
 }
 
 // logTailer is a zbuf.Reader that watches a specified directory and starts
-// tailing existing and new created files in the directory for new logs. Newly
+// tailing existing and newly created files in the directory for new logs. Newly
 // written log data are transformed into *zng.Records and returned on a
 // first-come-first serve basis.
 type logTailer struct {

--- a/zqd/ingest/logtailer_test.go
+++ b/zqd/ingest/logtailer_test.go
@@ -1,0 +1,160 @@
+package ingest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/brimsec/zq/driver"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/tzngio"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zql"
+	"github.com/stretchr/testify/suite"
+)
+
+var sortTs = zql.MustParseProc("sort ts")
+
+const expected = `#0:record[ts:time]
+0:[0;]
+0:[1;]
+0:[2;]
+0:[3;]
+0:[4;]
+0:[5;]
+0:[6;]
+0:[7;]
+0:[8;]
+0:[9;]
+0:[10;]
+0:[11;]
+0:[12;]
+0:[13;]
+0:[14;]
+0:[15;]
+0:[16;]
+0:[17;]
+0:[18;]
+0:[19;]
+`
+
+type logTailerTSuite struct {
+	suite.Suite
+	dir  string
+	zctx *resolver.Context
+	dr   *logTailer
+}
+
+func TestLogTailer(t *testing.T) {
+	suite.Run(t, new(logTailerTSuite))
+}
+
+func (s *logTailerTSuite) SetupTest() {
+	dir, err := ioutil.TempDir("", "TestLogTailer")
+	s.Require().NoError(err)
+	s.dir = dir
+	s.T().Cleanup(func() { os.RemoveAll(s.dir) })
+	s.zctx = resolver.NewContext()
+	s.dr, err = newLogTailer(s.zctx, s.dir, zio.ReaderOpts{Format: "tzng"})
+	s.Require().NoError(err)
+}
+
+func (s *logTailerTSuite) TestCreatedFiles() {
+	started, result, errCh := s.read()
+	<-started
+	f1 := s.createFile("test1.tzng")
+	f2 := s.createFile("test2.tzng")
+	s.write(f1, f2)
+	s.Require().NoError(<-errCh)
+	s.Equal(expected, <-result)
+}
+
+func (s *logTailerTSuite) TestIgnoreDir() {
+	started, result, errCh := s.read()
+	<-started
+	f1 := s.createFile("test1.tzng")
+	f2 := s.createFile("test2.tzng")
+	err := os.Mkdir(filepath.Join(s.dir, "testdir"), 0755)
+	s.Require().NoError(err)
+	s.write(f1, f2)
+	s.Require().NoError(<-errCh)
+	s.Equal(expected, <-result)
+}
+
+func (s *logTailerTSuite) TestExistingFiles() {
+	f1 := s.createFile("test1.tzng")
+	f2 := s.createFile("test2.tzng")
+	_, result, errCh := s.read()
+	s.write(f1, f2)
+	s.Require().NoError(<-errCh)
+	s.Equal(expected, <-result)
+}
+
+func (s *logTailerTSuite) TestInvalidFile() {
+	started, _, errCh := s.read()
+	<-started
+	f1 := s.createFile("test1.tzng")
+	_, err := f1.WriteString("#0:record[ts:time]\n")
+	s.Require().NoError(err)
+	_, err = f1.WriteString("this is an invalid line\n")
+	s.Require().NoError(err)
+	s.EqualError(<-errCh, "line 2: bad format")
+	s.NoError(s.dr.Stop())
+}
+
+func (s *logTailerTSuite) TestEmptyFile() {
+	_, result, errCh := s.read()
+	f1 := s.createFile("test1.tzng")
+	_ = s.createFile("test2.tzng")
+	s.write(f1)
+	s.Require().NoError(<-errCh)
+	s.Equal(expected, <-result)
+}
+
+func (s *logTailerTSuite) createFile(name string) *os.File {
+	f, err := os.Create(filepath.Join(s.dir, name))
+	s.Require().NoError(err)
+	// Call sync to ensure fs events are sent in a timely matter.
+	err = f.Sync()
+	s.Require().NoError(err)
+	return f
+}
+
+func (s *logTailerTSuite) read() (<-chan struct{}, <-chan string, <-chan error) {
+	started := make(chan struct{})
+	result := make(chan string)
+	errCh := make(chan error)
+	buf := bytes.NewBuffer(nil)
+	w := tzngio.NewWriter(zio.NopCloser(buf))
+	go func() {
+		close(started)
+		err := driver.Copy(context.Background(), w, sortTs, s.zctx, s.dr, driver.Config{})
+		if err != nil {
+			close(result)
+			errCh <- err
+		} else {
+			close(errCh)
+			result <- buf.String()
+		}
+	}()
+	return started, result, errCh
+}
+
+func (s *logTailerTSuite) write(files ...*os.File) {
+	for _, f := range files {
+		_, err := f.WriteString("#0:record[ts:time]\n")
+		s.Require().NoError(err)
+	}
+	for i := 0; i < 20; {
+		for _, f := range files {
+			_, err := f.WriteString(fmt.Sprintf("0:[%d;]\n", i))
+			s.Require().NoError(err)
+			i++
+		}
+	}
+	s.Require().NoError(s.dr.Stop())
+}

--- a/zqd/space/filespace.go
+++ b/zqd/space/filespace.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zqd/api"
-	"github.com/brimsec/zq/zqd/pcapstorage"
 	"github.com/brimsec/zq/zqe"
 )
 
@@ -28,10 +27,6 @@ func (s *fileSpace) Info(ctx context.Context) (api.SpaceInfo, error) {
 	si.Name = s.conf.Name
 	si.DataPath = s.dataURI()
 	return si, nil
-}
-
-func (s *fileSpace) PcapStore() *pcapstorage.Store {
-	return s.pcapstore
 }
 
 func (s *fileSpace) dataURI() iosrc.URI {

--- a/ztests/suite/zqd/archivestore/pcappost-suricata.yaml
+++ b/ztests/suite/zqd/archivestore/pcappost-suricata.yaml
@@ -1,0 +1,26 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new -k archivestore testsp 
+  zapi -h $ZQD_HOST -s testsp pcappost alerts.pcap >/dev/null
+  echo ===
+  zapi -h $ZQD_HOST -s testsp get -f tzng "event_type = alert | every 1s count()"
+  echo ===
+  zapi -h $ZQD_HOST -s testsp get -f tzng "_path != null | count()"
+
+inputs:
+  - name: alerts.pcap
+    source: ../alerts.pcap
+  - name: services.sh
+    source: ../services.sh
+
+outputs:
+  - name: stdout
+    data: |
+      testsp: space created
+      ===
+      #0:record[ts:time,count:uint64]
+      0:[1425568033;13;]
+      0:[1425567868;2;]
+      ===
+      #0:record[count:uint64]
+      0:[379;]

--- a/ztests/suite/zqd/archivestore/pcappost.yaml
+++ b/ztests/suite/zqd/archivestore/pcappost.yaml
@@ -1,0 +1,34 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new -k archivestore testsp
+  zapi -h $ZQD_HOST -s testsp pcappost ng.pcap >/dev/null
+  echo ===
+  zapi -h $ZQD_HOST -s testsp get -f tzng "_path != stats | cut -c uid | sort -r ts, _path"
+  echo ===
+  zapi -h $ZQD_HOST -s testsp get -f tzng "count()"
+
+inputs:
+  - name: ng.pcap
+    source: ../../pcap/ng.pcap
+  - name: services.sh
+    source: ../services.sh
+
+outputs:
+  - name: stdout
+    data: |
+      testsp: space created
+      ===
+      #0:record[_path:string,ts:time,ts_delta:duration,peer:bstring,gaps:uint64,acks:uint64,percent_lost:float64]
+      0:[capture_loss;1425568893.736974;0.001192;zeek;0;0;0;]
+      #port=uint16
+      #zenum=string
+      #1:record[_path:string,ts:time,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port],proto:zenum,service:bstring,duration:duration,orig_bytes:uint64,resp_bytes:uint64,conn_state:bstring,local_orig:bool,local_resp:bool,missed_bytes:uint64,history:bstring,orig_pkts:uint64,orig_ip_bytes:uint64,resp_pkts:uint64,resp_ip_bytes:uint64,tunnel_parents:set[bstring],geo:record[orig:record[country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64],resp:record[country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64]],community_id:bstring]
+      1:[conn;1425568893.735782;[192.168.0.2;34446;130.236.100.79;80;]tcp;-;0.001192;0;2776;OTH;-;-;0;Ad;1;52;2;2880;-;[[-;-;-;-;-;][SE;E;Linköping;58.4167;15.6167;]]1:tOxXSQENCvoWlZaDPdf9YgwpshQ=;]
+      0:[capture_loss;1425568893.735782;1460.943301;zeek;0;0;0;]
+      1:[conn;1425567432.792481;[192.168.0.51;50858;192.168.0.1;80;]tcp;-;0.00074;338;0;OTH;-;-;0;ADa;2;418;1;40;-;[[-;-;-;-;-;][-;-;-;-;-;]]1:YrhsMQd8siqxEOoc6A5E/gKZDgY=;]
+      1:[conn;1425567047.804914;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;[[-;-;-;-;-;][-;-;-;47;8;]]1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
+      1:[conn;1425567047.804906;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;[[-;-;-;-;-;][-;-;-;47;8;]]1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
+      1:[conn;1425567047.803929;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;[[-;-;-;-;-;][-;-;-;47;8;]]1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
+      ===
+      #0:record[count:uint64]
+      0:[10;]


### PR DESCRIPTION
Because of differences in how an archive ingests data implement
new ingest.PcapOp (ingest.archivePcapOp) for archive-backed spaces.

In order to take advantage of the streaming nature of ingest, abandon
the brute force snapshort approach taken with file stores. Instead,
temporary log files created by each pcap analyzer is are tailed and
written to the archive store as new data arrives (see fs.TFile and
Fs.DirWatcher).  As a result for pcap ingest on archive stores, new
data should constantly arriving.

In order to continue pcap ingest support for soon-to-be deprecated
filestore spaces, keep around existing ingest.PcapOp (renamed to
ingest.legacyPcapOp).

closes #1132