### PR TITLE
zqd root process

### DIFF
--- a/archive/multisource.go
+++ b/archive/multisource.go
@@ -198,6 +198,7 @@ func (s *chunkSource) Open(ctx context.Context, zctx *resolver.Context, sf drive
 	rc := detector.MultiFileReader(zctx, paths, zio.ReaderOpts{Format: "zng"})
 	sn, err := scanner.NewScanner(ctx, rc, sf.Filter, sf.FilterExpr, sf.Span)
 	if err != nil {
+		rc.Close()
 		return nil, err
 	}
 	return &scannerCloser{Scanner: sn, Closer: rc}, nil

--- a/archive/multisource.go
+++ b/archive/multisource.go
@@ -97,9 +97,7 @@ func NewMultiSource(ark *Archive, altPaths []string) driver.MultiSource {
 			altPaths: altPaths,
 		}
 	}
-	return &spanMultiSource{
-		ark: ark,
-	}
+	return &spanMultiSource{ark}
 }
 
 type spanMultiSource struct {

--- a/archive/multisource.go
+++ b/archive/multisource.go
@@ -151,6 +151,7 @@ func (s *spanSource) Open(ctx context.Context, zctx *resolver.Context, sf driver
 
 func (s *spanSource) ToRequest(req *api.WorkerRequest) error {
 	req.Span = s.spanInfo.Span
+	req.DataPath = s.ark.DataPath.String()
 	for _, c := range s.spanInfo.Chunks {
 		req.ChunkPaths = append(req.ChunkPaths, c.RelativePath())
 	}

--- a/archive/staticsource.go
+++ b/archive/staticsource.go
@@ -7,27 +7,20 @@ import (
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zqe"
 )
 
 // staticSource is an implementation of driver.MultiSource that provides
 // a single SpanInfo (with Chunks) to be processed by a zqd worker.
 // staticSource is used only for the zqd /worker call.
 type staticSource struct {
-	ark *Archive
-	sis SpanInfoSource
+	*spanMultiSource
+	src driver.Source
 }
 
-type SpanInfoSource struct {
-	Span       nano.Span
-	ChunkPaths []string
-}
-
-func NewStaticSource(ark *Archive, sis SpanInfoSource) driver.MultiSource {
+func NewStaticSource(ark *Archive, src driver.Source) driver.MultiSource {
 	return &staticSource{
-		ark: ark,
-		sis: sis,
+		spanMultiSource: &spanMultiSource{ark: ark},
+		src:             src,
 	}
 }
 
@@ -35,24 +28,9 @@ func (s *staticSource) OrderInfo() (field.Static, bool) {
 	return field.New("ts"), s.ark.DataOrder == zbuf.OrderDesc
 }
 
-func (s *staticSource) SendSources(ctx context.Context, zctx *resolver.Context, sf driver.SourceFilter, srcChan chan driver.SourceOpener) error {
-	si := SpanInfo{Span: s.sis.Span}
-	for _, p := range s.sis.ChunkPaths {
-		tsd, _, id, ok := parseChunkRelativePath(p)
-		if !ok {
-			return zqe.E(zqe.Invalid, "invalid chunk path: %v", p)
-		}
-		md, err := readChunkMetadata(ctx, chunkMetadataPath(s.ark, tsd, id))
-		if err != nil {
-			return err
-		}
-		si.Chunks = append(si.Chunks, md.Chunk(id))
-	}
-	so := func() (driver.ScannerCloser, error) {
-		return newSpanScanner(ctx, s.ark, zctx, sf.Filter, sf.FilterExpr, si)
-	}
+func (s *staticSource) SendSources(ctx context.Context, span nano.Span, srcChan chan driver.Source) error {
 	select {
-	case srcChan <- so:
+	case srcChan <- s.src:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -98,25 +99,26 @@ func (c *Command) Run(args []string) error {
 		expr = strings.Join(args, " ")
 	}
 	client := c.Client()
-	id, err := c.SpaceID()
-	if err != nil {
-		return err
-	}
 
 	var r io.ReadCloser
 	if c.chunkInfo == "" {
+		id, err := c.SpaceID()
+		if err != nil {
+			return err
+		}
 		req, err := parseExpr(id, expr)
 		if err != nil {
 			return fmt.Errorf("parse error: %s", err)
 		}
 		req.Span = nano.NewSpanTs(nano.Ts(c.from), nano.Ts(c.to))
+
 		params := map[string]string{"format": c.encoding}
 		r, err = client.SearchRaw(c.Context(), *req, params)
 		if err != nil {
 			return fmt.Errorf("search error: %w", err)
 		}
 	} else {
-		req, err := parseExprWithChunk(id, expr, c.chunkInfo)
+		req, err := parseExprWithChunk(expr, c.chunkInfo)
 		req.Span = nano.NewSpanTs(nano.Ts(c.from), nano.Ts(c.to))
 		params := map[string]string{"format": c.encoding}
 		if err != nil {
@@ -173,15 +175,25 @@ func parseExpr(spaceID api.SpaceID, expr string) (*api.SearchRequest, error) {
 }
 
 // parseExprWithChunk creates an api.WorkerRequest to be used with the client.
-func parseExprWithChunk(spaceID api.SpaceID, expr string, chunkInfo string) (*api.WorkerRequest, error) {
+func parseExprWithChunk(expr string, chunkPath string) (*api.WorkerRequest, error) {
 	// This is only for testing using the -chunk flag
-	searchRequest, err := parseExpr(spaceID, expr)
+	search, err := zql.ParseProc(expr)
 	if err != nil {
 		return nil, err
 	}
+	proc, err := json.Marshal(search)
+	if err != nil {
+		return nil, err
+	}
+	searchRequest := &api.SearchRequest{
+		Proc: proc,
+		Dir:  -1,
+	}
+	dataPath := filepath.Join(filepath.Dir(chunkPath), "../..")
 	return &api.WorkerRequest{
 		SearchRequest: *searchRequest,
-		ChunkPaths:    []string{chunkInfo},
+		DataPath:      dataPath,
+		ChunkPaths:    []string{chunkPath},
 	}, nil
 }
 

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -111,7 +111,6 @@ func (c *Command) Run(args []string) error {
 			return fmt.Errorf("parse error: %s", err)
 		}
 		req.Span = nano.NewSpanTs(nano.Ts(c.from), nano.Ts(c.to))
-
 		params := map[string]string{"format": c.encoding}
 		r, err = client.SearchRaw(c.Context(), *req, params)
 		if err != nil {

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -184,15 +184,13 @@ func parseExprWithChunk(expr string, chunkPath string) (*api.WorkerRequest, erro
 	if err != nil {
 		return nil, err
 	}
-	searchRequest := &api.SearchRequest{
-		Proc: proc,
-		Dir:  -1,
-	}
-	dataPath := filepath.Join(filepath.Dir(chunkPath), "../..")
 	return &api.WorkerRequest{
-		SearchRequest: *searchRequest,
-		DataPath:      dataPath,
-		ChunkPaths:    []string{chunkPath},
+		SearchRequest: api.SearchRequest{
+			Proc: proc,
+			Dir:  -1,
+		},
+		DataPath:   filepath.Join(filepath.Dir(chunkPath), "../.."),
+		ChunkPaths: []string{chunkPath},
 	}, nil
 }
 

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -189,7 +189,7 @@ func parseExprWithChunk(expr string, chunkPath string) (*api.WorkerRequest, erro
 			Proc: proc,
 			Dir:  -1,
 		},
-		DataPath:   filepath.Join(filepath.Dir(chunkPath), "../.."),
+		DataPath:   path.Join(path.Dir(chunkPath), "../.."),
 		ChunkPaths: []string{chunkPath},
 	}, nil
 }

--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -272,11 +272,14 @@ func (c *Command) initWorkers() error {
 		workerArr := strings.Split(c.workers, ",")
 		for i, addr := range workerArr {
 			// default host to 127.0.0.1
-			a := strings.Split(addr, ":")
-			if a[0] == "" {
-				a[0] = "127.0.0.1"
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return err
 			}
-			workerArr[i] = "http://" + strings.Join(a, ":")
+			if host == "" {
+				host = "127.0.0.1"
+			}
+			workerArr[i] = "http://" + host + ":" + port
 		}
 		driver.WorkerURLs = workerArr
 	}

--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -273,7 +273,8 @@ func (c *Command) initWorkers() error {
 			if _, _, err := net.SplitHostPort(w); err != nil {
 				return err
 			}
-			driver.WorkerURLs = append(driver.WorkerURLs, "http://" + w)
+			driver.WorkerURLs = append(driver.WorkerURLs, "http://"+w)
+		}
 	}
 	return nil
 }

--- a/cmd/zqd/listen/command.go
+++ b/cmd/zqd/listen/command.go
@@ -269,19 +269,11 @@ func (c *Command) initWorkers() error {
 	// This is for local testing only, at this point.
 	// Workers will be available through a K8s service in a prod deployment.
 	if c.workers != "" {
-		workers := strings.Split(c.workers, ",")
-		for i, addr := range workers {
-			// default host to 127.0.0.1
-			host, port, err := net.SplitHostPort(addr)
-			if err != nil {
+		for _, w := range strings.Split(c.workers, ",") {
+			if _, _, err := net.SplitHostPort(w); err != nil {
 				return err
 			}
-			if host == "" {
-				host = "127.0.0.1"
-			}
-			workers[i] = "http://" + host + ":" + port
-		}
-		driver.WorkerURLs = workers
+			driver.WorkerURLs = append(driver.WorkerURLs, "http://" + w)
 	}
 	return nil
 }

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -21,6 +21,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// Global variable for driver package
+// which determines whether this go process will
+// (1) implement parallelism by engaging multiple
+// remote zqd /worker processes, or
+// (2) implement parallelism with local goroutines
+var WorkerURLs []string
+
 // XXX ReaderSortKey should be a field.Static.  Issue #1467.
 type Config struct {
 	Custom            compiler.Hook
@@ -168,7 +175,7 @@ func compileMulti(ctx context.Context, program ast.Proc, zctx *resolver.Context,
 		Logger:      mcfg.Logger,
 		Warnings:    mcfg.Warnings,
 	}
-	sources, pgroup, err := createParallelGroup(pctx, filt, filterExpr, msrc, mcfg)
+	sources, pgroup, err := createParallelGroup(pctx, filt, filterExpr, msrc, mcfg, WorkerURLs)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -32,6 +32,13 @@ type Config struct {
 	Warnings          chan string
 }
 
+func zbufDirInt(reversed bool) int {
+	if reversed {
+		return -1
+	}
+	return 1
+}
+
 func programPrep(program ast.Proc, sortKey field.Static, sortReversed bool) (ast.Proc, filter.Filter, ast.BooleanExpr, error) {
 	ReplaceGroupByProcDurationWithKey(program)
 	if sortKey != nil {
@@ -102,6 +109,15 @@ func compileSingle(ctx context.Context, program ast.Proc, zctx *resolver.Context
 		return nil, err
 	}
 	return newMuxOutput(pctx, leaves, sn), nil
+}
+
+type MultiConfig struct {
+	Custom      compiler.Hook
+	Logger      *zap.Logger
+	Parallelism int
+	Span        nano.Span
+	StatsTick   <-chan time.Time
+	Warnings    chan string
 }
 
 func compileMulti(ctx context.Context, program ast.Proc, zctx *resolver.Context, msrc MultiSource, mcfg MultiConfig) (*muxOutput, error) {
@@ -180,6 +196,13 @@ func liftFilter(p ast.Proc) (ast.BooleanExpr, ast.Proc) {
 		}
 	}
 	return nil, p
+}
+
+func filterToProc(be ast.BooleanExpr) ast.Proc {
+	return &ast.FilterProc{
+		Node:   ast.Node{Op: "FilterProc"},
+		Filter: be,
+	}
 }
 
 func ReplaceGroupByProcDurationWithKey(p ast.Proc) {

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -18,6 +18,7 @@ import (
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zqd/api"
 	"go.uber.org/zap"
 )
 
@@ -113,8 +114,10 @@ func compileSingle(ctx context.Context, program ast.Proc, zctx *resolver.Context
 
 type MultiConfig struct {
 	Custom      compiler.Hook
+	Dir         int
 	Logger      *zap.Logger
 	Parallelism int
+	SpaceID     api.SpaceID
 	Span        nano.Span
 	StatsTick   <-chan time.Time
 	Warnings    chan string
@@ -130,8 +133,21 @@ func compileMulti(ctx context.Context, program ast.Proc, zctx *resolver.Context,
 	if mcfg.Warnings == nil {
 		mcfg.Warnings = make(chan string, 5)
 	}
+
 	if mcfg.Parallelism == 0 {
-		mcfg.Parallelism = runtime.GOMAXPROCS(0)
+		// If mcfg.Parallelism has not been set by external configuration,
+		// then it will be zero here.
+		if len(WorkerURLs) >= 2 {
+			// If zqd has been started as a "root" process,
+			// there is a -worker parameter with a list of WorkerURLs.
+			// In this case, initialize Parallelism as the number of workers.
+			mcfg.Parallelism = len(WorkerURLs)
+		} else {
+			// Otherwise, we will use threads (goroutines) for parallelism,
+			// so initialize Parallelism based on
+			// runtime configuation of max threads.
+			mcfg.Parallelism = runtime.GOMAXPROCS(0)
+		}
 	}
 
 	sortKey, sortReversed := msrc.OrderInfo()

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -118,7 +118,7 @@ func compileSingle(ctx context.Context, program ast.Proc, zctx *resolver.Context
 
 type MultiConfig struct {
 	Custom      compiler.Hook
-	Dir         int
+	Order       zbuf.Order
 	Logger      *zap.Logger
 	Parallelism int
 	Span        nano.Span

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -18,7 +18,6 @@ import (
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zqd/api"
 	"go.uber.org/zap"
 )
 
@@ -117,7 +116,6 @@ type MultiConfig struct {
 	Dir         int
 	Logger      *zap.Logger
 	Parallelism int
-	SpaceID     api.SpaceID
 	Span        nano.Span
 	StatsTick   <-chan time.Time
 	Warnings    chan string
@@ -137,7 +135,7 @@ func compileMulti(ctx context.Context, program ast.Proc, zctx *resolver.Context,
 	if mcfg.Parallelism == 0 {
 		// If mcfg.Parallelism has not been set by external configuration,
 		// then it will be zero here.
-		if len(WorkerURLs) >= 2 {
+		if len(WorkerURLs) > 0 {
 			// If zqd has been started as a "root" process,
 			// there is a -worker parameter with a list of WorkerURLs.
 			// In this case, initialize Parallelism as the number of workers.

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -21,11 +21,9 @@ import (
 	"go.uber.org/zap"
 )
 
-// Global variable for driver package
-// which determines whether this go process will
-// (1) implement parallelism by engaging multiple
-// remote zqd /worker processes, or
-// (2) implement parallelism with local goroutines
+// WorkerURLs, if not empty, causes this process to
+// implement parallelism using worker processes
+// instead of goroutines.
 var WorkerURLs []string
 
 // XXX ReaderSortKey should be a field.Static.  Issue #1467.

--- a/driver/multisource.go
+++ b/driver/multisource.go
@@ -3,16 +3,14 @@ package driver
 import (
 	"context"
 	"io"
-	"time"
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/filter"
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/brimsec/zq/proc/compiler"
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zng/resolver"
-	"go.uber.org/zap"
+	"github.com/brimsec/zq/zqd/api"
 )
 
 // A MultiSource is a set of one or more ZNG record sources, which could be
@@ -32,13 +30,14 @@ type MultiSource interface {
 	// performance, SendSources should perform quick filtering that performs
 	// little or no i/o, and let the returned ScannerCloser perform more intensive
 	// filtering (e.g., reading a micro-index to check for filter matching).
-	SendSources(context.Context, *resolver.Context, SourceFilter, chan SourceOpener) error
+	SendSources(context.Context, nano.Span, chan Source) error
+	SourceFromRequest(context.Context, *api.WorkerRequest) (Source, error)
 }
 
-// A SourceOpener is a closure sent by a MultiSource to provide scanning
-// access to a single source. It may return a nil ScannerCloser, in the
-// case that it represents a logically empty source.
-type SourceOpener func() (ScannerCloser, error)
+type Source interface {
+	Open(context.Context, *resolver.Context, SourceFilter) (ScannerCloser, error)
+	ToRequest(*api.WorkerRequest) error
+}
 
 type ScannerCloser interface {
 	scanner.Scanner
@@ -49,20 +48,4 @@ type SourceFilter struct {
 	Filter     filter.Filter
 	FilterExpr ast.BooleanExpr
 	Span       nano.Span
-}
-
-type MultiConfig struct {
-	Custom      compiler.Hook
-	Logger      *zap.Logger
-	Parallelism int
-	Span        nano.Span
-	StatsTick   <-chan time.Time
-	Warnings    chan string
-}
-
-func zbufDirInt(reversed bool) int {
-	if reversed {
-		return -1
-	}
-	return 1
 }

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -257,10 +257,8 @@ func createParallelGroup(pctx *proc.Context, filt filter.Filter, filterExpr ast.
 		// and driver.compile has determined that execution should be parallel
 		// then the sources are parallelHead procs that hold connections to
 		// remote zqd workers.
-		sources = make([]proc.Interface, len(workerURLs))
-		for i := range sources {
-			conn := api.NewConnectionTo(workerURLs[i])
-			sources[i] = &parallelHead{pctx: pctx, parent: nil, pg: pg, workerConn: conn}
+		range _, w := range workerURLs {
+			sources = append(sources, &parallelHead{pctx: pctx, pg: pg, workerConn: api.NewConnectionTo(w)}
 		}
 	} else {
 		// Normal: the sources are regular parallelHead procs

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -135,7 +135,7 @@ func (pg *parallelGroup) nextSource() (ScannerCloser, error) {
 // nextSourceForConn is similar to nextSource, but instead of returning the scannerCloser
 // for an open file (i.e. the stream for the open file),
 // nextSourceForConn sends a request to a remote zqd worker process, and returns
-// the scannerCloser (i.e.output stream) for the remote zqd worker.
+// the ScannerCloser (i.e.output stream) for the remote zqd worker.
 func (pg *parallelGroup) nextSourceForConn(conn *api.Connection) (ScannerCloser, error) {
 	select {
 	case src, ok := <-pg.sourceChan:

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -61,15 +61,13 @@ func (ph *parallelHead) Pull() (zbuf.Batch, error) {
 			if ph.workerConn == nil {
 				// Thread (goroutine) parallelism uses nextSource
 				sc, err = ph.pg.nextSource()
-				if sc == nil || err != nil {
-					return nil, err
-				}
+	
 			} else {
 				// Worker process parallelism uses nextSourceForConn
 				sc, err = ph.pg.nextSourceForConn(ph.workerConn)
-				if sc == nil || err != nil {
-					return nil, err
-				}
+			}
+			if sc == nil || err != nil {
+				return nil, err
 			}
 			ph.sc = sc
 		}

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -261,7 +261,7 @@ func createParallelGroup(pctx *proc.Context, filt filter.Filter, filterExpr ast.
 
 	var sources []proc.Interface
 	// Two type of parallelGroups:
-	if len(WorkerURLs) > 0 && mcfg.Parallelism > 1 {
+	if len(WorkerURLs) > 0 {
 		// If -worker URLs are passed in zqd listen command,
 		// and driver.compile has determined that execution should be parallel
 		// then the sources are parallelHead procs that hold connections to

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -185,8 +185,7 @@ func (pg *parallelGroup) sourceToRequest(src Source) (*api.WorkerRequest, error)
 	if err := src.ToRequest(&req); err != nil {
 		return nil, err
 	}
-	filterExpr := pg.filter.FilterExpr
-	if filterExpr != nil {
+	if filterExpr := pg.filter.FilterExpr; filterExpr != nil {
 		b, err := json.Marshal(filterToProc(filterExpr))
 		if err != nil {
 			return nil, err

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -265,7 +265,7 @@ func createParallelGroup(pctx *proc.Context, filt filter.Filter, filterExpr ast.
 		// and Parallelism is determined by mcfg
 		sources = make([]proc.Interface, mcfg.Parallelism)
 		for i := range sources {
-			sources[i] = &parallelHead{pctx: pctx, parent: nil, pg: pg}
+			sources[i] = &parallelHead{pctx: pctx, pg: pg}
 		}
 	}
 	return sources, pg, nil

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -192,7 +192,7 @@ func (pg *parallelGroup) sourceToRequest(src Source) (*api.WorkerRequest, error)
 		}
 		req.Proc = b
 	}
-	req.Dir = pg.mcfg.Dir
+	req.Dir = pg.mcfg.Order.Int()
 	return &req, nil
 }
 

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -100,7 +100,7 @@ type parallelGroup struct {
 	pctx       *proc.Context
 	filter     SourceFilter
 	msrc       MultiSource
-	mcfg       MultiConfig // supports a hack -MTW
+	mcfg       MultiConfig
 	once       sync.Once
 	sourceChan chan Source
 	sourceErr  error

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -134,7 +134,7 @@ func (pg *parallelGroup) nextSource() (ScannerCloser, error) {
 
 // nextSourceForConn is similar to nextSource, but instead of returning the scannerCloser
 // for an open file (i.e. the stream for the open file),
-// nextSourceForConn sends an zapi api request to a remote zqd worker process, and returns
+// nextSourceForConn sends a request to a remote zqd worker process, and returns
 // the scannerCloser (i.e.output stream) for the remote zqd worker.
 func (pg *parallelGroup) nextSourceForConn(conn *api.Connection) (ScannerCloser, error) {
 	for {

--- a/driver/parallel_test.go
+++ b/driver/parallel_test.go
@@ -3,17 +3,20 @@ package driver
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zqd/api"
 	"github.com/brimsec/zq/zql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,6 +36,18 @@ func (c *onClose) Close() error {
 		return nil
 	}
 	return c.fn()
+}
+
+type testSource struct {
+	opener func(*resolver.Context, SourceFilter) (ScannerCloser, error)
+}
+
+func (s *testSource) Open(ctx context.Context, zctx *resolver.Context, sf SourceFilter) (ScannerCloser, error) {
+	return s.opener(zctx, sf)
+}
+
+func (s *testSource) ToRequest(*api.WorkerRequest) error {
+	return errors.New("ToRequest called on testSource")
 }
 
 var parallelTestInputs []string = []string{
@@ -59,7 +74,7 @@ func (m *orderedmsrc) OrderInfo() (field.Static, bool) {
 	return field.New("ts"), false
 }
 
-func (m *orderedmsrc) SendSources(ctx context.Context, zctx *resolver.Context, sf SourceFilter, srcChan chan SourceOpener) error {
+func (m *orderedmsrc) SendSources(ctx context.Context, span nano.Span, srcChan chan Source) error {
 	// Create SourceOpeners that await a signal before returning, then
 	// signal them in reverse of expected order.
 	var releaseChs []chan struct{}
@@ -68,12 +83,12 @@ func (m *orderedmsrc) SendSources(ctx context.Context, zctx *resolver.Context, s
 	}
 	for i := range parallelTestInputs {
 		i := i
-		rdr := tzngio.NewReader(strings.NewReader(parallelTestInputs[i]), zctx)
-		sn, err := scanner.NewScanner(ctx, rdr, sf.Filter, sf.FilterExpr, sf.Span)
-		if err != nil {
-			return err
-		}
-		srcChan <- func() (ScannerCloser, error) {
+		opener := func(zctx *resolver.Context, sf SourceFilter) (ScannerCloser, error) {
+			rdr := tzngio.NewReader(strings.NewReader(parallelTestInputs[i]), zctx)
+			sn, err := scanner.NewScanner(ctx, rdr, sf.Filter, sf.FilterExpr, sf.Span)
+			if err != nil {
+				return nil, err
+			}
 			select {
 			case <-releaseChs[i]:
 			}
@@ -82,11 +97,16 @@ func (m *orderedmsrc) SendSources(ctx context.Context, zctx *resolver.Context, s
 				Closer:  &onClose{},
 			}, nil
 		}
+		srcChan <- &testSource{opener: opener}
 	}
 	for i := len(parallelTestInputs) - 1; i >= 0; i-- {
 		close(releaseChs[i])
 	}
 	return nil
+}
+
+func (m *orderedmsrc) SourceFromRequest(context.Context, *api.WorkerRequest) (Source, error) {
+	return nil, errors.New("SourceFromRequest called on orderedmsrc")
 }
 
 func trim(s string) string {
@@ -142,8 +162,8 @@ func (m *scannerCloseMS) OrderInfo() (field.Static, bool) {
 	return nil, false
 }
 
-func (m *scannerCloseMS) SendSources(ctx context.Context, zctx *resolver.Context, sf SourceFilter, srcChan chan SourceOpener) error {
-	srcChan <- func() (ScannerCloser, error) {
+func (m *scannerCloseMS) SendSources(ctx context.Context, span nano.Span, srcChan chan Source) error {
+	opener := func(zctx *resolver.Context, _ SourceFilter) (ScannerCloser, error) {
 		return &scannerCloser{
 			// Use a noEndScanner so that a parallel head never tries to
 			// close the ScannerCloser in its Pull. That way, if the Close fires,
@@ -155,7 +175,12 @@ func (m *scannerCloseMS) SendSources(ctx context.Context, zctx *resolver.Context
 			}},
 		}, nil
 	}
+	srcChan <- &testSource{opener: opener}
 	return nil
+}
+
+func (m *scannerCloseMS) SourceFromRequest(context.Context, *api.WorkerRequest) (Source, error) {
+	return nil, errors.New("SourceFromRequest called on scannerCloseMS")
 }
 
 // TestScannerClose verifies that any open ScannerCloser's will be closed soon

--- a/k8s/dist-test.sh
+++ b/k8s/dist-test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -x #echo on
+
+# This shell file helps set up ad-hoc testing of a local
+# "cluster" of zqd processes. It is helpful for trouble-shooting.
+# it should be run in a seperate directory that contains smtp.log.gz
+
+# remove processes from previous run of dist-test.sh:
+kill $(ps aux | grep '[z]qd' | awk '{print $2}')
+kill $(ps aux | grep '[t]ail' | awk '{print $2}')
+
+# remove directories from previous run of dist-test.sh:
+rm -rf spacedir
+
+mkdir -p spacedir
+# Start 2 zqd/workers
+zqd listen -l :9871 -data spacedir &> zqd-w1.log &
+zqd listen -l :9872 -data spacedir &> zqd-w2.log &
+# start the root zqd
+zqd listen -l :9867 -data spacedir -workers :9871,:9872  &> zqd-root.log &
+# tail everything
+tail -f zqd-w1.log &
+tail -f zqd-w2.log &
+tail -f zqd-root.log &
+
+sleep 1
+
+# create an archive with the records from smtp.log.gz
+zapi new -k archivestore -d spacedir -thresh 15KB testsp
+zapi -s testsp post smtp.log.gz
+
+sleep 1
+echo "Here is a example zapi query that uses the cluster:"
+zapi -s testsp get -t "count()"

--- a/k8s/dist-test.sh
+++ b/k8s/dist-test.sh
@@ -6,8 +6,7 @@ set -x #echo on
 # it should be run in a seperate directory that contains smtp.log.gz
 
 # remove processes from previous run of dist-test.sh:
-kill $(ps aux | grep '[z]qd' | awk '{print $2}')
-kill $(ps aux | grep '[t]ail' | awk '{print $2}')
+pkill tail zqd
 
 # remove directories from previous run of dist-test.sh:
 rm -rf spacedir

--- a/proc/compiler/compiler.go
+++ b/proc/compiler/compiler.go
@@ -160,6 +160,9 @@ func compileParallel(custom Hook, pp *ast.ParallelProc, c *proc.Context, parents
 		}
 	}
 	if len(parents) != n {
+		// TODO: This should not be able to happen.
+		// Consider modifying the flow control before this so parents and pp.Procs are
+		// created in the same loop. -MTW
 		return nil, fmt.Errorf("proc.CompileProc: %d parents for parallel proc with %d branches", len(parents), len(pp.Procs))
 	}
 	var procs []proc.Interface

--- a/proc/compiler/compiler.go
+++ b/proc/compiler/compiler.go
@@ -160,9 +160,6 @@ func compileParallel(custom Hook, pp *ast.ParallelProc, c *proc.Context, parents
 		}
 	}
 	if len(parents) != n {
-		// TODO: This should not be able to happen.
-		// Consider modifying the flow control before this so parents and pp.Procs are
-		// created in the same loop. -MTW
 		return nil, fmt.Errorf("proc.CompileProc: %d parents for parallel proc with %d branches", len(parents), len(pp.Procs))
 	}
 	var procs []proc.Interface

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -48,7 +48,7 @@ type SearchRequest struct {
 type WorkerRequest struct {
 	SearchRequest
 	ChunkPaths []string `json:"chunk_paths"`
-	DataPath   string   `json:"datapath"`
+	DataPath   string   `json:"data_path"`
 }
 
 type SearchRecords struct {

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -48,6 +48,7 @@ type SearchRequest struct {
 type WorkerRequest struct {
 	SearchRequest
 	ChunkPaths []string `json:"chunk_paths"`
+	DataPath   string   `json:"datapath"`
 }
 
 type SearchRecords struct {

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/brimsec/zq/archive"
+
 	"github.com/brimsec/zq/pcap"
 	"github.com/brimsec/zq/pkg/ctxio"
 	"github.com/brimsec/zq/zbuf"
@@ -106,7 +108,7 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", out.ContentType())
-	if err := srch.Run(ctx, s.Storage(), out); err != nil {
+	if err := srch.Run(ctx, req.Dir, s, out); err != nil {
 		c.requestLogger(r).Warn("Error writing response", zap.Error(err))
 	}
 }
@@ -117,20 +119,15 @@ func handleWorker(c *Core, w http.ResponseWriter, httpReq *http.Request) {
 		return
 	}
 
-	space, err := c.spaces.Get(req.Space)
+	ctx := httpReq.Context()
+
+	ark, err := archive.OpenArchiveWithContext(ctx, req.DataPath, &archive.OpenOptions{})
 	if err != nil {
 		respondError(c, w, httpReq, err)
 		return
 	}
 
-	ctx, cancel, err := space.StartOp(httpReq.Context())
-	if err != nil {
-		respondError(c, w, httpReq, err)
-		return
-	}
-	defer cancel()
-
-	srch, err := search.NewWorkerOp(ctx, req, space.Storage())
+	work, err := search.NewWorkerOp(ctx, req, archivestore.NewStorage(ark))
 	if err != nil {
 		respondError(c, w, httpReq, err)
 		return
@@ -144,7 +141,7 @@ func handleWorker(c *Core, w http.ResponseWriter, httpReq *http.Request) {
 
 	w.Header().Set("Content-Type", out.ContentType())
 
-	if err := srch.Run(ctx, out); err != nil {
+	if err := work.Run(ctx, out); err != nil {
 		c.requestLogger(httpReq).Warn("Error writing response", zap.Error(err))
 	}
 

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/brimsec/zq/archive"
-
 	"github.com/brimsec/zq/pcap"
 	"github.com/brimsec/zq/pkg/ctxio"
 	"github.com/brimsec/zq/zbuf"

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -106,8 +106,13 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var order zbuf.Order
+	if req.Dir == -1 {
+		order = zbuf.OrderDesc
+	}
+
 	w.Header().Set("Content-Type", out.ContentType())
-	if err := srch.Run(ctx, req.Dir, s, out); err != nil {
+	if err := srch.Run(ctx, order, s, out); err != nil {
 		c.requestLogger(r).Warn("Error writing response", zap.Error(err))
 	}
 }

--- a/zqd/handlers.go
+++ b/zqd/handlers.go
@@ -130,7 +130,7 @@ func handleWorker(c *Core, w http.ResponseWriter, httpReq *http.Request) {
 	}
 	defer cancel()
 
-	srch, err := search.NewWorkerOp(req)
+	srch, err := search.NewWorkerOp(ctx, req, space.Storage())
 	if err != nil {
 		respondError(c, w, httpReq, err)
 		return
@@ -144,7 +144,7 @@ func handleWorker(c *Core, w http.ResponseWriter, httpReq *http.Request) {
 
 	w.Header().Set("Content-Type", out.ContentType())
 
-	if err := srch.Run(ctx, space.Storage(), out); err != nil {
+	if err := srch.Run(ctx, out); err != nil {
 		c.requestLogger(httpReq).Warn("Error writing response", zap.Error(err))
 	}
 

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -78,8 +78,7 @@ func (s *SearchOp) Run(ctx context.Context, dir int, spc space.Space, output Out
 	defer statsTicker.Stop()
 	zctx := resolver.NewContext()
 
-	store := spc.Storage()
-	switch st := store.(type) {
+	switch st := spc.Storage().(type) {
 	case *archivestore.Storage:
 		return driver.MultiRun(ctx, d, s.query.Proc, zctx, st.MultiSource(), driver.MultiConfig{
 			Span:      s.query.Span,

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -84,7 +84,6 @@ func (s *SearchOp) Run(ctx context.Context, dir int, spc space.Space, output Out
 		return driver.MultiRun(ctx, d, s.query.Proc, zctx, st.MultiSource(), driver.MultiConfig{
 			Span:      s.query.Span,
 			StatsTick: statsTicker.C,
-			SpaceID:   spc.ID(),
 			Dir:       dir,
 		})
 	case *filestore.Storage:

--- a/zqd/search/search.go
+++ b/zqd/search/search.go
@@ -60,7 +60,7 @@ func NewSearchOp(req api.SearchRequest) (*SearchOp, error) {
 	return &SearchOp{query: query}, nil
 }
 
-func (s *SearchOp) Run(ctx context.Context, dir int, spc space.Space, output Output) (err error) {
+func (s *SearchOp) Run(ctx context.Context, order zbuf.Order, spc space.Space, output Output) (err error) {
 	d := &searchdriver{
 		output:    output,
 		startTime: nano.Now(),
@@ -83,7 +83,7 @@ func (s *SearchOp) Run(ctx context.Context, dir int, spc space.Space, output Out
 		return driver.MultiRun(ctx, d, s.query.Proc, zctx, st.MultiSource(), driver.MultiConfig{
 			Span:      s.query.Span,
 			StatsTick: statsTicker.C,
-			Dir:       dir,
+			Order:     order,
 		})
 	case *filestore.Storage:
 		rc, err := st.Open(ctx, zctx, s.query.Span)

--- a/zqd/storage/archivestore/archivestore.go
+++ b/zqd/storage/archivestore/archivestore.go
@@ -45,6 +45,10 @@ type Storage struct {
 	ark *archive.Archive
 }
 
+func NewStorage(ark *archive.Archive) *Storage {
+	return &Storage{ark: ark}
+}
+
 func (s *Storage) NativeOrder() zbuf.Order {
 	return s.ark.DataOrder
 }

--- a/zqd/storage/archivestore/archivestore.go
+++ b/zqd/storage/archivestore/archivestore.go
@@ -53,8 +53,8 @@ func (s *Storage) MultiSource() driver.MultiSource {
 	return archive.NewMultiSource(s.ark, nil)
 }
 
-func (s *Storage) StaticSource(ss archive.SpanInfoSource) driver.MultiSource {
-	return archive.NewStaticSource(s.ark, ss)
+func (s *Storage) StaticSource(src driver.Source) driver.MultiSource {
+	return archive.NewStaticSource(s.ark, src)
 }
 
 func (s *Storage) Summary(ctx context.Context) (storage.Summary, error) {

--- a/ztests/suite/zqd/services.sh
+++ b/ztests/suite/zqd/services.sh
@@ -49,7 +49,7 @@ if [[ "$2" == workers ]]; then
   awaitfile $portdir/zqd-w2
   portw2=$(cat $portdir/zqd-w2)
 
-  workers=":$portw1,:$portw2"
+  workers="127.0.0.1:$portw1,127.0.0.1:$portw2"
   zqd listen -l=localhost:0 -portfile="$portdir/zqd" -data="$zqdroot" -workers $workers -loglevel=warn &> zqd-root.log &
   zqdpid=$!
   awaitfile $portdir/zqd

--- a/ztests/suite/zqd/services.sh
+++ b/ztests/suite/zqd/services.sh
@@ -44,10 +44,10 @@ if [[ "$2" == workers ]]; then
   zqdw2pid=$!
 
   awaitfile $portdir/zqd-w1
-  portw1=$(cat $portdir/zqd-w1 | tr -d '[:space:]')
+  portw1=$(cat $portdir/zqd-w1)
 
   awaitfile $portdir/zqd-w2
-  portw2=$(cat $portdir/zqd-w2 | tr -d '[:space:]')
+  portw2=$(cat $portdir/zqd-w2)
 
   workers=":$portw1,:$portw2"
   zqd listen -l=localhost:0 -portfile="$portdir/zqd" -data="$zqdroot" -workers $workers -loglevel=warn &> zqd-root.log &

--- a/ztests/suite/zqd/services.sh
+++ b/ztests/suite/zqd/services.sh
@@ -20,14 +20,13 @@ function awaitfile {
 zqdroot=$1
 if [ -z "$zqdroot" ]; then
   zqdroot=zqdroot
-  mkdir -p zqdroot
 fi
+mkdir -p $zqdroot
 
 mkdir -p s3/bucket
 portdir=$(mktemp -d)
 
-
-minio server --writeportfile="$portdir/minio" --quiet --address localhost:0 ./s3  > minio.log 2>&1 &
+minio server --writeportfile="$portdir/minio" --quiet --address localhost:0 ./s3 > minio.log 2>&1 &
 miniopid=$!
 awaitfile $portdir/minio
 
@@ -37,10 +36,28 @@ export AWS_ACCESS_KEY_ID=minioadmin
 export AWS_SECRET_ACCESS_KEY=minioadmin
 export AWS_S3_ENDPOINT=http://localhost:$(cat $portdir/minio)
 
-zqd listen -l=localhost:0 -portfile="$portdir/zqd" -data="$zqdroot" > zqd.log 2>&1 &
-zqdpid=$!
-trap "rm -rf $portdir; kill -9 $miniopid $zqdpid" EXIT
+if [[ "$2" == workers ]]; then
+  # start two zqd workers and a zqd root process
+  zqd listen -l=localhost:0 -portfile="$portdir/zqd-w1" -data="$zqdroot" -loglevel=warn &> zqd-w1.log &
+  zqdw1pid=$!
+  zqd listen -l=localhost:0 -portfile="$portdir/zqd-w2" -data="$zqdroot" -loglevel=warn &> zqd-w2.log &
+  zqdw2pid=$!
 
-awaitfile $portdir/zqd
+  awaitfile $portdir/zqd-w1
+  portw1=$(cat $portdir/zqd-w1 | tr -d '[:space:]')
+
+  awaitfile $portdir/zqd-w2
+  portw2=$(cat $portdir/zqd-w2 | tr -d '[:space:]')
+
+  workers=":$portw1,:$portw2"
+  zqd listen -l=localhost:0 -portfile="$portdir/zqd" -data="$zqdroot" -workers $workers -loglevel=warn &> zqd-root.log &
+  zqdpid=$!
+  awaitfile $portdir/zqd
+else
+  zqd listen -l=localhost:0 -portfile="$portdir/zqd" -data="$zqdroot" -loglevel=warn &> zqd.log &
+  zqdpid=$!
+  awaitfile $portdir/zqd
+fi
+trap "rm -rf $portdir; kill -9 $miniopid $zqdpid $zqdw1pid $zqdw2pid" EXIT
 
 export ZQD_HOST=localhost:$(cat $portdir/zqd)

--- a/ztests/suite/zqd/worker-dist.yaml
+++ b/ztests/suite/zqd/worker-dist.yaml
@@ -1,0 +1,60 @@
+script: |
+  # This test is a variation on worker-count.
+  # This starts both a zqd root process and worker processes
+  # then runs the same queries.
+  # The zapi queries are different because they do not use
+  # the -chunk flag.
+  # The "workers" parameter to service.sh tells it to start workers.
+  #
+  source services.sh zqdroot workers
+  mkdir spacedir
+  #
+  # This creates a space with a small threshold in order to produce
+  # three or more "chunks" in the space
+  #
+  zapi -h $ZQD_HOST new -k archivestore -d spacedir -thresh 15KB testsp > /dev/null
+  #
+  # This is the same smtp.log from zq-sample-data
+  #
+  zapi -h $ZQD_HOST -s testsp post smtp.log.gz > /dev/null
+  #
+  # The count() from zq should be identical to 
+  # the count() from zapi get -chunk
+  #
+  zq -t "count()" smtp.log.gz > zqcount.tzng
+  zapi -h $ZQD_HOST -s testsp get -t "count()" > zapicount.tzng
+  echo ===
+  diff -s zqcount.tzng zapicount.tzng
+  #
+  # Compare output from a simple filter for a unique string.
+  # This will verify that filter expressions are 
+  # passed though to the worker zqd.
+  #
+  zq -t "39161" smtp.log.gz > zqfilter.tzng
+  zapi -h $ZQD_HOST -s testsp get -t "39161" > zapifilter.tzng
+  echo ===
+  diff -s zqfilter.tzng zapifilter.tzng
+  #
+  # Compare output from the tail function to make sure 
+  # the record order is the same.
+  #
+  zq -t "sort -r ts | tail 5" smtp.log.gz > zqtail.tzng
+  zapi -h $ZQD_HOST -s testsp get -t "tail 5" > zapitail.tzng
+  echo ===
+  diff -s zqtail.tzng zapitail.tzng
+  
+inputs:
+  - name: services.sh
+    source: services.sh
+  - name: smtp.log.gz
+    source: ../data/smtp.log.gz
+
+outputs:
+  - name: stdout
+    data: |
+      ===
+      Files zqcount.tzng and zapicount.tzng are identical
+      ===
+      Files zqfilter.tzng and zapifilter.tzng are identical
+      ===
+      Files zqtail.tzng and zapitail.tzng are identical


### PR DESCRIPTION
This implements distributed queries with a zqd root process that will parallelize the work in a FlowGraph by sending it to multiple zqd worker processes. This feature is intended for testing the scalability of distributed zqd and to try out K8s deployment. It is not yet ready for production.

A zqd root process must be provided with a list of the ports for its zqd worker with the command line argument -workers. Each zqd worker process must have access to the same spaces as the zqd root process.

Example:
```
# Start 3 zqd/workers
zqd listen -l :9871 -data spaces &> zqd-w1.log &
zqd listen -l :9872 -data spaces &> zqd-w2.log &
zqd listen -l :9873 -data spaces &> zqd-w3.log &
# Start the root zqd
zqd listen -l :9867 -data spaces -workers :9871,:9872,:9873  &> zqd-root.log &
```