### PR TITLE
change error to ErrNoSuchField accessing field of non-record

### DIFF
--- a/expr/fieldexpr.go
+++ b/expr/fieldexpr.go
@@ -38,7 +38,7 @@ func newFieldNode(field string, record Evaluator, root bool) *FieldExpr {
 func accessField(record zng.Value, field string) (zng.Value, error) {
 	recType, ok := record.Type.(*zng.TypeRecord)
 	if !ok {
-		return zng.Value{}, ErrIncompatibleTypes
+		return zng.Value{}, ErrNoSuchField
 	}
 	idx, ok := recType.ColumnOfField(field)
 	if !ok {

--- a/proc/groupby/ztests/mixed-type-key.yaml
+++ b/proc/groupby/ztests/mixed-type-key.yaml
@@ -1,0 +1,14 @@
+zql: 'count() by id.orig_h | sort id'
+
+input: |
+  #port=uint16
+  #0:record[_path:string,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port]]
+  0:[weird;[10.47.1.152;49562;23.217.103.245;80;]]
+  #1:record[_path:string,id:bstring]
+  1:[x509;FYNFkU3KccxXgIuUg5;]
+  0:[weird;[10.47.5.155;40712;91.189.91.23;80;]]
+
+output: |
+  #0:record[id:record[orig_h:ip],count:uint64]
+  0:[[10.47.1.152;]1;]
+  0:[[10.47.5.155;]1;]


### PR DESCRIPTION
This commit changes the dot accessor expression to return a
no-such-field error consistent with behavior prior to the
expr package overhaul.  This is important because group-by
gladly ignores keys that don't exist and should do so in the
case of accessing fields in data types that don't happen to
be a record.  This is a feature of the robust way zq/zng
handles queries over heterogeneously typed records.

Fixes #1415 
