### PR TITLE
Add float16 to TZNG type grammar

### DIFF
--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -675,7 +675,7 @@ grammar describing the textual type encodings is:
 ```
 <primitive> := uint8 | uint16 | uint32 | uint64 |
              | int8 | int16 | int32 | int64 | duration | time
-             | float32 | float64 | decimal
+             | float16 | float32 | float64 | decimal
              | bool | bytes | string | bstring
              | ip | net | type | error | null
 


### PR DESCRIPTION
I noticed `float16` was in the Primitive Types table but not mentioned in the TZNG Type Grammar, so I've added it.