### PR TITLE
Fix intermittent zqd system test failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ bin/minio:
 	@mkdir -p bin
 	@echo 'module deps' > bin/go.mod
 	@echo 'require github.com/minio/minio latest' >> bin/go.mod
-	@echo 'replace github.com/minio/minio => github.com/brimsec/minio v0.0.0-20200716214025-90d56627f750' >> bin/go.mod
+	@echo 'replace github.com/minio/minio => github.com/brimsec/minio v0.0.0-20201019191454-3c6f24527f6d' >> bin/go.mod
 	@cd bin && GOBIN=$(CURDIR)/bin go install github.com/minio/minio
 
 generate:

--- a/go.mod
+++ b/go.mod
@@ -38,4 +38,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71
 )
 
-replace github.com/minio/minio => github.com/brimsec/minio v0.0.0-20200716214025-90d56627f750
+replace github.com/minio/minio => github.com/brimsec/minio v0.0.0-20201019191454-3c6f24527f6d

--- a/ztests/suite/zqd/services.sh
+++ b/ztests/suite/zqd/services.sh
@@ -6,10 +6,10 @@ function awaitfile {
   until [ -f $file ]; do
     let i+=1
     if [ $i -gt 5 ]; then
-      echo "timed out waiting for file \"$file\" to appear\n"
-      echo "minio log:\n"
+      echo "timed out waiting for file \"$file\" to appear"
+      echo "minio log:"
       cat minio.log
-      echo "zqd log:\n"
+      echo "zqd log:"
       cat zqd.log
       exit 1
     fi


### PR DESCRIPTION
Intermittent bug came from an issue in the brimsec minio fork where
the portfile would be written before the minio service was ready to
receive requests. This has been solved here in https://github.com/brimsec/minio/pull/2,
bump minio to current version.

Also:
- Echo zqd/minio logs on wait file fail.