### PR TITLE
Move link checker to separate Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,11 +38,6 @@ jobs:
       - run: go build -o dist ./cmd/...
       - run: go test -v ./tests
       - run: make test-pcapingest
-  markdown-link-check:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
   zng-output-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,14 @@
+name: Link checker
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,4 +1,4 @@
-name: Link checker
+name: Markdown link check
 
 on:
   pull_request:


### PR DESCRIPTION
(This is equivalent to what just merged in https://github.com/brimsec/brim/pull/1153.)

The automation for the link checker has been doing its job insofar as it's noticed when external links go bad or act flaky. However, it's also been correctly noted that having it run as a Job in the same Action with the rest of ci.yml can be troublesome, since it makes it more difficult to debug when there's link problems at the same time as legit code breakages, or CI infra instability.

To address this, here we break out the link checker to its own separate Actions Workflow.