### PR TITLE
fix bug with groupby ast

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -268,13 +268,13 @@ type (
 	// if any reducer in Reducers is non-decomposable.
 	GroupByProc struct {
 		Node
-		Duration     Duration     `json:"duration"`
+		Duration     Duration     `json:"duration,omitempty"`
 		InputSortDir int          `json:"input_sort_dir,omitempty"`
 		Limit        int          `json:"limit,omitempty"`
-		Keys         []Assignment `json:"keys"`
-		Reducers     []Assignment `json:"reducers"`
-		ConsumePart  bool         `json:"consume_part"`
-		EmitPart     bool         `json:"emit_part"`
+		Keys         []Assignment `json:"keys,omitempty"`
+		Reducers     []Assignment `json:"reducers,omitempty"`
+		ConsumePart  bool         `json:"consume_part,omitempty"`
+		EmitPart     bool         `json:"emit_part,omitempty"`
 	}
 	// TopProc is similar to proc.SortProc with a few key differences:
 	// - It only sorts in descending order.

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -478,20 +478,17 @@ function peg$parse(input, options) {
             return result
           },
       peg$c99 = function(every, reducers, keys, limit) {
-          if (OR(keys, every)) {
-            if (keys) {
-              keys = keys[1];
-            } else {
-              keys = [];
-            }
-
-            if (every) {
-              every = every[0];
-            }
-
-            return {"op": "GroupByProc", "duration": every, "limit": limit, "keys": keys, "reducers": reducers}
+          let p = {"op": "GroupByProc", "reducers": reducers};
+          if (keys) {
+            p["keys"] = keys;
           }
-          return {"op": "GroupByProc", "reducers": reducers}
+          if (every) {
+            p["duration"] = every;
+          }
+          if (limit) {
+            p["limit"] = limit;
+          }
+          return p
         },
       peg$c100 = "=",
       peg$c101 = peg$literalExpectation("=", false),
@@ -2256,24 +2253,30 @@ function peg$parse(input, options) {
   }
 
   function peg$parsegroupByKeys() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c60) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c61); }
-    }
+    s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c60) {
+        s2 = input.substr(peg$currPos, 2);
+        peg$currPos += 2;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+      }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseFlexAssignments();
+        s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c62(s3);
-          s0 = s1;
+          s4 = peg$parseFlexAssignments();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c62(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2402,24 +2405,30 @@ function peg$parse(input, options) {
   }
 
   function peg$parseeveryDur() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c68) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
-    }
+    s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c68) {
+        s2 = input.substr(peg$currPos, 5);
+        peg$currPos += 5;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c69); }
+      }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseduration();
+        s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c70(s3);
-          s0 = s1;
+          s4 = peg$parseduration();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c70(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -3021,45 +3030,17 @@ function peg$parse(input, options) {
   }
 
   function peg$parsegroupByProc() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$currPos;
-    s2 = peg$parseeveryDur();
-    if (s2 !== peg$FAILED) {
-      s3 = peg$parse_();
-      if (s3 !== peg$FAILED) {
-        s2 = [s2, s3];
-        s1 = s2;
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s1;
-      s1 = peg$FAILED;
-    }
+    s1 = peg$parseeveryDur();
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsereducerList();
       if (s2 !== peg$FAILED) {
-        s3 = peg$currPos;
-        s4 = peg$parse_();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parsegroupByKeys();
-          if (s5 !== peg$FAILED) {
-            s4 = [s4, s5];
-            s3 = s4;
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
+        s3 = peg$parsegroupByKeys();
         if (s3 === peg$FAILED) {
           s3 = null;
         }
@@ -7809,10 +7790,6 @@ function peg$parse(input, options) {
 
   function joinChars(chars) {
     return chars.join("");
-  }
-
-  function OR(a, b) {
-    return a || b
   }
 
   function makeUnicodeChar(chars) {

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -2408,22 +2408,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parse_();
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c68) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c69); }
+    }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c68) {
-        s2 = input.substr(peg$currPos, 5);
-        peg$currPos += 5;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c69); }
-      }
+      s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
+        s3 = peg$parseduration();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseduration();
+          s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c70(s4);
+            s1 = peg$c70(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -1372,26 +1372,26 @@ var g = &grammar{
 				expr: &seqExpr{
 					pos: position{line: 209, col: 5, offset: 6801},
 					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 209, col: 5, offset: 6801},
-							name: "_",
-						},
 						&litMatcher{
-							pos:        position{line: 209, col: 7, offset: 6803},
+							pos:        position{line: 209, col: 5, offset: 6801},
 							val:        "every",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 209, col: 16, offset: 6812},
+							pos:  position{line: 209, col: 14, offset: 6810},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 209, col: 18, offset: 6814},
+							pos:   position{line: 209, col: 16, offset: 6812},
 							label: "dur",
 							expr: &ruleRefExpr{
-								pos:  position{line: 209, col: 22, offset: 6818},
+								pos:  position{line: 209, col: 20, offset: 6816},
 								name: "duration",
 							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 209, col: 29, offset: 6825},
+							name: "_",
 						},
 					},
 				},

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -1255,20 +1255,24 @@ var g = &grammar{
 				expr: &seqExpr{
 					pos: position{line: 194, col: 5, offset: 6186},
 					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 194, col: 5, offset: 6186},
+							name: "_",
+						},
 						&litMatcher{
-							pos:        position{line: 194, col: 5, offset: 6186},
+							pos:        position{line: 194, col: 7, offset: 6188},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 194, col: 11, offset: 6192},
+							pos:  position{line: 194, col: 13, offset: 6194},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 194, col: 13, offset: 6194},
+							pos:   position{line: 194, col: 15, offset: 6196},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 194, col: 21, offset: 6202},
+								pos:  position{line: 194, col: 23, offset: 6204},
 								name: "FlexAssignments",
 							},
 						},
@@ -1278,22 +1282,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 199, col: 1, offset: 6481},
+			pos:  position{line: 199, col: 1, offset: 6483},
 			expr: &choiceExpr{
-				pos: position{line: 200, col: 5, offset: 6500},
+				pos: position{line: 200, col: 5, offset: 6502},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 200, col: 5, offset: 6500},
+						pos:  position{line: 200, col: 5, offset: 6502},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 201, col: 5, offset: 6515},
+						pos: position{line: 201, col: 5, offset: 6517},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 201, col: 5, offset: 6515},
+							pos:   position{line: 201, col: 5, offset: 6517},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 201, col: 10, offset: 6520},
+								pos:  position{line: 201, col: 10, offset: 6522},
 								name: "Expression",
 							},
 						},
@@ -1303,50 +1307,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 203, col: 1, offset: 6604},
+			pos:  position{line: 203, col: 1, offset: 6606},
 			expr: &actionExpr{
-				pos: position{line: 204, col: 5, offset: 6624},
+				pos: position{line: 204, col: 5, offset: 6626},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 204, col: 5, offset: 6624},
+					pos: position{line: 204, col: 5, offset: 6626},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 204, col: 5, offset: 6624},
+							pos:   position{line: 204, col: 5, offset: 6626},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 204, col: 11, offset: 6630},
+								pos:  position{line: 204, col: 11, offset: 6632},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 204, col: 26, offset: 6645},
+							pos:   position{line: 204, col: 26, offset: 6647},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 204, col: 31, offset: 6650},
+								pos: position{line: 204, col: 31, offset: 6652},
 								expr: &actionExpr{
-									pos: position{line: 204, col: 32, offset: 6651},
+									pos: position{line: 204, col: 32, offset: 6653},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 204, col: 32, offset: 6651},
+										pos: position{line: 204, col: 32, offset: 6653},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 204, col: 32, offset: 6651},
+												pos:  position{line: 204, col: 32, offset: 6653},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 204, col: 35, offset: 6654},
+												pos:        position{line: 204, col: 35, offset: 6656},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 204, col: 39, offset: 6658},
+												pos:  position{line: 204, col: 39, offset: 6660},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 204, col: 42, offset: 6661},
+												pos:   position{line: 204, col: 42, offset: 6663},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 204, col: 47, offset: 6666},
+													pos:  position{line: 204, col: 47, offset: 6668},
 													name: "FlexAssignment",
 												},
 											},
@@ -1361,27 +1365,31 @@ var g = &grammar{
 		},
 		{
 			name: "everyDur",
-			pos:  position{line: 208, col: 1, offset: 6786},
+			pos:  position{line: 208, col: 1, offset: 6788},
 			expr: &actionExpr{
-				pos: position{line: 209, col: 5, offset: 6799},
+				pos: position{line: 209, col: 5, offset: 6801},
 				run: (*parser).calloneveryDur1,
 				expr: &seqExpr{
-					pos: position{line: 209, col: 5, offset: 6799},
+					pos: position{line: 209, col: 5, offset: 6801},
 					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 209, col: 5, offset: 6801},
+							name: "_",
+						},
 						&litMatcher{
-							pos:        position{line: 209, col: 5, offset: 6799},
+							pos:        position{line: 209, col: 7, offset: 6803},
 							val:        "every",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 209, col: 14, offset: 6808},
+							pos:  position{line: 209, col: 16, offset: 6812},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 209, col: 16, offset: 6810},
+							pos:   position{line: 209, col: 18, offset: 6814},
 							label: "dur",
 							expr: &ruleRefExpr{
-								pos:  position{line: 209, col: 20, offset: 6814},
+								pos:  position{line: 209, col: 22, offset: 6818},
 								name: "duration",
 							},
 						},
@@ -1391,16 +1399,16 @@ var g = &grammar{
 		},
 		{
 			name: "equalityToken",
-			pos:  position{line: 211, col: 1, offset: 6844},
+			pos:  position{line: 211, col: 1, offset: 6848},
 			expr: &choiceExpr{
-				pos: position{line: 212, col: 5, offset: 6862},
+				pos: position{line: 212, col: 5, offset: 6866},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 212, col: 5, offset: 6862},
+						pos:  position{line: 212, col: 5, offset: 6866},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 212, col: 24, offset: 6881},
+						pos:  position{line: 212, col: 24, offset: 6885},
 						name: "RelativeOperator",
 					},
 				},
@@ -1408,12 +1416,12 @@ var g = &grammar{
 		},
 		{
 			name: "andToken",
-			pos:  position{line: 214, col: 1, offset: 6899},
+			pos:  position{line: 214, col: 1, offset: 6903},
 			expr: &actionExpr{
-				pos: position{line: 214, col: 12, offset: 6910},
+				pos: position{line: 214, col: 12, offset: 6914},
 				run: (*parser).callonandToken1,
 				expr: &litMatcher{
-					pos:        position{line: 214, col: 12, offset: 6910},
+					pos:        position{line: 214, col: 12, offset: 6914},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -1421,12 +1429,12 @@ var g = &grammar{
 		},
 		{
 			name: "orToken",
-			pos:  position{line: 215, col: 1, offset: 6948},
+			pos:  position{line: 215, col: 1, offset: 6952},
 			expr: &actionExpr{
-				pos: position{line: 215, col: 11, offset: 6958},
+				pos: position{line: 215, col: 11, offset: 6962},
 				run: (*parser).callonorToken1,
 				expr: &litMatcher{
-					pos:        position{line: 215, col: 11, offset: 6958},
+					pos:        position{line: 215, col: 11, offset: 6962},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -1434,12 +1442,12 @@ var g = &grammar{
 		},
 		{
 			name: "inToken",
-			pos:  position{line: 216, col: 1, offset: 6995},
+			pos:  position{line: 216, col: 1, offset: 6999},
 			expr: &actionExpr{
-				pos: position{line: 216, col: 11, offset: 7005},
+				pos: position{line: 216, col: 11, offset: 7009},
 				run: (*parser).calloninToken1,
 				expr: &litMatcher{
-					pos:        position{line: 216, col: 11, offset: 7005},
+					pos:        position{line: 216, col: 11, offset: 7009},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -1447,12 +1455,12 @@ var g = &grammar{
 		},
 		{
 			name: "notToken",
-			pos:  position{line: 217, col: 1, offset: 7042},
+			pos:  position{line: 217, col: 1, offset: 7046},
 			expr: &actionExpr{
-				pos: position{line: 217, col: 12, offset: 7053},
+				pos: position{line: 217, col: 12, offset: 7057},
 				run: (*parser).callonnotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 217, col: 12, offset: 7053},
+					pos:        position{line: 217, col: 12, offset: 7057},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -1460,21 +1468,21 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 219, col: 1, offset: 7092},
+			pos:  position{line: 219, col: 1, offset: 7096},
 			expr: &actionExpr{
-				pos: position{line: 219, col: 18, offset: 7109},
+				pos: position{line: 219, col: 18, offset: 7113},
 				run: (*parser).callonIdentifierName1,
 				expr: &seqExpr{
-					pos: position{line: 219, col: 18, offset: 7109},
+					pos: position{line: 219, col: 18, offset: 7113},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 219, col: 18, offset: 7109},
+							pos:  position{line: 219, col: 18, offset: 7113},
 							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 219, col: 34, offset: 7125},
+							pos: position{line: 219, col: 34, offset: 7129},
 							expr: &ruleRefExpr{
-								pos:  position{line: 219, col: 34, offset: 7125},
+								pos:  position{line: 219, col: 34, offset: 7129},
 								name: "IdentifierRest",
 							},
 						},
@@ -1484,9 +1492,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 221, col: 1, offset: 7173},
+			pos:  position{line: 221, col: 1, offset: 7177},
 			expr: &charClassMatcher{
-				pos:        position{line: 221, col: 19, offset: 7191},
+				pos:        position{line: 221, col: 19, offset: 7195},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -1496,16 +1504,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 222, col: 1, offset: 7202},
+			pos:  position{line: 222, col: 1, offset: 7206},
 			expr: &choiceExpr{
-				pos: position{line: 222, col: 18, offset: 7219},
+				pos: position{line: 222, col: 18, offset: 7223},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 222, col: 18, offset: 7219},
+						pos:  position{line: 222, col: 18, offset: 7223},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 222, col: 36, offset: 7237},
+						pos:        position{line: 222, col: 36, offset: 7241},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -1516,21 +1524,21 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 224, col: 1, offset: 7244},
+			pos:  position{line: 224, col: 1, offset: 7248},
 			expr: &actionExpr{
-				pos: position{line: 225, col: 5, offset: 7259},
+				pos: position{line: 225, col: 5, offset: 7263},
 				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 225, col: 5, offset: 7259},
+					pos: position{line: 225, col: 5, offset: 7263},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 225, col: 5, offset: 7259},
+							pos:  position{line: 225, col: 5, offset: 7263},
 							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 225, col: 21, offset: 7275},
+							pos: position{line: 225, col: 21, offset: 7279},
 							expr: &ruleRefExpr{
-								pos:  position{line: 225, col: 21, offset: 7275},
+								pos:  position{line: 225, col: 21, offset: 7279},
 								name: "IdentifierRest",
 							},
 						},
@@ -1540,45 +1548,45 @@ var g = &grammar{
 		},
 		{
 			name: "RootField",
-			pos:  position{line: 227, col: 1, offset: 7375},
+			pos:  position{line: 227, col: 1, offset: 7379},
 			expr: &choiceExpr{
-				pos: position{line: 228, col: 5, offset: 7389},
+				pos: position{line: 228, col: 5, offset: 7393},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 228, col: 5, offset: 7389},
+						pos: position{line: 228, col: 5, offset: 7393},
 						run: (*parser).callonRootField2,
 						expr: &seqExpr{
-							pos: position{line: 228, col: 5, offset: 7389},
+							pos: position{line: 228, col: 5, offset: 7393},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 228, col: 5, offset: 7389},
+									pos: position{line: 228, col: 5, offset: 7393},
 									expr: &litMatcher{
-										pos:        position{line: 228, col: 5, offset: 7389},
+										pos:        position{line: 228, col: 5, offset: 7393},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&notExpr{
-									pos: position{line: 228, col: 10, offset: 7394},
+									pos: position{line: 228, col: 10, offset: 7398},
 									expr: &choiceExpr{
-										pos: position{line: 228, col: 12, offset: 7396},
+										pos: position{line: 228, col: 12, offset: 7400},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 228, col: 12, offset: 7396},
+												pos:  position{line: 228, col: 12, offset: 7400},
 												name: "BooleanLiteral",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 228, col: 29, offset: 7413},
+												pos:  position{line: 228, col: 29, offset: 7417},
 												name: "NullLiteral",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 228, col: 42, offset: 7426},
+									pos:   position{line: 228, col: 42, offset: 7430},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 228, col: 48, offset: 7432},
+										pos:  position{line: 228, col: 48, offset: 7436},
 										name: "Identifier",
 									},
 								},
@@ -1586,20 +1594,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 229, col: 5, offset: 7585},
+						pos: position{line: 229, col: 5, offset: 7589},
 						run: (*parser).callonRootField12,
 						expr: &seqExpr{
-							pos: position{line: 229, col: 5, offset: 7585},
+							pos: position{line: 229, col: 5, offset: 7589},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 229, col: 5, offset: 7585},
+									pos:        position{line: 229, col: 5, offset: 7589},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 229, col: 9, offset: 7589},
+									pos: position{line: 229, col: 9, offset: 7593},
 									expr: &ruleRefExpr{
-										pos:  position{line: 229, col: 11, offset: 7591},
+										pos:  position{line: 229, col: 11, offset: 7595},
 										name: "Identifier",
 									},
 								},
@@ -1611,36 +1619,36 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 231, col: 1, offset: 7664},
+			pos:  position{line: 231, col: 1, offset: 7668},
 			expr: &ruleRefExpr{
-				pos:  position{line: 231, col: 8, offset: 7671},
+				pos:  position{line: 231, col: 8, offset: 7675},
 				name: "DerefExpression",
 			},
 		},
 		{
 			name: "DerefExpression",
-			pos:  position{line: 233, col: 1, offset: 7688},
+			pos:  position{line: 233, col: 1, offset: 7692},
 			expr: &actionExpr{
-				pos: position{line: 234, col: 5, offset: 7708},
+				pos: position{line: 234, col: 5, offset: 7712},
 				run: (*parser).callonDerefExpression1,
 				expr: &seqExpr{
-					pos: position{line: 234, col: 5, offset: 7708},
+					pos: position{line: 234, col: 5, offset: 7712},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 234, col: 5, offset: 7708},
+							pos:   position{line: 234, col: 5, offset: 7712},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 234, col: 11, offset: 7714},
+								pos:  position{line: 234, col: 11, offset: 7718},
 								name: "RootField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 234, col: 21, offset: 7724},
+							pos:   position{line: 234, col: 21, offset: 7728},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 234, col: 26, offset: 7729},
+								pos: position{line: 234, col: 26, offset: 7733},
 								expr: &ruleRefExpr{
-									pos:  position{line: 234, col: 27, offset: 7730},
+									pos:  position{line: 234, col: 27, offset: 7734},
 									name: "Deref",
 								},
 							},
@@ -1651,31 +1659,31 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 238, col: 1, offset: 7795},
+			pos:  position{line: 238, col: 1, offset: 7799},
 			expr: &choiceExpr{
-				pos: position{line: 239, col: 5, offset: 7805},
+				pos: position{line: 239, col: 5, offset: 7809},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 239, col: 5, offset: 7805},
+						pos: position{line: 239, col: 5, offset: 7809},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 239, col: 5, offset: 7805},
+							pos: position{line: 239, col: 5, offset: 7809},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 239, col: 5, offset: 7805},
+									pos:        position{line: 239, col: 5, offset: 7809},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 239, col: 9, offset: 7809},
+									pos:   position{line: 239, col: 9, offset: 7813},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 239, col: 14, offset: 7814},
+										pos:  position{line: 239, col: 14, offset: 7818},
 										name: "Expression",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 239, col: 25, offset: 7825},
