### PR TITLE
move chunk metadata to separate file

### DIFF
--- a/archive/finder.go
+++ b/archive/finder.go
@@ -55,7 +55,7 @@ func AddPath(pathField string, absolutePath bool) FindOption {
 					path = chunk.Path(ark).String()
 				}
 			} else {
-				path = string(chunk.LogID())
+				path = string(chunk.RelativePath())
 			}
 			return opt.zctx.AddColumns(rec, cols, []zng.Value{
 				{cols[0].Type, zng.EncodeString(path)},

--- a/archive/import.go
+++ b/archive/import.go
@@ -124,7 +124,7 @@ func (iw *importWriter) close() error {
 type tsDirWriter struct {
 	ark          *Archive
 	bufSize      int64
-	count        int64
+	count        uint64
 	ctx          context.Context
 	importWriter *importWriter
 	maxTs        nano.Ts
@@ -332,6 +332,15 @@ func (cw *chunkWriter) close(ctx context.Context) error {
 	if closeErr := cw.indexTempWriter.Close(); err == nil {
 		err = closeErr
 	}
+	if err != nil {
+		return err
+	}
+	err = writeChunkMetadata(ctx, chunkMetadataPath(cw.ark, cw.tsDir, cw.chunk.Id), chunkMetadata{
+		First:       cw.chunk.First,
+		Last:        cw.chunk.Last,
+		Kind:        FileKindData,
+		RecordCount: cw.chunk.RecordCount,
+	})
 	if err != nil {
 		return err
 	}

--- a/archive/schema.go
+++ b/archive/schema.go
@@ -165,11 +165,11 @@ func openArchive(ctx context.Context, root iosrc.URI, oo *OpenOptions) (*Archive
 	}
 	if oo != nil {
 		for _, l := range oo.LogFilter {
-			c, ok := ChunkNameMatch(l)
+			_, id, ok := chunkFileMatch(l)
 			if !ok {
 				return nil, zqe.E(zqe.Invalid, "log filter %s not a chunk file name", l)
 			}
-			ark.LogFilter = append(ark.LogFilter, c.Id)
+			ark.LogFilter = append(ark.LogFilter, id)
 		}
 	}
 

--- a/archive/stat.go
+++ b/archive/stat.go
@@ -62,7 +62,7 @@ func (s *statReadCloser) chunkRecord(chunk Chunk) error {
 
 	rec := s.chunkBuilder.Build(
 		zng.EncodeString("chunk"),
-		zng.EncodeString(string(chunk.LogID())),
+		zng.EncodeString(string(chunk.RelativePath())),
 		zng.EncodeTime(chunk.First),
 		zng.EncodeTime(chunk.Last),
 		zng.EncodeUint(uint64(fi.Size())),
@@ -121,7 +121,7 @@ func (s *statReadCloser) indexRecord(chunk Chunk, indexPath string) error {
 
 	rec := s.indexBuilders[indexPath].Build(
 		zng.EncodeString("index"),
-		zng.EncodeString(string(chunk.LogID())),
+		zng.EncodeString(string(chunk.RelativePath())),
 		zng.EncodeTime(chunk.First),
 		zng.EncodeTime(chunk.Last),
 		zng.EncodeString(indexPath),

--- a/archive/staticsource.go
+++ b/archive/staticsource.go
@@ -5,22 +5,29 @@ import (
 
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zqe"
 )
 
-// staticSource is an implemetation of driver.MultiSource that provides
+// staticSource is an implementation of driver.MultiSource that provides
 // a single SpanInfo (with Chunks) to be processed by a zqd worker.
 // staticSource is used only for the zqd /worker call.
 type staticSource struct {
 	ark *Archive
-	si  SpanInfo
+	sis SpanInfoSource
 }
 
-func NewStaticSource(ark *Archive, si SpanInfo) driver.MultiSource {
+type SpanInfoSource struct {
+	Span               nano.Span
+	ChunkRelativePaths []string
+}
+
+func NewStaticSource(ark *Archive, sis SpanInfoSource) driver.MultiSource {
 	return &staticSource{
 		ark: ark,
-		si:  si,
+		sis: sis,
 	}
 }
 
@@ -29,8 +36,20 @@ func (s *staticSource) OrderInfo() (field.Static, bool) {
 }
 
 func (s *staticSource) SendSources(ctx context.Context, zctx *resolver.Context, sf driver.SourceFilter, srcChan chan driver.SourceOpener) error {
+	si := SpanInfo{Span: s.sis.Span}
+	for _, p := range s.sis.ChunkRelativePaths {
+		tsd, _, id, ok := parseChunkRelativePath(p)
+		if !ok {
+			return zqe.E(zqe.Invalid, "invalid chunk path: %v", p)
+		}
+		md, err := readChunkMetadata(ctx, chunkMetadataPath(s.ark, tsd, id))
+		if err != nil {
+			return err
+		}
+		si.Chunks = append(si.Chunks, md.Chunk(id))
+	}
 	so := func() (driver.ScannerCloser, error) {
-		return newSpanScanner(ctx, s.ark, zctx, sf.Filter, sf.FilterExpr, s.si)
+		return newSpanScanner(ctx, s.ark, zctx, sf.Filter, sf.FilterExpr, si)
 	}
 	select {
 	case srcChan <- so:

--- a/archive/staticsource.go
+++ b/archive/staticsource.go
@@ -20,8 +20,8 @@ type staticSource struct {
 }
 
 type SpanInfoSource struct {
-	Span               nano.Span
-	ChunkRelativePaths []string
+	Span       nano.Span
+	ChunkPaths []string
 }
 
 func NewStaticSource(ark *Archive, sis SpanInfoSource) driver.MultiSource {
@@ -37,7 +37,7 @@ func (s *staticSource) OrderInfo() (field.Static, bool) {
 
 func (s *staticSource) SendSources(ctx context.Context, zctx *resolver.Context, sf driver.SourceFilter, srcChan chan driver.SourceOpener) error {
 	si := SpanInfo{Span: s.sis.Span}
-	for _, p := range s.sis.ChunkRelativePaths {
+	for _, p := range s.sis.ChunkPaths {
 		tsd, _, id, ok := parseChunkRelativePath(p)
 		if !ok {
 			return zqe.E(zqe.Invalid, "invalid chunk path: %v", p)

--- a/archive/walk.go
+++ b/archive/walk.go
@@ -6,12 +6,16 @@ import (
 	"path"
 	"regexp"
 	"sort"
-	"strconv"
+	"strings"
 	"time"
 
+	"github.com/brimsec/zq/pkg/bufwriter"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zqe"
 	"github.com/segmentio/ksuid"
 )
 
@@ -25,9 +29,10 @@ const (
 type FileKind string
 
 const (
-	FileKindUnknown FileKind = ""
-	FileKindData             = "d"
-	FileKindSeek             = "ts"
+	FileKindUnknown  FileKind = ""
+	FileKindData              = "d"
+	FileKindSeek              = "ts"
+	FileKindMetadata          = "m"
 )
 
 // A tsDir is a directory found in the "<DataPath>/zd" directory of the archive,
@@ -90,85 +95,95 @@ func tsDirVisit(ctx context.Context, ark *Archive, filterSpan nano.Span, visitor
 		if err != nil {
 			return err
 		}
-		if err := visitor(d, tsDirEntriesToChunks(ark, filterSpan, dirents)); err != nil {
+		chunks, err := tsDirEntriesToChunks(ctx, ark, filterSpan, d, dirents)
+		if err != nil {
+			return err
+		}
+		if err := visitor(d, chunks); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func tsDirEntriesToChunks(ark *Archive, filterSpan nano.Span, entries []iosrc.Info) []Chunk {
-	var chunks []Chunk
+func tsDirEntriesToChunks(ctx context.Context, ark *Archive, filterSpan nano.Span, tsDir tsDir, entries []iosrc.Info) ([]Chunk, error) {
+	type seen struct {
+		data bool
+		meta bool
+	}
+	m := make(map[ksuid.KSUID]seen)
 	for _, e := range entries {
-		chunk, ok := ChunkNameMatch(e.Name())
-		if !ok {
+		if kind, id, ok := chunkFileMatch(e.Name()); ok {
+			if !ark.filterAllowed(id) {
+				continue
+			}
+			s := m[id]
+			switch kind {
+			case FileKindData:
+				s.data = true
+				m[id] = s
+			case FileKindMetadata:
+				s.meta = true
+				m[id] = s
+			}
+		}
+	}
+	var chunks []Chunk
+	for id, seen := range m {
+		if !seen.meta || !seen.data {
 			continue
 		}
-		if !ark.filterAllowed(chunk.Id) {
-			continue
+		md, err := readChunkMetadata(ctx, chunkMetadataPath(ark, tsDir, id))
+		if err != nil {
+			if zqe.IsNotFound(err) {
+				continue
+			}
+			return nil, err
 		}
+		chunk := md.Chunk(id)
 		if !filterSpan.Overlaps(chunk.Span()) {
 			continue
 		}
 		chunks = append(chunks, chunk)
 	}
-	return chunks
+	return chunks, nil
 }
 
-// A LogID identifies a single zng file within an archive. It is created
-// by doing a path join (with forward slashes, regardless of platform)
-// of the relative location of the file under the archive's root directory.
-type LogID string
+var chunkFileRegex = regexp.MustCompile(`(d|m)-([0-9A-Za-z]{27}).zng$`)
 
-// Path returns the local filesystem path for the log file, using the
-// platforms file separator.
-func (l LogID) Path(ark *Archive) iosrc.URI {
-	return ark.DataPath.AppendPath(string(l))
+func chunkFileMatch(s string) (kind FileKind, id ksuid.KSUID, ok bool) {
+	match := chunkFileRegex.FindStringSubmatch(s)
+	if match == nil {
+		return
+	}
+	k := FileKind(match[1])
+	switch k {
+	case FileKindData:
+	case FileKindMetadata:
+	default:
+		return
+	}
+	id, err := ksuid.Parse(match[2])
+	if err != nil {
+		return
+	}
+	return k, id, true
 }
 
 // A Chunk is a file that holds records ordered according to the archive's
-// data order. The name of the file encodes the number of records it contains
-// and the timestamps of its first & last records. seekIndexPath returns the
-// path of an associated microindex written at import time, which can be used
-// to lookup a nearby seek offset for a desired timestamp.
+// data order.
+// seekIndexPath returns the path of an associated microindex written at import
+// time, which can be used to lookup a nearby seek offset for a desired
+// timestamp.
+// metadataPath returns the path of an associated zng file that holds
+// information about the records in the chunk, including the total number,
+// and the first and last record timestamps.
 type Chunk struct {
 	Id          ksuid.KSUID
 	First       nano.Ts
 	Last        nano.Ts
 	Kind        FileKind
-	RecordCount int64
-}
-
-var chunkNameRegex = regexp.MustCompile(`d-([0-9A-Za-z]{27})-([0-9]+)-([0-9]+)-([0-9]+).zng$`)
-
-func ChunkNameMatch(s string) (c Chunk, ok bool) {
-	match := chunkNameRegex.FindStringSubmatch(s)
-	if match == nil {
-		return
-	}
-	id, err := ksuid.Parse(match[1])
-	if err != nil {
-		return
-	}
-	recordCount, err := strconv.ParseInt(match[2], 10, 64)
-	if err != nil {
-		return
-	}
-	firstTs, err := strconv.ParseInt(match[3], 10, 64)
-	if err != nil {
-		return
-	}
-	lastTs, err := strconv.ParseInt(match[4], 10, 64)
-	if err != nil {
-		return
-	}
-	return Chunk{
-		Id:          id,
-		First:       nano.Ts(firstTs),
-		Last:        nano.Ts(lastTs),
-		Kind:        FileKindData,
-		RecordCount: recordCount,
-	}, true
+	RecordCount uint64
 }
 
 func (c Chunk) tsDir() tsDir {
@@ -179,19 +194,38 @@ func (c Chunk) seekIndexPath(ark *Archive) iosrc.URI {
 	return c.tsDir().path(ark).AppendPath(fmt.Sprintf("%s-%s.zng", FileKindSeek, c.Id))
 }
 
+func (c Chunk) metadataPath(ark *Archive) iosrc.URI {
+	return chunkMetadataPath(ark, c.tsDir(), c.Id)
+}
+
 func (c Chunk) Span() nano.Span {
 	return firstLastToSpan(c.First, c.Last)
 }
 
-func (c Chunk) LogID() LogID {
-	name := fmt.Sprintf("%s-%s-%d-%d-%d.zng", c.Kind, c.Id, c.RecordCount, c.First, c.Last)
-	return LogID(path.Join(dataDirname, newTsDir(c.First).name(), name))
+func (c Chunk) RelativePath() string {
+	return path.Join(dataDirname, c.tsDir().name(), fmt.Sprintf("%s-%s.zng", c.Kind, c.Id))
+}
+
+func parseChunkRelativePath(s string) (tsDir, FileKind, ksuid.KSUID, bool) {
+	ss := strings.Split(s, "/")
+	if len(ss) < 2 {
+		return tsDir{}, FileKindUnknown, ksuid.Nil, false
+	}
+	kind, id, ok := chunkFileMatch(ss[len(ss)-1])
+	if !ok {
+		return tsDir{}, FileKindUnknown, ksuid.Nil, false
+	}
+	tsd, ok := parseTsDirName(ss[len(ss)-2])
+	if !ok {
+		return tsDir{}, FileKindUnknown, ksuid.Nil, false
+	}
+	return tsd, kind, id, true
 }
 
 // ZarDir returns a URI for a directory specific to this data file, expected
 // to hold microindexes or other files associated with this chunk's data.
 func (c Chunk) ZarDir(ark *Archive) iosrc.URI {
-	return ark.DataPath.AppendPath(string(c.LogID() + zarExt))
+	return ark.DataPath.AppendPath(string(c.RelativePath() + zarExt))
 }
 
 // Localize returns a URI that joins the provided relative path name to the
@@ -205,7 +239,7 @@ func (c Chunk) Localize(ark *Archive, pathname string) iosrc.URI {
 }
 
 func (c Chunk) Path(ark *Archive) iosrc.URI {
-	return ark.DataPath.AppendPath(string(c.LogID()))
+	return ark.DataPath.AppendPath(string(c.RelativePath()))
 }
 
 func (c Chunk) Range() string {
@@ -229,6 +263,64 @@ func chunksSort(order zbuf.Order, c []Chunk) {
 	sort.Slice(c, func(i, j int) bool {
 		return chunkTsLess(order, c[i].First, c[i].Id, c[j].First, c[j].Id)
 	})
+}
+
+type chunkMetadata struct {
+	Kind        FileKind
+	First       nano.Ts
+	Last        nano.Ts
+	RecordCount uint64
+}
+
+func (md chunkMetadata) Chunk(id ksuid.KSUID) Chunk {
+	return Chunk{
+		Id:          id,
+		First:       md.First,
+		Last:        md.Last,
+		Kind:        md.Kind,
+		RecordCount: md.RecordCount,
+	}
+}
+
+func chunkMetadataPath(ark *Archive, tsDir tsDir, id ksuid.KSUID) iosrc.URI {
+	return tsDir.path(ark).AppendPath(fmt.Sprintf("%s-%s.zng", FileKindMetadata, id))
+}
+
+func writeChunkMetadata(ctx context.Context, uri iosrc.URI, md chunkMetadata) error {
+	zctx := resolver.NewContext()
+	rec, err := resolver.MarshalRecord(zctx, md)
+	if err != nil {
+		return err
+	}
+	out, err := iosrc.NewWriter(ctx, uri)
+	if err != nil {
+		return err
+	}
+	zw := zngio.NewWriter(bufwriter.New(out), zngio.WriterOpts{})
+	if err := zw.Write(rec); err != nil {
+		zw.Close()
+		return err
+	}
+	return zw.Close()
+}
+
+func readChunkMetadata(ctx context.Context, uri iosrc.URI) (chunkMetadata, error) {
+	in, err := iosrc.NewReader(ctx, uri)
+	if err != nil {
+		return chunkMetadata{}, err
+	}
+	defer in.Close()
+	zctx := resolver.NewContext()
+	zr := zngio.NewReader(in, zctx)
+	rec, err := zr.Read()
+	if err != nil {
+		return chunkMetadata{}, err
+	}
+	var md chunkMetadata
+	if err := resolver.UnmarshalRecord(zctx, rec, &md); err != nil {
+		return chunkMetadata{}, err
+	}
+	return md, nil
 }
 
 type Visitor func(chunk Chunk) error

--- a/archive/walk.go
+++ b/archive/walk.go
@@ -31,8 +31,8 @@ type FileKind string
 const (
 	FileKindUnknown  FileKind = ""
 	FileKindData              = "d"
-	FileKindSeek              = "ts"
 	FileKindMetadata          = "m"
+	FileKindSeek              = "ts"
 )
 
 // A tsDir is a directory found in the "<DataPath>/zd" directory of the archive,
@@ -121,11 +121,10 @@ func tsDirEntriesToChunks(ctx context.Context, ark *Archive, filterSpan nano.Spa
 			switch kind {
 			case FileKindData:
 				s.data = true
-				m[id] = s
 			case FileKindMetadata:
 				s.meta = true
-				m[id] = s
 			}
+			m[id] = s
 		}
 	}
 	var chunks []Chunk

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/brimsec/zq/archive"
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/emitter"
@@ -180,20 +179,9 @@ func parseExprWithChunk(spaceID api.SpaceID, expr string, chunkInfo string) (*ap
 	if err != nil {
 		return nil, err
 	}
-	chunk, ok := archive.ChunkNameMatch(chunkInfo)
-	if !ok {
-		return nil, errors.New("bad format for chunk name")
-	}
-
 	return &api.WorkerRequest{
-		SearchRequest: *searchRequest,
-		Chunks: []api.Chunk{{
-			Id:          chunk.Id.String(),
-			First:       chunk.First,
-			Last:        chunk.Last,
-			Kind:        string(chunk.Kind),
-			RecordCount: chunk.RecordCount,
-		}},
+		SearchRequest:      *searchRequest,
+		ChunkRelativePaths: []string{chunkInfo},
 	}, nil
 }
 

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -180,8 +180,8 @@ func parseExprWithChunk(spaceID api.SpaceID, expr string, chunkInfo string) (*ap
 		return nil, err
 	}
 	return &api.WorkerRequest{
-		SearchRequest:      *searchRequest,
-		ChunkRelativePaths: []string{chunkInfo},
+		SearchRequest: *searchRequest,
+		ChunkPaths:    []string{chunkInfo},
 	}, nil
 }
 

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -47,15 +47,7 @@ type SearchRequest struct {
 
 type WorkerRequest struct {
 	SearchRequest
-	Chunks []Chunk `json:"chunks"`
-}
-
-type Chunk struct {
-	Id          string  `json:"id" validate:"required"`
-	First       nano.Ts `json:"first" validate:"required"`
-	Last        nano.Ts `json:"last" validate:"required"`
-	Kind        string  `json:"kind" validate:"required"`
-	RecordCount int64   `json:"record_count" validate:"required"`
+	ChunkRelativePaths []string `json:"chunk_relative_paths"`
 }
 
 type SearchRecords struct {

--- a/zqd/api/api.go
+++ b/zqd/api/api.go
@@ -47,7 +47,7 @@ type SearchRequest struct {
 
 type WorkerRequest struct {
 	SearchRequest
-	ChunkRelativePaths []string `json:"chunk_relative_paths"`
+	ChunkPaths []string `json:"chunk_paths"`
 }
 
 type SearchRecords struct {

--- a/zqd/search/worker.go
+++ b/zqd/search/worker.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/brimsec/zq/archive"
-	"github.com/segmentio/ksuid"
-
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/nano"
@@ -19,7 +17,7 @@ import (
 )
 
 type WorkerOp struct {
-	si   archive.SpanInfo
+	ss   archive.SpanInfoSource
 	proc ast.Proc
 	dir  int
 }
@@ -34,30 +32,16 @@ func NewWorkerOp(req api.WorkerRequest) (*WorkerOp, error) {
 		return nil, zqe.E(zqe.Invalid, "time direction must be 1 or -1")
 	}
 
-	chunks := make([]archive.Chunk, len(req.Chunks))
-	for i, chunk := range req.Chunks {
-		id, err := ksuid.Parse(chunk.Id)
-		if err != nil {
-			return nil, zqe.E(zqe.Invalid, "unparsable ksuid")
-		}
-		chunks[i].Id = id
-		chunks[i].First = chunk.First
-		chunks[i].Last = chunk.Last
-		chunks[i].Kind = archive.FileKind(chunk.Kind)
-		chunks[i].RecordCount = chunk.RecordCount
-	}
-
-	si := archive.SpanInfo{
-		Span:   req.Span,
-		Chunks: chunks,
-	}
-
 	proc, err := ast.UnpackJSON(nil, req.Proc)
 	if err != nil {
 		return nil, err
 	}
 
-	return &WorkerOp{si: si, proc: proc, dir: req.Dir}, nil
+	ss := archive.SpanInfoSource{
+		Span:               req.Span,
+		ChunkRelativePaths: req.ChunkRelativePaths,
+	}
+	return &WorkerOp{ss: ss, proc: proc, dir: req.Dir}, nil
 }
 
 func (w *WorkerOp) Run(ctx context.Context, store storage.Storage, output Output) (err error) {
@@ -80,8 +64,7 @@ func (w *WorkerOp) Run(ctx context.Context, store storage.Storage, output Output
 
 	switch st := store.(type) {
 	case *archivestore.Storage:
-		return driver.MultiRun(ctx, d, w.proc, zctx, st.StaticSource(w.si), driver.MultiConfig{
-			Span:      w.si.Span,
+		return driver.MultiRun(ctx, d, w.proc, zctx, st.StaticSource(w.ss), driver.MultiConfig{
 			StatsTick: statsTicker.C,
 		})
 	default:

--- a/zqd/search/worker.go
+++ b/zqd/search/worker.go
@@ -38,8 +38,8 @@ func NewWorkerOp(req api.WorkerRequest) (*WorkerOp, error) {
 	}
 
 	ss := archive.SpanInfoSource{
-		Span:               req.Span,
-		ChunkRelativePaths: req.ChunkRelativePaths,
+		Span:       req.Span,
+		ChunkPaths: req.ChunkPaths,
 	}
 	return &WorkerOp{ss: ss, proc: proc, dir: req.Dir}, nil
 }

--- a/zqd/storage/archivestore/archivestore.go
+++ b/zqd/storage/archivestore/archivestore.go
@@ -53,8 +53,8 @@ func (s *Storage) MultiSource() driver.MultiSource {
 	return archive.NewMultiSource(s.ark, nil)
 }
 
-func (s *Storage) StaticSource(si archive.SpanInfo) driver.MultiSource {
-	return archive.NewStaticSource(s.ark, si)
+func (s *Storage) StaticSource(ss archive.SpanInfoSource) driver.MultiSource {
+	return archive.NewStaticSource(s.ark, ss)
 }
 
 func (s *Storage) Summary(ctx context.Context) (storage.Summary, error) {

--- a/ztests/suite/zqd/worker-count.yaml
+++ b/ztests/suite/zqd/worker-count.yaml
@@ -15,14 +15,13 @@ script: |
   # it does not matter which one.
   #
   ZNG_FILE_PATH=$(find . -name "d-*.zng" -print | head -1)
-  CHUNK_INFO=$(basename $ZNG_FILE_PATH)
   #
   # The count() from zq should be identical to 
   # the count() from zapi get -chunk
   #
   zq -t "count()" $ZNG_FILE_PATH > zqcount.tzng
   zapi -h $ZQD_HOST -s testsp get -t \
-    -chunk $CHUNK_INFO "count()" > zapicount.tzng
+    -chunk $ZNG_FILE_PATH "count()" > zapicount.tzng
   echo ===
   diff -s zqcount.tzng zapicount.tzng
   #
@@ -31,7 +30,7 @@ script: |
   #
   zq -t "tail 5" $ZNG_FILE_PATH > zqtail.tzng
   zapi -h $ZQD_HOST -s testsp get -t \
-    -chunk $CHUNK_INFO "tail 5" > zapitail.tzng
+    -chunk $ZNG_FILE_PATH "tail 5" > zapitail.tzng
   echo ===
   diff -s zqtail.tzng zapitail.tzng
   #
@@ -41,7 +40,7 @@ script: |
   #
   zq -t "39161" $ZNG_FILE_PATH > zqfilter.tzng
   zapi -h $ZQD_HOST -s testsp get -t \
-    -chunk $CHUNK_INFO "39161" > zapifilter.tzng
+    -chunk $ZNG_FILE_PATH "39161" > zapifilter.tzng
   echo ===
   diff -s zqfilter.tzng zapifilter.tzng
   


### PR DESCRIPTION
This PR moves the first & last timestamp, and the record count of a chunk, from the name of the chunk file to a separate metadata file. While working on compaction for overlapping files, I ran into local filesystem (not S3) limitations on the maximum length of a file name, which implied I'd need to store the masked chunk ids in a separate file. Since we plan on eventually storing metadata about a chunk to use for query optimization, I think it makes sense to encode all of the existing meta info to a separate file now, and add more content to it later as needed.

A repercussion of storing the timestamps this way is that all of the metadata files in a tsdir must be consulted at query time to determine which chunks to include for an query's time span. However, the metadata is immutable, so it can easily & safely be cached keyed on the chunk id.

