### PR TITLE
Allow zapi post of s3 objects

### DIFF
--- a/charts/zqd/templates/deployment.yaml
+++ b/charts/zqd/templates/deployment.yaml
@@ -84,7 +84,9 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /spaces
-              name: spaces-volume     
+              name: spaces-volume
+            - mountPath: /tmp
+              name: tmp-volume                   
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -99,4 +101,6 @@ spec:
       {{- end }}
       volumes:
         - name: spaces-volume
+          emptyDir: {}
+        - name: tmp-volume
           emptyDir: {}

--- a/cmd/zapi/cmd/post/post.go
+++ b/cmd/zapi/cmd/post/post.go
@@ -116,6 +116,19 @@ func abspaths(paths []string) ([]string, error) {
 	var err error
 	out := make([]string, len(paths))
 	for i, path := range paths {
+		// Special handling for paths starting with S3:
+		// we will not convert to absolute path -MTW
+		if path[0:4] == "s3:/" {
+			out[i] = path
+			continue
+		}
+		// TODO: This looks wrong to me,
+		// because it assumes that zapi and zqd
+		// are using the same filesystem. If they do not,
+		// then filepath.Abs(path) will produce a path
+		// that will not work when passed to zqd.
+		// I think the filepath.Abs function should be called
+		// in the zqd process instead. -MTW
 		out[i], err = filepath.Abs(path)
 		if err != nil {
 			return nil, err

--- a/cmd/zapi/cmd/post/post.go
+++ b/cmd/zapi/cmd/post/post.go
@@ -118,7 +118,7 @@ func abspaths(paths []string) ([]string, error) {
 	for i, path := range paths {
 		// Special handling for paths starting with S3:
 		// we will not convert to absolute path -MTW
-		if path[0:4] == "s3:/" {
+		if path[0:5] == "s3://" {
 			out[i] = path
 			continue
 		}

--- a/cmd/zapi/cmd/post/post.go
+++ b/cmd/zapi/cmd/post/post.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sync/atomic"
 	"time"
 
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/cmd/zapi/format"
 	"github.com/brimsec/zq/pkg/display"
+	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zqd/api"
 	"github.com/mccanne/charm"
 )
@@ -113,26 +113,13 @@ loop:
 }
 
 func abspaths(paths []string) ([]string, error) {
-	var err error
 	out := make([]string, len(paths))
 	for i, path := range paths {
-		// Special handling for paths starting with S3:
-		// we will not convert to absolute path -MTW
-		if path[0:5] == "s3://" {
-			out[i] = path
-			continue
-		}
-		// TODO: This looks wrong to me,
-		// because it assumes that zapi and zqd
-		// are using the same filesystem. If they do not,
-		// then filepath.Abs(path) will produce a path
-		// that will not work when passed to zqd.
-		// I think the filepath.Abs function should be called
-		// in the zqd process instead. -MTW
-		out[i], err = filepath.Abs(path)
+		uri, err := iosrc.ParseURI(path)
 		if err != nil {
 			return nil, err
 		}
+		out[i] = uri.String()
 	}
 	return out, nil
 }


### PR DESCRIPTION
This change allows zapi push to be used with S3 data, e.g.

zapi -s sp1 post s3://mybucket/conn.log.gz

I wanted this feature for testing distributed zqd features, and I also think it is useful for end-users.

Three things needed to change:

(1) the zapi api needed to not change names prefixed by "s3://" into absolute paths

(2) zqd/ingest/log.go needed to switch from opening files to using ReadClosers provided by iosrc.
This was Al's idea, and it worked really well!

(3) zqd spills to /tmp when processing the post request, so I needed to add a /tmp dir in the K8s deployment template.