### PR TITLE
fix chunk merge on adjacent boundaries within other chunks

### DIFF
--- a/archive/overlap.go
+++ b/archive/overlap.go
@@ -18,7 +18,7 @@ func mergeChunksToSpans(chunks []Chunk, dir zbuf.Direction, filter nano.Span) []
 	boundaries(chunks, dir, func(ts nano.Ts, firstChunks, lastChunks []Chunk) {
 		if len(firstChunks) > 0 {
 			// ts is the 'First' timestamp for these chunks.
-			if len(siChunks) > 0 {
+			if len(siChunks) > 0 && ts != siFirst {
 				// We have accumulated chunks; create a span with them whose
 				// last timestamp was just before ts.
 				siSpan := firstLastToSpan(siFirst, prevTs(ts, dir))

--- a/archive/overlap_test.go
+++ b/archive/overlap_test.go
@@ -130,6 +130,51 @@ func TestMergeChunksToSpans(t *testing.T) {
 			},
 		},
 		{
+			chunks: []Chunk{
+				{Id: kid("a"), First: 0, Last: 5},
+				{Id: kid("b"), First: 1, Last: 8},
+				{Id: kid("c"), First: 6, Last: 6},
+				{Id: kid("d"), First: 7, Last: 10},
+			},
+			filter: nano.MaxSpan,
+			dir:    zbuf.DirTimeForward,
+			exp: []SpanInfo{
+				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []Chunk{
+					{Id: kid("a"), First: 0, Last: 5}}},
+				{Span: nano.Span{Ts: 1, Dur: 5}, Chunks: []Chunk{
+					{Id: kid("a"), First: 0, Last: 5},
+					{Id: kid("b"), First: 1, Last: 8}}},
+				{Span: nano.Span{Ts: 6, Dur: 1}, Chunks: []Chunk{
+					{Id: kid("b"), First: 1, Last: 8},
+					{Id: kid("c"), First: 6, Last: 6}}},
+				{Span: nano.Span{Ts: 7, Dur: 2}, Chunks: []Chunk{
+					{Id: kid("b"), First: 1, Last: 8},
+					{Id: kid("d"), First: 7, Last: 10}}},
+				{Span: nano.Span{Ts: 9, Dur: 2}, Chunks: []Chunk{
+					{Id: kid("d"), First: 7, Last: 10}}},
+			},
+		},
+		{
+			chunks: []Chunk{
+				{Id: kid("a"), First: 0, Last: 10},
+				{Id: kid("b"), First: 1, Last: 10},
+				{Id: kid("c"), First: 2, Last: 10},
+			},
+			filter: nano.MaxSpan,
+			dir:    zbuf.DirTimeForward,
+			exp: []SpanInfo{
+				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []Chunk{
+					{Id: kid("a"), First: 0, Last: 10}}},
+				{Span: nano.Span{Ts: 1, Dur: 1}, Chunks: []Chunk{
+					{Id: kid("a"), First: 0, Last: 10},
+					{Id: kid("b"), First: 1, Last: 10}}},
+				{Span: nano.Span{Ts: 2, Dur: 9}, Chunks: []Chunk{
+					{Id: kid("a"), First: 0, Last: 10},
+					{Id: kid("b"), First: 1, Last: 10},
+					{Id: kid("c"), First: 2, Last: 10}}},
+			},
+		},
+		{
 			chunks: nil,
 			filter: nano.MaxSpan,
 			dir:    zbuf.DirTimeForward,


### PR DESCRIPTION
I discovered this while working on #1266 . Without this fix, if two chunks are adjacent (start of one occurs 1 nanosecond after the last timestamp of the other), and their boundary lies inside one or more spans for other chunks, we would create a spurious spaninfo.
