### PR TITLE
Remove references to "type codes" and "descriptors" from TZNG spec

### DIFF
--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -750,7 +750,7 @@ a null value.  A value that is not to be interpreted as null
 but is the single-character string `-`, must be escaped (e.g., `\x2d`).
 
 Note that this syntax can be scanned and parsed independent of the
-actual type definition indicated by the descriptor.  It is a semantic error
+actual type definition indicated by the tag.  It is a semantic error
 if the parsed value does not match the indicated type in terms of number and
 sub-structure of value elements present and their interpretation as a valid
 string of the specified type.
@@ -798,7 +798,7 @@ to `-` as opposed to representing a null value.
 ### 4.3.2 Value Syntax
 
 Each UTF-8 string field parsed from a value line is interpreted according to the
-type descriptor of the line using the formats shown in the
+type binding of the line using the formats shown in the
 [Primitive Types](#5-primitive-types) table.
 
 ## 4.4 Examples

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -715,7 +715,7 @@ grammar describing the textual type encodings is:
 ### 4.3 Values
 
 A TZNG value is encoded on a line as a typed value, which is encoded as
-an integer type code followed by `:`, which is in turn followed
+an integer type tag followed by `:`, which is in turn followed
 by a value encoding.
 
 Here is a pseudo-grammar for typed values:


### PR DESCRIPTION
In a previous pass through the ZNG spec, I'd sought to remove references to "type codes" in the TZNG section, since I'd been taught how these numbers are different from the derived ones in binary ZNG. We'd therefore standardized on calling the TZNG ones "type tags" to remove any confusion. However, I just noticed a lingering reference to "type code" that got missed, so I try to fix that here.

While I was at it, I also noticed a couple references to "descriptors", which are another artifact from a previous time that are no longer explicitly defined in the spec. While their meaning still seems pretty evident without formal introduction, I've tried to replace them here with official wording.