+									pos:        position{line: 239, col: 25, offset: 7829},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -1683,29 +1691,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 240, col: 5, offset: 7874},
+						pos: position{line: 240, col: 5, offset: 7878},
 						run: (*parser).callonDeref8,
 						expr: &seqExpr{
-							pos: position{line: 240, col: 5, offset: 7874},
+							pos: position{line: 240, col: 5, offset: 7878},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 240, col: 5, offset: 7874},
+									pos:        position{line: 240, col: 5, offset: 7878},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 240, col: 9, offset: 7878},
+									pos: position{line: 240, col: 9, offset: 7882},
 									expr: &litMatcher{
-										pos:        position{line: 240, col: 11, offset: 7880},
+										pos:        position{line: 240, col: 11, offset: 7884},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 240, col: 16, offset: 7885},
+									pos:   position{line: 240, col: 16, offset: 7889},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 240, col: 19, offset: 7888},
+										pos:  position{line: 240, col: 19, offset: 7892},
 										name: "Identifier",
 									},
 								},
@@ -1717,40 +1725,40 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionExpr",
-			pos:  position{line: 247, col: 1, offset: 8200},
+			pos:  position{line: 247, col: 1, offset: 8204},
 			expr: &actionExpr{
-				pos: position{line: 248, col: 7, offset: 8219},
+				pos: position{line: 248, col: 7, offset: 8223},
 				run: (*parser).callonFunctionExpr1,
 				expr: &seqExpr{
-					pos: position{line: 248, col: 7, offset: 8219},
+					pos: position{line: 248, col: 7, offset: 8223},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 248, col: 7, offset: 8219},
+							pos:   position{line: 248, col: 7, offset: 8223},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 248, col: 10, offset: 8222},
+								pos:  position{line: 248, col: 10, offset: 8226},
 								name: "FunctionName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 248, col: 23, offset: 8235},
+							pos:  position{line: 248, col: 23, offset: 8239},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 248, col: 26, offset: 8238},
+							pos:        position{line: 248, col: 26, offset: 8242},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 248, col: 30, offset: 8242},
+							pos:   position{line: 248, col: 30, offset: 8246},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 248, col: 35, offset: 8247},
+								pos:  position{line: 248, col: 35, offset: 8251},
 								name: "ArgumentList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 248, col: 48, offset: 8260},
+							pos:        position{line: 248, col: 48, offset: 8264},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1760,52 +1768,52 @@ var g = &grammar{
 		},
 		{
 			name: "fieldExpr",
-			pos:  position{line: 252, col: 1, offset: 8372},
+			pos:  position{line: 252, col: 1, offset: 8376},
 			expr: &ruleRefExpr{
-				pos:  position{line: 252, col: 13, offset: 8384},
+				pos:  position{line: 252, col: 13, offset: 8388},
 				name: "Lval",
 			},
 		},
 		{
 			name: "fieldExprList",
-			pos:  position{line: 254, col: 1, offset: 8390},
+			pos:  position{line: 254, col: 1, offset: 8394},
 			expr: &actionExpr{
-				pos: position{line: 255, col: 5, offset: 8408},
+				pos: position{line: 255, col: 5, offset: 8412},
 				run: (*parser).callonfieldExprList1,
 				expr: &seqExpr{
-					pos: position{line: 255, col: 5, offset: 8408},
+					pos: position{line: 255, col: 5, offset: 8412},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 255, col: 5, offset: 8408},
+							pos:   position{line: 255, col: 5, offset: 8412},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 255, col: 11, offset: 8414},
+								pos:  position{line: 255, col: 11, offset: 8418},
 								name: "fieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 255, col: 21, offset: 8424},
+							pos:   position{line: 255, col: 21, offset: 8428},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 255, col: 26, offset: 8429},
+								pos: position{line: 255, col: 26, offset: 8433},
 								expr: &seqExpr{
-									pos: position{line: 255, col: 27, offset: 8430},
+									pos: position{line: 255, col: 27, offset: 8434},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 255, col: 27, offset: 8430},
+											pos:  position{line: 255, col: 27, offset: 8434},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 255, col: 30, offset: 8433},
+											pos:        position{line: 255, col: 30, offset: 8437},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 255, col: 34, offset: 8437},
+											pos:  position{line: 255, col: 34, offset: 8441},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 255, col: 37, offset: 8440},
+											pos:  position{line: 255, col: 37, offset: 8444},
 											name: "fieldExpr",
 										},
 									},
@@ -1818,44 +1826,44 @@ var g = &grammar{
 		},
 		{
 			name: "ExprList",
-			pos:  position{line: 265, col: 1, offset: 8637},
+			pos:  position{line: 265, col: 1, offset: 8641},
 			expr: &actionExpr{
-				pos: position{line: 266, col: 5, offset: 8650},
+				pos: position{line: 266, col: 5, offset: 8654},
 				run: (*parser).callonExprList1,
 				expr: &seqExpr{
-					pos: position{line: 266, col: 5, offset: 8650},
+					pos: position{line: 266, col: 5, offset: 8654},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 266, col: 5, offset: 8650},
+							pos:   position{line: 266, col: 5, offset: 8654},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 266, col: 11, offset: 8656},
+								pos:  position{line: 266, col: 11, offset: 8660},
 								name: "Expression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 266, col: 22, offset: 8667},
+							pos:   position{line: 266, col: 22, offset: 8671},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 266, col: 27, offset: 8672},
+								pos: position{line: 266, col: 27, offset: 8676},
 								expr: &seqExpr{
-									pos: position{line: 266, col: 28, offset: 8673},
+									pos: position{line: 266, col: 28, offset: 8677},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 266, col: 28, offset: 8673},
+											pos:  position{line: 266, col: 28, offset: 8677},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 266, col: 31, offset: 8676},
+											pos:        position{line: 266, col: 31, offset: 8680},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 266, col: 35, offset: 8680},
+											pos:  position{line: 266, col: 35, offset: 8684},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 266, col: 38, offset: 8683},
+											pos:  position{line: 266, col: 38, offset: 8687},
 											name: "Expression",
 										},
 									},
@@ -1868,68 +1876,50 @@ var g = &grammar{
 		},
 		{
 			name: "groupByProc",
-			pos:  position{line: 276, col: 1, offset: 8883},
+			pos:  position{line: 276, col: 1, offset: 8887},
 			expr: &actionExpr{
-				pos: position{line: 277, col: 5, offset: 8899},
+				pos: position{line: 277, col: 5, offset: 8903},
 				run: (*parser).callongroupByProc1,
 				expr: &seqExpr{
-					pos: position{line: 277, col: 5, offset: 8899},
+					pos: position{line: 277, col: 5, offset: 8903},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 277, col: 5, offset: 8899},
+							pos:   position{line: 277, col: 5, offset: 8903},
 							label: "every",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 277, col: 11, offset: 8905},
-								expr: &seqExpr{
-									pos: position{line: 277, col: 12, offset: 8906},
-									exprs: []interface{}{
-										&ruleRefExpr{
-											pos:  position{line: 277, col: 12, offset: 8906},
-											name: "everyDur",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 277, col: 21, offset: 8915},
-											name: "_",
-										},
-									},
+								pos: position{line: 277, col: 11, offset: 8909},
+								expr: &ruleRefExpr{
+									pos:  position{line: 277, col: 11, offset: 8909},
+									name: "everyDur",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 277, col: 25, offset: 8919},
+							pos:   position{line: 277, col: 21, offset: 8919},
 							label: "reducers",
 							expr: &ruleRefExpr{
-								pos:  position{line: 277, col: 34, offset: 8928},
+								pos:  position{line: 277, col: 30, offset: 8928},
 								name: "reducerList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 277, col: 46, offset: 8940},
+							pos:   position{line: 277, col: 42, offset: 8940},
 							label: "keys",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 277, col: 51, offset: 8945},
-								expr: &seqExpr{
-									pos: position{line: 277, col: 52, offset: 8946},
-									exprs: []interface{}{
-										&ruleRefExpr{
-											pos:  position{line: 277, col: 52, offset: 8946},
-											name: "_",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 277, col: 54, offset: 8948},
-											name: "groupByKeys",
-										},
-									},
+								pos: position{line: 277, col: 47, offset: 8945},
+								expr: &ruleRefExpr{
+									pos:  position{line: 277, col: 47, offset: 8945},
+									name: "groupByKeys",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 277, col: 68, offset: 8962},
+							pos:   position{line: 277, col: 60, offset: 8958},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 277, col: 74, offset: 8968},
+								pos: position{line: 277, col: 66, offset: 8964},
 								expr: &ruleRefExpr{
-									pos:  position{line: 277, col: 74, offset: 8968},
+									pos:  position{line: 277, col: 66, offset: 8964},
 									name: "procLimitArg",
 								},
 							},
@@ -1940,38 +1930,38 @@ var g = &grammar{
 		},
 		{
 			name: "ReducerAssignment",
-			pos:  position{line: 294, col: 1, offset: 9433},
+			pos:  position{line: 291, col: 1, offset: 9240},
 			expr: &choiceExpr{
-				pos: position{line: 295, col: 5, offset: 9455},
+				pos: position{line: 292, col: 5, offset: 9262},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 295, col: 5, offset: 9455},
+						pos: position{line: 292, col: 5, offset: 9262},
 						run: (*parser).callonReducerAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 295, col: 5, offset: 9455},
+							pos: position{line: 292, col: 5, offset: 9262},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 295, col: 5, offset: 9455},
+									pos:   position{line: 292, col: 5, offset: 9262},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 295, col: 10, offset: 9460},
+										pos:  position{line: 292, col: 10, offset: 9267},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 295, col: 15, offset: 9465},
+									pos:  position{line: 292, col: 15, offset: 9272},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 295, col: 18, offset: 9468},
+									pos:        position{line: 292, col: 18, offset: 9275},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 295, col: 22, offset: 9472},
+									pos:   position{line: 292, col: 22, offset: 9279},
 									label: "reducer",
 									expr: &ruleRefExpr{
-										pos:  position{line: 295, col: 30, offset: 9480},
+										pos:  position{line: 292, col: 30, offset: 9287},
 										name: "reducer",
 									},
 								},
@@ -1979,13 +1969,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 298, col: 5, offset: 9588},
+						pos: position{line: 295, col: 5, offset: 9395},
 						run: (*parser).callonReducerAssignment10,
 						expr: &labeledExpr{
-							pos:   position{line: 298, col: 5, offset: 9588},
+							pos:   position{line: 295, col: 5, offset: 9395},
 							label: "reducer",
 							expr: &ruleRefExpr{
-								pos:  position{line: 298, col: 13, offset: 9596},
+								pos:  position{line: 295, col: 13, offset: 9403},
 								name: "reducer",
 							},
 						},
@@ -1995,25 +1985,25 @@ var g = &grammar{
 		},
 		{
 			name: "reducer",
-			pos:  position{line: 302, col: 1, offset: 9688},
+			pos:  position{line: 299, col: 1, offset: 9495},
 			expr: &actionExpr{
-				pos: position{line: 303, col: 5, offset: 9700},
+				pos: position{line: 300, col: 5, offset: 9507},
 				run: (*parser).callonreducer1,
 				expr: &seqExpr{
-					pos: position{line: 303, col: 5, offset: 9700},
+					pos: position{line: 300, col: 5, offset: 9507},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 303, col: 5, offset: 9700},
+							pos: position{line: 300, col: 5, offset: 9507},
 							expr: &choiceExpr{
-								pos: position{line: 303, col: 7, offset: 9702},
+								pos: position{line: 300, col: 7, offset: 9509},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 303, col: 7, offset: 9702},
+										pos:        position{line: 300, col: 7, offset: 9509},
 										val:        "not",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 303, col: 13, offset: 9708},
+										pos:        position{line: 300, col: 13, offset: 9515},
 										val:        "len",
 										ignoreCase: false,
 									},
@@ -2021,53 +2011,53 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 303, col: 20, offset: 9715},
+							pos:   position{line: 300, col: 20, offset: 9522},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 303, col: 23, offset: 9718},
+								pos:  position{line: 300, col: 23, offset: 9525},
 								name: "FunctionName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 303, col: 36, offset: 9731},
+							pos:  position{line: 300, col: 36, offset: 9538},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 303, col: 39, offset: 9734},
+							pos:        position{line: 300, col: 39, offset: 9541},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 303, col: 43, offset: 9738},
+							pos:  position{line: 300, col: 43, offset: 9545},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 303, col: 46, offset: 9741},
+							pos:   position{line: 300, col: 46, offset: 9548},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 303, col: 51, offset: 9746},
+								pos: position{line: 300, col: 51, offset: 9553},
 								expr: &ruleRefExpr{
-									pos:  position{line: 303, col: 51, offset: 9746},
+									pos:  position{line: 300, col: 51, offset: 9553},
 									name: "Expression",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 303, col: 64, offset: 9759},
+							pos:  position{line: 300, col: 64, offset: 9566},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 303, col: 67, offset: 9762},
+							pos:        position{line: 300, col: 67, offset: 9569},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 303, col: 71, offset: 9766},
+							pos:   position{line: 300, col: 71, offset: 9573},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 303, col: 77, offset: 9772},
+								pos: position{line: 300, col: 77, offset: 9579},
 								expr: &ruleRefExpr{
-									pos:  position{line: 303, col: 77, offset: 9772},
+									pos:  position{line: 300, col: 77, offset: 9579},
 									name: "where",
 								},
 							},
@@ -2078,31 +2068,31 @@ var g = &grammar{
 		},
 		{
 			name: "where",
-			pos:  position{line: 311, col: 1, offset: 9937},
+			pos:  position{line: 308, col: 1, offset: 9744},
 			expr: &actionExpr{
-				pos: position{line: 311, col: 9, offset: 9945},
+				pos: position{line: 308, col: 9, offset: 9752},
 				run: (*parser).callonwhere1,
 				expr: &seqExpr{
-					pos: position{line: 311, col: 9, offset: 9945},
+					pos: position{line: 308, col: 9, offset: 9752},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 311, col: 9, offset: 9945},
+							pos:  position{line: 308, col: 9, offset: 9752},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 311, col: 11, offset: 9947},
+							pos:        position{line: 308, col: 11, offset: 9754},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 311, col: 19, offset: 9955},
+							pos:  position{line: 308, col: 19, offset: 9762},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 311, col: 21, offset: 9957},
+							pos:   position{line: 308, col: 21, offset: 9764},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 311, col: 26, offset: 9962},
+								pos:  position{line: 308, col: 26, offset: 9769},
 								name: "Expression",
 							},
 						},
@@ -2112,44 +2102,44 @@ var g = &grammar{
 		},
 		{
 			name: "reducerList",
-			pos:  position{line: 313, col: 1, offset: 9995},
+			pos:  position{line: 310, col: 1, offset: 9802},
 			expr: &actionExpr{
-				pos: position{line: 314, col: 5, offset: 10011},
+				pos: position{line: 311, col: 5, offset: 9818},
 				run: (*parser).callonreducerList1,
 				expr: &seqExpr{
-					pos: position{line: 314, col: 5, offset: 10011},
+					pos: position{line: 311, col: 5, offset: 9818},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 314, col: 5, offset: 10011},
+							pos:   position{line: 311, col: 5, offset: 9818},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 314, col: 11, offset: 10017},
+								pos:  position{line: 311, col: 11, offset: 9824},
 								name: "ReducerAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 314, col: 29, offset: 10035},
+							pos:   position{line: 311, col: 29, offset: 9842},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 314, col: 34, offset: 10040},
+								pos: position{line: 311, col: 34, offset: 9847},
 								expr: &seqExpr{
-									pos: position{line: 314, col: 35, offset: 10041},
+									pos: position{line: 311, col: 35, offset: 9848},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 314, col: 35, offset: 10041},
+											pos:  position{line: 311, col: 35, offset: 9848},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 314, col: 38, offset: 10044},
+											pos:        position{line: 311, col: 38, offset: 9851},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 314, col: 42, offset: 10048},
+											pos:  position{line: 311, col: 42, offset: 9855},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 314, col: 45, offset: 10051},
+											pos:  position{line: 311, col: 45, offset: 9858},
 											name: "ReducerAssignment",
 										},
 									},
@@ -2162,48 +2152,48 @@ var g = &grammar{
 		},
 		{
 			name: "simpleProc",
-			pos:  position{line: 322, col: 1, offset: 10256},
+			pos:  position{line: 319, col: 1, offset: 10063},
 			expr: &choiceExpr{
-				pos: position{line: 323, col: 5, offset: 10271},
+				pos: position{line: 320, col: 5, offset: 10078},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 323, col: 5, offset: 10271},
+						pos:  position{line: 320, col: 5, offset: 10078},
 						name: "sort",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 324, col: 5, offset: 10280},
+						pos:  position{line: 321, col: 5, offset: 10087},
 						name: "top",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 325, col: 5, offset: 10288},
+						pos:  position{line: 322, col: 5, offset: 10095},
 						name: "cut",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 326, col: 5, offset: 10296},
+						pos:  position{line: 323, col: 5, offset: 10103},
 						name: "head",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 327, col: 5, offset: 10305},
+						pos:  position{line: 324, col: 5, offset: 10112},
 						name: "tail",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 328, col: 5, offset: 10314},
+						pos:  position{line: 325, col: 5, offset: 10121},
 						name: "filter",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 329, col: 5, offset: 10325},
+						pos:  position{line: 326, col: 5, offset: 10132},
 						name: "uniq",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 330, col: 5, offset: 10334},
+						pos:  position{line: 327, col: 5, offset: 10141},
 						name: "put",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 331, col: 5, offset: 10342},
+						pos:  position{line: 328, col: 5, offset: 10149},
 						name: "rename",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 332, col: 5, offset: 10353},
+						pos:  position{line: 329, col: 5, offset: 10160},
 						name: "fuse",
 					},
 				},
@@ -2211,46 +2201,46 @@ var g = &grammar{
 		},
 		{
 			name: "sort",
-			pos:  position{line: 334, col: 1, offset: 10359},
+			pos:  position{line: 331, col: 1, offset: 10166},
 			expr: &actionExpr{
-				pos: position{line: 335, col: 5, offset: 10368},
+				pos: position{line: 332, col: 5, offset: 10175},
 				run: (*parser).callonsort1,
 				expr: &seqExpr{
-					pos: position{line: 335, col: 5, offset: 10368},
+					pos: position{line: 332, col: 5, offset: 10175},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 335, col: 5, offset: 10368},
+							pos:        position{line: 332, col: 5, offset: 10175},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 335, col: 13, offset: 10376},
+							pos:   position{line: 332, col: 13, offset: 10183},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 335, col: 18, offset: 10381},
+								pos:  position{line: 332, col: 18, offset: 10188},
 								name: "sortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 335, col: 27, offset: 10390},
+							pos:   position{line: 332, col: 27, offset: 10197},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 335, col: 32, offset: 10395},
+								pos: position{line: 332, col: 32, offset: 10202},
 								expr: &actionExpr{
-									pos: position{line: 335, col: 33, offset: 10396},
+									pos: position{line: 332, col: 33, offset: 10203},
 									run: (*parser).callonsort8,
 									expr: &seqExpr{
-										pos: position{line: 335, col: 33, offset: 10396},
+										pos: position{line: 332, col: 33, offset: 10203},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 335, col: 33, offset: 10396},
+												pos:  position{line: 332, col: 33, offset: 10203},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 335, col: 35, offset: 10398},
+												pos:   position{line: 332, col: 35, offset: 10205},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 335, col: 37, offset: 10400},
+													pos:  position{line: 332, col: 37, offset: 10207},
 													name: "ExprList",
 												},
 											},
