### PR TITLE
Link fixes mostly related to ZNG spec update

### DIFF
--- a/cmd/zar/README.md
+++ b/cmd/zar/README.md
@@ -134,7 +134,7 @@ which gives this somewhat cryptic result in text zng format:
 0:[conn;1521911721.307472;C4NuQHXpLAuXjndmi;[10.10.23.2;11;10.0.0.111;0;]icmp;-;1260.819589;23184;0;OTH;-;-;0;-;828;46368;0;0;-;]
 ```
 (If you want to learn more about this format, check out the
-[ZNG spec](https://github.com/brimsec/zq/blob/master/zng/docs/spec.md).)
+[ZNG spec](../../zng/docs/spec.md).)
 
 You might have noticed that this is kind of slow --- like all the counting above ---
 because every record is read to search for that IP.

--- a/zeek/README.md
+++ b/zeek/README.md
@@ -190,7 +190,7 @@ If you examine it in a JSON browser, you'll see that the type definition in
 specifies a `_path` of a unique Zeek event type, then names a corresponding
 `descriptor` configuration.
 2. A section of `descriptors` that define the expected the name and
-[ZNG](https://github.com/brimsec/zq/blob/master/zng/docs/spec.md)
+[ZNG](../zng/docs/spec.md)
 data type for each field in a Zeek event that was identified by a rule.
 
 Zeek's `_path` field plays an important role in this definition. `zq` will

--- a/zng/docs/compression-spec.md
+++ b/zng/docs/compression-spec.md
@@ -1,7 +1,7 @@
 # ZNG Compression Format Specification
 
 This document specifies values for the `<format>` field of a
-[ZNG compressed value message block](./spec.md#312-compressed-value-message-block
+[ZNG compressed value message block](spec.md#312-compressed-value-message-block)
 and the corresponding algorithms for the `<compressed-messages>` field.
 
 A `<format>` of `0` specifies that `<compressed-messages>` contains an

--- a/zng/docs/compression-spec.md
+++ b/zng/docs/compression-spec.md
@@ -1,7 +1,7 @@
 # ZNG Compression Format Specification
 
 This document specifies values for the `<format>` field of a
-[ZNG compressed value message block](./spec.md#313-compressed-value-message-block)
+[ZNG compressed value message block](./spec.md#312-compressed-value-message-block
 and the corresponding algorithms for the `<compressed-messages>` field.
 
 A `<format>` of `0` specifies that `<compressed-messages>` contains an

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -95,7 +95,7 @@ meta-records, and ZNG merely modernizes this original approach.
 The [`zq`](https://github.com/brimsec/zq) command-line tool provides a
 reference implementation of ZNG as it's described here, including the type
 system, error handling, etc., barring the exceptions
-described in the [alpha notice](#note-this-specification-is-alpha-and-a-work-in-progress)
+described in the [beta notice](#note-this-specification-is-in-beta-development)
 at the top of this specification.
 
 ## 2. The ZNG Data Model
@@ -645,7 +645,7 @@ Here, `<type-name>` is an identifier and `<type-string>`
 is a string defining a type (`<type>`) according to the [TZNG type grammar](#42-type-grammar). They create a
 binding between the indicated tag and the indicated type.
 This form defines an alias mapping the identifier to the indicated type.
-`<type-name>` is an identifier with semantics as defined in [Section 3.1.1.5](#3115-alias-typedef).
+`<type-name>` is an identifier with semantics as defined in [Section 3.1.1.7](#3117-alias-typedef).
 
 
 ### 4.1.3 Application-Defined Messages

--- a/zng/docs/zeek-compat.md
+++ b/zng/docs/zeek-compat.md
@@ -146,14 +146,14 @@ how Zeek's `enum` type behaves inside the Zeek scripting language,
 when the `enum` type is output in a Zeek log, the log does not communicate
 any such set of "allowed" values as they were originally defined. Therefore,
 when `zq` reads a Zeek `enum` into ZNG, it defines a
-[type alias](spec.md#412-type-alias) called `zenum` to use for such a field,
+[type alias](spec.md#3117-alias-typedef) called `zenum` to use for such a field,
 ultimately treating the value as if it were of the ZNG `string` type. The use
 of the alias maintains the history of the field having originally been read in
 from a Zeek `enum` field. This allows `zq` to restore the Zeek `enum` type
 if/when the field may be later output again in Zeek log format. However, when
 working with the value in ZQL, only `string`-type operations will be possible.
 
-As explained in the [alpha notice in the ZNG specification](spec.md#note-this-specification-is-alpha-and-a-work-in-progress), a true
+As explained in the [beta notice in the ZNG specification](spec.md#note-this-specification-is-in-beta-development), a true
 ZNG `enum` type with predefined values has not yet been defined in the spec
 nor implemented in `zq`. Once available in ZNG, Zeek could potentially
 offer direct log output in ZNG format that communicates the full definition of

--- a/zng/docs/zng-over-json.md
+++ b/zng/docs/zng-over-json.md
@@ -238,7 +238,7 @@ types that specifies the type of `<value>`, which is a JSON string or array
 as described recursively herein, and
 * each primitive is encoded as a string conforming to its TZNG representation,
 as described in the
-[corresponding section of the ZNG specification](https://github.com/brimsec/zq/blob/master/zng/docs/spec.md#5-primitive-types).
+[corresponding section of the ZNG specification](spec.md#5-primitive-types).
 
 For example, a record with three columns --- a string, an array of integers,
 and an array of union of string, and float64 --- might have a value that looks like this:

--- a/zst/README.md
+++ b/zst/README.md
@@ -1,7 +1,7 @@
 # Zst - *z*ng-*st*acked format
 
 Zst, pronounced "zest", is a format for columnar data based on
-[zng](https://github.com/brimsec/zq/blob/master/zng/docs/spec.md).
+[zng](../zng/docs/spec.md).
 Zst is the "stacked" version of zng, where the fields from a stream of
 zng records are stacked into vectors that form columns.
 
@@ -144,7 +144,7 @@ in a single pass.
 The data section contains raw data values organized into "segments",
 where a segment is simply a seek offset and byte length relative to the
 data section.  Each segment contains a sequence of
-[primitive-type zng values](https://github.com/brimsec/zq/blob/master/zng/docs/spec.md#5-primitive-types),
+[primitive-type zng values](../zng/docs/spec.md#5-primitive-types),
 encoded as counted-length byte sequences where the counted-length is
 variable-length encoded as in the zng spec.
 
@@ -178,7 +178,7 @@ Segments are sub-divided into frames where each frame is compressed
 independently of each other, similar to zng compression framing.
 
 > TBD: use the
-> [same compression format](https://github.com/brimsec/zq/blob/master/zng/docs/spec.md#313-compressed-value-message-block)
+> [same compression format](../zng/docs/spec.md#312-compressed-value-message-block)
 > exactly?
 
 > The intent here is that segments are sized so that sequential read access


### PR DESCRIPTION
While it's convenient to be able to link directly to anchors for specific sections in docs as we've been doing, one of the hazards is that when a destination changes, the link doesn't show up as "broken" by our automation because the user just ends up being redirected to the top of the page in question. #1394 renumbered some sections in the ZNG spec, so here I've manually rechecked relevant anchor links and made sure they go to the right places again.

While I was at it, I found some absolute URLs that I changed to be relative. This makes for better links when working in branches.