### PR TITLE
move chunk metadata from seek to data file name

### DIFF
--- a/archive/import.go
+++ b/archive/import.go
@@ -18,6 +18,7 @@ import (
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
+	"github.com/segmentio/ksuid"
 	"go.uber.org/multierr"
 )
 
@@ -122,13 +123,15 @@ func (iw *importWriter) close() error {
 // the archive.
 type tsDirWriter struct {
 	ark          *Archive
+	bufSize      int64
+	count        int64
 	ctx          context.Context
 	importWriter *importWriter
+	maxTs        nano.Ts
+	minTs        nano.Ts
 	records      []*zng.Record
-	bufSize      int64
 	spiller      *spill.MergeSort
 	tsDir        tsDir
-	uri          iosrc.URI
 }
 
 func newTsDirWriter(iw *importWriter, tsDir tsDir) (*tsDirWriter, error) {
@@ -137,10 +140,11 @@ func newTsDirWriter(iw *importWriter, tsDir tsDir) (*tsDirWriter, error) {
 		ctx:          iw.ctx,
 		importWriter: iw,
 		tsDir:        tsDir,
-		uri:          iw.ark.DataPath.AppendPath(dataDirname, tsDir.name()),
+		minTs:        nano.MaxTs,
+		maxTs:        nano.MinTs,
 	}
 	if dirmkr, ok := d.ark.dataSrc.(iosrc.DirMaker); ok {
-		if err := dirmkr.MkdirAll(d.uri, 0755); err != nil {
+		if err := dirmkr.MkdirAll(tsDir.path(iw.ark), 0755); err != nil {
 			return nil, err
 		}
 	}
@@ -164,6 +168,14 @@ func (dw *tsDirWriter) totalRecordBytes() int64 {
 
 func (dw *tsDirWriter) writeOne(rec *zng.Record) error {
 	dw.records = append(dw.records, rec)
+	ts := rec.Ts()
+	if ts < dw.minTs {
+		dw.minTs = ts
+	}
+	if ts > dw.maxTs {
+		dw.maxTs = ts
+	}
+	dw.count++
 	dw.addBufSize(int64(len(rec.Raw)))
 	if dw.totalRecordBytes() > dw.ark.LogSizeThreshold {
 		if err := dw.flush(); err != nil {
@@ -209,12 +221,19 @@ func (dw *tsDirWriter) flush() error {
 		}
 		expr.SortStable(dw.records, importCompareFn(dw.ark))
 		r = zbuf.Array(dw.records).NewReader()
-		defer func() {
-			dw.records = dw.records[:0]
-			dw.addBufSize(dw.bufSize * -1)
-		}()
 	}
-	w, err := newChunkWriter(dw.ctx, dw.ark, dw.uri)
+	first, last := dw.minTs, dw.maxTs
+	if dw.ark.DataSortDirection == zbuf.DirTimeReverse {
+		first, last = last, first
+	}
+	chunk := Chunk{
+		Id:          ksuid.New(),
+		First:       first,
+		Last:        last,
+		Kind:        FileKindData,
+		RecordCount: dw.count,
+	}
+	w, err := newChunkWriter(dw.ctx, dw.ark, dw.tsDir, chunk)
 	if err != nil {
 		return err
 	}
@@ -225,27 +244,29 @@ func (dw *tsDirWriter) flush() error {
 	if err := w.close(dw.ctx); err != nil {
 		return err
 	}
+	dw.records = dw.records[:0]
+	dw.addBufSize(dw.bufSize * -1)
+	dw.minTs = nano.MaxTs
+	dw.maxTs = nano.MinTs
+	dw.count = 0
 	return nil
 }
 
 // chunkWriter is a zbuf.Writer that writes a stream of sorted records into an
 // archive chunk file.
 type chunkWriter struct {
-	dataFile        dataFile
+	ark             *Archive
+	chunk           Chunk
 	dataFileWriter  *zngio.Writer
 	indexBuilder    *zng.Builder
 	indexTempPath   string
 	indexTempWriter *zngio.Writer
-
-	firstTs, lastTs nano.Ts
 	needIndexWrite  bool
-	rcount          int
-	uri             iosrc.URI
+	tsDir           tsDir
 }
 
-func newChunkWriter(ctx context.Context, ark *Archive, tsDirUri iosrc.URI) (*chunkWriter, error) {
-	dataFile := newDataFile()
-	out, err := ark.dataSrc.NewWriter(ctx, tsDirUri.AppendPath(dataFile.name()))
+func newChunkWriter(ctx context.Context, ark *Archive, tsDir tsDir, chunk Chunk) (*chunkWriter, error) {
+	out, err := ark.dataSrc.NewWriter(ctx, chunk.Path(ark))
 	if err != nil {
 		return nil, err
 	}
@@ -266,13 +287,14 @@ func newChunkWriter(ctx context.Context, ark *Archive, tsDirUri iosrc.URI) (*chu
 		{"offset", zng.TypeInt64},
 	}))
 	return &chunkWriter{
-		dataFile:        dataFile,
+		ark:             ark,
+		chunk:           chunk,
 		dataFileWriter:  dataFileWriter,
 		indexBuilder:    indexBuilder,
 		indexTempPath:   indexTempPath,
 		indexTempWriter: indexTempWriter,
-		uri:             tsDirUri,
 		needIndexWrite:  true,
+		tsDir:           tsDir,
 	}, nil
 }
 
@@ -284,13 +306,8 @@ func (cw *chunkWriter) Write(rec *zng.Record) error {
 	if err := cw.dataFileWriter.Write(rec); err != nil {
 		return err
 	}
-	cw.lastTs = rec.Ts()
-	if cw.firstTs == 0 {
-		cw.firstTs = cw.lastTs
-	}
-	cw.rcount++
 	if cw.needIndexWrite {
-		out := cw.indexBuilder.Build(zng.EncodeTime(cw.lastTs), zng.EncodeInt(sos))
+		out := cw.indexBuilder.Build(zng.EncodeTime(rec.Ts()), zng.EncodeInt(sos))
 		if err := cw.indexTempWriter.Write(out); err != nil {
 			return err
 		}
@@ -330,8 +347,7 @@ func (cw *chunkWriter) close(ctx context.Context) error {
 	}()
 	zctx := resolver.NewContext()
 	tfr := zngio.NewReader(tf, zctx)
-	sf := seekIndexFile{id: cw.dataFile.id, recordCount: cw.rcount, first: cw.firstTs, last: cw.lastTs}
-	idxURI := cw.uri.AppendPath(sf.name())
+	idxURI := cw.chunk.seekIndexPath(cw.ark)
 	idxWriter, err := microindex.NewWriter(zctx, idxURI.String(), []field.Static{field.New("ts")}, framesize)
 	if err != nil {
 		return err

--- a/archive/schema.go
+++ b/archive/schema.go
@@ -165,11 +165,11 @@ func openArchive(ctx context.Context, root iosrc.URI, oo *OpenOptions) (*Archive
 	}
 	if oo != nil {
 		for _, l := range oo.LogFilter {
-			df, ok := dataFileNameMatch(l)
+			c, ok := ChunkNameMatch(l)
 			if !ok {
-				return nil, zqe.E(zqe.Invalid, "log filter %s not a data filename", l)
+				return nil, zqe.E(zqe.Invalid, "log filter %s not a chunk file name", l)
 			}
-			ark.LogFilter = append(ark.LogFilter, df.id)
+			ark.LogFilter = append(ark.LogFilter, c.Id)
 		}
 	}
 

--- a/archive/walk.go
+++ b/archive/walk.go
@@ -127,7 +127,7 @@ func (l LogID) Path(ark *Archive) iosrc.URI {
 }
 
 // A Chunk is a file that holds records ordered according to the archive's
-// data order. The name of the file encodes the number of records it contains,
+// data order. The name of the file encodes the number of records it contains
 // and the timestamps of its first & last records. seekIndexPath returns the
 // path of an associated microindex written at import time, which can be used
 // to lookup a nearby seek offset for a desired timestamp.

--- a/archive/walk.go
+++ b/archive/walk.go
@@ -30,86 +30,6 @@ const (
 	FileKindSeek             = "ts"
 )
 
-// A dataFile holds archive record data. Only one kind of data file
-// currently exists, representing a file created during ingest.
-type dataFile struct {
-	id   ksuid.KSUID
-	kind FileKind
-}
-
-func newDataFile() dataFile {
-	return dataFile{ksuid.New(), FileKindData}
-}
-
-func (f dataFile) name() string {
-	return fmt.Sprintf("%s-%s.zng", f.kind, f.id)
-}
-
-var dataFileNameRegex = regexp.MustCompile(`d-([0-9A-Za-z]{27}).zng$`)
-
-func dataFileNameMatch(s string) (f dataFile, ok bool) {
-	match := dataFileNameRegex.FindStringSubmatch(s)
-	if match == nil {
-		return
-	}
-	id, err := ksuid.Parse(match[1])
-	if err != nil {
-		return
-	}
-	return dataFile{id, FileKindData}, true
-}
-
-// A seekIndexFile is a microindex whose keys are record timestamps, and whose
-// values are seek offsets into the data file with the same id. The name
-// of a seekIndexFile encodes the number of records, and the first & last
-// record timestamps of the corresponding data file. The order of the
-// first & last records matches the archive's data order.
-type seekIndexFile struct {
-	id          ksuid.KSUID
-	first       nano.Ts
-	last        nano.Ts
-	recordCount int
-}
-
-func (f seekIndexFile) name() string {
-	return fmt.Sprintf("%s-%s-%d-%d-%d.zng", FileKindSeek, f.id, f.recordCount, f.first, f.last)
-}
-
-func (f seekIndexFile) span() nano.Span {
-	return firstLastToSpan(f.first, f.last)
-}
-
-var seekIndexNameRegex = regexp.MustCompile(`ts-([0-9A-Za-z]{27})-([0-9]+)-([0-9]+)-([0-9]+).zng$`)
-
-func seekIndexNameMatch(s string) (f seekIndexFile, ok bool) {
-	match := seekIndexNameRegex.FindStringSubmatch(s)
-	if match == nil {
-		return
-	}
-	id, err := ksuid.Parse(match[1])
-	if err != nil {
-		return
-	}
-	recordCount, err := strconv.ParseInt(match[2], 10, 64)
-	if err != nil {
-		return
-	}
-	firstTs, err := strconv.ParseInt(match[3], 10, 64)
-	if err != nil {
-		return
-	}
-	lastTs, err := strconv.ParseInt(match[4], 10, 64)
-	if err != nil {
-		return
-	}
-	return seekIndexFile{
-		id:          id,
-		first:       nano.Ts(firstTs),
-		last:        nano.Ts(lastTs),
-		recordCount: int(recordCount),
-	}, true
-}
-
 // A tsDir is a directory found in the "<DataPath>/zd" directory of the archive,
 // and holds all of the data & associated files for a span of time, currently
 // fixed to a single day.
@@ -127,6 +47,10 @@ func parseTsDirName(name string) (tsDir, bool) {
 		return tsDir{}, false
 	}
 	return newTsDir(nano.TimeToTs(t)), true
+}
+
+func (t tsDir) path(ark *Archive) iosrc.URI {
+	return ark.DataPath.AppendPath(dataDirname, t.name())
 }
 
 func (t tsDir) name() string {
@@ -174,37 +98,19 @@ func tsDirVisit(ctx context.Context, ark *Archive, filterSpan nano.Span, visitor
 }
 
 func tsDirEntriesToChunks(ark *Archive, filterSpan nano.Span, entries []iosrc.Info) []Chunk {
-	dfileMap := make(map[ksuid.KSUID]dataFile)
-	sfileMap := make(map[ksuid.KSUID]seekIndexFile)
-	for _, e := range entries {
-		if df, ok := dataFileNameMatch(e.Name()); ok {
-			dfileMap[df.id] = df
-			continue
-		}
-		if sf, ok := seekIndexNameMatch(e.Name()); ok {
-			sfileMap[sf.id] = sf
-			continue
-		}
-	}
 	var chunks []Chunk
-	for id, sf := range sfileMap {
-		if !ark.filterAllowed(id) {
-			continue
-		}
-		if !filterSpan.Overlaps(sf.span()) {
-			continue
-		}
-		df, ok := dfileMap[id]
+	for _, e := range entries {
+		chunk, ok := ChunkNameMatch(e.Name())
 		if !ok {
 			continue
 		}
-		chunks = append(chunks, Chunk{
-			Id:           sf.id,
-			First:        sf.first,
-			Last:         sf.last,
-			DataFileKind: df.kind,
-			RecordCount:  sf.recordCount,
-		})
+		if !ark.filterAllowed(chunk.Id) {
+			continue
+		}
+		if !filterSpan.Overlaps(chunk.Span()) {
+			continue
+		}
+		chunks = append(chunks, chunk)
 	}
 	return chunks
 }
@@ -214,22 +120,63 @@ func tsDirEntriesToChunks(ark *Archive, filterSpan nano.Span, entries []iosrc.In
 // of the relative location of the file under the archive's root directory.
 type LogID string
 
-func newLogID(ts nano.Ts, id ksuid.KSUID) LogID {
-	return LogID(path.Join(dataDirname, newTsDir(ts).name(), fmt.Sprintf("%s-%s.zng", FileKindData, id)))
-}
-
 // Path returns the local filesystem path for the log file, using the
 // platforms file separator.
 func (l LogID) Path(ark *Archive) iosrc.URI {
 	return ark.DataPath.AppendPath(string(l))
 }
 
+// A Chunk is a file that holds records ordered according to the archive's
+// data order. The name of the file encodes the number of records it contains,
+// and the timestamps of its first & last records. seekIndexPath returns the
+// path of an associated microindex written at import time, which can be used
+// to lookup a nearby seek offset for a desired timestamp.
 type Chunk struct {
-	Id           ksuid.KSUID
-	First        nano.Ts
-	Last         nano.Ts
-	DataFileKind FileKind
-	RecordCount  int
+	Id          ksuid.KSUID
+	First       nano.Ts
+	Last        nano.Ts
+	Kind        FileKind
+	RecordCount int64
+}
+
+var chunkNameRegex = regexp.MustCompile(`d-([0-9A-Za-z]{27})-([0-9]+)-([0-9]+)-([0-9]+).zng$`)
+
+func ChunkNameMatch(s string) (c Chunk, ok bool) {
+	match := chunkNameRegex.FindStringSubmatch(s)
+	if match == nil {
+		return
+	}
+	id, err := ksuid.Parse(match[1])
+	if err != nil {
+		return
+	}
+	recordCount, err := strconv.ParseInt(match[2], 10, 64)
+	if err != nil {
+		return
+	}
+	firstTs, err := strconv.ParseInt(match[3], 10, 64)
+	if err != nil {
+		return
+	}
+	lastTs, err := strconv.ParseInt(match[4], 10, 64)
+	if err != nil {
+		return
+	}
+	return Chunk{
+		Id:          id,
+		First:       nano.Ts(firstTs),
+		Last:        nano.Ts(lastTs),
+		Kind:        FileKindData,
+		RecordCount: recordCount,
+	}, true
+}
+
+func (c Chunk) tsDir() tsDir {
+	return newTsDir(c.First)
+}
+
+func (c Chunk) seekIndexPath(ark *Archive) iosrc.URI {
+	return c.tsDir().path(ark).AppendPath(fmt.Sprintf("%s-%s.zng", FileKindSeek, c.Id))
 }
 
 func (c Chunk) Span() nano.Span {
@@ -237,7 +184,8 @@ func (c Chunk) Span() nano.Span {
 }
 
 func (c Chunk) LogID() LogID {
-	return LogID(path.Join(dataDirname, newTsDir(c.First).name(), fmt.Sprintf("%s-%s.zng", c.DataFileKind, c.Id)))
+	name := fmt.Sprintf("%s-%s-%d-%d-%d.zng", c.Kind, c.Id, c.RecordCount, c.First, c.Last)
+	return LogID(path.Join(dataDirname, newTsDir(c.First).name(), name))
 }
 
 // ZarDir returns a URI for a directory specific to this data file, expected

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -54,8 +54,8 @@ type Chunk struct {
 	Id          string  `json:"id" validate:"required"`
 	First       nano.Ts `json:"first" validate:"required"`
 	Last        nano.Ts `json:"last" validate:"required"`
-	FileKind    string  `json:"data_file_kind" validate:"required"`
-	RecordCount int     `json:"record_count" validate:"required"`
+	Kind        string  `json:"kind" validate:"required"`
+	RecordCount int64   `json:"record_count" validate:"required"`
 }
 
 type SearchRecords struct {

--- a/zqd/search/worker.go
+++ b/zqd/search/worker.go
@@ -43,7 +43,7 @@ func NewWorkerOp(req api.WorkerRequest) (*WorkerOp, error) {
 		chunks[i].Id = id
 		chunks[i].First = chunk.First
 		chunks[i].Last = chunk.Last
-		chunks[i].DataFileKind = archive.FileKind(chunk.FileKind)
+		chunks[i].Kind = archive.FileKind(chunk.Kind)
 		chunks[i].RecordCount = chunk.RecordCount
 	}
 

--- a/ztests/suite/zqd/worker-count.yaml
+++ b/ztests/suite/zqd/worker-count.yaml
@@ -15,18 +15,7 @@ script: |
   # it does not matter which one.
   #
   ZNG_FILE_PATH=$(find . -name "d-*.zng" -print | head -1)
-  #
-  # The ksuid is embedded in the filename, and it can be
-  # used to find the "matching" TS file, which will have all
-  # the information we need to do a zapi get with the -chunk flag
-  #
-  KSUID=$(echo $ZNG_FILE_PATH \
-    | awk '{split($0,a,"/d-"); print a[2]}' \
-    | awk '{split($0,a,"\.zng"); print a[1]}')
-  TS_FILE_PATH=$(find . -name "ts-${KSUID}*.zng" -print)
-  CHUNK_INFO=d-$(echo $TS_FILE_PATH \
-    | awk '{split($0,a,"/ts-"); print a[2]}' \
-    | awk '{split($0,a,"\.zng"); print a[1]}')
+  CHUNK_INFO=$(basename $ZNG_FILE_PATH)
   #
   # The count() from zq should be identical to 
   # the count() from zapi get -chunk


### PR DESCRIPTION
With the recent changes in archive.Import, when we create a new data file, we know the first & last record timestamps & record count. So we no longer need to encode that information in the seek file name, which simplifies the walk code that parses file names & identifies chunks.

Closes #1448 