@@ -2265,30 +2255,30 @@ var g = &grammar{
 		},
 		{
 			name: "sortArgs",
-			pos:  position{line: 349, col: 1, offset: 10798},
+			pos:  position{line: 346, col: 1, offset: 10605},
 			expr: &actionExpr{
-				pos: position{line: 349, col: 12, offset: 10809},
+				pos: position{line: 346, col: 12, offset: 10616},
 				run: (*parser).callonsortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 349, col: 12, offset: 10809},
+					pos:   position{line: 346, col: 12, offset: 10616},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 349, col: 17, offset: 10814},
+						pos: position{line: 346, col: 17, offset: 10621},
 						expr: &actionExpr{
-							pos: position{line: 349, col: 18, offset: 10815},
+							pos: position{line: 346, col: 18, offset: 10622},
 							run: (*parser).callonsortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 349, col: 18, offset: 10815},
+								pos: position{line: 346, col: 18, offset: 10622},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 349, col: 18, offset: 10815},
+										pos:  position{line: 346, col: 18, offset: 10622},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 349, col: 20, offset: 10817},
+										pos:   position{line: 346, col: 20, offset: 10624},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 349, col: 22, offset: 10819},
+											pos:  position{line: 346, col: 22, offset: 10626},
 											name: "sortArg",
 										},
 									},
@@ -2301,50 +2291,50 @@ var g = &grammar{
 		},
 		{
 			name: "sortArg",
-			pos:  position{line: 353, col: 1, offset: 10879},
+			pos:  position{line: 350, col: 1, offset: 10686},
 			expr: &choiceExpr{
-				pos: position{line: 354, col: 5, offset: 10891},
+				pos: position{line: 351, col: 5, offset: 10698},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 354, col: 5, offset: 10891},
+						pos: position{line: 351, col: 5, offset: 10698},
 						run: (*parser).callonsortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 354, col: 5, offset: 10891},
+							pos:        position{line: 351, col: 5, offset: 10698},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 355, col: 5, offset: 10966},
+						pos: position{line: 352, col: 5, offset: 10773},
 						run: (*parser).callonsortArg4,
 						expr: &seqExpr{
-							pos: position{line: 355, col: 5, offset: 10966},
+							pos: position{line: 352, col: 5, offset: 10773},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 355, col: 5, offset: 10966},
+									pos:        position{line: 352, col: 5, offset: 10773},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 355, col: 14, offset: 10975},
+									pos:  position{line: 352, col: 14, offset: 10782},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 355, col: 16, offset: 10977},
+									pos:   position{line: 352, col: 16, offset: 10784},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 355, col: 23, offset: 10984},
+										pos: position{line: 352, col: 23, offset: 10791},
 										run: (*parser).callonsortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 355, col: 24, offset: 10985},
+											pos: position{line: 352, col: 24, offset: 10792},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 355, col: 24, offset: 10985},
+													pos:        position{line: 352, col: 24, offset: 10792},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 355, col: 34, offset: 10995},
+													pos:        position{line: 352, col: 34, offset: 10802},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2360,38 +2350,38 @@ var g = &grammar{
 		},
 		{
 			name: "top",
-			pos:  position{line: 357, col: 1, offset: 11109},
+			pos:  position{line: 354, col: 1, offset: 10916},
 			expr: &actionExpr{
-				pos: position{line: 358, col: 5, offset: 11117},
+				pos: position{line: 355, col: 5, offset: 10924},
 				run: (*parser).callontop1,
 				expr: &seqExpr{
-					pos: position{line: 358, col: 5, offset: 11117},
+					pos: position{line: 355, col: 5, offset: 10924},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 358, col: 5, offset: 11117},
+							pos:        position{line: 355, col: 5, offset: 10924},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 358, col: 12, offset: 11124},
+							pos:   position{line: 355, col: 12, offset: 10931},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 358, col: 18, offset: 11130},
+								pos: position{line: 355, col: 18, offset: 10937},
 								expr: &actionExpr{
-									pos: position{line: 358, col: 19, offset: 11131},
+									pos: position{line: 355, col: 19, offset: 10938},
 									run: (*parser).callontop6,
 									expr: &seqExpr{
-										pos: position{line: 358, col: 19, offset: 11131},
+										pos: position{line: 355, col: 19, offset: 10938},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 358, col: 19, offset: 11131},
+												pos:  position{line: 355, col: 19, offset: 10938},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 358, col: 21, offset: 11133},
+												pos:   position{line: 355, col: 21, offset: 10940},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 358, col: 23, offset: 11135},
+													pos:  position{line: 355, col: 23, offset: 10942},
 													name: "unsignedInteger",
 												},
 											},
@@ -2401,19 +2391,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 358, col: 58, offset: 11170},
+							pos:   position{line: 355, col: 58, offset: 10977},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 358, col: 64, offset: 11176},
+								pos: position{line: 355, col: 64, offset: 10983},
 								expr: &seqExpr{
-									pos: position{line: 358, col: 65, offset: 11177},
+									pos: position{line: 355, col: 65, offset: 10984},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 65, offset: 11177},
+											pos:  position{line: 355, col: 65, offset: 10984},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 358, col: 67, offset: 11179},
+											pos:        position{line: 355, col: 67, offset: 10986},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2422,25 +2412,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 358, col: 78, offset: 11190},
+							pos:   position{line: 355, col: 78, offset: 10997},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 358, col: 85, offset: 11197},
+								pos: position{line: 355, col: 85, offset: 11004},
 								expr: &actionExpr{
-									pos: position{line: 358, col: 86, offset: 11198},
+									pos: position{line: 355, col: 86, offset: 11005},
 									run: (*parser).callontop18,
 									expr: &seqExpr{
-										pos: position{line: 358, col: 86, offset: 11198},
+										pos: position{line: 355, col: 86, offset: 11005},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 358, col: 86, offset: 11198},
+												pos:  position{line: 355, col: 86, offset: 11005},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 358, col: 88, offset: 11200},
+												pos:   position{line: 355, col: 88, offset: 11007},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 358, col: 90, offset: 11202},
+													pos:  position{line: 355, col: 90, offset: 11009},
 													name: "fieldExprList",
 												},
 											},
@@ -2455,40 +2445,40 @@ var g = &grammar{
 		},
 		{
 			name: "procLimitArg",
-			pos:  position{line: 372, col: 1, offset: 11489},
+			pos:  position{line: 369, col: 1, offset: 11296},
 			expr: &actionExpr{
-				pos: position{line: 373, col: 5, offset: 11506},
+				pos: position{line: 370, col: 5, offset: 11313},
 				run: (*parser).callonprocLimitArg1,
 				expr: &seqExpr{
-					pos: position{line: 373, col: 5, offset: 11506},
+					pos: position{line: 370, col: 5, offset: 11313},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 373, col: 5, offset: 11506},
+							pos:  position{line: 370, col: 5, offset: 11313},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 373, col: 7, offset: 11508},
+							pos:        position{line: 370, col: 7, offset: 11315},
 							val:        "with",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 373, col: 14, offset: 11515},
+							pos:  position{line: 370, col: 14, offset: 11322},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 373, col: 16, offset: 11517},
+							pos:        position{line: 370, col: 16, offset: 11324},
 							val:        "-limit",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 373, col: 25, offset: 11526},
+							pos:  position{line: 370, col: 25, offset: 11333},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 373, col: 27, offset: 11528},
+							pos:   position{line: 370, col: 27, offset: 11335},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 373, col: 33, offset: 11534},
+								pos:  position{line: 370, col: 33, offset: 11341},
 								name: "unsignedInteger",
 							},
 						},
@@ -2498,27 +2488,27 @@ var g = &grammar{
 		},
 		{
 			name: "cutArgs",
-			pos:  position{line: 375, col: 1, offset: 11573},
+			pos:  position{line: 372, col: 1, offset: 11380},
 			expr: &actionExpr{
-				pos: position{line: 376, col: 5, offset: 11585},
+				pos: position{line: 373, col: 5, offset: 11392},
 				run: (*parser).calloncutArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 376, col: 5, offset: 11585},
+					pos:   position{line: 373, col: 5, offset: 11392},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 376, col: 10, offset: 11590},
+						pos: position{line: 373, col: 10, offset: 11397},
 						expr: &actionExpr{
-							pos: position{line: 376, col: 11, offset: 11591},
+							pos: position{line: 373, col: 11, offset: 11398},
 							run: (*parser).calloncutArgs4,
 							expr: &seqExpr{
-								pos: position{line: 376, col: 11, offset: 11591},
+								pos: position{line: 373, col: 11, offset: 11398},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 376, col: 11, offset: 11591},
+										pos:  position{line: 373, col: 11, offset: 11398},
 										name: "_",
 									},
 									&litMatcher{
-										pos:        position{line: 376, col: 13, offset: 11593},
+										pos:        position{line: 373, col: 13, offset: 11400},
 										val:        "-c",
 										ignoreCase: false,
 									},
@@ -2531,35 +2521,35 @@ var g = &grammar{
 		},
 		{
 			name: "cut",
-			pos:  position{line: 380, col: 1, offset: 11701},
+			pos:  position{line: 377, col: 1, offset: 11508},
 			expr: &actionExpr{
-				pos: position{line: 381, col: 5, offset: 11709},
+				pos: position{line: 378, col: 5, offset: 11516},
 				run: (*parser).calloncut1,
 				expr: &seqExpr{
-					pos: position{line: 381, col: 5, offset: 11709},
+					pos: position{line: 378, col: 5, offset: 11516},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 381, col: 5, offset: 11709},
+							pos:        position{line: 378, col: 5, offset: 11516},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 381, col: 12, offset: 11716},
+							pos:   position{line: 378, col: 12, offset: 11523},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 381, col: 17, offset: 11721},
+								pos:  position{line: 378, col: 17, offset: 11528},
 								name: "cutArgs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 381, col: 25, offset: 11729},
+							pos:  position{line: 378, col: 25, offset: 11536},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 381, col: 27, offset: 11731},
+							pos:   position{line: 378, col: 27, offset: 11538},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 381, col: 35, offset: 11739},
+								pos:  position{line: 378, col: 35, offset: 11546},
 								name: "FlexAssignments",
 							},
 						},
@@ -2569,30 +2559,30 @@ var g = &grammar{
 		},
 		{
 			name: "head",
-			pos:  position{line: 391, col: 1, offset: 11995},
+			pos:  position{line: 388, col: 1, offset: 11802},
 			expr: &choiceExpr{
-				pos: position{line: 392, col: 5, offset: 12004},
+				pos: position{line: 389, col: 5, offset: 11811},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 392, col: 5, offset: 12004},
+						pos: position{line: 389, col: 5, offset: 11811},
 						run: (*parser).callonhead2,
 						expr: &seqExpr{
-							pos: position{line: 392, col: 5, offset: 12004},
+							pos: position{line: 389, col: 5, offset: 11811},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 392, col: 5, offset: 12004},
+									pos:        position{line: 389, col: 5, offset: 11811},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 392, col: 13, offset: 12012},
+									pos:  position{line: 389, col: 13, offset: 11819},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 392, col: 15, offset: 12014},
+									pos:   position{line: 389, col: 15, offset: 11821},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 392, col: 21, offset: 12020},
+										pos:  position{line: 389, col: 21, offset: 11827},
 										name: "unsignedInteger",
 									},
 								},
@@ -2600,10 +2590,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 393, col: 5, offset: 12113},
+						pos: position{line: 390, col: 5, offset: 11920},
 						run: (*parser).callonhead8,
 						expr: &litMatcher{
-							pos:        position{line: 393, col: 5, offset: 12113},
+							pos:        position{line: 390, col: 5, offset: 11920},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2613,30 +2603,30 @@ var g = &grammar{
 		},
 		{
 			name: "tail",
-			pos:  position{line: 394, col: 1, offset: 12190},
+			pos:  position{line: 391, col: 1, offset: 11997},
 			expr: &choiceExpr{
-				pos: position{line: 395, col: 5, offset: 12199},
+				pos: position{line: 392, col: 5, offset: 12006},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 395, col: 5, offset: 12199},
+						pos: position{line: 392, col: 5, offset: 12006},
 						run: (*parser).callontail2,
 						expr: &seqExpr{
-							pos: position{line: 395, col: 5, offset: 12199},
+							pos: position{line: 392, col: 5, offset: 12006},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 395, col: 5, offset: 12199},
+									pos:        position{line: 392, col: 5, offset: 12006},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 395, col: 13, offset: 12207},
+									pos:  position{line: 392, col: 13, offset: 12014},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 395, col: 15, offset: 12209},
+									pos:   position{line: 392, col: 15, offset: 12016},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 395, col: 21, offset: 12215},
+										pos:  position{line: 392, col: 21, offset: 12022},
 										name: "unsignedInteger",
 									},
 								},
@@ -2644,10 +2634,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 396, col: 5, offset: 12308},
+						pos: position{line: 393, col: 5, offset: 12115},
 						run: (*parser).callontail8,
 						expr: &litMatcher{
-							pos:        position{line: 396, col: 5, offset: 12308},
+							pos:        position{line: 393, col: 5, offset: 12115},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2657,27 +2647,27 @@ var g = &grammar{
 		},
 		{
 			name: "filter",
-			pos:  position{line: 398, col: 1, offset: 12386},
+			pos:  position{line: 395, col: 1, offset: 12193},
 			expr: &actionExpr{
-				pos: position{line: 399, col: 5, offset: 12397},
+				pos: position{line: 396, col: 5, offset: 12204},
 				run: (*parser).callonfilter1,
 				expr: &seqExpr{
-					pos: position{line: 399, col: 5, offset: 12397},
+					pos: position{line: 396, col: 5, offset: 12204},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 399, col: 5, offset: 12397},
+							pos:        position{line: 396, col: 5, offset: 12204},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 399, col: 15, offset: 12407},
+							pos:  position{line: 396, col: 15, offset: 12214},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 399, col: 17, offset: 12409},
+							pos:   position{line: 396, col: 17, offset: 12216},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 399, col: 22, offset: 12414},
+								pos:  position{line: 396, col: 22, offset: 12221},
 								name: "searchExpr",
 							},
 						},
@@ -2687,27 +2677,27 @@ var g = &grammar{
 		},
 		{
 			name: "uniq",
-			pos:  position{line: 402, col: 1, offset: 12510},
+			pos:  position{line: 399, col: 1, offset: 12317},
 			expr: &choiceExpr{
-				pos: position{line: 403, col: 5, offset: 12519},
+				pos: position{line: 400, col: 5, offset: 12326},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 403, col: 5, offset: 12519},
+						pos: position{line: 400, col: 5, offset: 12326},
 						run: (*parser).callonuniq2,
 						expr: &seqExpr{
-							pos: position{line: 403, col: 5, offset: 12519},
+							pos: position{line: 400, col: 5, offset: 12326},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 403, col: 5, offset: 12519},
+									pos:        position{line: 400, col: 5, offset: 12326},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 403, col: 13, offset: 12527},
+									pos:  position{line: 400, col: 13, offset: 12334},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 403, col: 15, offset: 12529},
+									pos:        position{line: 400, col: 15, offset: 12336},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2715,10 +2705,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 406, col: 5, offset: 12620},
+						pos: position{line: 403, col: 5, offset: 12427},
 						run: (*parser).callonuniq7,
 						expr: &litMatcher{
-							pos:        position{line: 406, col: 5, offset: 12620},
+							pos:        position{line: 403, col: 5, offset: 12427},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2728,27 +2718,27 @@ var g = &grammar{
 		},
 		{
 			name: "put",
-			pos:  position{line: 410, col: 1, offset: 12712},
+			pos:  position{line: 407, col: 1, offset: 12519},
 			expr: &actionExpr{
-				pos: position{line: 411, col: 5, offset: 12720},
+				pos: position{line: 408, col: 5, offset: 12527},
 				run: (*parser).callonput1,
 				expr: &seqExpr{
-					pos: position{line: 411, col: 5, offset: 12720},
+					pos: position{line: 408, col: 5, offset: 12527},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 411, col: 5, offset: 12720},
+							pos:        position{line: 408, col: 5, offset: 12527},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 411, col: 12, offset: 12727},
+							pos:  position{line: 408, col: 12, offset: 12534},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 411, col: 14, offset: 12729},
+							pos:   position{line: 408, col: 14, offset: 12536},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 411, col: 22, offset: 12737},
+								pos:  position{line: 408, col: 22, offset: 12544},
 								name: "FlexAssignments",
 							},
 						},
@@ -2758,59 +2748,59 @@ var g = &grammar{
 		},
 		{
 			name: "rename",
-			pos:  position{line: 415, col: 1, offset: 12840},
+			pos:  position{line: 412, col: 1, offset: 12647},
 			expr: &actionExpr{
-				pos: position{line: 416, col: 5, offset: 12851},
+				pos: position{line: 413, col: 5, offset: 12658},
 				run: (*parser).callonrename1,
 				expr: &seqExpr{
-					pos: position{line: 416, col: 5, offset: 12851},
+					pos: position{line: 413, col: 5, offset: 12658},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 416, col: 5, offset: 12851},
+							pos:        position{line: 413, col: 5, offset: 12658},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 416, col: 15, offset: 12861},
+							pos:  position{line: 413, col: 15, offset: 12668},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 416, col: 17, offset: 12863},
+							pos:   position{line: 413, col: 17, offset: 12670},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 416, col: 23, offset: 12869},
+								pos:  position{line: 413, col: 23, offset: 12676},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 416, col: 34, offset: 12880},
+							pos:   position{line: 413, col: 34, offset: 12687},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 416, col: 39, offset: 12885},
+								pos: position{line: 413, col: 39, offset: 12692},
 								expr: &actionExpr{
-									pos: position{line: 416, col: 40, offset: 12886},
+									pos: position{line: 413, col: 40, offset: 12693},
 									run: (*parser).callonrename9,
 									expr: &seqExpr{
-										pos: position{line: 416, col: 40, offset: 12886},
+										pos: position{line: 413, col: 40, offset: 12693},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 416, col: 40, offset: 12886},
+												pos:  position{line: 413, col: 40, offset: 12693},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 416, col: 43, offset: 12889},
+												pos:        position{line: 413, col: 43, offset: 12696},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 416, col: 47, offset: 12893},
+												pos:  position{line: 413, col: 47, offset: 12700},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 416, col: 50, offset: 12896},
+												pos:   position{line: 413, col: 50, offset: 12703},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 416, col: 53, offset: 12899},
+													pos:  position{line: 413, col: 53, offset: 12706},
 													name: "Assignment",
 												},
 											},
@@ -2825,12 +2815,12 @@ var g = &grammar{
 		},
 		{
 			name: "fuse",
-			pos:  position{line: 420, col: 1, offset: 13069},
+			pos:  position{line: 417, col: 1, offset: 12876},
 			expr: &actionExpr{
-				pos: position{line: 421, col: 5, offset: 13078},
+				pos: position{line: 418, col: 5, offset: 12885},
 				run: (*parser).callonfuse1,
 				expr: &litMatcher{
-					pos:        position{line: 421, col: 5, offset: 13078},
+					pos:        position{line: 418, col: 5, offset: 12885},
 					val:        "fuse",
 					ignoreCase: true,
 				},
@@ -2838,39 +2828,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 425, col: 1, offset: 13152},
+			pos:  position{line: 422, col: 1, offset: 12959},
 			expr: &actionExpr{
-				pos: position{line: 426, col: 5, offset: 13167},
+				pos: position{line: 423, col: 5, offset: 12974},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 426, col: 5, offset: 13167},
+					pos: position{line: 423, col: 5, offset: 12974},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 426, col: 5, offset: 13167},
+							pos:   position{line: 423, col: 5, offset: 12974},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 426, col: 9, offset: 13171},
+								pos:  position{line: 423, col: 9, offset: 12978},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 426, col: 14, offset: 13176},
+							pos:  position{line: 423, col: 14, offset: 12983},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 426, col: 17, offset: 13179},
+							pos:        position{line: 423, col: 17, offset: 12986},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 426, col: 21, offset: 13183},
+							pos:  position{line: 423, col: 21, offset: 12990},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 426, col: 24, offset: 13186},
+							pos:   position{line: 423, col: 24, offset: 12993},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 426, col: 28, offset: 13190},
+								pos:  position{line: 423, col: 28, offset: 12997},
 								name: "Expression",
 							},
 						},
