### PR TITLE
Add more beta notice items and adjust TZNG EOS text

### DIFF
--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -3,18 +3,18 @@
 > ### Note: This specification is in BETA development.
 > We hope that no backward incompatible changes will be made during
 > the BETA phase.  We plan to
-> declare the specification stable and finalized in spring 2021.
+> declare the specification stable and finalized in Spring, 2021.
 >
 > [Zq](https://github.com/brimsec/zq/blob/master/README.md)'s
 > implementation of ZNG is tracking this spec and as it changes,
 > the zq output format is subject to change.  In this branch,
 > zq attempts to implement everything herein excepting:
 >
-> * only streams of `record` types (which may consist of any combination of
+> * Only streams of `record` types (which may consist of any combination of
 >   other implemented types) are supported by zq even though a stream of
 >   any types may currently be expressed in value messages.
->
-> TBD: implement TZNG EOS in zq
+> * [TZNG End of Stream](#414-end-of-stream) markers are not yet implemented. ([zq/1364](https://github.com/brimsec/zq/issues/1364))
+> * [Primitive Types](#5-primitive-types) for `float16`, `float32`, and `decimal` are not yet implemented. ([zq/1312](https://github.com/brimsec/zq/issues/1312), [zq/1522](https://github.com/brimsec/zq/issues/1522))
 
 * [1. Introduction](#1-introduction)
 * [2. The ZNG Data Model](#2-the-zng-data-model)
@@ -663,10 +663,11 @@ A TZNG end-of-stream marker has the following form:
 ```
 #eos
 ```
-A TZNG stream or file should always be terminated with end-of-stream.
-This clears all of the previous type tag bindings and aliases, allowing
-multiple TZNG files with overlapping tags to be concatenated without the
-tags colliding.
+
+It is recommended that a TZNG stream or file be terminated with an
+end-of-stream marker. This explicitly clears all of the previous type tag
+bindings and aliases, allowing multiple TZNG files with overlapping tags to be concatenated without the tags colliding. However, a TZNG reader should not
+generate an error if a TZNG end-of-stream marker is not present.
 
 ### 4.2 Type Grammar
 

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -3,7 +3,7 @@
 > ### Note: This specification is in BETA development.
 > We hope that no backward incompatible changes will be made during
 > the BETA phase.  We plan to
-> declare the specification stable and finalized in Spring, 2021.
+> declare the specification stable and finalized in spring 2021.
 >
 > [Zq](https://github.com/brimsec/zq/blob/master/README.md)'s
 > implementation of ZNG is tracking this spec and as it changes,
@@ -665,10 +665,11 @@ A TZNG end-of-stream marker has the following form:
 #eos
 ```
 
-It is recommended that a TZNG stream or file be terminated with an
-end-of-stream marker. This explicitly clears all of the previous type tag
-bindings and aliases, allowing multiple TZNG files with overlapping tags to be concatenated without the tags colliding. However, a TZNG reader should not
-generate an error if a TZNG end-of-stream marker is not present.
+A TZNG stream or file should be terminated with an end-of-stream marker. This
+This explicitly clears all of the previous type tag bindings and aliases,
+allowing multiple TZNG files with overlapping tags to be concatenated without
+the tags colliding. However, a TZNG reader should not generate an error if a
+TZNG end-of-stream marker is not present.
 
 ### 4.2 Type Grammar
 

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -14,6 +14,7 @@
 >   other implemented types) are supported by zq even though a stream of
 >   any types may currently be expressed in value messages.
 > * [TZNG End of Stream](#414-end-of-stream) markers are not yet implemented. ([zq/1364](https://github.com/brimsec/zq/issues/1364))
+> * ZQL syntax for working with the [`enum` type](http://0.0.0.0:6419/#3115-enum-typedef) is not yet implemented. ([zq/1498](https://github.com/brimsec/zq/issues/1498))
 > * [Primitive Types](#5-primitive-types) for `float16`, `float32`, and `decimal` are not yet implemented. ([zq/1312](https://github.com/brimsec/zq/issues/1312), [zq/1522](https://github.com/brimsec/zq/issues/1522))
 
 * [1. Introduction](#1-introduction)

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -14,7 +14,7 @@
 >   other implemented types) are supported by zq even though a stream of
 >   any types may currently be expressed in value messages.
 > * [TZNG End of Stream](#414-end-of-stream) markers are not yet implemented. ([zq/1364](https://github.com/brimsec/zq/issues/1364))
-> * ZQL syntax for working with the [`enum` type](http://0.0.0.0:6419/#3115-enum-typedef) is not yet implemented. ([zq/1498](https://github.com/brimsec/zq/issues/1498))
+> * ZQL syntax for working with the [`enum` type](#3115-enum-typedef) is not yet implemented. ([zq/1498](https://github.com/brimsec/zq/issues/1498))
 > * [Primitive Types](#5-primitive-types) for `float16`, `float32`, and `decimal` are not yet implemented. ([zq/1312](https://github.com/brimsec/zq/issues/1312), [zq/1522](https://github.com/brimsec/zq/issues/1522))
 
 * [1. Introduction](#1-introduction)


### PR DESCRIPTION
@alfred-landrum @mccanne: Per our discussion this morning, here I've made some adjustments to the ZNG spec to line up with loose ends we're holding off on implementing in zq for now:

* TZNG EOS
* ZQL syntax for `enum`
* `float16`, `float32`, and `decimal`

I also adjusted the TZNG EOS text to emphasize that it's recommended, but optional.

I've included references to open issues in case users stumble onto these bullet items and want to express their use cases for adding them sooner.