### PR TITLE
Add a comment about why _uniq has a leading underscore

### DIFF
--- a/proc/uniq/uniq.go
+++ b/proc/uniq/uniq.go
@@ -25,13 +25,13 @@ func New(pctx *proc.Context, parent proc.Interface, cflag bool) *Proc {
 	}
 }
 
-// The leading underscore in "_uniq" is to avoid clashing with existing field
-// names. Reducers don't have this problem since ZQL has a way to assign
-// a field name to their returned result. At some point we could maybe add an
-// option like "-f foo" to set a field name, at which point we could safely
-// use a non-underscore field name by default, such as "count".
 func (p *Proc) wrap(t *zng.Record) *zng.Record {
 	if p.cflag {
+		// The leading underscore in "_uniq" is to avoid clashing with existing field
+		// names. Reducers don't have this problem since ZQL has a way to assign
+		// a field name to their returned result. At some point we could maybe add an
+		// option like "-f foo" to set a field name, at which point we could safely
+		// use a non-underscore field name by default, such as "count".
 		cols := []zng.Column{zng.NewColumn("_uniq", zng.TypeUint64)}
 		vals := []zng.Value{zng.NewUint64(p.count)}
 		newR, err := p.pctx.TypeContext.AddColumns(t, cols, vals)

--- a/proc/uniq/uniq.go
+++ b/proc/uniq/uniq.go
@@ -25,6 +25,11 @@ func New(pctx *proc.Context, parent proc.Interface, cflag bool) *Proc {
 	}
 }
 
+// The leading underscore in "_uniq" is to avoid clashing with existing field
+// names. Reducers don't have this problem since ZQL has a way to assign
+// a field name to their returned result. At some point we could maybe add an
+// option like "-f foo" to set a field name, at which point we could safely
+// use a non-underscore field name by default, such as "count".
 func (p *Proc) wrap(t *zng.Record) *zng.Record {
 	if p.cflag {
 		cols := []zng.Column{zng.NewColumn("_uniq", zng.TypeUint64)}


### PR DESCRIPTION
When recently looking at output for a ZQL query that contained `uniq -c`, I was puzzled by the leading underscore in the auto-generated field name `_uniq`, since by comparison with aggregate functions we have underscore-free default field names like `count` and `sum`. @mccanne was able to give me a very good explanation for why, so I thought I'd add a comment as a reminder to myself in case I forget and need to be reminded again in the future, or maybe for others who have the same question. Of course, the Go code is not my domain, so if I've polluted the beauty of what & how we comment, I'm prepared to be told to bug off and keep my notes-to-self elsewhere. 😄 