### PR TITLE
Include ppl/ commands when creating release assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ create-release-assets:
 		rm -rf dist/$${zqdir} ; \
 		mkdir -p dist/$${zqdir} ; \
 		cp LICENSE.txt acknowledgments.txt dist/$${zqdir} ; \
-		GOOS=$${os} GOARCH=amd64 go build -ldflags='$(LDFLAGS)' -o dist/$${zqdir} ./cmd/... ; \
+		GOOS=$${os} GOARCH=amd64 go build -ldflags='$(LDFLAGS)' -o dist/$${zqdir} ./cmd/... ./ppl/cmd/... ; \
 	done
 	rm -rf dist/release && mkdir -p dist/release
 	cd dist && for d in zq-$(VERSION)* ; do \


### PR DESCRIPTION
When working on bundling the `v0.23.0` release, it was uncovered that the `zqd` and `zar` binaries weren't making it into the release asset bundle. This is due to these files having been moved to a separate `ppl/` directory. This Makefile tweak restores them.

```
~/work/zq/dist/release/zq-v0.23.0-dirty.darwin-amd64$ ls -al
total 284368
drwxr-xr-x  13 phil  staff       416 Nov  9 12:09 .
drwxr-xr-x   6 phil  staff       192 Nov  9 12:10 ..
-rw-r--r--   1 phil  staff      1533 Nov  9 12:09 LICENSE.txt
-rw-r--r--   1 phil  staff      4651 Nov  9 12:09 acknowledgments.txt
-rwxr-xr-x   1 phil  staff   4141232 Nov  9 12:09 ast
-rwxr-xr-x   1 phil  staff  16689940 Nov  9 12:09 microindex
-rwxr-xr-x   1 phil  staff   2465656 Nov  9 12:09 mockbrim
-rwxr-xr-x   1 phil  staff  16474500 Nov  9 12:09 pcap
-rwxr-xr-x   1 phil  staff  18602828 Nov  9 12:09 zapi
-rwxr-xr-x   1 phil  staff  20964260 Nov  9 12:09 zar
-rwxr-xr-x   1 phil  staff  19815468 Nov  9 12:09 zq
-rwxr-xr-x   1 phil  staff  29886572 Nov  9 12:09 zqd
-rwxr-xr-x   1 phil  staff  16523892 Nov  9 12:09 zst
```