### PR TITLE
move Cutter and ColumnBuilder out of proc

### DIFF
--- a/microindex/writer.go
+++ b/microindex/writer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/pkg/bufwriter"
 	"github.com/brimsec/zq/pkg/iosrc"
-	"github.com/brimsec/zq/proc/cut"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng"
@@ -51,7 +50,7 @@ type Writer struct {
 	keyFields   []field.Static
 	zctx        *resolver.Context
 	writer      *indexWriter
-	cutter      *cut.Cutter
+	cutter      *expr.Cutter
 	tmpdir      string
 	frameThresh int
 	keyType     *zng.TypeRecord
@@ -111,7 +110,7 @@ func NewWriterWithContext(ctx context.Context, zctx *resolver.Context, path stri
 		return nil, err
 	}
 	fields, resolvers := expr.CompileAssignments(w.keyFields, w.keyFields)
-	w.cutter = cut.NewStrictCutter(zctx, false, fields, resolvers)
+	w.cutter = expr.NewStrictCutter(zctx, false, fields, resolvers)
 	return w, nil
 }
 

--- a/ppl/archive/indexer.go
+++ b/ppl/archive/indexer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/microindex"
 	"github.com/brimsec/zq/pkg/iosrc"
-	"github.com/brimsec/zq/proc/cut"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng"
@@ -74,7 +73,7 @@ type FlowgraphIndexer struct {
 	zctx    *resolver.Context
 	w       *microindex.Writer
 	keyType zng.Type
-	cutter  *cut.Cutter
+	cutter  *expr.Cutter
 }
 
 func NewFlowgraphIndexer(ctx context.Context, zctx *resolver.Context, uri iosrc.URI, keys []field.Static, framesize int) (*FlowgraphIndexer, error) {
@@ -89,7 +88,7 @@ func NewFlowgraphIndexer(ctx context.Context, zctx *resolver.Context, uri iosrc.
 	return &FlowgraphIndexer{
 		zctx:   zctx,
 		w:      writer,
-		cutter: cut.NewStrictCutter(zctx, false, fields, resolvers),
+		cutter: expr.NewStrictCutter(zctx, false, fields, resolvers),
 	}, nil
 }
 

--- a/proc/cut/cut.go
+++ b/proc/cut/cut.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/builder"
 )
 
 type Proc struct {
@@ -17,7 +18,7 @@ type Proc struct {
 	parent     proc.Interface
 	complement bool
 	resolvers  []expr.Evaluator
-	cutter     *Cutter
+	cutter     *expr.Cutter
 }
 
 func New(pctx *proc.Context, parent proc.Interface, node *ast.CutProc) (*Proc, error) {
@@ -33,7 +34,7 @@ func New(pctx *proc.Context, parent proc.Interface, node *ast.CutProc) (*Proc, e
 	}
 	// build this once at compile time for error checking.
 	if !node.Complement {
-		_, err := proc.NewColumnBuilder(pctx.TypeContext, lhs)
+		_, err := builder.NewColumnBuilder(pctx.TypeContext, lhs)
 		if err != nil {
 			return nil, fmt.Errorf("compiling cut: %w", err)
 		}
@@ -44,7 +45,7 @@ func New(pctx *proc.Context, parent proc.Interface, node *ast.CutProc) (*Proc, e
 		parent:     parent,
 		complement: node.Complement,
 		resolvers:  rhs,
-		cutter:     NewCutter(pctx.TypeContext, node.Complement, lhs, rhs),
+		cutter:     expr.NewCutter(pctx.TypeContext, node.Complement, lhs, rhs),
 	}, nil
 }
 

--- a/proc/cut/cut_test.go
+++ b/proc/cut/cut_test.go
@@ -5,8 +5,8 @@ import (
 
 	"errors"
 
-	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/proc/proctest"
+	"github.com/brimsec/zq/zng/builder"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,7 +85,7 @@ func TestCutComplement(t *testing.T) {
 func testNonAdjacentFields(t *testing.T, zql string) {
 	_, err := proctest.CompileTestProc(zql, proctest.NewTestContext(nil), nil)
 	require.Error(t, err, "cut with non-adjacent records did not fail")
-	ok := errors.Is(err, proc.ErrNonAdjacent)
+	ok := errors.Is(err, builder.ErrNonAdjacent)
 	require.True(t, ok, "cut with non-adjacent records failed with the wrong error")
 }
 
@@ -101,7 +101,7 @@ func TestNotAdjacentErrors(t *testing.T) {
 func testDuplicateFields(t *testing.T, zql string) {
 	_, err := proctest.CompileTestProc(zql, proctest.NewTestContext(nil), nil)
 	require.Error(t, err, "cut with duplicate records did not fail")
-	ok := errors.Is(err, proc.ErrDuplicateFields)
+	ok := errors.Is(err, builder.ErrDuplicateFields)
 	require.True(t, ok, "cut with duplicate records failed with wrong error")
 }
 

--- a/proc/groupby/compile.go
+++ b/proc/groupby/compile.go
@@ -7,8 +7,8 @@ import (
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/field"
-	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/reducer"
+	"github.com/brimsec/zq/zng/builder"
 	"github.com/brimsec/zq/zng/resolver"
 )
 
@@ -35,7 +35,7 @@ func compileParams(node *ast.GroupByProc, zctx *resolver.Context) (*Params, erro
 		}
 		reducerMakers = append(reducerMakers, reducerMaker{name, f})
 	}
-	builder, err := proc.NewColumnBuilder(zctx, targets)
+	builder, err := builder.NewColumnBuilder(zctx, targets)
 	if err != nil {
 		return nil, fmt.Errorf("compiling groupby: %w", err)
 	}

--- a/proc/groupby/groupby.go
+++ b/proc/groupby/groupby.go
@@ -15,6 +15,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/builder"
 	"github.com/brimsec/zq/zng/resolver"
 )
 
@@ -34,7 +35,7 @@ type Params struct {
 	limit        int
 	keys         []Key
 	makers       []reducerMaker
-	builder      *proc.ColumnBuilder
+	builder      *builder.ColumnBuilder
 	consumePart  bool
 	emitPart     bool
 }
@@ -98,7 +99,7 @@ type Aggregator struct {
 	keyResolvers []expr.Evaluator
 	decomposable bool
 	makers       []reducerMaker
-	builder      *proc.ColumnBuilder
+	builder      *builder.ColumnBuilder
 	table        map[string]*Row
 	limit        int
 	valueCompare expr.ValueCompareFn // to compare primary group keys for early key output

--- a/zio/ndjsonio/inferparser.go
+++ b/zio/ndjsonio/inferparser.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/pkg/byteconv"
-	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/builder"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/buger/jsonparser"
 )
@@ -57,7 +57,7 @@ func (p *inferParser) parseObject(b []byte) (zng.Value, error) {
 		zngTypes = append(zngTypes, v.Type)
 		zngValues = append(zngValues, v)
 	}
-	columnBuilder, err := proc.NewColumnBuilder(p.zctx, fields)
+	columnBuilder, err := builder.NewColumnBuilder(p.zctx, fields)
 	if err != nil {
 		return zng.Value{}, err
 	}

--- a/zng/builder/colbuilder.go
+++ b/zng/builder/colbuilder.go
@@ -1,4 +1,4 @@
-package proc
+package builder
 
 import (
 	"errors"


### PR DESCRIPTION
This commit moves the Cutter and ColumnBuilder out of the proc
package so they can be reused by expr, which will be needed by
the cut() function.

ColumnBuilder was moved to its own package under zng/builder since
this purely a zng function to construct zng record values.  The Cutter
type has logic to take a stream of zng records and create "cuts" of
those value so this more complicated machinery was moved to package
expr.