@@ -2880,71 +2870,71 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 428, col: 1, offset: 13265},
+			pos:  position{line: 425, col: 1, offset: 13072},
 			expr: &choiceExpr{
-				pos: position{line: 429, col: 5, offset: 13277},
+				pos: position{line: 426, col: 5, offset: 13084},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 429, col: 5, offset: 13277},
+						pos:  position{line: 426, col: 5, offset: 13084},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 430, col: 5, offset: 13295},
+						pos:  position{line: 427, col: 5, offset: 13102},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 431, col: 5, offset: 13313},
+						pos:  position{line: 428, col: 5, offset: 13120},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 432, col: 5, offset: 13331},
+						pos:  position{line: 429, col: 5, offset: 13138},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 433, col: 5, offset: 13350},
+						pos:  position{line: 430, col: 5, offset: 13157},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 434, col: 5, offset: 13367},
+						pos:  position{line: 431, col: 5, offset: 13174},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 435, col: 5, offset: 13386},
+						pos:  position{line: 432, col: 5, offset: 13193},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 436, col: 5, offset: 13405},
+						pos:  position{line: 433, col: 5, offset: 13212},
 						name: "NullLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 437, col: 5, offset: 13421},
+						pos: position{line: 434, col: 5, offset: 13228},
 						run: (*parser).callonPrimary10,
 						expr: &seqExpr{
-							pos: position{line: 437, col: 5, offset: 13421},
+							pos: position{line: 434, col: 5, offset: 13228},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 437, col: 5, offset: 13421},
+									pos:        position{line: 434, col: 5, offset: 13228},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 437, col: 9, offset: 13425},
+									pos:  position{line: 434, col: 9, offset: 13232},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 437, col: 12, offset: 13428},
+									pos:   position{line: 434, col: 12, offset: 13235},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 437, col: 17, offset: 13433},
+										pos:  position{line: 434, col: 17, offset: 13240},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 437, col: 28, offset: 13444},
+									pos:  position{line: 434, col: 28, offset: 13251},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 437, col: 31, offset: 13447},
+									pos:        position{line: 434, col: 31, offset: 13254},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -2956,71 +2946,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expression",
-			pos:  position{line: 445, col: 1, offset: 13649},
+			pos:  position{line: 442, col: 1, offset: 13456},
 			expr: &ruleRefExpr{
-				pos:  position{line: 445, col: 14, offset: 13662},
+				pos:  position{line: 442, col: 14, offset: 13469},
 				name: "ConditionalExpression",
 			},
 		},
 		{
 			name: "ConditionalExpression",
-			pos:  position{line: 447, col: 1, offset: 13685},
+			pos:  position{line: 444, col: 1, offset: 13492},
 			expr: &choiceExpr{
-				pos: position{line: 448, col: 5, offset: 13711},
+				pos: position{line: 445, col: 5, offset: 13518},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 448, col: 5, offset: 13711},
+						pos: position{line: 445, col: 5, offset: 13518},
 						run: (*parser).callonConditionalExpression2,
 						expr: &seqExpr{
-							pos: position{line: 448, col: 5, offset: 13711},
+							pos: position{line: 445, col: 5, offset: 13518},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 448, col: 5, offset: 13711},
+									pos:   position{line: 445, col: 5, offset: 13518},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 448, col: 15, offset: 13721},
+										pos:  position{line: 445, col: 15, offset: 13528},
 										name: "LogicalORExpression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 448, col: 35, offset: 13741},
+									pos:  position{line: 445, col: 35, offset: 13548},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 448, col: 38, offset: 13744},
+									pos:        position{line: 445, col: 38, offset: 13551},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 448, col: 42, offset: 13748},
+									pos:  position{line: 445, col: 42, offset: 13555},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 448, col: 45, offset: 13751},
+									pos:   position{line: 445, col: 45, offset: 13558},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 448, col: 56, offset: 13762},
+										pos:  position{line: 445, col: 56, offset: 13569},
 										name: "Expression",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 448, col: 67, offset: 13773},
+									pos:  position{line: 445, col: 67, offset: 13580},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 448, col: 70, offset: 13776},
+									pos:        position{line: 445, col: 70, offset: 13583},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 448, col: 74, offset: 13780},
+									pos:  position{line: 445, col: 74, offset: 13587},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 448, col: 77, offset: 13783},
+									pos:   position{line: 445, col: 77, offset: 13590},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 448, col: 88, offset: 13794},
+										pos:  position{line: 445, col: 88, offset: 13601},
 										name: "Expression",
 									},
 								},
@@ -3028,7 +3018,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 451, col: 5, offset: 13943},
+						pos:  position{line: 448, col: 5, offset: 13750},
 						name: "LogicalORExpression",
 					},
 				},
@@ -3036,53 +3026,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalORExpression",
-			pos:  position{line: 453, col: 1, offset: 13964},
+			pos:  position{line: 450, col: 1, offset: 13771},
 			expr: &actionExpr{
-				pos: position{line: 454, col: 5, offset: 13988},
+				pos: position{line: 451, col: 5, offset: 13795},
 				run: (*parser).callonLogicalORExpression1,
 				expr: &seqExpr{
-					pos: position{line: 454, col: 5, offset: 13988},
+					pos: position{line: 451, col: 5, offset: 13795},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 454, col: 5, offset: 13988},
+							pos:   position{line: 451, col: 5, offset: 13795},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 454, col: 11, offset: 13994},
+								pos:  position{line: 451, col: 11, offset: 13801},
 								name: "LogicalANDExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 455, col: 5, offset: 14019},
+							pos:   position{line: 452, col: 5, offset: 13826},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 455, col: 10, offset: 14024},
+								pos: position{line: 452, col: 10, offset: 13831},
 								expr: &actionExpr{
-									pos: position{line: 455, col: 11, offset: 14025},
+									pos: position{line: 452, col: 11, offset: 13832},
 									run: (*parser).callonLogicalORExpression7,
 									expr: &seqExpr{
-										pos: position{line: 455, col: 11, offset: 14025},
+										pos: position{line: 452, col: 11, offset: 13832},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 455, col: 11, offset: 14025},
+												pos:  position{line: 452, col: 11, offset: 13832},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 455, col: 14, offset: 14028},
+												pos:   position{line: 452, col: 14, offset: 13835},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 455, col: 17, offset: 14031},
+													pos:  position{line: 452, col: 17, offset: 13838},
 													name: "orToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 455, col: 25, offset: 14039},
+												pos:  position{line: 452, col: 25, offset: 13846},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 455, col: 28, offset: 14042},
+												pos:   position{line: 452, col: 28, offset: 13849},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 455, col: 33, offset: 14047},
+													pos:  position{line: 452, col: 33, offset: 13854},
 													name: "LogicalANDExpression",
 												},
 											},
@@ -3097,53 +3087,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalANDExpression",
-			pos:  position{line: 459, col: 1, offset: 14171},
+			pos:  position{line: 456, col: 1, offset: 13978},
 			expr: &actionExpr{
-				pos: position{line: 460, col: 5, offset: 14196},
+				pos: position{line: 457, col: 5, offset: 14003},
 				run: (*parser).callonLogicalANDExpression1,
 				expr: &seqExpr{
-					pos: position{line: 460, col: 5, offset: 14196},
+					pos: position{line: 457, col: 5, offset: 14003},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 460, col: 5, offset: 14196},
+							pos:   position{line: 457, col: 5, offset: 14003},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 460, col: 11, offset: 14202},
+								pos:  position{line: 457, col: 11, offset: 14009},
 								name: "EqualityCompareExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 461, col: 5, offset: 14232},
+							pos:   position{line: 458, col: 5, offset: 14039},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 461, col: 10, offset: 14237},
+								pos: position{line: 458, col: 10, offset: 14044},
 								expr: &actionExpr{
-									pos: position{line: 461, col: 11, offset: 14238},
+									pos: position{line: 458, col: 11, offset: 14045},
 									run: (*parser).callonLogicalANDExpression7,
 									expr: &seqExpr{
-										pos: position{line: 461, col: 11, offset: 14238},
+										pos: position{line: 458, col: 11, offset: 14045},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 461, col: 11, offset: 14238},
+												pos:  position{line: 458, col: 11, offset: 14045},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 461, col: 14, offset: 14241},
+												pos:   position{line: 458, col: 14, offset: 14048},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 461, col: 17, offset: 14244},
+													pos:  position{line: 458, col: 17, offset: 14051},
 													name: "andToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 461, col: 26, offset: 14253},
+												pos:  position{line: 458, col: 26, offset: 14060},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 461, col: 29, offset: 14256},
+												pos:   position{line: 458, col: 29, offset: 14063},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 461, col: 34, offset: 14261},
+													pos:  position{line: 458, col: 34, offset: 14068},
 													name: "EqualityCompareExpression",
 												},
 											},
@@ -3158,53 +3148,53 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpression",
-			pos:  position{line: 465, col: 1, offset: 14390},
+			pos:  position{line: 462, col: 1, offset: 14197},
 			expr: &actionExpr{
-				pos: position{line: 466, col: 5, offset: 14420},
+				pos: position{line: 463, col: 5, offset: 14227},
 				run: (*parser).callonEqualityCompareExpression1,
 				expr: &seqExpr{
-					pos: position{line: 466, col: 5, offset: 14420},
+					pos: position{line: 463, col: 5, offset: 14227},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 466, col: 5, offset: 14420},
+							pos:   position{line: 463, col: 5, offset: 14227},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 466, col: 11, offset: 14426},
+								pos:  position{line: 463, col: 11, offset: 14233},
 								name: "RelativeExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 467, col: 5, offset: 14449},
+							pos:   position{line: 464, col: 5, offset: 14256},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 467, col: 10, offset: 14454},
+								pos: position{line: 464, col: 10, offset: 14261},
 								expr: &actionExpr{
-									pos: position{line: 467, col: 11, offset: 14455},
+									pos: position{line: 464, col: 11, offset: 14262},
 									run: (*parser).callonEqualityCompareExpression7,
 									expr: &seqExpr{
-										pos: position{line: 467, col: 11, offset: 14455},
+										pos: position{line: 464, col: 11, offset: 14262},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 467, col: 11, offset: 14455},
+												pos:  position{line: 464, col: 11, offset: 14262},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 467, col: 14, offset: 14458},
+												pos:   position{line: 464, col: 14, offset: 14265},
 												label: "comp",
 												expr: &ruleRefExpr{
-													pos:  position{line: 467, col: 19, offset: 14463},
+													pos:  position{line: 464, col: 19, offset: 14270},
 													name: "EqualityComparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 467, col: 38, offset: 14482},
+												pos:  position{line: 464, col: 38, offset: 14289},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 467, col: 41, offset: 14485},
+												pos:   position{line: 464, col: 41, offset: 14292},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 467, col: 46, offset: 14490},
+													pos:  position{line: 464, col: 46, offset: 14297},
 													name: "RelativeExpression",
 												},
 											},
@@ -3219,30 +3209,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 471, col: 1, offset: 14614},
+			pos:  position{line: 468, col: 1, offset: 14421},
 			expr: &actionExpr{
-				pos: position{line: 471, col: 20, offset: 14633},
+				pos: position{line: 468, col: 20, offset: 14440},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 471, col: 21, offset: 14634},
+					pos: position{line: 468, col: 21, offset: 14441},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 471, col: 21, offset: 14634},
+							pos:        position{line: 468, col: 21, offset: 14441},
 							val:        "=~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 471, col: 28, offset: 14641},
+							pos:        position{line: 468, col: 28, offset: 14448},
 							val:        "!~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 471, col: 35, offset: 14648},
+							pos:        position{line: 468, col: 35, offset: 14455},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 471, col: 41, offset: 14654},
+							pos:        position{line: 468, col: 41, offset: 14461},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3252,19 +3242,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 473, col: 1, offset: 14692},
+			pos:  position{line: 470, col: 1, offset: 14499},
 			expr: &choiceExpr{
-				pos: position{line: 474, col: 5, offset: 14715},
+				pos: position{line: 471, col: 5, offset: 14522},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 474, col: 5, offset: 14715},
+						pos:  position{line: 471, col: 5, offset: 14522},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 475, col: 5, offset: 14736},
+						pos: position{line: 472, col: 5, offset: 14543},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 475, col: 5, offset: 14736},
+							pos:        position{line: 472, col: 5, offset: 14543},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3274,53 +3264,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpression",
-			pos:  position{line: 477, col: 1, offset: 14773},
+			pos:  position{line: 474, col: 1, offset: 14580},
 			expr: &actionExpr{
-				pos: position{line: 478, col: 5, offset: 14796},
+				pos: position{line: 475, col: 5, offset: 14603},
 				run: (*parser).callonRelativeExpression1,
 				expr: &seqExpr{
-					pos: position{line: 478, col: 5, offset: 14796},
+					pos: position{line: 475, col: 5, offset: 14603},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 478, col: 5, offset: 14796},
+							pos:   position{line: 475, col: 5, offset: 14603},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 478, col: 11, offset: 14802},
+								pos:  position{line: 475, col: 11, offset: 14609},
 								name: "AdditiveExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 479, col: 5, offset: 14825},
+							pos:   position{line: 476, col: 5, offset: 14632},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 479, col: 10, offset: 14830},
+								pos: position{line: 476, col: 10, offset: 14637},
 								expr: &actionExpr{
-									pos: position{line: 479, col: 11, offset: 14831},
+									pos: position{line: 476, col: 11, offset: 14638},
 									run: (*parser).callonRelativeExpression7,
 									expr: &seqExpr{
-										pos: position{line: 479, col: 11, offset: 14831},
+										pos: position{line: 476, col: 11, offset: 14638},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 479, col: 11, offset: 14831},
+												pos:  position{line: 476, col: 11, offset: 14638},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 479, col: 14, offset: 14834},
+												pos:   position{line: 476, col: 14, offset: 14641},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 479, col: 17, offset: 14837},
+													pos:  position{line: 476, col: 17, offset: 14644},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 479, col: 34, offset: 14854},
+												pos:  position{line: 476, col: 34, offset: 14661},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 479, col: 37, offset: 14857},
+												pos:   position{line: 476, col: 37, offset: 14664},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 479, col: 42, offset: 14862},
+													pos:  position{line: 476, col: 42, offset: 14669},
 													name: "AdditiveExpression",
 												},
 											},
@@ -3335,30 +3325,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 483, col: 1, offset: 14984},
+			pos:  position{line: 480, col: 1, offset: 14791},
 			expr: &actionExpr{
-				pos: position{line: 483, col: 20, offset: 15003},
+				pos: position{line: 480, col: 20, offset: 14810},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 483, col: 21, offset: 15004},
+					pos: position{line: 480, col: 21, offset: 14811},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 483, col: 21, offset: 15004},
+							pos:        position{line: 480, col: 21, offset: 14811},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 483, col: 28, offset: 15011},
+							pos:        position{line: 480, col: 28, offset: 14818},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 483, col: 34, offset: 15017},
+							pos:        position{line: 480, col: 34, offset: 14824},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 483, col: 41, offset: 15024},
+							pos:        position{line: 480, col: 41, offset: 14831},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -3368,53 +3358,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpression",
-			pos:  position{line: 485, col: 1, offset: 15061},
+			pos:  position{line: 482, col: 1, offset: 14868},
 			expr: &actionExpr{
-				pos: position{line: 486, col: 5, offset: 15084},
+				pos: position{line: 483, col: 5, offset: 14891},
 				run: (*parser).callonAdditiveExpression1,
 				expr: &seqExpr{
-					pos: position{line: 486, col: 5, offset: 15084},
+					pos: position{line: 483, col: 5, offset: 14891},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 486, col: 5, offset: 15084},
+							pos:   position{line: 483, col: 5, offset: 14891},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 486, col: 11, offset: 15090},
+								pos:  position{line: 483, col: 11, offset: 14897},
 								name: "MultiplicativeExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 487, col: 5, offset: 15119},
+							pos:   position{line: 484, col: 5, offset: 14926},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 487, col: 10, offset: 15124},
+								pos: position{line: 484, col: 10, offset: 14931},
 								expr: &actionExpr{
-									pos: position{line: 487, col: 11, offset: 15125},
+									pos: position{line: 484, col: 11, offset: 14932},
 									run: (*parser).callonAdditiveExpression7,
 									expr: &seqExpr{
-										pos: position{line: 487, col: 11, offset: 15125},
+										pos: position{line: 484, col: 11, offset: 14932},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 487, col: 11, offset: 15125},
+												pos:  position{line: 484, col: 11, offset: 14932},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 487, col: 14, offset: 15128},
+												pos:   position{line: 484, col: 14, offset: 14935},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 487, col: 17, offset: 15131},
+													pos:  position{line: 484, col: 17, offset: 14938},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 487, col: 34, offset: 15148},
+												pos:  position{line: 484, col: 34, offset: 14955},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 487, col: 37, offset: 15151},
+												pos:   position{line: 484, col: 37, offset: 14958},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 487, col: 42, offset: 15156},
+													pos:  position{line: 484, col: 42, offset: 14963},
 													name: "MultiplicativeExpression",
 												},
 											},
@@ -3429,20 +3419,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 491, col: 1, offset: 15284},
+			pos:  position{line: 488, col: 1, offset: 15091},
 			expr: &actionExpr{
-				pos: position{line: 491, col: 20, offset: 15303},
+				pos: position{line: 488, col: 20, offset: 15110},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 491, col: 21, offset: 15304},
+					pos: position{line: 488, col: 21, offset: 15111},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 491, col: 21, offset: 15304},
+							pos:        position{line: 488, col: 21, offset: 15111},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 491, col: 27, offset: 15310},
+							pos:        position{line: 488, col: 27, offset: 15117},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3452,53 +3442,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpression",
-			pos:  position{line: 493, col: 1, offset: 15347},
+			pos:  position{line: 490, col: 1, offset: 15154},
 			expr: &actionExpr{
-				pos: position{line: 494, col: 5, offset: 15376},
+				pos: position{line: 491, col: 5, offset: 15183},
 				run: (*parser).callonMultiplicativeExpression1,
 				expr: &seqExpr{
-					pos: position{line: 494, col: 5, offset: 15376},
+					pos: position{line: 491, col: 5, offset: 15183},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 494, col: 5, offset: 15376},
+							pos:   position{line: 491, col: 5, offset: 15183},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 494, col: 11, offset: 15382},
+								pos:  position{line: 491, col: 11, offset: 15189},
 								name: "NotExpression",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 495, col: 5, offset: 15400},
+							pos:   position{line: 492, col: 5, offset: 15207},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 495, col: 10, offset: 15405},
+								pos: position{line: 492, col: 10, offset: 15212},
 								expr: &actionExpr{
-									pos: position{line: 495, col: 11, offset: 15406},
+									pos: position{line: 492, col: 11, offset: 15213},
 									run: (*parser).callonMultiplicativeExpression7,
 									expr: &seqExpr{
-										pos: position{line: 495, col: 11, offset: 15406},
+										pos: position{line: 492, col: 11, offset: 15213},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 495, col: 11, offset: 15406},
+												pos:  position{line: 492, col: 11, offset: 15213},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 495, col: 14, offset: 15409},
+												pos:   position{line: 492, col: 14, offset: 15216},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 495, col: 17, offset: 15412},
+													pos:  position{line: 492, col: 17, offset: 15219},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 495, col: 40, offset: 15435},
+												pos:  position{line: 492, col: 40, offset: 15242},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 495, col: 43, offset: 15438},
+												pos:   position{line: 492, col: 43, offset: 15245},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 495, col: 48, offset: 15443},
+													pos:  position{line: 492, col: 48, offset: 15250},
 													name: "NotExpression",
 												},
 											},
