### PR TITLE
Replace output-format with output-flags in ztests

### DIFF
--- a/ztests/formats/csv/hello.yaml
+++ b/ztests/formats/csv/hello.yaml
@@ -6,7 +6,7 @@ input: |
   0:[goodnight;gracie;]
   0:[,;gracie;]
 
-output-format: csv
+output-flags: -f csv
 
 output: |
   a,b

--- a/ztests/formats/csv/nested.yaml
+++ b/ztests/formats/csv/nested.yaml
@@ -4,7 +4,7 @@ input: |
   #0:record[a:string,b:record[c:string,d:string]]
   0:[hello;[world;goodbye;]]
 
-output-format: csv
+output-flags: -f csv
 
 output: |
   a,b.c,b.d

--- a/ztests/formats/flatten/1.yaml
+++ b/ztests/formats/flatten/1.yaml
@@ -10,7 +10,7 @@ input: |
   #types	time	string	addr	port	addr	port	bool
   1425565514.419939	CogZFI3py5JsFZGik	192.168.1.1	80	192.168.1.2	5353	F
 
-output-format: zeek
+output-flags: -f zeek
 
 output: |
   #separator \x09

--- a/ztests/formats/flatten/2.yaml
+++ b/ztests/formats/flatten/2.yaml
@@ -5,7 +5,7 @@ input: |
   #0:record[_path:string,ts:time,uid:string,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port]]
   0:[conn;1425565514.419939;CogZFI3py5JsFZGik;-;]
 
-output-format: text
+output-flags: -f text
 
 output: |
   conn	2015-03-05T14:25:14.419939Z	CogZFI3py5JsFZGik	-	-	-	-

--- a/ztests/formats/flatten/3.yaml
+++ b/ztests/formats/flatten/3.yaml
@@ -5,7 +5,7 @@ input: |
   #0:record[_path:string,ts:time,uid:string,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port]]
   0:[conn;1425565514.419939;CogZFI3py5JsFZGik;-;]
 
-output-format: table
+output-flags: -f table
 
 output: |
   _PATH TS                UID               ID.ORIG_H ID.ORIG_P ID.RESP_H ID.RESP_P

--- a/ztests/formats/time/1.yaml
+++ b/ztests/formats/time/1.yaml
@@ -8,7 +8,7 @@ input: |
   0:[conn;-1425565514.419939;1;]
   0:[conn;-;-;]
 
-output-format: zeek
+output-flags: -f zeek
 
 output: |
   #separator \x09

--- a/ztests/formats/time/4.yaml
+++ b/ztests/formats/time/4.yaml
@@ -8,7 +8,7 @@ input: |
   0:[conn;1.123e8;1.123e8;]
   0:[conn;1e-8;1e-8;]
 
-output-format: zeek
+output-flags: -f zeek
 
 output: |
   #separator \x09

--- a/ztests/formats/time/6.yaml
+++ b/ztests/formats/time/6.yaml
@@ -8,7 +8,7 @@ input: |
   0:[conn;1.123e8;1.123e8;]
   0:[conn;1e-8;1e-8;]
 
-output-format: ndjson
+output-flags: -f ndjson
 
 output: |
   {"_path":"conn","d":"1000000000","ts":"1000000000"}

--- a/ztests/formats/zeek/multizng.yaml
+++ b/ztests/formats/zeek/multizng.yaml
@@ -6,7 +6,7 @@ input: |
   #1:record[_path:string,ts:time,d:int64]
   1:[b;11;1;]
 
-output-format: zeek
+output-flags: -f zeek
 
 output: |
   #separator \x09

--- a/ztests/formats/zeek/nested-2.yaml
+++ b/ztests/formats/zeek/nested-2.yaml
@@ -5,7 +5,7 @@ input: |
   #0:record[_path:string,ts:time,uid:bstring,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port],referenced_file:record[ts:time,uid:bstring,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port],fuid:bstring]]
   0:[smb_cmd;1258594907.85978;Chjxid42dvvzIzdeG8;[192.168.1.102;1076;192.168.1.1;139;][1258594907.85978;Chjxid42dvvzIzdeG8;[192.168.1.102;1076;192.168.1.1;139;]ZYjxid42dvvzIzdeG8;]]
 
-output-format: zeek
+output-flags: -f zeek
 
 output: |
   #separator \x09

--- a/ztests/formats/zeek/zeek-empty-close.yaml
+++ b/ztests/formats/zeek/zeek-empty-close.yaml
@@ -10,6 +10,6 @@ input: |
   #types	time	string	addr	port	addr	port	string	string	string	string	bool	string	string	bool	vector[string]	vector[string]	string	string	string	string	string
   #close  2019-10-10-08-30-35
 
-output-format: zeek
+output-flags: -f zeek
 
 output: ""

--- a/ztests/formats/zng/streams-1.yaml
+++ b/ztests/formats/zng/streams-1.yaml
@@ -8,9 +8,7 @@ input: |
   0:[a;10;1;]
   0:[xyz;20;1.5;]
 
-output-format: zng
-
-output-flags: -b 1
+output-flags: -f zng -b 1
 
 outputHex: |
   # define a record with 3 columns

--- a/ztests/formats/zng/streams-2.yaml
+++ b/ztests/formats/zng/streams-2.yaml
@@ -9,9 +9,7 @@ input: |
   1:[1;]
   1:[2;]
 
