### PR TITLE
add union aggregator

### DIFF
--- a/proc/groupby/row.go
+++ b/proc/groupby/row.go
@@ -19,11 +19,11 @@ type valCol struct {
 
 type valRow []valCol
 
-func newValRow(makers []reducerMaker) valRow {
+func newValRow(zctx *resolver.Context, makers []reducerMaker) valRow {
 	cols := make([]valCol, 0, len(makers))
 	for _, maker := range makers {
 		e := expr.NewDotExpr(maker.name)
-		cols = append(cols, valCol{maker.name, e, maker.create()})
+		cols = append(cols, valCol{maker.name, e, maker.create(zctx)})
 	}
 	return cols
 }
@@ -40,7 +40,8 @@ func (v valRow) ConsumePart(rec *zng.Record) error {
 		if !ok {
 			return errors.New("reducer row doesn't decompose")
 		}
-		v, err := col.nameExpr.Eval(rec)
+		resolver := col.nameExpr
+		v, err := resolver.Eval(rec)
 		if err != nil {
 			return err
 		}

--- a/proc/groupby/row.go
+++ b/proc/groupby/row.go
@@ -40,8 +40,7 @@ func (v valRow) ConsumePart(rec *zng.Record) error {
 		if !ok {
 			return errors.New("reducer row doesn't decompose")
 		}
-		resolver := col.nameExpr
-		v, err := resolver.Eval(rec)
+		v, err := col.nameExpr.Eval(rec)
 		if err != nil {
 			return err
 		}

--- a/reducer/reducer.go
+++ b/reducer/reducer.go
@@ -14,6 +14,11 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 )
 
+// MaxValueSize is a limit on an individual aggregation value since sets
+// and arrays could otherwise grow without limit leading to a single record
+// value that cannot fit in memory.
+const MaxValueSize = 20 * 1024 * 1024
+
 var (
 	ErrBadValue      = errors.New("bad value")
 	ErrFieldRequired = errors.New("field parameter required")
@@ -35,6 +40,7 @@ type Decomposable interface {
 type Stats struct {
 	TypeMismatch  int64
 	FieldNotFound int64
+	MemExceeded   int64
 }
 
 type Reducer struct {

--- a/reducer/reducer_test.go
+++ b/reducer/reducer_test.go
@@ -36,13 +36,13 @@ func parse(zctx *resolver.Context, src string) (zbuf.Array, error) {
 // partial results into a second reducer, and feed any remaining
 // records into that reducer.
 func runOne(t *testing.T, zctx *resolver.Context, create reducer.Maker, i int, recs []*zng.Record) zng.Value {
-	red := create().(reducer.Decomposable)
+	red := create(zctx).(reducer.Decomposable)
 	for _, rec := range recs[:i] {
 		red.Consume(rec)
 	}
 	part, err := red.ResultPart(zctx)
 	require.NoError(t, err)
-	red = create().(reducer.Decomposable)
+	red = create(zctx).(reducer.Decomposable)
 	err = red.ConsumePart(part)
 	require.NoError(t, err)
 	for _, rec := range recs[i:] {

--- a/reducer/reducer_test.go
+++ b/reducer/reducer_test.go
@@ -56,11 +56,11 @@ func runOne(t *testing.T, zctx *resolver.Context, create reducer.Maker, i int, r
 func runMany(t *testing.T, zctx *resolver.Context, create reducer.Maker, recs []*zng.Record) zng.Value {
 	var reds []reducer.Decomposable
 	for i := range recs {
-		red := create().(reducer.Decomposable)
+		red := create(zctx).(reducer.Decomposable)
 		red.Consume(recs[i])
 		reds = append(reds, red)
 	}
-	composer := create().(reducer.Decomposable)
+	composer := create(zctx).(reducer.Decomposable)
 	for i := range recs {
 		part, err := reds[i].ResultPart(zctx)
 		require.NoError(t, err)

--- a/reducer/union.go
+++ b/reducer/union.go
@@ -55,14 +55,14 @@ func (u *Union) update(b zcode.Bytes) {
 
 func (u *Union) deleteOne() {
 	for key := range u.val {
-		u.size -= len([]byte(key))
+		u.size -= len(key)
 		delete(u.val, key)
 		return
 	}
 }
 
 func (u *Union) Result() zng.Value {
-	b := zcode.NewBuilder()
+	var b zcode.Builder
 	container := zng.IsContainerType(u.typ)
 	for s, _ := range u.val {
 		if container {

--- a/reducer/union.go
+++ b/reducer/union.go
@@ -1,0 +1,71 @@
+package reducer
+
+import (
+	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type Union struct {
+	Reducer
+	zctx *resolver.Context
+	arg  expr.Evaluator
+	typ  zng.Type
+	set  map[string]struct{}
+}
+
+func newUnion(zctx *resolver.Context, arg, where expr.Evaluator) *Union {
+	return &Union{
+		Reducer: Reducer{where: where},
+		zctx:    zctx,
+		arg:     arg,
+		set:     make(map[string]struct{}),
+	}
+}
+
+func (u *Union) Consume(r *zng.Record) {
+	if u.filter(r) {
+		return
+	}
+	v, err := u.arg.Eval(r)
+	if err != nil || v.IsNil() {
+		return
+	}
+	if u.typ == nil {
+		u.typ = v.Type
+	} else if u.typ != v.Type {
+		u.TypeMismatch++
+		return
+	}
+	u.set[string(v.Bytes)] = struct{}{}
+}
+
+func (u *Union) Result() zng.Value {
+	b := zcode.NewBuilder()
+	container := zng.IsContainerType(u.typ)
+	for s, _ := range u.set {
+		if container {
+			b.AppendContainer([]byte(s))
+		} else {
+			b.AppendPrimitive([]byte(s))
+		}
+	}
+	setType := u.zctx.LookupTypeSet(u.typ)
+	return zng.Value{setType, zng.NormalizeSet(b.Bytes())}
+}
+
+func (u *Union) ConsumePart(zv zng.Value) error {
+	for it := zv.Iter(); !it.Done(); {
+		elem, _, err := it.NextTagAndBody()
+		if err != nil {
+			return err
+		}
+		u.set[string(elem)] = struct{}{}
+	}
+	return nil
+}
+
+func (u *Union) ResultPart(*resolver.Context) (zng.Value, error) {
+	return u.Result(), nil
+}

--- a/reducer/union.go
+++ b/reducer/union.go
@@ -55,7 +55,7 @@ func (u *Union) update(b zcode.Bytes) {
 
 func (u *Union) deleteOne() {
 	for key := range u.val {
-		u.size -= len(key)
+		u.size -= len([]byte(key))
 		delete(u.val, key)
 		return
 	}

--- a/reducer/ztests/union-rec.yaml
+++ b/reducer/ztests/union-rec.yaml
@@ -1,0 +1,14 @@
+zql: 's=union(.) | put n=len(s)'
+
+input: |
+  #0:record[x:int32]
+  0:[1;]
+  0:[-1;]
+  0:[2;]
+  0:[1;]
+  0:[8;]
+  0:[1;]
+
+output: |
+  #0:record[s:set[record[x:int32]],n:int64]
+  0:[[[1;][-1;][2;][8;]]4;]

--- a/reducer/ztests/union-spill.yaml
+++ b/reducer/ztests/union-spill.yaml
@@ -1,0 +1,19 @@
+script: |
+  zq -t -fusemem 1B "union(x)" in.tzng
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[x:int32]
+      0:[1;]
+      0:[-1;]
+      0:[2;]
+      0:[1;]
+      0:[8;]
+      0:[1;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[union:set[int32]]
+      0:[[1;-1;2;8;]]

--- a/reducer/ztests/union.yaml
+++ b/reducer/ztests/union.yaml
@@ -1,0 +1,14 @@
+zql: 'union(x)'
+
+input: |
+  #0:record[x:int32]
+  0:[1;]
+  0:[-1;]
+  0:[2;]
+  0:[1;]
+  0:[8;]
+  0:[1;]
+
+output: |
+  #0:record[union:set[int32]]
+  0:[[1;-1;2;8;]]


### PR DESCRIPTION
This commit adds a union aggregator that takes union over all of its
input values and produces a value of type set of this computed union.
The type of the input values must be uniform.