@@ -3513,20 +3503,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 499, col: 1, offset: 15560},
+			pos:  position{line: 496, col: 1, offset: 15367},
 			expr: &actionExpr{
-				pos: position{line: 499, col: 26, offset: 15585},
+				pos: position{line: 496, col: 26, offset: 15392},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 499, col: 27, offset: 15586},
+					pos: position{line: 496, col: 27, offset: 15393},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 499, col: 27, offset: 15586},
+							pos:        position{line: 496, col: 27, offset: 15393},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 499, col: 33, offset: 15592},
+							pos:        position{line: 496, col: 33, offset: 15399},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -3536,30 +3526,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpression",
-			pos:  position{line: 501, col: 1, offset: 15629},
+			pos:  position{line: 498, col: 1, offset: 15436},
 			expr: &choiceExpr{
-				pos: position{line: 502, col: 5, offset: 15647},
+				pos: position{line: 499, col: 5, offset: 15454},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 502, col: 5, offset: 15647},
+						pos: position{line: 499, col: 5, offset: 15454},
 						run: (*parser).callonNotExpression2,
 						expr: &seqExpr{
-							pos: position{line: 502, col: 5, offset: 15647},
+							pos: position{line: 499, col: 5, offset: 15454},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 502, col: 5, offset: 15647},
+									pos:        position{line: 499, col: 5, offset: 15454},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 502, col: 9, offset: 15651},
+									pos:  position{line: 499, col: 9, offset: 15458},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 502, col: 12, offset: 15654},
+									pos:   position{line: 499, col: 12, offset: 15461},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 502, col: 14, offset: 15656},
+										pos:  position{line: 499, col: 14, offset: 15463},
 										name: "NotExpression",
 									},
 								},
@@ -3567,7 +3557,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 505, col: 5, offset: 15775},
+						pos:  position{line: 502, col: 5, offset: 15582},
 						name: "CastExpression",
 					},
 				},
@@ -3575,43 +3565,43 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpression",
-			pos:  position{line: 507, col: 1, offset: 15791},
+			pos:  position{line: 504, col: 1, offset: 15598},
 			expr: &choiceExpr{
-				pos: position{line: 508, col: 5, offset: 15810},
+				pos: position{line: 505, col: 5, offset: 15617},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 508, col: 5, offset: 15810},
+						pos: position{line: 505, col: 5, offset: 15617},
 						run: (*parser).callonCastExpression2,
 						expr: &seqExpr{
-							pos: position{line: 508, col: 5, offset: 15810},
+							pos: position{line: 505, col: 5, offset: 15617},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 508, col: 5, offset: 15810},
+									pos:   position{line: 505, col: 5, offset: 15617},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 508, col: 7, offset: 15812},
+										pos:  position{line: 505, col: 7, offset: 15619},
 										name: "FuncExpression",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 508, col: 22, offset: 15827},
+									pos:   position{line: 505, col: 22, offset: 15634},
 									label: "typ",
 									expr: &actionExpr{
-										pos: position{line: 508, col: 28, offset: 15833},
+										pos: position{line: 505, col: 28, offset: 15640},
 										run: (*parser).callonCastExpression7,
 										expr: &seqExpr{
-											pos: position{line: 508, col: 28, offset: 15833},
+											pos: position{line: 505, col: 28, offset: 15640},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 508, col: 28, offset: 15833},
+													pos:        position{line: 505, col: 28, offset: 15640},
 													val:        ":",
 													ignoreCase: false,
 												},
 												&labeledExpr{
-													pos:   position{line: 508, col: 32, offset: 15837},
+													pos:   position{line: 505, col: 32, offset: 15644},
 													label: "typ",
 													expr: &ruleRefExpr{
-														pos:  position{line: 508, col: 36, offset: 15841},
+														pos:  position{line: 505, col: 36, offset: 15648},
 														name: "PrimitiveType",
 													},
 												},
@@ -3623,7 +3613,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 511, col: 5, offset: 15967},
+						pos:  position{line: 508, col: 5, offset: 15774},
 						name: "FuncExpression",
 					},
 				},
@@ -3631,115 +3621,115 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 514, col: 1, offset: 15984},
+			pos:  position{line: 511, col: 1, offset: 15791},
 			expr: &actionExpr{
-				pos: position{line: 515, col: 5, offset: 16002},
+				pos: position{line: 512, col: 5, offset: 15809},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 515, col: 9, offset: 16006},
+					pos: position{line: 512, col: 9, offset: 15813},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 515, col: 9, offset: 16006},
+							pos:        position{line: 512, col: 9, offset: 15813},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 515, col: 19, offset: 16016},
+							pos:        position{line: 512, col: 19, offset: 15823},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 515, col: 29, offset: 16026},
+							pos:        position{line: 512, col: 29, offset: 15833},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 515, col: 40, offset: 16037},
+							pos:        position{line: 512, col: 40, offset: 15844},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 515, col: 51, offset: 16048},
+							pos:        position{line: 512, col: 51, offset: 15855},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 516, col: 9, offset: 16065},
+							pos:        position{line: 513, col: 9, offset: 15872},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 516, col: 18, offset: 16074},
+							pos:        position{line: 513, col: 18, offset: 15881},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 516, col: 28, offset: 16084},
+							pos:        position{line: 513, col: 28, offset: 15891},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 516, col: 38, offset: 16094},
+							pos:        position{line: 513, col: 38, offset: 15901},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 517, col: 9, offset: 16110},
+							pos:        position{line: 514, col: 9, offset: 15917},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 517, col: 22, offset: 16123},
+							pos:        position{line: 514, col: 22, offset: 15930},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 518, col: 9, offset: 16138},
+							pos:        position{line: 515, col: 9, offset: 15945},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 519, col: 9, offset: 16156},
+							pos:        position{line: 516, col: 9, offset: 15963},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 519, col: 18, offset: 16165},
+							pos:        position{line: 516, col: 18, offset: 15972},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 519, col: 28, offset: 16175},
+							pos:        position{line: 516, col: 28, offset: 15982},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 519, col: 39, offset: 16186},
+							pos:        position{line: 516, col: 39, offset: 15993},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 520, col: 9, offset: 16204},
+							pos:        position{line: 517, col: 9, offset: 16011},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 520, col: 16, offset: 16211},
+							pos:        position{line: 517, col: 16, offset: 16018},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 521, col: 9, offset: 16225},
+							pos:        position{line: 518, col: 9, offset: 16032},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 521, col: 18, offset: 16234},
+							pos:        position{line: 518, col: 18, offset: 16041},
 							val:        "error",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 521, col: 28, offset: 16244},
+							pos:        position{line: 518, col: 28, offset: 16051},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -3749,31 +3739,31 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpression",
-			pos:  position{line: 523, col: 1, offset: 16285},
+			pos:  position{line: 520, col: 1, offset: 16092},
 			expr: &choiceExpr{
-				pos: position{line: 524, col: 5, offset: 16304},
+				pos: position{line: 521, col: 5, offset: 16111},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 524, col: 5, offset: 16304},
+						pos: position{line: 521, col: 5, offset: 16111},
 						run: (*parser).callonFuncExpression2,
 						expr: &seqExpr{
-							pos: position{line: 524, col: 5, offset: 16304},
+							pos: position{line: 521, col: 5, offset: 16111},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 524, col: 5, offset: 16304},
+									pos:   position{line: 521, col: 5, offset: 16111},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 524, col: 11, offset: 16310},
+										pos:  position{line: 521, col: 11, offset: 16117},
 										name: "FunctionCall",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 524, col: 24, offset: 16323},
+									pos:   position{line: 521, col: 24, offset: 16130},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 524, col: 29, offset: 16328},
+										pos: position{line: 521, col: 29, offset: 16135},
 										expr: &ruleRefExpr{
-											pos:  position{line: 524, col: 30, offset: 16329},
+											pos:  position{line: 521, col: 30, offset: 16136},
 											name: "Deref",
 										},
 									},
@@ -3782,11 +3772,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 527, col: 5, offset: 16396},
+						pos:  position{line: 524, col: 5, offset: 16203},
 						name: "DerefExpression",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 528, col: 5, offset: 16416},
+						pos:  position{line: 525, col: 5, offset: 16223},
 						name: "Primary",
 					},
 				},
@@ -3794,40 +3784,40 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionCall",
-			pos:  position{line: 530, col: 1, offset: 16425},
+			pos:  position{line: 527, col: 1, offset: 16232},
 			expr: &actionExpr{
-				pos: position{line: 531, col: 5, offset: 16442},
+				pos: position{line: 528, col: 5, offset: 16249},
 				run: (*parser).callonFunctionCall1,
 				expr: &seqExpr{
-					pos: position{line: 531, col: 5, offset: 16442},
+					pos: position{line: 528, col: 5, offset: 16249},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 531, col: 5, offset: 16442},
+							pos:   position{line: 528, col: 5, offset: 16249},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 531, col: 8, offset: 16445},
+								pos:  position{line: 528, col: 8, offset: 16252},
 								name: "FunctionName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 531, col: 21, offset: 16458},
+							pos:  position{line: 528, col: 21, offset: 16265},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 531, col: 24, offset: 16461},
+							pos:        position{line: 528, col: 24, offset: 16268},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 531, col: 28, offset: 16465},
+							pos:   position{line: 528, col: 28, offset: 16272},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 531, col: 33, offset: 16470},
+								pos:  position{line: 528, col: 33, offset: 16277},
 								name: "ArgumentList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 531, col: 46, offset: 16483},
+							pos:        position{line: 528, col: 46, offset: 16290},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -3837,21 +3827,21 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionName",
-			pos:  position{line: 535, col: 1, offset: 16591},
+			pos:  position{line: 532, col: 1, offset: 16398},
 			expr: &actionExpr{
-				pos: position{line: 536, col: 5, offset: 16608},
+				pos: position{line: 533, col: 5, offset: 16415},
 				run: (*parser).callonFunctionName1,
 				expr: &seqExpr{
-					pos: position{line: 536, col: 5, offset: 16608},
+					pos: position{line: 533, col: 5, offset: 16415},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 536, col: 5, offset: 16608},
+							pos:  position{line: 533, col: 5, offset: 16415},
 							name: "FunctionNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 536, col: 23, offset: 16626},
+							pos: position{line: 533, col: 23, offset: 16433},
 							expr: &ruleRefExpr{
-								pos:  position{line: 536, col: 23, offset: 16626},
+								pos:  position{line: 533, col: 23, offset: 16433},
 								name: "FunctionNameRest",
 							},
 						},
@@ -3861,9 +3851,9 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionNameStart",
-			pos:  position{line: 538, col: 1, offset: 16676},
+			pos:  position{line: 535, col: 1, offset: 16483},
 			expr: &charClassMatcher{
-				pos:        position{line: 538, col: 21, offset: 16696},
+				pos:        position{line: 535, col: 21, offset: 16503},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -3872,16 +3862,16 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionNameRest",
-			pos:  position{line: 539, col: 1, offset: 16705},
+			pos:  position{line: 536, col: 1, offset: 16512},
 			expr: &choiceExpr{
-				pos: position{line: 539, col: 20, offset: 16724},
+				pos: position{line: 536, col: 20, offset: 16531},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 539, col: 20, offset: 16724},
+						pos:  position{line: 536, col: 20, offset: 16531},
 						name: "FunctionNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 539, col: 40, offset: 16744},
+						pos:        position{line: 536, col: 40, offset: 16551},
 						val:        "[.0-9]",
 						chars:      []rune{'.'},
 						ranges:     []rune{'0', '9'},
@@ -3893,53 +3883,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 541, col: 1, offset: 16752},
+			pos:  position{line: 538, col: 1, offset: 16559},
 			expr: &choiceExpr{
-				pos: position{line: 542, col: 5, offset: 16769},
+				pos: position{line: 539, col: 5, offset: 16576},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 542, col: 5, offset: 16769},
+						pos: position{line: 539, col: 5, offset: 16576},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 542, col: 5, offset: 16769},
+							pos: position{line: 539, col: 5, offset: 16576},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 542, col: 5, offset: 16769},
+									pos:   position{line: 539, col: 5, offset: 16576},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 542, col: 11, offset: 16775},
+										pos:  position{line: 539, col: 11, offset: 16582},
 										name: "Expression",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 542, col: 22, offset: 16786},
+									pos:   position{line: 539, col: 22, offset: 16593},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 542, col: 27, offset: 16791},
+										pos: position{line: 539, col: 27, offset: 16598},
 										expr: &actionExpr{
-											pos: position{line: 542, col: 28, offset: 16792},
+											pos: position{line: 539, col: 28, offset: 16599},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 542, col: 28, offset: 16792},
+												pos: position{line: 539, col: 28, offset: 16599},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 542, col: 28, offset: 16792},
+														pos:  position{line: 539, col: 28, offset: 16599},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 542, col: 31, offset: 16795},
+														pos:        position{line: 539, col: 31, offset: 16602},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 542, col: 35, offset: 16799},
+														pos:  position{line: 539, col: 35, offset: 16606},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 542, col: 38, offset: 16802},
+														pos:   position{line: 539, col: 38, offset: 16609},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 542, col: 40, offset: 16804},
+															pos:  position{line: 539, col: 40, offset: 16611},
 															name: "Expression",
 														},
 													},
@@ -3952,10 +3942,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 545, col: 5, offset: 16920},
+						pos: position{line: 542, col: 5, offset: 16727},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 545, col: 5, offset: 16920},
+							pos:  position{line: 542, col: 5, offset: 16727},
 							name: "__",
 						},
 					},
@@ -3964,54 +3954,54 @@ var g = &grammar{
 		},
 		{
 			name: "duration",
-			pos:  position{line: 547, col: 1, offset: 16956},
+			pos:  position{line: 544, col: 1, offset: 16763},
 			expr: &choiceExpr{
-				pos: position{line: 548, col: 5, offset: 16969},
+				pos: position{line: 545, col: 5, offset: 16776},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 548, col: 5, offset: 16969},
+						pos:  position{line: 545, col: 5, offset: 16776},
 						name: "seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 549, col: 5, offset: 16981},
+						pos:  position{line: 546, col: 5, offset: 16788},
 						name: "minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 550, col: 5, offset: 16993},
+						pos:  position{line: 547, col: 5, offset: 16800},
 						name: "hours",
 					},
 					&seqExpr{
-						pos: position{line: 551, col: 5, offset: 17003},
+						pos: position{line: 548, col: 5, offset: 16810},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 551, col: 5, offset: 17003},
+								pos:  position{line: 548, col: 5, offset: 16810},
 								name: "hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 551, col: 11, offset: 17009},
+								pos:  position{line: 548, col: 11, offset: 16816},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 551, col: 13, offset: 17011},
+								pos:        position{line: 548, col: 13, offset: 16818},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 551, col: 19, offset: 17017},
+								pos:  position{line: 548, col: 19, offset: 16824},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 551, col: 21, offset: 17019},
+								pos:  position{line: 548, col: 21, offset: 16826},
 								name: "minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 552, col: 5, offset: 17031},
+						pos:  position{line: 549, col: 5, offset: 16838},
 						name: "days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 553, col: 5, offset: 17040},
+						pos:  position{line: 550, col: 5, offset: 16847},
 						name: "weeks",
 					},
 				},
@@ -4019,32 +4009,32 @@ var g = &grammar{
 		},
 		{
 			name: "sec_abbrev",
-			pos:  position{line: 555, col: 1, offset: 17047},
+			pos:  position{line: 552, col: 1, offset: 16854},
 			expr: &choiceExpr{
-				pos: position{line: 556, col: 5, offset: 17062},
+				pos: position{line: 553, col: 5, offset: 16869},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 556, col: 5, offset: 17062},
+						pos:        position{line: 553, col: 5, offset: 16869},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 557, col: 5, offset: 17076},
+						pos:        position{line: 554, col: 5, offset: 16883},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 558, col: 5, offset: 17089},
+						pos:        position{line: 555, col: 5, offset: 16896},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 559, col: 5, offset: 17100},
+						pos:        position{line: 556, col: 5, offset: 16907},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 560, col: 5, offset: 17110},
+						pos:        position{line: 557, col: 5, offset: 16917},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -4053,32 +4043,32 @@ var g = &grammar{
 		},
 		{
 			name: "min_abbrev",
-			pos:  position{line: 562, col: 1, offset: 17115},
+			pos:  position{line: 559, col: 1, offset: 16922},
 			expr: &choiceExpr{
-				pos: position{line: 563, col: 5, offset: 17130},
+				pos: position{line: 560, col: 5, offset: 16937},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 563, col: 5, offset: 17130},
+						pos:        position{line: 560, col: 5, offset: 16937},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 564, col: 5, offset: 17144},
+						pos:        position{line: 561, col: 5, offset: 16951},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 565, col: 5, offset: 17157},
+						pos:        position{line: 562, col: 5, offset: 16964},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 566, col: 5, offset: 17168},
+						pos:        position{line: 563, col: 5, offset: 16975},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 567, col: 5, offset: 17178},
+						pos:        position{line: 564, col: 5, offset: 16985},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -4087,32 +4077,32 @@ var g = &grammar{
 		},
 		{
 			name: "hour_abbrev",
-			pos:  position{line: 569, col: 1, offset: 17183},
+			pos:  position{line: 566, col: 1, offset: 16990},
 			expr: &choiceExpr{
-				pos: position{line: 570, col: 5, offset: 17199},
+				pos: position{line: 567, col: 5, offset: 17006},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 570, col: 5, offset: 17199},
+						pos:        position{line: 567, col: 5, offset: 17006},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 571, col: 5, offset: 17211},
+						pos:        position{line: 568, col: 5, offset: 17018},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 572, col: 5, offset: 17221},
+						pos:        position{line: 569, col: 5, offset: 17028},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 573, col: 5, offset: 17230},
+						pos:        position{line: 570, col: 5, offset: 17037},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 574, col: 5, offset: 17238},
+						pos:        position{line: 571, col: 5, offset: 17045},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -4121,22 +4111,22 @@ var g = &grammar{
 		},
 		{
 			name: "day_abbrev",
-			pos:  position{line: 576, col: 1, offset: 17246},
+			pos:  position{line: 573, col: 1, offset: 17053},
 			expr: &choiceExpr{
-				pos: position{line: 576, col: 14, offset: 17259},
+				pos: position{line: 573, col: 14, offset: 17066},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 576, col: 14, offset: 17259},
+						pos:        position{line: 573, col: 14, offset: 17066},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 576, col: 21, offset: 17266},
+						pos:        position{line: 573, col: 21, offset: 17073},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 576, col: 27, offset: 17272},
+						pos:        position{line: 573, col: 27, offset: 17079},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -4145,32 +4135,32 @@ var g = &grammar{
 		},
 		{
 			name: "week_abbrev",
-			pos:  position{line: 577, col: 1, offset: 17276},
+			pos:  position{line: 574, col: 1, offset: 17083},
 			expr: &choiceExpr{
-				pos: position{line: 577, col: 15, offset: 17290},
+				pos: position{line: 574, col: 15, offset: 17097},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 577, col: 15, offset: 17290},
+						pos:        position{line: 574, col: 15, offset: 17097},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 577, col: 23, offset: 17298},
+						pos:        position{line: 574, col: 23, offset: 17105},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 577, col: 30, offset: 17305},
+						pos:        position{line: 574, col: 30, offset: 17112},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 577, col: 36, offset: 17311},
+						pos:        position{line: 574, col: 36, offset: 17118},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 577, col: 41, offset: 17316},
+						pos:        position{line: 574, col: 41, offset: 17123},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -4179,39 +4169,39 @@ var g = &grammar{
 		},
 		{
 			name: "seconds",
-			pos:  position{line: 579, col: 1, offset: 17321},
+			pos:  position{line: 576, col: 1, offset: 17128},
 			expr: &choiceExpr{
-				pos: position{line: 580, col: 5, offset: 17333},
+				pos: position{line: 577, col: 5, offset: 17140},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 580, col: 5, offset: 17333},
+						pos: position{line: 577, col: 5, offset: 17140},
 						run: (*parser).callonseconds2,
 						expr: &litMatcher{
-							pos:        position{line: 580, col: 5, offset: 17333},
+							pos:        position{line: 577, col: 5, offset: 17140},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 581, col: 5, offset: 17419},
+						pos: position{line: 578, col: 5, offset: 17226},
 						run: (*parser).callonseconds4,
 						expr: &seqExpr{
-							pos: position{line: 581, col: 5, offset: 17419},
+							pos: position{line: 578, col: 5, offset: 17226},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 581, col: 5, offset: 17419},
+									pos:   position{line: 578, col: 5, offset: 17226},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 581, col: 9, offset: 17423},
+										pos:  position{line: 578, col: 9, offset: 17230},
 										name: "number",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 581, col: 16, offset: 17430},