-output-format: zng
-
-output-flags: -b 2 -znglz4blocksize=0
+output-flags: -f zng -b 2 -znglz4blocksize=0
 
 outputHex: |
   # define the record corresponding to type 0 above: 1 col, name s, type string

--- a/ztests/formats/zng/type-reset.yaml
+++ b/ztests/formats/zng/type-reset.yaml
@@ -5,9 +5,7 @@ input: |
   0:[a;10;1;]
   0:[xyz;20;1.5;]
 
-output-format: zng
-
-output-flags: -b 2
+output-flags: -f zng -b 2
 
 output: !!binary |
   9gMFX3BhdGgQAnRzCQFkDBcRBGEMAMgXqAQSAAAAAAAA8D8XEwh4eXoMAJAvUAkSAAAAAAAA+D//

--- a/ztests/formats/zng/write.yaml
+++ b/ztests/formats/zng/write.yaml
@@ -5,7 +5,7 @@ input: |
   0:[a;10;1;]
   0:[xyz;20;1.5;]
 
-output-format: zng
+output-flags: -f zng
 
 outputHex: |
   # define a record with 3 columns

--- a/ztests/suite/cut/cut.yaml
+++ b/ztests/suite/cut/cut.yaml
@@ -11,7 +11,7 @@ input: |
   key1 value1	key2 value1
   key1 value2	key2 value2
 
-output-format: table
+output-flags: -f table
 
 output: |
   FOO

--- a/ztests/suite/format/format.yaml
+++ b/ztests/suite/format/format.yaml
@@ -11,7 +11,7 @@ input: |
   key1 value1	key2 value1
   key1 value2	key2 value2
 
-output-format: ndjson
+output-flags: -f ndjson
 
 output: |
   {"_path":"conn","bar":"key2 value1","foo":"key1 value1"}

--- a/ztests/suite/format/json_types.yaml
+++ b/ztests/suite/format/json_types.yaml
@@ -6,7 +6,7 @@ input: |
   #0:record[a:ip,a2:ip,b:bool,c:uint64,f:float64,i:int32,interval:duration,p:uint16,s:string,t:time]
   0:[10.1.1.1;fe80::eef4:bbff:fe51:89ec;t;517;3.14159;18;60.0;443;Hello, world!;1578407783.487;]
 
-output-format: ndjson
+output-flags: -f ndjson
 
 output: |
   {"a":"10.1.1.1","a2":"fe80::eef4:bbff:fe51:89ec","b":true,"c":517,"f":3.14159,"i":18,"interval":"60","p":443,"s":"Hello, world!","t":"1578407783.487"}

--- a/ztests/suite/ndjson/empty-objects.yaml
+++ b/ztests/suite/ndjson/empty-objects.yaml
@@ -4,7 +4,7 @@ input: |
   {}
   {"ja3s":{}}
 
-output-format: ndjson
+output-flags: -f ndjson
 output: |
   {}
   {"ja3s":{}}

--- a/ztests/suite/reducer/count-assign.yaml
+++ b/ztests/suite/reducer/count-assign.yaml
@@ -13,7 +13,7 @@ input: |
   0:[conn;9;]
   0:[conn;10;]
 
-output-format: table
+output-flags: -f table
 
 output: |
   C

--- a/ztests/suite/reducer/count.yaml
+++ b/ztests/suite/reducer/count.yaml
@@ -13,7 +13,7 @@ input: |
   0:[conn;9;]
   0:[conn;10;]
 
-output-format: table
+output-flags: -f table
 
 output: |
   COUNT

--- a/ztests/suite/zeek/zeek-types.yaml
+++ b/ztests/suite/zeek/zeek-types.yaml
@@ -14,6 +14,6 @@ input: &input |
   #types	string	enum	vector[int]	vector[string]	port	count	addr	subnet	interval	time	bool
   foo	bar	1,2,3	a,b,c	80	1000	10.5.100.20	10.0.0.0/8	1000	1582404982.000000	T
 
-output-format: zeek
+output-flags: -f zeek
 
 output: *input

--- a/ztests/suite/zeek/zng-types.yaml
+++ b/ztests/suite/zeek/zng-types.yaml
@@ -6,7 +6,7 @@ input: |
   #0:record[b:uint8,i16:int16,u16:uint16,i32:int32,u32:uint32,i64:int64,u64:uint64,a:ip,n:net,d:duration]
   0:[0;0;0;0;0;0;0;10.1.2.3;10.0.0.0/8;1000;]
 
-output-format: zeek
+output-flags: -f zeek
 
 output: |
   #separator \x09

--- a/ztests/suite/zjson/empty-records.yaml
+++ b/ztests/suite/zjson/empty-records.yaml
@@ -3,6 +3,6 @@ zql: '*'
 input: |
   {"id":23,"schema":{"type":"record","of":[{"name":"ja3s","type":"int32"}]},"values":[null]}
 
-output-format: zjson
+output-flags: -f zjson
 output: |
   {"id":23,"schema":{"of":[{"name":"ja3s","type":"int32"}],"type":"record"},"values":[null]}


### PR DESCRIPTION
The output-format key in ztest YAML files is redundant to output-flags.
Accordingly, replace "output-format: x" with "output-flags: -f x" in
YAML files and remove support for output-format from the ztest package.