### PR TITLE
Remove *Literal case in expr.DotExprToField

### DIFF
--- a/expr/dot.go
+++ b/expr/dot.go
@@ -77,8 +77,6 @@ func DotExprToField(e Evaluator) (field.Static, error) {
 			return nil, err
 		}
 		return append(lhs, e.field), nil
-	case *Literal:
-		return field.New(e.zv.String()), nil
 	case *Index:
 		lhs, err := DotExprToField(e.container)
 		if err != nil {


### PR DESCRIPTION
It's an unused and unwanted remnant of expr.DotExprToField's previous
life as expr.FieldExprToString.