+									pos:  position{line: 578, col: 16, offset: 17237},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 581, col: 19, offset: 17433},
+									pos:  position{line: 578, col: 19, offset: 17240},
 									name: "sec_abbrev",
 								},
 							},
@@ -4222,39 +4212,39 @@ var g = &grammar{
 		},
 		{
 			name: "minutes",
-			pos:  position{line: 583, col: 1, offset: 17520},
+			pos:  position{line: 580, col: 1, offset: 17327},
 			expr: &choiceExpr{
-				pos: position{line: 584, col: 5, offset: 17532},
+				pos: position{line: 581, col: 5, offset: 17339},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 584, col: 5, offset: 17532},
+						pos: position{line: 581, col: 5, offset: 17339},
 						run: (*parser).callonminutes2,
 						expr: &litMatcher{
-							pos:        position{line: 584, col: 5, offset: 17532},
+							pos:        position{line: 581, col: 5, offset: 17339},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 585, col: 5, offset: 17619},
+						pos: position{line: 582, col: 5, offset: 17426},
 						run: (*parser).callonminutes4,
 						expr: &seqExpr{
-							pos: position{line: 585, col: 5, offset: 17619},
+							pos: position{line: 582, col: 5, offset: 17426},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 585, col: 5, offset: 17619},
+									pos:   position{line: 582, col: 5, offset: 17426},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 585, col: 9, offset: 17623},
+										pos:  position{line: 582, col: 9, offset: 17430},
 										name: "number",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 585, col: 16, offset: 17630},
+									pos:  position{line: 582, col: 16, offset: 17437},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 585, col: 19, offset: 17633},
+									pos:  position{line: 582, col: 19, offset: 17440},
 									name: "min_abbrev",
 								},
 							},
@@ -4265,39 +4255,39 @@ var g = &grammar{
 		},
 		{
 			name: "hours",
-			pos:  position{line: 587, col: 1, offset: 17729},
+			pos:  position{line: 584, col: 1, offset: 17536},
 			expr: &choiceExpr{
-				pos: position{line: 588, col: 5, offset: 17739},
+				pos: position{line: 585, col: 5, offset: 17546},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 588, col: 5, offset: 17739},
+						pos: position{line: 585, col: 5, offset: 17546},
 						run: (*parser).callonhours2,
 						expr: &litMatcher{
-							pos:        position{line: 588, col: 5, offset: 17739},
+							pos:        position{line: 585, col: 5, offset: 17546},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 589, col: 5, offset: 17826},
+						pos: position{line: 586, col: 5, offset: 17633},
 						run: (*parser).callonhours4,
 						expr: &seqExpr{
-							pos: position{line: 589, col: 5, offset: 17826},
+							pos: position{line: 586, col: 5, offset: 17633},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 589, col: 5, offset: 17826},
+									pos:   position{line: 586, col: 5, offset: 17633},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 589, col: 9, offset: 17830},
+										pos:  position{line: 586, col: 9, offset: 17637},
 										name: "number",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 589, col: 16, offset: 17837},
+									pos:  position{line: 586, col: 16, offset: 17644},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 589, col: 19, offset: 17840},
+									pos:  position{line: 586, col: 19, offset: 17647},
 									name: "hour_abbrev",
 								},
 							},
@@ -4308,39 +4298,39 @@ var g = &grammar{
 		},
 		{
 			name: "days",
-			pos:  position{line: 591, col: 1, offset: 17939},
+			pos:  position{line: 588, col: 1, offset: 17746},
 			expr: &choiceExpr{
-				pos: position{line: 592, col: 5, offset: 17948},
+				pos: position{line: 589, col: 5, offset: 17755},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 592, col: 5, offset: 17948},
+						pos: position{line: 589, col: 5, offset: 17755},
 						run: (*parser).callondays2,
 						expr: &litMatcher{
-							pos:        position{line: 592, col: 5, offset: 17948},
+							pos:        position{line: 589, col: 5, offset: 17755},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 593, col: 5, offset: 18037},
+						pos: position{line: 590, col: 5, offset: 17844},
 						run: (*parser).callondays4,
 						expr: &seqExpr{
-							pos: position{line: 593, col: 5, offset: 18037},
+							pos: position{line: 590, col: 5, offset: 17844},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 593, col: 5, offset: 18037},
+									pos:   position{line: 590, col: 5, offset: 17844},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 593, col: 9, offset: 18041},
+										pos:  position{line: 590, col: 9, offset: 17848},
 										name: "number",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 16, offset: 18048},
+									pos:  position{line: 590, col: 16, offset: 17855},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 19, offset: 18051},
+									pos:  position{line: 590, col: 19, offset: 17858},
 									name: "day_abbrev",
 								},
 							},
@@ -4351,39 +4341,39 @@ var g = &grammar{
 		},
 		{
 			name: "weeks",
-			pos:  position{line: 595, col: 1, offset: 18154},
+			pos:  position{line: 592, col: 1, offset: 17961},
 			expr: &choiceExpr{
-				pos: position{line: 596, col: 5, offset: 18164},
+				pos: position{line: 593, col: 5, offset: 17971},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 596, col: 5, offset: 18164},
+						pos: position{line: 593, col: 5, offset: 17971},
 						run: (*parser).callonweeks2,
 						expr: &litMatcher{
-							pos:        position{line: 596, col: 5, offset: 18164},
+							pos:        position{line: 593, col: 5, offset: 17971},
 							val:        "week",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 597, col: 5, offset: 18256},
+						pos: position{line: 594, col: 5, offset: 18063},
 						run: (*parser).callonweeks4,
 						expr: &seqExpr{
-							pos: position{line: 597, col: 5, offset: 18256},
+							pos: position{line: 594, col: 5, offset: 18063},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 597, col: 5, offset: 18256},
+									pos:   position{line: 594, col: 5, offset: 18063},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 597, col: 9, offset: 18260},
+										pos:  position{line: 594, col: 9, offset: 18067},
 										name: "number",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 597, col: 16, offset: 18267},
+									pos:  position{line: 594, col: 16, offset: 18074},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 597, col: 19, offset: 18270},
+									pos:  position{line: 594, col: 19, offset: 18077},
 									name: "week_abbrev",
 								},
 							},
@@ -4394,53 +4384,53 @@ var g = &grammar{
 		},
 		{
 			name: "number",
-			pos:  position{line: 599, col: 1, offset: 18374},
+			pos:  position{line: 596, col: 1, offset: 18181},
 			expr: &ruleRefExpr{
-				pos:  position{line: 599, col: 10, offset: 18383},
+				pos:  position{line: 596, col: 10, offset: 18190},
 				name: "unsignedInteger",
 			},
 		},
 		{
 			name: "addr",
-			pos:  position{line: 603, col: 1, offset: 18429},
+			pos:  position{line: 600, col: 1, offset: 18236},
 			expr: &actionExpr{
-				pos: position{line: 604, col: 5, offset: 18438},
+				pos: position{line: 601, col: 5, offset: 18245},
 				run: (*parser).callonaddr1,
 				expr: &labeledExpr{
-					pos:   position{line: 604, col: 5, offset: 18438},
+					pos:   position{line: 601, col: 5, offset: 18245},
 					label: "a",
 					expr: &seqExpr{
-						pos: position{line: 604, col: 8, offset: 18441},
+						pos: position{line: 601, col: 8, offset: 18248},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 604, col: 8, offset: 18441},
+								pos:  position{line: 601, col: 8, offset: 18248},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 604, col: 24, offset: 18457},
+								pos:        position{line: 601, col: 24, offset: 18264},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 604, col: 28, offset: 18461},
+								pos:  position{line: 601, col: 28, offset: 18268},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 604, col: 44, offset: 18477},
+								pos:        position{line: 601, col: 44, offset: 18284},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 604, col: 48, offset: 18481},
+								pos:  position{line: 601, col: 48, offset: 18288},
 								name: "unsignedInteger",
 							},
 							&litMatcher{
-								pos:        position{line: 604, col: 64, offset: 18497},
+								pos:        position{line: 601, col: 64, offset: 18304},
 								val:        ".",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 604, col: 68, offset: 18501},
+								pos:  position{line: 601, col: 68, offset: 18308},
 								name: "unsignedInteger",
 							},
 						},
@@ -4450,32 +4440,32 @@ var g = &grammar{
 		},
 		{
 			name: "ip6addr",
-			pos:  position{line: 608, col: 1, offset: 18681},
+			pos:  position{line: 605, col: 1, offset: 18488},
 			expr: &choiceExpr{
-				pos: position{line: 609, col: 5, offset: 18693},
+				pos: position{line: 606, col: 5, offset: 18500},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 609, col: 5, offset: 18693},
+						pos: position{line: 606, col: 5, offset: 18500},
 						run: (*parser).callonip6addr2,
 						expr: &seqExpr{
-							pos: position{line: 609, col: 5, offset: 18693},
+							pos: position{line: 606, col: 5, offset: 18500},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 609, col: 5, offset: 18693},
+									pos:   position{line: 606, col: 5, offset: 18500},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 609, col: 7, offset: 18695},
+										pos: position{line: 606, col: 7, offset: 18502},
 										expr: &ruleRefExpr{
-											pos:  position{line: 609, col: 8, offset: 18696},
+											pos:  position{line: 606, col: 8, offset: 18503},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 609, col: 20, offset: 18708},
+									pos:   position{line: 606, col: 20, offset: 18515},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 609, col: 22, offset: 18710},
+										pos:  position{line: 606, col: 22, offset: 18517},
 										name: "ip6tail",
 									},
 								},
@@ -4483,51 +4473,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 612, col: 5, offset: 18774},
+						pos: position{line: 609, col: 5, offset: 18581},
 						run: (*parser).callonip6addr9,
 						expr: &seqExpr{
-							pos: position{line: 612, col: 5, offset: 18774},
+							pos: position{line: 609, col: 5, offset: 18581},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 612, col: 5, offset: 18774},
+									pos:   position{line: 609, col: 5, offset: 18581},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 612, col: 7, offset: 18776},
+										pos:  position{line: 609, col: 7, offset: 18583},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 612, col: 11, offset: 18780},
+									pos:   position{line: 609, col: 11, offset: 18587},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 612, col: 13, offset: 18782},
+										pos: position{line: 609, col: 13, offset: 18589},
 										expr: &ruleRefExpr{
-											pos:  position{line: 612, col: 14, offset: 18783},
+											pos:  position{line: 609, col: 14, offset: 18590},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 612, col: 25, offset: 18794},
+									pos:        position{line: 609, col: 25, offset: 18601},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 612, col: 30, offset: 18799},
+									pos:   position{line: 609, col: 30, offset: 18606},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 612, col: 32, offset: 18801},
+										pos: position{line: 609, col: 32, offset: 18608},
 										expr: &ruleRefExpr{
-											pos:  position{line: 612, col: 33, offset: 18802},
+											pos:  position{line: 609, col: 33, offset: 18609},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 612, col: 45, offset: 18814},
+									pos:   position{line: 609, col: 45, offset: 18621},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 612, col: 47, offset: 18816},
+										pos:  position{line: 609, col: 47, offset: 18623},
 										name: "ip6tail",
 									},
 								},
@@ -4535,32 +4525,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 615, col: 5, offset: 18915},
+						pos: position{line: 612, col: 5, offset: 18722},
 						run: (*parser).callonip6addr22,
 						expr: &seqExpr{
-							pos: position{line: 615, col: 5, offset: 18915},
+							pos: position{line: 612, col: 5, offset: 18722},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 615, col: 5, offset: 18915},
+									pos:        position{line: 612, col: 5, offset: 18722},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 615, col: 10, offset: 18920},
+									pos:   position{line: 612, col: 10, offset: 18727},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 615, col: 12, offset: 18922},
+										pos: position{line: 612, col: 12, offset: 18729},
 										expr: &ruleRefExpr{
-											pos:  position{line: 615, col: 13, offset: 18923},
+											pos:  position{line: 612, col: 13, offset: 18730},
 											name: "h_prepend",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 615, col: 25, offset: 18935},
+									pos:   position{line: 612, col: 25, offset: 18742},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 615, col: 27, offset: 18937},
+										pos:  position{line: 612, col: 27, offset: 18744},
 										name: "ip6tail",
 									},
 								},
@@ -4568,32 +4558,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 618, col: 5, offset: 19008},
+						pos: position{line: 615, col: 5, offset: 18815},
 						run: (*parser).callonip6addr30,
 						expr: &seqExpr{
-							pos: position{line: 618, col: 5, offset: 19008},
+							pos: position{line: 615, col: 5, offset: 18815},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 618, col: 5, offset: 19008},
+									pos:   position{line: 615, col: 5, offset: 18815},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 618, col: 7, offset: 19010},
+										pos:  position{line: 615, col: 7, offset: 18817},
 										name: "h16",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 618, col: 11, offset: 19014},
+									pos:   position{line: 615, col: 11, offset: 18821},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 618, col: 13, offset: 19016},
+										pos: position{line: 615, col: 13, offset: 18823},
 										expr: &ruleRefExpr{
-											pos:  position{line: 618, col: 14, offset: 19017},
+											pos:  position{line: 615, col: 14, offset: 18824},
 											name: "h_append",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 618, col: 25, offset: 19028},
+									pos:        position{line: 615, col: 25, offset: 18835},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -4601,10 +4591,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 621, col: 5, offset: 19096},
+						pos: position{line: 618, col: 5, offset: 18903},
 						run: (*parser).callonip6addr38,
 						expr: &litMatcher{
-							pos:        position{line: 621, col: 5, offset: 19096},
+							pos:        position{line: 618, col: 5, offset: 18903},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -4614,16 +4604,16 @@ var g = &grammar{
 		},
 		{
 			name: "ip6tail",
-			pos:  position{line: 625, col: 1, offset: 19133},
+			pos:  position{line: 622, col: 1, offset: 18940},
 			expr: &choiceExpr{
-				pos: position{line: 626, col: 5, offset: 19145},
+				pos: position{line: 623, col: 5, offset: 18952},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 626, col: 5, offset: 19145},
+						pos:  position{line: 623, col: 5, offset: 18952},
 						name: "addr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 627, col: 5, offset: 19154},
+						pos:  position{line: 624, col: 5, offset: 18961},
 						name: "h16",
 					},
 				},
@@ -4631,23 +4621,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_append",
-			pos:  position{line: 629, col: 1, offset: 19159},
+			pos:  position{line: 626, col: 1, offset: 18966},
 			expr: &actionExpr{
-				pos: position{line: 629, col: 12, offset: 19170},
+				pos: position{line: 626, col: 12, offset: 18977},
 				run: (*parser).callonh_append1,
 				expr: &seqExpr{
-					pos: position{line: 629, col: 12, offset: 19170},
+					pos: position{line: 626, col: 12, offset: 18977},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 629, col: 12, offset: 19170},
+							pos:        position{line: 626, col: 12, offset: 18977},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 629, col: 16, offset: 19174},
+							pos:   position{line: 626, col: 16, offset: 18981},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 629, col: 18, offset: 19176},
+								pos:  position{line: 626, col: 18, offset: 18983},
 								name: "h16",
 							},
 						},
@@ -4657,23 +4647,23 @@ var g = &grammar{
 		},
 		{
 			name: "h_prepend",
-			pos:  position{line: 630, col: 1, offset: 19213},
+			pos:  position{line: 627, col: 1, offset: 19020},
 			expr: &actionExpr{
-				pos: position{line: 630, col: 13, offset: 19225},
+				pos: position{line: 627, col: 13, offset: 19032},
 				run: (*parser).callonh_prepend1,
 				expr: &seqExpr{
-					pos: position{line: 630, col: 13, offset: 19225},
+					pos: position{line: 627, col: 13, offset: 19032},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 630, col: 13, offset: 19225},
+							pos:   position{line: 627, col: 13, offset: 19032},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 630, col: 15, offset: 19227},
+								pos:  position{line: 627, col: 15, offset: 19034},
 								name: "h16",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 630, col: 19, offset: 19231},
+							pos:        position{line: 627, col: 19, offset: 19038},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -4683,31 +4673,31 @@ var g = &grammar{
 		},
 		{
 			name: "subnet",
-			pos:  position{line: 632, col: 1, offset: 19269},
+			pos:  position{line: 629, col: 1, offset: 19076},
 			expr: &actionExpr{
-				pos: position{line: 633, col: 5, offset: 19280},
+				pos: position{line: 630, col: 5, offset: 19087},
 				run: (*parser).callonsubnet1,
 				expr: &seqExpr{
-					pos: position{line: 633, col: 5, offset: 19280},
+					pos: position{line: 630, col: 5, offset: 19087},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 633, col: 5, offset: 19280},
+							pos:   position{line: 630, col: 5, offset: 19087},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 633, col: 7, offset: 19282},
+								pos:  position{line: 630, col: 7, offset: 19089},
 								name: "addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 633, col: 12, offset: 19287},
+							pos:        position{line: 630, col: 12, offset: 19094},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 633, col: 16, offset: 19291},
+							pos:   position{line: 630, col: 16, offset: 19098},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 633, col: 18, offset: 19293},
+								pos:  position{line: 630, col: 18, offset: 19100},
 								name: "unsignedInteger",
 							},
 						},
@@ -4717,31 +4707,31 @@ var g = &grammar{
 		},
 		{
 			name: "ip6subnet",
-			pos:  position{line: 637, col: 1, offset: 19377},
+			pos:  position{line: 634, col: 1, offset: 19184},
 			expr: &actionExpr{
-				pos: position{line: 638, col: 5, offset: 19391},
+				pos: position{line: 635, col: 5, offset: 19198},
 				run: (*parser).callonip6subnet1,
 				expr: &seqExpr{
-					pos: position{line: 638, col: 5, offset: 19391},
+					pos: position{line: 635, col: 5, offset: 19198},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 638, col: 5, offset: 19391},
+							pos:   position{line: 635, col: 5, offset: 19198},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 638, col: 7, offset: 19393},
+								pos:  position{line: 635, col: 7, offset: 19200},
 								name: "ip6addr",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 638, col: 15, offset: 19401},
