### PR TITLE
convert alpha zng spaces in background

### DIFF
--- a/ppl/zqd/core.go
+++ b/ppl/zqd/core.go
@@ -1,6 +1,7 @@
 package zqd
 
 import (
+	"context"
 	"net/http"
 	"sync/atomic"
 
@@ -31,7 +32,7 @@ type Core struct {
 	logger    *zap.Logger
 }
 
-func NewCore(conf Config) (*Core, error) {
+func NewCore(ctx context.Context, conf Config) (*Core, error) {
 	logger := conf.Logger
 	if logger == nil {
 		logger = zap.NewNop()
@@ -40,7 +41,7 @@ func NewCore(conf Config) (*Core, error) {
 	if err != nil {
 		return nil, err
 	}
-	spaces, err := space.NewManager(root, conf.Logger)
+	spaces, err := space.NewManager(ctx, root, conf.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/ppl/zqd/handlers_test.go
+++ b/ppl/zqd/handlers_test.go
@@ -1087,7 +1087,7 @@ func newCoreWithConfig(t *testing.T, conf zqd.Config) (*zqd.Core, *client.Connec
 	if conf.Logger == nil {
 		conf.Logger = zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel))
 	}
-	core, err := zqd.NewCore(conf)
+	core, err := zqd.NewCore(context.Background(), conf)
 	require.NoError(t, err)
 	srv := httptest.NewServer(zqd.NewHandler(core, conf.Logger))
 	t.Cleanup(srv.Close)

--- a/ppl/zqd/space/manager.go
+++ b/ppl/zqd/space/manager.go
@@ -12,23 +12,19 @@ import (
 )
 
 type Manager struct {
-	rootPath iosrc.URI
-	spacesMu sync.Mutex
-	spaces   map[api.SpaceID]Space
-	names    map[string]api.SpaceID
-	logger   *zap.Logger
+	logger            *zap.Logger
+	names             map[string]api.SpaceID
+	rootPath          iosrc.URI
+	spaces            map[api.SpaceID]Space
+	spacesMu          sync.Mutex
 }
 
-func NewManager(root iosrc.URI, logger *zap.Logger) (*Manager, error) {
-	return NewManagerWithContext(context.Background(), root, logger)
-}
-
-func NewManagerWithContext(ctx context.Context, root iosrc.URI, logger *zap.Logger) (*Manager, error) {
+func NewManager(ctx context.Context, root iosrc.URI, logger *zap.Logger) (*Manager, error) {
 	mgr := &Manager{
-		rootPath: root,
-		spaces:   make(map[api.SpaceID]Space),
-		names:    make(map[string]api.SpaceID),
-		logger:   logger,
+		logger:            logger,
+		names:             make(map[string]api.SpaceID),
+		rootPath:          root,
+		spaces:            make(map[api.SpaceID]Space),
 	}
 
 	list, err := iosrc.ReadDir(ctx, root)
@@ -50,7 +46,7 @@ func NewManagerWithContext(ctx context.Context, root iosrc.URI, logger *zap.Logg
 			continue
 		}
 
-		spaces, err := loadSpaces(ctx, dir, config, mgr.logger)
+		spaces, err := mgr.loadSpaces(ctx, dir, config)
 		if err != nil {
 			return nil, err
 		}
@@ -115,7 +111,7 @@ func (m *Manager) Create(ctx context.Context, req api.SpacePostRequest) (Space, 
 		iosrc.RemoveAll(context.Background(), path)
 		return nil, err
 	}
-	spaces, err := loadSpaces(ctx, path, conf, m.logger)
+	spaces, err := m.loadSpaces(ctx, path, conf)
 	if err != nil {
 		return nil, err
 	}

--- a/ppl/zqd/space/manager.go
+++ b/ppl/zqd/space/manager.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/ppl/zqd/storage/filestore"
 	"github.com/brimsec/zq/zqe"
 	"go.uber.org/zap"
 )
 
 type Manager struct {
+	alphaFileMigrator *filestore.Migrator
 	logger            *zap.Logger
 	names             map[string]api.SpaceID
 	rootPath          iosrc.URI
@@ -21,6 +23,7 @@ type Manager struct {
 
 func NewManager(ctx context.Context, root iosrc.URI, logger *zap.Logger) (*Manager, error) {
 	mgr := &Manager{
+		alphaFileMigrator: filestore.NewMigrator(ctx),
 		logger:            logger,
 		names:             make(map[string]api.SpaceID),
 		rootPath:          root,

--- a/ppl/zqd/space/manager_test.go
+++ b/ppl/zqd/space/manager_test.go
@@ -24,9 +24,10 @@ func TestConfigCurrentVersion(t *testing.T) {
 	defer os.RemoveAll(root)
 	u, err := iosrc.ParseURI(root)
 	require.NoError(t, err)
-	m, err := NewManager(u, zap.NewNop())
+	ctx := context.Background()
+	m, err := NewManager(ctx, u, zap.NewNop())
 	require.NoError(t, err)
-	s, err := m.Create(context.Background(), api.SpacePostRequest{Name: "test"})
+	s, err := m.Create(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	id := s.ID()
 	versionConfig := struct {
@@ -162,7 +163,7 @@ func (tm *testMigration) initRoot() {
 
 func (tm *testMigration) manager() *Manager {
 	if tm.mgr == nil {
-		mgr, err := NewManager(tm.root, zap.NewNop())
+		mgr, err := NewManager(context.Background(), tm.root, zap.NewNop())
 		require.NoError(tm.T, err)
 		tm.mgr = mgr
 	}

--- a/ppl/zqd/space/space.go
+++ b/ppl/zqd/space/space.go
@@ -109,13 +109,13 @@ func (g *guard) acquireForDelete() error {
 	return nil
 }
 
-func loadSpaces(ctx context.Context, p iosrc.URI, conf config, logger *zap.Logger) ([]Space, error) {
+func (m *Manager) loadSpaces(ctx context.Context, p iosrc.URI, conf config) ([]Space, error) {
 	datapath := conf.DataURI
 	if datapath.IsZero() {
 		datapath = p
 	}
 	id := api.SpaceID(path.Base(p.Path))
-	logger = logger.With(zap.String("space_id", string(id)))
+	logger := m.logger.With(zap.String("space_id", string(id)))
 	pcapstore, err := loadPcapStore(ctx, datapath)
 	if err != nil {
 		return nil, err

--- a/ppl/zqd/space/space.go
+++ b/ppl/zqd/space/space.go
@@ -126,6 +126,7 @@ func (m *Manager) loadSpaces(ctx context.Context, p iosrc.URI, conf config) ([]S
 		if err != nil {
 			return nil, err
 		}
+		m.alphaFileMigrator.Add(store)
 		s := &fileSpace{
 			spaceBase: spaceBase{id, store, pcapstore, newGuard(), logger},
 			path:      p,

--- a/ppl/zqd/storage/filestore/filestore.go
+++ b/ppl/zqd/storage/filestore/filestore.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/driver"
@@ -328,4 +329,49 @@ func (s *Storage) migrateAlphaZngFile() (err error) {
 		}
 		return err
 	})
+}
+
+type Migrator struct {
+	ctx     context.Context
+	once    sync.Once
+	sem     *semaphore.Weighted
+	storeCh chan *Storage
+}
+
+func NewMigrator(ctx context.Context) *Migrator {
+	m := &Migrator{
+		ctx:     ctx,
+		storeCh: make(chan *Storage),
+		sem:     semaphore.NewWeighted(1),
+	}
+	return m
+}
+
+func (m *Migrator) Add(s *Storage) {
+	if s.alphaMigrated {
+		return
+	}
+	m.once.Do(func() { go m.run() })
+	select {
+	case m.storeCh <- s:
+	case <-m.ctx.Done():
+	}
+}
+
+func (m *Migrator) run() {
+	for {
+		select {
+		case s := <-m.storeCh:
+			go func() {
+				if err := m.sem.Acquire(m.ctx, 1); err != nil {
+					return
+				}
+				defer m.sem.Release(1)
+				// Error handling and logging handled inside the migrate call.
+				_ = s.migrateAlphaZngIfNeeded(m.ctx)
+			}()
+		case <-m.ctx.Done():
+			return
+		}
+	}
 }


### PR DESCRIPTION
When zqd starts, it will begin migrating any alpha zng filestores one at a time in the background. If a search request comes in for a space while its data is being migrated, the search will wait for the migration to complete.

Depends on https://github.com/brimsec/zq/pull/1574 .