### PR TITLE
Add api.SearchRequest.ZQL as a .Proc alternative

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -37,9 +37,11 @@ type TaskEnd struct {
 	Error  *Error `json:"error,omitempty"`
 }
 
+// A SearchRequest can have either Proc or ZQL set, but not both.
 type SearchRequest struct {
 	Space SpaceID         `json:"space" validate:"required"`
-	Proc  json.RawMessage `json:"proc" validate:"required"`
+	Proc  json.RawMessage `json:"proc,omitempty"`
+	ZQL   string          `json:"zql,omitempty"`
 	Span  nano.Span       `json:"span"`
 	Dir   int             `json:"dir" validate:"required"`
 }

--- a/ppl/zqd/handlers.go
+++ b/ppl/zqd/handlers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
+	"github.com/brimsec/zq/zql"
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
 )
@@ -78,6 +79,23 @@ func handleSearch(c *Core, w http.ResponseWriter, r *http.Request) {
 	var req api.SearchRequest
 	if !request(c, w, r, &req) {
 		return
+	}
+
+	if req.ZQL != "" {
+		if req.Proc != nil {
+			respondError(c, w, r, zqe.ErrInvalid("specify either proc or zql"))
+			return
+		}
+		search, err := zql.ParseProc(req.ZQL)
+		if err != nil {
+			respondError(c, w, r, err)
+			return
+		}
+		req.Proc, err = json.Marshal(search)
+		if err != nil {
+			respondError(c, w, r, err)
+			return
+		}
 	}
 
 	s, err := c.spaces.Get(req.Space)


### PR DESCRIPTION
A zqd client must provide an AST in api.SearchRequest.Proc, requiring
the client to implement a ZQL parser if it is to allow searches with
arbitrary ZQL.  Add api.SearchRequest.ZQL to lift this requirement.
Either the Proc field or the ZQL field may be provided in requests to
zqd, but providing both is an error.

Part of #1519.