+							pos:        position{line: 635, col: 15, offset: 19208},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 638, col: 19, offset: 19405},
+							pos:   position{line: 635, col: 19, offset: 19212},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 638, col: 21, offset: 19407},
+								pos:  position{line: 635, col: 21, offset: 19214},
 								name: "unsignedInteger",
 							},
 						},
@@ -4751,15 +4741,15 @@ var g = &grammar{
 		},
 		{
 			name: "unsignedInteger",
-			pos:  position{line: 642, col: 1, offset: 19481},
+			pos:  position{line: 639, col: 1, offset: 19288},
 			expr: &actionExpr{
-				pos: position{line: 643, col: 5, offset: 19501},
+				pos: position{line: 640, col: 5, offset: 19308},
 				run: (*parser).callonunsignedInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 643, col: 5, offset: 19501},
+					pos:   position{line: 640, col: 5, offset: 19308},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 643, col: 7, offset: 19503},
+						pos:  position{line: 640, col: 7, offset: 19310},
 						name: "suint",
 					},
 				},
@@ -4767,14 +4757,14 @@ var g = &grammar{
 		},
 		{
 			name: "suint",
-			pos:  position{line: 645, col: 1, offset: 19538},
+			pos:  position{line: 642, col: 1, offset: 19345},
 			expr: &actionExpr{
-				pos: position{line: 646, col: 5, offset: 19548},
+				pos: position{line: 643, col: 5, offset: 19355},
 				run: (*parser).callonsuint1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 646, col: 5, offset: 19548},
+					pos: position{line: 643, col: 5, offset: 19355},
 					expr: &charClassMatcher{
-						pos:        position{line: 646, col: 5, offset: 19548},
+						pos:        position{line: 643, col: 5, offset: 19355},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4785,15 +4775,15 @@ var g = &grammar{
 		},
 		{
 			name: "integer",
-			pos:  position{line: 648, col: 1, offset: 19587},
+			pos:  position{line: 645, col: 1, offset: 19394},
 			expr: &actionExpr{
-				pos: position{line: 649, col: 5, offset: 19599},
+				pos: position{line: 646, col: 5, offset: 19406},
 				run: (*parser).calloninteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 649, col: 5, offset: 19599},
+					pos:   position{line: 646, col: 5, offset: 19406},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 649, col: 7, offset: 19601},
+						pos:  position{line: 646, col: 7, offset: 19408},
 						name: "sinteger",
 					},
 				},
@@ -4801,17 +4791,17 @@ var g = &grammar{
 		},
 		{
 			name: "sinteger",
-			pos:  position{line: 651, col: 1, offset: 19639},
+			pos:  position{line: 648, col: 1, offset: 19446},
 			expr: &actionExpr{
-				pos: position{line: 652, col: 5, offset: 19652},
+				pos: position{line: 649, col: 5, offset: 19459},
 				run: (*parser).callonsinteger1,
 				expr: &seqExpr{
-					pos: position{line: 652, col: 5, offset: 19652},
+					pos: position{line: 649, col: 5, offset: 19459},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 652, col: 5, offset: 19652},
+							pos: position{line: 649, col: 5, offset: 19459},
 							expr: &charClassMatcher{
-								pos:        position{line: 652, col: 5, offset: 19652},
+								pos:        position{line: 649, col: 5, offset: 19459},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -4819,7 +4809,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 652, col: 11, offset: 19658},
+							pos:  position{line: 649, col: 11, offset: 19465},
 							name: "suint",
 						},
 					},
@@ -4828,15 +4818,15 @@ var g = &grammar{
 		},
 		{
 			name: "double",
-			pos:  position{line: 654, col: 1, offset: 19696},
+			pos:  position{line: 651, col: 1, offset: 19503},
 			expr: &actionExpr{
-				pos: position{line: 655, col: 5, offset: 19707},
+				pos: position{line: 652, col: 5, offset: 19514},
 				run: (*parser).callondouble1,
 				expr: &labeledExpr{
-					pos:   position{line: 655, col: 5, offset: 19707},
+					pos:   position{line: 652, col: 5, offset: 19514},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 655, col: 7, offset: 19709},
+						pos:  position{line: 652, col: 7, offset: 19516},
 						name: "sdouble",
 					},
 				},
@@ -4844,47 +4834,47 @@ var g = &grammar{
 		},
 		{
 			name: "sdouble",
-			pos:  position{line: 659, col: 1, offset: 19756},
+			pos:  position{line: 656, col: 1, offset: 19563},
 			expr: &choiceExpr{
-				pos: position{line: 660, col: 5, offset: 19768},
+				pos: position{line: 657, col: 5, offset: 19575},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 660, col: 5, offset: 19768},
+						pos: position{line: 657, col: 5, offset: 19575},
 						run: (*parser).callonsdouble2,
 						expr: &seqExpr{
-							pos: position{line: 660, col: 5, offset: 19768},
+							pos: position{line: 657, col: 5, offset: 19575},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 660, col: 5, offset: 19768},
+									pos: position{line: 657, col: 5, offset: 19575},
 									expr: &litMatcher{
-										pos:        position{line: 660, col: 5, offset: 19768},
+										pos:        position{line: 657, col: 5, offset: 19575},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 660, col: 10, offset: 19773},
+									pos: position{line: 657, col: 10, offset: 19580},
 									expr: &ruleRefExpr{
-										pos:  position{line: 660, col: 10, offset: 19773},
+										pos:  position{line: 657, col: 10, offset: 19580},
 										name: "doubleInteger",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 660, col: 25, offset: 19788},
+									pos:        position{line: 657, col: 25, offset: 19595},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 660, col: 29, offset: 19792},
+									pos: position{line: 657, col: 29, offset: 19599},
 									expr: &ruleRefExpr{
-										pos:  position{line: 660, col: 29, offset: 19792},
+										pos:  position{line: 657, col: 29, offset: 19599},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 660, col: 42, offset: 19805},
+									pos: position{line: 657, col: 42, offset: 19612},
 									expr: &ruleRefExpr{
-										pos:  position{line: 660, col: 42, offset: 19805},
+										pos:  position{line: 657, col: 42, offset: 19612},
 										name: "exponentPart",
 									},
 								},
@@ -4892,35 +4882,35 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 663, col: 5, offset: 19864},
+						pos: position{line: 660, col: 5, offset: 19671},
 						run: (*parser).callonsdouble13,
 						expr: &seqExpr{
-							pos: position{line: 663, col: 5, offset: 19864},
+							pos: position{line: 660, col: 5, offset: 19671},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 663, col: 5, offset: 19864},
+									pos: position{line: 660, col: 5, offset: 19671},
 									expr: &litMatcher{
-										pos:        position{line: 663, col: 5, offset: 19864},
+										pos:        position{line: 660, col: 5, offset: 19671},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 663, col: 10, offset: 19869},
+									pos:        position{line: 660, col: 10, offset: 19676},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 663, col: 14, offset: 19873},
+									pos: position{line: 660, col: 14, offset: 19680},
 									expr: &ruleRefExpr{
-										pos:  position{line: 663, col: 14, offset: 19873},
+										pos:  position{line: 660, col: 14, offset: 19680},
 										name: "doubleDigit",
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 663, col: 27, offset: 19886},
+									pos: position{line: 660, col: 27, offset: 19693},
 									expr: &ruleRefExpr{
-										pos:  position{line: 663, col: 27, offset: 19886},
+										pos:  position{line: 660, col: 27, offset: 19693},
 										name: "exponentPart",
 									},
 								},
@@ -4932,29 +4922,29 @@ var g = &grammar{
 		},
 		{
 			name: "doubleInteger",
-			pos:  position{line: 667, col: 1, offset: 19942},
+			pos:  position{line: 664, col: 1, offset: 19749},
 			expr: &choiceExpr{
-				pos: position{line: 668, col: 5, offset: 19960},
+				pos: position{line: 665, col: 5, offset: 19767},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 668, col: 5, offset: 19960},
+						pos:        position{line: 665, col: 5, offset: 19767},
 						val:        "0",
 						ignoreCase: false,
 					},
 					&seqExpr{
-						pos: position{line: 669, col: 5, offset: 19968},
+						pos: position{line: 666, col: 5, offset: 19775},
 						exprs: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 669, col: 5, offset: 19968},
+								pos:        position{line: 666, col: 5, offset: 19775},
 								val:        "[1-9]",
 								ranges:     []rune{'1', '9'},
 								ignoreCase: false,
 								inverted:   false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 669, col: 11, offset: 19974},
+								pos: position{line: 666, col: 11, offset: 19781},
 								expr: &charClassMatcher{
-									pos:        position{line: 669, col: 11, offset: 19974},
+									pos:        position{line: 666, col: 11, offset: 19781},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -4968,9 +4958,9 @@ var g = &grammar{
 		},
 		{
 			name: "doubleDigit",
-			pos:  position{line: 671, col: 1, offset: 19982},
+			pos:  position{line: 668, col: 1, offset: 19789},
 			expr: &charClassMatcher{
-				pos:        position{line: 671, col: 15, offset: 19996},
+				pos:        position{line: 668, col: 15, offset: 19803},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -4979,17 +4969,17 @@ var g = &grammar{
 		},
 		{
 			name: "exponentPart",
-			pos:  position{line: 673, col: 1, offset: 20003},
+			pos:  position{line: 670, col: 1, offset: 19810},
 			expr: &seqExpr{
-				pos: position{line: 673, col: 16, offset: 20018},
+				pos: position{line: 670, col: 16, offset: 19825},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 673, col: 16, offset: 20018},
+						pos:        position{line: 670, col: 16, offset: 19825},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&ruleRefExpr{
-						pos:  position{line: 673, col: 21, offset: 20023},
+						pos:  position{line: 670, col: 21, offset: 19830},
 						name: "sinteger",
 					},
 				},
@@ -4997,17 +4987,17 @@ var g = &grammar{
 		},
 		{
 			name: "h16",
-			pos:  position{line: 675, col: 1, offset: 20033},
+			pos:  position{line: 672, col: 1, offset: 19840},
 			expr: &actionExpr{
-				pos: position{line: 675, col: 7, offset: 20039},
+				pos: position{line: 672, col: 7, offset: 19846},
 				run: (*parser).callonh161,
 				expr: &labeledExpr{
-					pos:   position{line: 675, col: 7, offset: 20039},
+					pos:   position{line: 672, col: 7, offset: 19846},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 675, col: 13, offset: 20045},
+						pos: position{line: 672, col: 13, offset: 19852},
 						expr: &ruleRefExpr{
-							pos:  position{line: 675, col: 13, offset: 20045},
+							pos:  position{line: 672, col: 13, offset: 19852},
 							name: "hexdigit",
 						},
 					},
@@ -5016,9 +5006,9 @@ var g = &grammar{
 		},
 		{
 			name: "hexdigit",
-			pos:  position{line: 677, col: 1, offset: 20087},
+			pos:  position{line: 674, col: 1, offset: 19894},
 			expr: &charClassMatcher{
-				pos:        position{line: 677, col: 12, offset: 20098},
+				pos:        position{line: 674, col: 12, offset: 19905},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -5027,17 +5017,17 @@ var g = &grammar{
 		},
 		{
 			name: "searchWord",
-			pos:  position{line: 679, col: 1, offset: 20111},
+			pos:  position{line: 676, col: 1, offset: 19918},
 			expr: &actionExpr{
-				pos: position{line: 680, col: 5, offset: 20126},
+				pos: position{line: 677, col: 5, offset: 19933},
 				run: (*parser).callonsearchWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 680, col: 5, offset: 20126},
+					pos:   position{line: 677, col: 5, offset: 19933},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 680, col: 11, offset: 20132},
+						pos: position{line: 677, col: 11, offset: 19939},
 						expr: &ruleRefExpr{
-							pos:  position{line: 680, col: 11, offset: 20132},
+							pos:  position{line: 677, col: 11, offset: 19939},
 							name: "searchWordPart",
 						},
 					},
@@ -5046,33 +5036,33 @@ var g = &grammar{
 		},
 		{
 			name: "searchWordPart",
-			pos:  position{line: 682, col: 1, offset: 20182},
+			pos:  position{line: 679, col: 1, offset: 19989},
 			expr: &choiceExpr{
-				pos: position{line: 683, col: 5, offset: 20201},
+				pos: position{line: 680, col: 5, offset: 20008},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 683, col: 5, offset: 20201},
+						pos: position{line: 680, col: 5, offset: 20008},
 						run: (*parser).callonsearchWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 683, col: 5, offset: 20201},
+							pos: position{line: 680, col: 5, offset: 20008},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 683, col: 5, offset: 20201},
+									pos:        position{line: 680, col: 5, offset: 20008},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 683, col: 10, offset: 20206},
+									pos:   position{line: 680, col: 10, offset: 20013},
 									label: "s",
 									expr: &choiceExpr{
-										pos: position{line: 683, col: 13, offset: 20209},
+										pos: position{line: 680, col: 13, offset: 20016},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 683, col: 13, offset: 20209},
+												pos:  position{line: 680, col: 13, offset: 20016},
 												name: "escapeSequence",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 683, col: 30, offset: 20226},
+												pos:  position{line: 680, col: 30, offset: 20033},
 												name: "searchEscape",
 											},
 										},
@@ -5082,18 +5072,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 684, col: 5, offset: 20263},
+						pos: position{line: 681, col: 5, offset: 20070},
 						run: (*parser).callonsearchWordPart9,
 						expr: &seqExpr{
-							pos: position{line: 684, col: 5, offset: 20263},
+							pos: position{line: 681, col: 5, offset: 20070},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 684, col: 5, offset: 20263},
+									pos: position{line: 681, col: 5, offset: 20070},
 									expr: &choiceExpr{
-										pos: position{line: 684, col: 7, offset: 20265},
+										pos: position{line: 681, col: 7, offset: 20072},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 684, col: 7, offset: 20265},
+												pos:        position{line: 681, col: 7, offset: 20072},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;:]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';', ':'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -5101,14 +5091,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 684, col: 43, offset: 20301},
+												pos:  position{line: 681, col: 43, offset: 20108},
 												name: "ws",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 684, col: 47, offset: 20305,
+									line: 681, col: 47, offset: 20112,
 								},
 							},
 						},
@@ -5118,34 +5108,34 @@ var g = &grammar{
 		},
 		{
 			name: "quotedString",
-			pos:  position{line: 686, col: 1, offset: 20339},
+			pos:  position{line: 683, col: 1, offset: 20146},
 			expr: &choiceExpr{
-				pos: position{line: 687, col: 5, offset: 20356},
+				pos: position{line: 684, col: 5, offset: 20163},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 687, col: 5, offset: 20356},
+						pos: position{line: 684, col: 5, offset: 20163},
 						run: (*parser).callonquotedString2,
 						expr: &seqExpr{
-							pos: position{line: 687, col: 5, offset: 20356},
+							pos: position{line: 684, col: 5, offset: 20163},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 687, col: 5, offset: 20356},
+									pos:        position{line: 684, col: 5, offset: 20163},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 687, col: 9, offset: 20360},
+									pos:   position{line: 684, col: 9, offset: 20167},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 687, col: 11, offset: 20362},
+										pos: position{line: 684, col: 11, offset: 20169},
 										expr: &ruleRefExpr{
-											pos:  position{line: 687, col: 11, offset: 20362},
+											pos:  position{line: 684, col: 11, offset: 20169},
 											name: "doubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 687, col: 29, offset: 20380},
+									pos:        position{line: 684, col: 29, offset: 20187},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5153,29 +5143,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 688, col: 5, offset: 20417},
+						pos: position{line: 685, col: 5, offset: 20224},
 						run: (*parser).callonquotedString9,
 						expr: &seqExpr{
-							pos: position{line: 688, col: 5, offset: 20417},
+							pos: position{line: 685, col: 5, offset: 20224},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 688, col: 5, offset: 20417},
+									pos:        position{line: 685, col: 5, offset: 20224},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 688, col: 9, offset: 20421},
+									pos:   position{line: 685, col: 9, offset: 20228},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 688, col: 11, offset: 20423},
+										pos: position{line: 685, col: 11, offset: 20230},
 										expr: &ruleRefExpr{
-											pos:  position{line: 688, col: 11, offset: 20423},
+											pos:  position{line: 685, col: 11, offset: 20230},
 											name: "singleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 688, col: 29, offset: 20441},
+									pos:        position{line: 685, col: 29, offset: 20248},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5187,55 +5177,55 @@ var g = &grammar{
 		},
 		{
 			name: "doubleQuotedChar",
-			pos:  position{line: 690, col: 1, offset: 20475},
+			pos:  position{line: 687, col: 1, offset: 20282},
 			expr: &choiceExpr{
-				pos: position{line: 691, col: 5, offset: 20496},
+				pos: position{line: 688, col: 5, offset: 20303},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 691, col: 5, offset: 20496},
+						pos: position{line: 688, col: 5, offset: 20303},
 						run: (*parser).callondoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 691, col: 5, offset: 20496},
+							pos: position{line: 688, col: 5, offset: 20303},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 691, col: 5, offset: 20496},
+									pos: position{line: 688, col: 5, offset: 20303},
 									expr: &choiceExpr{
-										pos: position{line: 691, col: 7, offset: 20498},
+										pos: position{line: 688, col: 7, offset: 20305},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 691, col: 7, offset: 20498},
+												pos:        position{line: 688, col: 7, offset: 20305},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 691, col: 13, offset: 20504},
+												pos:  position{line: 688, col: 13, offset: 20311},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 691, col: 26, offset: 20517,
+									line: 688, col: 26, offset: 20324,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 692, col: 5, offset: 20554},
+						pos: position{line: 689, col: 5, offset: 20361},
 						run: (*parser).callondoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 692, col: 5, offset: 20554},
+							pos: position{line: 689, col: 5, offset: 20361},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 692, col: 5, offset: 20554},
+									pos:        position{line: 689, col: 5, offset: 20361},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 692, col: 10, offset: 20559},
+									pos:   position{line: 689, col: 10, offset: 20366},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 692, col: 12, offset: 20561},
+										pos:  position{line: 689, col: 12, offset: 20368},
 										name: "escapeSequence",
 									},
 								},
@@ -5247,55 +5237,55 @@ var g = &grammar{
 		},
 		{
 			name: "singleQuotedChar",
-			pos:  position{line: 694, col: 1, offset: 20595},
+			pos:  position{line: 691, col: 1, offset: 20402},
 			expr: &choiceExpr{
-				pos: position{line: 695, col: 5, offset: 20616},
+				pos: position{line: 692, col: 5, offset: 20423},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 695, col: 5, offset: 20616},
+						pos: position{line: 692, col: 5, offset: 20423},
 						run: (*parser).callonsingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 695, col: 5, offset: 20616},
+							pos: position{line: 692, col: 5, offset: 20423},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 695, col: 5, offset: 20616},
+									pos: position{line: 692, col: 5, offset: 20423},
 									expr: &choiceExpr{
-										pos: position{line: 695, col: 7, offset: 20618},
+										pos: position{line: 692, col: 7, offset: 20425},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 695, col: 7, offset: 20618},
+												pos:        position{line: 692, col: 7, offset: 20425},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 695, col: 13, offset: 20624},
+												pos:  position{line: 692, col: 13, offset: 20431},
 												name: "escapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 695, col: 26, offset: 20637,
+									line: 692, col: 26, offset: 20444,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 696, col: 5, offset: 20674},
+						pos: position{line: 693, col: 5, offset: 20481},
 						run: (*parser).callonsingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 696, col: 5, offset: 20674},
+							pos: position{line: 693, col: 5, offset: 20481},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 696, col: 5, offset: 20674},
+									pos:        position{line: 693, col: 5, offset: 20481},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 696, col: 10, offset: 20679},
+									pos:   position{line: 693, col: 10, offset: 20486},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 696, col: 12, offset: 20681},
+										pos:  position{line: 693, col: 12, offset: 20488},
 										name: "escapeSequence",
 									},
 								},
