### PR TITLE
fix bug where right bracket not properly escaped

### DIFF
--- a/zng/escape.go
+++ b/zng/escape.go
@@ -17,7 +17,7 @@ func ShouldEscape(r rune, fmt OutFmt, pos int, inContainer bool) bool {
 		return true
 	}
 
-	if fmt == OutFormatZNG && (r == ';' || (pos == 0 && r == '[')) {
+	if fmt == OutFormatZNG && (r == ';' || (pos == 0 && (r == '[' || r == ']'))) {
 		return true
 	}
 

--- a/ztests/fixedbugs/1305.yaml
+++ b/ztests/fixedbugs/1305.yaml
@@ -1,0 +1,12 @@
+script: zq -t -
+
+inputs:
+  - name: stdin
+    data: |
+      {"dstUdata": "]..3O7x"}
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[dstUdata:string]
+      0:[\u{5d}..3O7x;]


### PR DESCRIPTION
This commit fixes a bug where the right bracket appearing as a
first character of a tzng value was not escaped in accordance
with the zng spec.

Fixes #1305