### PR TITLE
ZQL docs for aggregate functions: and, or, collect, union

### DIFF
--- a/zql/docs/aggregate-functions/README.md
+++ b/zql/docs/aggregate-functions/README.md
@@ -396,7 +396,7 @@ MIN
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
-| **Description**           | Returns the boolean value `true` if the provided expression evaluates to `true` for any input value. Contrast with [`and`](#and). |
+| **Description**           | Returns the boolean value `true` if the provided expression evaluates to `true` for one or more inputs. Contrast with [`and`](#and). |
 | **Syntax**                | `or(<expression>)`                                             |
 | **Required<br>arguments** | `<expression>`<br>A valid ZQL [expression](../expressions/README.md). |
 | **Optional<br>arguments** | None                                                           |

--- a/zql/docs/aggregate-functions/README.md
+++ b/zql/docs/aggregate-functions/README.md
@@ -105,7 +105,7 @@ TS                SHORT_RTT            SHORT_COUNT LONG_RTT             LONG_COU
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
-| **Description**           | Returns the boolean value `true` if the provided expression evaluates to `true` for all input values. Contrast with [`or`](#or). |
+| **Description**           | Returns the boolean value `true` if the provided expression evaluates to `true` for all inputs. Contrast with [`or`](#or). |
 | **Syntax**                | `and(<expression>)`                                            |
 | **Required<br>arguments** | `<expression>`<br>A valid ZQL [expression](../expressions/README.md). |
 | **Optional<br>arguments** | None                                                           |

--- a/zql/docs/aggregate-functions/README.md
+++ b/zql/docs/aggregate-functions/README.md
@@ -9,14 +9,18 @@ relevant to all aggregate functions, then the following
 [Available Aggregate Functions](#available-aggregate-functions) are
 documented in detail:
 
+* [`and`](#and)
 * [`avg`](#avg)
+* [`collect`](#collect)
 * [`count`](#count)
 * [`countdistinct`](#countdistinct)
 * [`first`](#first)
 * [`last`](#last)
 * [`max`](#max)
 * [`min`](#min)
+* [`or`](#or)
 * [`sum`](#sum)
+* [`union`](#union)
 
 **Note**: Per ZQL [search syntax](../search-syntax/README.md), many examples
 below use shorthand that leaves off the explicit leading `* |`, matching all
@@ -66,6 +70,49 @@ QUICKEST LONGEST     TYPICAL
 
 # Available Aggregate Functions
 
+## `and`
+
+|                           |                                                                |
+| ------------------------- | -------------------------------------------------------------- |
+| **Description**           | Returns the boolean value `true` if the provided expression evaluates to `true` for all input values. Contrast with [`or`](#or). |
+| **Syntax**                | `and(<expression>)`                                            |
+| **Required<br>arguments** | `<expression>`<br>A valid ZQL [expression](../expressions/README.md). |
+| **Optional<br>arguments** | None                                                           |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer/logical       |
+
+#### Example:
+
+Let's say you've been studying `weird` events and noticed that lots of
+connections have made one or more bad HTTP requests.
+
+```zq-command
+zq -f table 'count() by name | sort -r count' weird.log.gz
+```
+
+#### Output:
+```zq-output head:5
+NAME                                        COUNT
+bad_HTTP_request                            11777
+line_terminated_with_single_CR              11734
+unknown_HTTP_method                         140
+above_hole_data_without_any_acks            107
+...
+```
+
+To count the number of connections for which this was the _only_ category of
+`weird` event observed:
+
+```zq-command
+zq -f table 'only_bads=and(name="bad_HTTP_request") by uid | count() where only_bads=true' weird.log.gz
+```
+
+#### Output:
+```zq-output
+COUNT
+37
+```
+
+---
 ## `avg`
 
 |                           |                                                                |
@@ -74,7 +121,7 @@ QUICKEST LONGEST     TYPICAL
 | **Syntax**                | `avg(<field-name>)`                                            |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Avg            |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Avg           |
 
 #### Example:
 
@@ -93,15 +140,46 @@ AVG
 
 ---
 
+## `collect`
+
+|                           |                                                                |
+| ------------------------- | -------------------------------------------------------------- |
+| **Description**           | Assemble all input values into an array. Contrast with [`union`](#union). |
+| **Syntax**                | `collect(<field-name>)`                                        |
+| **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
+| **Optional<br>arguments** | None                                                           |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Collect       |
+
+#### Example #1:
+
+To assemble the sequence of HTTP methods invoked in each interaction with the
+Bing search engine:
+
+```zq-command
+zq -f table 'host=www.bing.com | methods=collect(method) by uid | sort uid' http.log.gz
+```
+
+#### Output:
+```zq-output head:5
+UID                METHODS
+C1iilt2FG8PnyEl0bb GET,GET,POST,GET,GET,POST
+C31wi6XQB8h9igoa5  GET,GET,POST,POST,POST
+CFwagt4ivDe3p6R7U8 GET,GET,POST,POST,GET,GET,GET,POST,POST,GET,GET,GET,GET,POST
+CI0SCN14gWpY087KA3 GET,POST,GET,GET,GET,GET,GET,GET,GET,GET,GET,GET,GET
+...
+```
+
+---
+
 ## `count`
 
 |                           |                                                                |
 | ------------------------- | -------------------------------------------------------------- |
-| **Description**           | Return the number of events. |
+| **Description**           | Return the number of events.                                   |
 | **Syntax**                | `count([field-name])`                                          |
 | **Required<br>arguments** | None                                                           |
 | **Optional<br>arguments** | `[field-name]`<br>The name a field. If specified, only events that contain this field will be counted. |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Count          |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Count         |
 
 #### Example #1:
 
@@ -135,6 +213,7 @@ ftp   93
 
 ---
 
+
 ## `countdistinct`
 
 |                           |                                                                |
@@ -144,7 +223,7 @@ ftp   93
 | **Required<br>arguments** | `<field-name>`<br>The name of a field containing values to be counted. |
 | **Optional<br>arguments** | None                                                           |
 | **Limitations**           | The potential inaccuracy of the calculated result is described in detail in the code and research linked from the [HyperLogLog repository](https://github.com/axiomhq/hyperloglog). |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#CountDistinct  |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#CountDistinct |
 
 #### Example:
 
@@ -185,7 +264,7 @@ to perform this test, the ZQL using `countdistinct()` executed almost 3x faster.
 | **Syntax**                | `first(<field-name>)`                                          |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#First          |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#First         |
 
 #### Example:
 
@@ -211,7 +290,7 @@ TCP_ack_underflow_or_misorder
 | **Syntax**                | `last(<field-name>)`                                           |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Last           |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Last          |
 
 #### Example:
 
@@ -283,6 +362,50 @@ MIN
 
 ---
 
+## `or`
+
+|                           |                                                                |
+| ------------------------- | -------------------------------------------------------------- |
+| **Description**           | Returns the boolean value `true` if the provided expression evaluates to `true` for any input value. Contrast with [`and`](#and). |
+| **Syntax**                | `or(<expression>)`                                             |
+| **Required<br>arguments** | `<expression>`<br>A valid ZQL [expression](../expressions/README.md). |
+| **Optional<br>arguments** | None                                                           |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer/logical       |
+
+#### Example:
+
+Let's say you've noticed there's lots of HTTP traffic happening on ports higher
+than the standard port `80`.
+
+```zq-command
+zq -f table 'count() by id.resp_p | sort -r' http.log.gz
+```
+
+#### Output:
+```zq-output head:5
+ID.RESP_P COUNT
+80        134496
+8080      5204
+5800      1691
+65534     903
+...
+```
+
+The following query confirms this high-port traffic is present, but that none of
+those ports are higher than what TCP allows.
+
+```zq-command
+zq -f table 'some_highports=or(id.resp_p>80),impossible_ports=or(id.resp_p>65535)' http.log.gz
+```
+
+#### Output:
+```zq-output
+SOME_HIGHPORTS IMPOSSIBLE_PORTS
+T              F
+```
+
+---
+
 ## `sum`
 
 |                           |                                                                |
@@ -306,4 +429,40 @@ zq -f table 'sum(total_bytes)' files.log.gz
 ```zq-output
 SUM
 3092961270
+```
+
+---
+
+## `union`
+
+|                           |                                                                |
+| ------------------------- | -------------------------------------------------------------- |
+| **Description**           | Gather all unique input values into a set. Contrast with [`collect`](#collect). |
+| **Syntax**                | `union(<field-name>)`                                          |
+| **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
+| **Optional<br>arguments** | None                                                           |
+| **Limitations**           | The data type of the input values must be uniform.             |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Union         |
+
+#### Example #1:
+
+To observe which HTTP methods were invoked in each interaction with the Bing
+search engine:
+
+```zq-command
+zq -f table 'host=www.bing.com | methods=union(method) by uid | sort uid' http.log.gz
+```
+
+#### Output:
+```zq-output head:9
+UID                METHODS
+C1iilt2FG8PnyEl0bb GET,POST
+C31wi6XQB8h9igoa5  GET,POST
+CFwagt4ivDe3p6R7U8 GET,POST
+CI0SCN14gWpY087KA3 GET,POST
+CJcF5E1DVn8FLq5JVc POST
+CLsXgZ1W5l9gMzx7e8 GET,POST
+CM2qfb4dhM2KJ6uAZk GET
+CSOmBD4vJEGRU6pJmg POST
+...
 ```

--- a/zql/docs/aggregate-functions/README.md
+++ b/zql/docs/aggregate-functions/README.md
@@ -78,7 +78,7 @@ QUICKEST LONGEST     TYPICAL
 | **Syntax**                | `and(<expression>)`                                            |
 | **Required<br>arguments** | `<expression>`<br>A valid ZQL [expression](../expressions/README.md). |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer/logical       |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer               |
 
 #### Example:
 
@@ -370,7 +370,7 @@ MIN
 | **Syntax**                | `or(<expression>)`                                             |
 | **Required<br>arguments** | `<expression>`<br>A valid ZQL [expression](../expressions/README.md). |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer/logical       |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer               |
 
 #### Example:
 


### PR DESCRIPTION
This PR adds ZQL docs for the recently-added aggregate functions `and()`, `or()`, `collect()`, and `union()`. I cleaned up a touch of other formatting while I was in there.

I've also noticed that the stuff under https://pkg.go.dev/github.com/brimsec/zq that we link to from the Developer Docs entries only seems to get updated when we tag a new release. Therefore the Developer Docs links I've added to these new reducers are not "broken" per se but they don't land at meaningful content yet. Likewise, some of the existing links still point at valid content that's been recently moved as part of code re-org and are going to need to be adjusted when we bundle the next release. Rather than trying to be fancy about timing the merge of docs PRs at the precise moment we bundle the next release, I'm inclined to merge docs now for the benefit of bleeding edge users working off the new stuff `master`. I've made a note-to-self to check/update links when I assemble the next GA release.