### PR TITLE
separate compilation for driver.Run calls

### DIFF
--- a/driver/compile.go
+++ b/driver/compile.go
@@ -3,16 +3,20 @@ package driver
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"runtime"
 	"strconv"
 	"time"
 
 	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/filter"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/proc/compiler"
 	"github.com/brimsec/zq/reducer"
 	rcompile "github.com/brimsec/zq/reducer/compile"
+	"github.com/brimsec/zq/scanner"
+	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"go.uber.org/zap"
 )
@@ -27,7 +31,80 @@ type Config struct {
 	Warnings          chan string
 }
 
-func compile(ctx context.Context, program ast.Proc, zctx *resolver.Context, msrc MultiSource, mcfg MultiConfig) (*muxOutput, error) {
+func programPrep(program ast.Proc, sortKey string, sortReversed bool) (ast.Proc, ast.BooleanExpr, filter.Filter, error) {
+	ReplaceGroupByProcDurationWithKey(program)
+	if sortKey != "" {
+		setGroupByProcInputSortDir(program, sortKey, zbufDirInt(sortReversed))
+	}
+	var filterExpr ast.BooleanExpr
+	var filt filter.Filter
+	filterExpr, program = liftFilter(program)
+	if filterExpr != nil {
+		var err error
+		if filt, err = filter.Compile(filterExpr); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	return program, filterExpr, filt, nil
+}
+
+type scannerProc struct {
+	scanner.Scanner
+}
+
+func (s *scannerProc) Done() {}
+
+type namedScanner struct {
+	scanner.Scanner
+	name string
+}
+
+func (n *namedScanner) Pull() (zbuf.Batch, error) {
+	b, err := n.Scanner.Pull()
+	if err != nil {
+		err = fmt.Errorf("%s: %w", n.name, err)
+	}
+	return b, err
+}
+
+func compileSingle(ctx context.Context, program ast.Proc, zctx *resolver.Context, r zbuf.Reader, cfg Config) (*muxOutput, error) {
+	if cfg.Logger == nil {
+		cfg.Logger = zap.NewNop()
+	}
+	if cfg.Span.Dur == 0 {
+		cfg.Span = nano.MaxSpan
+	}
+	if cfg.Warnings == nil {
+		cfg.Warnings = make(chan string, 5)
+	}
+
+	program, filterExpr, filt, err := programPrep(program, cfg.ReaderSortKey, cfg.ReaderSortReverse)
+	if err != nil {
+		return nil, err
+	}
+
+	sn, err := scanner.NewScanner(ctx, r, filt, filterExpr, cfg.Span)
+	if err != nil {
+		return nil, err
+	}
+	if stringer, ok := r.(fmt.Stringer); ok {
+		sn = &namedScanner{sn, stringer.String()}
+	}
+
+	pctx := &proc.Context{
+		Context:     ctx,
+		TypeContext: zctx,
+		Logger:      cfg.Logger,
+		Warnings:    cfg.Warnings,
+	}
+	leaves, err := compiler.Compile(cfg.Custom, program, pctx, []proc.Interface{&scannerProc{sn}})
+	if err != nil {
+		return nil, err
+	}
+	return newMuxOutput(pctx, leaves, sn), nil
+}
+
+func compileMulti(ctx context.Context, program ast.Proc, zctx *resolver.Context, msrc MultiSource, mcfg MultiConfig) (*muxOutput, error) {
 	if mcfg.Logger == nil {
 		mcfg.Logger = zap.NewNop()
 	}
@@ -41,14 +118,11 @@ func compile(ctx context.Context, program ast.Proc, zctx *resolver.Context, msrc
 		mcfg.Parallelism = runtime.GOMAXPROCS(0)
 	}
 
-	ReplaceGroupByProcDurationWithKey(program)
-
 	sortKey, sortReversed := msrc.OrderInfo()
-	if sortKey != "" {
-		setGroupByProcInputSortDir(program, sortKey, zbufDirInt(sortReversed))
+	program, filterExpr, filt, err := programPrep(program, sortKey, sortReversed)
+	if err != nil {
+		return nil, err
 	}
-	var filterExpr ast.BooleanExpr
-	filterExpr, program = liftFilter(program)
 
 	var isParallel bool
 	if mcfg.Parallelism > 1 {
@@ -64,7 +138,7 @@ func compile(ctx context.Context, program ast.Proc, zctx *resolver.Context, msrc
 		Logger:      mcfg.Logger,
 		Warnings:    mcfg.Warnings,
 	}
-	sources, pgroup, err := createParallelGroup(pctx, filterExpr, msrc, mcfg)
+	sources, pgroup, err := createParallelGroup(pctx, filt, filterExpr, msrc, mcfg)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/multi.go
+++ b/driver/multi.go
@@ -2,7 +2,6 @@ package driver
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/proc/compiler"
 	"github.com/brimsec/zq/scanner"
-	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"go.uber.org/zap"
 )
@@ -61,87 +59,9 @@ type MultiConfig struct {
 	Warnings    chan string
 }
 
-type oneSource struct {
-	r            zbuf.Reader
-	sortKey      string
-	sortReversed bool
-}
-
-func (o *oneSource) OrderInfo() (field string, reversed bool) {
-	return o.sortKey, o.sortReversed
-}
-
-func (o *oneSource) SendSources(ctx context.Context, _ *resolver.Context, sf SourceFilter, c chan SourceOpener) error {
-	scanner, err := scanner.NewScanner(ctx, o.r, sf.Filter, sf.FilterExpr, sf.Span)
-	if err != nil {
-		return err
-	}
-	if stringer, ok := o.r.(fmt.Stringer); ok {
-		scanner = &namedScanner{scanner, stringer.String()}
-	}
-	f := func() (ScannerCloser, error) {
-		return &scannerCloser{
-			Scanner: scanner,
-			Closer:  &onClose{},
-		}, nil
-	}
-	select {
-	case c <- f:
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-	return nil
-}
-
-func rdrToMulti(r zbuf.Reader, cfg Config) (MultiSource, MultiConfig) {
-	msrc := &oneSource{
-		r:            r,
-		sortKey:      cfg.ReaderSortKey,
-		sortReversed: cfg.ReaderSortReverse,
-	}
-	mcfg := MultiConfig{
-		Custom:      cfg.Custom,
-		Logger:      cfg.Logger,
-		Parallelism: 1,
-		Span:        cfg.Span,
-		StatsTick:   cfg.StatsTick,
-		Warnings:    cfg.Warnings,
-	}
-	return msrc, mcfg
-}
-
 func zbufDirInt(reversed bool) int {
 	if reversed {
 		return -1
 	}
 	return 1
-}
-
-type scannerCloser struct {
-	scanner.Scanner
-	io.Closer
-}
-
-type onClose struct {
-	fn func() error
-}
-
-func (c *onClose) Close() error {
-	if c.fn == nil {
-		return nil
-	}
-	return c.fn()
-}
-
-type namedScanner struct {
-	scanner.Scanner
-	name string
-}
-
-func (n *namedScanner) Pull() (zbuf.Batch, error) {
-	b, err := n.Scanner.Pull()
-	if err != nil {
-		err = fmt.Errorf("%s: %w", n.name, err)
-	}
-	return b, err
 }

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -157,14 +157,7 @@ func newCompareFn(field string, reversed bool) (zbuf.RecordCmpFn, error) {
 	}, nil
 }
 
-func createParallelGroup(pctx *proc.Context, filterExpr ast.BooleanExpr, msrc MultiSource, mcfg MultiConfig) ([]proc.Interface, *parallelGroup, error) {
-	var filt filter.Filter
-	if filterExpr != nil {
-		var err error
-		if filt, err = filter.Compile(filterExpr); err != nil {
-			return nil, nil, err
-		}
-	}
+func createParallelGroup(pctx *proc.Context, filt filter.Filter, filterExpr ast.BooleanExpr, msrc MultiSource, mcfg MultiConfig) ([]proc.Interface, *parallelGroup, error) {
 	pg := &parallelGroup{
 		pctx: pctx,
 		filter: SourceFilter{

--- a/driver/parallel_test.go
+++ b/driver/parallel_test.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type scannerCloser struct {
+	scanner.Scanner
+	io.Closer
+}
+
+type onClose struct {
+	fn func() error
+}
+
+func (c *onClose) Close() error {
+	if c.fn == nil {
+		return nil
+	}
+	return c.fn()
+}
 
 var parallelTestInputs []string = []string{
 	`


### PR DESCRIPTION
Instead of creating a fake multisource for calls to driver.Run, break
out the compilation for single reader vs multisource. This makes
upcoming changes to multisource easier to manage.

