### PR TITLE
Remove reference to "top" in ZQL doc, for now

### DIFF
--- a/zql/docs/processors/README.md
+++ b/zql/docs/processors/README.md
@@ -280,22 +280,17 @@ conn  1521911720.607695 CpjMvj2Cvj048u6bF1 10.164.94.120 39169     10.47.3.200 8
 Compute a `total_bytes` field in `conn` records:
 
 ```zq-command
-zq -q -f table 'put total_bytes = orig_bytes + resp_bytes | top 10 total_bytes | cut id, orig_bytes, resp_bytes, total_bytes' conn.log.gz
+zq -q -f table 'put total_bytes = orig_bytes + resp_bytes | sort -r total_bytes | cut id, orig_bytes, resp_bytes, total_bytes' conn.log.gz
 ```
 
 #### Output:
-```zq-output
+```zq-output head:5
 ID.ORIG_H     ID.ORIG_P ID.RESP_H       ID.RESP_P ORIG_BYTES RESP_BYTES TOTAL_BYTES
 10.47.7.154   27300     52.216.132.61   443       859        1781771107 1781771966
 10.164.94.120 33691     10.47.3.200     80        355        1543916493 1543916848
 10.47.8.100   37110     128.101.240.215 80        16398      376626606  376643004
 10.47.3.151   11120     198.255.68.110  80        392        274063633  274064025
-10.47.1.155   56594     198.255.68.110  80        392        274063633  274064025
-10.47.5.155   40736     91.189.91.23    80        22706      141877415  141900121
-10.47.5.155   40726     91.189.91.23    80        23204      120752961  120776165
-10.47.8.100   37126     52.216.162.155  443       1213       105936976  105938189
-10.47.8.100   37127     52.216.162.155  443       1494       105936280  105937774
-10.47.5.155   40728     91.189.91.23    80        21396      98972170   98993566
+...
 ```
 
 ---


### PR DESCRIPTION
The `top` processor is not currently documented, as it's been cited how its name and functionality clash with `top` processors in other log search systems, and this has the potential to be confusing to users. We've got an open item to decide on whether we can rename it and reveal it, but it's not a high priority at the moment since the `sort`+`head` combo functionally gets the job done (indeed, we've seen users from a UNIX background reach for those naturally).

I recently became aware that this one reference to `top` does appear in the docs in the context of another processor, but the example can easily be adjusted to avoid `top` for now until we resolve our debate.