### PR TITLE
Add "where" docs and reformat

### DIFF
--- a/zql/docs/aggregate-functions/README.md
+++ b/zql/docs/aggregate-functions/README.md
@@ -4,30 +4,28 @@ A pipeline may contain one or more _aggregate functions_, which operate on
 batches of events to carry out a running computation over values contained in
 the events.
 
-The [General Usage](#general-usage) section below describes details
-relevant to all aggregate functions, then the following
-[Available Aggregate Functions](#available-aggregate-functions) are
-documented in detail:
-
-* [`avg`](#avg)
-* [`count`](#count)
-* [`countdistinct`](#countdistinct)
-* [`first`](#first)
-* [`last`](#last)
-* [`max`](#max)
-* [`min`](#min)
-* [`sum`](#sum)
+   * [General Usage](#general-usage)
+     + [Invoking](#invoking)
+     + [Field naming](#field-naming)
+     + [Grouping](#grouping)
+     + [`where` filtering](#where-filtering)
+   * [Available Aggregate Functions](#available-aggregate-functions)
+     + [`avg`](#avg)
+     + [`count`](#count)
+     + [`countdistinct`](#countdistinct)
+     + [`first`](#first)
+     + [`last`](#last)
+     + [`max`](#max)
+     + [`min`](#min)
+     + [`sum`](#sum)
 
 **Note**: Per ZQL [search syntax](../search-syntax/README.md), many examples
 below use shorthand that leaves off the explicit leading `* |`, matching all
 events before invoking the first element in a pipeline.
 
-# General Usage
+## General Usage
 
-All aggregate functions may be invoked with one or more
-[grouping](../grouping/README.md) options that define the batches of events on
-which they operate. If explicit grouping is not used, an aggregate function
-will operate over all events in the input stream.
+### Invoking
 
 Multiple aggregate functions may be invoked at the same time.
 
@@ -46,6 +44,8 @@ MIN      MAX         AVG
 0.000001 1269.512465 1.6373747834138621
 ```
 
+### Field naming
+
 As just shown, by default the result returned by an aggregate function is
 placed in a field with the same name as the aggregate function. You may
 instead use `=` to specify an explicit name for the generated field.
@@ -62,11 +62,42 @@ QUICKEST LONGEST     TYPICAL
 0.000001 1269.512465 1.6373747834138621
 ```
 
+### Grouping
+
+All aggregate functions may be invoked with one or more
+[grouping](../grouping/README.md) options that define the batches of events on
+which they operate. If explicit grouping is not used, an aggregate function
+will operate over all events in the input stream.
+
+### `where` filtering
+
+A `where` clause may also be added to filter the values on which an aggregate
+function will operate.
+
+#### Example:
+
+To check whether we've seen higher DNS round-trip times when servers return
+longer lists of `answers`:
+
+```zq-command
+zq -f table 'answers != null | every 5 minutes short_rtt=avg(rtt) where len(answers)<=2, short_count=count() where len(answers)<=2, long_rtt=avg(rtt) where len(answers)>2, long_count=count() where len(answers)>2 | sort ts' dns.log.gz
+```
+
+#### Output:
+```zq-output
+TS                SHORT_RTT            SHORT_COUNT LONG_RTT             LONG_COUNT
+1521911700.000000 0.004386461911629731 7628        0.01571223665048545  824
+1521912000.000000 0.006360169034406226 9010        0.01992656544502617  764
+1521912300.000000 0.006063177039132521 8486        0.02742244411764705  680
+1521912600.000000 0.005641562210915819 8652        0.021644265586034935 802
+1521912900.000000 0.008572169213139795 2618        0.01933044954128441  218
+```
+
 ---
 
-# Available Aggregate Functions
+## Available Aggregate Functions
 
-## `avg`
+### `avg`
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
@@ -93,7 +124,7 @@ AVG
 
 ---
 
-## `count`
+### `count`
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
@@ -135,7 +166,7 @@ ftp   93
 
 ---
 
-## `countdistinct`
+### `countdistinct`
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
@@ -177,7 +208,7 @@ to perform this test, the ZQL using `countdistinct()` executed almost 3x faster.
 
 ---
 
-## `first`
+### `first`
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
@@ -203,7 +234,7 @@ TCP_ack_underflow_or_misorder
 
 ---
 
-## `last`
+### `last`
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
@@ -229,7 +260,7 @@ talk.google.com
 
 ---
 
-## `max`
+### `max`
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
@@ -256,7 +287,7 @@ MAX
 
 ---
 
-## `min`
+### `min`
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
@@ -283,7 +314,7 @@ MIN
 
 ---
 
-## `sum`
+### `sum`
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |

--- a/zql/docs/grouping/README.md
+++ b/zql/docs/grouping/README.md
@@ -1,8 +1,9 @@
 # Grouping
 
 All [aggregate functions](../aggregate-functions/README.md) may be invoked with
-one or more _grouping_ options that partition the input stream into batches that are aggregated separately. If explicit grouping is not used, an aggregate function will operate
-over all events in the input stream.
+one or more _grouping_ options that partition the input stream into batches
+that are aggregated separately. If explicit grouping is not used, an aggregate
+function will operate over all events in the input stream.
 
 Below you will find details regarding the available grouping mechanisms and
 tips for their effective use.


### PR DESCRIPTION
Here's my attempt to add ZQL docs for the recently-added `where` clause. If users try to get super sophisticated with this functionality right now they're likely to uncover some rough edges related to the differences between searches & expressions, which we have plans to address soon. But I figured it'd be good to get the docs out there with what's working.

I wondered if this belonged in the [Grouping](https://github.com/brimsec/zq/blob/master/zql/docs/grouping/README.md) page, but when comparing to how `by` and `every` work, this seems different enough that I've opted to include it with the other "General Usage" guidance. But I'm open to hearing other opinions on that.

I did some reformatting while I'm at it.