### PR TITLE
zar: Use chunk seek index for searching chunk data files

### DIFF
--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -148,10 +148,10 @@ func TestSeekIndex(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(datapath)
 
-	orig := importStreamRecordsMax
-	importStreamRecordsMax = 1
+	orig := ImportStreamRecordsMax
+	ImportStreamRecordsMax = 1
 	defer func() {
-		importStreamRecordsMax = orig
+		ImportStreamRecordsMax = orig
 	}()
 	createArchiveSpace(t, datapath, babble, &CreateOptions{
 		// Must use SortAscending: true until zq#1329 is addressed.

--- a/archive/overlap.go
+++ b/archive/overlap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 
+	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng"
@@ -303,7 +304,7 @@ func compactOverlaps(ctx context.Context, ark *Archive, s SpanInfo) error {
 	if len(s.Chunks) == 1 {
 		return nil
 	}
-	ss, err := newSpanScanner(ctx, ark, resolver.NewContext(), nil, nil, s)
+	ss, _, err := newSpanScanner(ctx, ark, resolver.NewContext(), driver.SourceFilter{Span: nano.MaxSpan}, s)
 	if err != nil {
 		return err
 	}

--- a/archive/ztests/seek-index-overlap.yaml
+++ b/archive/ztests/seek-index-overlap.yaml
@@ -1,0 +1,28 @@
+script: |
+  zq "tail 900" babble.tzng | zar import -R asc -asc -streammax=100 -
+  zq "head 250" babble.tzng | zar import -R asc -streammax=100 -
+  zar zq -R asc -t -s "count()"
+  echo === | tee /dev/stderr
+  zq "tail 900" babble.tzng | zar import -R desc -streammax=100 -
+  zq "head 250" babble.tzng | zar import -R desc -streammax=100 -
+  zar zq -R desc -t -s "count()"
+
+inputs:
+  - name: babble.tzng
+    source: ../../ztests/suite/data/babble.tzng
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[count:uint64]
+      0:[1150;]
+      ===
+      #0:record[count:uint64]
+      0:[1150;]
+  - name: stderr
+    data: |
+      data opened: 49051
+      data read:   40293
+      ===
+      data opened: 49036
+      data read:   43751

--- a/archive/ztests/seek-index.yaml
+++ b/archive/ztests/seek-index.yaml
@@ -1,0 +1,30 @@
+script: |
+  zar import -streammax=100 -asc -R asc babble.tzng
+  zar zq -f tzng -start 2020-04-21T23:59:26.063Z -end 2020-04-21T23:59:38.069Z -s -R asc "*"
+  echo === | tee /dev/stderr
+  zar import -streammax=100 -R desc babble.tzng
+  zar zq -f tzng -start 2020-04-21T23:59:26.063Z -end 2020-04-21T23:59:38.069Z -s -R desc "*"
+
+inputs:
+  - name: babble.tzng
+    source: ../../ztests/suite/data/babble.tzng
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[ts:time,s:string,v:int64]
+      0:[1587513566.06326664;potbellied-Dedanim;230;]
+      0:[1587513569.06985813;areek-ashless;266;]
+      0:[1587513578.0687693;topcoating-rhexis;415;]
+      ===
+      #0:record[ts:time,s:string,v:int64]
+      0:[1587513578.0687693;topcoating-rhexis;415;]
+      0:[1587513569.06985813;areek-ashless;266;]
+      0:[1587513566.06326664;potbellied-Dedanim;230;]
+  - name: stderr
+    data: |
+      data opened: 17565
+      data read:   3642
+      ===
+      data opened: 17555
+      data read:   3473

--- a/cli/searchflags/flags.go
+++ b/cli/searchflags/flags.go
@@ -1,0 +1,59 @@
+package searchflags
+
+import (
+	"errors"
+	"flag"
+	"math"
+
+	"github.com/brimsec/zq/pkg/nano"
+)
+
+type tsArg nano.Ts
+
+func (t tsArg) String() string {
+	if nano.Ts(t) == nano.MinTs {
+		return "min"
+	}
+	if nano.Ts(t) == math.MaxInt64 {
+		return "max"
+	}
+	return t.String()
+}
+
+func (t *tsArg) Set(s string) error {
+	switch s {
+	case "min":
+		*t = tsArg(nano.MinTs)
+		return nil
+	case "max":
+		*t = tsArg(nano.MaxTs)
+		return nil
+	default:
+		out, err := nano.ParseRFC3339Nano([]byte(s))
+		*t = tsArg(out)
+		return err
+	}
+}
+
+type Flags struct {
+	start tsArg
+	end   tsArg
+}
+
+func (f *Flags) SetFlags(fs *flag.FlagSet) {
+	f.start = tsArg(nano.MinTs)
+	fs.Var(&f.start, "start", "starting timestamp of query in RFC3339Nano format")
+	f.end = tsArg(nano.MaxTs)
+	fs.Var(&f.end, "end", "ending timestamp of query in RFC3339Nano format")
+}
+
+func (f *Flags) Init() error {
+	if f.start >= f.end {
+		return errors.New("start must be less than end")
+	}
+	return nil
+}
+
+func (f *Flags) Span() nano.Span {
+	return nano.NewSpanTs(nano.Ts(f.start), nano.Ts(f.end))
+}

--- a/microindex/reader.go
+++ b/microindex/reader.go
@@ -134,6 +134,10 @@ func (r *Reader) Path() string {
 	return r.path.String()
 }
 
+func (r *Reader) Order() zbuf.Order {
+	return r.trailer.Order
+}
+
 func (r *Reader) Keys() *zng.TypeRecord {
 	return r.trailer.KeyType
 }


### PR DESCRIPTION
If the span of a SpanInfo bisects a child chunk, leverage the chunk
file offset index not read data known to be outside the SpanInfo's time
window.

Also:
- Add plumbing to archive multiSource and staticSource to gather stats on
the amount of data read (used in zar zq -stats option).
- zar import: add -streammax option to specify the number of
records imported into a chunk before a new offset is created (for testing
purposes only).
- zar import: add -asc option to allow creation of archives with data
stored in ascending order.
- zar zq: add -start and -end options to specify the time window of a search.
- zar zq: add -stats arg that prints the total size of chunks opened vs. the
size of data read from opened chunks (mostly for testing purposes, allows tests
to verify the offset index is being used).

Closes #1470