### PR TITLE
add collect aggregator

### DIFF
--- a/reducer/collect.go
+++ b/reducer/collect.go
@@ -1,0 +1,72 @@
+package reducer
+
+import (
+	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type Collect struct {
+	Reducer
+	zctx *resolver.Context
+	arg  expr.Evaluator
+	typ  zng.Type
+	val  []zcode.Bytes
+	size int
+}
+
+func (c *Collect) Consume(r *zng.Record) {
+	if c.filter(r) {
+		return
+	}
+	v, err := c.arg.Eval(r)
+	if err != nil || v.IsNil() {
+		return
+	}
+	if c.typ == nil {
+		c.typ = v.Type
+	} else if c.typ != v.Type {
+		c.TypeMismatch++
+		return
+	}
+	c.update(v.Bytes)
+}
+
+func (c *Collect) update(b zcode.Bytes) {
+	c.val = append(c.val, b)
+	c.size += len(b)
+	for c.size > MaxValueSize {
+		c.size -= len(c.val[0])
+		c.val = c.val[1:]
+	}
+}
+
+func (c *Collect) Result() zng.Value {
+	b := zcode.NewBuilder()
+	container := zng.IsContainerType(c.typ)
+	for _, item := range c.val {
+		if container {
+			b.AppendContainer(item)
+		} else {
+			b.AppendPrimitive(item)
+		}
+	}
+	typ := c.zctx.LookupTypeArray(c.typ)
+	return zng.Value{typ, b.Bytes()}
+}
+
+func (c *Collect) ConsumePart(zv zng.Value) error {
+	for it := zv.Iter(); !it.Done(); {
+		elem, _, err := it.NextTagAndBody()
+		if err != nil {
+			return err
+		}
+		c.update(elem)
+	}
+	return nil
+}
+
+func (c *Collect) ResultPart(*resolver.Context) (zng.Value, error) {
+	return c.Result(), nil
+}

--- a/reducer/collect.go
+++ b/reducer/collect.go
@@ -43,7 +43,7 @@ func (c *Collect) update(b zcode.Bytes) {
 }
 
 func (c *Collect) Result() zng.Value {
-	b := zcode.NewBuilder()
+	var b zcode.Builder
 	container := zng.IsContainerType(c.typ)
 	for _, item := range c.val {
 		if container {

--- a/reducer/reducer.go
+++ b/reducer/reducer.go
@@ -102,6 +102,10 @@ func NewMaker(op string, arg, where expr.Evaluator) (Maker, error) {
 		return func(zctx *resolver.Context) Interface {
 			return newUnion(zctx, arg, where)
 		}, nil
+	case "collect":
+		return func(zctx *resolver.Context) Interface {
+			return &Collect{Reducer: r, zctx: zctx, arg: arg}
+		}, nil
 	default:
 		return nil, fmt.Errorf("unknown reducer op: %s", op)
 	}

--- a/reducer/ztests/collect.yaml
+++ b/reducer/ztests/collect.yaml
@@ -1,0 +1,14 @@
+zql: 'collect(x)'
+
+input: |
+  #0:record[x:int32]
+  0:[1;]
+  0:[-1;]
+  0:[2;]
+  0:[1;]
+  0:[8;]
+  0:[1;]
+
+output: |
+  #0:record[collect:array[int32]]
+  0:[[1;-1;2;1;8;1;]]


### PR DESCRIPTION
This commit adds an aggregator called "collect" that assembles its input 
into an array.

This is needed in the beacon work.