@@ -5307,38 +5297,38 @@ var g = &grammar{
 		},
 		{
 			name: "escapeSequence",
-			pos:  position{line: 698, col: 1, offset: 20715},
+			pos:  position{line: 695, col: 1, offset: 20522},
 			expr: &choiceExpr{
-				pos: position{line: 699, col: 5, offset: 20734},
+				pos: position{line: 696, col: 5, offset: 20541},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 699, col: 5, offset: 20734},
+						pos: position{line: 696, col: 5, offset: 20541},
 						run: (*parser).callonescapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 699, col: 5, offset: 20734},
+							pos: position{line: 696, col: 5, offset: 20541},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 699, col: 5, offset: 20734},
+									pos:        position{line: 696, col: 5, offset: 20541},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 699, col: 9, offset: 20738},
+									pos:  position{line: 696, col: 9, offset: 20545},
 									name: "hexdigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 699, col: 18, offset: 20747},
+									pos:  position{line: 696, col: 18, offset: 20554},
 									name: "hexdigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 700, col: 5, offset: 20798},
+						pos:  position{line: 697, col: 5, offset: 20605},
 						name: "singleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 701, col: 5, offset: 20819},
+						pos:  position{line: 698, col: 5, offset: 20626},
 						name: "unicodeEscape",
 					},
 				},
@@ -5346,75 +5336,75 @@ var g = &grammar{
 		},
 		{
 			name: "singleCharEscape",
-			pos:  position{line: 703, col: 1, offset: 20834},
+			pos:  position{line: 700, col: 1, offset: 20641},
 			expr: &choiceExpr{
-				pos: position{line: 704, col: 5, offset: 20855},
+				pos: position{line: 701, col: 5, offset: 20662},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 704, col: 5, offset: 20855},
+						pos:        position{line: 701, col: 5, offset: 20662},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 705, col: 5, offset: 20863},
+						pos:        position{line: 702, col: 5, offset: 20670},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 706, col: 5, offset: 20871},
+						pos:        position{line: 703, col: 5, offset: 20678},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 707, col: 5, offset: 20880},
+						pos: position{line: 704, col: 5, offset: 20687},
 						run: (*parser).callonsingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 707, col: 5, offset: 20880},
+							pos:        position{line: 704, col: 5, offset: 20687},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 708, col: 5, offset: 20909},
+						pos: position{line: 705, col: 5, offset: 20716},
 						run: (*parser).callonsingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 708, col: 5, offset: 20909},
+							pos:        position{line: 705, col: 5, offset: 20716},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 709, col: 5, offset: 20938},
+						pos: position{line: 706, col: 5, offset: 20745},
 						run: (*parser).callonsingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 709, col: 5, offset: 20938},
+							pos:        position{line: 706, col: 5, offset: 20745},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 710, col: 5, offset: 20967},
+						pos: position{line: 707, col: 5, offset: 20774},
 						run: (*parser).callonsingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 710, col: 5, offset: 20967},
+							pos:        position{line: 707, col: 5, offset: 20774},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 711, col: 5, offset: 20996},
+						pos: position{line: 708, col: 5, offset: 20803},
 						run: (*parser).callonsingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 711, col: 5, offset: 20996},
+							pos:        position{line: 708, col: 5, offset: 20803},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 712, col: 5, offset: 21025},
+						pos: position{line: 709, col: 5, offset: 20832},
 						run: (*parser).callonsingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 712, col: 5, offset: 21025},
+							pos:        position{line: 709, col: 5, offset: 20832},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5424,24 +5414,24 @@ var g = &grammar{
 		},
 		{
 			name: "searchEscape",
-			pos:  position{line: 714, col: 1, offset: 21051},
+			pos:  position{line: 711, col: 1, offset: 20858},
 			expr: &choiceExpr{
-				pos: position{line: 715, col: 5, offset: 21068},
+				pos: position{line: 712, col: 5, offset: 20875},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 715, col: 5, offset: 21068},
+						pos: position{line: 712, col: 5, offset: 20875},
 						run: (*parser).callonsearchEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 715, col: 5, offset: 21068},
+							pos:        position{line: 712, col: 5, offset: 20875},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 716, col: 5, offset: 21096},
+						pos: position{line: 713, col: 5, offset: 20903},
 						run: (*parser).callonsearchEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 716, col: 5, offset: 21096},
+							pos:        position{line: 713, col: 5, offset: 20903},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -5451,41 +5441,41 @@ var g = &grammar{
 		},
 		{
 			name: "unicodeEscape",
-			pos:  position{line: 718, col: 1, offset: 21123},
+			pos:  position{line: 715, col: 1, offset: 20930},
 			expr: &choiceExpr{
-				pos: position{line: 719, col: 5, offset: 21141},
+				pos: position{line: 716, col: 5, offset: 20948},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 719, col: 5, offset: 21141},
+						pos: position{line: 716, col: 5, offset: 20948},
 						run: (*parser).callonunicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 719, col: 5, offset: 21141},
+							pos: position{line: 716, col: 5, offset: 20948},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 719, col: 5, offset: 21141},
+									pos:        position{line: 716, col: 5, offset: 20948},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 719, col: 9, offset: 21145},
+									pos:   position{line: 716, col: 9, offset: 20952},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 719, col: 16, offset: 21152},
+										pos: position{line: 716, col: 16, offset: 20959},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 719, col: 16, offset: 21152},
+												pos:  position{line: 716, col: 16, offset: 20959},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 719, col: 25, offset: 21161},
+												pos:  position{line: 716, col: 25, offset: 20968},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 719, col: 34, offset: 21170},
+												pos:  position{line: 716, col: 34, offset: 20977},
 												name: "hexdigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 719, col: 43, offset: 21179},
+												pos:  position{line: 716, col: 43, offset: 20986},
 												name: "hexdigit",
 											},
 										},
@@ -5495,63 +5485,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 722, col: 5, offset: 21242},
+						pos: position{line: 719, col: 5, offset: 21049},
 						run: (*parser).callonunicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 722, col: 5, offset: 21242},
+							pos: position{line: 719, col: 5, offset: 21049},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 722, col: 5, offset: 21242},
+									pos:        position{line: 719, col: 5, offset: 21049},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 722, col: 9, offset: 21246},
+									pos:        position{line: 719, col: 9, offset: 21053},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 722, col: 13, offset: 21250},
+									pos:   position{line: 719, col: 13, offset: 21057},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 722, col: 20, offset: 21257},
+										pos: position{line: 719, col: 20, offset: 21064},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 722, col: 20, offset: 21257},
+												pos:  position{line: 719, col: 20, offset: 21064},
 												name: "hexdigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 722, col: 29, offset: 21266},
+												pos: position{line: 719, col: 29, offset: 21073},
 												expr: &ruleRefExpr{
-													pos:  position{line: 722, col: 29, offset: 21266},
+													pos:  position{line: 719, col: 29, offset: 21073},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 722, col: 39, offset: 21276},
+												pos: position{line: 719, col: 39, offset: 21083},
 												expr: &ruleRefExpr{
-													pos:  position{line: 722, col: 39, offset: 21276},
+													pos:  position{line: 719, col: 39, offset: 21083},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 722, col: 49, offset: 21286},
+												pos: position{line: 719, col: 49, offset: 21093},
 												expr: &ruleRefExpr{
-													pos:  position{line: 722, col: 49, offset: 21286},
+													pos:  position{line: 719, col: 49, offset: 21093},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 722, col: 59, offset: 21296},
+												pos: position{line: 719, col: 59, offset: 21103},
 												expr: &ruleRefExpr{
-													pos:  position{line: 722, col: 59, offset: 21296},
+													pos:  position{line: 719, col: 59, offset: 21103},
 													name: "hexdigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 722, col: 69, offset: 21306},
+												pos: position{line: 719, col: 69, offset: 21113},
 												expr: &ruleRefExpr{
-													pos:  position{line: 722, col: 69, offset: 21306},
+													pos:  position{line: 719, col: 69, offset: 21113},
 													name: "hexdigit",
 												},
 											},
@@ -5559,7 +5549,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 722, col: 80, offset: 21317},
+									pos:        position{line: 719, col: 80, offset: 21124},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5571,28 +5561,28 @@ var g = &grammar{
 		},
 		{
 			name: "reString",
-			pos:  position{line: 726, col: 1, offset: 21371},
+			pos:  position{line: 723, col: 1, offset: 21178},
 			expr: &actionExpr{
-				pos: position{line: 727, col: 5, offset: 21384},
+				pos: position{line: 724, col: 5, offset: 21191},
 				run: (*parser).callonreString1,
 				expr: &seqExpr{
-					pos: position{line: 727, col: 5, offset: 21384},
+					pos: position{line: 724, col: 5, offset: 21191},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 727, col: 5, offset: 21384},
+							pos:        position{line: 724, col: 5, offset: 21191},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 727, col: 9, offset: 21388},
+							pos:   position{line: 724, col: 9, offset: 21195},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 727, col: 11, offset: 21390},
+								pos:  position{line: 724, col: 11, offset: 21197},
 								name: "reBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 727, col: 18, offset: 21397},
+							pos:        position{line: 724, col: 18, offset: 21204},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5602,24 +5592,24 @@ var g = &grammar{
 		},
 		{
 			name: "reBody",
-			pos:  position{line: 729, col: 1, offset: 21420},
+			pos:  position{line: 726, col: 1, offset: 21227},
 			expr: &actionExpr{
-				pos: position{line: 730, col: 5, offset: 21431},
+				pos: position{line: 727, col: 5, offset: 21238},
 				run: (*parser).callonreBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 730, col: 5, offset: 21431},
+					pos: position{line: 727, col: 5, offset: 21238},
 					expr: &choiceExpr{
-						pos: position{line: 730, col: 6, offset: 21432},
+						pos: position{line: 727, col: 6, offset: 21239},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 730, col: 6, offset: 21432},
+								pos:        position{line: 727, col: 6, offset: 21239},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 730, col: 13, offset: 21439},
+								pos:        position{line: 727, col: 13, offset: 21246},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -5630,9 +5620,9 @@ var g = &grammar{
 		},
 		{
 			name: "escapedChar",
-			pos:  position{line: 732, col: 1, offset: 21479},
+			pos:  position{line: 729, col: 1, offset: 21286},
 			expr: &charClassMatcher{
-				pos:        position{line: 733, col: 5, offset: 21495},
+				pos:        position{line: 730, col: 5, offset: 21302},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5642,37 +5632,37 @@ var g = &grammar{
 		},
 		{
 			name: "ws",
-			pos:  position{line: 735, col: 1, offset: 21510},
+			pos:  position{line: 732, col: 1, offset: 21317},
 			expr: &choiceExpr{
-				pos: position{line: 736, col: 5, offset: 21517},
+				pos: position{line: 733, col: 5, offset: 21324},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 736, col: 5, offset: 21517},
+						pos:        position{line: 733, col: 5, offset: 21324},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 737, col: 5, offset: 21526},
+						pos:        position{line: 734, col: 5, offset: 21333},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 738, col: 5, offset: 21535},
+						pos:        position{line: 735, col: 5, offset: 21342},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 739, col: 5, offset: 21544},
+						pos:        position{line: 736, col: 5, offset: 21351},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 740, col: 5, offset: 21552},
+						pos:        position{line: 737, col: 5, offset: 21359},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 741, col: 5, offset: 21565},
+						pos:        position{line: 738, col: 5, offset: 21372},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5682,33 +5672,33 @@ var g = &grammar{
 		{
 			name:        "_",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 743, col: 1, offset: 21575},
+			pos:         position{line: 740, col: 1, offset: 21382},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 743, col: 18, offset: 21592},
+				pos: position{line: 740, col: 18, offset: 21399},
 				expr: &ruleRefExpr{
-					pos:  position{line: 743, col: 18, offset: 21592},
+					pos:  position{line: 740, col: 18, offset: 21399},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 744, col: 1, offset: 21596},
+			pos:  position{line: 741, col: 1, offset: 21403},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 744, col: 6, offset: 21601},
+				pos: position{line: 741, col: 6, offset: 21408},
 				expr: &ruleRefExpr{
-					pos:  position{line: 744, col: 6, offset: 21601},
+					pos:  position{line: 741, col: 6, offset: 21408},
 					name: "ws",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 746, col: 1, offset: 21606},
+			pos:  position{line: 743, col: 1, offset: 21413},
 			expr: &notExpr{
-				pos: position{line: 746, col: 7, offset: 21612},
+				pos: position{line: 743, col: 7, offset: 21419},
 				expr: &anyMatcher{
-					line: 746, col: 8, offset: 21613,
+					line: 743, col: 8, offset: 21420,
 				},
 			},
 		},
@@ -6373,20 +6363,17 @@ func (p *parser) callonExprList1() (interface{}, error) {
 }
 
 func (c *current) ongroupByProc1(every, reducers, keys, limit interface{}) (interface{}, error) {
-	if OR(keys, every) != nil {
-		if keys != nil {
-			keys = keys.([]interface{})[1]
-		} else {
-			keys = []interface{}{}
-		}
-
-		if every != nil {
-			every = every.([]interface{})[0]
-		}
-
-		return map[string]interface{}{"op": "GroupByProc", "duration": every, "limit": limit, "keys": keys, "reducers": reducers}, nil
+	var p = map[string]interface{}{"op": "GroupByProc", "reducers": reducers}
+	if keys != nil {
+		p["keys"] = keys
 	}
-	return map[string]interface{}{"op": "GroupByProc", "reducers": reducers}, nil
+	if every != nil {
+		p["duration"] = every
+	}
+	if limit != nil {
+		p["limit"] = limit
+	}
+	return p, nil
 
 }
 

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -334,20 +334,17 @@ function peg$parse(input, options) {
             return result
           },
       peg$c99 = function(every, reducers, keys, limit) {
-          if (OR(keys, every)) {
-            if (keys) {
-              keys = keys[1]
-            } else {
-              keys = []
-            }
-
-            if (every) {
-              every = every[0]
-            }
-
-            return {"op": "GroupByProc", "duration": every, "limit": limit, "keys": keys, "reducers": reducers}
+          let p = {"op": "GroupByProc", "reducers": reducers}
+          if (keys) {
+            p["keys"] = keys
           }
-          return {"op": "GroupByProc", "reducers": reducers}
+          if (every) {
+            p["duration"] = every
+          }
+          if (limit) {
+            p["limit"] = limit
+          }
+          return p
         },
       peg$c100 = "=",
       peg$c101 = peg$literalExpectation("=", false),
@@ -2139,24 +2136,30 @@ function peg$parse(input, options) {
   }
 
   function peg$parsegroupByKeys() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c60) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c61); }
-    }
+    s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c60) {
+        s2 = input.substr(peg$currPos, 2);
+        peg$currPos += 2;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+      }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseFlexAssignments();
+        s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c62(s3);
-          s0 = s1;
+          s4 = peg$parseFlexAssignments();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c62(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2285,24 +2288,30 @@ function peg$parse(input, options) {
   }
 
   function peg$parseeveryDur() {
-    var s0, s1, s2, s3;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c68) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
-    }
+    s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
+      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c68) {
+        s2 = input.substr(peg$currPos, 5);
+        peg$currPos += 5;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c69); }
+      }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseduration();
+        s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c70(s3);
-          s0 = s1;
+          s4 = peg$parseduration();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c70(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2932,45 +2941,17 @@ function peg$parse(input, options) {
   }
 
   function peg$parsegroupByProc() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$currPos;
-    s2 = peg$parseeveryDur();
-    if (s2 !== peg$FAILED) {
-      s3 = peg$parse_();
-      if (s3 !== peg$FAILED) {
-        s2 = [s2, s3];
-        s1 = s2;
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s1;
-      s1 = peg$FAILED;
-    }
+    s1 = peg$parseeveryDur();
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsereducerList();
       if (s2 !== peg$FAILED) {
-        s3 = peg$currPos;
-        s4 = peg$parse_();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parsegroupByKeys();
-          if (s5 !== peg$FAILED) {
-            s4 = [s4, s5];
-            s3 = s4;
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
+        s3 = peg$parsegroupByKeys();
         if (s3 === peg$FAILED) {
           s3 = null;
         }

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -2291,22 +2291,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parse_();
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c68) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c69); }
+    }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5).toLowerCase() === peg$c68) {
-        s2 = input.substr(peg$currPos, 5);
-        peg$currPos += 5;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c69); }
-      }
+      s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
+        s3 = peg$parseduration();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseduration();
+          s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c70(s4);
+            s1 = peg$c70(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -231,7 +231,7 @@ proc
     }
 
 groupByKeys
-  = "by"i _ columns:FlexAssignments { RETURN(columns) }
+  = _ "by"i _ columns:FlexAssignments { RETURN(columns) }
 
 // A FlexAssignment is like an Assignment but it can optionally omit the lhs,
 // in which case the semantic pass will infer a name from the rhs, e.g., for
@@ -246,7 +246,7 @@ FlexAssignments
   }
 
 everyDur
-  = "every"i _ dur:duration { RETURN(dur) }
+  = _ "every"i _ dur:duration { RETURN(dur) }
 
 equalityToken
   = EqualityOperator / RelativeOperator
@@ -314,21 +314,18 @@ ExprList
     }
 
 groupByProc
-  = every:(everyDur _)? reducers:reducerList keys:(_ groupByKeys)? limit:procLimitArg? {
-    if ISNOTNULL(OR(keys, every)) {
-      if ISNOTNULL(keys) {
-        keys = ASSERT_ARRAY(keys)[1]
-      } else {
-        keys = ARRAY()
-      }
-
-      if ISNOTNULL(every) {
-        every = ASSERT_ARRAY(every)[0]
-      }
-
-      RETURN(MAP("op": "GroupByProc", "duration": every, "limit": limit, "keys": keys, "reducers": reducers))
+  = every:everyDur? reducers:reducerList keys:groupByKeys? limit:procLimitArg? {
+    VAR(p) = MAP("op": "GroupByProc", "reducers": reducers)
+    if ISNOTNULL(keys) {
+      p["keys"] = keys
     }
-    RETURN(MAP("op": "GroupByProc", "reducers": reducers))
+    if ISNOTNULL(every) {
+      p["duration"] = every
+    }
+    if ISNOTNULL(limit) {
+      p["limit"] = limit
+    }
+    RETURN(p)
   }
 
 ReducerAssignment

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -246,7 +246,7 @@ FlexAssignments
   }
 
 everyDur
-  = _ "every"i _ dur:duration { RETURN(dur) }
+  = "every"i _ dur:duration _ { RETURN(dur) }
 
 equalityToken
   = EqualityOperator / RelativeOperator

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -316,11 +316,11 @@ ExprList
 groupByProc
   = every:everyDur? reducers:reducerList keys:groupByKeys? limit:procLimitArg? {
     VAR(p) = MAP("op": "GroupByProc", "reducers": reducers)
-    if ISNOTNULL(keys) {
-      p["keys"] = keys
-    }
     if ISNOTNULL(every) {
       p["duration"] = every
+    }
+    if ISNOTNULL(keys) {
+      p["keys"] = keys
     }
     if ISNOTNULL(limit) {
       p["limit"] = limit


### PR DESCRIPTION
This commit fixes a bug in the groupby ast where the limit arg wasn't
being passed through without a keys argument (arguably the limit isn't
needed without keys, but that will no longer be the case for large-valued
reducers using union or collect).

We also simplify the groupby ast assembly logic in the peg rule by
following the pattern that any optional args with leading space
have space in the child rule not the parent.

Also, we added several omitempty tags to make the go ast json more
in line with the javascript json.