### PR TITLE
update coding style in peg grammar to conform with CamelCase 

### DIFF
--- a/zql/Makefile
+++ b/zql/Makefile
@@ -29,7 +29,7 @@ zql.js:
 ifeq "$(shell $(deps)/bin/pegjs --version 2>&1 | fgrep $(PEGJS_VERSION))" ""
 	$(npm) install pegjs@$(PEGJS_VERSION)
 endif
-	cpp -E -P zql.peg | $(deps)/bin/pegjs --allowed-start-rules start,Expression -o $@
+	cpp -E -P zql.peg | $(deps)/bin/pegjs --allowed-start-rules start,Expr -o $@
 
 .PHONY: zql.es.js
 zql.es.js: zql.js

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -22,7 +22,7 @@ func ParseProc(query string, opts ...Option) (ast.Proc, error) {
 }
 
 func ParseExpression(expr string) (ast.Expression, error) {
-	m, err := Parse("", []byte(expr), Entrypoint("Expression"))
+	m, err := Parse("", []byte(expr), Entrypoint("Expr"))
 	if err != nil {
 		return nil, err
 	}

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -282,7 +282,7 @@ function peg$parse(input, options) {
 
   var peg$FAILED = {},
 
-      peg$startRuleFunctions = { start: peg$parsestart, Expression: peg$parseExpression },
+      peg$startRuleFunctions = { start: peg$parsestart, Expr: peg$parseExpr },
       peg$startRuleFunction  = peg$parsestart,
 
       peg$c0 = function(ast) { return ast },
@@ -298,70 +298,61 @@ function peg$parse(input, options) {
             }
           },
       peg$c3 = function(s) {
+            // XXX does this ever match?  Rule above shoul;d match first
             return {"op": "SequentialProc", "procs": [s]}
           },
-      peg$c4 = function(first, rest) {
-            if (rest) {
-              return [first, ... rest]
-            } else {
-              return [first]
-            }
-          },
-      peg$c5 = "|",
-      peg$c6 = peg$literalExpectation("|", false),
-      peg$c7 = function(p) { return p },
-      peg$c8 = function(expr) {
+      peg$c4 = function(expr) {
             return {"op": "FilterProc", "filter": expr}
           },
-      peg$c9 = function(first, rest) {
+      peg$c5 = function(first, rest) {
             return makeChain(first, rest, "LogicalOr")
           },
-      peg$c10 = function(t) { return t },
-      peg$c11 = function(first, rest) {
+      peg$c6 = function(t) { return t },
+      peg$c7 = function(first, rest) {
             return makeChain(first, rest, "LogicalAnd")
           },
-      peg$c12 = function(f) { return f },
-      peg$c13 = "!",
-      peg$c14 = peg$literalExpectation("!", false),
-      peg$c15 = function(e) {
+      peg$c8 = function(f) { return f },
+      peg$c9 = "!",
+      peg$c10 = peg$literalExpectation("!", false),
+      peg$c11 = function(e) {
             return {"op": "LogicalNot", "expr": e}
           },
-      peg$c16 = "-",
-      peg$c17 = peg$literalExpectation("-", false),
-      peg$c18 = function(s) { return s },
-      peg$c19 = "(",
-      peg$c20 = peg$literalExpectation("(", false),
-      peg$c21 = ")",
-      peg$c22 = peg$literalExpectation(")", false),
-      peg$c23 = function(expr) { return expr },
-      peg$c24 = "*",
-      peg$c25 = peg$literalExpectation("*", false),
-      peg$c26 = function(comp, v) {
+      peg$c12 = "-",
+      peg$c13 = peg$literalExpectation("-", false),
+      peg$c14 = function(s) { return s },
+      peg$c15 = "(",
+      peg$c16 = peg$literalExpectation("(", false),
+      peg$c17 = ")",
+      peg$c18 = peg$literalExpectation(")", false),
+      peg$c19 = function(expr) { return expr },
+      peg$c20 = "*",
+      peg$c21 = peg$literalExpectation("*", false),
+      peg$c22 = function(comp, v) {
             return {"op": "CompareAny", "comparator": comp, "recursive": false, "value": v}
           },
-      peg$c27 = "**",
-      peg$c28 = peg$literalExpectation("**", false),
-      peg$c29 = function(comp, v) {
+      peg$c23 = "**",
+      peg$c24 = peg$literalExpectation("**", false),
+      peg$c25 = function(comp, v) {
             return {"op": "CompareAny", "comparator": comp, "recursive": true, "value": v}
           },
-      peg$c30 = function(f, comp, v) {
+      peg$c26 = function(f, comp, v) {
             return {"op": "CompareField", "comparator": comp, "field": f, "value": v}
           },
-      peg$c31 = "len",
-      peg$c32 = peg$literalExpectation("len", false),
-      peg$c33 = function(expr, comp, v) {
+      peg$c27 = "len",
+      peg$c28 = peg$literalExpectation("len", false),
+      peg$c29 = function(expr, comp, v) {
           return {"op": "BinaryExpression", "operator": comp, "lhs": expr, "rhs": v}
         },
-      peg$c34 = function(v) {
+      peg$c30 = function(v) {
             return {"op": "CompareAny", "comparator": "in", "recursive": false, "value": v}
           },
-      peg$c35 = function(v, f) {
+      peg$c31 = function(v, f) {
             return {"op": "CompareField", "comparator": "in", "field": f, "value": v}
           },
-      peg$c36 = function(v) {
+      peg$c32 = function(v) {
             return {"op": "Search", "text": text(), "value": v}
           },
-      peg$c37 = function(v) {
+      peg$c33 = function(v) {
             let str = v;
             if (str == "*") {
               return {"op": "MatchAll"}
@@ -373,36 +364,49 @@ function peg$parse(input, options) {
             }
             return {"op": "Search", "text": text(), "value": literal}
           },
-      peg$c38 = function(i) { return i },
-      peg$c39 = function(v) { return v },
-      peg$c40 = function(v) {
+      peg$c34 = function(v) {
             return {"op": "Literal", "type": "string", "value": v}
           },
-      peg$c41 = function(v) {
+      peg$c35 = function(i) { return i },
+      peg$c36 = function(v) { return v },
+      peg$c37 = function(v) {
             return {"op": "Literal", "type": "regexp", "value": v}
           },
-      peg$c42 = function(v) {
+      peg$c38 = function(v) {
             return {"op": "Literal", "type": "net", "value": v}
           },
-      peg$c43 = function(v) {
+      peg$c39 = function(v) {
             return {"op": "Literal", "type": "ip", "value": v}
           },
-      peg$c44 = function(v) {
+      peg$c40 = function(v) {
             return {"op": "Literal", "type": "float64", "value": v}
           },
-      peg$c45 = function(v) {
+      peg$c41 = function(v) {
             return {"op": "Literal", "type": "int64", "value": v}
           },
-      peg$c46 = "true",
-      peg$c47 = peg$literalExpectation("true", false),
-      peg$c48 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
-      peg$c49 = "false",
-      peg$c50 = peg$literalExpectation("false", false),
-      peg$c51 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
-      peg$c52 = "null",
-      peg$c53 = peg$literalExpectation("null", false),
-      peg$c54 = function() { return {"op": "Literal", "type": "null"} },
-      peg$c55 = function(first, rest) {
+      peg$c42 = "true",
+      peg$c43 = peg$literalExpectation("true", false),
+      peg$c44 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
+      peg$c45 = "false",
+      peg$c46 = peg$literalExpectation("false", false),
+      peg$c47 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
+      peg$c48 = "null",
+      peg$c49 = peg$literalExpectation("null", false),
+      peg$c50 = function() { return {"op": "Literal", "type": "null"} },
+      peg$c51 = function(first, rest) {
+           if (rest) {
+              return [first, ... rest]
+            } else {
+              return [first]
+            }
+          },
+      peg$c52 = "|",
+      peg$c53 = peg$literalExpectation("|", false),
+      peg$c54 = function(p) { return p },
+      peg$c55 = function(proc) {
+            return proc
+          },
+      peg$c56 = function(first, rest) {
             let fp = {"op": "SequentialProc", "procs": first};
             if (rest) {
               return {"op": "ParallelProc", "procs": [fp, ... rest]}
@@ -410,464 +414,438 @@ function peg$parse(input, options) {
               return fp
             }
           },
-      peg$c56 = ";",
-      peg$c57 = peg$literalExpectation(";", false),
-      peg$c58 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
-      peg$c59 = function(proc) {
+      peg$c57 = ";",
+      peg$c58 = peg$literalExpectation(";", false),
+      peg$c59 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
+      peg$c60 = function(every, reducers, keys, limit) {
+            let p = {"op": "GroupByProc", "reducers": reducers};
+            if (every) {
+              p["duration"] = every;
+            }
+            if (keys) {
+              p["keys"] = keys;
+            }
+            if (limit) {
+              p["limit"] = limit;
+            }
+            return p
+          },
+      peg$c61 = "every",
+      peg$c62 = peg$literalExpectation("every", true),
+      peg$c63 = function(dur) { return dur },
+      peg$c64 = "by",
+      peg$c65 = peg$literalExpectation("by", true),
+      peg$c66 = function(columns) { return columns },
+      peg$c67 = "with",
+      peg$c68 = peg$literalExpectation("with", false),
+      peg$c69 = "-limit",
+      peg$c70 = peg$literalExpectation("-limit", false),
+      peg$c71 = function(limit) { return limit },
+      peg$c72 = function(expr) { return {"op": "Assignment", "rhs": expr} },
+      peg$c73 = ",",
+      peg$c74 = peg$literalExpectation(",", false),
+      peg$c75 = function(first, expr) { return expr },
+      peg$c76 = function(first, rest) {
+            return [first, ... rest]
+          },
+      peg$c77 = "=",
+      peg$c78 = peg$literalExpectation("=", false),
+      peg$c79 = function(lval, reducer) {
+            return {"op": "Assignment", "lhs": lval, "rhs": reducer}
+          },
+      peg$c80 = function(reducer) {
+            return {"op": "Assignment", "rhs": reducer}
+          },
+      peg$c81 = "not",
+      peg$c82 = peg$literalExpectation("not", false),
+      peg$c83 = function(op, expr, where) {
+            let r = {"op": "Reducer", "operator": op, "where":where};
+            if (expr) {
+              r["expr"] = expr;
+            }
+            return r
+          },
+      peg$c84 = "where",
+      peg$c85 = peg$literalExpectation("where", false),
+      peg$c86 = function(first, rest) {
+            let result = [first];
+            for(let  r of rest) {
+              result.push( r[3]);
+            }
+            return result
+          },
+      peg$c87 = "sort",
+      peg$c88 = peg$literalExpectation("sort", true),
+      peg$c89 = function(args, l) { return l },
+      peg$c90 = function(args, list) {
+            let argm = args;
+            let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false};
+            if ( "r" in argm) {
+              proc["sortdir"] = -1;
+            }
+            if ( "nulls" in argm) {
+              if (argm["nulls"] == "first") {
+                proc["nullsfirst"] = true;
+              }
+            }
             return proc
           },
-      peg$c60 = "by",
-      peg$c61 = peg$literalExpectation("by", true),
-      peg$c62 = function(columns) { return columns },
-      peg$c63 = function(expr) { return {"op": "Assignment", "rhs": expr} },
-      peg$c64 = ",",
-      peg$c65 = peg$literalExpectation(",", false),
-      peg$c66 = function(first, expr) { return expr },
-      peg$c67 = function(first, rest) {
-            return [first, ... rest]
-        },
-      peg$c68 = "every",
-      peg$c69 = peg$literalExpectation("every", true),
-      peg$c70 = function(dur) { return dur },
-      peg$c71 = "and",
-      peg$c72 = peg$literalExpectation("and", true),
-      peg$c73 = function() { return text() },
-      peg$c74 = "or",
-      peg$c75 = peg$literalExpectation("or", true),
-      peg$c76 = "in",
-      peg$c77 = peg$literalExpectation("in", true),
-      peg$c78 = "not",
-      peg$c79 = peg$literalExpectation("not", true),
-      peg$c80 = /^[A-Za-z_$]/,
-      peg$c81 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c82 = /^[0-9]/,
-      peg$c83 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c84 = function() { return {"op": "Identifier", "name": text()} },
-      peg$c85 = ".",
-      peg$c86 = peg$literalExpectation(".", false),
-      peg$c87 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
-      peg$c88 = function() { return {"op": "RootRecord"} },
-      peg$c89 = function(first, rest) {
-          return makeBinaryExprChain(first, rest)
-         },
-      peg$c90 = "[",
-      peg$c91 = peg$literalExpectation("[", false),
-      peg$c92 = "]",
-      peg$c93 = peg$literalExpectation("]", false),
-      peg$c94 = function(expr) { return ["[", expr] },
-      peg$c95 = function(id) { return [".", id] },
-      peg$c96 = function(fn, args) {
-                return {"op": "FunctionCall", "function": fn, "args": args}
-            },
-      peg$c97 = function(first, rest) {
-            let result = [first];
-
-            for(let  r of rest) {
-              result.push( r[3]);
+      peg$c91 = function(a) { return a },
+      peg$c92 = function(args) { return makeArgMap(args) },
+      peg$c93 = "-r",
+      peg$c94 = peg$literalExpectation("-r", false),
+      peg$c95 = function() { return {"name": "r", "value": null} },
+      peg$c96 = "-nulls",
+      peg$c97 = peg$literalExpectation("-nulls", false),
+      peg$c98 = "first",
+      peg$c99 = peg$literalExpectation("first", false),
+      peg$c100 = "last",
+      peg$c101 = peg$literalExpectation("last", false),
+      peg$c102 = function() { return text() },
+      peg$c103 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c104 = "top",
+      peg$c105 = peg$literalExpectation("top", true),
+      peg$c106 = function(n) { return n},
+      peg$c107 = "-flush",
+      peg$c108 = peg$literalExpectation("-flush", false),
+      peg$c109 = function(limit, flush, f) { return f },
+      peg$c110 = function(limit, flush, fields) {
+            let proc = {"op": "TopProc"};
+            if (limit) {
+              proc["limit"] = limit;
             }
-
-            return result
-        },
-      peg$c98 = function(first, rest) {
-            let result = [first];
-
-            for(let  r of rest) {
-              result.push( r[3]);
+            if (fields) {
+              proc["fields"] = fields;
             }
-
-            return result
+            if (flush) {
+             proc["flush"] = true;
+            }
+            return proc
           },
-      peg$c99 = function(every, reducers, keys, limit) {
-          let p = {"op": "GroupByProc", "reducers": reducers};
-          if (keys) {
-            p["keys"] = keys;
-          }
-          if (every) {
-            p["duration"] = every;
-          }
-          if (limit) {
-            p["limit"] = limit;
-          }
-          return p
-        },
-      peg$c100 = "=",
-      peg$c101 = peg$literalExpectation("=", false),
-      peg$c102 = function(lval, reducer) {
-            return {"op": "Assignment", "lhs": lval, "rhs": reducer}
-        },
-      peg$c103 = function(reducer) {
-            return {"op": "Assignment", "rhs": reducer}
-        },
-      peg$c104 = peg$literalExpectation("not", false),
-      peg$c105 = function(op, expr, where) {
-          let r = {"op": "Reducer", "operator": op, "where":where};
-          if (expr) {
-            r["expr"] = expr;
-          }
-          return r
-        },
-      peg$c106 = "where",
-      peg$c107 = peg$literalExpectation("where", false),
-      peg$c108 = function(first, rest) {
-            let result = [first];
-            for(let  r of rest) {
-              result.push( r[3]);
+      peg$c111 = "cut",
+      peg$c112 = peg$literalExpectation("cut", true),
+      peg$c113 = function(args, columns) {
+            let argm = args;
+            let proc = {"op": "CutProc", "fields": columns, "complement": false};
+            if ( "c" in argm) {
+              proc["complement"] = true;
             }
-            return result
+            return proc
           },
-      peg$c109 = "sort",
-      peg$c110 = peg$literalExpectation("sort", true),
-      peg$c111 = function(args, l) { return l },
-      peg$c112 = function(args, list) {
-          let argm = args;
-          let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false};
-          if ( "r" in argm) {
-            proc["sortdir"] = -1;
-          }
-          if ( "nulls" in argm) {
-            if (argm["nulls"] == "first") {
-              proc["nullsfirst"] = true;
-            }
-          }
-          return proc
-        },
-      peg$c113 = function(a) { return a },
-      peg$c114 = function(args) {
-          return makeArgMap(args)
-      },
-      peg$c115 = "-r",
-      peg$c116 = peg$literalExpectation("-r", false),
-      peg$c117 = function() { return {"name": "r", "value": null} },
-      peg$c118 = "-nulls",
-      peg$c119 = peg$literalExpectation("-nulls", false),
-      peg$c120 = "first",
-      peg$c121 = peg$literalExpectation("first", false),
-      peg$c122 = "last",
-      peg$c123 = peg$literalExpectation("last", false),
-      peg$c124 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c125 = "top",
-      peg$c126 = peg$literalExpectation("top", true),
-      peg$c127 = function(n) { return n},
-      peg$c128 = "-flush",
-      peg$c129 = peg$literalExpectation("-flush", false),
-      peg$c130 = function(limit, flush, f) { return f },
-      peg$c131 = function(limit, flush, fields) {
-          let proc = {"op": "TopProc"};
-          if (limit) {
-            proc["limit"] = limit;
-          }
-          if (fields) {
-            proc["fields"] = fields;
-          }
-          if (flush) {
-            proc["flush"] = true;
-          }
-          return proc
-        },
-      peg$c132 = "with",
-      peg$c133 = peg$literalExpectation("with", false),
-      peg$c134 = "-limit",
-      peg$c135 = peg$literalExpectation("-limit", false),
-      peg$c136 = function(limit) { return limit },
-      peg$c137 = "-c",
-      peg$c138 = peg$literalExpectation("-c", false),
-      peg$c139 = function() { return {"name": "c", "value": null} },
-      peg$c140 = function(args) {
-          return makeArgMap(args)
-        },
-      peg$c141 = "cut",
-      peg$c142 = peg$literalExpectation("cut", true),
-      peg$c143 = function(args, columns) {
-          let argm = args;
-          let proc = {"op": "CutProc", "fields": columns, "complement": false};
-          if ( "c" in argm) {
-            proc["complement"] = true;
-          }
-          return proc
-        },
-      peg$c144 = "head",
-      peg$c145 = peg$literalExpectation("head", true),
-      peg$c146 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c147 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c148 = "tail",
-      peg$c149 = peg$literalExpectation("tail", true),
-      peg$c150 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c151 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c152 = "filter",
-      peg$c153 = peg$literalExpectation("filter", true),
-      peg$c154 = "uniq",
-      peg$c155 = peg$literalExpectation("uniq", true),
-      peg$c156 = function() {
+      peg$c114 = "-c",
+      peg$c115 = peg$literalExpectation("-c", false),
+      peg$c116 = function() { return {"name": "c", "value": null} },
+      peg$c117 = function(args) {
+            return makeArgMap(args)
+          },
+      peg$c118 = "head",
+      peg$c119 = peg$literalExpectation("head", true),
+      peg$c120 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c121 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c122 = "tail",
+      peg$c123 = peg$literalExpectation("tail", true),
+      peg$c124 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c125 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c126 = "filter",
+      peg$c127 = peg$literalExpectation("filter", true),
+      peg$c128 = "uniq",
+      peg$c129 = peg$literalExpectation("uniq", true),
+      peg$c130 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c157 = function() {
+      peg$c131 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c158 = "put",
-      peg$c159 = peg$literalExpectation("put", true),
-      peg$c160 = function(columns) {
+      peg$c132 = "put",
+      peg$c133 = peg$literalExpectation("put", true),
+      peg$c134 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c161 = "rename",
-      peg$c162 = peg$literalExpectation("rename", true),
-      peg$c163 = function(first, cl) { return cl },
-      peg$c164 = function(first, rest) {
+      peg$c135 = "rename",
+      peg$c136 = peg$literalExpectation("rename", true),
+      peg$c137 = function(first, cl) { return cl },
+      peg$c138 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c165 = "fuse",
-      peg$c166 = peg$literalExpectation("fuse", true),
-      peg$c167 = function() {
+      peg$c139 = "fuse",
+      peg$c140 = peg$literalExpectation("fuse", true),
+      peg$c141 = function() {
             return {"op": "FuseProc"}
-        },
-      peg$c168 = function(lhs, rhs) { return {"lhs": lhs, "rhs": rhs} },
-      peg$c169 = "?",
-      peg$c170 = peg$literalExpectation("?", false),
-      peg$c171 = ":",
-      peg$c172 = peg$literalExpectation(":", false),
-      peg$c173 = function(condition, thenClause, elseClause) {
-          return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
-        },
-      peg$c174 = function(first, op, expr) { return [op, expr] },
-      peg$c175 = function(first, rest) {
+          },
+      peg$c142 = ".",
+      peg$c143 = peg$literalExpectation(".", false),
+      peg$c144 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
+      peg$c145 = function() { return {"op": "RootRecord"} },
+      peg$c146 = function(first, rest) {
+            let result = [first];
+
+            for(let  r of rest) {
+              result.push( r[3]);
+            }
+
+            return result
+          },
+      peg$c147 = function(lhs, rhs) { return {"lhs": lhs, "rhs": rhs} },
+      peg$c148 = "?",
+      peg$c149 = peg$literalExpectation("?", false),
+      peg$c150 = ":",
+      peg$c151 = peg$literalExpectation(":", false),
+      peg$c152 = function(condition, thenClause, elseClause) {
+            return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
+          },
+      peg$c153 = function(first, op, expr) { return [op, expr] },
+      peg$c154 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c176 = function(first, comp, expr) { return [comp, expr] },
-      peg$c177 = "=~",
-      peg$c178 = peg$literalExpectation("=~", false),
-      peg$c179 = "!~",
-      peg$c180 = peg$literalExpectation("!~", false),
-      peg$c181 = "!=",
-      peg$c182 = peg$literalExpectation("!=", false),
-      peg$c183 = peg$literalExpectation("in", false),
-      peg$c184 = "<=",
-      peg$c185 = peg$literalExpectation("<=", false),
-      peg$c186 = "<",
-      peg$c187 = peg$literalExpectation("<", false),
-      peg$c188 = ">=",
-      peg$c189 = peg$literalExpectation(">=", false),
-      peg$c190 = ">",
-      peg$c191 = peg$literalExpectation(">", false),
-      peg$c192 = "+",
-      peg$c193 = peg$literalExpectation("+", false),
-      peg$c194 = "/",
-      peg$c195 = peg$literalExpectation("/", false),
-      peg$c196 = function(e) {
+      peg$c155 = function(first, comp, expr) { return [comp, expr] },
+      peg$c156 = "=~",
+      peg$c157 = peg$literalExpectation("=~", false),
+      peg$c158 = "!~",
+      peg$c159 = peg$literalExpectation("!~", false),
+      peg$c160 = "!=",
+      peg$c161 = peg$literalExpectation("!=", false),
+      peg$c162 = "in",
+      peg$c163 = peg$literalExpectation("in", false),
+      peg$c164 = "<=",
+      peg$c165 = peg$literalExpectation("<=", false),
+      peg$c166 = "<",
+      peg$c167 = peg$literalExpectation("<", false),
+      peg$c168 = ">=",
+      peg$c169 = peg$literalExpectation(">=", false),
+      peg$c170 = ">",
+      peg$c171 = peg$literalExpectation(">", false),
+      peg$c172 = "+",
+      peg$c173 = peg$literalExpectation("+", false),
+      peg$c174 = "/",
+      peg$c175 = peg$literalExpectation("/", false),
+      peg$c176 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c197 = function(e, typ) { return typ },
-      peg$c198 = function(e, typ) {
-          return {"op": "CastExpr", "expr": e, "type": typ}
-        },
-      peg$c199 = "bytes",
-      peg$c200 = peg$literalExpectation("bytes", false),
-      peg$c201 = "uint8",
-      peg$c202 = peg$literalExpectation("uint8", false),
-      peg$c203 = "uint16",
-      peg$c204 = peg$literalExpectation("uint16", false),
-      peg$c205 = "uint32",
-      peg$c206 = peg$literalExpectation("uint32", false),
-      peg$c207 = "uint64",
-      peg$c208 = peg$literalExpectation("uint64", false),
-      peg$c209 = "int8",
-      peg$c210 = peg$literalExpectation("int8", false),
-      peg$c211 = "int16",
-      peg$c212 = peg$literalExpectation("int16", false),
-      peg$c213 = "int32",
-      peg$c214 = peg$literalExpectation("int32", false),
-      peg$c215 = "int64",
-      peg$c216 = peg$literalExpectation("int64", false),
-      peg$c217 = "duration",
-      peg$c218 = peg$literalExpectation("duration", false),
-      peg$c219 = "time",
-      peg$c220 = peg$literalExpectation("time", false),
-      peg$c221 = "float64",
-      peg$c222 = peg$literalExpectation("float64", false),
-      peg$c223 = "bool",
-      peg$c224 = peg$literalExpectation("bool", false),
-      peg$c225 = "string",
-      peg$c226 = peg$literalExpectation("string", false),
-      peg$c227 = "bstring",
-      peg$c228 = peg$literalExpectation("bstring", false),
-      peg$c229 = "ip",
-      peg$c230 = peg$literalExpectation("ip", false),
-      peg$c231 = "net",
-      peg$c232 = peg$literalExpectation("net", false),
-      peg$c233 = "type",
-      peg$c234 = peg$literalExpectation("type", false),
-      peg$c235 = "error",
-      peg$c236 = peg$literalExpectation("error", false),
-      peg$c237 = function(first, rest) {
-          return makeBinaryExprChain(first, rest)
-        },
-      peg$c238 = function(fn, args) {
-              return {"op": "FunctionCall", "function": fn, "args": args}
+      peg$c177 = function(e, typ) { return typ },
+      peg$c178 = function(e, typ) {
+            return {"op": "CastExpr", "expr": e, "type": typ}
           },
-      peg$c239 = /^[A-Za-z]/,
-      peg$c240 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
-      peg$c241 = /^[.0-9]/,
-      peg$c242 = peg$classExpectation([".", ["0", "9"]], false, false),
-      peg$c243 = function(first, e) { return e },
-      peg$c244 = function() { return [] },
-      peg$c245 = peg$literalExpectation("and", false),
-      peg$c246 = "seconds",
-      peg$c247 = peg$literalExpectation("seconds", false),
-      peg$c248 = "second",
-      peg$c249 = peg$literalExpectation("second", false),
-      peg$c250 = "secs",
-      peg$c251 = peg$literalExpectation("secs", false),
-      peg$c252 = "sec",
-      peg$c253 = peg$literalExpectation("sec", false),
-      peg$c254 = "s",
-      peg$c255 = peg$literalExpectation("s", false),
-      peg$c256 = "minutes",
-      peg$c257 = peg$literalExpectation("minutes", false),
-      peg$c258 = "minute",
-      peg$c259 = peg$literalExpectation("minute", false),
-      peg$c260 = "mins",
-      peg$c261 = peg$literalExpectation("mins", false),
-      peg$c262 = "min",
-      peg$c263 = peg$literalExpectation("min", false),
-      peg$c264 = "m",
-      peg$c265 = peg$literalExpectation("m", false),
-      peg$c266 = "hours",
-      peg$c267 = peg$literalExpectation("hours", false),
-      peg$c268 = "hrs",
-      peg$c269 = peg$literalExpectation("hrs", false),
-      peg$c270 = "hr",
-      peg$c271 = peg$literalExpectation("hr", false),
-      peg$c272 = "h",
-      peg$c273 = peg$literalExpectation("h", false),
-      peg$c274 = "hour",
-      peg$c275 = peg$literalExpectation("hour", false),
-      peg$c276 = "days",
-      peg$c277 = peg$literalExpectation("days", false),
-      peg$c278 = "day",
-      peg$c279 = peg$literalExpectation("day", false),
-      peg$c280 = "d",
-      peg$c281 = peg$literalExpectation("d", false),
-      peg$c282 = "weeks",
-      peg$c283 = peg$literalExpectation("weeks", false),
-      peg$c284 = "week",
-      peg$c285 = peg$literalExpectation("week", false),
-      peg$c286 = "wks",
-      peg$c287 = peg$literalExpectation("wks", false),
-      peg$c288 = "wk",
-      peg$c289 = peg$literalExpectation("wk", false),
-      peg$c290 = "w",
-      peg$c291 = peg$literalExpectation("w", false),
-      peg$c292 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c293 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c294 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c295 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c296 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c297 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c298 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c299 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c300 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c301 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c302 = function(a) { return text() },
-      peg$c303 = function(a, b) {
+      peg$c179 = "bytes",
+      peg$c180 = peg$literalExpectation("bytes", false),
+      peg$c181 = "uint8",
+      peg$c182 = peg$literalExpectation("uint8", false),
+      peg$c183 = "uint16",
+      peg$c184 = peg$literalExpectation("uint16", false),
+      peg$c185 = "uint32",
+      peg$c186 = peg$literalExpectation("uint32", false),
+      peg$c187 = "uint64",
+      peg$c188 = peg$literalExpectation("uint64", false),
+      peg$c189 = "int8",
+      peg$c190 = peg$literalExpectation("int8", false),
+      peg$c191 = "int16",
+      peg$c192 = peg$literalExpectation("int16", false),
+      peg$c193 = "int32",
+      peg$c194 = peg$literalExpectation("int32", false),
+      peg$c195 = "int64",
+      peg$c196 = peg$literalExpectation("int64", false),
+      peg$c197 = "duration",
+      peg$c198 = peg$literalExpectation("duration", false),
+      peg$c199 = "time",
+      peg$c200 = peg$literalExpectation("time", false),
+      peg$c201 = "float64",
+      peg$c202 = peg$literalExpectation("float64", false),
+      peg$c203 = "bool",
+      peg$c204 = peg$literalExpectation("bool", false),
+      peg$c205 = "string",
+      peg$c206 = peg$literalExpectation("string", false),
+      peg$c207 = "bstring",
+      peg$c208 = peg$literalExpectation("bstring", false),
+      peg$c209 = "ip",
+      peg$c210 = peg$literalExpectation("ip", false),
+      peg$c211 = "net",
+      peg$c212 = peg$literalExpectation("net", false),
+      peg$c213 = "type",
+      peg$c214 = peg$literalExpectation("type", false),
+      peg$c215 = "error",
+      peg$c216 = peg$literalExpectation("error", false),
+      peg$c217 = function(first, rest) {
+            return makeBinaryExprChain(first, rest)
+          },
+      peg$c218 = function(fn, args) {
+            return {"op": "FunctionCall", "function": fn, "args": args}
+          },
+      peg$c219 = /^[A-Za-z]/,
+      peg$c220 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
+      peg$c221 = /^[.0-9]/,
+      peg$c222 = peg$classExpectation([".", ["0", "9"]], false, false),
+      peg$c223 = function(first, e) { return e },
+      peg$c224 = function() { return [] },
+      peg$c225 = "[",
+      peg$c226 = peg$literalExpectation("[", false),
+      peg$c227 = "]",
+      peg$c228 = peg$literalExpectation("]", false),
+      peg$c229 = function(expr) { return ["[", expr] },
+      peg$c230 = function(id) { return [".", id] },
+      peg$c231 = "and",
+      peg$c232 = peg$literalExpectation("and", true),
+      peg$c233 = "or",
+      peg$c234 = peg$literalExpectation("or", true),
+      peg$c235 = peg$literalExpectation("in", true),
+      peg$c236 = peg$literalExpectation("not", true),
+      peg$c237 = /^[A-Za-z_$]/,
+      peg$c238 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c239 = /^[0-9]/,
+      peg$c240 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c241 = function() { return {"op": "Identifier", "name": text()} },
+      peg$c242 = peg$literalExpectation("and", false),
+      peg$c243 = "seconds",
+      peg$c244 = peg$literalExpectation("seconds", false),
+      peg$c245 = "second",
+      peg$c246 = peg$literalExpectation("second", false),
+      peg$c247 = "secs",
+      peg$c248 = peg$literalExpectation("secs", false),
+      peg$c249 = "sec",
+      peg$c250 = peg$literalExpectation("sec", false),
+      peg$c251 = "s",
+      peg$c252 = peg$literalExpectation("s", false),
+      peg$c253 = "minutes",
+      peg$c254 = peg$literalExpectation("minutes", false),
+      peg$c255 = "minute",
+      peg$c256 = peg$literalExpectation("minute", false),
+      peg$c257 = "mins",
+      peg$c258 = peg$literalExpectation("mins", false),
+      peg$c259 = "min",
+      peg$c260 = peg$literalExpectation("min", false),
+      peg$c261 = "m",
+      peg$c262 = peg$literalExpectation("m", false),
+      peg$c263 = "hours",
+      peg$c264 = peg$literalExpectation("hours", false),
+      peg$c265 = "hrs",
+      peg$c266 = peg$literalExpectation("hrs", false),
+      peg$c267 = "hr",
+      peg$c268 = peg$literalExpectation("hr", false),
+      peg$c269 = "h",
+      peg$c270 = peg$literalExpectation("h", false),
+      peg$c271 = "hour",
+      peg$c272 = peg$literalExpectation("hour", false),
+      peg$c273 = "days",
+      peg$c274 = peg$literalExpectation("days", false),
+      peg$c275 = "day",
+      peg$c276 = peg$literalExpectation("day", false),
+      peg$c277 = "d",
+      peg$c278 = peg$literalExpectation("d", false),
+      peg$c279 = "weeks",
+      peg$c280 = peg$literalExpectation("weeks", false),
+      peg$c281 = "week",
+      peg$c282 = peg$literalExpectation("week", false),
+      peg$c283 = "wks",
+      peg$c284 = peg$literalExpectation("wks", false),
+      peg$c285 = "wk",
+      peg$c286 = peg$literalExpectation("wk", false),
+      peg$c287 = "w",
+      peg$c288 = peg$literalExpectation("w", false),
+      peg$c289 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c290 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c291 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c292 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c293 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c294 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c295 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c296 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c297 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c298 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c299 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c304 = "::",
-      peg$c305 = peg$literalExpectation("::", false),
-      peg$c306 = function(a, b, d, e) {
+      peg$c300 = "::",
+      peg$c301 = peg$literalExpectation("::", false),
+      peg$c302 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c307 = function(a, b) {
+      peg$c303 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c308 = function(a, b) {
+      peg$c304 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c309 = function() {
+      peg$c305 = function() {
             return "::"
           },
-      peg$c310 = function(v) { return ":" + v },
-      peg$c311 = function(v) { return v + ":" },
-      peg$c312 = function(a, m) {
+      peg$c306 = function(v) { return ":" + v },
+      peg$c307 = function(v) { return v + ":" },
+      peg$c308 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c313 = function(a, m) {
+      peg$c309 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c314 = function(s) { return parseInt(s) },
-      peg$c315 = /^[+\-]/,
-      peg$c316 = peg$classExpectation(["+", "-"], false, false),
-      peg$c318 = function() {
+      peg$c310 = function(s) { return parseInt(s) },
+      peg$c311 = function() {
             return text()
           },
-      peg$c319 = "0",
-      peg$c320 = peg$literalExpectation("0", false),
-      peg$c321 = /^[1-9]/,
-      peg$c322 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c323 = "e",
-      peg$c324 = peg$literalExpectation("e", true),
-      peg$c325 = function(chars) { return text() },
-      peg$c326 = /^[0-9a-fA-F]/,
-      peg$c327 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c328 = function(chars) { return joinChars(chars) },
-      peg$c329 = "\\",
-      peg$c330 = peg$literalExpectation("\\", false),
-      peg$c331 = /^[\0-\x1F\\(),!><="|';:]/,
-      peg$c332 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
-      peg$c333 = peg$anyExpectation(),
-      peg$c334 = "\"",
-      peg$c335 = peg$literalExpectation("\"", false),
-      peg$c336 = function(v) { return joinChars(v) },
-      peg$c337 = "'",
-      peg$c338 = peg$literalExpectation("'", false),
-      peg$c339 = "x",
-      peg$c340 = peg$literalExpectation("x", false),
-      peg$c341 = function() { return "\\" + text() },
-      peg$c342 = "b",
-      peg$c343 = peg$literalExpectation("b", false),
-      peg$c344 = function() { return "\b" },
-      peg$c345 = "f",
-      peg$c346 = peg$literalExpectation("f", false),
-      peg$c347 = function() { return "\f" },
-      peg$c348 = "n",
-      peg$c349 = peg$literalExpectation("n", false),
-      peg$c350 = function() { return "\n" },
-      peg$c351 = "r",
-      peg$c352 = peg$literalExpectation("r", false),
-      peg$c353 = function() { return "\r" },
-      peg$c354 = "t",
-      peg$c355 = peg$literalExpectation("t", false),
-      peg$c356 = function() { return "\t" },
-      peg$c357 = "v",
-      peg$c358 = peg$literalExpectation("v", false),
-      peg$c359 = function() { return "\v" },
-      peg$c360 = function() { return "=" },
-      peg$c361 = function() { return "\\*" },
-      peg$c362 = "u",
-      peg$c363 = peg$literalExpectation("u", false),
-      peg$c364 = function(chars) {
+      peg$c312 = "e",
+      peg$c313 = peg$literalExpectation("e", true),
+      peg$c314 = /^[+\-]/,
+      peg$c315 = peg$classExpectation(["+", "-"], false, false),
+      peg$c316 = /^[0-9a-fA-F]/,
+      peg$c317 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c318 = function(chars) { return joinChars(chars) },
+      peg$c319 = "\\",
+      peg$c320 = peg$literalExpectation("\\", false),
+      peg$c321 = /^[\0-\x1F\\(),!><="|';:]/,
+      peg$c322 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
+      peg$c323 = peg$anyExpectation(),
+      peg$c324 = "\"",
+      peg$c325 = peg$literalExpectation("\"", false),
+      peg$c326 = function(v) { return joinChars(v) },
+      peg$c327 = "'",
+      peg$c328 = peg$literalExpectation("'", false),
+      peg$c329 = "x",
+      peg$c330 = peg$literalExpectation("x", false),
+      peg$c331 = function() { return "\\" + text() },
+      peg$c332 = "b",
+      peg$c333 = peg$literalExpectation("b", false),
+      peg$c334 = function() { return "\b" },
+      peg$c335 = "f",
+      peg$c336 = peg$literalExpectation("f", false),
+      peg$c337 = function() { return "\f" },
+      peg$c338 = "n",
+      peg$c339 = peg$literalExpectation("n", false),
+      peg$c340 = function() { return "\n" },
+      peg$c341 = "r",
+      peg$c342 = peg$literalExpectation("r", false),
+      peg$c343 = function() { return "\r" },
+      peg$c344 = "t",
+      peg$c345 = peg$literalExpectation("t", false),
+      peg$c346 = function() { return "\t" },
+      peg$c347 = "v",
+      peg$c348 = peg$literalExpectation("v", false),
+      peg$c349 = function() { return "\v" },
+      peg$c350 = function() { return "=" },
+      peg$c351 = function() { return "\\*" },
+      peg$c352 = "u",
+      peg$c353 = peg$literalExpectation("u", false),
+      peg$c354 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c365 = "{",
-      peg$c366 = peg$literalExpectation("{", false),
-      peg$c367 = "}",
-      peg$c368 = peg$literalExpectation("}", false),
-      peg$c369 = /^[^\/\\]/,
-      peg$c370 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c371 = "\\/",
-      peg$c372 = peg$literalExpectation("\\/", false),
-      peg$c373 = /^[\0-\x1F\\]/,
-      peg$c374 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c375 = "\t",
-      peg$c376 = peg$literalExpectation("\t", false),
-      peg$c377 = "\x0B",
-      peg$c378 = peg$literalExpectation("\x0B", false),
-      peg$c379 = "\f",
-      peg$c380 = peg$literalExpectation("\f", false),
-      peg$c381 = " ",
-      peg$c382 = peg$literalExpectation(" ", false),
-      peg$c383 = "\xA0",
-      peg$c384 = peg$literalExpectation("\xA0", false),
-      peg$c385 = "\uFEFF",
-      peg$c386 = peg$literalExpectation("\uFEFF", false),
-      peg$c387 = peg$otherExpectation("whitespace"),
+      peg$c355 = "{",
+      peg$c356 = peg$literalExpectation("{", false),
+      peg$c357 = "}",
+      peg$c358 = peg$literalExpectation("}", false),
+      peg$c359 = /^[^\/\\]/,
+      peg$c360 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c361 = "\\/",
+      peg$c362 = peg$literalExpectation("\\/", false),
+      peg$c363 = function(body) { return body },
+      peg$c364 = /^[\0-\x1F\\]/,
+      peg$c365 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c366 = "\t",
+      peg$c367 = peg$literalExpectation("\t", false),
+      peg$c368 = "\x0B",
+      peg$c369 = peg$literalExpectation("\x0B", false),
+      peg$c370 = "\f",
+      peg$c371 = peg$literalExpectation("\f", false),
+      peg$c372 = " ",
+      peg$c373 = peg$literalExpectation(" ", false),
+      peg$c374 = "\xA0",
+      peg$c375 = peg$literalExpectation("\xA0", false),
+      peg$c376 = "\uFEFF",
+      peg$c377 = peg$literalExpectation("\uFEFF", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -904,10 +882,6 @@ function peg$parse(input, options) {
 
   function peg$endExpectation() {
     return { type: "end" };
-  }
-
-  function peg$otherExpectation(description) {
-    return { type: "other", description: description };
   }
 
   function peg$computePosDetails(pos) {
@@ -987,7 +961,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parsequery();
+      s2 = peg$parseQuery();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
@@ -1016,11 +990,11 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsequery() {
+  function peg$parseQuery() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parseprocChain();
+    s1 = peg$parseSequentialProcs();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
       s1 = peg$c1(s1);
@@ -1028,15 +1002,15 @@ function peg$parse(input, options) {
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parsesearch();
+      s1 = peg$parseSearch();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           s3 = [];
-          s4 = peg$parsechainedProc();
+          s4 = peg$parseSequentialTail();
           while (s4 !== peg$FAILED) {
             s3.push(s4);
-            s4 = peg$parsechainedProc();
+            s4 = peg$parseSequentialTail();
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -1056,7 +1030,7 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parsesearch();
+        s1 = peg$parseSearch();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$c3(s1);
@@ -1068,104 +1042,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseprocChain() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseproc();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parsechainedProc();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parsechainedProc();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c4(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsechainedProc() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parse__();
-    if (s1 !== peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 124) {
-        s2 = peg$c5;
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c6); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse__();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseproc();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c7(s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsesearch() {
+  function peg$parseSearch() {
     var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parsesearchExpr();
+    s1 = peg$parseSearchExpr();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c8(s1);
+      s1 = peg$c4(s1);
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsesearchExpr() {
+  function peg$parseSearchExpr() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parsesearchTerm();
+    s1 = peg$parseSearchTerm();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseoredSearchTerm();
+      s3 = peg$parseOredSearchTerm();
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$parseoredSearchTerm();
+        s3 = peg$parseOredSearchTerm();
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c9(s1, s2);
+        s1 = peg$c5(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1179,20 +1084,20 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseoredSearchTerm() {
+  function peg$parseOredSearchTerm() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseorToken();
+      s2 = peg$parseOrToken();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parsesearchTerm();
+          s4 = peg$parseSearchTerm();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c10(s4);
+            s1 = peg$c6(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1214,21 +1119,21 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesearchTerm() {
+  function peg$parseSearchTerm() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parsesearchFactor();
+    s1 = peg$parseSearchFactor();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseandedSearchTerm();
+      s3 = peg$parseAndedSearchTerm();
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$parseandedSearchTerm();
+        s3 = peg$parseAndedSearchTerm();
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c11(s1, s2);
+        s1 = peg$c7(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1242,14 +1147,14 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseandedSearchTerm() {
+  function peg$parseAndedSearchTerm() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      s3 = peg$parseandToken();
+      s3 = peg$parseAndToken();
       if (s3 !== peg$FAILED) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
@@ -1267,10 +1172,10 @@ function peg$parse(input, options) {
         s2 = null;
       }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parsesearchFactor();
+        s3 = peg$parseSearchFactor();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c12(s3);
+          s1 = peg$c8(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1288,12 +1193,12 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesearchFactor() {
+  function peg$parseSearchFactor() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    s2 = peg$parsenotToken();
+    s2 = peg$parseNotToken();
     if (s2 !== peg$FAILED) {
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
@@ -1310,11 +1215,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c13;
+        s2 = peg$c9;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c14); }
+        if (peg$silentFails === 0) { peg$fail(peg$c10); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -1331,10 +1236,10 @@ function peg$parse(input, options) {
       }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parsesearchExpr();
+      s2 = peg$parseSearchExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c15(s2);
+        s1 = peg$c11(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1349,11 +1254,11 @@ function peg$parse(input, options) {
       s1 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c16;
+        s2 = peg$c12;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        if (peg$silentFails === 0) { peg$fail(peg$c13); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -1363,10 +1268,10 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parsesearchPred();
+        s2 = peg$parseSearchPred();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c18(s2);
+          s1 = peg$c14(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1379,29 +1284,29 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c19;
+          s1 = peg$c15;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c20); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parsesearchExpr();
+            s3 = peg$parseSearchExpr();
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c21;
+                  s5 = peg$c17;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c22); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c23(s3);
+                  s1 = peg$c19(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1429,28 +1334,28 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesearchPred() {
+  function peg$parseSearchPred() {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c24;
+      s1 = peg$c20;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c25); }
+      if (peg$silentFails === 0) { peg$fail(peg$c21); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseequalityToken();
+        s3 = peg$parseEqualityToken();
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsesearchValue();
+            s5 = peg$parseSearchValue();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c26(s3, s5);
+              s1 = peg$c22(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1474,24 +1379,24 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c27) {
-        s1 = peg$c27;
+      if (input.substr(peg$currPos, 2) === peg$c23) {
+        s1 = peg$c23;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c28); }
+        if (peg$silentFails === 0) { peg$fail(peg$c24); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parseequalityToken();
+          s3 = peg$parseEqualityToken();
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
-              s5 = peg$parsesearchValue();
+              s5 = peg$parseSearchValue();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c29(s3, s5);
+                s1 = peg$c25(s3, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1515,18 +1420,18 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parseDerefExpression();
+        s1 = peg$parseDerefExpr();
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parseequalityToken();
+            s3 = peg$parseEqualityToken();
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                s5 = peg$parsesearchValue();
+                s5 = peg$parseSearchValue();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c30(s1, s3, s5);
+                  s1 = peg$c26(s1, s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1552,12 +1457,12 @@ function peg$parse(input, options) {
           s0 = peg$currPos;
           s1 = peg$currPos;
           peg$silentFails++;
-          if (input.substr(peg$currPos, 3) === peg$c31) {
-            s2 = peg$c31;
+          if (input.substr(peg$currPos, 3) === peg$c27) {
+            s2 = peg$c27;
             peg$currPos += 3;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c32); }
+            if (peg$silentFails === 0) { peg$fail(peg$c28); }
           }
           peg$silentFails--;
           if (s2 !== peg$FAILED) {
@@ -1567,18 +1472,18 @@ function peg$parse(input, options) {
             s1 = peg$FAILED;
           }
           if (s1 !== peg$FAILED) {
-            s2 = peg$parseFunctionExpr();
+            s2 = peg$parseFunction();
             if (s2 !== peg$FAILED) {
               s3 = peg$parse__();
               if (s3 !== peg$FAILED) {
-                s4 = peg$parseequalityToken();
+                s4 = peg$parseEqualityToken();
                 if (s4 !== peg$FAILED) {
                   s5 = peg$parse__();
                   if (s5 !== peg$FAILED) {
-                    s6 = peg$parsesearchValue();
+                    s6 = peg$parseSearchValue();
                     if (s6 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c33(s2, s4, s6);
+                      s1 = peg$c29(s2, s4, s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1606,24 +1511,24 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            s1 = peg$parsesearchValue();
+            s1 = peg$parseSearchValue();
             if (s1 !== peg$FAILED) {
               s2 = peg$parse__();
               if (s2 !== peg$FAILED) {
-                s3 = peg$parseinToken();
+                s3 = peg$parseInToken();
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse__();
                   if (s4 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 42) {
-                      s5 = peg$c24;
+                      s5 = peg$c20;
                       peg$currPos++;
                     } else {
                       s5 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c25); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c21); }
                     }
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c34(s1);
+                      s1 = peg$c30(s1);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1647,18 +1552,18 @@ function peg$parse(input, options) {
             }
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              s1 = peg$parsesearchValue();
+              s1 = peg$parseSearchValue();
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
                 if (s2 !== peg$FAILED) {
-                  s3 = peg$parseinToken();
+                  s3 = peg$parseInToken();
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse__();
                     if (s4 !== peg$FAILED) {
-                      s5 = peg$parseDerefExpression();
+                      s5 = peg$parseDerefExpr();
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c35(s1, s5);
+                        s1 = peg$c31(s1, s5);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -1682,10 +1587,10 @@ function peg$parse(input, options) {
               }
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                s1 = peg$parsesearchLiteral();
+                s1 = peg$parseSearchLiteral();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c36(s1);
+                  s1 = peg$c32(s1);
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
@@ -1693,7 +1598,7 @@ function peg$parse(input, options) {
                   s1 = peg$currPos;
                   peg$silentFails++;
                   s2 = peg$currPos;
-                  s3 = peg$parsesearchKeywords();
+                  s3 = peg$parseSearchKeywords();
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse_();
                     if (s4 !== peg$FAILED) {
@@ -1715,10 +1620,10 @@ function peg$parse(input, options) {
                     s1 = peg$FAILED;
                   }
                   if (s1 !== peg$FAILED) {
-                    s2 = peg$parsesearchWord();
+                    s2 = peg$parseSearchWord();
                     if (s2 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c37(s2);
+                      s1 = peg$c33(s2);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1739,7 +1644,70 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesearchLiteral() {
+  function peg$parseSearchValue() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$parseSearchLiteral();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$currPos;
+      peg$silentFails++;
+      s2 = peg$currPos;
+      s3 = peg$parseSearchKeywords();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parse_();
+        if (s4 !== peg$FAILED) {
+          s3 = [s3, s4];
+          s2 = s3;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      peg$silentFails--;
+      if (s2 === peg$FAILED) {
+        s1 = void 0;
+      } else {
+        peg$currPos = s1;
+        s1 = peg$FAILED;
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseSearchWord();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c34(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchKeywords() {
+    var s0;
+
+    s0 = peg$parseAndToken();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseOrToken();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseInToken();
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchLiteral() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$parseStringLiteral();
@@ -1757,7 +1725,7 @@ function peg$parse(input, options) {
               if (s1 !== peg$FAILED) {
                 s2 = peg$currPos;
                 peg$silentFails++;
-                s3 = peg$parsesearchWord();
+                s3 = peg$parseSearchWord();
                 peg$silentFails--;
                 if (s3 === peg$FAILED) {
                   s2 = void 0;
@@ -1767,7 +1735,7 @@ function peg$parse(input, options) {
                 }
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c38(s1);
+                  s1 = peg$c35(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1782,7 +1750,7 @@ function peg$parse(input, options) {
                 s1 = peg$currPos;
                 peg$silentFails++;
                 s2 = peg$currPos;
-                s3 = peg$parsesearchKeywords();
+                s3 = peg$parseSearchKeywords();
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse_();
                   if (s4 !== peg$FAILED) {
@@ -1807,7 +1775,7 @@ function peg$parse(input, options) {
                   s2 = peg$parseBooleanLiteral();
                   if (s2 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c39(s2);
+                    s1 = peg$c36(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1822,7 +1790,7 @@ function peg$parse(input, options) {
                   s1 = peg$currPos;
                   peg$silentFails++;
                   s2 = peg$currPos;
-                  s3 = peg$parsesearchKeywords();
+                  s3 = peg$parseSearchKeywords();
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse_();
                     if (s4 !== peg$FAILED) {
@@ -1847,7 +1815,7 @@ function peg$parse(input, options) {
                     s2 = peg$parseNullLiteral();
                     if (s2 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c39(s2);
+                      s1 = peg$c36(s2);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1868,63 +1836,14 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesearchValue() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$parsesearchLiteral();
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$currPos;
-      peg$silentFails++;
-      s2 = peg$currPos;
-      s3 = peg$parsesearchKeywords();
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parse_();
-        if (s4 !== peg$FAILED) {
-          s3 = [s3, s4];
-          s2 = s3;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      peg$silentFails--;
-      if (s2 === peg$FAILED) {
-        s1 = void 0;
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parsesearchWord();
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c40(s2);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
   function peg$parseStringLiteral() {
     var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parsequotedString();
+    s1 = peg$parseQuotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c40(s1);
+      s1 = peg$c34(s1);
     }
     s0 = s1;
 
@@ -1935,10 +1854,10 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parsereString();
+    s1 = peg$parseRegexp();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c41(s1);
+      s1 = peg$c37(s1);
     }
     s0 = s1;
 
@@ -1949,7 +1868,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseip6subnet();
+    s1 = peg$parseIP6Net();
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
@@ -1963,7 +1882,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c42(s1);
+        s1 = peg$c38(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1975,10 +1894,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parsesubnet();
+      s1 = peg$parseIPNet();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c42(s1);
+        s1 = peg$c38(s1);
       }
       s0 = s1;
     }
@@ -1990,7 +1909,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseip6addr();
+    s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
@@ -2004,7 +1923,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c43(s1);
+        s1 = peg$c39(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2016,10 +1935,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseaddr();
+      s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c43(s1);
+        s1 = peg$c39(s1);
       }
       s0 = s1;
     }
@@ -2031,10 +1950,10 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parsesdouble();
+    s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c44(s1);
+      s1 = peg$c40(s1);
     }
     s0 = s1;
 
@@ -2045,10 +1964,10 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parsesinteger();
+    s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c45(s1);
+      s1 = peg$c41(s1);
     }
     s0 = s1;
 
@@ -2059,30 +1978,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c46) {
-      s1 = peg$c46;
+    if (input.substr(peg$currPos, 4) === peg$c42) {
+      s1 = peg$c42;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c47); }
+      if (peg$silentFails === 0) { peg$fail(peg$c43); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c48();
+      s1 = peg$c44();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c49) {
-        s1 = peg$c49;
+      if (input.substr(peg$currPos, 5) === peg$c45) {
+        s1 = peg$c45;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c50); }
+        if (peg$silentFails === 0) { peg$fail(peg$c46); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c51();
+        s1 = peg$c47();
       }
       s0 = s1;
     }
@@ -2094,51 +2013,37 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c52) {
-      s1 = peg$c52;
+    if (input.substr(peg$currPos, 4) === peg$c48) {
+      s1 = peg$c48;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c54();
+      s1 = peg$c50();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsesearchKeywords() {
-    var s0;
-
-    s0 = peg$parseandToken();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseorToken();
-      if (s0 === peg$FAILED) {
-        s0 = peg$parseinToken();
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseprocList() {
+  function peg$parseSequentialProcs() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseprocChain();
+    s1 = peg$parseProc();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseparallelChain();
+      s3 = peg$parseSequentialTail();
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$parseparallelChain();
+        s3 = peg$parseSequentialTail();
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c55(s1, s2);
+        s1 = peg$c51(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2152,26 +2057,26 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseparallelChain() {
+  function peg$parseSequentialTail() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 59) {
-        s2 = peg$c56;
+      if (input.charCodeAt(peg$currPos) === 124) {
+        s2 = peg$c52;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c57); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseprocChain();
+          s4 = peg$parseProc();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c58(s4);
+            s1 = peg$c54(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2193,38 +2098,38 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseproc() {
+  function peg$parseProc() {
     var s0, s1, s2, s3, s4, s5;
 
-    s0 = peg$parsesimpleProc();
+    s0 = peg$parseNamedProc();
     if (s0 === peg$FAILED) {
-      s0 = peg$parsegroupByProc();
+      s0 = peg$parseGroupByProc();
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c19;
+          s1 = peg$c15;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c20); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parseprocList();
+            s3 = peg$parseProcs();
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c21;
+                  s5 = peg$c17;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c22); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c59(s3);
+                  s1 = peg$c55(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2252,18 +2157,172 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsegroupByKeys() {
+  function peg$parseProcs() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSequentialProcs();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseParallelTail();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseParallelTail();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c56(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseParallelTail() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parse__();
+    if (s1 !== peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 59) {
+        s2 = peg$c57;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c58); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse__();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseSequentialProcs();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c59(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseGroupByProc() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parseEveryDur();
+    if (s1 === peg$FAILED) {
+      s1 = null;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseReducers();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseGroupByKeys();
+        if (s3 === peg$FAILED) {
+          s3 = null;
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseLimitArg();
+          if (s4 === peg$FAILED) {
+            s4 = null;
+          }
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c60(s1, s2, s3, s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseEveryDur() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c61) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseDuration();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c63(s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseGroupByKeys() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c60) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c64) {
         s2 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+        if (peg$silentFails === 0) { peg$fail(peg$c65); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -2271,8 +2330,67 @@ function peg$parse(input, options) {
           s4 = peg$parseFlexAssignments();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c62(s4);
+            s1 = peg$c66(s4);
             s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseLimitArg() {
+    var s0, s1, s2, s3, s4, s5, s6;
+
+    s0 = peg$currPos;
+    s1 = peg$parse_();
+    if (s1 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 4) === peg$c67) {
+        s2 = peg$c67;
+        peg$currPos += 4;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse_();
+        if (s3 !== peg$FAILED) {
+          if (input.substr(peg$currPos, 6) === peg$c69) {
+            s4 = peg$c69;
+            peg$currPos += 6;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c70); }
+          }
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parse_();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parseUInt();
+              if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c71(s6);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -2299,10 +2417,10 @@ function peg$parse(input, options) {
     s0 = peg$parseAssignment();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseConditionalExpression();
+      s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c63(s1);
+        s1 = peg$c72(s1);
       }
       s0 = s1;
     }
@@ -2321,11 +2439,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c64;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2333,7 +2451,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c66(s1, s7);
+              s4 = peg$c75(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2357,11 +2475,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c64;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2369,7 +2487,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c66(s1, s7);
+                s4 = peg$c75(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2390,677 +2508,8 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c67(s1, s2);
+        s1 = peg$c76(s1, s2);
         s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseeveryDur() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c68) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseduration();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse_();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c70(s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseequalityToken() {
-    var s0;
-
-    s0 = peg$parseEqualityOperator();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseRelativeOperator();
-    }
-
-    return s0;
-  }
-
-  function peg$parseandToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c71) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c72); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseorToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c74) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c75); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseinToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c76) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c77); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parsenotToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c78) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c79); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseIdentifierStart() {
-    var s0;
-
-    if (peg$c80.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c81); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseIdentifierRest() {
-    var s0;
-
-    s0 = peg$parseIdentifierStart();
-    if (s0 === peg$FAILED) {
-      if (peg$c82.test(input.charAt(peg$currPos))) {
-        s0 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c83); }
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseIdentifier() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseIdentifierStart();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseIdentifierRest();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseIdentifierRest();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c84();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseRootField() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c85;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c86); }
-    }
-    if (s1 === peg$FAILED) {
-      s1 = null;
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseBooleanLiteral();
-      if (s3 === peg$FAILED) {
-        s3 = peg$parseNullLiteral();
-      }
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseIdentifier();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c87(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c85;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$currPos;
-        peg$silentFails++;
-        s3 = peg$parseIdentifier();
-        peg$silentFails--;
-        if (s3 === peg$FAILED) {
-          s2 = void 0;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c88();
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseDerefExpression() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseRootField();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseDeref();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseDeref();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c89(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseDeref() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c90;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c91); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseConditionalExpression();
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c92;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c93); }
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c94(s2);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c85;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$currPos;
-        peg$silentFails++;
-        if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c85;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
-        }
-        peg$silentFails--;
-        if (s3 === peg$FAILED) {
-          s2 = void 0;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseIdentifier();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c95(s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseFunctionExpr() {
-    var s0, s1, s2, s3, s4, s5;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFunctionName();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c19;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c20); }
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseArgumentList();
-          if (s4 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c21;
-              peg$currPos++;
-            } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c22); }
-            }
-            if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c96(s1, s4);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsefieldExprList() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseDerefExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c64;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseDerefExpression();
-            if (s7 !== peg$FAILED) {
-              s4 = [s4, s5, s6, s7];
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c64;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseDerefExpression();
-              if (s7 !== peg$FAILED) {
-                s4 = [s4, s5, s6, s7];
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c97(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseExprList() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseConditionalExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c64;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseConditionalExpression();
-            if (s7 !== peg$FAILED) {
-              s4 = [s4, s5, s6, s7];
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c64;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseConditionalExpression();
-              if (s7 !== peg$FAILED) {
-                s4 = [s4, s5, s6, s7];
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c98(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsegroupByProc() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parseeveryDur();
-    if (s1 === peg$FAILED) {
-      s1 = null;
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parsereducerList();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parsegroupByKeys();
-        if (s3 === peg$FAILED) {
-          s3 = null;
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseprocLimitArg();
-          if (s4 === peg$FAILED) {
-            s4 = null;
-          }
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c99(s1, s2, s3, s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3077,22 +2526,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parseDerefExpression();
+    s1 = peg$parseDerefExpr();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c100;
+          s3 = peg$c77;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c101); }
+          if (peg$silentFails === 0) { peg$fail(peg$c78); }
         }
         if (s3 !== peg$FAILED) {
-          s4 = peg$parsereducer();
+          s4 = peg$parseReducer();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c102(s1, s4);
+            s1 = peg$c79(s1, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3112,10 +2561,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parsereducer();
+      s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c103(s1);
+        s1 = peg$c80(s1);
       }
       s0 = s1;
     }
@@ -3123,26 +2572,26 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsereducer() {
+  function peg$parseReducer() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
-    if (input.substr(peg$currPos, 3) === peg$c78) {
-      s2 = peg$c78;
+    if (input.substr(peg$currPos, 3) === peg$c81) {
+      s2 = peg$c81;
       peg$currPos += 3;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c104); }
+      if (peg$silentFails === 0) { peg$fail(peg$c82); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c31) {
-        s2 = peg$c31;
+      if (input.substr(peg$currPos, 3) === peg$c27) {
+        s2 = peg$c27;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c32); }
+        if (peg$silentFails === 0) { peg$fail(peg$c28); }
       }
     }
     peg$silentFails--;
@@ -3153,21 +2602,21 @@ function peg$parse(input, options) {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseFunctionName();
+      s2 = peg$parseFuncName();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c19;
+            s4 = peg$c15;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c20); }
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parseConditionalExpression();
+              s6 = peg$parseConditionalExpr();
               if (s6 === peg$FAILED) {
                 s6 = null;
               }
@@ -3175,20 +2624,20 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c21;
+                    s8 = peg$c17;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c22); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c18); }
                   }
                   if (s8 !== peg$FAILED) {
-                    s9 = peg$parsewhere();
+                    s9 = peg$parseWhereClause();
                     if (s9 === peg$FAILED) {
                       s9 = null;
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c105(s2, s6, s9);
+                      s1 = peg$c83(s2, s6, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -3230,26 +2679,26 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsewhere() {
+  function peg$parseWhereClause() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c106) {
-        s2 = peg$c106;
+      if (input.substr(peg$currPos, 5) === peg$c84) {
+        s2 = peg$c84;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseConditionalExpression();
+          s4 = peg$parseConditionalExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c23(s4);
+            s1 = peg$c19(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3271,7 +2720,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsereducerList() {
+  function peg$parseReducers() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
@@ -3282,11 +2731,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c64;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3317,11 +2766,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c64;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3349,7 +2798,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c108(s1, s2);
+        s1 = peg$c86(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3363,28 +2812,28 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesimpleProc() {
+  function peg$parseNamedProc() {
     var s0;
 
-    s0 = peg$parsesort();
+    s0 = peg$parseSortProc();
     if (s0 === peg$FAILED) {
-      s0 = peg$parsetop();
+      s0 = peg$parseTopProc();
       if (s0 === peg$FAILED) {
-        s0 = peg$parsecut();
+        s0 = peg$parseCutProc();
         if (s0 === peg$FAILED) {
-          s0 = peg$parsehead();
+          s0 = peg$parseHeadProc();
           if (s0 === peg$FAILED) {
-            s0 = peg$parsetail();
+            s0 = peg$parseTailProc();
             if (s0 === peg$FAILED) {
-              s0 = peg$parsefilter();
+              s0 = peg$parseFilterProc();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseuniq();
+                s0 = peg$parseUniqProc();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseput();
+                  s0 = peg$parsePutProc();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parserename();
+                    s0 = peg$parseRenameProc();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parsefuse();
+                      s0 = peg$parseFuseProc();
                     }
                   }
                 }
@@ -3398,27 +2847,27 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesort() {
+  function peg$parseSortProc() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c109) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c87) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c110); }
+      if (peg$silentFails === 0) { peg$fail(peg$c88); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parsesortArgs();
+      s2 = peg$parseSortArgs();
       if (s2 !== peg$FAILED) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          s5 = peg$parseExprList();
+          s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c111(s2, s5);
+            s4 = peg$c89(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -3433,7 +2882,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c112(s2, s3);
+          s1 = peg$c90(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3451,7 +2900,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesortArgs() {
+  function peg$parseSortArgs() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
@@ -3459,10 +2908,10 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     s3 = peg$parse_();
     if (s3 !== peg$FAILED) {
-      s4 = peg$parsesortArg();
+      s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c113(s4);
+        s3 = peg$c91(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3477,10 +2926,10 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        s4 = peg$parsesortArg();
+        s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c113(s4);
+          s3 = peg$c91(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3493,66 +2942,66 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c114(s1);
+      s1 = peg$c92(s1);
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsesortArg() {
+  function peg$parseSortArg() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c115) {
-      s1 = peg$c115;
+    if (input.substr(peg$currPos, 2) === peg$c93) {
+      s1 = peg$c93;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c116); }
+      if (peg$silentFails === 0) { peg$fail(peg$c94); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c117();
+      s1 = peg$c95();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c118) {
-        s1 = peg$c118;
+      if (input.substr(peg$currPos, 6) === peg$c96) {
+        s1 = peg$c96;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c119); }
+        if (peg$silentFails === 0) { peg$fail(peg$c97); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c120) {
-            s4 = peg$c120;
+          if (input.substr(peg$currPos, 5) === peg$c98) {
+            s4 = peg$c98;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c121); }
+            if (peg$silentFails === 0) { peg$fail(peg$c99); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c122) {
-              s4 = peg$c122;
+            if (input.substr(peg$currPos, 4) === peg$c100) {
+              s4 = peg$c100;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c123); }
+              if (peg$silentFails === 0) { peg$fail(peg$c101); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c73();
+            s4 = peg$c102();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c124(s3);
+            s1 = peg$c103(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3571,25 +3020,25 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsetop() {
+  function peg$parseTopProc() {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c125) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c104) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c126); }
+      if (peg$silentFails === 0) { peg$fail(peg$c105); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        s4 = peg$parseunsignedInteger();
+        s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c127(s4);
+          s3 = peg$c106(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3606,12 +3055,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c128) {
-            s5 = peg$c128;
+          if (input.substr(peg$currPos, 6) === peg$c107) {
+            s5 = peg$c107;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c129); }
+            if (peg$silentFails === 0) { peg$fail(peg$c108); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3631,10 +3080,10 @@ function peg$parse(input, options) {
           s4 = peg$currPos;
           s5 = peg$parse_();
           if (s5 !== peg$FAILED) {
-            s6 = peg$parsefieldExprList();
+            s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c130(s2, s3, s6);
+              s5 = peg$c109(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3649,7 +3098,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c131(s2, s3, s4);
+            s1 = peg$c110(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3671,37 +3120,837 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseprocLimitArg() {
-    var s0, s1, s2, s3, s4, s5, s6;
+  function peg$parseCutProc() {
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parse_();
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c111) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c112); }
+    }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c132) {
-        s2 = peg$c132;
-        peg$currPos += 4;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
-      }
+      s2 = peg$parseCutArgs();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c134) {
-            s4 = peg$c134;
-            peg$currPos += 6;
+          s4 = peg$parseFlexAssignments();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c113(s2, s4);
+            s0 = s1;
           } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c135); }
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseCutArgs() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parse_();
+    if (s3 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c114) {
+        s4 = peg$c114;
+        peg$currPos += 2;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+      }
+      if (s4 !== peg$FAILED) {
+        peg$savedPos = s2;
+        s3 = peg$c116();
+        s2 = s3;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$currPos;
+      s3 = peg$parse_();
+      if (s3 !== peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c114) {
+          s4 = peg$c114;
+          peg$currPos += 2;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        }
+        if (s4 !== peg$FAILED) {
+          peg$savedPos = s2;
+          s3 = peg$c116();
+          s2 = s3;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c117(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseHeadProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c118) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c119); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseUInt();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c120(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c118) {
+        s1 = input.substr(peg$currPos, 4);
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c121();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseTailProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c122) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c123); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseUInt();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c124(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c122) {
+        s1 = input.substr(peg$currPos, 4);
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c123); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c125();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseFilterProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c126) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c127); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseSearchExpr();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c4(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseUniqProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c129); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c114) {
+          s3 = peg$c114;
+          peg$currPos += 2;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c130();
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+        s1 = input.substr(peg$currPos, 4);
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c129); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c131();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parsePutProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c132) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c133); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseFlexAssignments();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c134(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseRenameProc() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c135) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c136); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseAssignment();
+        if (s3 !== peg$FAILED) {
+          s4 = [];
+          s5 = peg$currPos;
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 44) {
+              s7 = peg$c73;
+              peg$currPos++;
+            } else {
+              s7 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            }
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parse__();
+              if (s8 !== peg$FAILED) {
+                s9 = peg$parseAssignment();
+                if (s9 !== peg$FAILED) {
+                  peg$savedPos = s5;
+                  s6 = peg$c137(s3, s9);
+                  s5 = s6;
+                } else {
+                  peg$currPos = s5;
+                  s5 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s5;
+                s5 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+          while (s5 !== peg$FAILED) {
+            s4.push(s5);
+            s5 = peg$currPos;
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 44) {
+                s7 = peg$c73;
+                peg$currPos++;
+              } else {
+                s7 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c74); }
+              }
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parse__();
+                if (s8 !== peg$FAILED) {
+                  s9 = peg$parseAssignment();
+                  if (s9 !== peg$FAILED) {
+                    peg$savedPos = s5;
+                    s6 = peg$c137(s3, s9);
+                    s5 = s6;
+                  } else {
+                    peg$currPos = s5;
+                    s5 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s5;
+                  s5 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s5;
+                s5 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
           }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parse_();
+            peg$savedPos = s0;
+            s1 = peg$c138(s3, s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseFuseProc() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c141();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseRootField() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 46) {
+      s1 = peg$c142;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+    }
+    if (s1 === peg$FAILED) {
+      s1 = null;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseBooleanLiteral();
+      if (s3 === peg$FAILED) {
+        s3 = peg$parseNullLiteral();
+      }
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseIdentifier();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c144(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 46) {
+        s1 = peg$c142;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$currPos;
+        peg$silentFails++;
+        s3 = peg$parseIdentifier();
+        peg$silentFails--;
+        if (s3 === peg$FAILED) {
+          s2 = void 0;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c145();
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseFieldExprs() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseDerefExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c73;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseDerefExpr();
+            if (s7 !== peg$FAILED) {
+              s4 = [s4, s5, s6, s7];
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c73;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseDerefExpr();
+              if (s7 !== peg$FAILED) {
+                s4 = [s4, s5, s6, s7];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c146(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseExprs() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseConditionalExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c73;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseConditionalExpr();
+            if (s7 !== peg$FAILED) {
+              s4 = [s4, s5, s6, s7];
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c73;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseConditionalExpr();
+              if (s7 !== peg$FAILED) {
+                s4 = [s4, s5, s6, s7];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c146(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAssignment() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = peg$parseDerefExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 61) {
+          s3 = peg$c77;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parseunsignedInteger();
+              peg$savedPos = s0;
+              s1 = peg$c147(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseExpr() {
+    var s0;
+
+    s0 = peg$parseConditionalExpr();
+
+    return s0;
+  }
+
+  function peg$parseConditionalExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    s0 = peg$currPos;
+    s1 = peg$parseLogicalORExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 63) {
+          s3 = peg$c148;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c149); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseConditionalExpr();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c136(s6);
-                s0 = s1;
+                if (input.charCodeAt(peg$currPos) === 58) {
+                  s7 = peg$c150;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c151); }
+                }
+                if (s7 !== peg$FAILED) {
+                  s8 = peg$parse__();
+                  if (s8 !== peg$FAILED) {
+                    s9 = peg$parseConditionalExpr();
+                    if (s9 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c152(s1, s5, s9);
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -3726,52 +3975,737 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseLogicalORExpr();
+    }
 
     return s0;
   }
 
-  function peg$parsecutArgs() {
+  function peg$parseLogicalORExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseLogicalANDExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseOrToken();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseLogicalANDExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c153(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseOrToken();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseLogicalANDExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c153(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c154(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseLogicalANDExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseEqualityCompareExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseAndToken();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseEqualityCompareExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c153(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseAndToken();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseEqualityCompareExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c153(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c154(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseEqualityCompareExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseRelativeExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseEqualityComparator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseRelativeExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c155(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseEqualityComparator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseRelativeExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c155(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c154(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseEqualityOperator() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2) === peg$c156) {
+      s1 = peg$c156;
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c158) {
+        s1 = peg$c158;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c159); }
+      }
+      if (s1 === peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 61) {
+          s1 = peg$c77;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+        }
+        if (s1 === peg$FAILED) {
+          if (input.substr(peg$currPos, 2) === peg$c160) {
+            s1 = peg$c160;
+            peg$currPos += 2;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c161); }
+          }
+        }
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c102();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseEqualityComparator() {
+    var s0, s1;
+
+    s0 = peg$parseEqualityOperator();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 2) === peg$c162) {
+        s1 = peg$c162;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c102();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseRelativeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseAdditiveExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseRelativeOperator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseAdditiveExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c153(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseRelativeOperator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseAdditiveExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c153(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c154(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseRelativeOperator() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2) === peg$c164) {
+      s1 = peg$c164;
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c165); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 60) {
+        s1 = peg$c166;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c167); }
+      }
+      if (s1 === peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c168) {
+          s1 = peg$c168;
+          peg$currPos += 2;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c169); }
+        }
+        if (s1 === peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 62) {
+            s1 = peg$c170;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c171); }
+          }
+        }
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c102();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseAdditiveExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseMultiplicativeExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseAdditiveOperator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseMultiplicativeExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c153(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseAdditiveOperator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseMultiplicativeExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c153(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c154(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAdditiveOperator() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 43) {
+      s1 = peg$c172;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c173); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 45) {
+        s1 = peg$c12;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c13); }
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c102();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseMultiplicativeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseNotExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseMultiplicativeOperator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseNotExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c153(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseMultiplicativeOperator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseNotExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c153(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c154(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseMultiplicativeOperator() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 42) {
+      s1 = peg$c20;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c21); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 47) {
+        s1 = peg$c174;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c102();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseNotExpr() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 33) {
+      s1 = peg$c9;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c10); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseNotExpr();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c176(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseCastExpr();
+    }
+
+    return s0;
+  }
+
+  function peg$parseCastExpr() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$currPos;
-    s3 = peg$parse_();
-    if (s3 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c137) {
-        s4 = peg$c137;
-        peg$currPos += 2;
-      } else {
-        s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c138); }
-      }
-      if (s4 !== peg$FAILED) {
-        peg$savedPos = s2;
-        s3 = peg$c139();
-        s2 = s3;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s2;
-      s2 = peg$FAILED;
-    }
-    while (s2 !== peg$FAILED) {
-      s1.push(s2);
+    s1 = peg$parseFuncExpr();
+    if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      s3 = peg$parse_();
+      if (input.charCodeAt(peg$currPos) === 58) {
+        s3 = peg$c150;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      }
       if (s3 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c137) {
-          s4 = peg$c137;
-          peg$currPos += 2;
-        } else {
-          s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c138); }
-        }
+        s4 = peg$parsePrimitiveType();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c139();
+          s3 = peg$c177(s1, s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3781,80 +4715,10 @@ function peg$parse(input, options) {
         peg$currPos = s2;
         s2 = peg$FAILED;
       }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c140(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parsecut() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c141) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c142); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parsecutArgs();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseFlexAssignments();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c143(s2, s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsehead() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c144) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c145); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseunsignedInteger();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c146(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+        peg$savedPos = s0;
+        s1 = peg$c178(s1, s2);
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3864,354 +4728,274 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c144) {
-        s1 = input.substr(peg$currPos, 4);
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c145); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c147();
-      }
-      s0 = s1;
+      s0 = peg$parseFuncExpr();
     }
 
     return s0;
   }
 
-  function peg$parsetail() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c148) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c149); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseunsignedInteger();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c150(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c148) {
-        s1 = input.substr(peg$currPos, 4);
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c149); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c151();
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parsefilter() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c152) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c153); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parsesearchExpr();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c8(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseuniq() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c137) {
-          s3 = peg$c137;
-          peg$currPos += 2;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c138); }
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c156();
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
-        s1 = input.substr(peg$currPos, 4);
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c157();
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseput() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c158) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c159); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseFlexAssignments();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c160(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parserename() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c161) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c162); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseAssignment();
-        if (s3 !== peg$FAILED) {
-          s4 = [];
-          s5 = peg$currPos;
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c64;
-              peg$currPos++;
-            } else {
-              s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c65); }
-            }
-            if (s7 !== peg$FAILED) {
-              s8 = peg$parse__();
-              if (s8 !== peg$FAILED) {
-                s9 = peg$parseAssignment();
-                if (s9 !== peg$FAILED) {
-                  peg$savedPos = s5;
-                  s6 = peg$c163(s3, s9);
-                  s5 = s6;
-                } else {
-                  peg$currPos = s5;
-                  s5 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s5;
-                s5 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s5;
-              s5 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s5;
-            s5 = peg$FAILED;
-          }
-          while (s5 !== peg$FAILED) {
-            s4.push(s5);
-            s5 = peg$currPos;
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c64;
-                peg$currPos++;
-              } else {
-                s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c65); }
-              }
-              if (s7 !== peg$FAILED) {
-                s8 = peg$parse__();
-                if (s8 !== peg$FAILED) {
-                  s9 = peg$parseAssignment();
-                  if (s9 !== peg$FAILED) {
-                    peg$savedPos = s5;
-                    s6 = peg$c163(s3, s9);
-                    s5 = s6;
-                  } else {
-                    peg$currPos = s5;
-                    s5 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s5;
-                  s5 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s5;
-                s5 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s5;
-              s5 = peg$FAILED;
-            }
-          }
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c164(s3, s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsefuse() {
+  function peg$parsePrimitiveType() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c165) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
+    if (input.substr(peg$currPos, 5) === peg$c179) {
+      s1 = peg$c179;
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c166); }
+      if (peg$silentFails === 0) { peg$fail(peg$c180); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.substr(peg$currPos, 5) === peg$c181) {
+        s1 = peg$c181;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c182); }
+      }
+      if (s1 === peg$FAILED) {
+        if (input.substr(peg$currPos, 6) === peg$c183) {
+          s1 = peg$c183;
+          peg$currPos += 6;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c184); }
+        }
+        if (s1 === peg$FAILED) {
+          if (input.substr(peg$currPos, 6) === peg$c185) {
+            s1 = peg$c185;
+            peg$currPos += 6;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c186); }
+          }
+          if (s1 === peg$FAILED) {
+            if (input.substr(peg$currPos, 6) === peg$c187) {
+              s1 = peg$c187;
+              peg$currPos += 6;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c188); }
+            }
+            if (s1 === peg$FAILED) {
+              if (input.substr(peg$currPos, 4) === peg$c189) {
+                s1 = peg$c189;
+                peg$currPos += 4;
+              } else {
+                s1 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c190); }
+              }
+              if (s1 === peg$FAILED) {
+                if (input.substr(peg$currPos, 5) === peg$c191) {
+                  s1 = peg$c191;
+                  peg$currPos += 5;
+                } else {
+                  s1 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c192); }
+                }
+                if (s1 === peg$FAILED) {
+                  if (input.substr(peg$currPos, 5) === peg$c193) {
+                    s1 = peg$c193;
+                    peg$currPos += 5;
+                  } else {
+                    s1 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c194); }
+                  }
+                  if (s1 === peg$FAILED) {
+                    if (input.substr(peg$currPos, 5) === peg$c195) {
+                      s1 = peg$c195;
+                      peg$currPos += 5;
+                    } else {
+                      s1 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+                    }
+                    if (s1 === peg$FAILED) {
+                      if (input.substr(peg$currPos, 8) === peg$c197) {
+                        s1 = peg$c197;
+                        peg$currPos += 8;
+                      } else {
+                        s1 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+                      }
+                      if (s1 === peg$FAILED) {
+                        if (input.substr(peg$currPos, 4) === peg$c199) {
+                          s1 = peg$c199;
+                          peg$currPos += 4;
+                        } else {
+                          s1 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c200); }
+                        }
+                        if (s1 === peg$FAILED) {
+                          if (input.substr(peg$currPos, 7) === peg$c201) {
+                            s1 = peg$c201;
+                            peg$currPos += 7;
+                          } else {
+                            s1 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c202); }
+                          }
+                          if (s1 === peg$FAILED) {
+                            if (input.substr(peg$currPos, 4) === peg$c203) {
+                              s1 = peg$c203;
+                              peg$currPos += 4;
+                            } else {
+                              s1 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c204); }
+                            }
+                            if (s1 === peg$FAILED) {
+                              if (input.substr(peg$currPos, 5) === peg$c179) {
+                                s1 = peg$c179;
+                                peg$currPos += 5;
+                              } else {
+                                s1 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c180); }
+                              }
+                              if (s1 === peg$FAILED) {
+                                if (input.substr(peg$currPos, 6) === peg$c205) {
+                                  s1 = peg$c205;
+                                  peg$currPos += 6;
+                                } else {
+                                  s1 = peg$FAILED;
+                                  if (peg$silentFails === 0) { peg$fail(peg$c206); }
+                                }
+                                if (s1 === peg$FAILED) {
+                                  if (input.substr(peg$currPos, 7) === peg$c207) {
+                                    s1 = peg$c207;
+                                    peg$currPos += 7;
+                                  } else {
+                                    s1 = peg$FAILED;
+                                    if (peg$silentFails === 0) { peg$fail(peg$c208); }
+                                  }
+                                  if (s1 === peg$FAILED) {
+                                    if (input.substr(peg$currPos, 2) === peg$c209) {
+                                      s1 = peg$c209;
+                                      peg$currPos += 2;
+                                    } else {
+                                      s1 = peg$FAILED;
+                                      if (peg$silentFails === 0) { peg$fail(peg$c210); }
+                                    }
+                                    if (s1 === peg$FAILED) {
+                                      if (input.substr(peg$currPos, 3) === peg$c211) {
+                                        s1 = peg$c211;
+                                        peg$currPos += 3;
+                                      } else {
+                                        s1 = peg$FAILED;
+                                        if (peg$silentFails === 0) { peg$fail(peg$c212); }
+                                      }
+                                      if (s1 === peg$FAILED) {
+                                        if (input.substr(peg$currPos, 4) === peg$c213) {
+                                          s1 = peg$c213;
+                                          peg$currPos += 4;
+                                        } else {
+                                          s1 = peg$FAILED;
+                                          if (peg$silentFails === 0) { peg$fail(peg$c214); }
+                                        }
+                                        if (s1 === peg$FAILED) {
+                                          if (input.substr(peg$currPos, 5) === peg$c215) {
+                                            s1 = peg$c215;
+                                            peg$currPos += 5;
+                                          } else {
+                                            s1 = peg$FAILED;
+                                            if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                                          }
+                                          if (s1 === peg$FAILED) {
+                                            if (input.substr(peg$currPos, 4) === peg$c48) {
+                                              s1 = peg$c48;
+                                              peg$currPos += 4;
+                                            } else {
+                                              s1 = peg$FAILED;
+                                              if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c167();
+      s1 = peg$c102();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseAssignment() {
+  function peg$parseFuncExpr() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseFunction();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseDeref();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseDeref();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c217(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseDerefExpr();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parsePrimary();
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseFunction() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    s1 = peg$parseDerefExpression();
+    s1 = peg$parseFuncName();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c100;
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c15;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c101); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
+          s4 = peg$parseArgumentList();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseConditionalExpression();
+            if (input.charCodeAt(peg$currPos) === 41) {
+              s5 = peg$c17;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c18); }
+            }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c168(s1, s5);
+              s1 = peg$c218(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4232,6 +5016,282 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseFuncName() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseFuncNameStart();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseFuncNameRest();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseFuncNameRest();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c102();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseFuncNameStart() {
+    var s0;
+
+    if (peg$c219.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c220); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseFuncNameRest() {
+    var s0;
+
+    s0 = peg$parseFuncNameStart();
+    if (s0 === peg$FAILED) {
+      if (peg$c221.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c222); }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseArgumentList() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseConditionalExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c73;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseConditionalExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c223(s1, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c73;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseConditionalExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c223(s1, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c76(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parse__();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c224();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseDerefExpr() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseRootField();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseDeref();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseDeref();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c217(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseDeref() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 91) {
+      s1 = peg$c225;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseConditionalExpr();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 93) {
+          s3 = peg$c227;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c228); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c229(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 46) {
+        s1 = peg$c142;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$currPos;
+        peg$silentFails++;
+        if (input.charCodeAt(peg$currPos) === 46) {
+          s3 = peg$c142;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c143); }
+        }
+        peg$silentFails--;
+        if (s3 === peg$FAILED) {
+          s2 = void 0;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseIdentifier();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c230(s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     }
 
     return s0;
@@ -4258,29 +5318,29 @@ function peg$parse(input, options) {
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 40) {
-                      s1 = peg$c19;
+                      s1 = peg$c15;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c20); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c16); }
                     }
                     if (s1 !== peg$FAILED) {
                       s2 = peg$parse__();
                       if (s2 !== peg$FAILED) {
-                        s3 = peg$parseConditionalExpression();
+                        s3 = peg$parseConditionalExpr();
                         if (s3 !== peg$FAILED) {
                           s4 = peg$parse__();
                           if (s4 !== peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 41) {
-                              s5 = peg$c21;
+                              s5 = peg$c17;
                               peg$currPos++;
                             } else {
                               s5 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c22); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c18); }
                             }
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c23(s3);
+                              s1 = peg$c19(s3);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4314,1273 +5374,143 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseExpression() {
+  function peg$parseEqualityToken() {
     var s0;
-
-    s0 = peg$parseConditionalExpression();
-
-    return s0;
-  }
-
-  function peg$parseConditionalExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
-
-    s0 = peg$currPos;
-    s1 = peg$parseLogicalORExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c169;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c170); }
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseConditionalExpression();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
-              if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c171;
-                  peg$currPos++;
-                } else {
-                  s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c172); }
-                }
-                if (s7 !== peg$FAILED) {
-                  s8 = peg$parse__();
-                  if (s8 !== peg$FAILED) {
-                    s9 = peg$parseConditionalExpression();
-                    if (s9 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c173(s1, s5, s9);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseLogicalORExpression();
-    }
-
-    return s0;
-  }
-
-  function peg$parseLogicalORExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseLogicalANDExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseorToken();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseLogicalANDExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c174(s1, s5, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseorToken();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseLogicalANDExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c174(s1, s5, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c175(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseLogicalANDExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseEqualityCompareExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseandToken();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseEqualityCompareExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c174(s1, s5, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseandToken();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseEqualityCompareExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c174(s1, s5, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c175(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseEqualityCompareExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseRelativeExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseEqualityComparator();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseRelativeExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c176(s1, s5, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseEqualityComparator();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseRelativeExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c176(s1, s5, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c175(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseEqualityOperator() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c177) {
-      s1 = peg$c177;
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c178); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c179) {
-        s1 = peg$c179;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c180); }
-      }
-      if (s1 === peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c100;
-          peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c101); }
-        }
-        if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c181) {
-            s1 = peg$c181;
-            peg$currPos += 2;
-          } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c182); }
-          }
-        }
-      }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseEqualityComparator() {
-    var s0, s1;
 
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c76) {
-        s1 = peg$c76;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c73();
-      }
-      s0 = s1;
+      s0 = peg$parseRelativeOperator();
     }
 
     return s0;
   }
 
-  function peg$parseRelativeExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseAdditiveExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseRelativeOperator();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseAdditiveExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c174(s1, s5, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseRelativeOperator();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseAdditiveExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c174(s1, s5, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c175(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseRelativeOperator() {
+  function peg$parseAndToken() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c184) {
-      s1 = peg$c184;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c231) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c232); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c102();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseOrToken() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c233) {
+      s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c185); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c186;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c187); }
-      }
-      if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c188) {
-          s1 = peg$c188;
-          peg$currPos += 2;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c189); }
-        }
-        if (s1 === peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c190;
-            peg$currPos++;
-          } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c191); }
-          }
-        }
-      }
+      if (peg$silentFails === 0) { peg$fail(peg$c234); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c73();
+      s1 = peg$c102();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseAdditiveExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseMultiplicativeExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseAdditiveOperator();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseMultiplicativeExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c174(s1, s5, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseAdditiveOperator();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseMultiplicativeExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c174(s1, s5, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c175(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseAdditiveOperator() {
+  function peg$parseInToken() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c192;
-      peg$currPos++;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c162) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c193); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c16;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
-      }
+      if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c73();
+      s1 = peg$c102();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseMultiplicativeExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseNotExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseMultiplicativeOperator();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseNotExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c174(s1, s5, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseMultiplicativeOperator();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseNotExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c174(s1, s5, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c175(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseMultiplicativeOperator() {
+  function peg$parseNotToken() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c24;
-      peg$currPos++;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c81) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c25); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c194;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c195); }
-      }
+      if (peg$silentFails === 0) { peg$fail(peg$c236); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c73();
+      s1 = peg$c102();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseNotExpression() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c13;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c14); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseNotExpression();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c196(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseCastExpression();
-    }
-
-    return s0;
-  }
-
-  function peg$parseCastExpression() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFuncExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      if (input.charCodeAt(peg$currPos) === 58) {
-        s3 = peg$c171;
-        peg$currPos++;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c172); }
-      }
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parsePrimitiveType();
-        if (s4 !== peg$FAILED) {
-          peg$savedPos = s2;
-          s3 = peg$c197(s1, s4);
-          s2 = s3;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseFuncExpression();
-    }
-
-    return s0;
-  }
-
-  function peg$parsePrimitiveType() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c199) {
-      s1 = peg$c199;
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c200); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c201) {
-        s1 = peg$c201;
-        peg$currPos += 5;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c202); }
-      }
-      if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c203) {
-          s1 = peg$c203;
-          peg$currPos += 6;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c204); }
-        }
-        if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c205) {
-            s1 = peg$c205;
-            peg$currPos += 6;
-          } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c206); }
-          }
-          if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c207) {
-              s1 = peg$c207;
-              peg$currPos += 6;
-            } else {
-              s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c208); }
-            }
-            if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4) === peg$c209) {
-                s1 = peg$c209;
-                peg$currPos += 4;
-              } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c210); }
-              }
-              if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c211) {
-                  s1 = peg$c211;
-                  peg$currPos += 5;
-                } else {
-                  s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c212); }
-                }
-                if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c213) {
-                    s1 = peg$c213;
-                    peg$currPos += 5;
-                  } else {
-                    s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c214); }
-                  }
-                  if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c215) {
-                      s1 = peg$c215;
-                      peg$currPos += 5;
-                    } else {
-                      s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c216); }
-                    }
-                    if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 8) === peg$c217) {
-                        s1 = peg$c217;
-                        peg$currPos += 8;
-                      } else {
-                        s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c218); }
-                      }
-                      if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c219) {
-                          s1 = peg$c219;
-                          peg$currPos += 4;
-                        } else {
-                          s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c220); }
-                        }
-                        if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 7) === peg$c221) {
-                            s1 = peg$c221;
-                            peg$currPos += 7;
-                          } else {
-                            s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c222); }
-                          }
-                          if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 4) === peg$c223) {
-                              s1 = peg$c223;
-                              peg$currPos += 4;
-                            } else {
-                              s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c224); }
-                            }
-                            if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 5) === peg$c199) {
-                                s1 = peg$c199;
-                                peg$currPos += 5;
-                              } else {
-                                s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c200); }
-                              }
-                              if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 6) === peg$c225) {
-                                  s1 = peg$c225;
-                                  peg$currPos += 6;
-                                } else {
-                                  s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c226); }
-                                }
-                                if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 7) === peg$c227) {
-                                    s1 = peg$c227;
-                                    peg$currPos += 7;
-                                  } else {
-                                    s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c228); }
-                                  }
-                                  if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c229) {
-                                      s1 = peg$c229;
-                                      peg$currPos += 2;
-                                    } else {
-                                      s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c230); }
-                                    }
-                                    if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c231) {
-                                        s1 = peg$c231;
-                                        peg$currPos += 3;
-                                      } else {
-                                        s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c232); }
-                                      }
-                                      if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c233) {
-                                          s1 = peg$c233;
-                                          peg$currPos += 4;
-                                        } else {
-                                          s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c234); }
-                                        }
-                                        if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 5) === peg$c235) {
-                                            s1 = peg$c235;
-                                            peg$currPos += 5;
-                                          } else {
-                                            s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c236); }
-                                          }
-                                          if (s1 === peg$FAILED) {
-                                            if (input.substr(peg$currPos, 4) === peg$c52) {
-                                              s1 = peg$c52;
-                                              peg$currPos += 4;
-                                            } else {
-                                              s1 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c53); }
-                                            }
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseFuncExpression() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFunctionCall();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseDeref();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseDeref();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c237(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseDerefExpression();
-      if (s0 === peg$FAILED) {
-        s0 = peg$parsePrimary();
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseFunctionCall() {
-    var s0, s1, s2, s3, s4, s5;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFunctionName();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c19;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c20); }
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseArgumentList();
-          if (s4 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c21;
-              peg$currPos++;
-            } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c22); }
-            }
-            if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c238(s1, s4);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseFunctionName() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFunctionNameStart();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseFunctionNameRest();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseFunctionNameRest();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c73();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseFunctionNameStart() {
+  function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c239.test(input.charAt(peg$currPos))) {
+    if (peg$c237.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
 
     return s0;
   }
 
-  function peg$parseFunctionNameRest() {
+  function peg$parseIdentifierRest() {
     var s0;
 
-    s0 = peg$parseFunctionNameStart();
+    s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c241.test(input.charAt(peg$currPos))) {
+      if (peg$c239.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c242); }
+        if (peg$silentFails === 0) { peg$fail(peg$c240); }
       }
     }
 
     return s0;
   }
 
-  function peg$parseArgumentList() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+  function peg$parseIdentifier() {
+    var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseConditionalExpression();
+    s1 = peg$parseIdentifierStart();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c64;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseConditionalExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c243(s1, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
+      s3 = peg$parseIdentifierRest();
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c64;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseConditionalExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c243(s1, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
+        s3 = peg$parseIdentifierRest();
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c67(s1, s2);
+        s1 = peg$c241();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5590,44 +5520,35 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parse__();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c244();
-      }
-      s0 = s1;
-    }
 
     return s0;
   }
 
-  function peg$parseduration() {
+  function peg$parseDuration() {
     var s0, s1, s2, s3, s4, s5;
 
-    s0 = peg$parseseconds();
+    s0 = peg$parseSeconds();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseminutes();
+      s0 = peg$parseMinutes();
       if (s0 === peg$FAILED) {
-        s0 = peg$parsehours();
+        s0 = peg$parseHours();
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parsehours();
+          s1 = peg$parseHours();
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c71) {
-                s3 = peg$c71;
+              if (input.substr(peg$currPos, 3) === peg$c231) {
+                s3 = peg$c231;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c245); }
+                if (peg$silentFails === 0) { peg$fail(peg$c242); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
                 if (s4 !== peg$FAILED) {
-                  s5 = peg$parseminutes();
+                  s5 = peg$parseMinutes();
                   if (s5 !== peg$FAILED) {
                     s1 = [s1, s2, s3, s4, s5];
                     s0 = s1;
@@ -5652,9 +5573,9 @@ function peg$parse(input, options) {
             s0 = peg$FAILED;
           }
           if (s0 === peg$FAILED) {
-            s0 = peg$parsedays();
+            s0 = peg$parseDays();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseweeks();
+              s0 = peg$parseWeeks();
             }
           }
         }
@@ -5664,47 +5585,47 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesec_abbrev() {
+  function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c246) {
-      s0 = peg$c246;
+    if (input.substr(peg$currPos, 7) === peg$c243) {
+      s0 = peg$c243;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c248) {
-        s0 = peg$c248;
+      if (input.substr(peg$currPos, 6) === peg$c245) {
+        s0 = peg$c245;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c249); }
+        if (peg$silentFails === 0) { peg$fail(peg$c246); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c250) {
-          s0 = peg$c250;
+        if (input.substr(peg$currPos, 4) === peg$c247) {
+          s0 = peg$c247;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c251); }
+          if (peg$silentFails === 0) { peg$fail(peg$c248); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c252) {
-            s0 = peg$c252;
+          if (input.substr(peg$currPos, 3) === peg$c249) {
+            s0 = peg$c249;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c253); }
+            if (peg$silentFails === 0) { peg$fail(peg$c250); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c254;
+              s0 = peg$c251;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c255); }
+              if (peg$silentFails === 0) { peg$fail(peg$c252); }
             }
           }
         }
@@ -5714,47 +5635,47 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsemin_abbrev() {
+  function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c256) {
-      s0 = peg$c256;
+    if (input.substr(peg$currPos, 7) === peg$c253) {
+      s0 = peg$c253;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c257); }
+      if (peg$silentFails === 0) { peg$fail(peg$c254); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c258) {
-        s0 = peg$c258;
+      if (input.substr(peg$currPos, 6) === peg$c255) {
+        s0 = peg$c255;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c259); }
+        if (peg$silentFails === 0) { peg$fail(peg$c256); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c260) {
-          s0 = peg$c260;
+        if (input.substr(peg$currPos, 4) === peg$c257) {
+          s0 = peg$c257;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c261); }
+          if (peg$silentFails === 0) { peg$fail(peg$c258); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c262) {
-            s0 = peg$c262;
+          if (input.substr(peg$currPos, 3) === peg$c259) {
+            s0 = peg$c259;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c263); }
+            if (peg$silentFails === 0) { peg$fail(peg$c260); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c264;
+              s0 = peg$c261;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c265); }
+              if (peg$silentFails === 0) { peg$fail(peg$c262); }
             }
           }
         }
@@ -5764,47 +5685,47 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsehour_abbrev() {
+  function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c266) {
-      s0 = peg$c266;
+    if (input.substr(peg$currPos, 5) === peg$c263) {
+      s0 = peg$c263;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c267); }
+      if (peg$silentFails === 0) { peg$fail(peg$c264); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c268) {
-        s0 = peg$c268;
+      if (input.substr(peg$currPos, 3) === peg$c265) {
+        s0 = peg$c265;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c269); }
+        if (peg$silentFails === 0) { peg$fail(peg$c266); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c270) {
-          s0 = peg$c270;
+        if (input.substr(peg$currPos, 2) === peg$c267) {
+          s0 = peg$c267;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c271); }
+          if (peg$silentFails === 0) { peg$fail(peg$c268); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c272;
+            s0 = peg$c269;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c273); }
+            if (peg$silentFails === 0) { peg$fail(peg$c270); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c274) {
-              s0 = peg$c274;
+            if (input.substr(peg$currPos, 4) === peg$c271) {
+              s0 = peg$c271;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c275); }
+              if (peg$silentFails === 0) { peg$fail(peg$c272); }
             }
           }
         }
@@ -5814,31 +5735,31 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseday_abbrev() {
+  function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c276) {
-      s0 = peg$c276;
+    if (input.substr(peg$currPos, 4) === peg$c273) {
+      s0 = peg$c273;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c274); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c278) {
-        s0 = peg$c278;
+      if (input.substr(peg$currPos, 3) === peg$c275) {
+        s0 = peg$c275;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c280;
+          s0 = peg$c277;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c281); }
+          if (peg$silentFails === 0) { peg$fail(peg$c278); }
         }
       }
     }
@@ -5846,47 +5767,47 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseweek_abbrev() {
+  function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c282) {
-      s0 = peg$c282;
+    if (input.substr(peg$currPos, 5) === peg$c279) {
+      s0 = peg$c279;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c283); }
+      if (peg$silentFails === 0) { peg$fail(peg$c280); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c284) {
-        s0 = peg$c284;
+      if (input.substr(peg$currPos, 4) === peg$c281) {
+        s0 = peg$c281;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c285); }
+        if (peg$silentFails === 0) { peg$fail(peg$c282); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c286) {
-          s0 = peg$c286;
+        if (input.substr(peg$currPos, 3) === peg$c283) {
+          s0 = peg$c283;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c287); }
+          if (peg$silentFails === 0) { peg$fail(peg$c284); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c288) {
-            s0 = peg$c288;
+          if (input.substr(peg$currPos, 2) === peg$c285) {
+            s0 = peg$c285;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c289); }
+            if (peg$silentFails === 0) { peg$fail(peg$c286); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c290;
+              s0 = peg$c287;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c291); }
+              if (peg$silentFails === 0) { peg$fail(peg$c288); }
             }
           }
         }
@@ -5896,32 +5817,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseseconds() {
+  function peg$parseSeconds() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c248) {
-      s1 = peg$c248;
+    if (input.substr(peg$currPos, 6) === peg$c245) {
+      s1 = peg$c245;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c249); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c292();
+      s1 = peg$c289();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseunsignedInteger();
+      s1 = peg$parseUInt();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parsesec_abbrev();
+          s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c293(s1);
+            s1 = peg$c290(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5940,32 +5861,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseminutes() {
+  function peg$parseMinutes() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c258) {
-      s1 = peg$c258;
+    if (input.substr(peg$currPos, 6) === peg$c255) {
+      s1 = peg$c255;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c259); }
+      if (peg$silentFails === 0) { peg$fail(peg$c256); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c294();
+      s1 = peg$c291();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseunsignedInteger();
+      s1 = peg$parseUInt();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parsemin_abbrev();
+          s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c295(s1);
+            s1 = peg$c292(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5984,32 +5905,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsehours() {
+  function peg$parseHours() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c274) {
-      s1 = peg$c274;
+    if (input.substr(peg$currPos, 4) === peg$c271) {
+      s1 = peg$c271;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c275); }
+      if (peg$silentFails === 0) { peg$fail(peg$c272); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c296();
+      s1 = peg$c293();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseunsignedInteger();
+      s1 = peg$parseUInt();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parsehour_abbrev();
+          s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c297(s1);
+            s1 = peg$c294(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6028,32 +5949,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsedays() {
+  function peg$parseDays() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c278) {
-      s1 = peg$c278;
+    if (input.substr(peg$currPos, 3) === peg$c275) {
+      s1 = peg$c275;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c298();
+      s1 = peg$c295();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseunsignedInteger();
+      s1 = peg$parseUInt();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parseday_abbrev();
+          s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c299(s1);
+            s1 = peg$c296(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6072,32 +5993,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseweeks() {
+  function peg$parseWeeks() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c284) {
-      s1 = peg$c284;
+    if (input.substr(peg$currPos, 4) === peg$c281) {
+      s1 = peg$c281;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c285); }
+      if (peg$silentFails === 0) { peg$fail(peg$c282); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c300();
+      s1 = peg$c297();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseunsignedInteger();
+      s1 = peg$parseUInt();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parseweek_abbrev();
+          s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c301(s1);
+            s1 = peg$c298(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6116,101 +6037,96 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseaddr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+  function peg$parseIP() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    s1 = peg$currPos;
-    s2 = peg$parseunsignedInteger();
-    if (s2 !== peg$FAILED) {
+    s1 = peg$parseUInt();
+    if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c85;
+        s2 = peg$c142;
         peg$currPos++;
       } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c143); }
       }
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parseunsignedInteger();
-        if (s4 !== peg$FAILED) {
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseUInt();
+        if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s5 = peg$c85;
+            s4 = peg$c142;
             peg$currPos++;
           } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c86); }
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c143); }
           }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parseunsignedInteger();
-            if (s6 !== peg$FAILED) {
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseUInt();
+            if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s7 = peg$c85;
+                s6 = peg$c142;
                 peg$currPos++;
               } else {
-                s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c86); }
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c143); }
               }
-              if (s7 !== peg$FAILED) {
-                s8 = peg$parseunsignedInteger();
-                if (s8 !== peg$FAILED) {
-                  s2 = [s2, s3, s4, s5, s6, s7, s8];
-                  s1 = s2;
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseUInt();
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c102();
+                  s0 = s1;
                 } else {
-                  peg$currPos = s1;
-                  s1 = peg$FAILED;
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
                 }
               } else {
-                peg$currPos = s1;
-                s1 = peg$FAILED;
+                peg$currPos = s0;
+                s0 = peg$FAILED;
               }
             } else {
-              peg$currPos = s1;
-              s1 = peg$FAILED;
+              peg$currPos = s0;
+              s0 = peg$FAILED;
             }
           } else {
-            peg$currPos = s1;
-            s1 = peg$FAILED;
+            peg$currPos = s0;
+            s0 = peg$FAILED;
           }
         } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
       } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
+        peg$currPos = s0;
+        s0 = peg$FAILED;
       }
     } else {
-      peg$currPos = s1;
-      s1 = peg$FAILED;
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c302();
-    }
-    s0 = s1;
 
     return s0;
   }
 
-  function peg$parseip6addr() {
+  function peg$parseIP6() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     s1 = [];
-    s2 = peg$parseh_prepend();
+    s2 = peg$parseHexColon();
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        s2 = peg$parseh_prepend();
+        s2 = peg$parseHexColon();
       }
     } else {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseip6tail();
+      s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c303(s1, s2);
+        s1 = peg$c299(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6222,34 +6138,34 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseh16();
+      s1 = peg$parseHex();
       if (s1 !== peg$FAILED) {
         s2 = [];
-        s3 = peg$parseh_append();
+        s3 = peg$parseColonHex();
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          s3 = peg$parseh_append();
+          s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c304) {
-            s3 = peg$c304;
+          if (input.substr(peg$currPos, 2) === peg$c300) {
+            s3 = peg$c300;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c305); }
+            if (peg$silentFails === 0) { peg$fail(peg$c301); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
-            s5 = peg$parseh_prepend();
+            s5 = peg$parseHexColon();
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              s5 = peg$parseh_prepend();
+              s5 = peg$parseHexColon();
             }
             if (s4 !== peg$FAILED) {
-              s5 = peg$parseip6tail();
+              s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c306(s1, s2, s4, s5);
+                s1 = peg$c302(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6273,25 +6189,25 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c304) {
-          s1 = peg$c304;
+        if (input.substr(peg$currPos, 2) === peg$c300) {
+          s1 = peg$c300;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c305); }
+          if (peg$silentFails === 0) { peg$fail(peg$c301); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
-          s3 = peg$parseh_prepend();
+          s3 = peg$parseHexColon();
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            s3 = peg$parseh_prepend();
+            s3 = peg$parseHexColon();
           }
           if (s2 !== peg$FAILED) {
-            s3 = peg$parseip6tail();
+            s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c307(s2, s3);
+              s1 = peg$c303(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6307,25 +6223,25 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parseh16();
+          s1 = peg$parseHex();
           if (s1 !== peg$FAILED) {
             s2 = [];
-            s3 = peg$parseh_append();
+            s3 = peg$parseColonHex();
             while (s3 !== peg$FAILED) {
               s2.push(s3);
-              s3 = peg$parseh_append();
+              s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c304) {
-                s3 = peg$c304;
+              if (input.substr(peg$currPos, 2) === peg$c300) {
+                s3 = peg$c300;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c305); }
+                if (peg$silentFails === 0) { peg$fail(peg$c301); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c308(s1, s2);
+                s1 = peg$c304(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6341,16 +6257,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c304) {
-              s1 = peg$c304;
+            if (input.substr(peg$currPos, 2) === peg$c300) {
+              s1 = peg$c300;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c301); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c309();
+              s1 = peg$c305();
             }
             s0 = s1;
           }
@@ -6361,33 +6277,33 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseip6tail() {
+  function peg$parseIP6Tail() {
     var s0;
 
-    s0 = peg$parseaddr();
+    s0 = peg$parseIP();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseh16();
+      s0 = peg$parseHex();
     }
 
     return s0;
   }
 
-  function peg$parseh_append() {
+  function peg$parseColonHex() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c171;
+      s1 = peg$c150;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c172); }
+      if (peg$silentFails === 0) { peg$fail(peg$c151); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseh16();
+      s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c310(s2);
+        s1 = peg$c306(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6401,22 +6317,22 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseh_prepend() {
+  function peg$parseHexColon() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    s1 = peg$parseh16();
+    s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c171;
+        s2 = peg$c150;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c172); }
+        if (peg$silentFails === 0) { peg$fail(peg$c151); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c311(s1);
+        s1 = peg$c307(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6430,24 +6346,24 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesubnet() {
+  function peg$parseIPNet() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseaddr();
+    s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c194;
+        s2 = peg$c174;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c195); }
+        if (peg$silentFails === 0) { peg$fail(peg$c175); }
       }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseunsignedInteger();
+        s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c312(s1, s3);
+          s1 = peg$c308(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6465,24 +6381,24 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseip6subnet() {
+  function peg$parseIP6Net() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseip6addr();
+    s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c194;
+        s2 = peg$c174;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c195); }
+        if (peg$silentFails === 0) { peg$fail(peg$c175); }
       }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseunsignedInteger();
+        s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c313(s1, s3);
+          s1 = peg$c309(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6500,41 +6416,52 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseunsignedInteger() {
+  function peg$parseUInt() {
     var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parsesuint();
+    s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c314(s1);
+      s1 = peg$c310(s1);
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsesuint() {
+  function peg$parseIntString() {
+    var s0;
+
+    s0 = peg$parseUIntString();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseMinusIntString();
+    }
+
+    return s0;
+  }
+
+  function peg$parseUIntString() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c82.test(input.charAt(peg$currPos))) {
+    if (peg$c239.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c83); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c82.test(input.charAt(peg$currPos))) {
+        if (peg$c239.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c83); }
+          if (peg$silentFails === 0) { peg$fail(peg$c240); }
         }
       }
     } else {
@@ -6542,32 +6469,29 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c73();
+      s1 = peg$c102();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsesinteger() {
+  function peg$parseMinusIntString() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c315.test(input.charAt(peg$currPos))) {
-      s1 = input.charAt(peg$currPos);
+    if (input.charCodeAt(peg$currPos) === 45) {
+      s1 = peg$c12;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
-    }
-    if (s1 === peg$FAILED) {
-      s1 = null;
+      if (peg$silentFails === 0) { peg$fail(peg$c13); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parsesuint();
+      s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c73();
+        s1 = peg$c102();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6581,58 +6505,82 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesdouble() {
+  function peg$parseFloatString() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c16;
+      s1 = peg$c12;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c17); }
+      if (peg$silentFails === 0) { peg$fail(peg$c13); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parsedoubleInteger();
+      if (peg$c239.test(input.charAt(peg$currPos))) {
+        s3 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          s3 = peg$parsedoubleInteger();
+          if (peg$c239.test(input.charAt(peg$currPos))) {
+            s3 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          }
         }
       } else {
         s2 = peg$FAILED;
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c85;
+          s3 = peg$c142;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+          if (peg$silentFails === 0) { peg$fail(peg$c143); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          s5 = peg$parsedoubleDigit();
+          if (peg$c239.test(input.charAt(peg$currPos))) {
+            s5 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              s5 = peg$parsedoubleDigit();
+              if (peg$c239.test(input.charAt(peg$currPos))) {
+                s5 = input.charAt(peg$currPos);
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c240); }
+              }
             }
           } else {
             s4 = peg$FAILED;
           }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseexponentPart();
+            s5 = peg$parseExponentPart();
             if (s5 === peg$FAILED) {
               s5 = null;
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c318();
+              s1 = peg$c311();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6657,42 +6605,54 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c16;
+        s1 = peg$c12;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        if (peg$silentFails === 0) { peg$fail(peg$c13); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c85;
+          s2 = peg$c142;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+          if (peg$silentFails === 0) { peg$fail(peg$c143); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          s4 = peg$parsedoubleDigit();
+          if (peg$c239.test(input.charAt(peg$currPos))) {
+            s4 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              s4 = peg$parsedoubleDigit();
+              if (peg$c239.test(input.charAt(peg$currPos))) {
+                s4 = input.charAt(peg$currPos);
+                peg$currPos++;
+              } else {
+                s4 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c240); }
+              }
             }
           } else {
             s3 = peg$FAILED;
           }
           if (s3 !== peg$FAILED) {
-            s4 = peg$parseexponentPart();
+            s4 = peg$parseExponentPart();
             if (s4 === peg$FAILED) {
               s4 = null;
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c318();
+              s1 = peg$c311();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6715,90 +6675,37 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsedoubleInteger() {
+  function peg$parseExponentPart() {
     var s0, s1, s2, s3;
 
-    if (input.charCodeAt(peg$currPos) === 48) {
-      s0 = peg$c319;
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c312) {
+      s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c320); }
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c313); }
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (peg$c321.test(input.charAt(peg$currPos))) {
-        s1 = input.charAt(peg$currPos);
+    if (s1 !== peg$FAILED) {
+      if (peg$c314.test(input.charAt(peg$currPos))) {
+        s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c315); }
       }
-      if (s1 !== peg$FAILED) {
-        s2 = [];
-        if (peg$c82.test(input.charAt(peg$currPos))) {
-          s3 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c83); }
-        }
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          if (peg$c82.test(input.charAt(peg$currPos))) {
-            s3 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c83); }
-          }
-        }
-        if (s2 !== peg$FAILED) {
-          s1 = [s1, s2];
+      if (s2 === peg$FAILED) {
+        s2 = null;
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseUIntString();
+        if (s3 !== peg$FAILED) {
+          s1 = [s1, s2, s3];
           s0 = s1;
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parsedoubleDigit() {
-    var s0;
-
-    if (peg$c82.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c83); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseexponentPart() {
-    var s0, s1, s2;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c323) {
-      s1 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c324); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parsesinteger();
-      if (s2 !== peg$FAILED) {
-        s1 = [s1, s2];
-        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -6811,85 +6718,85 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseh16() {
+  function peg$parseHex() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = [];
-    s2 = peg$parsehexdigit();
+    s2 = peg$parseHexDigit();
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        s2 = peg$parsehexdigit();
+        s2 = peg$parseHexDigit();
       }
     } else {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c325();
+      s1 = peg$c102();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsehexdigit() {
+  function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c326.test(input.charAt(peg$currPos))) {
+    if (peg$c316.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c327); }
+      if (peg$silentFails === 0) { peg$fail(peg$c317); }
     }
 
     return s0;
   }
 
-  function peg$parsesearchWord() {
+  function peg$parseSearchWord() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = [];
-    s2 = peg$parsesearchWordPart();
+    s2 = peg$parseSearchWordPart();
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        s2 = peg$parsesearchWordPart();
+        s2 = peg$parseSearchWordPart();
       }
     } else {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c328(s1);
+      s1 = peg$c318(s1);
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsesearchWordPart() {
+  function peg$parseSearchWordPart() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c329;
+      s1 = peg$c319;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c320); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseescapeSequence();
+      s2 = peg$parseEscapeSequence();
       if (s2 === peg$FAILED) {
-        s2 = peg$parsesearchEscape();
+        s2 = peg$parseSearchEscape();
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c18(s2);
+        s1 = peg$c14(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6903,15 +6810,15 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c331.test(input.charAt(peg$currPos))) {
+      if (peg$c321.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c332); }
+        if (peg$silentFails === 0) { peg$fail(peg$c322); }
       }
       if (s2 === peg$FAILED) {
-        s2 = peg$parsews();
+        s2 = peg$parseWhiteSpace();
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -6926,11 +6833,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c333); }
+          if (peg$silentFails === 0) { peg$fail(peg$c323); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c73();
+          s1 = peg$c102();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6945,35 +6852,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsequotedString() {
+  function peg$parseQuotedString() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c334;
+      s1 = peg$c324;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parsedoubleQuotedChar();
+      s3 = peg$parseDoubleQuotedChar();
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$parsedoubleQuotedChar();
+        s3 = peg$parseDoubleQuotedChar();
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c334;
+          s3 = peg$c324;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c335); }
+          if (peg$silentFails === 0) { peg$fail(peg$c325); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c336(s2);
+          s1 = peg$c326(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6990,30 +6897,30 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c337;
+        s1 = peg$c327;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c338); }
+        if (peg$silentFails === 0) { peg$fail(peg$c328); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        s3 = peg$parsesingleQuotedChar();
+        s3 = peg$parseSingleQuotedChar();
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          s3 = peg$parsesingleQuotedChar();
+          s3 = peg$parseSingleQuotedChar();
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c337;
+            s3 = peg$c327;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c338); }
+            if (peg$silentFails === 0) { peg$fail(peg$c328); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c336(s2);
+            s1 = peg$c326(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7032,21 +6939,21 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsedoubleQuotedChar() {
+  function peg$parseDoubleQuotedChar() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c334;
+      s2 = peg$c324;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s2 === peg$FAILED) {
-      s2 = peg$parseescapedChar();
+      s2 = peg$parseEscapedChar();
     }
     peg$silentFails--;
     if (s2 === peg$FAILED) {
@@ -7061,11 +6968,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c333); }
+        if (peg$silentFails === 0) { peg$fail(peg$c323); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c73();
+        s1 = peg$c102();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7078,17 +6985,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c329;
+        s1 = peg$c319;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c330); }
+        if (peg$silentFails === 0) { peg$fail(peg$c320); }
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseescapeSequence();
+        s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c18(s2);
+          s1 = peg$c14(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7103,21 +7010,21 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesingleQuotedChar() {
+  function peg$parseSingleQuotedChar() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c337;
+      s2 = peg$c327;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c328); }
     }
     if (s2 === peg$FAILED) {
-      s2 = peg$parseescapedChar();
+      s2 = peg$parseEscapedChar();
     }
     peg$silentFails--;
     if (s2 === peg$FAILED) {
@@ -7132,11 +7039,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c333); }
+        if (peg$silentFails === 0) { peg$fail(peg$c323); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c73();
+        s1 = peg$c102();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7149,17 +7056,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c329;
+        s1 = peg$c319;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c330); }
+        if (peg$silentFails === 0) { peg$fail(peg$c320); }
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseescapeSequence();
+        s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c18(s2);
+          s1 = peg$c14(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7174,24 +7081,24 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseescapeSequence() {
+  function peg$parseEscapeSequence() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c339;
+      s1 = peg$c329;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parsehexdigit();
+      s2 = peg$parseHexDigit();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parsehexdigit();
+        s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c341();
+          s1 = peg$c331();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7206,123 +7113,123 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$parsesingleCharEscape();
+      s0 = peg$parseSingleCharEscape();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseunicodeEscape();
+        s0 = peg$parseUnicodeEscape();
       }
     }
 
     return s0;
   }
 
-  function peg$parsesingleCharEscape() {
+  function peg$parseSingleCharEscape() {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c337;
+      s0 = peg$c327;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c328); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c334;
+        s0 = peg$c324;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c335); }
+        if (peg$silentFails === 0) { peg$fail(peg$c325); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c329;
+          s0 = peg$c319;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c330); }
+          if (peg$silentFails === 0) { peg$fail(peg$c320); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c342;
+            s1 = peg$c332;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c343); }
+            if (peg$silentFails === 0) { peg$fail(peg$c333); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c344();
+            s1 = peg$c334();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c345;
+              s1 = peg$c335;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c346); }
+              if (peg$silentFails === 0) { peg$fail(peg$c336); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c347();
+              s1 = peg$c337();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c348;
+                s1 = peg$c338;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c349); }
+                if (peg$silentFails === 0) { peg$fail(peg$c339); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c350();
+                s1 = peg$c340();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c351;
+                  s1 = peg$c341;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c352); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c342); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c353();
+                  s1 = peg$c343();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c354;
+                    s1 = peg$c344;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c355); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c345); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c356();
+                    s1 = peg$c346();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c357;
+                      s1 = peg$c347;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c358); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c348); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c359();
+                      s1 = peg$c349();
                     }
                     s0 = s1;
                   }
@@ -7337,34 +7244,34 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesearchEscape() {
+  function peg$parseSearchEscape() {
     var s0, s1;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c100;
+      s1 = peg$c77;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c101); }
+      if (peg$silentFails === 0) { peg$fail(peg$c78); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c360();
+      s1 = peg$c350();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c24;
+        s1 = peg$c20;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c25); }
+        if (peg$silentFails === 0) { peg$fail(peg$c21); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c361();
+        s1 = peg$c351();
       }
       s0 = s1;
     }
@@ -7372,26 +7279,26 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseunicodeEscape() {
+  function peg$parseUnicodeEscape() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c362;
+      s1 = peg$c352;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c363); }
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      s3 = peg$parsehexdigit();
+      s3 = peg$parseHexDigit();
       if (s3 !== peg$FAILED) {
-        s4 = peg$parsehexdigit();
+        s4 = peg$parseHexDigit();
         if (s4 !== peg$FAILED) {
-          s5 = peg$parsehexdigit();
+          s5 = peg$parseHexDigit();
           if (s5 !== peg$FAILED) {
-            s6 = peg$parsehexdigit();
+            s6 = peg$parseHexDigit();
             if (s6 !== peg$FAILED) {
               s3 = [s3, s4, s5, s6];
               s2 = s3;
@@ -7413,7 +7320,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c364(s2);
+        s1 = peg$c354(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7426,45 +7333,45 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c362;
+        s1 = peg$c352;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c363); }
+        if (peg$silentFails === 0) { peg$fail(peg$c353); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c365;
+          s2 = peg$c355;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c366); }
+          if (peg$silentFails === 0) { peg$fail(peg$c356); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          s4 = peg$parsehexdigit();
+          s4 = peg$parseHexDigit();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsehexdigit();
+            s5 = peg$parseHexDigit();
             if (s5 === peg$FAILED) {
               s5 = null;
             }
             if (s5 !== peg$FAILED) {
-              s6 = peg$parsehexdigit();
+              s6 = peg$parseHexDigit();
               if (s6 === peg$FAILED) {
                 s6 = null;
               }
               if (s6 !== peg$FAILED) {
-                s7 = peg$parsehexdigit();
+                s7 = peg$parseHexDigit();
                 if (s7 === peg$FAILED) {
                   s7 = null;
                 }
                 if (s7 !== peg$FAILED) {
-                  s8 = peg$parsehexdigit();
+                  s8 = peg$parseHexDigit();
                   if (s8 === peg$FAILED) {
                     s8 = null;
                   }
                   if (s8 !== peg$FAILED) {
-                    s9 = peg$parsehexdigit();
+                    s9 = peg$parseHexDigit();
                     if (s9 === peg$FAILED) {
                       s9 = null;
                     }
@@ -7497,15 +7404,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c367;
+              s4 = peg$c357;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c368); }
+              if (peg$silentFails === 0) { peg$fail(peg$c358); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c364(s3);
+              s1 = peg$c354(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7528,30 +7435,69 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsereString() {
+  function peg$parseRegexp() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c194;
+      s1 = peg$c174;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c195); }
+      if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parsereBody();
+      s2 = [];
+      if (peg$c359.test(input.charAt(peg$currPos))) {
+        s3 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c360); }
+      }
+      if (s3 === peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c361) {
+          s3 = peg$c361;
+          peg$currPos += 2;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c362); }
+        }
+      }
+      if (s3 !== peg$FAILED) {
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          if (peg$c359.test(input.charAt(peg$currPos))) {
+            s3 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c360); }
+          }
+          if (s3 === peg$FAILED) {
+            if (input.substr(peg$currPos, 2) === peg$c361) {
+              s3 = peg$c361;
+              peg$currPos += 2;
+            } else {
+              s3 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c362); }
+            }
+          }
+        }
+      } else {
+        s2 = peg$FAILED;
+      }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c194;
+          s3 = peg$c174;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c195); }
+          if (peg$silentFails === 0) { peg$fail(peg$c175); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c39(s2);
+          s1 = peg$c363(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7569,122 +7515,69 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsereBody() {
-    var s0, s1, s2;
-
-    s0 = peg$currPos;
-    s1 = [];
-    if (peg$c369.test(input.charAt(peg$currPos))) {
-      s2 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
-    }
-    if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c371) {
-        s2 = peg$c371;
-        peg$currPos += 2;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c372); }
-      }
-    }
-    if (s2 !== peg$FAILED) {
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        if (peg$c369.test(input.charAt(peg$currPos))) {
-          s2 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c370); }
-        }
-        if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c371) {
-            s2 = peg$c371;
-            peg$currPos += 2;
-          } else {
-            s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c372); }
-          }
-        }
-      }
-    } else {
-      s1 = peg$FAILED;
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseescapedChar() {
+  function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c373.test(input.charAt(peg$currPos))) {
+    if (peg$c364.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c374); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
 
     return s0;
   }
 
-  function peg$parsews() {
+  function peg$parseWhiteSpace() {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c375;
+      s0 = peg$c366;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c376); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c377;
+        s0 = peg$c368;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c378); }
+        if (peg$silentFails === 0) { peg$fail(peg$c369); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c379;
+          s0 = peg$c370;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c380); }
+          if (peg$silentFails === 0) { peg$fail(peg$c371); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c381;
+            s0 = peg$c372;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c382); }
+            if (peg$silentFails === 0) { peg$fail(peg$c373); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c383;
+              s0 = peg$c374;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c384); }
+              if (peg$silentFails === 0) { peg$fail(peg$c375); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c385;
+                s0 = peg$c376;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c386); }
+                if (peg$silentFails === 0) { peg$fail(peg$c377); }
               }
             }
           }
@@ -7698,21 +7591,15 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    peg$silentFails++;
     s0 = [];
-    s1 = peg$parsews();
+    s1 = peg$parseWhiteSpace();
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        s1 = peg$parsews();
+        s1 = peg$parseWhiteSpace();
       }
     } else {
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c387); }
     }
 
     return s0;
@@ -7722,10 +7609,10 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = [];
-    s1 = peg$parsews();
+    s1 = peg$parseWhiteSpace();
     while (s1 !== peg$FAILED) {
       s0.push(s1);
-      s1 = peg$parsews();
+      s1 = peg$parseWhiteSpace();
     }
 
     return s0;
@@ -7741,7 +7628,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c333); }
+      if (peg$silentFails === 0) { peg$fail(peg$c323); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -297,62 +297,58 @@ function peg$parse(input, options) {
                 return {"op": "SequentialProc", "procs": [s, ... rest]}
             }
           },
-      peg$c3 = function(s) {
-            // XXX does this ever match?  Rule above shoul;d match first
-            return {"op": "SequentialProc", "procs": [s]}
-          },
-      peg$c4 = function(expr) {
+      peg$c3 = function(expr) {
             return {"op": "FilterProc", "filter": expr}
           },
-      peg$c5 = function(first, rest) {
+      peg$c4 = function(first, rest) {
             return makeChain(first, rest, "LogicalOr")
           },
-      peg$c6 = function(t) { return t },
-      peg$c7 = function(first, rest) {
+      peg$c5 = function(t) { return t },
+      peg$c6 = function(first, rest) {
             return makeChain(first, rest, "LogicalAnd")
           },
-      peg$c8 = function(f) { return f },
-      peg$c9 = "!",
-      peg$c10 = peg$literalExpectation("!", false),
-      peg$c11 = function(e) {
+      peg$c7 = function(f) { return f },
+      peg$c8 = "!",
+      peg$c9 = peg$literalExpectation("!", false),
+      peg$c10 = function(e) {
             return {"op": "LogicalNot", "expr": e}
           },
-      peg$c12 = "-",
-      peg$c13 = peg$literalExpectation("-", false),
-      peg$c14 = function(s) { return s },
-      peg$c15 = "(",
-      peg$c16 = peg$literalExpectation("(", false),
-      peg$c17 = ")",
-      peg$c18 = peg$literalExpectation(")", false),
-      peg$c19 = function(expr) { return expr },
-      peg$c20 = "*",
-      peg$c21 = peg$literalExpectation("*", false),
-      peg$c22 = function(comp, v) {
+      peg$c11 = "-",
+      peg$c12 = peg$literalExpectation("-", false),
+      peg$c13 = function(s) { return s },
+      peg$c14 = "(",
+      peg$c15 = peg$literalExpectation("(", false),
+      peg$c16 = ")",
+      peg$c17 = peg$literalExpectation(")", false),
+      peg$c18 = function(expr) { return expr },
+      peg$c19 = "*",
+      peg$c20 = peg$literalExpectation("*", false),
+      peg$c21 = function(comp, v) {
             return {"op": "CompareAny", "comparator": comp, "recursive": false, "value": v}
           },
-      peg$c23 = "**",
-      peg$c24 = peg$literalExpectation("**", false),
-      peg$c25 = function(comp, v) {
+      peg$c22 = "**",
+      peg$c23 = peg$literalExpectation("**", false),
+      peg$c24 = function(comp, v) {
             return {"op": "CompareAny", "comparator": comp, "recursive": true, "value": v}
           },
-      peg$c26 = function(f, comp, v) {
+      peg$c25 = function(f, comp, v) {
             return {"op": "CompareField", "comparator": comp, "field": f, "value": v}
           },
-      peg$c27 = "len",
-      peg$c28 = peg$literalExpectation("len", false),
-      peg$c29 = function(expr, comp, v) {
+      peg$c26 = "len",
+      peg$c27 = peg$literalExpectation("len", false),
+      peg$c28 = function(expr, comp, v) {
           return {"op": "BinaryExpression", "operator": comp, "lhs": expr, "rhs": v}
         },
-      peg$c30 = function(v) {
+      peg$c29 = function(v) {
             return {"op": "CompareAny", "comparator": "in", "recursive": false, "value": v}
           },
-      peg$c31 = function(v, f) {
+      peg$c30 = function(v, f) {
             return {"op": "CompareField", "comparator": "in", "field": f, "value": v}
           },
-      peg$c32 = function(v) {
+      peg$c31 = function(v) {
             return {"op": "Search", "text": text(), "value": v}
           },
-      peg$c33 = function(v) {
+      peg$c32 = function(v) {
             let str = v;
             if (str == "*") {
               return {"op": "MatchAll"}
@@ -364,49 +360,48 @@ function peg$parse(input, options) {
             }
             return {"op": "Search", "text": text(), "value": literal}
           },
-      peg$c34 = function(v) {
+      peg$c33 = function(v) {
             return {"op": "Literal", "type": "string", "value": v}
           },
-      peg$c35 = function(i) { return i },
-      peg$c36 = function(v) { return v },
-      peg$c37 = function(v) {
+      peg$c34 = function(i) { return i },
+      peg$c35 = function(v) { return v },
+      peg$c36 = function(v) {
             return {"op": "Literal", "type": "regexp", "value": v}
           },
-      peg$c38 = function(v) {
+      peg$c37 = function(v) {
             return {"op": "Literal", "type": "net", "value": v}
           },
-      peg$c39 = function(v) {
+      peg$c38 = function(v) {
             return {"op": "Literal", "type": "ip", "value": v}
           },
-      peg$c40 = function(v) {
+      peg$c39 = function(v) {
             return {"op": "Literal", "type": "float64", "value": v}
           },
-      peg$c41 = function(v) {
+      peg$c40 = function(v) {
             return {"op": "Literal", "type": "int64", "value": v}
           },
-      peg$c42 = "true",
-      peg$c43 = peg$literalExpectation("true", false),
-      peg$c44 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
-      peg$c45 = "false",
-      peg$c46 = peg$literalExpectation("false", false),
-      peg$c47 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
-      peg$c48 = "null",
-      peg$c49 = peg$literalExpectation("null", false),
-      peg$c50 = function() { return {"op": "Literal", "type": "null"} },
-      peg$c51 = function(first, rest) {
+      peg$c41 = "true",
+      peg$c42 = peg$literalExpectation("true", false),
+      peg$c43 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
+      peg$c44 = "false",
+      peg$c45 = peg$literalExpectation("false", false),
+      peg$c46 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
+      peg$c47 = "null",
+      peg$c48 = peg$literalExpectation("null", false),
+      peg$c49 = function() { return {"op": "Literal", "type": "null"} },
+      peg$c50 = function(first, rest) {
            if (rest) {
               return [first, ... rest]
-            } else {
-              return [first]
             }
+            return [first]
           },
-      peg$c52 = "|",
-      peg$c53 = peg$literalExpectation("|", false),
-      peg$c54 = function(p) { return p },
-      peg$c55 = function(proc) {
+      peg$c51 = "|",
+      peg$c52 = peg$literalExpectation("|", false),
+      peg$c53 = function(p) { return p },
+      peg$c54 = function(proc) {
             return proc
           },
-      peg$c56 = function(first, rest) {
+      peg$c55 = function(first, rest) {
             let fp = {"op": "SequentialProc", "procs": first};
             if (rest) {
               return {"op": "ParallelProc", "procs": [fp, ... rest]}
@@ -414,10 +409,10 @@ function peg$parse(input, options) {
               return fp
             }
           },
-      peg$c57 = ";",
-      peg$c58 = peg$literalExpectation(";", false),
-      peg$c59 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
-      peg$c60 = function(every, reducers, keys, limit) {
+      peg$c56 = ";",
+      peg$c57 = peg$literalExpectation(";", false),
+      peg$c58 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
+      peg$c59 = function(every, reducers, keys, limit) {
             let p = {"op": "GroupByProc", "reducers": reducers};
             if (every) {
               p["duration"] = every;
@@ -430,54 +425,54 @@ function peg$parse(input, options) {
             }
             return p
           },
-      peg$c61 = "every",
-      peg$c62 = peg$literalExpectation("every", true),
-      peg$c63 = function(dur) { return dur },
-      peg$c64 = "by",
-      peg$c65 = peg$literalExpectation("by", true),
-      peg$c66 = function(columns) { return columns },
-      peg$c67 = "with",
-      peg$c68 = peg$literalExpectation("with", false),
-      peg$c69 = "-limit",
-      peg$c70 = peg$literalExpectation("-limit", false),
-      peg$c71 = function(limit) { return limit },
-      peg$c72 = function(expr) { return {"op": "Assignment", "rhs": expr} },
-      peg$c73 = ",",
-      peg$c74 = peg$literalExpectation(",", false),
-      peg$c75 = function(first, expr) { return expr },
-      peg$c76 = function(first, rest) {
+      peg$c60 = "every",
+      peg$c61 = peg$literalExpectation("every", true),
+      peg$c62 = function(dur) { return dur },
+      peg$c63 = "by",
+      peg$c64 = peg$literalExpectation("by", true),
+      peg$c65 = function(columns) { return columns },
+      peg$c66 = "with",
+      peg$c67 = peg$literalExpectation("with", false),
+      peg$c68 = "-limit",
+      peg$c69 = peg$literalExpectation("-limit", false),
+      peg$c70 = function(limit) { return limit },
+      peg$c71 = function(expr) { return {"op": "Assignment", "rhs": expr} },
+      peg$c72 = ",",
+      peg$c73 = peg$literalExpectation(",", false),
+      peg$c74 = function(first, expr) { return expr },
+      peg$c75 = function(first, rest) {
             return [first, ... rest]
           },
-      peg$c77 = "=",
-      peg$c78 = peg$literalExpectation("=", false),
-      peg$c79 = function(lval, reducer) {
+      peg$c76 = "=",
+      peg$c77 = peg$literalExpectation("=", false),
+      peg$c78 = function(lval, reducer) {
             return {"op": "Assignment", "lhs": lval, "rhs": reducer}
           },
-      peg$c80 = function(reducer) {
+      peg$c79 = function(reducer) {
             return {"op": "Assignment", "rhs": reducer}
           },
-      peg$c81 = "not",
-      peg$c82 = peg$literalExpectation("not", false),
-      peg$c83 = function(op, expr, where) {
+      peg$c80 = "not",
+      peg$c81 = peg$literalExpectation("not", false),
+      peg$c82 = function(op, expr, where) {
             let r = {"op": "Reducer", "operator": op, "where":where};
             if (expr) {
               r["expr"] = expr;
             }
             return r
           },
-      peg$c84 = "where",
-      peg$c85 = peg$literalExpectation("where", false),
-      peg$c86 = function(first, rest) {
+      peg$c83 = "where",
+      peg$c84 = peg$literalExpectation("where", false),
+      peg$c85 = function(first, rest) {
             let result = [first];
             for(let  r of rest) {
               result.push( r[3]);
             }
             return result
           },
-      peg$c87 = "sort",
-      peg$c88 = peg$literalExpectation("sort", true),
-      peg$c89 = function(args, l) { return l },
-      peg$c90 = function(args, list) {
+      peg$c86 = "sort",
+      peg$c87 = peg$literalExpectation("sort", true),
+      peg$c88 = function(args, l) { return l },
+      peg$c89 = function(args, list) {
             let argm = args;
             let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false};
             if ( "r" in argm) {
@@ -490,26 +485,26 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c91 = function(a) { return a },
-      peg$c92 = function(args) { return makeArgMap(args) },
-      peg$c93 = "-r",
-      peg$c94 = peg$literalExpectation("-r", false),
-      peg$c95 = function() { return {"name": "r", "value": null} },
-      peg$c96 = "-nulls",
-      peg$c97 = peg$literalExpectation("-nulls", false),
-      peg$c98 = "first",
-      peg$c99 = peg$literalExpectation("first", false),
-      peg$c100 = "last",
-      peg$c101 = peg$literalExpectation("last", false),
-      peg$c102 = function() { return text() },
-      peg$c103 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c104 = "top",
-      peg$c105 = peg$literalExpectation("top", true),
-      peg$c106 = function(n) { return n},
-      peg$c107 = "-flush",
-      peg$c108 = peg$literalExpectation("-flush", false),
-      peg$c109 = function(limit, flush, f) { return f },
-      peg$c110 = function(limit, flush, fields) {
+      peg$c90 = function(a) { return a },
+      peg$c91 = function(args) { return makeArgMap(args) },
+      peg$c92 = "-r",
+      peg$c93 = peg$literalExpectation("-r", false),
+      peg$c94 = function() { return {"name": "r", "value": null} },
+      peg$c95 = "-nulls",
+      peg$c96 = peg$literalExpectation("-nulls", false),
+      peg$c97 = "first",
+      peg$c98 = peg$literalExpectation("first", false),
+      peg$c99 = "last",
+      peg$c100 = peg$literalExpectation("last", false),
+      peg$c101 = function() { return text() },
+      peg$c102 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c103 = "top",
+      peg$c104 = peg$literalExpectation("top", true),
+      peg$c105 = function(n) { return n},
+      peg$c106 = "-flush",
+      peg$c107 = peg$literalExpectation("-flush", false),
+      peg$c108 = function(limit, flush, f) { return f },
+      peg$c109 = function(limit, flush, fields) {
             let proc = {"op": "TopProc"};
             if (limit) {
               proc["limit"] = limit;
@@ -518,13 +513,13 @@ function peg$parse(input, options) {
               proc["fields"] = fields;
             }
             if (flush) {
-             proc["flush"] = true;
+              proc["flush"] = true;
             }
             return proc
           },
-      peg$c111 = "cut",
-      peg$c112 = peg$literalExpectation("cut", true),
-      peg$c113 = function(args, columns) {
+      peg$c110 = "cut",
+      peg$c111 = peg$literalExpectation("cut", true),
+      peg$c112 = function(args, columns) {
             let argm = args;
             let proc = {"op": "CutProc", "fields": columns, "complement": false};
             if ( "c" in argm) {
@@ -532,51 +527,51 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c114 = "-c",
-      peg$c115 = peg$literalExpectation("-c", false),
-      peg$c116 = function() { return {"name": "c", "value": null} },
-      peg$c117 = function(args) {
+      peg$c113 = "-c",
+      peg$c114 = peg$literalExpectation("-c", false),
+      peg$c115 = function() { return {"name": "c", "value": null} },
+      peg$c116 = function(args) {
             return makeArgMap(args)
           },
-      peg$c118 = "head",
-      peg$c119 = peg$literalExpectation("head", true),
-      peg$c120 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c121 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c122 = "tail",
-      peg$c123 = peg$literalExpectation("tail", true),
-      peg$c124 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c125 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c126 = "filter",
-      peg$c127 = peg$literalExpectation("filter", true),
-      peg$c128 = "uniq",
-      peg$c129 = peg$literalExpectation("uniq", true),
-      peg$c130 = function() {
+      peg$c117 = "head",
+      peg$c118 = peg$literalExpectation("head", true),
+      peg$c119 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c120 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c121 = "tail",
+      peg$c122 = peg$literalExpectation("tail", true),
+      peg$c123 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c124 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c125 = "filter",
+      peg$c126 = peg$literalExpectation("filter", true),
+      peg$c127 = "uniq",
+      peg$c128 = peg$literalExpectation("uniq", true),
+      peg$c129 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c131 = function() {
+      peg$c130 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c132 = "put",
-      peg$c133 = peg$literalExpectation("put", true),
-      peg$c134 = function(columns) {
+      peg$c131 = "put",
+      peg$c132 = peg$literalExpectation("put", true),
+      peg$c133 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c135 = "rename",
-      peg$c136 = peg$literalExpectation("rename", true),
-      peg$c137 = function(first, cl) { return cl },
-      peg$c138 = function(first, rest) {
+      peg$c134 = "rename",
+      peg$c135 = peg$literalExpectation("rename", true),
+      peg$c136 = function(first, cl) { return cl },
+      peg$c137 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c139 = "fuse",
-      peg$c140 = peg$literalExpectation("fuse", true),
-      peg$c141 = function() {
+      peg$c138 = "fuse",
+      peg$c139 = peg$literalExpectation("fuse", true),
+      peg$c140 = function() {
             return {"op": "FuseProc"}
           },
-      peg$c142 = ".",
-      peg$c143 = peg$literalExpectation(".", false),
-      peg$c144 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
-      peg$c145 = function() { return {"op": "RootRecord"} },
-      peg$c146 = function(first, rest) {
+      peg$c141 = ".",
+      peg$c142 = peg$literalExpectation(".", false),
+      peg$c143 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
+      peg$c144 = function() { return {"op": "RootRecord"} },
+      peg$c145 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -585,267 +580,267 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c147 = function(lhs, rhs) { return {"lhs": lhs, "rhs": rhs} },
-      peg$c148 = "?",
-      peg$c149 = peg$literalExpectation("?", false),
-      peg$c150 = ":",
-      peg$c151 = peg$literalExpectation(":", false),
-      peg$c152 = function(condition, thenClause, elseClause) {
+      peg$c146 = function(lhs, rhs) { return {"lhs": lhs, "rhs": rhs} },
+      peg$c147 = "?",
+      peg$c148 = peg$literalExpectation("?", false),
+      peg$c149 = ":",
+      peg$c150 = peg$literalExpectation(":", false),
+      peg$c151 = function(condition, thenClause, elseClause) {
             return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c153 = function(first, op, expr) { return [op, expr] },
-      peg$c154 = function(first, rest) {
+      peg$c152 = function(first, op, expr) { return [op, expr] },
+      peg$c153 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c155 = function(first, comp, expr) { return [comp, expr] },
-      peg$c156 = "=~",
-      peg$c157 = peg$literalExpectation("=~", false),
-      peg$c158 = "!~",
-      peg$c159 = peg$literalExpectation("!~", false),
-      peg$c160 = "!=",
-      peg$c161 = peg$literalExpectation("!=", false),
-      peg$c162 = "in",
-      peg$c163 = peg$literalExpectation("in", false),
-      peg$c164 = "<=",
-      peg$c165 = peg$literalExpectation("<=", false),
-      peg$c166 = "<",
-      peg$c167 = peg$literalExpectation("<", false),
-      peg$c168 = ">=",
-      peg$c169 = peg$literalExpectation(">=", false),
-      peg$c170 = ">",
-      peg$c171 = peg$literalExpectation(">", false),
-      peg$c172 = "+",
-      peg$c173 = peg$literalExpectation("+", false),
-      peg$c174 = "/",
-      peg$c175 = peg$literalExpectation("/", false),
-      peg$c176 = function(e) {
+      peg$c154 = function(first, comp, expr) { return [comp, expr] },
+      peg$c155 = "=~",
+      peg$c156 = peg$literalExpectation("=~", false),
+      peg$c157 = "!~",
+      peg$c158 = peg$literalExpectation("!~", false),
+      peg$c159 = "!=",
+      peg$c160 = peg$literalExpectation("!=", false),
+      peg$c161 = "in",
+      peg$c162 = peg$literalExpectation("in", false),
+      peg$c163 = "<=",
+      peg$c164 = peg$literalExpectation("<=", false),
+      peg$c165 = "<",
+      peg$c166 = peg$literalExpectation("<", false),
+      peg$c167 = ">=",
+      peg$c168 = peg$literalExpectation(">=", false),
+      peg$c169 = ">",
+      peg$c170 = peg$literalExpectation(">", false),
+      peg$c171 = "+",
+      peg$c172 = peg$literalExpectation("+", false),
+      peg$c173 = "/",
+      peg$c174 = peg$literalExpectation("/", false),
+      peg$c175 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c177 = function(e, typ) { return typ },
-      peg$c178 = function(e, typ) {
+      peg$c176 = function(e, typ) { return typ },
+      peg$c177 = function(e, typ) {
             return {"op": "CastExpr", "expr": e, "type": typ}
           },
-      peg$c179 = "bytes",
-      peg$c180 = peg$literalExpectation("bytes", false),
-      peg$c181 = "uint8",
-      peg$c182 = peg$literalExpectation("uint8", false),
-      peg$c183 = "uint16",
-      peg$c184 = peg$literalExpectation("uint16", false),
-      peg$c185 = "uint32",
-      peg$c186 = peg$literalExpectation("uint32", false),
-      peg$c187 = "uint64",
-      peg$c188 = peg$literalExpectation("uint64", false),
-      peg$c189 = "int8",
-      peg$c190 = peg$literalExpectation("int8", false),
-      peg$c191 = "int16",
-      peg$c192 = peg$literalExpectation("int16", false),
-      peg$c193 = "int32",
-      peg$c194 = peg$literalExpectation("int32", false),
-      peg$c195 = "int64",
-      peg$c196 = peg$literalExpectation("int64", false),
-      peg$c197 = "duration",
-      peg$c198 = peg$literalExpectation("duration", false),
-      peg$c199 = "time",
-      peg$c200 = peg$literalExpectation("time", false),
-      peg$c201 = "float64",
-      peg$c202 = peg$literalExpectation("float64", false),
-      peg$c203 = "bool",
-      peg$c204 = peg$literalExpectation("bool", false),
-      peg$c205 = "string",
-      peg$c206 = peg$literalExpectation("string", false),
-      peg$c207 = "bstring",
-      peg$c208 = peg$literalExpectation("bstring", false),
-      peg$c209 = "ip",
-      peg$c210 = peg$literalExpectation("ip", false),
-      peg$c211 = "net",
-      peg$c212 = peg$literalExpectation("net", false),
-      peg$c213 = "type",
-      peg$c214 = peg$literalExpectation("type", false),
-      peg$c215 = "error",
-      peg$c216 = peg$literalExpectation("error", false),
-      peg$c217 = function(first, rest) {
+      peg$c178 = "bytes",
+      peg$c179 = peg$literalExpectation("bytes", false),
+      peg$c180 = "uint8",
+      peg$c181 = peg$literalExpectation("uint8", false),
+      peg$c182 = "uint16",
+      peg$c183 = peg$literalExpectation("uint16", false),
+      peg$c184 = "uint32",
+      peg$c185 = peg$literalExpectation("uint32", false),
+      peg$c186 = "uint64",
+      peg$c187 = peg$literalExpectation("uint64", false),
+      peg$c188 = "int8",
+      peg$c189 = peg$literalExpectation("int8", false),
+      peg$c190 = "int16",
+      peg$c191 = peg$literalExpectation("int16", false),
+      peg$c192 = "int32",
+      peg$c193 = peg$literalExpectation("int32", false),
+      peg$c194 = "int64",
+      peg$c195 = peg$literalExpectation("int64", false),
+      peg$c196 = "duration",
+      peg$c197 = peg$literalExpectation("duration", false),
+      peg$c198 = "time",
+      peg$c199 = peg$literalExpectation("time", false),
+      peg$c200 = "float64",
+      peg$c201 = peg$literalExpectation("float64", false),
+      peg$c202 = "bool",
+      peg$c203 = peg$literalExpectation("bool", false),
+      peg$c204 = "string",
+      peg$c205 = peg$literalExpectation("string", false),
+      peg$c206 = "bstring",
+      peg$c207 = peg$literalExpectation("bstring", false),
+      peg$c208 = "ip",
+      peg$c209 = peg$literalExpectation("ip", false),
+      peg$c210 = "net",
+      peg$c211 = peg$literalExpectation("net", false),
+      peg$c212 = "type",
+      peg$c213 = peg$literalExpectation("type", false),
+      peg$c214 = "error",
+      peg$c215 = peg$literalExpectation("error", false),
+      peg$c216 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c218 = function(fn, args) {
+      peg$c217 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c219 = /^[A-Za-z]/,
-      peg$c220 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
-      peg$c221 = /^[.0-9]/,
-      peg$c222 = peg$classExpectation([".", ["0", "9"]], false, false),
-      peg$c223 = function(first, e) { return e },
-      peg$c224 = function() { return [] },
-      peg$c225 = "[",
-      peg$c226 = peg$literalExpectation("[", false),
-      peg$c227 = "]",
-      peg$c228 = peg$literalExpectation("]", false),
-      peg$c229 = function(expr) { return ["[", expr] },
-      peg$c230 = function(id) { return [".", id] },
-      peg$c231 = "and",
-      peg$c232 = peg$literalExpectation("and", true),
-      peg$c233 = "or",
-      peg$c234 = peg$literalExpectation("or", true),
-      peg$c235 = peg$literalExpectation("in", true),
-      peg$c236 = peg$literalExpectation("not", true),
-      peg$c237 = /^[A-Za-z_$]/,
-      peg$c238 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c239 = /^[0-9]/,
-      peg$c240 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c241 = function() { return {"op": "Identifier", "name": text()} },
-      peg$c242 = peg$literalExpectation("and", false),
-      peg$c243 = "seconds",
-      peg$c244 = peg$literalExpectation("seconds", false),
-      peg$c245 = "second",
-      peg$c246 = peg$literalExpectation("second", false),
-      peg$c247 = "secs",
-      peg$c248 = peg$literalExpectation("secs", false),
-      peg$c249 = "sec",
-      peg$c250 = peg$literalExpectation("sec", false),
-      peg$c251 = "s",
-      peg$c252 = peg$literalExpectation("s", false),
-      peg$c253 = "minutes",
-      peg$c254 = peg$literalExpectation("minutes", false),
-      peg$c255 = "minute",
-      peg$c256 = peg$literalExpectation("minute", false),
-      peg$c257 = "mins",
-      peg$c258 = peg$literalExpectation("mins", false),
-      peg$c259 = "min",
-      peg$c260 = peg$literalExpectation("min", false),
-      peg$c261 = "m",
-      peg$c262 = peg$literalExpectation("m", false),
-      peg$c263 = "hours",
-      peg$c264 = peg$literalExpectation("hours", false),
-      peg$c265 = "hrs",
-      peg$c266 = peg$literalExpectation("hrs", false),
-      peg$c267 = "hr",
-      peg$c268 = peg$literalExpectation("hr", false),
-      peg$c269 = "h",
-      peg$c270 = peg$literalExpectation("h", false),
-      peg$c271 = "hour",
-      peg$c272 = peg$literalExpectation("hour", false),
-      peg$c273 = "days",
-      peg$c274 = peg$literalExpectation("days", false),
-      peg$c275 = "day",
-      peg$c276 = peg$literalExpectation("day", false),
-      peg$c277 = "d",
-      peg$c278 = peg$literalExpectation("d", false),
-      peg$c279 = "weeks",
-      peg$c280 = peg$literalExpectation("weeks", false),
-      peg$c281 = "week",
-      peg$c282 = peg$literalExpectation("week", false),
-      peg$c283 = "wks",
-      peg$c284 = peg$literalExpectation("wks", false),
-      peg$c285 = "wk",
-      peg$c286 = peg$literalExpectation("wk", false),
-      peg$c287 = "w",
-      peg$c288 = peg$literalExpectation("w", false),
-      peg$c289 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c290 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c291 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c292 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c293 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c294 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c295 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c296 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c297 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c298 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c299 = function(a, b) {
+      peg$c218 = /^[A-Za-z]/,
+      peg$c219 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
+      peg$c220 = /^[.0-9]/,
+      peg$c221 = peg$classExpectation([".", ["0", "9"]], false, false),
+      peg$c222 = function(first, e) { return e },
+      peg$c223 = function() { return [] },
+      peg$c224 = "[",
+      peg$c225 = peg$literalExpectation("[", false),
+      peg$c226 = "]",
+      peg$c227 = peg$literalExpectation("]", false),
+      peg$c228 = function(expr) { return ["[", expr] },
+      peg$c229 = function(id) { return [".", id] },
+      peg$c230 = "and",
+      peg$c231 = peg$literalExpectation("and", true),
+      peg$c232 = "or",
+      peg$c233 = peg$literalExpectation("or", true),
+      peg$c234 = peg$literalExpectation("in", true),
+      peg$c235 = peg$literalExpectation("not", true),
+      peg$c236 = /^[A-Za-z_$]/,
+      peg$c237 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c238 = /^[0-9]/,
+      peg$c239 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c240 = function() { return {"op": "Identifier", "name": text()} },
+      peg$c241 = peg$literalExpectation("and", false),
+      peg$c242 = "seconds",
+      peg$c243 = peg$literalExpectation("seconds", false),
+      peg$c244 = "second",
+      peg$c245 = peg$literalExpectation("second", false),
+      peg$c246 = "secs",
+      peg$c247 = peg$literalExpectation("secs", false),
+      peg$c248 = "sec",
+      peg$c249 = peg$literalExpectation("sec", false),
+      peg$c250 = "s",
+      peg$c251 = peg$literalExpectation("s", false),
+      peg$c252 = "minutes",
+      peg$c253 = peg$literalExpectation("minutes", false),
+      peg$c254 = "minute",
+      peg$c255 = peg$literalExpectation("minute", false),
+      peg$c256 = "mins",
+      peg$c257 = peg$literalExpectation("mins", false),
+      peg$c258 = "min",
+      peg$c259 = peg$literalExpectation("min", false),
+      peg$c260 = "m",
+      peg$c261 = peg$literalExpectation("m", false),
+      peg$c262 = "hours",
+      peg$c263 = peg$literalExpectation("hours", false),
+      peg$c264 = "hrs",
+      peg$c265 = peg$literalExpectation("hrs", false),
+      peg$c266 = "hr",
+      peg$c267 = peg$literalExpectation("hr", false),
+      peg$c268 = "h",
+      peg$c269 = peg$literalExpectation("h", false),
+      peg$c270 = "hour",
+      peg$c271 = peg$literalExpectation("hour", false),
+      peg$c272 = "days",
+      peg$c273 = peg$literalExpectation("days", false),
+      peg$c274 = "day",
+      peg$c275 = peg$literalExpectation("day", false),
+      peg$c276 = "d",
+      peg$c277 = peg$literalExpectation("d", false),
+      peg$c278 = "weeks",
+      peg$c279 = peg$literalExpectation("weeks", false),
+      peg$c280 = "week",
+      peg$c281 = peg$literalExpectation("week", false),
+      peg$c282 = "wks",
+      peg$c283 = peg$literalExpectation("wks", false),
+      peg$c284 = "wk",
+      peg$c285 = peg$literalExpectation("wk", false),
+      peg$c286 = "w",
+      peg$c287 = peg$literalExpectation("w", false),
+      peg$c288 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c289 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c290 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c291 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c292 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c293 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c294 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c295 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c296 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c297 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c298 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c300 = "::",
-      peg$c301 = peg$literalExpectation("::", false),
-      peg$c302 = function(a, b, d, e) {
+      peg$c299 = "::",
+      peg$c300 = peg$literalExpectation("::", false),
+      peg$c301 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c303 = function(a, b) {
+      peg$c302 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c304 = function(a, b) {
+      peg$c303 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c305 = function() {
+      peg$c304 = function() {
             return "::"
           },
-      peg$c306 = function(v) { return ":" + v },
-      peg$c307 = function(v) { return v + ":" },
-      peg$c308 = function(a, m) {
+      peg$c305 = function(v) { return ":" + v },
+      peg$c306 = function(v) { return v + ":" },
+      peg$c307 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c309 = function(a, m) {
+      peg$c308 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c310 = function(s) { return parseInt(s) },
-      peg$c311 = function() {
+      peg$c309 = function(s) { return parseInt(s) },
+      peg$c310 = function() {
             return text()
           },
-      peg$c312 = "e",
-      peg$c313 = peg$literalExpectation("e", true),
-      peg$c314 = /^[+\-]/,
-      peg$c315 = peg$classExpectation(["+", "-"], false, false),
-      peg$c316 = /^[0-9a-fA-F]/,
-      peg$c317 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c318 = function(chars) { return joinChars(chars) },
-      peg$c319 = "\\",
-      peg$c320 = peg$literalExpectation("\\", false),
-      peg$c321 = /^[\0-\x1F\\(),!><="|';:]/,
-      peg$c322 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
-      peg$c323 = peg$anyExpectation(),
-      peg$c324 = "\"",
-      peg$c325 = peg$literalExpectation("\"", false),
-      peg$c326 = function(v) { return joinChars(v) },
-      peg$c327 = "'",
-      peg$c328 = peg$literalExpectation("'", false),
-      peg$c329 = "x",
-      peg$c330 = peg$literalExpectation("x", false),
-      peg$c331 = function() { return "\\" + text() },
-      peg$c332 = "b",
-      peg$c333 = peg$literalExpectation("b", false),
-      peg$c334 = function() { return "\b" },
-      peg$c335 = "f",
-      peg$c336 = peg$literalExpectation("f", false),
-      peg$c337 = function() { return "\f" },
-      peg$c338 = "n",
-      peg$c339 = peg$literalExpectation("n", false),
-      peg$c340 = function() { return "\n" },
-      peg$c341 = "r",
-      peg$c342 = peg$literalExpectation("r", false),
-      peg$c343 = function() { return "\r" },
-      peg$c344 = "t",
-      peg$c345 = peg$literalExpectation("t", false),
-      peg$c346 = function() { return "\t" },
-      peg$c347 = "v",
-      peg$c348 = peg$literalExpectation("v", false),
-      peg$c349 = function() { return "\v" },
-      peg$c350 = function() { return "=" },
-      peg$c351 = function() { return "\\*" },
-      peg$c352 = "u",
-      peg$c353 = peg$literalExpectation("u", false),
-      peg$c354 = function(chars) {
+      peg$c311 = "e",
+      peg$c312 = peg$literalExpectation("e", true),
+      peg$c313 = /^[+\-]/,
+      peg$c314 = peg$classExpectation(["+", "-"], false, false),
+      peg$c315 = /^[0-9a-fA-F]/,
+      peg$c316 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c317 = function(chars) { return joinChars(chars) },
+      peg$c318 = "\\",
+      peg$c319 = peg$literalExpectation("\\", false),
+      peg$c320 = /^[\0-\x1F\\(),!><="|';:]/,
+      peg$c321 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
+      peg$c322 = peg$anyExpectation(),
+      peg$c323 = "\"",
+      peg$c324 = peg$literalExpectation("\"", false),
+      peg$c325 = function(v) { return joinChars(v) },
+      peg$c326 = "'",
+      peg$c327 = peg$literalExpectation("'", false),
+      peg$c328 = "x",
+      peg$c329 = peg$literalExpectation("x", false),
+      peg$c330 = function() { return "\\" + text() },
+      peg$c331 = "b",
+      peg$c332 = peg$literalExpectation("b", false),
+      peg$c333 = function() { return "\b" },
+      peg$c334 = "f",
+      peg$c335 = peg$literalExpectation("f", false),
+      peg$c336 = function() { return "\f" },
+      peg$c337 = "n",
+      peg$c338 = peg$literalExpectation("n", false),
+      peg$c339 = function() { return "\n" },
+      peg$c340 = "r",
+      peg$c341 = peg$literalExpectation("r", false),
+      peg$c342 = function() { return "\r" },
+      peg$c343 = "t",
+      peg$c344 = peg$literalExpectation("t", false),
+      peg$c345 = function() { return "\t" },
+      peg$c346 = "v",
+      peg$c347 = peg$literalExpectation("v", false),
+      peg$c348 = function() { return "\v" },
+      peg$c349 = function() { return "=" },
+      peg$c350 = function() { return "\\*" },
+      peg$c351 = "u",
+      peg$c352 = peg$literalExpectation("u", false),
+      peg$c353 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c355 = "{",
-      peg$c356 = peg$literalExpectation("{", false),
-      peg$c357 = "}",
-      peg$c358 = peg$literalExpectation("}", false),
-      peg$c359 = function(body) { return body },
-      peg$c360 = /^[^\/\\]/,
-      peg$c361 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c362 = "\\/",
-      peg$c363 = peg$literalExpectation("\\/", false),
-      peg$c364 = /^[\0-\x1F\\]/,
-      peg$c365 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c366 = "\t",
-      peg$c367 = peg$literalExpectation("\t", false),
-      peg$c368 = "\x0B",
-      peg$c369 = peg$literalExpectation("\x0B", false),
-      peg$c370 = "\f",
-      peg$c371 = peg$literalExpectation("\f", false),
-      peg$c372 = " ",
-      peg$c373 = peg$literalExpectation(" ", false),
-      peg$c374 = "\xA0",
-      peg$c375 = peg$literalExpectation("\xA0", false),
-      peg$c376 = "\uFEFF",
-      peg$c377 = peg$literalExpectation("\uFEFF", false),
+      peg$c354 = "{",
+      peg$c355 = peg$literalExpectation("{", false),
+      peg$c356 = "}",
+      peg$c357 = peg$literalExpectation("}", false),
+      peg$c358 = function(body) { return body },
+      peg$c359 = /^[^\/\\]/,
+      peg$c360 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c361 = "\\/",
+      peg$c362 = peg$literalExpectation("\\/", false),
+      peg$c363 = /^[\0-\x1F\\]/,
+      peg$c364 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c365 = "\t",
+      peg$c366 = peg$literalExpectation("\t", false),
+      peg$c367 = "\x0B",
+      peg$c368 = peg$literalExpectation("\x0B", false),
+      peg$c369 = "\f",
+      peg$c370 = peg$literalExpectation("\f", false),
+      peg$c371 = " ",
+      peg$c372 = peg$literalExpectation(" ", false),
+      peg$c373 = "\xA0",
+      peg$c374 = peg$literalExpectation("\xA0", false),
+      peg$c375 = "\uFEFF",
+      peg$c376 = peg$literalExpectation("\uFEFF", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1028,15 +1023,6 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parseSearch();
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c3(s1);
-        }
-        s0 = s1;
-      }
     }
 
     return s0;
@@ -1049,7 +1035,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSearchExpr();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c4(s1);
+      s1 = peg$c3(s1);
     }
     s0 = s1;
 
@@ -1070,7 +1056,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c5(s1, s2);
+        s1 = peg$c4(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1097,7 +1083,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchTerm();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c6(s4);
+            s1 = peg$c5(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1133,7 +1119,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c7(s1, s2);
+        s1 = peg$c6(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1175,7 +1161,7 @@ function peg$parse(input, options) {
         s3 = peg$parseSearchFactor();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c8(s3);
+          s1 = peg$c7(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1215,11 +1201,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c9;
+        s2 = peg$c8;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c10); }
+        if (peg$silentFails === 0) { peg$fail(peg$c9); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -1239,7 +1225,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSearchExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c11(s2);
+        s1 = peg$c10(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1254,11 +1240,11 @@ function peg$parse(input, options) {
       s1 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c12;
+        s2 = peg$c11;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c13); }
+        if (peg$silentFails === 0) { peg$fail(peg$c12); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -1271,7 +1257,7 @@ function peg$parse(input, options) {
         s2 = peg$parseSearchPred();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c14(s2);
+          s1 = peg$c13(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1284,11 +1270,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c15;
+          s1 = peg$c14;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          if (peg$silentFails === 0) { peg$fail(peg$c15); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -1298,15 +1284,15 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c17;
+                  s5 = peg$c16;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c17); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c19(s3);
+                  s1 = peg$c18(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1339,11 +1325,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c20;
+      s1 = peg$c19;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c21); }
+      if (peg$silentFails === 0) { peg$fail(peg$c20); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -1355,7 +1341,7 @@ function peg$parse(input, options) {
             s5 = peg$parseSearchValue();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c22(s3, s5);
+              s1 = peg$c21(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1379,12 +1365,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c23) {
-        s1 = peg$c23;
+      if (input.substr(peg$currPos, 2) === peg$c22) {
+        s1 = peg$c22;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c24); }
+        if (peg$silentFails === 0) { peg$fail(peg$c23); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -1396,7 +1382,7 @@ function peg$parse(input, options) {
               s5 = peg$parseSearchValue();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c25(s3, s5);
+                s1 = peg$c24(s3, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1431,7 +1417,7 @@ function peg$parse(input, options) {
                 s5 = peg$parseSearchValue();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c26(s1, s3, s5);
+                  s1 = peg$c25(s1, s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1457,12 +1443,12 @@ function peg$parse(input, options) {
           s0 = peg$currPos;
           s1 = peg$currPos;
           peg$silentFails++;
-          if (input.substr(peg$currPos, 3) === peg$c27) {
-            s2 = peg$c27;
+          if (input.substr(peg$currPos, 3) === peg$c26) {
+            s2 = peg$c26;
             peg$currPos += 3;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c28); }
+            if (peg$silentFails === 0) { peg$fail(peg$c27); }
           }
           peg$silentFails--;
           if (s2 !== peg$FAILED) {
@@ -1483,7 +1469,7 @@ function peg$parse(input, options) {
                     s6 = peg$parseSearchValue();
                     if (s6 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c29(s2, s4, s6);
+                      s1 = peg$c28(s2, s4, s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1520,15 +1506,15 @@ function peg$parse(input, options) {
                   s4 = peg$parse__();
                   if (s4 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 42) {
-                      s5 = peg$c20;
+                      s5 = peg$c19;
                       peg$currPos++;
                     } else {
                       s5 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c21); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c20); }
                     }
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c30(s1);
+                      s1 = peg$c29(s1);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1563,7 +1549,7 @@ function peg$parse(input, options) {
                       s5 = peg$parseDerefExpr();
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c31(s1, s5);
+                        s1 = peg$c30(s1, s5);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -1590,7 +1576,7 @@ function peg$parse(input, options) {
                 s1 = peg$parseSearchLiteral();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c32(s1);
+                  s1 = peg$c31(s1);
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
@@ -1623,7 +1609,7 @@ function peg$parse(input, options) {
                     s2 = peg$parseSearchWord();
                     if (s2 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c33(s2);
+                      s1 = peg$c32(s2);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1678,7 +1664,7 @@ function peg$parse(input, options) {
         s2 = peg$parseSearchWord();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c34(s2);
+          s1 = peg$c33(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1735,7 +1721,7 @@ function peg$parse(input, options) {
                 }
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c35(s1);
+                  s1 = peg$c34(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1775,7 +1761,7 @@ function peg$parse(input, options) {
                   s2 = peg$parseBooleanLiteral();
                   if (s2 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c36(s2);
+                    s1 = peg$c35(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1815,7 +1801,7 @@ function peg$parse(input, options) {
                     s2 = peg$parseNullLiteral();
                     if (s2 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c36(s2);
+                      s1 = peg$c35(s2);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1843,7 +1829,7 @@ function peg$parse(input, options) {
     s1 = peg$parseQuotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c34(s1);
+      s1 = peg$c33(s1);
     }
     s0 = s1;
 
@@ -1857,7 +1843,7 @@ function peg$parse(input, options) {
     s1 = peg$parseRegexp();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c37(s1);
+      s1 = peg$c36(s1);
     }
     s0 = s1;
 
@@ -1882,7 +1868,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c38(s1);
+        s1 = peg$c37(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1894,10 +1880,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseIPNet();
+      s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c38(s1);
+        s1 = peg$c37(s1);
       }
       s0 = s1;
     }
@@ -1923,7 +1909,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c39(s1);
+        s1 = peg$c38(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1938,7 +1924,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c39(s1);
+        s1 = peg$c38(s1);
       }
       s0 = s1;
     }
@@ -1953,7 +1939,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c40(s1);
+      s1 = peg$c39(s1);
     }
     s0 = s1;
 
@@ -1967,7 +1953,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c41(s1);
+      s1 = peg$c40(s1);
     }
     s0 = s1;
 
@@ -1978,30 +1964,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c42) {
-      s1 = peg$c42;
+    if (input.substr(peg$currPos, 4) === peg$c41) {
+      s1 = peg$c41;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c43); }
+      if (peg$silentFails === 0) { peg$fail(peg$c42); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c44();
+      s1 = peg$c43();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c45) {
-        s1 = peg$c45;
+      if (input.substr(peg$currPos, 5) === peg$c44) {
+        s1 = peg$c44;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c46); }
+        if (peg$silentFails === 0) { peg$fail(peg$c45); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c47();
+        s1 = peg$c46();
       }
       s0 = s1;
     }
@@ -2013,16 +1999,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c48) {
-      s1 = peg$c48;
+    if (input.substr(peg$currPos, 4) === peg$c47) {
+      s1 = peg$c47;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c48); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c50();
+      s1 = peg$c49();
     }
     s0 = s1;
 
@@ -2043,7 +2029,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c51(s1, s2);
+        s1 = peg$c50(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2064,11 +2050,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 124) {
-        s2 = peg$c52;
+        s2 = peg$c51;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c52); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2076,7 +2062,7 @@ function peg$parse(input, options) {
           s4 = peg$parseProc();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c54(s4);
+            s1 = peg$c53(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2107,11 +2093,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c15;
+          s1 = peg$c14;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          if (peg$silentFails === 0) { peg$fail(peg$c15); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -2121,15 +2107,15 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c17;
+                  s5 = peg$c16;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c17); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c55(s3);
+                  s1 = peg$c54(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2171,7 +2157,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c56(s1, s2);
+        s1 = peg$c55(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2192,11 +2178,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 59) {
-        s2 = peg$c57;
+        s2 = peg$c56;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c58); }
+        if (peg$silentFails === 0) { peg$fail(peg$c57); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2204,7 +2190,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSequentialProcs();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c59(s4);
+            s1 = peg$c58(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2248,7 +2234,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c60(s1, s2, s3, s4);
+            s1 = peg$c59(s1, s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2274,12 +2260,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c61) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c60) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+      if (peg$silentFails === 0) { peg$fail(peg$c61); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2289,7 +2275,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c63(s3);
+            s1 = peg$c62(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2317,12 +2303,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c64) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c63) {
         s2 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c65); }
+        if (peg$silentFails === 0) { peg$fail(peg$c64); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -2330,7 +2316,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFlexAssignments();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c66(s4);
+            s1 = peg$c65(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2358,22 +2344,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c67) {
-        s2 = peg$c67;
+      if (input.substr(peg$currPos, 4) === peg$c66) {
+        s2 = peg$c66;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c67); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c69) {
-            s4 = peg$c69;
+          if (input.substr(peg$currPos, 6) === peg$c68) {
+            s4 = peg$c68;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c70); }
+            if (peg$silentFails === 0) { peg$fail(peg$c69); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -2381,7 +2367,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c71(s6);
+                s1 = peg$c70(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2420,7 +2406,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72(s1);
+        s1 = peg$c71(s1);
       }
       s0 = s1;
     }
@@ -2439,11 +2425,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2451,7 +2437,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c75(s1, s7);
+              s4 = peg$c74(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2475,11 +2461,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2487,7 +2473,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c75(s1, s7);
+                s4 = peg$c74(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2508,7 +2494,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c76(s1, s2);
+        s1 = peg$c75(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2531,17 +2517,17 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c77;
+          s3 = peg$c76;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c77); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseReducer();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c79(s1, s4);
+            s1 = peg$c78(s1, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2564,7 +2550,7 @@ function peg$parse(input, options) {
       s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1);
+        s1 = peg$c79(s1);
       }
       s0 = s1;
     }
@@ -2578,20 +2564,20 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
-    if (input.substr(peg$currPos, 3) === peg$c81) {
-      s2 = peg$c81;
+    if (input.substr(peg$currPos, 3) === peg$c80) {
+      s2 = peg$c80;
       peg$currPos += 3;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c82); }
+      if (peg$silentFails === 0) { peg$fail(peg$c81); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c27) {
-        s2 = peg$c27;
+      if (input.substr(peg$currPos, 3) === peg$c26) {
+        s2 = peg$c26;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c28); }
+        if (peg$silentFails === 0) { peg$fail(peg$c27); }
       }
     }
     peg$silentFails--;
@@ -2607,11 +2593,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c15;
+            s4 = peg$c14;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c16); }
+            if (peg$silentFails === 0) { peg$fail(peg$c15); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -2624,11 +2610,11 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c17;
+                    s8 = peg$c16;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c17); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$parseWhereClause();
@@ -2637,7 +2623,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c83(s2, s6, s9);
+                      s1 = peg$c82(s2, s6, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -2685,12 +2671,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c84) {
-        s2 = peg$c84;
+      if (input.substr(peg$currPos, 5) === peg$c83) {
+        s2 = peg$c83;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -2698,7 +2684,7 @@ function peg$parse(input, options) {
           s4 = peg$parseConditionalExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c19(s4);
+            s1 = peg$c18(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2731,11 +2717,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2766,11 +2752,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2798,7 +2784,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c86(s1, s2);
+        s1 = peg$c85(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2851,12 +2837,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c87) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c86) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c88); }
+      if (peg$silentFails === 0) { peg$fail(peg$c87); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -2867,7 +2853,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c89(s2, s5);
+            s4 = peg$c88(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2882,7 +2868,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c90(s2, s3);
+          s1 = peg$c89(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2911,7 +2897,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c91(s4);
+        s3 = peg$c90(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -2929,7 +2915,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c91(s4);
+          s3 = peg$c90(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -2942,7 +2928,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c92(s1);
+      s1 = peg$c91(s1);
     }
     s0 = s1;
 
@@ -2953,55 +2939,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c93) {
-      s1 = peg$c93;
+    if (input.substr(peg$currPos, 2) === peg$c92) {
+      s1 = peg$c92;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      if (peg$silentFails === 0) { peg$fail(peg$c93); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c95();
+      s1 = peg$c94();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c96) {
-        s1 = peg$c96;
+      if (input.substr(peg$currPos, 6) === peg$c95) {
+        s1 = peg$c95;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+        if (peg$silentFails === 0) { peg$fail(peg$c96); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c98) {
-            s4 = peg$c98;
+          if (input.substr(peg$currPos, 5) === peg$c97) {
+            s4 = peg$c97;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c99); }
+            if (peg$silentFails === 0) { peg$fail(peg$c98); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c100) {
-              s4 = peg$c100;
+            if (input.substr(peg$currPos, 4) === peg$c99) {
+              s4 = peg$c99;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c101); }
+              if (peg$silentFails === 0) { peg$fail(peg$c100); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c102();
+            s4 = peg$c101();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c103(s3);
+            s1 = peg$c102(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3024,12 +3010,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c104) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c103) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c105); }
+      if (peg$silentFails === 0) { peg$fail(peg$c104); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -3038,7 +3024,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c106(s4);
+          s3 = peg$c105(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3055,12 +3041,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c107) {
-            s5 = peg$c107;
+          if (input.substr(peg$currPos, 6) === peg$c106) {
+            s5 = peg$c106;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c108); }
+            if (peg$silentFails === 0) { peg$fail(peg$c107); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3083,7 +3069,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c109(s2, s3, s6);
+              s5 = peg$c108(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3098,7 +3084,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c110(s2, s3, s4);
+            s1 = peg$c109(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3124,12 +3110,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c111) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c110) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c112); }
+      if (peg$silentFails === 0) { peg$fail(peg$c111); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseCutArgs();
@@ -3139,7 +3125,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFlexAssignments();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c113(s2, s4);
+            s1 = peg$c112(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3169,16 +3155,16 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     s3 = peg$parse_();
     if (s3 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c114) {
-        s4 = peg$c114;
+      if (input.substr(peg$currPos, 2) === peg$c113) {
+        s4 = peg$c113;
         peg$currPos += 2;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c116();
+        s3 = peg$c115();
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3193,16 +3179,16 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c114) {
-          s4 = peg$c114;
+        if (input.substr(peg$currPos, 2) === peg$c113) {
+          s4 = peg$c113;
           peg$currPos += 2;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c116();
+          s3 = peg$c115();
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3215,7 +3201,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c117(s1);
+      s1 = peg$c116(s1);
     }
     s0 = s1;
 
@@ -3226,12 +3212,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c118) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c117) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c119); }
+      if (peg$silentFails === 0) { peg$fail(peg$c118); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3239,7 +3225,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c120(s3);
+          s1 = peg$c119(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3255,16 +3241,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c118) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c117) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c119); }
+        if (peg$silentFails === 0) { peg$fail(peg$c118); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c121();
+        s1 = peg$c120();
       }
       s0 = s1;
     }
@@ -3276,12 +3262,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c122) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c121) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c123); }
+      if (peg$silentFails === 0) { peg$fail(peg$c122); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3289,7 +3275,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c124(s3);
+          s1 = peg$c123(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3305,16 +3291,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c122) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c121) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c123); }
+        if (peg$silentFails === 0) { peg$fail(peg$c122); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c125();
+        s1 = peg$c124();
       }
       s0 = s1;
     }
@@ -3326,12 +3312,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c126) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c125) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c127); }
+      if (peg$silentFails === 0) { peg$fail(peg$c126); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3339,7 +3325,7 @@ function peg$parse(input, options) {
         s3 = peg$parseSearchExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c4(s3);
+          s1 = peg$c3(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3361,26 +3347,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c127) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c129); }
+      if (peg$silentFails === 0) { peg$fail(peg$c128); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c114) {
-          s3 = peg$c114;
+        if (input.substr(peg$currPos, 2) === peg$c113) {
+          s3 = peg$c113;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c130();
+          s1 = peg$c129();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3396,16 +3382,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c127) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c129); }
+        if (peg$silentFails === 0) { peg$fail(peg$c128); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c131();
+        s1 = peg$c130();
       }
       s0 = s1;
     }
@@ -3417,12 +3403,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c132) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c131) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c133); }
+      if (peg$silentFails === 0) { peg$fail(peg$c132); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3430,7 +3416,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c134(s3);
+          s1 = peg$c133(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3452,12 +3438,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c135) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c134) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c136); }
+      if (peg$silentFails === 0) { peg$fail(peg$c135); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3469,11 +3455,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c73;
+              s7 = peg$c72;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c74); }
+              if (peg$silentFails === 0) { peg$fail(peg$c73); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -3481,7 +3467,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c137(s3, s9);
+                  s6 = peg$c136(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -3505,11 +3491,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c73;
+                s7 = peg$c72;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                if (peg$silentFails === 0) { peg$fail(peg$c73); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -3517,7 +3503,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c137(s3, s9);
+                    s6 = peg$c136(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -3538,7 +3524,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c138(s3, s4);
+            s1 = peg$c137(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3564,16 +3550,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c138) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c139); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c141();
+      s1 = peg$c140();
     }
     s0 = s1;
 
@@ -3585,11 +3571,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c142;
+      s1 = peg$c141;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      if (peg$silentFails === 0) { peg$fail(peg$c142); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -3612,7 +3598,7 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifier();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c144(s3);
+          s1 = peg$c143(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3629,11 +3615,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c142;
+        s1 = peg$c141;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
@@ -3648,7 +3634,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c145();
+          s1 = peg$c144();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3674,11 +3660,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3709,11 +3695,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3741,7 +3727,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c146(s1, s2);
+        s1 = peg$c145(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3766,11 +3752,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3801,11 +3787,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3833,7 +3819,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c146(s1, s2);
+        s1 = peg$c145(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3856,11 +3842,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c77;
+          s3 = peg$c76;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c77); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3868,7 +3854,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c147(s1, s5);
+              s1 = peg$c146(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3906,16 +3892,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    s1 = peg$parseLogicalORExpr();
+    s1 = peg$parseLogicalOrExpr();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c148;
+          s3 = peg$c147;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c149); }
+          if (peg$silentFails === 0) { peg$fail(peg$c148); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3925,11 +3911,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c150;
+                  s7 = peg$c149;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c151); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c150); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -3937,7 +3923,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c152(s1, s5, s9);
+                      s1 = peg$c151(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -3976,17 +3962,17 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$parseLogicalORExpr();
+      s0 = peg$parseLogicalOrExpr();
     }
 
     return s0;
   }
 
-  function peg$parseLogicalORExpr() {
+  function peg$parseLogicalOrExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    s1 = peg$parseLogicalANDExpr();
+    s1 = peg$parseLogicalAndExpr();
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
@@ -3996,10 +3982,10 @@ function peg$parse(input, options) {
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
-            s7 = peg$parseLogicalANDExpr();
+            s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c153(s1, s5, s7);
+              s4 = peg$c152(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4026,10 +4012,10 @@ function peg$parse(input, options) {
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
-              s7 = peg$parseLogicalANDExpr();
+              s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c153(s1, s5, s7);
+                s4 = peg$c152(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4050,7 +4036,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c154(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4064,7 +4050,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseLogicalANDExpr() {
+  function peg$parseLogicalAndExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
@@ -4081,7 +4067,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c153(s1, s5, s7);
+              s4 = peg$c152(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4111,7 +4097,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c153(s1, s5, s7);
+                s4 = peg$c152(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4132,7 +4118,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c154(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4163,7 +4149,7 @@ function peg$parse(input, options) {
             s7 = peg$parseRelativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c155(s1, s5, s7);
+              s4 = peg$c154(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4193,7 +4179,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c155(s1, s5, s7);
+                s4 = peg$c154(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4214,7 +4200,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c154(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4232,43 +4218,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c156) {
-      s1 = peg$c156;
+    if (input.substr(peg$currPos, 2) === peg$c155) {
+      s1 = peg$c155;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+      if (peg$silentFails === 0) { peg$fail(peg$c156); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c158) {
-        s1 = peg$c158;
+      if (input.substr(peg$currPos, 2) === peg$c157) {
+        s1 = peg$c157;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c159); }
+        if (peg$silentFails === 0) { peg$fail(peg$c158); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c77;
+          s1 = peg$c76;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c77); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c160) {
-            s1 = peg$c160;
+          if (input.substr(peg$currPos, 2) === peg$c159) {
+            s1 = peg$c159;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c161); }
+            if (peg$silentFails === 0) { peg$fail(peg$c160); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -4281,16 +4267,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c162) {
-        s1 = peg$c162;
+      if (input.substr(peg$currPos, 2) === peg$c161) {
+        s1 = peg$c161;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c162); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c101();
       }
       s0 = s1;
     }
@@ -4315,7 +4301,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c153(s1, s5, s7);
+              s4 = peg$c152(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4345,7 +4331,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c153(s1, s5, s7);
+                s4 = peg$c152(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4366,7 +4352,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c154(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4384,43 +4370,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c164) {
-      s1 = peg$c164;
+    if (input.substr(peg$currPos, 2) === peg$c163) {
+      s1 = peg$c163;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c165); }
+      if (peg$silentFails === 0) { peg$fail(peg$c164); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c166;
+        s1 = peg$c165;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c167); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c168) {
-          s1 = peg$c168;
+        if (input.substr(peg$currPos, 2) === peg$c167) {
+          s1 = peg$c167;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c169); }
+          if (peg$silentFails === 0) { peg$fail(peg$c168); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c170;
+            s1 = peg$c169;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c171); }
+            if (peg$silentFails === 0) { peg$fail(peg$c170); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -4444,7 +4430,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c153(s1, s5, s7);
+              s4 = peg$c152(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4474,7 +4460,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c153(s1, s5, s7);
+                s4 = peg$c152(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4495,7 +4481,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c154(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4514,24 +4500,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c172;
+      s1 = peg$c171;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c173); }
+      if (peg$silentFails === 0) { peg$fail(peg$c172); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c12;
+        s1 = peg$c11;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c13); }
+        if (peg$silentFails === 0) { peg$fail(peg$c12); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -4555,7 +4541,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c153(s1, s5, s7);
+              s4 = peg$c152(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4585,7 +4571,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c153(s1, s5, s7);
+                s4 = peg$c152(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4606,7 +4592,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c154(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4625,24 +4611,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c20;
+      s1 = peg$c19;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c21); }
+      if (peg$silentFails === 0) { peg$fail(peg$c20); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c174;
+        s1 = peg$c173;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+        if (peg$silentFails === 0) { peg$fail(peg$c174); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -4654,11 +4640,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c9;
+      s1 = peg$c8;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c10); }
+      if (peg$silentFails === 0) { peg$fail(peg$c9); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -4666,7 +4652,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s3);
+          s1 = peg$c175(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4695,17 +4681,17 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 58) {
-        s3 = peg$c150;
+        s3 = peg$c149;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c151); }
+        if (peg$silentFails === 0) { peg$fail(peg$c150); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parsePrimitiveType();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c177(s1, s4);
+          s3 = peg$c176(s1, s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4717,7 +4703,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c178(s1, s2);
+        s1 = peg$c177(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4738,172 +4724,172 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c179) {
-      s1 = peg$c179;
+    if (input.substr(peg$currPos, 5) === peg$c178) {
+      s1 = peg$c178;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c180); }
+      if (peg$silentFails === 0) { peg$fail(peg$c179); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c181) {
-        s1 = peg$c181;
+      if (input.substr(peg$currPos, 5) === peg$c180) {
+        s1 = peg$c180;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c182); }
+        if (peg$silentFails === 0) { peg$fail(peg$c181); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c183) {
-          s1 = peg$c183;
+        if (input.substr(peg$currPos, 6) === peg$c182) {
+          s1 = peg$c182;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c184); }
+          if (peg$silentFails === 0) { peg$fail(peg$c183); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c185) {
-            s1 = peg$c185;
+          if (input.substr(peg$currPos, 6) === peg$c184) {
+            s1 = peg$c184;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c186); }
+            if (peg$silentFails === 0) { peg$fail(peg$c185); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c187) {
-              s1 = peg$c187;
+            if (input.substr(peg$currPos, 6) === peg$c186) {
+              s1 = peg$c186;
               peg$currPos += 6;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c188); }
+              if (peg$silentFails === 0) { peg$fail(peg$c187); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4) === peg$c189) {
-                s1 = peg$c189;
+              if (input.substr(peg$currPos, 4) === peg$c188) {
+                s1 = peg$c188;
                 peg$currPos += 4;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c190); }
+                if (peg$silentFails === 0) { peg$fail(peg$c189); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c191) {
-                  s1 = peg$c191;
+                if (input.substr(peg$currPos, 5) === peg$c190) {
+                  s1 = peg$c190;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c192); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c191); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c193) {
-                    s1 = peg$c193;
+                  if (input.substr(peg$currPos, 5) === peg$c192) {
+                    s1 = peg$c192;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c194); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c193); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c195) {
-                      s1 = peg$c195;
+                    if (input.substr(peg$currPos, 5) === peg$c194) {
+                      s1 = peg$c194;
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c195); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 8) === peg$c197) {
-                        s1 = peg$c197;
+                      if (input.substr(peg$currPos, 8) === peg$c196) {
+                        s1 = peg$c196;
                         peg$currPos += 8;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c197); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c199) {
-                          s1 = peg$c199;
+                        if (input.substr(peg$currPos, 4) === peg$c198) {
+                          s1 = peg$c198;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c200); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c199); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 7) === peg$c201) {
-                            s1 = peg$c201;
+                          if (input.substr(peg$currPos, 7) === peg$c200) {
+                            s1 = peg$c200;
                             peg$currPos += 7;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c202); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c201); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 4) === peg$c203) {
-                              s1 = peg$c203;
+                            if (input.substr(peg$currPos, 4) === peg$c202) {
+                              s1 = peg$c202;
                               peg$currPos += 4;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c204); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c203); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 5) === peg$c179) {
-                                s1 = peg$c179;
+                              if (input.substr(peg$currPos, 5) === peg$c178) {
+                                s1 = peg$c178;
                                 peg$currPos += 5;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c180); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c179); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 6) === peg$c205) {
-                                  s1 = peg$c205;
+                                if (input.substr(peg$currPos, 6) === peg$c204) {
+                                  s1 = peg$c204;
                                   peg$currPos += 6;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c206); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c205); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 7) === peg$c207) {
-                                    s1 = peg$c207;
+                                  if (input.substr(peg$currPos, 7) === peg$c206) {
+                                    s1 = peg$c206;
                                     peg$currPos += 7;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c208); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c207); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c209) {
-                                      s1 = peg$c209;
+                                    if (input.substr(peg$currPos, 2) === peg$c208) {
+                                      s1 = peg$c208;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c210); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c209); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c211) {
-                                        s1 = peg$c211;
+                                      if (input.substr(peg$currPos, 3) === peg$c210) {
+                                        s1 = peg$c210;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c212); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c211); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c213) {
-                                          s1 = peg$c213;
+                                        if (input.substr(peg$currPos, 4) === peg$c212) {
+                                          s1 = peg$c212;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c214); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c213); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 5) === peg$c215) {
-                                            s1 = peg$c215;
+                                          if (input.substr(peg$currPos, 5) === peg$c214) {
+                                            s1 = peg$c214;
                                             peg$currPos += 5;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c215); }
                                           }
                                           if (s1 === peg$FAILED) {
-                                            if (input.substr(peg$currPos, 4) === peg$c48) {
-                                              s1 = peg$c48;
+                                            if (input.substr(peg$currPos, 4) === peg$c47) {
+                                              s1 = peg$c47;
                                               peg$currPos += 4;
                                             } else {
                                               s1 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                              if (peg$silentFails === 0) { peg$fail(peg$c48); }
                                             }
                                           }
                                         }
@@ -4927,7 +4913,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -4948,7 +4934,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c217(s1, s2);
+        s1 = peg$c216(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4977,25 +4963,25 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c15;
+          s3 = peg$c14;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          if (peg$silentFails === 0) { peg$fail(peg$c15); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseArgumentList();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c17;
+              s5 = peg$c16;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c18); }
+              if (peg$silentFails === 0) { peg$fail(peg$c17); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c218(s1, s4);
+              s1 = peg$c217(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5035,7 +5021,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c101();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5052,12 +5038,12 @@ function peg$parse(input, options) {
   function peg$parseFuncNameStart() {
     var s0;
 
-    if (peg$c219.test(input.charAt(peg$currPos))) {
+    if (peg$c218.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c220); }
+      if (peg$silentFails === 0) { peg$fail(peg$c219); }
     }
 
     return s0;
@@ -5068,12 +5054,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseFuncNameStart();
     if (s0 === peg$FAILED) {
-      if (peg$c221.test(input.charAt(peg$currPos))) {
+      if (peg$c220.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c222); }
+        if (peg$silentFails === 0) { peg$fail(peg$c221); }
       }
     }
 
@@ -5091,11 +5077,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5103,7 +5089,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c223(s1, s7);
+              s4 = peg$c222(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5127,11 +5113,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5139,7 +5125,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c223(s1, s7);
+                s4 = peg$c222(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5160,7 +5146,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c76(s1, s2);
+        s1 = peg$c75(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5175,7 +5161,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c224();
+        s1 = peg$c223();
       }
       s0 = s1;
     }
@@ -5197,7 +5183,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c217(s1, s2);
+        s1 = peg$c216(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5216,25 +5202,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c225;
+      s1 = peg$c224;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+      if (peg$silentFails === 0) { peg$fail(peg$c225); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseConditionalExpr();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c227;
+          s3 = peg$c226;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c228); }
+          if (peg$silentFails === 0) { peg$fail(peg$c227); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c229(s2);
+          s1 = peg$c228(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5251,21 +5237,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c142;
+        s1 = peg$c141;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c142;
+          s3 = peg$c141;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c143); }
+          if (peg$silentFails === 0) { peg$fail(peg$c142); }
         }
         peg$silentFails--;
         if (s3 === peg$FAILED) {
@@ -5278,7 +5264,7 @@ function peg$parse(input, options) {
           s3 = peg$parseIdentifier();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c230(s3);
+            s1 = peg$c229(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5318,11 +5304,11 @@ function peg$parse(input, options) {
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 40) {
-                      s1 = peg$c15;
+                      s1 = peg$c14;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c15); }
                     }
                     if (s1 !== peg$FAILED) {
                       s2 = peg$parse__();
@@ -5332,15 +5318,15 @@ function peg$parse(input, options) {
                           s4 = peg$parse__();
                           if (s4 !== peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 41) {
-                              s5 = peg$c17;
+                              s5 = peg$c16;
                               peg$currPos++;
                             } else {
                               s5 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c17); }
                             }
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c19(s3);
+                              s1 = peg$c18(s3);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -5389,16 +5375,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c231) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c230) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c232); }
+      if (peg$silentFails === 0) { peg$fail(peg$c231); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -5409,16 +5395,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c233) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c232) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
+      if (peg$silentFails === 0) { peg$fail(peg$c233); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -5429,16 +5415,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c162) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c161) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c234); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -5449,16 +5435,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c81) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c80) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c236); }
+      if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -5468,12 +5454,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c237.test(input.charAt(peg$currPos))) {
+    if (peg$c236.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c237); }
     }
 
     return s0;
@@ -5484,12 +5470,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c239.test(input.charAt(peg$currPos))) {
+      if (peg$c238.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c240); }
+        if (peg$silentFails === 0) { peg$fail(peg$c239); }
       }
     }
 
@@ -5510,7 +5496,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c241();
+        s1 = peg$c240();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5538,12 +5524,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c231) {
-                s3 = peg$c231;
+              if (input.substr(peg$currPos, 3) === peg$c230) {
+                s3 = peg$c230;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c242); }
+                if (peg$silentFails === 0) { peg$fail(peg$c241); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -5588,44 +5574,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c243) {
-      s0 = peg$c243;
+    if (input.substr(peg$currPos, 7) === peg$c242) {
+      s0 = peg$c242;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c243); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c245) {
-        s0 = peg$c245;
+      if (input.substr(peg$currPos, 6) === peg$c244) {
+        s0 = peg$c244;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c246); }
+        if (peg$silentFails === 0) { peg$fail(peg$c245); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c247) {
-          s0 = peg$c247;
+        if (input.substr(peg$currPos, 4) === peg$c246) {
+          s0 = peg$c246;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c248); }
+          if (peg$silentFails === 0) { peg$fail(peg$c247); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c249) {
-            s0 = peg$c249;
+          if (input.substr(peg$currPos, 3) === peg$c248) {
+            s0 = peg$c248;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c250); }
+            if (peg$silentFails === 0) { peg$fail(peg$c249); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c251;
+              s0 = peg$c250;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c252); }
+              if (peg$silentFails === 0) { peg$fail(peg$c251); }
             }
           }
         }
@@ -5638,44 +5624,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c253) {
-      s0 = peg$c253;
+    if (input.substr(peg$currPos, 7) === peg$c252) {
+      s0 = peg$c252;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c254); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c255) {
-        s0 = peg$c255;
+      if (input.substr(peg$currPos, 6) === peg$c254) {
+        s0 = peg$c254;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c256); }
+        if (peg$silentFails === 0) { peg$fail(peg$c255); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c257) {
-          s0 = peg$c257;
+        if (input.substr(peg$currPos, 4) === peg$c256) {
+          s0 = peg$c256;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c258); }
+          if (peg$silentFails === 0) { peg$fail(peg$c257); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c259) {
-            s0 = peg$c259;
+          if (input.substr(peg$currPos, 3) === peg$c258) {
+            s0 = peg$c258;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c260); }
+            if (peg$silentFails === 0) { peg$fail(peg$c259); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c261;
+              s0 = peg$c260;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c262); }
+              if (peg$silentFails === 0) { peg$fail(peg$c261); }
             }
           }
         }
@@ -5688,44 +5674,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c263) {
-      s0 = peg$c263;
+    if (input.substr(peg$currPos, 5) === peg$c262) {
+      s0 = peg$c262;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c263); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c265) {
-        s0 = peg$c265;
+      if (input.substr(peg$currPos, 3) === peg$c264) {
+        s0 = peg$c264;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+        if (peg$silentFails === 0) { peg$fail(peg$c265); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c267) {
-          s0 = peg$c267;
+        if (input.substr(peg$currPos, 2) === peg$c266) {
+          s0 = peg$c266;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c268); }
+          if (peg$silentFails === 0) { peg$fail(peg$c267); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c269;
+            s0 = peg$c268;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c270); }
+            if (peg$silentFails === 0) { peg$fail(peg$c269); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c271) {
-              s0 = peg$c271;
+            if (input.substr(peg$currPos, 4) === peg$c270) {
+              s0 = peg$c270;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c272); }
+              if (peg$silentFails === 0) { peg$fail(peg$c271); }
             }
           }
         }
@@ -5738,28 +5724,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c273) {
-      s0 = peg$c273;
+    if (input.substr(peg$currPos, 4) === peg$c272) {
+      s0 = peg$c272;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c274); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c275) {
-        s0 = peg$c275;
+      if (input.substr(peg$currPos, 3) === peg$c274) {
+        s0 = peg$c274;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c276); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c277;
+          s0 = peg$c276;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c278); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
       }
     }
@@ -5770,44 +5756,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c279) {
-      s0 = peg$c279;
+    if (input.substr(peg$currPos, 5) === peg$c278) {
+      s0 = peg$c278;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c281) {
-        s0 = peg$c281;
+      if (input.substr(peg$currPos, 4) === peg$c280) {
+        s0 = peg$c280;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c281); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c283) {
-          s0 = peg$c283;
+        if (input.substr(peg$currPos, 3) === peg$c282) {
+          s0 = peg$c282;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c284); }
+          if (peg$silentFails === 0) { peg$fail(peg$c283); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c285) {
-            s0 = peg$c285;
+          if (input.substr(peg$currPos, 2) === peg$c284) {
+            s0 = peg$c284;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c286); }
+            if (peg$silentFails === 0) { peg$fail(peg$c285); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c287;
+              s0 = peg$c286;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c288); }
+              if (peg$silentFails === 0) { peg$fail(peg$c287); }
             }
           }
         }
@@ -5821,16 +5807,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c245) {
-      s1 = peg$c245;
+    if (input.substr(peg$currPos, 6) === peg$c244) {
+      s1 = peg$c244;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c245); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c289();
+      s1 = peg$c288();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5842,7 +5828,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c290(s1);
+            s1 = peg$c289(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5865,16 +5851,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c255) {
-      s1 = peg$c255;
+    if (input.substr(peg$currPos, 6) === peg$c254) {
+      s1 = peg$c254;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c256); }
+      if (peg$silentFails === 0) { peg$fail(peg$c255); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c291();
+      s1 = peg$c290();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5886,7 +5872,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c292(s1);
+            s1 = peg$c291(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5909,16 +5895,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c271) {
-      s1 = peg$c271;
+    if (input.substr(peg$currPos, 4) === peg$c270) {
+      s1 = peg$c270;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c272); }
+      if (peg$silentFails === 0) { peg$fail(peg$c271); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c293();
+      s1 = peg$c292();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5930,7 +5916,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c294(s1);
+            s1 = peg$c293(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5953,16 +5939,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c275) {
-      s1 = peg$c275;
+    if (input.substr(peg$currPos, 3) === peg$c274) {
+      s1 = peg$c274;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c276); }
+      if (peg$silentFails === 0) { peg$fail(peg$c275); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c295();
+      s1 = peg$c294();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5974,7 +5960,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c296(s1);
+            s1 = peg$c295(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5997,16 +5983,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c281) {
-      s1 = peg$c281;
+    if (input.substr(peg$currPos, 4) === peg$c280) {
+      s1 = peg$c280;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c281); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c297();
+      s1 = peg$c296();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6018,7 +6004,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c298(s1);
+            s1 = peg$c297(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6044,37 +6030,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c142;
+        s2 = peg$c141;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c142;
+            s4 = peg$c141;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c143); }
+            if (peg$silentFails === 0) { peg$fail(peg$c142); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c142;
+                s6 = peg$c141;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c143); }
+                if (peg$silentFails === 0) { peg$fail(peg$c142); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c102();
+                  s1 = peg$c101();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6126,7 +6112,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c298(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6147,12 +6133,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c300) {
-            s3 = peg$c300;
+          if (input.substr(peg$currPos, 2) === peg$c299) {
+            s3 = peg$c299;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c301); }
+            if (peg$silentFails === 0) { peg$fail(peg$c300); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6165,7 +6151,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c302(s1, s2, s4, s5);
+                s1 = peg$c301(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6189,12 +6175,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c300) {
-          s1 = peg$c300;
+        if (input.substr(peg$currPos, 2) === peg$c299) {
+          s1 = peg$c299;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c301); }
+          if (peg$silentFails === 0) { peg$fail(peg$c300); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6207,7 +6193,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c303(s2, s3);
+              s1 = peg$c302(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6232,16 +6218,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c300) {
-                s3 = peg$c300;
+              if (input.substr(peg$currPos, 2) === peg$c299) {
+                s3 = peg$c299;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c301); }
+                if (peg$silentFails === 0) { peg$fail(peg$c300); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c304(s1, s2);
+                s1 = peg$c303(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6257,16 +6243,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c300) {
-              s1 = peg$c300;
+            if (input.substr(peg$currPos, 2) === peg$c299) {
+              s1 = peg$c299;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c301); }
+              if (peg$silentFails === 0) { peg$fail(peg$c300); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c305();
+              s1 = peg$c304();
             }
             s0 = s1;
           }
@@ -6293,17 +6279,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c150;
+      s1 = peg$c149;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      if (peg$silentFails === 0) { peg$fail(peg$c150); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c306(s2);
+        s1 = peg$c305(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6324,15 +6310,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c150;
+        s2 = peg$c149;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c151); }
+        if (peg$silentFails === 0) { peg$fail(peg$c150); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c307(s1);
+        s1 = peg$c306(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6346,24 +6332,24 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseIPNet() {
+  function peg$parseIP4Net() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c174;
+        s2 = peg$c173;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+        if (peg$silentFails === 0) { peg$fail(peg$c174); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c308(s1, s3);
+          s1 = peg$c307(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6388,17 +6374,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c174;
+        s2 = peg$c173;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+        if (peg$silentFails === 0) { peg$fail(peg$c174); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c309(s1, s3);
+          s1 = peg$c308(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6423,7 +6409,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c310(s1);
+      s1 = peg$c309(s1);
     }
     s0 = s1;
 
@@ -6446,22 +6432,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c239.test(input.charAt(peg$currPos))) {
+    if (peg$c238.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      if (peg$silentFails === 0) { peg$fail(peg$c239); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c239.test(input.charAt(peg$currPos))) {
+        if (peg$c238.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          if (peg$silentFails === 0) { peg$fail(peg$c239); }
         }
       }
     } else {
@@ -6469,7 +6455,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -6481,17 +6467,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c12;
+      s1 = peg$c11;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c13); }
+      if (peg$silentFails === 0) { peg$fail(peg$c12); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c101();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6510,33 +6496,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c12;
+      s1 = peg$c11;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c13); }
+      if (peg$silentFails === 0) { peg$fail(peg$c12); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c239.test(input.charAt(peg$currPos))) {
+      if (peg$c238.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c240); }
+        if (peg$silentFails === 0) { peg$fail(peg$c239); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c239.test(input.charAt(peg$currPos))) {
+          if (peg$c238.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c239); }
           }
         }
       } else {
@@ -6544,30 +6530,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c142;
+          s3 = peg$c141;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c143); }
+          if (peg$silentFails === 0) { peg$fail(peg$c142); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c239.test(input.charAt(peg$currPos))) {
+          if (peg$c238.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c239); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c239.test(input.charAt(peg$currPos))) {
+              if (peg$c238.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c240); }
+                if (peg$silentFails === 0) { peg$fail(peg$c239); }
               }
             }
           } else {
@@ -6580,7 +6566,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311();
+              s1 = peg$c310();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6605,41 +6591,41 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c12;
+        s1 = peg$c11;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c13); }
+        if (peg$silentFails === 0) { peg$fail(peg$c12); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c142;
+          s2 = peg$c141;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c143); }
+          if (peg$silentFails === 0) { peg$fail(peg$c142); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c239.test(input.charAt(peg$currPos))) {
+          if (peg$c238.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c239); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c239.test(input.charAt(peg$currPos))) {
+              if (peg$c238.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c240); }
+                if (peg$silentFails === 0) { peg$fail(peg$c239); }
               }
             }
           } else {
@@ -6652,7 +6638,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311();
+              s1 = peg$c310();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6679,20 +6665,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c312) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c311) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c313); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c314.test(input.charAt(peg$currPos))) {
+      if (peg$c313.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c315); }
+        if (peg$silentFails === 0) { peg$fail(peg$c314); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -6734,7 +6720,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -6744,12 +6730,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c316.test(input.charAt(peg$currPos))) {
+    if (peg$c315.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c317); }
+      if (peg$silentFails === 0) { peg$fail(peg$c316); }
     }
 
     return s0;
@@ -6771,7 +6757,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c318(s1);
+      s1 = peg$c317(s1);
     }
     s0 = s1;
 
@@ -6783,11 +6769,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c319;
+      s1 = peg$c318;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c320); }
+      if (peg$silentFails === 0) { peg$fail(peg$c319); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
@@ -6796,7 +6782,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c14(s2);
+        s1 = peg$c13(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6810,12 +6796,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c321.test(input.charAt(peg$currPos))) {
+      if (peg$c320.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        if (peg$silentFails === 0) { peg$fail(peg$c321); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseWhiteSpace();
@@ -6833,11 +6819,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c323); }
+          if (peg$silentFails === 0) { peg$fail(peg$c322); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c102();
+          s1 = peg$c101();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6857,11 +6843,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c324;
+      s1 = peg$c323;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c324); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -6872,15 +6858,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c324;
+          s3 = peg$c323;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c325); }
+          if (peg$silentFails === 0) { peg$fail(peg$c324); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c326(s2);
+          s1 = peg$c325(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6897,11 +6883,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c327;
+        s1 = peg$c326;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c328); }
+        if (peg$silentFails === 0) { peg$fail(peg$c327); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -6912,15 +6898,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c327;
+            s3 = peg$c326;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c328); }
+            if (peg$silentFails === 0) { peg$fail(peg$c327); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c326(s2);
+            s1 = peg$c325(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6946,11 +6932,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c324;
+      s2 = peg$c323;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c324); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -6968,11 +6954,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c323); }
+        if (peg$silentFails === 0) { peg$fail(peg$c322); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c101();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6985,17 +6971,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c319;
+        s1 = peg$c318;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c320); }
+        if (peg$silentFails === 0) { peg$fail(peg$c319); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c14(s2);
+          s1 = peg$c13(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7017,11 +7003,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c327;
+      s2 = peg$c326;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c327); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -7039,11 +7025,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c323); }
+        if (peg$silentFails === 0) { peg$fail(peg$c322); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c101();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7056,17 +7042,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c319;
+        s1 = peg$c318;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c320); }
+        if (peg$silentFails === 0) { peg$fail(peg$c319); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c14(s2);
+          s1 = peg$c13(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7086,11 +7072,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c329;
+      s1 = peg$c328;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c329); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -7098,7 +7084,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c331();
+          s1 = peg$c330();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7126,110 +7112,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c327;
+      s0 = peg$c326;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c327); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c324;
+        s0 = peg$c323;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c325); }
+        if (peg$silentFails === 0) { peg$fail(peg$c324); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c319;
+          s0 = peg$c318;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c320); }
+          if (peg$silentFails === 0) { peg$fail(peg$c319); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c332;
+            s1 = peg$c331;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c333); }
+            if (peg$silentFails === 0) { peg$fail(peg$c332); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c334();
+            s1 = peg$c333();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c335;
+              s1 = peg$c334;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c336); }
+              if (peg$silentFails === 0) { peg$fail(peg$c335); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c337();
+              s1 = peg$c336();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c338;
+                s1 = peg$c337;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c339); }
+                if (peg$silentFails === 0) { peg$fail(peg$c338); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c340();
+                s1 = peg$c339();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c341;
+                  s1 = peg$c340;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c342); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c341); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c343();
+                  s1 = peg$c342();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c344;
+                    s1 = peg$c343;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c345); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c344); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c346();
+                    s1 = peg$c345();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c347;
+                      s1 = peg$c346;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c347); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c349();
+                      s1 = peg$c348();
                     }
                     s0 = s1;
                   }
@@ -7249,29 +7235,29 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c77;
+      s1 = peg$c76;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c78); }
+      if (peg$silentFails === 0) { peg$fail(peg$c77); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c350();
+      s1 = peg$c349();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c20;
+        s1 = peg$c19;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c21); }
+        if (peg$silentFails === 0) { peg$fail(peg$c20); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c351();
+        s1 = peg$c350();
       }
       s0 = s1;
     }
@@ -7284,11 +7270,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c352;
+      s1 = peg$c351;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7320,7 +7306,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c354(s2);
+        s1 = peg$c353(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7333,19 +7319,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c352;
+        s1 = peg$c351;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c353); }
+        if (peg$silentFails === 0) { peg$fail(peg$c352); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c355;
+          s2 = peg$c354;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c356); }
+          if (peg$silentFails === 0) { peg$fail(peg$c355); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7404,15 +7390,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c357;
+              s4 = peg$c356;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c358); }
+              if (peg$silentFails === 0) { peg$fail(peg$c357); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c354(s3);
+              s1 = peg$c353(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7440,25 +7426,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c174;
+      s1 = peg$c173;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c175); }
+      if (peg$silentFails === 0) { peg$fail(peg$c174); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c174;
+          s3 = peg$c173;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c175); }
+          if (peg$silentFails === 0) { peg$fail(peg$c174); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c359(s2);
+          s1 = peg$c358(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7481,39 +7467,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c360.test(input.charAt(peg$currPos))) {
+    if (peg$c359.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c362) {
-        s2 = peg$c362;
+      if (input.substr(peg$currPos, 2) === peg$c361) {
+        s2 = peg$c361;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c363); }
+        if (peg$silentFails === 0) { peg$fail(peg$c362); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c360.test(input.charAt(peg$currPos))) {
+        if (peg$c359.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c361); }
+          if (peg$silentFails === 0) { peg$fail(peg$c360); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c362) {
-            s2 = peg$c362;
+          if (input.substr(peg$currPos, 2) === peg$c361) {
+            s2 = peg$c361;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c363); }
+            if (peg$silentFails === 0) { peg$fail(peg$c362); }
           }
         }
       }
@@ -7522,7 +7508,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -7532,12 +7518,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c364.test(input.charAt(peg$currPos))) {
+    if (peg$c363.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
 
     return s0;
@@ -7547,51 +7533,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c366;
+      s0 = peg$c365;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c368;
+        s0 = peg$c367;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c369); }
+        if (peg$silentFails === 0) { peg$fail(peg$c368); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c370;
+          s0 = peg$c369;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c371); }
+          if (peg$silentFails === 0) { peg$fail(peg$c370); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c372;
+            s0 = peg$c371;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c373); }
+            if (peg$silentFails === 0) { peg$fail(peg$c372); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c374;
+              s0 = peg$c373;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c375); }
+              if (peg$silentFails === 0) { peg$fail(peg$c374); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c376;
+                s0 = peg$c375;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c377); }
+                if (peg$silentFails === 0) { peg$fail(peg$c376); }
               }
             }
           }
@@ -7642,7 +7628,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c323); }
+      if (peg$silentFails === 0) { peg$fail(peg$c322); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -827,11 +827,11 @@ function peg$parse(input, options) {
       peg$c356 = peg$literalExpectation("{", false),
       peg$c357 = "}",
       peg$c358 = peg$literalExpectation("}", false),
-      peg$c359 = /^[^\/\\]/,
-      peg$c360 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c361 = "\\/",
-      peg$c362 = peg$literalExpectation("\\/", false),
-      peg$c363 = function(body) { return body },
+      peg$c359 = function(body) { return body },
+      peg$c360 = /^[^\/\\]/,
+      peg$c361 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c362 = "\\/",
+      peg$c363 = peg$literalExpectation("\\/", false),
       peg$c364 = /^[\0-\x1F\\]/,
       peg$c365 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
       peg$c366 = "\t",
@@ -7447,46 +7447,7 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      if (peg$c359.test(input.charAt(peg$currPos))) {
-        s3 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c360); }
-      }
-      if (s3 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c361) {
-          s3 = peg$c361;
-          peg$currPos += 2;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c362); }
-        }
-      }
-      if (s3 !== peg$FAILED) {
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          if (peg$c359.test(input.charAt(peg$currPos))) {
-            s3 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c360); }
-          }
-          if (s3 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c361) {
-              s3 = peg$c361;
-              peg$currPos += 2;
-            } else {
-              s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c362); }
-            }
-          }
-        }
-      } else {
-        s2 = peg$FAILED;
-      }
+      s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
           s3 = peg$c174;
@@ -7497,7 +7458,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c363(s2);
+          s1 = peg$c359(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7511,6 +7472,59 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+
+    return s0;
+  }
+
+  function peg$parseRegexpBody() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = [];
+    if (peg$c360.test(input.charAt(peg$currPos))) {
+      s2 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s2 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+    }
+    if (s2 === peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c362) {
+        s2 = peg$c362;
+        peg$currPos += 2;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c363); }
+      }
+    }
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        if (peg$c360.test(input.charAt(peg$currPos))) {
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c361); }
+        }
+        if (s2 === peg$FAILED) {
+          if (input.substr(peg$currPos, 2) === peg$c362) {
+            s2 = peg$c362;
+            peg$currPos += 2;
+          } else {
+            s2 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c363); }
+          }
+        }
+      }
+    } else {
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c102();
+    }
+    s0 = s1;
 
     return s0;
   }

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -104,32 +104,20 @@ var g = &grammar{
 							},
 						},
 					},
-					&actionExpr{
-						pos: position{line: 24, col: 5, offset: 631},
-						run: (*parser).callonQuery13,
-						expr: &labeledExpr{
-							pos:   position{line: 24, col: 5, offset: 631},
-							label: "s",
-							expr: &ruleRefExpr{
-								pos:  position{line: 24, col: 7, offset: 633},
-								name: "Search",
-							},
-						},
-					},
 				},
 			},
 		},
 		{
 			name: "Search",
-			pos:  position{line: 29, col: 1, offset: 808},
+			pos:  position{line: 25, col: 1, offset: 628},
 			expr: &actionExpr{
-				pos: position{line: 30, col: 5, offset: 819},
+				pos: position{line: 26, col: 5, offset: 639},
 				run: (*parser).callonSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 30, col: 5, offset: 819},
+					pos:   position{line: 26, col: 5, offset: 639},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 30, col: 10, offset: 824},
+						pos:  position{line: 26, col: 10, offset: 644},
 						name: "SearchExpr",
 					},
 				},
@@ -137,28 +125,28 @@ var g = &grammar{
 		},
 		{
 			name: "SearchExpr",
-			pos:  position{line: 34, col: 1, offset: 921},
+			pos:  position{line: 30, col: 1, offset: 741},
 			expr: &actionExpr{
-				pos: position{line: 35, col: 5, offset: 936},
+				pos: position{line: 31, col: 5, offset: 756},
 				run: (*parser).callonSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 35, col: 5, offset: 936},
+					pos: position{line: 31, col: 5, offset: 756},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 35, col: 5, offset: 936},
+							pos:   position{line: 31, col: 5, offset: 756},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 35, col: 11, offset: 942},
+								pos:  position{line: 31, col: 11, offset: 762},
 								name: "SearchTerm",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 35, col: 22, offset: 953},
+							pos:   position{line: 31, col: 22, offset: 773},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 35, col: 27, offset: 958},
+								pos: position{line: 31, col: 27, offset: 778},
 								expr: &ruleRefExpr{
-									pos:  position{line: 35, col: 27, offset: 958},
+									pos:  position{line: 31, col: 27, offset: 778},
 									name: "OredSearchTerm",
 								},
 							},
@@ -169,30 +157,30 @@ var g = &grammar{
 		},
 		{
 			name: "OredSearchTerm",
-			pos:  position{line: 39, col: 1, offset: 1037},
+			pos:  position{line: 35, col: 1, offset: 857},
 			expr: &actionExpr{
-				pos: position{line: 39, col: 18, offset: 1054},
+				pos: position{line: 35, col: 18, offset: 874},
 				run: (*parser).callonOredSearchTerm1,
 				expr: &seqExpr{
-					pos: position{line: 39, col: 18, offset: 1054},
+					pos: position{line: 35, col: 18, offset: 874},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 39, col: 18, offset: 1054},
+							pos:  position{line: 35, col: 18, offset: 874},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 39, col: 20, offset: 1056},
+							pos:  position{line: 35, col: 20, offset: 876},
 							name: "OrToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 39, col: 28, offset: 1064},
+							pos:  position{line: 35, col: 28, offset: 884},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 39, col: 30, offset: 1066},
+							pos:   position{line: 35, col: 30, offset: 886},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 39, col: 32, offset: 1068},
+								pos:  position{line: 35, col: 32, offset: 888},
 								name: "SearchTerm",
 							},
 						},
@@ -202,28 +190,28 @@ var g = &grammar{
 		},
 		{
 			name: "SearchTerm",
-			pos:  position{line: 41, col: 1, offset: 1098},
+			pos:  position{line: 37, col: 1, offset: 918},
 			expr: &actionExpr{
-				pos: position{line: 42, col: 5, offset: 1113},
+				pos: position{line: 38, col: 5, offset: 933},
 				run: (*parser).callonSearchTerm1,
 				expr: &seqExpr{
-					pos: position{line: 42, col: 5, offset: 1113},
+					pos: position{line: 38, col: 5, offset: 933},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 42, col: 5, offset: 1113},
+							pos:   position{line: 38, col: 5, offset: 933},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 42, col: 11, offset: 1119},
+								pos:  position{line: 38, col: 11, offset: 939},
 								name: "SearchFactor",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 42, col: 24, offset: 1132},
+							pos:   position{line: 38, col: 24, offset: 952},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 42, col: 29, offset: 1137},
+								pos: position{line: 38, col: 29, offset: 957},
 								expr: &ruleRefExpr{
-									pos:  position{line: 42, col: 29, offset: 1137},
+									pos:  position{line: 38, col: 29, offset: 957},
 									name: "AndedSearchTerm",
 								},
 							},
@@ -234,38 +222,38 @@ var g = &grammar{
 		},
 		{
 			name: "AndedSearchTerm",
-			pos:  position{line: 46, col: 1, offset: 1218},
+			pos:  position{line: 42, col: 1, offset: 1038},
 			expr: &actionExpr{
-				pos: position{line: 46, col: 19, offset: 1236},
+				pos: position{line: 42, col: 19, offset: 1056},
 				run: (*parser).callonAndedSearchTerm1,
 				expr: &seqExpr{
-					pos: position{line: 46, col: 19, offset: 1236},
+					pos: position{line: 42, col: 19, offset: 1056},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 46, col: 19, offset: 1236},
+							pos:  position{line: 42, col: 19, offset: 1056},
 							name: "_",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 46, col: 21, offset: 1238},
+							pos: position{line: 42, col: 21, offset: 1058},
 							expr: &seqExpr{
-								pos: position{line: 46, col: 22, offset: 1239},
+								pos: position{line: 42, col: 22, offset: 1059},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 46, col: 22, offset: 1239},
+										pos:  position{line: 42, col: 22, offset: 1059},
 										name: "AndToken",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 46, col: 31, offset: 1248},
+										pos:  position{line: 42, col: 31, offset: 1068},
 										name: "_",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 46, col: 35, offset: 1252},
+							pos:   position{line: 42, col: 35, offset: 1072},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 46, col: 37, offset: 1254},
+								pos:  position{line: 42, col: 37, offset: 1074},
 								name: "SearchFactor",
 							},
 						},
@@ -275,42 +263,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchFactor",
-			pos:  position{line: 48, col: 1, offset: 1286},
+			pos:  position{line: 44, col: 1, offset: 1106},
 			expr: &choiceExpr{
-				pos: position{line: 49, col: 5, offset: 1303},
+				pos: position{line: 45, col: 5, offset: 1123},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 49, col: 5, offset: 1303},
+						pos: position{line: 45, col: 5, offset: 1123},
 						run: (*parser).callonSearchFactor2,
 						expr: &seqExpr{
-							pos: position{line: 49, col: 5, offset: 1303},
+							pos: position{line: 45, col: 5, offset: 1123},
 							exprs: []interface{}{
 								&choiceExpr{
-									pos: position{line: 49, col: 6, offset: 1304},
+									pos: position{line: 45, col: 6, offset: 1124},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 49, col: 6, offset: 1304},
+											pos: position{line: 45, col: 6, offset: 1124},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 49, col: 6, offset: 1304},
+													pos:  position{line: 45, col: 6, offset: 1124},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 49, col: 15, offset: 1313},
+													pos:  position{line: 45, col: 15, offset: 1133},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 49, col: 19, offset: 1317},
+											pos: position{line: 45, col: 19, offset: 1137},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 49, col: 19, offset: 1317},
+													pos:        position{line: 45, col: 19, offset: 1137},
 													val:        "!",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 49, col: 23, offset: 1321},
+													pos:  position{line: 45, col: 23, offset: 1141},
 													name: "__",
 												},
 											},
@@ -318,10 +306,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 49, col: 27, offset: 1325},
+									pos:   position{line: 45, col: 27, offset: 1145},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 49, col: 29, offset: 1327},
+										pos:  position{line: 45, col: 29, offset: 1147},
 										name: "SearchExpr",
 									},
 								},
@@ -329,24 +317,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 52, col: 5, offset: 1422},
+						pos: position{line: 48, col: 5, offset: 1242},
 						run: (*parser).callonSearchFactor13,
 						expr: &seqExpr{
-							pos: position{line: 52, col: 5, offset: 1422},
+							pos: position{line: 48, col: 5, offset: 1242},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 52, col: 5, offset: 1422},
+									pos: position{line: 48, col: 5, offset: 1242},
 									expr: &litMatcher{
-										pos:        position{line: 52, col: 7, offset: 1424},
+										pos:        position{line: 48, col: 7, offset: 1244},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 52, col: 12, offset: 1429},
+									pos:   position{line: 48, col: 12, offset: 1249},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 52, col: 14, offset: 1431},
+										pos:  position{line: 48, col: 14, offset: 1251},
 										name: "SearchPred",
 									},
 								},
@@ -354,34 +342,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 53, col: 5, offset: 1464},
+						pos: position{line: 49, col: 5, offset: 1284},
 						run: (*parser).callonSearchFactor19,
 						expr: &seqExpr{
-							pos: position{line: 53, col: 5, offset: 1464},
+							pos: position{line: 49, col: 5, offset: 1284},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 53, col: 5, offset: 1464},
+									pos:        position{line: 49, col: 5, offset: 1284},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 53, col: 9, offset: 1468},
+									pos:  position{line: 49, col: 9, offset: 1288},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 53, col: 12, offset: 1471},
+									pos:   position{line: 49, col: 12, offset: 1291},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 53, col: 17, offset: 1476},
+										pos:  position{line: 49, col: 17, offset: 1296},
 										name: "SearchExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 53, col: 28, offset: 1487},
+									pos:  position{line: 49, col: 28, offset: 1307},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 53, col: 31, offset: 1490},
+									pos:        position{line: 49, col: 31, offset: 1310},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -393,42 +381,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchPred",
-			pos:  position{line: 55, col: 1, offset: 1516},
+			pos:  position{line: 51, col: 1, offset: 1336},
 			expr: &choiceExpr{
-				pos: position{line: 56, col: 5, offset: 1531},
+				pos: position{line: 52, col: 5, offset: 1351},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 56, col: 5, offset: 1531},
+						pos: position{line: 52, col: 5, offset: 1351},
 						run: (*parser).callonSearchPred2,
 						expr: &seqExpr{
-							pos: position{line: 56, col: 5, offset: 1531},
+							pos: position{line: 52, col: 5, offset: 1351},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 56, col: 5, offset: 1531},
+									pos:        position{line: 52, col: 5, offset: 1351},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 9, offset: 1535},
+									pos:  position{line: 52, col: 9, offset: 1355},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 56, col: 12, offset: 1538},
+									pos:   position{line: 52, col: 12, offset: 1358},
 									label: "comp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 56, col: 17, offset: 1543},
+										pos:  position{line: 52, col: 17, offset: 1363},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 56, col: 31, offset: 1557},
+									pos:  position{line: 52, col: 31, offset: 1377},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 56, col: 34, offset: 1560},
+									pos:   position{line: 52, col: 34, offset: 1380},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 56, col: 36, offset: 1562},
+										pos:  position{line: 52, col: 36, offset: 1382},
 										name: "SearchValue",
 									},
 								},
@@ -436,37 +424,37 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 59, col: 5, offset: 1699},
+						pos: position{line: 55, col: 5, offset: 1519},
 						run: (*parser).callonSearchPred11,
 						expr: &seqExpr{
-							pos: position{line: 59, col: 5, offset: 1699},
+							pos: position{line: 55, col: 5, offset: 1519},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 59, col: 5, offset: 1699},
+									pos:        position{line: 55, col: 5, offset: 1519},
 									val:        "**",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 59, col: 10, offset: 1704},
+									pos:  position{line: 55, col: 10, offset: 1524},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 59, col: 13, offset: 1707},
+									pos:   position{line: 55, col: 13, offset: 1527},
 									label: "comp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 59, col: 18, offset: 1712},
+										pos:  position{line: 55, col: 18, offset: 1532},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 59, col: 32, offset: 1726},
+									pos:  position{line: 55, col: 32, offset: 1546},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 59, col: 35, offset: 1729},
+									pos:   position{line: 55, col: 35, offset: 1549},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 59, col: 37, offset: 1731},
+										pos:  position{line: 55, col: 37, offset: 1551},
 										name: "SearchValue",
 									},
 								},
@@ -474,40 +462,40 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 62, col: 5, offset: 1867},
+						pos: position{line: 58, col: 5, offset: 1687},
 						run: (*parser).callonSearchPred20,
 						expr: &seqExpr{
-							pos: position{line: 62, col: 5, offset: 1867},
+							pos: position{line: 58, col: 5, offset: 1687},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 62, col: 5, offset: 1867},
+									pos:   position{line: 58, col: 5, offset: 1687},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 62, col: 7, offset: 1869},
+										pos:  position{line: 58, col: 7, offset: 1689},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 62, col: 12, offset: 1874},
+									pos:  position{line: 58, col: 12, offset: 1694},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 62, col: 15, offset: 1877},
+									pos:   position{line: 58, col: 15, offset: 1697},
 									label: "comp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 62, col: 20, offset: 1882},
+										pos:  position{line: 58, col: 20, offset: 1702},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 62, col: 34, offset: 1896},
+									pos:  position{line: 58, col: 34, offset: 1716},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 62, col: 37, offset: 1899},
+									pos:   position{line: 58, col: 37, offset: 1719},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 62, col: 39, offset: 1901},
+										pos:  position{line: 58, col: 39, offset: 1721},
 										name: "SearchValue",
 									},
 								},
@@ -515,48 +503,48 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 69, col: 5, offset: 2355},
+						pos: position{line: 65, col: 5, offset: 2175},
 						run: (*parser).callonSearchPred30,
 						expr: &seqExpr{
-							pos: position{line: 69, col: 5, offset: 2355},
+							pos: position{line: 65, col: 5, offset: 2175},
 							exprs: []interface{}{
 								&andExpr{
-									pos: position{line: 69, col: 5, offset: 2355},
+									pos: position{line: 65, col: 5, offset: 2175},
 									expr: &litMatcher{
-										pos:        position{line: 69, col: 6, offset: 2356},
+										pos:        position{line: 65, col: 6, offset: 2176},
 										val:        "len",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 69, col: 12, offset: 2362},
+									pos:   position{line: 65, col: 12, offset: 2182},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 69, col: 17, offset: 2367},
+										pos:  position{line: 65, col: 17, offset: 2187},
 										name: "Function",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 69, col: 26, offset: 2376},
+									pos:  position{line: 65, col: 26, offset: 2196},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 69, col: 29, offset: 2379},
+									pos:   position{line: 65, col: 29, offset: 2199},
 									label: "comp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 69, col: 34, offset: 2384},
+										pos:  position{line: 65, col: 34, offset: 2204},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 69, col: 48, offset: 2398},
+									pos:  position{line: 65, col: 48, offset: 2218},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 69, col: 51, offset: 2401},
+									pos:   position{line: 65, col: 51, offset: 2221},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 69, col: 53, offset: 2403},
+										pos:  position{line: 65, col: 53, offset: 2223},
 										name: "SearchValue",
 									},
 								},
@@ -564,33 +552,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 72, col: 5, offset: 2531},
+						pos: position{line: 68, col: 5, offset: 2351},
 						run: (*parser).callonSearchPred42,
 						expr: &seqExpr{
-							pos: position{line: 72, col: 5, offset: 2531},
+							pos: position{line: 68, col: 5, offset: 2351},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 72, col: 5, offset: 2531},
+									pos:   position{line: 68, col: 5, offset: 2351},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 72, col: 7, offset: 2533},
+										pos:  position{line: 68, col: 7, offset: 2353},
 										name: "SearchValue",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 72, col: 19, offset: 2545},
+									pos:  position{line: 68, col: 19, offset: 2365},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 72, col: 22, offset: 2548},
+									pos:  position{line: 68, col: 22, offset: 2368},
 									name: "InToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 72, col: 30, offset: 2556},
+									pos:  position{line: 68, col: 30, offset: 2376},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 72, col: 33, offset: 2559},
+									pos:        position{line: 68, col: 33, offset: 2379},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -598,36 +586,36 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 75, col: 5, offset: 2688},
+						pos: position{line: 71, col: 5, offset: 2508},
 						run: (*parser).callonSearchPred50,
 						expr: &seqExpr{
-							pos: position{line: 75, col: 5, offset: 2688},
+							pos: position{line: 71, col: 5, offset: 2508},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 75, col: 5, offset: 2688},
+									pos:   position{line: 71, col: 5, offset: 2508},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 75, col: 7, offset: 2690},
+										pos:  position{line: 71, col: 7, offset: 2510},
 										name: "SearchValue",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 19, offset: 2702},
+									pos:  position{line: 71, col: 19, offset: 2522},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 22, offset: 2705},
+									pos:  position{line: 71, col: 22, offset: 2525},
 									name: "InToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 75, col: 30, offset: 2713},
+									pos:  position{line: 71, col: 30, offset: 2533},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 75, col: 33, offset: 2716},
+									pos:   position{line: 71, col: 33, offset: 2536},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 75, col: 35, offset: 2718},
+										pos:  position{line: 71, col: 35, offset: 2538},
 										name: "FieldExpr",
 									},
 								},
@@ -635,44 +623,44 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 78, col: 5, offset: 2847},
+						pos: position{line: 74, col: 5, offset: 2667},
 						run: (*parser).callonSearchPred59,
 						expr: &labeledExpr{
-							pos:   position{line: 78, col: 5, offset: 2847},
+							pos:   position{line: 74, col: 5, offset: 2667},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 78, col: 7, offset: 2849},
+								pos:  position{line: 74, col: 7, offset: 2669},
 								name: "SearchLiteral",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 81, col: 5, offset: 2968},
+						pos: position{line: 77, col: 5, offset: 2788},
 						run: (*parser).callonSearchPred62,
 						expr: &seqExpr{
-							pos: position{line: 81, col: 5, offset: 2968},
+							pos: position{line: 77, col: 5, offset: 2788},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 81, col: 5, offset: 2968},
+									pos: position{line: 77, col: 5, offset: 2788},
 									expr: &seqExpr{
-										pos: position{line: 81, col: 7, offset: 2970},
+										pos: position{line: 77, col: 7, offset: 2790},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 81, col: 8, offset: 2971},
+												pos:  position{line: 77, col: 7, offset: 2790},
 												name: "SearchKeywords",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 81, col: 24, offset: 2987},
+												pos:  position{line: 77, col: 22, offset: 2805},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 81, col: 28, offset: 2991},
+									pos:   position{line: 77, col: 26, offset: 2809},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 81, col: 30, offset: 2993},
+										pos:  position{line: 77, col: 28, offset: 2811},
 										name: "SearchWord",
 									},
 								},
@@ -684,41 +672,41 @@ var g = &grammar{
 		},
 		{
 			name: "SearchValue",
-			pos:  position{line: 94, col: 1, offset: 3445},
+			pos:  position{line: 90, col: 1, offset: 3263},
 			expr: &choiceExpr{
-				pos: position{line: 95, col: 5, offset: 3461},
+				pos: position{line: 91, col: 5, offset: 3279},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 95, col: 5, offset: 3461},
+						pos:  position{line: 91, col: 5, offset: 3279},
 						name: "SearchLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 96, col: 5, offset: 3479},
+						pos: position{line: 92, col: 5, offset: 3297},
 						run: (*parser).callonSearchValue3,
 						expr: &seqExpr{
-							pos: position{line: 96, col: 5, offset: 3479},
+							pos: position{line: 92, col: 5, offset: 3297},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 96, col: 5, offset: 3479},
+									pos: position{line: 92, col: 5, offset: 3297},
 									expr: &seqExpr{
-										pos: position{line: 96, col: 7, offset: 3481},
+										pos: position{line: 92, col: 7, offset: 3299},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 96, col: 8, offset: 3482},
+												pos:  position{line: 92, col: 8, offset: 3300},
 												name: "SearchKeywords",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 96, col: 24, offset: 3498},
+												pos:  position{line: 92, col: 24, offset: 3316},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 96, col: 27, offset: 3501},
+									pos:   position{line: 92, col: 27, offset: 3319},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 96, col: 29, offset: 3503},
+										pos:  position{line: 92, col: 29, offset: 3321},
 										name: "SearchWord",
 									},
 								},
@@ -730,20 +718,20 @@ var g = &grammar{
 		},
 		{
 			name: "SearchKeywords",
-			pos:  position{line: 100, col: 1, offset: 3611},
+			pos:  position{line: 96, col: 1, offset: 3429},
 			expr: &choiceExpr{
-				pos: position{line: 101, col: 5, offset: 3630},
+				pos: position{line: 97, col: 5, offset: 3448},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 101, col: 5, offset: 3630},
+						pos:  position{line: 97, col: 5, offset: 3448},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 102, col: 5, offset: 3643},
+						pos:  position{line: 98, col: 5, offset: 3461},
 						name: "OrToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 103, col: 5, offset: 3655},
+						pos:  position{line: 99, col: 5, offset: 3473},
 						name: "InToken",
 					},
 				},
@@ -751,48 +739,48 @@ var g = &grammar{
 		},
 		{
 			name: "SearchLiteral",
-			pos:  position{line: 105, col: 1, offset: 3664},
+			pos:  position{line: 101, col: 1, offset: 3482},
 			expr: &choiceExpr{
-				pos: position{line: 106, col: 5, offset: 3682},
+				pos: position{line: 102, col: 5, offset: 3500},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 106, col: 5, offset: 3682},
+						pos:  position{line: 102, col: 5, offset: 3500},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 107, col: 5, offset: 3700},
+						pos:  position{line: 103, col: 5, offset: 3518},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 108, col: 5, offset: 3718},
+						pos:  position{line: 104, col: 5, offset: 3536},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 109, col: 5, offset: 3736},
+						pos:  position{line: 105, col: 5, offset: 3554},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 110, col: 5, offset: 3755},
+						pos:  position{line: 106, col: 5, offset: 3573},
 						name: "FloatLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 114, col: 5, offset: 3922},
+						pos: position{line: 110, col: 5, offset: 3740},
 						run: (*parser).callonSearchLiteral7,
 						expr: &seqExpr{
-							pos: position{line: 114, col: 5, offset: 3922},
+							pos: position{line: 110, col: 5, offset: 3740},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 114, col: 5, offset: 3922},
+									pos:   position{line: 110, col: 5, offset: 3740},
 									label: "i",
 									expr: &ruleRefExpr{
-										pos:  position{line: 114, col: 7, offset: 3924},
+										pos:  position{line: 110, col: 7, offset: 3742},
 										name: "IntegerLiteral",
 									},
 								},
 								&notExpr{
-									pos: position{line: 114, col: 22, offset: 3939},
+									pos: position{line: 110, col: 22, offset: 3757},
 									expr: &ruleRefExpr{
-										pos:  position{line: 114, col: 23, offset: 3940},
+										pos:  position{line: 110, col: 23, offset: 3758},
 										name: "SearchWord",
 									},
 								},
@@ -800,32 +788,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 116, col: 5, offset: 3974},
+						pos: position{line: 112, col: 5, offset: 3792},
 						run: (*parser).callonSearchLiteral13,
 						expr: &seqExpr{
-							pos: position{line: 116, col: 5, offset: 3974},
+							pos: position{line: 112, col: 5, offset: 3792},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 116, col: 5, offset: 3974},
+									pos: position{line: 112, col: 5, offset: 3792},
 									expr: &seqExpr{
-										pos: position{line: 116, col: 7, offset: 3976},
+										pos: position{line: 112, col: 7, offset: 3794},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 116, col: 7, offset: 3976},
+												pos:  position{line: 112, col: 7, offset: 3794},
 												name: "SearchKeywords",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 116, col: 22, offset: 3991},
+												pos:  position{line: 112, col: 22, offset: 3809},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 116, col: 25, offset: 3994},
+									pos:   position{line: 112, col: 25, offset: 3812},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 116, col: 27, offset: 3996},
+										pos:  position{line: 112, col: 27, offset: 3814},
 										name: "BooleanLiteral",
 									},
 								},
@@ -833,32 +821,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 117, col: 5, offset: 4033},
+						pos: position{line: 113, col: 5, offset: 3851},
 						run: (*parser).callonSearchLiteral21,
 						expr: &seqExpr{
-							pos: position{line: 117, col: 5, offset: 4033},
+							pos: position{line: 113, col: 5, offset: 3851},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 117, col: 5, offset: 4033},
+									pos: position{line: 113, col: 5, offset: 3851},
 									expr: &seqExpr{
-										pos: position{line: 117, col: 7, offset: 4035},
+										pos: position{line: 113, col: 7, offset: 3853},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 117, col: 7, offset: 4035},
+												pos:  position{line: 113, col: 7, offset: 3853},
 												name: "SearchKeywords",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 117, col: 22, offset: 4050},
+												pos:  position{line: 113, col: 22, offset: 3868},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 117, col: 25, offset: 4053},
+									pos:   position{line: 113, col: 25, offset: 3871},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 117, col: 27, offset: 4055},
+										pos:  position{line: 113, col: 27, offset: 3873},
 										name: "NullLiteral",
 									},
 								},
@@ -870,15 +858,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 120, col: 1, offset: 4087},
+			pos:  position{line: 116, col: 1, offset: 3905},
 			expr: &actionExpr{
-				pos: position{line: 121, col: 5, offset: 4105},
+				pos: position{line: 117, col: 5, offset: 3923},
 				run: (*parser).callonStringLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 121, col: 5, offset: 4105},
+					pos:   position{line: 117, col: 5, offset: 3923},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 121, col: 7, offset: 4107},
+						pos:  position{line: 117, col: 7, offset: 3925},
 						name: "QuotedString",
 					},
 				},
@@ -886,15 +874,15 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpLiteral",
-			pos:  position{line: 125, col: 1, offset: 4217},
+			pos:  position{line: 121, col: 1, offset: 4035},
 			expr: &actionExpr{
-				pos: position{line: 126, col: 5, offset: 4235},
+				pos: position{line: 122, col: 5, offset: 4053},
 				run: (*parser).callonRegexpLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 126, col: 5, offset: 4235},
+					pos:   position{line: 122, col: 5, offset: 4053},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 126, col: 7, offset: 4237},
+						pos:  position{line: 122, col: 7, offset: 4055},
 						name: "Regexp",
 					},
 				},
@@ -902,28 +890,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 130, col: 1, offset: 4341},
+			pos:  position{line: 126, col: 1, offset: 4159},
 			expr: &choiceExpr{
-				pos: position{line: 131, col: 5, offset: 4359},
+				pos: position{line: 127, col: 5, offset: 4177},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 131, col: 5, offset: 4359},
+						pos: position{line: 127, col: 5, offset: 4177},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 131, col: 5, offset: 4359},
+							pos: position{line: 127, col: 5, offset: 4177},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 131, col: 5, offset: 4359},
+									pos:   position{line: 127, col: 5, offset: 4177},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 131, col: 7, offset: 4361},
+										pos:  position{line: 127, col: 7, offset: 4179},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 131, col: 14, offset: 4368},
+									pos: position{line: 127, col: 14, offset: 4186},
 									expr: &ruleRefExpr{
-										pos:  position{line: 131, col: 15, offset: 4369},
+										pos:  position{line: 127, col: 15, offset: 4187},
 										name: "IdentifierRest",
 									},
 								},
@@ -931,14 +919,14 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 134, col: 5, offset: 4481},
+						pos: position{line: 130, col: 5, offset: 4299},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 134, col: 5, offset: 4481},
+							pos:   position{line: 130, col: 5, offset: 4299},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 134, col: 7, offset: 4483},
-								name: "IPNet",
+								pos:  position{line: 130, col: 7, offset: 4301},
+								name: "IP4Net",
 							},
 						},
 					},
@@ -947,28 +935,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 138, col: 1, offset: 4583},
+			pos:  position{line: 134, col: 1, offset: 4402},
 			expr: &choiceExpr{
-				pos: position{line: 139, col: 5, offset: 4602},
+				pos: position{line: 135, col: 5, offset: 4421},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 139, col: 5, offset: 4602},
+						pos: position{line: 135, col: 5, offset: 4421},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 139, col: 5, offset: 4602},
+							pos: position{line: 135, col: 5, offset: 4421},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 139, col: 5, offset: 4602},
+									pos:   position{line: 135, col: 5, offset: 4421},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 139, col: 7, offset: 4604},
+										pos:  position{line: 135, col: 7, offset: 4423},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 139, col: 11, offset: 4608},
+									pos: position{line: 135, col: 11, offset: 4427},
 									expr: &ruleRefExpr{
-										pos:  position{line: 139, col: 12, offset: 4609},
+										pos:  position{line: 135, col: 12, offset: 4428},
 										name: "IdentifierRest",
 									},
 								},
@@ -976,13 +964,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 142, col: 5, offset: 4720},
+						pos: position{line: 138, col: 5, offset: 4539},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 142, col: 5, offset: 4720},
+							pos:   position{line: 138, col: 5, offset: 4539},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 142, col: 7, offset: 4722},
+								pos:  position{line: 138, col: 7, offset: 4541},
 								name: "IP",
 							},
 						},
@@ -992,15 +980,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 146, col: 1, offset: 4818},
+			pos:  position{line: 142, col: 1, offset: 4637},
 			expr: &actionExpr{
-				pos: position{line: 147, col: 5, offset: 4835},
+				pos: position{line: 143, col: 5, offset: 4654},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 147, col: 5, offset: 4835},
+					pos:   position{line: 143, col: 5, offset: 4654},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 147, col: 7, offset: 4837},
+						pos:  position{line: 143, col: 7, offset: 4656},
 						name: "FloatString",
 					},
 				},
@@ -1008,15 +996,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 151, col: 1, offset: 4947},
+			pos:  position{line: 147, col: 1, offset: 4766},
 			expr: &actionExpr{
-				pos: position{line: 152, col: 5, offset: 4966},
+				pos: position{line: 148, col: 5, offset: 4785},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 152, col: 5, offset: 4966},
+					pos:   position{line: 148, col: 5, offset: 4785},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 152, col: 7, offset: 4968},
+						pos:  position{line: 148, col: 7, offset: 4787},
 						name: "IntString",
 					},
 				},
@@ -1024,24 +1012,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 156, col: 1, offset: 5074},
+			pos:  position{line: 152, col: 1, offset: 4893},
 			expr: &choiceExpr{
-				pos: position{line: 157, col: 5, offset: 5093},
+				pos: position{line: 153, col: 5, offset: 4912},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 157, col: 5, offset: 5093},
+						pos: position{line: 153, col: 5, offset: 4912},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 157, col: 5, offset: 5093},
+							pos:        position{line: 153, col: 5, offset: 4912},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 158, col: 5, offset: 5203},
+						pos: position{line: 154, col: 5, offset: 5022},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 158, col: 5, offset: 5203},
+							pos:        position{line: 154, col: 5, offset: 5022},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -1051,12 +1039,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 160, col: 1, offset: 5311},
+			pos:  position{line: 156, col: 1, offset: 5130},
 			expr: &actionExpr{
-				pos: position{line: 161, col: 5, offset: 5327},
+				pos: position{line: 157, col: 5, offset: 5146},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 161, col: 5, offset: 5327},
+					pos:        position{line: 157, col: 5, offset: 5146},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -1064,28 +1052,28 @@ var g = &grammar{
 		},
 		{
 			name: "SequentialProcs",
-			pos:  position{line: 163, col: 1, offset: 5417},
+			pos:  position{line: 159, col: 1, offset: 5236},
 			expr: &actionExpr{
-				pos: position{line: 164, col: 5, offset: 5437},
+				pos: position{line: 160, col: 5, offset: 5256},
 				run: (*parser).callonSequentialProcs1,
 				expr: &seqExpr{
-					pos: position{line: 164, col: 5, offset: 5437},
+					pos: position{line: 160, col: 5, offset: 5256},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 164, col: 5, offset: 5437},
+							pos:   position{line: 160, col: 5, offset: 5256},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 164, col: 11, offset: 5443},
+								pos:  position{line: 160, col: 11, offset: 5262},
 								name: "Proc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 164, col: 16, offset: 5448},
+							pos:   position{line: 160, col: 16, offset: 5267},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 164, col: 21, offset: 5453},
+								pos: position{line: 160, col: 21, offset: 5272},
 								expr: &ruleRefExpr{
-									pos:  position{line: 164, col: 21, offset: 5453},
+									pos:  position{line: 160, col: 21, offset: 5272},
 									name: "SequentialTail",
 								},
 							},
@@ -1096,31 +1084,31 @@ var g = &grammar{
 		},
 		{
 			name: "SequentialTail",
-			pos:  position{line: 172, col: 1, offset: 5641},
+			pos:  position{line: 167, col: 1, offset: 5443},
 			expr: &actionExpr{
-				pos: position{line: 172, col: 18, offset: 5658},
+				pos: position{line: 167, col: 18, offset: 5460},
 				run: (*parser).callonSequentialTail1,
 				expr: &seqExpr{
-					pos: position{line: 172, col: 18, offset: 5658},
+					pos: position{line: 167, col: 18, offset: 5460},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 172, col: 18, offset: 5658},
+							pos:  position{line: 167, col: 18, offset: 5460},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 172, col: 21, offset: 5661},
+							pos:        position{line: 167, col: 21, offset: 5463},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 172, col: 25, offset: 5665},
+							pos:  position{line: 167, col: 25, offset: 5467},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 172, col: 28, offset: 5668},
+							pos:   position{line: 167, col: 28, offset: 5470},
 							label: "p",
 							expr: &ruleRefExpr{
-								pos:  position{line: 172, col: 30, offset: 5670},
+								pos:  position{line: 167, col: 30, offset: 5472},
 								name: "Proc",
 							},
 						},
@@ -1130,47 +1118,47 @@ var g = &grammar{
 		},
 		{
 			name: "Proc",
-			pos:  position{line: 174, col: 1, offset: 5694},
+			pos:  position{line: 169, col: 1, offset: 5496},
 			expr: &choiceExpr{
-				pos: position{line: 175, col: 5, offset: 5703},
+				pos: position{line: 170, col: 5, offset: 5505},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 175, col: 5, offset: 5703},
+						pos:  position{line: 170, col: 5, offset: 5505},
 						name: "NamedProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 176, col: 5, offset: 5717},
+						pos:  position{line: 171, col: 5, offset: 5519},
 						name: "GroupByProc",
 					},
 					&actionExpr{
-						pos: position{line: 177, col: 5, offset: 5733},
+						pos: position{line: 172, col: 5, offset: 5535},
 						run: (*parser).callonProc4,
 						expr: &seqExpr{
-							pos: position{line: 177, col: 5, offset: 5733},
+							pos: position{line: 172, col: 5, offset: 5535},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 177, col: 5, offset: 5733},
+									pos:        position{line: 172, col: 5, offset: 5535},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 177, col: 9, offset: 5737},
+									pos:  position{line: 172, col: 9, offset: 5539},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 177, col: 12, offset: 5740},
+									pos:   position{line: 172, col: 12, offset: 5542},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 177, col: 17, offset: 5745},
+										pos:  position{line: 172, col: 17, offset: 5547},
 										name: "Procs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 177, col: 23, offset: 5751},
+									pos:  position{line: 172, col: 23, offset: 5553},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 177, col: 26, offset: 5754},
+									pos:        position{line: 172, col: 26, offset: 5556},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1182,28 +1170,28 @@ var g = &grammar{
 		},
 		{
 			name: "Procs",
-			pos:  position{line: 181, col: 1, offset: 5790},
+			pos:  position{line: 176, col: 1, offset: 5592},
 			expr: &actionExpr{
-				pos: position{line: 182, col: 5, offset: 5800},
+				pos: position{line: 177, col: 5, offset: 5602},
 				run: (*parser).callonProcs1,
 				expr: &seqExpr{
-					pos: position{line: 182, col: 5, offset: 5800},
+					pos: position{line: 177, col: 5, offset: 5602},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 182, col: 5, offset: 5800},
+							pos:   position{line: 177, col: 5, offset: 5602},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 182, col: 11, offset: 5806},
+								pos:  position{line: 177, col: 11, offset: 5608},
 								name: "SequentialProcs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 182, col: 27, offset: 5822},
+							pos:   position{line: 177, col: 27, offset: 5624},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 182, col: 32, offset: 5827},
+								pos: position{line: 177, col: 32, offset: 5629},
 								expr: &ruleRefExpr{
-									pos:  position{line: 182, col: 32, offset: 5827},
+									pos:  position{line: 177, col: 32, offset: 5629},
 									name: "ParallelTail",
 								},
 							},
@@ -1214,31 +1202,31 @@ var g = &grammar{
 		},
 		{
 			name: "ParallelTail",
-			pos:  position{line: 191, col: 1, offset: 6126},
+			pos:  position{line: 186, col: 1, offset: 5928},
 			expr: &actionExpr{
-				pos: position{line: 192, col: 5, offset: 6143},
+				pos: position{line: 187, col: 5, offset: 5945},
 				run: (*parser).callonParallelTail1,
 				expr: &seqExpr{
-					pos: position{line: 192, col: 5, offset: 6143},
+					pos: position{line: 187, col: 5, offset: 5945},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 192, col: 5, offset: 6143},
+							pos:  position{line: 187, col: 5, offset: 5945},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 192, col: 8, offset: 6146},
+							pos:        position{line: 187, col: 8, offset: 5948},
 							val:        ";",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 192, col: 12, offset: 6150},
+							pos:  position{line: 187, col: 12, offset: 5952},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 192, col: 15, offset: 6153},
+							pos:   position{line: 187, col: 15, offset: 5955},
 							label: "ch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 192, col: 18, offset: 6156},
+								pos:  position{line: 187, col: 18, offset: 5958},
 								name: "SequentialProcs",
 							},
 						},
@@ -1248,50 +1236,50 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByProc",
-			pos:  position{line: 194, col: 1, offset: 6249},
+			pos:  position{line: 189, col: 1, offset: 6051},
 			expr: &actionExpr{
-				pos: position{line: 195, col: 5, offset: 6265},
+				pos: position{line: 190, col: 5, offset: 6067},
 				run: (*parser).callonGroupByProc1,
 				expr: &seqExpr{
-					pos: position{line: 195, col: 5, offset: 6265},
+					pos: position{line: 190, col: 5, offset: 6067},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 195, col: 5, offset: 6265},
+							pos:   position{line: 190, col: 5, offset: 6067},
 							label: "every",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 195, col: 11, offset: 6271},
+								pos: position{line: 190, col: 11, offset: 6073},
 								expr: &ruleRefExpr{
-									pos:  position{line: 195, col: 11, offset: 6271},
+									pos:  position{line: 190, col: 11, offset: 6073},
 									name: "EveryDur",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 195, col: 21, offset: 6281},
+							pos:   position{line: 190, col: 21, offset: 6083},
 							label: "reducers",
 							expr: &ruleRefExpr{
-								pos:  position{line: 195, col: 30, offset: 6290},
+								pos:  position{line: 190, col: 30, offset: 6092},
 								name: "Reducers",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 195, col: 39, offset: 6299},
+							pos:   position{line: 190, col: 39, offset: 6101},
 							label: "keys",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 195, col: 44, offset: 6304},
+								pos: position{line: 190, col: 44, offset: 6106},
 								expr: &ruleRefExpr{
-									pos:  position{line: 195, col: 44, offset: 6304},
+									pos:  position{line: 190, col: 44, offset: 6106},
 									name: "GroupByKeys",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 195, col: 57, offset: 6317},
+							pos:   position{line: 190, col: 57, offset: 6119},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 195, col: 63, offset: 6323},
+								pos: position{line: 190, col: 63, offset: 6125},
 								expr: &ruleRefExpr{
-									pos:  position{line: 195, col: 63, offset: 6323},
+									pos:  position{line: 190, col: 63, offset: 6125},
 									name: "LimitArg",
 								},
 							},
@@ -1302,32 +1290,32 @@ var g = &grammar{
 		},
 		{
 			name: "EveryDur",
-			pos:  position{line: 209, col: 1, offset: 6619},
+			pos:  position{line: 204, col: 1, offset: 6421},
 			expr: &actionExpr{
-				pos: position{line: 210, col: 5, offset: 6632},
+				pos: position{line: 205, col: 5, offset: 6434},
 				run: (*parser).callonEveryDur1,
 				expr: &seqExpr{
-					pos: position{line: 210, col: 5, offset: 6632},
+					pos: position{line: 205, col: 5, offset: 6434},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 210, col: 5, offset: 6632},
+							pos:        position{line: 205, col: 5, offset: 6434},
 							val:        "every",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 210, col: 14, offset: 6641},
+							pos:  position{line: 205, col: 14, offset: 6443},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 210, col: 16, offset: 6643},
+							pos:   position{line: 205, col: 16, offset: 6445},
 							label: "dur",
 							expr: &ruleRefExpr{
-								pos:  position{line: 210, col: 20, offset: 6647},
+								pos:  position{line: 205, col: 20, offset: 6449},
 								name: "Duration",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 210, col: 29, offset: 6656},
+							pos:  position{line: 205, col: 29, offset: 6458},
 							name: "_",
 						},
 					},
@@ -1336,31 +1324,31 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 212, col: 1, offset: 6679},
+			pos:  position{line: 207, col: 1, offset: 6481},
 			expr: &actionExpr{
-				pos: position{line: 213, col: 5, offset: 6695},
+				pos: position{line: 208, col: 5, offset: 6497},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 213, col: 5, offset: 6695},
+					pos: position{line: 208, col: 5, offset: 6497},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 213, col: 5, offset: 6695},
+							pos:  position{line: 208, col: 5, offset: 6497},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 213, col: 7, offset: 6697},
+							pos:        position{line: 208, col: 7, offset: 6499},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 213, col: 13, offset: 6703},
+							pos:  position{line: 208, col: 13, offset: 6505},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 213, col: 15, offset: 6705},
+							pos:   position{line: 208, col: 15, offset: 6507},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 213, col: 23, offset: 6713},
+								pos:  position{line: 208, col: 23, offset: 6515},
 								name: "FlexAssignments",
 							},
 						},
@@ -1370,40 +1358,40 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 215, col: 1, offset: 6754},
+			pos:  position{line: 210, col: 1, offset: 6556},
 			expr: &actionExpr{
-				pos: position{line: 216, col: 5, offset: 6767},
+				pos: position{line: 211, col: 5, offset: 6569},
 				run: (*parser).callonLimitArg1,
 				expr: &seqExpr{
-					pos: position{line: 216, col: 5, offset: 6767},
+					pos: position{line: 211, col: 5, offset: 6569},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 216, col: 5, offset: 6767},
+							pos:  position{line: 211, col: 5, offset: 6569},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 216, col: 7, offset: 6769},
+							pos:        position{line: 211, col: 7, offset: 6571},
 							val:        "with",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 216, col: 14, offset: 6776},
+							pos:  position{line: 211, col: 14, offset: 6578},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 216, col: 16, offset: 6778},
+							pos:        position{line: 211, col: 16, offset: 6580},
 							val:        "-limit",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 216, col: 25, offset: 6787},
+							pos:  position{line: 211, col: 25, offset: 6589},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 216, col: 27, offset: 6789},
+							pos:   position{line: 211, col: 27, offset: 6591},
 							label: "limit",
 							expr: &ruleRefExpr{
-								pos:  position{line: 216, col: 33, offset: 6795},
+								pos:  position{line: 211, col: 33, offset: 6597},
 								name: "UInt",
 							},
 						},
@@ -1413,22 +1401,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 221, col: 1, offset: 7061},
+			pos:  position{line: 216, col: 1, offset: 6863},
 			expr: &choiceExpr{
-				pos: position{line: 222, col: 5, offset: 7080},
+				pos: position{line: 217, col: 5, offset: 6882},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 222, col: 5, offset: 7080},
+						pos:  position{line: 217, col: 5, offset: 6882},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 223, col: 5, offset: 7095},
+						pos: position{line: 218, col: 5, offset: 6897},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 223, col: 5, offset: 7095},
+							pos:   position{line: 218, col: 5, offset: 6897},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 223, col: 10, offset: 7100},
+								pos:  position{line: 218, col: 10, offset: 6902},
 								name: "Expr",
 							},
 						},
@@ -1438,50 +1426,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 225, col: 1, offset: 7178},
+			pos:  position{line: 220, col: 1, offset: 6980},
 			expr: &actionExpr{
-				pos: position{line: 226, col: 5, offset: 7198},
+				pos: position{line: 221, col: 5, offset: 7000},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 226, col: 5, offset: 7198},
+					pos: position{line: 221, col: 5, offset: 7000},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 226, col: 5, offset: 7198},
+							pos:   position{line: 221, col: 5, offset: 7000},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 226, col: 11, offset: 7204},
+								pos:  position{line: 221, col: 11, offset: 7006},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 226, col: 26, offset: 7219},
+							pos:   position{line: 221, col: 26, offset: 7021},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 226, col: 31, offset: 7224},
+								pos: position{line: 221, col: 31, offset: 7026},
 								expr: &actionExpr{
-									pos: position{line: 226, col: 32, offset: 7225},
+									pos: position{line: 221, col: 32, offset: 7027},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 226, col: 32, offset: 7225},
+										pos: position{line: 221, col: 32, offset: 7027},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 226, col: 32, offset: 7225},
+												pos:  position{line: 221, col: 32, offset: 7027},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 226, col: 35, offset: 7228},
+												pos:        position{line: 221, col: 35, offset: 7030},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 226, col: 39, offset: 7232},
+												pos:  position{line: 221, col: 39, offset: 7034},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 226, col: 42, offset: 7235},
+												pos:   position{line: 221, col: 42, offset: 7037},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 226, col: 47, offset: 7240},
+													pos:  position{line: 221, col: 47, offset: 7042},
 													name: "FlexAssignment",
 												},
 											},
@@ -1496,38 +1484,38 @@ var g = &grammar{
 		},
 		{
 			name: "ReducerAssignment",
-			pos:  position{line: 230, col: 1, offset: 7362},
+			pos:  position{line: 225, col: 1, offset: 7164},
 			expr: &choiceExpr{
-				pos: position{line: 231, col: 5, offset: 7384},
+				pos: position{line: 226, col: 5, offset: 7186},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 231, col: 5, offset: 7384},
+						pos: position{line: 226, col: 5, offset: 7186},
 						run: (*parser).callonReducerAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 231, col: 5, offset: 7384},
+							pos: position{line: 226, col: 5, offset: 7186},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 231, col: 5, offset: 7384},
+									pos:   position{line: 226, col: 5, offset: 7186},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 231, col: 10, offset: 7389},
+										pos:  position{line: 226, col: 10, offset: 7191},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 231, col: 15, offset: 7394},
+									pos:  position{line: 226, col: 15, offset: 7196},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 231, col: 18, offset: 7397},
+									pos:        position{line: 226, col: 18, offset: 7199},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 231, col: 22, offset: 7401},
+									pos:   position{line: 226, col: 22, offset: 7203},
 									label: "reducer",
 									expr: &ruleRefExpr{
-										pos:  position{line: 231, col: 30, offset: 7409},
+										pos:  position{line: 226, col: 30, offset: 7211},
 										name: "Reducer",
 									},
 								},
@@ -1535,13 +1523,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 234, col: 5, offset: 7519},
+						pos: position{line: 229, col: 5, offset: 7321},
 						run: (*parser).callonReducerAssignment10,
 						expr: &labeledExpr{
-							pos:   position{line: 234, col: 5, offset: 7519},
+							pos:   position{line: 229, col: 5, offset: 7321},
 							label: "reducer",
 							expr: &ruleRefExpr{
-								pos:  position{line: 234, col: 13, offset: 7527},
+								pos:  position{line: 229, col: 13, offset: 7329},
 								name: "Reducer",
 							},
 						},
@@ -1551,25 +1539,25 @@ var g = &grammar{
 		},
 		{
 			name: "Reducer",
-			pos:  position{line: 238, col: 1, offset: 7621},
+			pos:  position{line: 233, col: 1, offset: 7423},
 			expr: &actionExpr{
-				pos: position{line: 239, col: 5, offset: 7633},
+				pos: position{line: 234, col: 5, offset: 7435},
 				run: (*parser).callonReducer1,
 				expr: &seqExpr{
-					pos: position{line: 239, col: 5, offset: 7633},
+					pos: position{line: 234, col: 5, offset: 7435},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 239, col: 5, offset: 7633},
+							pos: position{line: 234, col: 5, offset: 7435},
 							expr: &choiceExpr{
-								pos: position{line: 239, col: 7, offset: 7635},
+								pos: position{line: 234, col: 7, offset: 7437},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 239, col: 7, offset: 7635},
+										pos:        position{line: 234, col: 7, offset: 7437},
 										val:        "not",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 239, col: 13, offset: 7641},
+										pos:        position{line: 234, col: 13, offset: 7443},
 										val:        "len",
 										ignoreCase: false,
 									},
@@ -1577,53 +1565,53 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 239, col: 20, offset: 7648},
+							pos:   position{line: 234, col: 20, offset: 7450},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 239, col: 23, offset: 7651},
+								pos:  position{line: 234, col: 23, offset: 7453},
 								name: "FuncName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 239, col: 32, offset: 7660},
+							pos:  position{line: 234, col: 32, offset: 7462},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 239, col: 35, offset: 7663},
+							pos:        position{line: 234, col: 35, offset: 7465},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 239, col: 39, offset: 7667},
+							pos:  position{line: 234, col: 39, offset: 7469},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 239, col: 42, offset: 7670},
+							pos:   position{line: 234, col: 42, offset: 7472},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 239, col: 47, offset: 7675},
+								pos: position{line: 234, col: 47, offset: 7477},
 								expr: &ruleRefExpr{
-									pos:  position{line: 239, col: 47, offset: 7675},
+									pos:  position{line: 234, col: 47, offset: 7477},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 239, col: 54, offset: 7682},
+							pos:  position{line: 234, col: 54, offset: 7484},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 239, col: 57, offset: 7685},
+							pos:        position{line: 234, col: 57, offset: 7487},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 239, col: 61, offset: 7689},
+							pos:   position{line: 234, col: 61, offset: 7491},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 239, col: 67, offset: 7695},
+								pos: position{line: 234, col: 67, offset: 7497},
 								expr: &ruleRefExpr{
-									pos:  position{line: 239, col: 67, offset: 7695},
+									pos:  position{line: 234, col: 67, offset: 7497},
 									name: "WhereClause",
 								},
 							},
@@ -1634,31 +1622,31 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 247, col: 1, offset: 7878},
+			pos:  position{line: 242, col: 1, offset: 7680},
 			expr: &actionExpr{
-				pos: position{line: 247, col: 15, offset: 7892},
+				pos: position{line: 242, col: 15, offset: 7694},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 247, col: 15, offset: 7892},
+					pos: position{line: 242, col: 15, offset: 7694},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 247, col: 15, offset: 7892},
+							pos:  position{line: 242, col: 15, offset: 7694},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 247, col: 17, offset: 7894},
+							pos:        position{line: 242, col: 17, offset: 7696},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 247, col: 25, offset: 7902},
+							pos:  position{line: 242, col: 25, offset: 7704},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 247, col: 27, offset: 7904},
+							pos:   position{line: 242, col: 27, offset: 7706},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 247, col: 32, offset: 7909},
+								pos:  position{line: 242, col: 32, offset: 7711},
 								name: "Expr",
 							},
 						},
@@ -1668,44 +1656,44 @@ var g = &grammar{
 		},
 		{
 			name: "Reducers",
-			pos:  position{line: 249, col: 1, offset: 7936},
+			pos:  position{line: 244, col: 1, offset: 7738},
 			expr: &actionExpr{
-				pos: position{line: 250, col: 5, offset: 7949},
+				pos: position{line: 245, col: 5, offset: 7751},
 				run: (*parser).callonReducers1,
 				expr: &seqExpr{
-					pos: position{line: 250, col: 5, offset: 7949},
+					pos: position{line: 245, col: 5, offset: 7751},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 250, col: 5, offset: 7949},
+							pos:   position{line: 245, col: 5, offset: 7751},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 250, col: 11, offset: 7955},
+								pos:  position{line: 245, col: 11, offset: 7757},
 								name: "ReducerAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 250, col: 29, offset: 7973},
+							pos:   position{line: 245, col: 29, offset: 7775},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 250, col: 34, offset: 7978},
+								pos: position{line: 245, col: 34, offset: 7780},
 								expr: &seqExpr{
-									pos: position{line: 250, col: 35, offset: 7979},
+									pos: position{line: 245, col: 35, offset: 7781},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 250, col: 35, offset: 7979},
+											pos:  position{line: 245, col: 35, offset: 7781},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 250, col: 38, offset: 7982},
+											pos:        position{line: 245, col: 38, offset: 7784},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 250, col: 42, offset: 7986},
+											pos:  position{line: 245, col: 42, offset: 7788},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 250, col: 45, offset: 7989},
+											pos:  position{line: 245, col: 45, offset: 7791},
 											name: "ReducerAssignment",
 										},
 									},
@@ -1718,48 +1706,48 @@ var g = &grammar{
 		},
 		{
 			name: "NamedProc",
-			pos:  position{line: 258, col: 1, offset: 8194},
+			pos:  position{line: 253, col: 1, offset: 7996},
 			expr: &choiceExpr{
-				pos: position{line: 259, col: 5, offset: 8208},
+				pos: position{line: 254, col: 5, offset: 8010},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 259, col: 5, offset: 8208},
+						pos:  position{line: 254, col: 5, offset: 8010},
 						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 260, col: 5, offset: 8221},
+						pos:  position{line: 255, col: 5, offset: 8023},
 						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 261, col: 5, offset: 8233},
+						pos:  position{line: 256, col: 5, offset: 8035},
 						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 262, col: 5, offset: 8245},
+						pos:  position{line: 257, col: 5, offset: 8047},
 						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 263, col: 5, offset: 8258},
+						pos:  position{line: 258, col: 5, offset: 8060},
 						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 264, col: 5, offset: 8271},
+						pos:  position{line: 259, col: 5, offset: 8073},
 						name: "FilterProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 265, col: 5, offset: 8286},
+						pos:  position{line: 260, col: 5, offset: 8088},
 						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 266, col: 5, offset: 8299},
+						pos:  position{line: 261, col: 5, offset: 8101},
 						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 267, col: 5, offset: 8311},
+						pos:  position{line: 262, col: 5, offset: 8113},
 						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 268, col: 5, offset: 8326},
+						pos:  position{line: 263, col: 5, offset: 8128},
 						name: "FuseProc",
 					},
 				},
@@ -1767,46 +1755,46 @@ var g = &grammar{
 		},
 		{
 			name: "SortProc",
-			pos:  position{line: 270, col: 1, offset: 8336},
+			pos:  position{line: 265, col: 1, offset: 8138},
 			expr: &actionExpr{
-				pos: position{line: 271, col: 5, offset: 8349},
+				pos: position{line: 266, col: 5, offset: 8151},
 				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 271, col: 5, offset: 8349},
+					pos: position{line: 266, col: 5, offset: 8151},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 271, col: 5, offset: 8349},
+							pos:        position{line: 266, col: 5, offset: 8151},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 271, col: 13, offset: 8357},
+							pos:   position{line: 266, col: 13, offset: 8159},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 271, col: 18, offset: 8362},
+								pos:  position{line: 266, col: 18, offset: 8164},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 271, col: 27, offset: 8371},
+							pos:   position{line: 266, col: 27, offset: 8173},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 271, col: 32, offset: 8376},
+								pos: position{line: 266, col: 32, offset: 8178},
 								expr: &actionExpr{
-									pos: position{line: 271, col: 33, offset: 8377},
+									pos: position{line: 266, col: 33, offset: 8179},
 									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 271, col: 33, offset: 8377},
+										pos: position{line: 266, col: 33, offset: 8179},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 271, col: 33, offset: 8377},
+												pos:  position{line: 266, col: 33, offset: 8179},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 271, col: 35, offset: 8379},
+												pos:   position{line: 266, col: 35, offset: 8181},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 271, col: 37, offset: 8381},
+													pos:  position{line: 266, col: 37, offset: 8183},
 													name: "Exprs",
 												},
 											},
@@ -1821,30 +1809,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 285, col: 1, offset: 8800},
+			pos:  position{line: 280, col: 1, offset: 8602},
 			expr: &actionExpr{
-				pos: position{line: 285, col: 12, offset: 8811},
+				pos: position{line: 280, col: 12, offset: 8613},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 285, col: 12, offset: 8811},
+					pos:   position{line: 280, col: 12, offset: 8613},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 285, col: 17, offset: 8816},
+						pos: position{line: 280, col: 17, offset: 8618},
 						expr: &actionExpr{
-							pos: position{line: 285, col: 18, offset: 8817},
+							pos: position{line: 280, col: 18, offset: 8619},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 285, col: 18, offset: 8817},
+								pos: position{line: 280, col: 18, offset: 8619},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 285, col: 18, offset: 8817},
+										pos:  position{line: 280, col: 18, offset: 8619},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 285, col: 20, offset: 8819},
+										pos:   position{line: 280, col: 20, offset: 8621},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 285, col: 22, offset: 8821},
+											pos:  position{line: 280, col: 22, offset: 8623},
 											name: "SortArg",
 										},
 									},
@@ -1857,50 +1845,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 287, col: 1, offset: 8877},
+			pos:  position{line: 282, col: 1, offset: 8679},
 			expr: &choiceExpr{
-				pos: position{line: 288, col: 5, offset: 8889},
+				pos: position{line: 283, col: 5, offset: 8691},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 288, col: 5, offset: 8889},
+						pos: position{line: 283, col: 5, offset: 8691},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 288, col: 5, offset: 8889},
+							pos:        position{line: 283, col: 5, offset: 8691},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 289, col: 5, offset: 8964},
+						pos: position{line: 284, col: 5, offset: 8766},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 289, col: 5, offset: 8964},
+							pos: position{line: 284, col: 5, offset: 8766},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 289, col: 5, offset: 8964},
+									pos:        position{line: 284, col: 5, offset: 8766},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 289, col: 14, offset: 8973},
+									pos:  position{line: 284, col: 14, offset: 8775},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 289, col: 16, offset: 8975},
+									pos:   position{line: 284, col: 16, offset: 8777},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 289, col: 23, offset: 8982},
+										pos: position{line: 284, col: 23, offset: 8784},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 289, col: 24, offset: 8983},
+											pos: position{line: 284, col: 24, offset: 8785},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 289, col: 24, offset: 8983},
+													pos:        position{line: 284, col: 24, offset: 8785},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 289, col: 34, offset: 8993},
+													pos:        position{line: 284, col: 34, offset: 8795},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -1916,38 +1904,38 @@ var g = &grammar{
 		},
 		{
 			name: "TopProc",
-			pos:  position{line: 291, col: 1, offset: 9107},
+			pos:  position{line: 286, col: 1, offset: 8909},
 			expr: &actionExpr{
-				pos: position{line: 292, col: 5, offset: 9119},
+				pos: position{line: 287, col: 5, offset: 8921},
 				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 292, col: 5, offset: 9119},
+					pos: position{line: 287, col: 5, offset: 8921},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 292, col: 5, offset: 9119},
+							pos:        position{line: 287, col: 5, offset: 8921},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 292, col: 12, offset: 9126},
+							pos:   position{line: 287, col: 12, offset: 8928},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 292, col: 18, offset: 9132},
+								pos: position{line: 287, col: 18, offset: 8934},
 								expr: &actionExpr{
-									pos: position{line: 292, col: 19, offset: 9133},
+									pos: position{line: 287, col: 19, offset: 8935},
 									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 292, col: 19, offset: 9133},
+										pos: position{line: 287, col: 19, offset: 8935},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 292, col: 19, offset: 9133},
+												pos:  position{line: 287, col: 19, offset: 8935},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 292, col: 21, offset: 9135},
+												pos:   position{line: 287, col: 21, offset: 8937},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 292, col: 23, offset: 9137},
+													pos:  position{line: 287, col: 23, offset: 8939},
 													name: "UInt",
 												},
 											},
@@ -1957,19 +1945,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 292, col: 47, offset: 9161},
+							pos:   position{line: 287, col: 47, offset: 8963},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 292, col: 53, offset: 9167},
+								pos: position{line: 287, col: 53, offset: 8969},
 								expr: &seqExpr{
-									pos: position{line: 292, col: 54, offset: 9168},
+									pos: position{line: 287, col: 54, offset: 8970},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 292, col: 54, offset: 9168},
+											pos:  position{line: 287, col: 54, offset: 8970},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 292, col: 56, offset: 9170},
+											pos:        position{line: 287, col: 56, offset: 8972},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -1978,25 +1966,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 292, col: 67, offset: 9181},
+							pos:   position{line: 287, col: 67, offset: 8983},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 292, col: 74, offset: 9188},
+								pos: position{line: 287, col: 74, offset: 8990},
 								expr: &actionExpr{
-									pos: position{line: 292, col: 75, offset: 9189},
+									pos: position{line: 287, col: 75, offset: 8991},
 									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 292, col: 75, offset: 9189},
+										pos: position{line: 287, col: 75, offset: 8991},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 292, col: 75, offset: 9189},
+												pos:  position{line: 287, col: 75, offset: 8991},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 292, col: 77, offset: 9191},
+												pos:   position{line: 287, col: 77, offset: 8993},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 292, col: 79, offset: 9193},
+													pos:  position{line: 287, col: 79, offset: 8995},
 													name: "FieldExprs",
 												},
 											},
@@ -2011,35 +1999,35 @@ var g = &grammar{
 		},
 		{
 			name: "CutProc",
-			pos:  position{line: 306, col: 1, offset: 9500},
+			pos:  position{line: 301, col: 1, offset: 9303},
 			expr: &actionExpr{
-				pos: position{line: 307, col: 5, offset: 9512},
+				pos: position{line: 302, col: 5, offset: 9315},
 				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 307, col: 5, offset: 9512},
+					pos: position{line: 302, col: 5, offset: 9315},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 307, col: 5, offset: 9512},
+							pos:        position{line: 302, col: 5, offset: 9315},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 307, col: 12, offset: 9519},
+							pos:   position{line: 302, col: 12, offset: 9322},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 307, col: 17, offset: 9524},
+								pos:  position{line: 302, col: 17, offset: 9327},
 								name: "CutArgs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 307, col: 25, offset: 9532},
+							pos:  position{line: 302, col: 25, offset: 9335},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 307, col: 27, offset: 9534},
+							pos:   position{line: 302, col: 27, offset: 9337},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 307, col: 35, offset: 9542},
+								pos:  position{line: 302, col: 35, offset: 9345},
 								name: "FlexAssignments",
 							},
 						},
@@ -2049,27 +2037,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutArgs",
-			pos:  position{line: 316, col: 1, offset: 9811},
+			pos:  position{line: 311, col: 1, offset: 9614},
 			expr: &actionExpr{
-				pos: position{line: 317, col: 5, offset: 9823},
+				pos: position{line: 312, col: 5, offset: 9626},
 				run: (*parser).callonCutArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 317, col: 5, offset: 9823},
+					pos:   position{line: 312, col: 5, offset: 9626},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 317, col: 10, offset: 9828},
+						pos: position{line: 312, col: 10, offset: 9631},
 						expr: &actionExpr{
-							pos: position{line: 317, col: 11, offset: 9829},
+							pos: position{line: 312, col: 11, offset: 9632},
 							run: (*parser).callonCutArgs4,
 							expr: &seqExpr{
-								pos: position{line: 317, col: 11, offset: 9829},
+								pos: position{line: 312, col: 11, offset: 9632},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 317, col: 11, offset: 9829},
+										pos:  position{line: 312, col: 11, offset: 9632},
 										name: "_",
 									},
 									&litMatcher{
-										pos:        position{line: 317, col: 13, offset: 9831},
+										pos:        position{line: 312, col: 13, offset: 9634},
 										val:        "-c",
 										ignoreCase: false,
 									},
@@ -2082,30 +2070,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadProc",
-			pos:  position{line: 321, col: 1, offset: 9943},
+			pos:  position{line: 316, col: 1, offset: 9746},
 			expr: &choiceExpr{
-				pos: position{line: 322, col: 5, offset: 9956},
+				pos: position{line: 317, col: 5, offset: 9759},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 322, col: 5, offset: 9956},
+						pos: position{line: 317, col: 5, offset: 9759},
 						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 322, col: 5, offset: 9956},
+							pos: position{line: 317, col: 5, offset: 9759},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 322, col: 5, offset: 9956},
+									pos:        position{line: 317, col: 5, offset: 9759},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 322, col: 13, offset: 9964},
+									pos:  position{line: 317, col: 13, offset: 9767},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 322, col: 15, offset: 9966},
+									pos:   position{line: 317, col: 15, offset: 9769},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 322, col: 21, offset: 9972},
+										pos:  position{line: 317, col: 21, offset: 9775},
 										name: "UInt",
 									},
 								},
@@ -2113,10 +2101,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 323, col: 5, offset: 10054},
+						pos: position{line: 318, col: 5, offset: 9857},
 						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 323, col: 5, offset: 10054},
+							pos:        position{line: 318, col: 5, offset: 9857},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2126,30 +2114,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailProc",
-			pos:  position{line: 325, col: 1, offset: 10132},
+			pos:  position{line: 320, col: 1, offset: 9935},
 			expr: &choiceExpr{
-				pos: position{line: 326, col: 5, offset: 10145},
+				pos: position{line: 321, col: 5, offset: 9948},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 326, col: 5, offset: 10145},
+						pos: position{line: 321, col: 5, offset: 9948},
 						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 326, col: 5, offset: 10145},
+							pos: position{line: 321, col: 5, offset: 9948},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 326, col: 5, offset: 10145},
+									pos:        position{line: 321, col: 5, offset: 9948},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 326, col: 13, offset: 10153},
+									pos:  position{line: 321, col: 13, offset: 9956},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 326, col: 15, offset: 10155},
+									pos:   position{line: 321, col: 15, offset: 9958},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 326, col: 21, offset: 10161},
+										pos:  position{line: 321, col: 21, offset: 9964},
 										name: "UInt",
 									},
 								},
@@ -2157,10 +2145,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 327, col: 5, offset: 10243},
+						pos: position{line: 322, col: 5, offset: 10046},
 						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 327, col: 5, offset: 10243},
+							pos:        position{line: 322, col: 5, offset: 10046},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2170,27 +2158,27 @@ var g = &grammar{
 		},
 		{
 			name: "FilterProc",
-			pos:  position{line: 329, col: 1, offset: 10321},
+			pos:  position{line: 324, col: 1, offset: 10124},
 			expr: &actionExpr{
-				pos: position{line: 330, col: 5, offset: 10336},
+				pos: position{line: 325, col: 5, offset: 10139},
 				run: (*parser).callonFilterProc1,
 				expr: &seqExpr{
-					pos: position{line: 330, col: 5, offset: 10336},
+					pos: position{line: 325, col: 5, offset: 10139},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 330, col: 5, offset: 10336},
+							pos:        position{line: 325, col: 5, offset: 10139},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 330, col: 15, offset: 10346},
+							pos:  position{line: 325, col: 15, offset: 10149},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 330, col: 17, offset: 10348},
+							pos:   position{line: 325, col: 17, offset: 10151},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 330, col: 22, offset: 10353},
+								pos:  position{line: 325, col: 22, offset: 10156},
 								name: "SearchExpr",
 							},
 						},
@@ -2200,27 +2188,27 @@ var g = &grammar{
 		},
 		{
 			name: "UniqProc",
-			pos:  position{line: 334, col: 1, offset: 10450},
+			pos:  position{line: 329, col: 1, offset: 10253},
 			expr: &choiceExpr{
-				pos: position{line: 335, col: 5, offset: 10463},
+				pos: position{line: 330, col: 5, offset: 10266},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 335, col: 5, offset: 10463},
+						pos: position{line: 330, col: 5, offset: 10266},
 						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 335, col: 5, offset: 10463},
+							pos: position{line: 330, col: 5, offset: 10266},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 335, col: 5, offset: 10463},
+									pos:        position{line: 330, col: 5, offset: 10266},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 335, col: 13, offset: 10471},
+									pos:  position{line: 330, col: 13, offset: 10274},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 335, col: 15, offset: 10473},
+									pos:        position{line: 330, col: 15, offset: 10276},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2228,10 +2216,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 338, col: 5, offset: 10564},
+						pos: position{line: 333, col: 5, offset: 10367},
 						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 338, col: 5, offset: 10564},
+							pos:        position{line: 333, col: 5, offset: 10367},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2241,27 +2229,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutProc",
-			pos:  position{line: 342, col: 1, offset: 10656},
+			pos:  position{line: 337, col: 1, offset: 10459},
 			expr: &actionExpr{
-				pos: position{line: 343, col: 5, offset: 10668},
+				pos: position{line: 338, col: 5, offset: 10471},
 				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 343, col: 5, offset: 10668},
+					pos: position{line: 338, col: 5, offset: 10471},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 343, col: 5, offset: 10668},
+							pos:        position{line: 338, col: 5, offset: 10471},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 343, col: 12, offset: 10675},
+							pos:  position{line: 338, col: 12, offset: 10478},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 343, col: 14, offset: 10677},
+							pos:   position{line: 338, col: 14, offset: 10480},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 343, col: 22, offset: 10685},
+								pos:  position{line: 338, col: 22, offset: 10488},
 								name: "FlexAssignments",
 							},
 						},
@@ -2271,59 +2259,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameProc",
-			pos:  position{line: 347, col: 1, offset: 10788},
+			pos:  position{line: 342, col: 1, offset: 10591},
 			expr: &actionExpr{
-				pos: position{line: 348, col: 5, offset: 10803},
+				pos: position{line: 343, col: 5, offset: 10606},
 				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 348, col: 5, offset: 10803},
+					pos: position{line: 343, col: 5, offset: 10606},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 348, col: 5, offset: 10803},
+							pos:        position{line: 343, col: 5, offset: 10606},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 348, col: 15, offset: 10813},
+							pos:  position{line: 343, col: 15, offset: 10616},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 348, col: 17, offset: 10815},
+							pos:   position{line: 343, col: 17, offset: 10618},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 348, col: 23, offset: 10821},
+								pos:  position{line: 343, col: 23, offset: 10624},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 348, col: 34, offset: 10832},
+							pos:   position{line: 343, col: 34, offset: 10635},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 348, col: 39, offset: 10837},
+								pos: position{line: 343, col: 39, offset: 10640},
 								expr: &actionExpr{
-									pos: position{line: 348, col: 40, offset: 10838},
+									pos: position{line: 343, col: 40, offset: 10641},
 									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 348, col: 40, offset: 10838},
+										pos: position{line: 343, col: 40, offset: 10641},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 348, col: 40, offset: 10838},
+												pos:  position{line: 343, col: 40, offset: 10641},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 348, col: 43, offset: 10841},
+												pos:        position{line: 343, col: 43, offset: 10644},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 348, col: 47, offset: 10845},
+												pos:  position{line: 343, col: 47, offset: 10648},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 348, col: 50, offset: 10848},
+												pos:   position{line: 343, col: 50, offset: 10651},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 348, col: 53, offset: 10851},
+													pos:  position{line: 343, col: 53, offset: 10654},
 													name: "Assignment",
 												},
 											},
@@ -2338,12 +2326,12 @@ var g = &grammar{
 		},
 		{
 			name: "FuseProc",
-			pos:  position{line: 352, col: 1, offset: 11021},
+			pos:  position{line: 347, col: 1, offset: 10824},
 			expr: &actionExpr{
-				pos: position{line: 353, col: 5, offset: 11034},
+				pos: position{line: 348, col: 5, offset: 10837},
 				run: (*parser).callonFuseProc1,
 				expr: &litMatcher{
-					pos:        position{line: 353, col: 5, offset: 11034},
+					pos:        position{line: 348, col: 5, offset: 10837},
 					val:        "fuse",
 					ignoreCase: true,
 				},
@@ -2351,45 +2339,45 @@ var g = &grammar{
 		},
 		{
 			name: "RootField",
-			pos:  position{line: 357, col: 1, offset: 11110},
+			pos:  position{line: 352, col: 1, offset: 10913},
 			expr: &choiceExpr{
-				pos: position{line: 358, col: 5, offset: 11124},
+				pos: position{line: 353, col: 5, offset: 10927},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 358, col: 5, offset: 11124},
+						pos: position{line: 353, col: 5, offset: 10927},
 						run: (*parser).callonRootField2,
 						expr: &seqExpr{
-							pos: position{line: 358, col: 5, offset: 11124},
+							pos: position{line: 353, col: 5, offset: 10927},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 358, col: 5, offset: 11124},
+									pos: position{line: 353, col: 5, offset: 10927},
 									expr: &litMatcher{
-										pos:        position{line: 358, col: 5, offset: 11124},
+										pos:        position{line: 353, col: 5, offset: 10927},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&notExpr{
-									pos: position{line: 358, col: 10, offset: 11129},
+									pos: position{line: 353, col: 10, offset: 10932},
 									expr: &choiceExpr{
-										pos: position{line: 358, col: 12, offset: 11131},
+										pos: position{line: 353, col: 12, offset: 10934},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 358, col: 12, offset: 11131},
+												pos:  position{line: 353, col: 12, offset: 10934},
 												name: "BooleanLiteral",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 358, col: 29, offset: 11148},
+												pos:  position{line: 353, col: 29, offset: 10951},
 												name: "NullLiteral",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 358, col: 42, offset: 11161},
+									pos:   position{line: 353, col: 42, offset: 10964},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 358, col: 48, offset: 11167},
+										pos:  position{line: 353, col: 48, offset: 10970},
 										name: "Identifier",
 									},
 								},
@@ -2397,20 +2385,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 359, col: 5, offset: 11320},
+						pos: position{line: 354, col: 5, offset: 11123},
 						run: (*parser).callonRootField12,
 						expr: &seqExpr{
-							pos: position{line: 359, col: 5, offset: 11320},
+							pos: position{line: 354, col: 5, offset: 11123},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 359, col: 5, offset: 11320},
+									pos:        position{line: 354, col: 5, offset: 11123},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 359, col: 9, offset: 11324},
+									pos: position{line: 354, col: 9, offset: 11127},
 									expr: &ruleRefExpr{
-										pos:  position{line: 359, col: 11, offset: 11326},
+										pos:  position{line: 354, col: 11, offset: 11129},
 										name: "Identifier",
 									},
 								},
@@ -2422,60 +2410,60 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 361, col: 1, offset: 11399},
+			pos:  position{line: 356, col: 1, offset: 11202},
 			expr: &ruleRefExpr{
-				pos:  position{line: 361, col: 8, offset: 11406},
+				pos:  position{line: 356, col: 8, offset: 11209},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 363, col: 1, offset: 11417},
+			pos:  position{line: 358, col: 1, offset: 11220},
 			expr: &ruleRefExpr{
-				pos:  position{line: 363, col: 13, offset: 11429},
+				pos:  position{line: 358, col: 13, offset: 11232},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 365, col: 1, offset: 11435},
+			pos:  position{line: 360, col: 1, offset: 11238},
 			expr: &actionExpr{
-				pos: position{line: 366, col: 5, offset: 11450},
+				pos: position{line: 361, col: 5, offset: 11253},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 366, col: 5, offset: 11450},
+					pos: position{line: 361, col: 5, offset: 11253},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 366, col: 5, offset: 11450},
+							pos:   position{line: 361, col: 5, offset: 11253},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 366, col: 11, offset: 11456},
+								pos:  position{line: 361, col: 11, offset: 11259},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 366, col: 21, offset: 11466},
+							pos:   position{line: 361, col: 21, offset: 11269},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 366, col: 26, offset: 11471},
+								pos: position{line: 361, col: 26, offset: 11274},
 								expr: &seqExpr{
-									pos: position{line: 366, col: 27, offset: 11472},
+									pos: position{line: 361, col: 27, offset: 11275},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 366, col: 27, offset: 11472},
+											pos:  position{line: 361, col: 27, offset: 11275},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 366, col: 30, offset: 11475},
+											pos:        position{line: 361, col: 30, offset: 11278},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 366, col: 34, offset: 11479},
+											pos:  position{line: 361, col: 34, offset: 11282},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 366, col: 37, offset: 11482},
+											pos:  position{line: 361, col: 37, offset: 11285},
 											name: "FieldExpr",
 										},
 									},
@@ -2488,44 +2476,44 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 376, col: 1, offset: 11681},
+			pos:  position{line: 371, col: 1, offset: 11484},
 			expr: &actionExpr{
-				pos: position{line: 377, col: 5, offset: 11691},
+				pos: position{line: 372, col: 5, offset: 11494},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 377, col: 5, offset: 11691},
+					pos: position{line: 372, col: 5, offset: 11494},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 377, col: 5, offset: 11691},
+							pos:   position{line: 372, col: 5, offset: 11494},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 377, col: 11, offset: 11697},
+								pos:  position{line: 372, col: 11, offset: 11500},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 377, col: 16, offset: 11702},
+							pos:   position{line: 372, col: 16, offset: 11505},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 377, col: 21, offset: 11707},
+								pos: position{line: 372, col: 21, offset: 11510},
 								expr: &seqExpr{
-									pos: position{line: 377, col: 22, offset: 11708},
+									pos: position{line: 372, col: 22, offset: 11511},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 377, col: 22, offset: 11708},
+											pos:  position{line: 372, col: 22, offset: 11511},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 377, col: 25, offset: 11711},
+											pos:        position{line: 372, col: 25, offset: 11514},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 377, col: 29, offset: 11715},
+											pos:  position{line: 372, col: 29, offset: 11518},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 377, col: 32, offset: 11718},
+											pos:  position{line: 372, col: 32, offset: 11521},
 											name: "Expr",
 										},
 									},
@@ -2538,39 +2526,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 387, col: 1, offset: 11912},
+			pos:  position{line: 382, col: 1, offset: 11715},
 			expr: &actionExpr{
-				pos: position{line: 388, col: 5, offset: 11927},
+				pos: position{line: 383, col: 5, offset: 11730},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 388, col: 5, offset: 11927},
+					pos: position{line: 383, col: 5, offset: 11730},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 388, col: 5, offset: 11927},
+							pos:   position{line: 383, col: 5, offset: 11730},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 388, col: 9, offset: 11931},
+								pos:  position{line: 383, col: 9, offset: 11734},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 388, col: 14, offset: 11936},
+							pos:  position{line: 383, col: 14, offset: 11739},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 388, col: 17, offset: 11939},
+							pos:        position{line: 383, col: 17, offset: 11742},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 388, col: 21, offset: 11943},
+							pos:  position{line: 383, col: 21, offset: 11746},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 388, col: 24, offset: 11946},
+							pos:   position{line: 383, col: 24, offset: 11749},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 388, col: 28, offset: 11950},
+								pos:  position{line: 383, col: 28, offset: 11753},
 								name: "Expr",
 							},
 						},
@@ -2580,71 +2568,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 390, col: 1, offset: 12019},
+			pos:  position{line: 385, col: 1, offset: 11822},
 			expr: &ruleRefExpr{
-				pos:  position{line: 390, col: 8, offset: 12026},
+				pos:  position{line: 385, col: 8, offset: 11829},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 392, col: 1, offset: 12043},
+			pos:  position{line: 387, col: 1, offset: 11846},
 			expr: &choiceExpr{
-				pos: position{line: 393, col: 5, offset: 12063},
+				pos: position{line: 388, col: 5, offset: 11866},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 393, col: 5, offset: 12063},
+						pos: position{line: 388, col: 5, offset: 11866},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 393, col: 5, offset: 12063},
+							pos: position{line: 388, col: 5, offset: 11866},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 393, col: 5, offset: 12063},
+									pos:   position{line: 388, col: 5, offset: 11866},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 393, col: 15, offset: 12073},
-										name: "LogicalORExpr",
+										pos:  position{line: 388, col: 15, offset: 11876},
+										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 393, col: 29, offset: 12087},
+									pos:  position{line: 388, col: 29, offset: 11890},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 393, col: 32, offset: 12090},
+									pos:        position{line: 388, col: 32, offset: 11893},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 393, col: 36, offset: 12094},
+									pos:  position{line: 388, col: 36, offset: 11897},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 393, col: 39, offset: 12097},
+									pos:   position{line: 388, col: 39, offset: 11900},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 393, col: 50, offset: 12108},
+										pos:  position{line: 388, col: 50, offset: 11911},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 393, col: 55, offset: 12113},
+									pos:  position{line: 388, col: 55, offset: 11916},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 393, col: 58, offset: 12116},
+									pos:        position{line: 388, col: 58, offset: 11919},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 393, col: 62, offset: 12120},
+									pos:  position{line: 388, col: 62, offset: 11923},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 393, col: 65, offset: 12123},
+									pos:   position{line: 388, col: 65, offset: 11926},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 393, col: 76, offset: 12134},
+										pos:  position{line: 388, col: 76, offset: 11937},
 										name: "Expr",
 									},
 								},
@@ -2652,62 +2640,62 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 396, col: 5, offset: 12281},
-						name: "LogicalORExpr",
+						pos:  position{line: 391, col: 5, offset: 12084},
+						name: "LogicalOrExpr",
 					},
 				},
 			},
 		},
 		{
-			name: "LogicalORExpr",
-			pos:  position{line: 398, col: 1, offset: 12296},
+			name: "LogicalOrExpr",
+			pos:  position{line: 393, col: 1, offset: 12099},
 			expr: &actionExpr{
-				pos: position{line: 399, col: 5, offset: 12314},
-				run: (*parser).callonLogicalORExpr1,
+				pos: position{line: 394, col: 5, offset: 12117},
+				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 399, col: 5, offset: 12314},
+					pos: position{line: 394, col: 5, offset: 12117},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 399, col: 5, offset: 12314},
+							pos:   position{line: 394, col: 5, offset: 12117},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 399, col: 11, offset: 12320},
-								name: "LogicalANDExpr",
+								pos:  position{line: 394, col: 11, offset: 12123},
+								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 400, col: 5, offset: 12339},
+							pos:   position{line: 395, col: 5, offset: 12142},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 400, col: 10, offset: 12344},
+								pos: position{line: 395, col: 10, offset: 12147},
 								expr: &actionExpr{
-									pos: position{line: 400, col: 11, offset: 12345},
-									run: (*parser).callonLogicalORExpr7,
+									pos: position{line: 395, col: 11, offset: 12148},
+									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 400, col: 11, offset: 12345},
+										pos: position{line: 395, col: 11, offset: 12148},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 400, col: 11, offset: 12345},
+												pos:  position{line: 395, col: 11, offset: 12148},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 400, col: 14, offset: 12348},
+												pos:   position{line: 395, col: 14, offset: 12151},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 400, col: 17, offset: 12351},
+													pos:  position{line: 395, col: 17, offset: 12154},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 400, col: 25, offset: 12359},
+												pos:  position{line: 395, col: 25, offset: 12162},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 400, col: 28, offset: 12362},
+												pos:   position{line: 395, col: 28, offset: 12165},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 400, col: 33, offset: 12367},
-													name: "LogicalANDExpr",
+													pos:  position{line: 395, col: 33, offset: 12170},
+													name: "LogicalAndExpr",
 												},
 											},
 										},
@@ -2720,54 +2708,54 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "LogicalANDExpr",
-			pos:  position{line: 404, col: 1, offset: 12485},
+			name: "LogicalAndExpr",
+			pos:  position{line: 399, col: 1, offset: 12288},
 			expr: &actionExpr{
-				pos: position{line: 405, col: 5, offset: 12504},
-				run: (*parser).callonLogicalANDExpr1,
+				pos: position{line: 400, col: 5, offset: 12307},
+				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 405, col: 5, offset: 12504},
+					pos: position{line: 400, col: 5, offset: 12307},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 405, col: 5, offset: 12504},
+							pos:   position{line: 400, col: 5, offset: 12307},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 405, col: 11, offset: 12510},
+								pos:  position{line: 400, col: 11, offset: 12313},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 406, col: 5, offset: 12534},
+							pos:   position{line: 401, col: 5, offset: 12337},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 406, col: 10, offset: 12539},
+								pos: position{line: 401, col: 10, offset: 12342},
 								expr: &actionExpr{
-									pos: position{line: 406, col: 11, offset: 12540},
-									run: (*parser).callonLogicalANDExpr7,
+									pos: position{line: 401, col: 11, offset: 12343},
+									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 406, col: 11, offset: 12540},
+										pos: position{line: 401, col: 11, offset: 12343},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 406, col: 11, offset: 12540},
+												pos:  position{line: 401, col: 11, offset: 12343},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 406, col: 14, offset: 12543},
+												pos:   position{line: 401, col: 14, offset: 12346},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 406, col: 17, offset: 12546},
+													pos:  position{line: 401, col: 17, offset: 12349},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 406, col: 26, offset: 12555},
+												pos:  position{line: 401, col: 26, offset: 12358},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 406, col: 29, offset: 12558},
+												pos:   position{line: 401, col: 29, offset: 12361},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 406, col: 34, offset: 12563},
+													pos:  position{line: 401, col: 34, offset: 12366},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -2782,53 +2770,53 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 410, col: 1, offset: 12686},
+			pos:  position{line: 405, col: 1, offset: 12489},
 			expr: &actionExpr{
-				pos: position{line: 411, col: 5, offset: 12710},
+				pos: position{line: 406, col: 5, offset: 12513},
 				run: (*parser).callonEqualityCompareExpr1,
 				expr: &seqExpr{
-					pos: position{line: 411, col: 5, offset: 12710},
+					pos: position{line: 406, col: 5, offset: 12513},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 411, col: 5, offset: 12710},
+							pos:   position{line: 406, col: 5, offset: 12513},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 411, col: 11, offset: 12716},
+								pos:  position{line: 406, col: 11, offset: 12519},
 								name: "RelativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 412, col: 5, offset: 12733},
+							pos:   position{line: 407, col: 5, offset: 12536},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 412, col: 10, offset: 12738},
+								pos: position{line: 407, col: 10, offset: 12541},
 								expr: &actionExpr{
-									pos: position{line: 412, col: 11, offset: 12739},
+									pos: position{line: 407, col: 11, offset: 12542},
 									run: (*parser).callonEqualityCompareExpr7,
 									expr: &seqExpr{
-										pos: position{line: 412, col: 11, offset: 12739},
+										pos: position{line: 407, col: 11, offset: 12542},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 412, col: 11, offset: 12739},
+												pos:  position{line: 407, col: 11, offset: 12542},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 412, col: 14, offset: 12742},
+												pos:   position{line: 407, col: 14, offset: 12545},
 												label: "comp",
 												expr: &ruleRefExpr{
-													pos:  position{line: 412, col: 19, offset: 12747},
+													pos:  position{line: 407, col: 19, offset: 12550},
 													name: "EqualityComparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 412, col: 38, offset: 12766},
+												pos:  position{line: 407, col: 38, offset: 12569},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 412, col: 41, offset: 12769},
+												pos:   position{line: 407, col: 41, offset: 12572},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 412, col: 46, offset: 12774},
+													pos:  position{line: 407, col: 46, offset: 12577},
 													name: "RelativeExpr",
 												},
 											},
@@ -2843,30 +2831,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 416, col: 1, offset: 12892},
+			pos:  position{line: 411, col: 1, offset: 12695},
 			expr: &actionExpr{
-				pos: position{line: 416, col: 20, offset: 12911},
+				pos: position{line: 411, col: 20, offset: 12714},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 416, col: 21, offset: 12912},
+					pos: position{line: 411, col: 21, offset: 12715},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 416, col: 21, offset: 12912},
+							pos:        position{line: 411, col: 21, offset: 12715},
 							val:        "=~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 416, col: 28, offset: 12919},
+							pos:        position{line: 411, col: 28, offset: 12722},
 							val:        "!~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 416, col: 35, offset: 12926},
+							pos:        position{line: 411, col: 35, offset: 12729},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 416, col: 41, offset: 12932},
+							pos:        position{line: 411, col: 41, offset: 12735},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -2876,19 +2864,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 418, col: 1, offset: 12970},
+			pos:  position{line: 413, col: 1, offset: 12773},
 			expr: &choiceExpr{
-				pos: position{line: 419, col: 5, offset: 12993},
+				pos: position{line: 414, col: 5, offset: 12796},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 419, col: 5, offset: 12993},
+						pos:  position{line: 414, col: 5, offset: 12796},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 420, col: 5, offset: 13014},
+						pos: position{line: 415, col: 5, offset: 12817},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 420, col: 5, offset: 13014},
+							pos:        position{line: 415, col: 5, offset: 12817},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -2898,53 +2886,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 422, col: 1, offset: 13051},
+			pos:  position{line: 417, col: 1, offset: 12854},
 			expr: &actionExpr{
-				pos: position{line: 423, col: 5, offset: 13068},
+				pos: position{line: 418, col: 5, offset: 12871},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 423, col: 5, offset: 13068},
+					pos: position{line: 418, col: 5, offset: 12871},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 423, col: 5, offset: 13068},
+							pos:   position{line: 418, col: 5, offset: 12871},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 423, col: 11, offset: 13074},
+								pos:  position{line: 418, col: 11, offset: 12877},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 424, col: 5, offset: 13091},
+							pos:   position{line: 419, col: 5, offset: 12894},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 424, col: 10, offset: 13096},
+								pos: position{line: 419, col: 10, offset: 12899},
 								expr: &actionExpr{
-									pos: position{line: 424, col: 11, offset: 13097},
+									pos: position{line: 419, col: 11, offset: 12900},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 424, col: 11, offset: 13097},
+										pos: position{line: 419, col: 11, offset: 12900},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 424, col: 11, offset: 13097},
+												pos:  position{line: 419, col: 11, offset: 12900},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 424, col: 14, offset: 13100},
+												pos:   position{line: 419, col: 14, offset: 12903},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 424, col: 17, offset: 13103},
+													pos:  position{line: 419, col: 17, offset: 12906},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 424, col: 34, offset: 13120},
+												pos:  position{line: 419, col: 34, offset: 12923},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 424, col: 37, offset: 13123},
+												pos:   position{line: 419, col: 37, offset: 12926},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 424, col: 42, offset: 13128},
+													pos:  position{line: 419, col: 42, offset: 12931},
 													name: "AdditiveExpr",
 												},
 											},
@@ -2959,30 +2947,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 428, col: 1, offset: 13244},
+			pos:  position{line: 423, col: 1, offset: 13047},
 			expr: &actionExpr{
-				pos: position{line: 428, col: 20, offset: 13263},
+				pos: position{line: 423, col: 20, offset: 13066},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 428, col: 21, offset: 13264},
+					pos: position{line: 423, col: 21, offset: 13067},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 428, col: 21, offset: 13264},
+							pos:        position{line: 423, col: 21, offset: 13067},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 428, col: 28, offset: 13271},
+							pos:        position{line: 423, col: 28, offset: 13074},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 428, col: 34, offset: 13277},
+							pos:        position{line: 423, col: 34, offset: 13080},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 428, col: 41, offset: 13284},
+							pos:        position{line: 423, col: 41, offset: 13087},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -2992,53 +2980,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 430, col: 1, offset: 13321},
+			pos:  position{line: 425, col: 1, offset: 13124},
 			expr: &actionExpr{
-				pos: position{line: 431, col: 5, offset: 13338},
+				pos: position{line: 426, col: 5, offset: 13141},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 431, col: 5, offset: 13338},
+					pos: position{line: 426, col: 5, offset: 13141},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 431, col: 5, offset: 13338},
+							pos:   position{line: 426, col: 5, offset: 13141},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 431, col: 11, offset: 13344},
+								pos:  position{line: 426, col: 11, offset: 13147},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 432, col: 5, offset: 13367},
+							pos:   position{line: 427, col: 5, offset: 13170},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 432, col: 10, offset: 13372},
+								pos: position{line: 427, col: 10, offset: 13175},
 								expr: &actionExpr{
-									pos: position{line: 432, col: 11, offset: 13373},
+									pos: position{line: 427, col: 11, offset: 13176},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 432, col: 11, offset: 13373},
+										pos: position{line: 427, col: 11, offset: 13176},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 432, col: 11, offset: 13373},
+												pos:  position{line: 427, col: 11, offset: 13176},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 432, col: 14, offset: 13376},
+												pos:   position{line: 427, col: 14, offset: 13179},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 432, col: 17, offset: 13379},
+													pos:  position{line: 427, col: 17, offset: 13182},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 432, col: 34, offset: 13396},
+												pos:  position{line: 427, col: 34, offset: 13199},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 432, col: 37, offset: 13399},
+												pos:   position{line: 427, col: 37, offset: 13202},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 432, col: 42, offset: 13404},
+													pos:  position{line: 427, col: 42, offset: 13207},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -3053,20 +3041,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 436, col: 1, offset: 13526},
+			pos:  position{line: 431, col: 1, offset: 13329},
 			expr: &actionExpr{
-				pos: position{line: 436, col: 20, offset: 13545},
+				pos: position{line: 431, col: 20, offset: 13348},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 436, col: 21, offset: 13546},
+					pos: position{line: 431, col: 21, offset: 13349},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 436, col: 21, offset: 13546},
+							pos:        position{line: 431, col: 21, offset: 13349},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 436, col: 27, offset: 13552},
+							pos:        position{line: 431, col: 27, offset: 13355},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3076,53 +3064,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 438, col: 1, offset: 13589},
+			pos:  position{line: 433, col: 1, offset: 13392},
 			expr: &actionExpr{
-				pos: position{line: 439, col: 5, offset: 13612},
+				pos: position{line: 434, col: 5, offset: 13415},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 439, col: 5, offset: 13612},
+					pos: position{line: 434, col: 5, offset: 13415},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 439, col: 5, offset: 13612},
+							pos:   position{line: 434, col: 5, offset: 13415},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 439, col: 11, offset: 13618},
+								pos:  position{line: 434, col: 11, offset: 13421},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 440, col: 5, offset: 13630},
+							pos:   position{line: 435, col: 5, offset: 13433},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 440, col: 10, offset: 13635},
+								pos: position{line: 435, col: 10, offset: 13438},
 								expr: &actionExpr{
-									pos: position{line: 440, col: 11, offset: 13636},
+									pos: position{line: 435, col: 11, offset: 13439},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 440, col: 11, offset: 13636},
+										pos: position{line: 435, col: 11, offset: 13439},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 440, col: 11, offset: 13636},
+												pos:  position{line: 435, col: 11, offset: 13439},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 440, col: 14, offset: 13639},
+												pos:   position{line: 435, col: 14, offset: 13442},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 440, col: 17, offset: 13642},
+													pos:  position{line: 435, col: 17, offset: 13445},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 440, col: 40, offset: 13665},
+												pos:  position{line: 435, col: 40, offset: 13468},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 440, col: 43, offset: 13668},
+												pos:   position{line: 435, col: 43, offset: 13471},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 440, col: 48, offset: 13673},
+													pos:  position{line: 435, col: 48, offset: 13476},
 													name: "NotExpr",
 												},
 											},
@@ -3137,20 +3125,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 444, col: 1, offset: 13784},
+			pos:  position{line: 439, col: 1, offset: 13587},
 			expr: &actionExpr{
-				pos: position{line: 444, col: 26, offset: 13809},
+				pos: position{line: 439, col: 26, offset: 13612},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 444, col: 27, offset: 13810},
+					pos: position{line: 439, col: 27, offset: 13613},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 444, col: 27, offset: 13810},
+							pos:        position{line: 439, col: 27, offset: 13613},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 444, col: 33, offset: 13816},
+							pos:        position{line: 439, col: 33, offset: 13619},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -3160,30 +3148,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 446, col: 1, offset: 13853},
+			pos:  position{line: 441, col: 1, offset: 13656},
 			expr: &choiceExpr{
-				pos: position{line: 447, col: 5, offset: 13865},
+				pos: position{line: 442, col: 5, offset: 13668},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 447, col: 5, offset: 13865},
+						pos: position{line: 442, col: 5, offset: 13668},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 447, col: 5, offset: 13865},
+							pos: position{line: 442, col: 5, offset: 13668},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 447, col: 5, offset: 13865},
+									pos:        position{line: 442, col: 5, offset: 13668},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 447, col: 9, offset: 13869},
+									pos:  position{line: 442, col: 9, offset: 13672},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 447, col: 12, offset: 13872},
+									pos:   position{line: 442, col: 12, offset: 13675},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 447, col: 14, offset: 13874},
+										pos:  position{line: 442, col: 14, offset: 13677},
 										name: "NotExpr",
 									},
 								},
@@ -3191,7 +3179,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 450, col: 5, offset: 13987},
+						pos:  position{line: 445, col: 5, offset: 13790},
 						name: "CastExpr",
 					},
 				},
@@ -3199,43 +3187,43 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpr",
-			pos:  position{line: 452, col: 1, offset: 13997},
+			pos:  position{line: 447, col: 1, offset: 13800},
 			expr: &choiceExpr{
-				pos: position{line: 453, col: 5, offset: 14010},
+				pos: position{line: 448, col: 5, offset: 13813},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 453, col: 5, offset: 14010},
+						pos: position{line: 448, col: 5, offset: 13813},
 						run: (*parser).callonCastExpr2,
 						expr: &seqExpr{
-							pos: position{line: 453, col: 5, offset: 14010},
+							pos: position{line: 448, col: 5, offset: 13813},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 453, col: 5, offset: 14010},
+									pos:   position{line: 448, col: 5, offset: 13813},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 453, col: 7, offset: 14012},
+										pos:  position{line: 448, col: 7, offset: 13815},
 										name: "FuncExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 453, col: 16, offset: 14021},
+									pos:   position{line: 448, col: 16, offset: 13824},
 									label: "typ",
 									expr: &actionExpr{
-										pos: position{line: 453, col: 22, offset: 14027},
+										pos: position{line: 448, col: 22, offset: 13830},
 										run: (*parser).callonCastExpr7,
 										expr: &seqExpr{
-											pos: position{line: 453, col: 22, offset: 14027},
+											pos: position{line: 448, col: 22, offset: 13830},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 453, col: 22, offset: 14027},
+													pos:        position{line: 448, col: 22, offset: 13830},
 													val:        ":",
 													ignoreCase: false,
 												},
 												&labeledExpr{
-													pos:   position{line: 453, col: 26, offset: 14031},
+													pos:   position{line: 448, col: 26, offset: 13834},
 													label: "typ",
 													expr: &ruleRefExpr{
-														pos:  position{line: 453, col: 30, offset: 14035},
+														pos:  position{line: 448, col: 30, offset: 13838},
 														name: "PrimitiveType",
 													},
 												},
@@ -3247,7 +3235,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 456, col: 5, offset: 14165},
+						pos:  position{line: 451, col: 5, offset: 13968},
 						name: "FuncExpr",
 					},
 				},
@@ -3255,115 +3243,115 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 459, col: 1, offset: 14176},
+			pos:  position{line: 454, col: 1, offset: 13979},
 			expr: &actionExpr{
-				pos: position{line: 460, col: 5, offset: 14194},
+				pos: position{line: 455, col: 5, offset: 13997},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 460, col: 9, offset: 14198},
+					pos: position{line: 455, col: 9, offset: 14001},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 460, col: 9, offset: 14198},
+							pos:        position{line: 455, col: 9, offset: 14001},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 460, col: 19, offset: 14208},
+							pos:        position{line: 455, col: 19, offset: 14011},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 460, col: 29, offset: 14218},
+							pos:        position{line: 455, col: 29, offset: 14021},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 460, col: 40, offset: 14229},
+							pos:        position{line: 455, col: 40, offset: 14032},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 460, col: 51, offset: 14240},
+							pos:        position{line: 455, col: 51, offset: 14043},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 461, col: 9, offset: 14257},
+							pos:        position{line: 456, col: 9, offset: 14060},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 461, col: 18, offset: 14266},
+							pos:        position{line: 456, col: 18, offset: 14069},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 461, col: 28, offset: 14276},
+							pos:        position{line: 456, col: 28, offset: 14079},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 461, col: 38, offset: 14286},
+							pos:        position{line: 456, col: 38, offset: 14089},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 462, col: 9, offset: 14302},
+							pos:        position{line: 457, col: 9, offset: 14105},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 462, col: 22, offset: 14315},
+							pos:        position{line: 457, col: 22, offset: 14118},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 463, col: 9, offset: 14330},
+							pos:        position{line: 458, col: 9, offset: 14133},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 464, col: 9, offset: 14348},
+							pos:        position{line: 459, col: 9, offset: 14151},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 464, col: 18, offset: 14357},
+							pos:        position{line: 459, col: 18, offset: 14160},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 464, col: 28, offset: 14367},
+							pos:        position{line: 459, col: 28, offset: 14170},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 464, col: 39, offset: 14378},
+							pos:        position{line: 459, col: 39, offset: 14181},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 465, col: 9, offset: 14396},
+							pos:        position{line: 460, col: 9, offset: 14199},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 465, col: 16, offset: 14403},
+							pos:        position{line: 460, col: 16, offset: 14206},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 466, col: 9, offset: 14417},
+							pos:        position{line: 461, col: 9, offset: 14220},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 466, col: 18, offset: 14426},
+							pos:        position{line: 461, col: 18, offset: 14229},
 							val:        "error",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 466, col: 28, offset: 14436},
+							pos:        position{line: 461, col: 28, offset: 14239},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -3373,31 +3361,31 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 468, col: 1, offset: 14477},
+			pos:  position{line: 463, col: 1, offset: 14280},
 			expr: &choiceExpr{
-				pos: position{line: 469, col: 5, offset: 14490},
+				pos: position{line: 464, col: 5, offset: 14293},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 469, col: 5, offset: 14490},
+						pos: position{line: 464, col: 5, offset: 14293},
 						run: (*parser).callonFuncExpr2,
 						expr: &seqExpr{
-							pos: position{line: 469, col: 5, offset: 14490},
+							pos: position{line: 464, col: 5, offset: 14293},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 469, col: 5, offset: 14490},
+									pos:   position{line: 464, col: 5, offset: 14293},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 469, col: 11, offset: 14496},
+										pos:  position{line: 464, col: 11, offset: 14299},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 469, col: 20, offset: 14505},
+									pos:   position{line: 464, col: 20, offset: 14308},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 469, col: 25, offset: 14510},
+										pos: position{line: 464, col: 25, offset: 14313},
 										expr: &ruleRefExpr{
-											pos:  position{line: 469, col: 26, offset: 14511},
+											pos:  position{line: 464, col: 26, offset: 14314},
 											name: "Deref",
 										},
 									},
@@ -3406,11 +3394,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 472, col: 5, offset: 14582},
+						pos:  position{line: 467, col: 5, offset: 14385},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 473, col: 5, offset: 14596},
+						pos:  position{line: 468, col: 5, offset: 14399},
 						name: "Primary",
 					},
 				},
@@ -3418,40 +3406,40 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 475, col: 1, offset: 14605},
+			pos:  position{line: 470, col: 1, offset: 14408},
 			expr: &actionExpr{
-				pos: position{line: 476, col: 5, offset: 14618},
+				pos: position{line: 471, col: 5, offset: 14421},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 476, col: 5, offset: 14618},
+					pos: position{line: 471, col: 5, offset: 14421},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 476, col: 5, offset: 14618},
+							pos:   position{line: 471, col: 5, offset: 14421},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 476, col: 8, offset: 14621},
+								pos:  position{line: 471, col: 8, offset: 14424},
 								name: "FuncName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 476, col: 17, offset: 14630},
+							pos:  position{line: 471, col: 17, offset: 14433},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 476, col: 20, offset: 14633},
+							pos:        position{line: 471, col: 20, offset: 14436},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 476, col: 24, offset: 14637},
+							pos:   position{line: 471, col: 24, offset: 14440},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 476, col: 29, offset: 14642},
+								pos:  position{line: 471, col: 29, offset: 14445},
 								name: "ArgumentList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 476, col: 42, offset: 14655},
+							pos:        position{line: 471, col: 42, offset: 14458},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -3461,21 +3449,21 @@ var g = &grammar{
 		},
 		{
 			name: "FuncName",
-			pos:  position{line: 480, col: 1, offset: 14761},
+			pos:  position{line: 475, col: 1, offset: 14564},
 			expr: &actionExpr{
-				pos: position{line: 481, col: 5, offset: 14774},
+				pos: position{line: 476, col: 5, offset: 14577},
 				run: (*parser).callonFuncName1,
 				expr: &seqExpr{
-					pos: position{line: 481, col: 5, offset: 14774},
+					pos: position{line: 476, col: 5, offset: 14577},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 481, col: 5, offset: 14774},
+							pos:  position{line: 476, col: 5, offset: 14577},
 							name: "FuncNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 481, col: 19, offset: 14788},
+							pos: position{line: 476, col: 19, offset: 14591},
 							expr: &ruleRefExpr{
-								pos:  position{line: 481, col: 19, offset: 14788},
+								pos:  position{line: 476, col: 19, offset: 14591},
 								name: "FuncNameRest",
 							},
 						},
@@ -3485,9 +3473,9 @@ var g = &grammar{
 		},
 		{
 			name: "FuncNameStart",
-			pos:  position{line: 483, col: 1, offset: 14834},
+			pos:  position{line: 478, col: 1, offset: 14637},
 			expr: &charClassMatcher{
-				pos:        position{line: 483, col: 17, offset: 14850},
+				pos:        position{line: 478, col: 17, offset: 14653},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -3496,16 +3484,16 @@ var g = &grammar{
 		},
 		{
 			name: "FuncNameRest",
-			pos:  position{line: 484, col: 1, offset: 14859},
+			pos:  position{line: 479, col: 1, offset: 14662},
 			expr: &choiceExpr{
-				pos: position{line: 484, col: 16, offset: 14874},
+				pos: position{line: 479, col: 16, offset: 14677},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 484, col: 16, offset: 14874},
+						pos:  position{line: 479, col: 16, offset: 14677},
 						name: "FuncNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 484, col: 32, offset: 14890},
+						pos:        position{line: 479, col: 32, offset: 14693},
 						val:        "[.0-9]",
 						chars:      []rune{'.'},
 						ranges:     []rune{'0', '9'},
@@ -3517,53 +3505,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 486, col: 1, offset: 14898},
+			pos:  position{line: 481, col: 1, offset: 14701},
 			expr: &choiceExpr{
-				pos: position{line: 487, col: 5, offset: 14915},
+				pos: position{line: 482, col: 5, offset: 14718},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 487, col: 5, offset: 14915},
+						pos: position{line: 482, col: 5, offset: 14718},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 487, col: 5, offset: 14915},
+							pos: position{line: 482, col: 5, offset: 14718},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 487, col: 5, offset: 14915},
+									pos:   position{line: 482, col: 5, offset: 14718},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 487, col: 11, offset: 14921},
+										pos:  position{line: 482, col: 11, offset: 14724},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 487, col: 16, offset: 14926},
+									pos:   position{line: 482, col: 16, offset: 14729},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 487, col: 21, offset: 14931},
+										pos: position{line: 482, col: 21, offset: 14734},
 										expr: &actionExpr{
-											pos: position{line: 487, col: 22, offset: 14932},
+											pos: position{line: 482, col: 22, offset: 14735},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 487, col: 22, offset: 14932},
+												pos: position{line: 482, col: 22, offset: 14735},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 487, col: 22, offset: 14932},
+														pos:  position{line: 482, col: 22, offset: 14735},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 487, col: 25, offset: 14935},
+														pos:        position{line: 482, col: 25, offset: 14738},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 487, col: 29, offset: 14939},
+														pos:  position{line: 482, col: 29, offset: 14742},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 487, col: 32, offset: 14942},
+														pos:   position{line: 482, col: 32, offset: 14745},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 487, col: 34, offset: 14944},
+															pos:  position{line: 482, col: 34, offset: 14747},
 															name: "Expr",
 														},
 													},
@@ -3576,10 +3564,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 490, col: 5, offset: 15056},
+						pos: position{line: 485, col: 5, offset: 14859},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 490, col: 5, offset: 15056},
+							pos:  position{line: 485, col: 5, offset: 14859},
 							name: "__",
 						},
 					},
@@ -3588,28 +3576,28 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 492, col: 1, offset: 15092},
+			pos:  position{line: 487, col: 1, offset: 14895},
 			expr: &actionExpr{
-				pos: position{line: 493, col: 5, offset: 15106},
+				pos: position{line: 488, col: 5, offset: 14909},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 493, col: 5, offset: 15106},
+					pos: position{line: 488, col: 5, offset: 14909},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 493, col: 5, offset: 15106},
+							pos:   position{line: 488, col: 5, offset: 14909},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 493, col: 11, offset: 15112},
+								pos:  position{line: 488, col: 11, offset: 14915},
 								name: "RootField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 493, col: 21, offset: 15122},
+							pos:   position{line: 488, col: 21, offset: 14925},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 493, col: 26, offset: 15127},
+								pos: position{line: 488, col: 26, offset: 14930},
 								expr: &ruleRefExpr{
-									pos:  position{line: 493, col: 27, offset: 15128},
+									pos:  position{line: 488, col: 27, offset: 14931},
 									name: "Deref",
 								},
 							},
@@ -3620,31 +3608,31 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 497, col: 1, offset: 15196},
+			pos:  position{line: 492, col: 1, offset: 14999},
 			expr: &choiceExpr{
-				pos: position{line: 498, col: 5, offset: 15206},
+				pos: position{line: 493, col: 5, offset: 15009},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 498, col: 5, offset: 15206},
+						pos: position{line: 493, col: 5, offset: 15009},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 498, col: 5, offset: 15206},
+							pos: position{line: 493, col: 5, offset: 15009},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 498, col: 5, offset: 15206},
+									pos:        position{line: 493, col: 5, offset: 15009},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 498, col: 9, offset: 15210},
+									pos:   position{line: 493, col: 9, offset: 15013},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 498, col: 14, offset: 15215},
+										pos:  position{line: 493, col: 14, offset: 15018},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 498, col: 19, offset: 15220},
+									pos:        position{line: 493, col: 19, offset: 15023},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -3652,29 +3640,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 499, col: 5, offset: 15269},
+						pos: position{line: 494, col: 5, offset: 15072},
 						run: (*parser).callonDeref8,
 						expr: &seqExpr{
-							pos: position{line: 499, col: 5, offset: 15269},
+							pos: position{line: 494, col: 5, offset: 15072},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 499, col: 5, offset: 15269},
+									pos:        position{line: 494, col: 5, offset: 15072},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 499, col: 9, offset: 15273},
+									pos: position{line: 494, col: 9, offset: 15076},
 									expr: &litMatcher{
-										pos:        position{line: 499, col: 11, offset: 15275},
+										pos:        position{line: 494, col: 11, offset: 15078},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 499, col: 16, offset: 15280},
+									pos:   position{line: 494, col: 16, offset: 15083},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 499, col: 19, offset: 15283},
+										pos:  position{line: 494, col: 19, offset: 15086},
 										name: "Identifier",
 									},
 								},
@@ -3686,71 +3674,71 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 501, col: 1, offset: 15334},
+			pos:  position{line: 496, col: 1, offset: 15137},
 			expr: &choiceExpr{
-				pos: position{line: 502, col: 5, offset: 15346},
+				pos: position{line: 497, col: 5, offset: 15149},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 502, col: 5, offset: 15346},
+						pos:  position{line: 497, col: 5, offset: 15149},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 503, col: 5, offset: 15364},
+						pos:  position{line: 498, col: 5, offset: 15167},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 504, col: 5, offset: 15382},
+						pos:  position{line: 499, col: 5, offset: 15185},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 505, col: 5, offset: 15400},
+						pos:  position{line: 500, col: 5, offset: 15203},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 506, col: 5, offset: 15419},
+						pos:  position{line: 501, col: 5, offset: 15222},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 507, col: 5, offset: 15436},
+						pos:  position{line: 502, col: 5, offset: 15239},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 508, col: 5, offset: 15455},
+						pos:  position{line: 503, col: 5, offset: 15258},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 509, col: 5, offset: 15474},
+						pos:  position{line: 504, col: 5, offset: 15277},
 						name: "NullLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 510, col: 5, offset: 15490},
+						pos: position{line: 505, col: 5, offset: 15293},
 						run: (*parser).callonPrimary10,
 						expr: &seqExpr{
-							pos: position{line: 510, col: 5, offset: 15490},
+							pos: position{line: 505, col: 5, offset: 15293},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 510, col: 5, offset: 15490},
+									pos:        position{line: 505, col: 5, offset: 15293},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 510, col: 9, offset: 15494},
+									pos:  position{line: 505, col: 9, offset: 15297},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 510, col: 12, offset: 15497},
+									pos:   position{line: 505, col: 12, offset: 15300},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 510, col: 17, offset: 15502},
+										pos:  position{line: 505, col: 17, offset: 15305},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 510, col: 22, offset: 15507},
+									pos:  position{line: 505, col: 22, offset: 15310},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 510, col: 25, offset: 15510},
+									pos:        position{line: 505, col: 25, offset: 15313},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3762,16 +3750,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 512, col: 1, offset: 15536},
+			pos:  position{line: 507, col: 1, offset: 15339},
 			expr: &choiceExpr{
-				pos: position{line: 513, col: 5, offset: 15554},
+				pos: position{line: 508, col: 5, offset: 15357},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 513, col: 5, offset: 15554},
+						pos:  position{line: 508, col: 5, offset: 15357},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 513, col: 24, offset: 15573},
+						pos:  position{line: 508, col: 24, offset: 15376},
 						name: "RelativeOperator",
 					},
 				},
@@ -3779,12 +3767,12 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 515, col: 1, offset: 15591},
+			pos:  position{line: 510, col: 1, offset: 15394},
 			expr: &actionExpr{
-				pos: position{line: 515, col: 12, offset: 15602},
+				pos: position{line: 510, col: 12, offset: 15405},
 				run: (*parser).callonAndToken1,
 				expr: &litMatcher{
-					pos:        position{line: 515, col: 12, offset: 15602},
+					pos:        position{line: 510, col: 12, offset: 15405},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -3792,12 +3780,12 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 516, col: 1, offset: 15640},
+			pos:  position{line: 511, col: 1, offset: 15443},
 			expr: &actionExpr{
-				pos: position{line: 516, col: 11, offset: 15650},
+				pos: position{line: 511, col: 11, offset: 15453},
 				run: (*parser).callonOrToken1,
 				expr: &litMatcher{
-					pos:        position{line: 516, col: 11, offset: 15650},
+					pos:        position{line: 511, col: 11, offset: 15453},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -3805,12 +3793,12 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 517, col: 1, offset: 15687},
+			pos:  position{line: 512, col: 1, offset: 15490},
 			expr: &actionExpr{
-				pos: position{line: 517, col: 11, offset: 15697},
+				pos: position{line: 512, col: 11, offset: 15500},
 				run: (*parser).callonInToken1,
 				expr: &litMatcher{
-					pos:        position{line: 517, col: 11, offset: 15697},
+					pos:        position{line: 512, col: 11, offset: 15500},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -3818,12 +3806,12 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 518, col: 1, offset: 15734},
+			pos:  position{line: 513, col: 1, offset: 15537},
 			expr: &actionExpr{
-				pos: position{line: 518, col: 12, offset: 15745},
+				pos: position{line: 513, col: 12, offset: 15548},
 				run: (*parser).callonNotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 518, col: 12, offset: 15745},
+					pos:        position{line: 513, col: 12, offset: 15548},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -3831,21 +3819,21 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 520, col: 1, offset: 15784},
+			pos:  position{line: 515, col: 1, offset: 15587},
 			expr: &actionExpr{
-				pos: position{line: 520, col: 18, offset: 15801},
+				pos: position{line: 515, col: 18, offset: 15604},
 				run: (*parser).callonIdentifierName1,
 				expr: &seqExpr{
-					pos: position{line: 520, col: 18, offset: 15801},
+					pos: position{line: 515, col: 18, offset: 15604},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 520, col: 18, offset: 15801},
+							pos:  position{line: 515, col: 18, offset: 15604},
 							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 520, col: 34, offset: 15817},
+							pos: position{line: 515, col: 34, offset: 15620},
 							expr: &ruleRefExpr{
-								pos:  position{line: 520, col: 34, offset: 15817},
+								pos:  position{line: 515, col: 34, offset: 15620},
 								name: "IdentifierRest",
 							},
 						},
@@ -3855,9 +3843,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 522, col: 1, offset: 15865},
+			pos:  position{line: 517, col: 1, offset: 15668},
 			expr: &charClassMatcher{
-				pos:        position{line: 522, col: 19, offset: 15883},
+				pos:        position{line: 517, col: 19, offset: 15686},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -3867,16 +3855,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 523, col: 1, offset: 15894},
+			pos:  position{line: 518, col: 1, offset: 15697},
 			expr: &choiceExpr{
-				pos: position{line: 523, col: 18, offset: 15911},
+				pos: position{line: 518, col: 18, offset: 15714},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 523, col: 18, offset: 15911},
+						pos:  position{line: 518, col: 18, offset: 15714},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 523, col: 36, offset: 15929},
+						pos:        position{line: 518, col: 36, offset: 15732},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -3887,21 +3875,21 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 525, col: 1, offset: 15936},
+			pos:  position{line: 520, col: 1, offset: 15739},
 			expr: &actionExpr{
-				pos: position{line: 526, col: 5, offset: 15951},
+				pos: position{line: 521, col: 5, offset: 15754},
 				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 526, col: 5, offset: 15951},
+					pos: position{line: 521, col: 5, offset: 15754},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 526, col: 5, offset: 15951},
+							pos:  position{line: 521, col: 5, offset: 15754},
 							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 526, col: 21, offset: 15967},
+							pos: position{line: 521, col: 21, offset: 15770},
 							expr: &ruleRefExpr{
-								pos:  position{line: 526, col: 21, offset: 15967},
+								pos:  position{line: 521, col: 21, offset: 15770},
 								name: "IdentifierRest",
 							},
 						},
@@ -3911,54 +3899,54 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 528, col: 1, offset: 16067},
+			pos:  position{line: 523, col: 1, offset: 15870},
 			expr: &choiceExpr{
-				pos: position{line: 529, col: 5, offset: 16080},
+				pos: position{line: 524, col: 5, offset: 15883},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 529, col: 5, offset: 16080},
+						pos:  position{line: 524, col: 5, offset: 15883},
 						name: "Seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 530, col: 5, offset: 16092},
+						pos:  position{line: 525, col: 5, offset: 15895},
 						name: "Minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 531, col: 5, offset: 16104},
+						pos:  position{line: 526, col: 5, offset: 15907},
 						name: "Hours",
 					},
 					&seqExpr{
-						pos: position{line: 532, col: 5, offset: 16114},
+						pos: position{line: 527, col: 5, offset: 15917},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 532, col: 5, offset: 16114},
+								pos:  position{line: 527, col: 5, offset: 15917},
 								name: "Hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 532, col: 11, offset: 16120},
+								pos:  position{line: 527, col: 11, offset: 15923},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 532, col: 13, offset: 16122},
+								pos:        position{line: 527, col: 13, offset: 15925},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 532, col: 19, offset: 16128},
+								pos:  position{line: 527, col: 19, offset: 15931},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 532, col: 21, offset: 16130},
+								pos:  position{line: 527, col: 21, offset: 15933},
 								name: "Minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 533, col: 5, offset: 16142},
+						pos:  position{line: 528, col: 5, offset: 15945},
 						name: "Days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 534, col: 5, offset: 16151},
+						pos:  position{line: 529, col: 5, offset: 15954},
 						name: "Weeks",
 					},
 				},
@@ -3966,32 +3954,32 @@ var g = &grammar{
 		},
 		{
 			name: "SecondsToken",
-			pos:  position{line: 536, col: 1, offset: 16158},
+			pos:  position{line: 531, col: 1, offset: 15961},
 			expr: &choiceExpr{
-				pos: position{line: 537, col: 5, offset: 16175},
+				pos: position{line: 532, col: 5, offset: 15978},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 537, col: 5, offset: 16175},
+						pos:        position{line: 532, col: 5, offset: 15978},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 538, col: 5, offset: 16189},
+						pos:        position{line: 533, col: 5, offset: 15992},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 539, col: 5, offset: 16202},
+						pos:        position{line: 534, col: 5, offset: 16005},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 540, col: 5, offset: 16213},
+						pos:        position{line: 535, col: 5, offset: 16016},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 541, col: 5, offset: 16223},
+						pos:        position{line: 536, col: 5, offset: 16026},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -4000,32 +3988,32 @@ var g = &grammar{
 		},
 		{
 			name: "MinutesToken",
-			pos:  position{line: 543, col: 1, offset: 16228},
+			pos:  position{line: 538, col: 1, offset: 16031},
 			expr: &choiceExpr{
-				pos: position{line: 544, col: 5, offset: 16245},
+				pos: position{line: 539, col: 5, offset: 16048},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 544, col: 5, offset: 16245},
+						pos:        position{line: 539, col: 5, offset: 16048},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 545, col: 5, offset: 16259},
+						pos:        position{line: 540, col: 5, offset: 16062},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 546, col: 5, offset: 16272},
+						pos:        position{line: 541, col: 5, offset: 16075},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 547, col: 5, offset: 16283},
+						pos:        position{line: 542, col: 5, offset: 16086},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 548, col: 5, offset: 16293},
+						pos:        position{line: 543, col: 5, offset: 16096},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -4034,32 +4022,32 @@ var g = &grammar{
 		},
 		{
 			name: "HoursToken",
-			pos:  position{line: 550, col: 1, offset: 16298},
+			pos:  position{line: 545, col: 1, offset: 16101},
 			expr: &choiceExpr{
-				pos: position{line: 551, col: 5, offset: 16313},
+				pos: position{line: 546, col: 5, offset: 16116},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 551, col: 5, offset: 16313},
+						pos:        position{line: 546, col: 5, offset: 16116},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 552, col: 5, offset: 16325},
+						pos:        position{line: 547, col: 5, offset: 16128},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 553, col: 5, offset: 16335},
+						pos:        position{line: 548, col: 5, offset: 16138},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 554, col: 5, offset: 16344},
+						pos:        position{line: 549, col: 5, offset: 16147},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 555, col: 5, offset: 16352},
+						pos:        position{line: 550, col: 5, offset: 16155},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -4068,22 +4056,22 @@ var g = &grammar{
 		},
 		{
 			name: "DaysToken",
-			pos:  position{line: 557, col: 1, offset: 16360},
+			pos:  position{line: 552, col: 1, offset: 16163},
 			expr: &choiceExpr{
-				pos: position{line: 557, col: 13, offset: 16372},
+				pos: position{line: 552, col: 13, offset: 16175},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 557, col: 13, offset: 16372},
+						pos:        position{line: 552, col: 13, offset: 16175},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 557, col: 20, offset: 16379},
+						pos:        position{line: 552, col: 20, offset: 16182},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 557, col: 26, offset: 16385},
+						pos:        position{line: 552, col: 26, offset: 16188},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -4092,32 +4080,32 @@ var g = &grammar{
 		},
 		{
 			name: "WeeksToken",
-			pos:  position{line: 558, col: 1, offset: 16389},
+			pos:  position{line: 553, col: 1, offset: 16192},
 			expr: &choiceExpr{
-				pos: position{line: 558, col: 14, offset: 16402},
+				pos: position{line: 553, col: 14, offset: 16205},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 558, col: 14, offset: 16402},
+						pos:        position{line: 553, col: 14, offset: 16205},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 558, col: 22, offset: 16410},
+						pos:        position{line: 553, col: 22, offset: 16213},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 558, col: 29, offset: 16417},
+						pos:        position{line: 553, col: 29, offset: 16220},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 558, col: 35, offset: 16423},
+						pos:        position{line: 553, col: 35, offset: 16226},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 558, col: 40, offset: 16428},
+						pos:        position{line: 553, col: 40, offset: 16231},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -4126,39 +4114,39 @@ var g = &grammar{
 		},
 		{
 			name: "Seconds",
-			pos:  position{line: 560, col: 1, offset: 16433},
+			pos:  position{line: 555, col: 1, offset: 16236},
 			expr: &choiceExpr{
-				pos: position{line: 561, col: 5, offset: 16445},
+				pos: position{line: 556, col: 5, offset: 16248},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 561, col: 5, offset: 16445},
+						pos: position{line: 556, col: 5, offset: 16248},
 						run: (*parser).callonSeconds2,
 						expr: &litMatcher{
-							pos:        position{line: 561, col: 5, offset: 16445},
+							pos:        position{line: 556, col: 5, offset: 16248},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 562, col: 5, offset: 16531},
+						pos: position{line: 557, col: 5, offset: 16334},
 						run: (*parser).callonSeconds4,
 						expr: &seqExpr{
-							pos: position{line: 562, col: 5, offset: 16531},
+							pos: position{line: 557, col: 5, offset: 16334},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 562, col: 5, offset: 16531},
+									pos:   position{line: 557, col: 5, offset: 16334},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 562, col: 9, offset: 16535},
+										pos:  position{line: 557, col: 9, offset: 16338},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 562, col: 14, offset: 16540},
+									pos:  position{line: 557, col: 14, offset: 16343},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 562, col: 17, offset: 16543},
+									pos:  position{line: 557, col: 17, offset: 16346},
 									name: "SecondsToken",
 								},
 							},
@@ -4169,39 +4157,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minutes",
-			pos:  position{line: 564, col: 1, offset: 16632},
+			pos:  position{line: 559, col: 1, offset: 16435},
 			expr: &choiceExpr{
-				pos: position{line: 565, col: 5, offset: 16644},
+				pos: position{line: 560, col: 5, offset: 16447},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 565, col: 5, offset: 16644},
+						pos: position{line: 560, col: 5, offset: 16447},
 						run: (*parser).callonMinutes2,
 						expr: &litMatcher{
-							pos:        position{line: 565, col: 5, offset: 16644},
+							pos:        position{line: 560, col: 5, offset: 16447},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 566, col: 5, offset: 16731},
+						pos: position{line: 561, col: 5, offset: 16534},
 						run: (*parser).callonMinutes4,
 						expr: &seqExpr{
-							pos: position{line: 566, col: 5, offset: 16731},
+							pos: position{line: 561, col: 5, offset: 16534},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 566, col: 5, offset: 16731},
+									pos:   position{line: 561, col: 5, offset: 16534},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 566, col: 9, offset: 16735},
+										pos:  position{line: 561, col: 9, offset: 16538},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 566, col: 14, offset: 16740},
+									pos:  position{line: 561, col: 14, offset: 16543},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 566, col: 17, offset: 16743},
+									pos:  position{line: 561, col: 17, offset: 16546},
 									name: "MinutesToken",
 								},
 							},
@@ -4212,39 +4200,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hours",
-			pos:  position{line: 568, col: 1, offset: 16841},
+			pos:  position{line: 563, col: 1, offset: 16644},
 			expr: &choiceExpr{
-				pos: position{line: 569, col: 5, offset: 16851},
+				pos: position{line: 564, col: 5, offset: 16654},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 569, col: 5, offset: 16851},
+						pos: position{line: 564, col: 5, offset: 16654},
 						run: (*parser).callonHours2,
 						expr: &litMatcher{
-							pos:        position{line: 569, col: 5, offset: 16851},
+							pos:        position{line: 564, col: 5, offset: 16654},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 570, col: 5, offset: 16938},
+						pos: position{line: 565, col: 5, offset: 16741},
 						run: (*parser).callonHours4,
 						expr: &seqExpr{
-							pos: position{line: 570, col: 5, offset: 16938},
+							pos: position{line: 565, col: 5, offset: 16741},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 570, col: 5, offset: 16938},
+									pos:   position{line: 565, col: 5, offset: 16741},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 570, col: 9, offset: 16942},
+										pos:  position{line: 565, col: 9, offset: 16745},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 570, col: 14, offset: 16947},
+									pos:  position{line: 565, col: 14, offset: 16750},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 570, col: 17, offset: 16950},
+									pos:  position{line: 565, col: 17, offset: 16753},
 									name: "HoursToken",
 								},
 							},
@@ -4255,39 +4243,39 @@ var g = &grammar{
 		},
 		{
 			name: "Days",
-			pos:  position{line: 572, col: 1, offset: 17048},
+			pos:  position{line: 567, col: 1, offset: 16851},
 			expr: &choiceExpr{
-				pos: position{line: 573, col: 5, offset: 17057},
+				pos: position{line: 568, col: 5, offset: 16860},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 573, col: 5, offset: 17057},
+						pos: position{line: 568, col: 5, offset: 16860},
 						run: (*parser).callonDays2,
 						expr: &litMatcher{
-							pos:        position{line: 573, col: 5, offset: 17057},
+							pos:        position{line: 568, col: 5, offset: 16860},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 574, col: 5, offset: 17146},
+						pos: position{line: 569, col: 5, offset: 16949},
 						run: (*parser).callonDays4,
 						expr: &seqExpr{
-							pos: position{line: 574, col: 5, offset: 17146},
+							pos: position{line: 569, col: 5, offset: 16949},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 574, col: 5, offset: 17146},
+									pos:   position{line: 569, col: 5, offset: 16949},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 574, col: 9, offset: 17150},
+										pos:  position{line: 569, col: 9, offset: 16953},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 574, col: 14, offset: 17155},
+									pos:  position{line: 569, col: 14, offset: 16958},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 574, col: 17, offset: 17158},
+									pos:  position{line: 569, col: 17, offset: 16961},
 									name: "DaysToken",
 								},
 							},
@@ -4298,39 +4286,39 @@ var g = &grammar{
 		},
 		{
 			name: "Weeks",
-			pos:  position{line: 576, col: 1, offset: 17260},
+			pos:  position{line: 571, col: 1, offset: 17063},
 			expr: &choiceExpr{
-				pos: position{line: 577, col: 5, offset: 17270},
+				pos: position{line: 572, col: 5, offset: 17073},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 577, col: 5, offset: 17270},
+						pos: position{line: 572, col: 5, offset: 17073},
 						run: (*parser).callonWeeks2,
 						expr: &litMatcher{
-							pos:        position{line: 577, col: 5, offset: 17270},
+							pos:        position{line: 572, col: 5, offset: 17073},
 							val:        "week",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 578, col: 5, offset: 17362},
+						pos: position{line: 573, col: 5, offset: 17165},
 						run: (*parser).callonWeeks4,
 						expr: &seqExpr{
-							pos: position{line: 578, col: 5, offset: 17362},
+							pos: position{line: 573, col: 5, offset: 17165},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 578, col: 5, offset: 17362},
+									pos:   position{line: 573, col: 5, offset: 17165},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 578, col: 9, offset: 17366},
+										pos:  position{line: 573, col: 9, offset: 17169},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 578, col: 14, offset: 17371},
+									pos:  position{line: 573, col: 14, offset: 17174},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 578, col: 17, offset: 17374},
+									pos:  position{line: 573, col: 17, offset: 17177},
 									name: "WeeksToken",
 								},
 							},
@@ -4341,42 +4329,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 581, col: 1, offset: 17505},
+			pos:  position{line: 576, col: 1, offset: 17308},
 			expr: &actionExpr{
-				pos: position{line: 582, col: 5, offset: 17512},
+				pos: position{line: 577, col: 5, offset: 17315},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 582, col: 5, offset: 17512},
+					pos: position{line: 577, col: 5, offset: 17315},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 582, col: 5, offset: 17512},
+							pos:  position{line: 577, col: 5, offset: 17315},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 582, col: 10, offset: 17517},
+							pos:        position{line: 577, col: 10, offset: 17320},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 582, col: 14, offset: 17521},
+							pos:  position{line: 577, col: 14, offset: 17324},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 582, col: 19, offset: 17526},
+							pos:        position{line: 577, col: 19, offset: 17329},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 582, col: 23, offset: 17530},
+							pos:  position{line: 577, col: 23, offset: 17333},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 582, col: 28, offset: 17535},
+							pos:        position{line: 577, col: 28, offset: 17338},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 582, col: 32, offset: 17539},
+							pos:  position{line: 577, col: 32, offset: 17342},
 							name: "UInt",
 						},
 					},
@@ -4385,32 +4373,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 586, col: 1, offset: 17707},
+			pos:  position{line: 581, col: 1, offset: 17510},
 			expr: &choiceExpr{
-				pos: position{line: 587, col: 5, offset: 17715},
+				pos: position{line: 582, col: 5, offset: 17518},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 587, col: 5, offset: 17715},
+						pos: position{line: 582, col: 5, offset: 17518},
 						run: (*parser).callonIP62,
 						expr: &seqExpr{
-							pos: position{line: 587, col: 5, offset: 17715},
+							pos: position{line: 582, col: 5, offset: 17518},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 587, col: 5, offset: 17715},
+									pos:   position{line: 582, col: 5, offset: 17518},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 587, col: 7, offset: 17717},
+										pos: position{line: 582, col: 7, offset: 17520},
 										expr: &ruleRefExpr{
-											pos:  position{line: 587, col: 7, offset: 17717},
+											pos:  position{line: 582, col: 7, offset: 17520},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 587, col: 17, offset: 17727},
+									pos:   position{line: 582, col: 17, offset: 17530},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 587, col: 19, offset: 17729},
+										pos:  position{line: 582, col: 19, offset: 17532},
 										name: "IP6Tail",
 									},
 								},
@@ -4418,51 +4406,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 590, col: 5, offset: 17793},
+						pos: position{line: 585, col: 5, offset: 17596},
 						run: (*parser).callonIP69,
 						expr: &seqExpr{
-							pos: position{line: 590, col: 5, offset: 17793},
+							pos: position{line: 585, col: 5, offset: 17596},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 590, col: 5, offset: 17793},
+									pos:   position{line: 585, col: 5, offset: 17596},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 590, col: 7, offset: 17795},
+										pos:  position{line: 585, col: 7, offset: 17598},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 590, col: 11, offset: 17799},
+									pos:   position{line: 585, col: 11, offset: 17602},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 590, col: 13, offset: 17801},
+										pos: position{line: 585, col: 13, offset: 17604},
 										expr: &ruleRefExpr{
-											pos:  position{line: 590, col: 13, offset: 17801},
+											pos:  position{line: 585, col: 13, offset: 17604},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 590, col: 23, offset: 17811},
+									pos:        position{line: 585, col: 23, offset: 17614},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 590, col: 28, offset: 17816},
+									pos:   position{line: 585, col: 28, offset: 17619},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 590, col: 30, offset: 17818},
+										pos: position{line: 585, col: 30, offset: 17621},
 										expr: &ruleRefExpr{
-											pos:  position{line: 590, col: 30, offset: 17818},
+											pos:  position{line: 585, col: 30, offset: 17621},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 590, col: 40, offset: 17828},
+									pos:   position{line: 585, col: 40, offset: 17631},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 590, col: 42, offset: 17830},
+										pos:  position{line: 585, col: 42, offset: 17633},
 										name: "IP6Tail",
 									},
 								},
@@ -4470,32 +4458,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 593, col: 5, offset: 17929},
+						pos: position{line: 588, col: 5, offset: 17732},
 						run: (*parser).callonIP622,
 						expr: &seqExpr{
-							pos: position{line: 593, col: 5, offset: 17929},
+							pos: position{line: 588, col: 5, offset: 17732},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 593, col: 5, offset: 17929},
+									pos:        position{line: 588, col: 5, offset: 17732},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 593, col: 10, offset: 17934},
+									pos:   position{line: 588, col: 10, offset: 17737},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 593, col: 12, offset: 17936},
+										pos: position{line: 588, col: 12, offset: 17739},
 										expr: &ruleRefExpr{
-											pos:  position{line: 593, col: 12, offset: 17936},
+											pos:  position{line: 588, col: 12, offset: 17739},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 593, col: 22, offset: 17946},
+									pos:   position{line: 588, col: 22, offset: 17749},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 593, col: 24, offset: 17948},
+										pos:  position{line: 588, col: 24, offset: 17751},
 										name: "IP6Tail",
 									},
 								},
@@ -4503,32 +4491,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 596, col: 5, offset: 18019},
+						pos: position{line: 591, col: 5, offset: 17822},
 						run: (*parser).callonIP630,
 						expr: &seqExpr{
-							pos: position{line: 596, col: 5, offset: 18019},
+							pos: position{line: 591, col: 5, offset: 17822},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 596, col: 5, offset: 18019},
+									pos:   position{line: 591, col: 5, offset: 17822},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 596, col: 7, offset: 18021},
+										pos:  position{line: 591, col: 7, offset: 17824},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 596, col: 11, offset: 18025},
+									pos:   position{line: 591, col: 11, offset: 17828},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 596, col: 13, offset: 18027},
+										pos: position{line: 591, col: 13, offset: 17830},
 										expr: &ruleRefExpr{
-											pos:  position{line: 596, col: 13, offset: 18027},
+											pos:  position{line: 591, col: 13, offset: 17830},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 596, col: 23, offset: 18037},
+									pos:        position{line: 591, col: 23, offset: 17840},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -4536,10 +4524,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 599, col: 5, offset: 18105},
+						pos: position{line: 594, col: 5, offset: 17908},
 						run: (*parser).callonIP638,
 						expr: &litMatcher{
-							pos:        position{line: 599, col: 5, offset: 18105},
+							pos:        position{line: 594, col: 5, offset: 17908},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -4549,16 +4537,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 603, col: 1, offset: 18142},
+			pos:  position{line: 598, col: 1, offset: 17945},
 			expr: &choiceExpr{
-				pos: position{line: 604, col: 5, offset: 18154},
+				pos: position{line: 599, col: 5, offset: 17957},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 604, col: 5, offset: 18154},
+						pos:  position{line: 599, col: 5, offset: 17957},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 605, col: 5, offset: 18161},
+						pos:  position{line: 600, col: 5, offset: 17964},
 						name: "Hex",
 					},
 				},
@@ -4566,23 +4554,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 607, col: 1, offset: 18166},
+			pos:  position{line: 602, col: 1, offset: 17969},
 			expr: &actionExpr{
-				pos: position{line: 607, col: 12, offset: 18177},
+				pos: position{line: 602, col: 12, offset: 17980},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 607, col: 12, offset: 18177},
+					pos: position{line: 602, col: 12, offset: 17980},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 607, col: 12, offset: 18177},
+							pos:        position{line: 602, col: 12, offset: 17980},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 607, col: 16, offset: 18181},
+							pos:   position{line: 602, col: 16, offset: 17984},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 607, col: 18, offset: 18183},
+								pos:  position{line: 602, col: 18, offset: 17986},
 								name: "Hex",
 							},
 						},
@@ -4592,23 +4580,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 608, col: 1, offset: 18220},
+			pos:  position{line: 603, col: 1, offset: 18023},
 			expr: &actionExpr{
-				pos: position{line: 608, col: 12, offset: 18231},
+				pos: position{line: 603, col: 12, offset: 18034},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 608, col: 12, offset: 18231},
+					pos: position{line: 603, col: 12, offset: 18034},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 608, col: 12, offset: 18231},
+							pos:   position{line: 603, col: 12, offset: 18034},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 608, col: 14, offset: 18233},
+								pos:  position{line: 603, col: 14, offset: 18036},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 608, col: 18, offset: 18237},
+							pos:        position{line: 603, col: 18, offset: 18040},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -4617,32 +4605,32 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "IPNet",
-			pos:  position{line: 610, col: 1, offset: 18275},
+			name: "IP4Net",
+			pos:  position{line: 605, col: 1, offset: 18078},
 			expr: &actionExpr{
-				pos: position{line: 611, col: 5, offset: 18285},
-				run: (*parser).callonIPNet1,
+				pos: position{line: 606, col: 5, offset: 18089},
+				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 611, col: 5, offset: 18285},
+					pos: position{line: 606, col: 5, offset: 18089},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 611, col: 5, offset: 18285},
+							pos:   position{line: 606, col: 5, offset: 18089},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 611, col: 7, offset: 18287},
+								pos:  position{line: 606, col: 7, offset: 18091},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 611, col: 10, offset: 18290},
+							pos:        position{line: 606, col: 10, offset: 18094},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 611, col: 14, offset: 18294},
+							pos:   position{line: 606, col: 14, offset: 18098},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 611, col: 16, offset: 18296},
+								pos:  position{line: 606, col: 16, offset: 18100},
 								name: "UInt",
 							},
 						},
@@ -4652,31 +4640,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 615, col: 1, offset: 18369},
+			pos:  position{line: 610, col: 1, offset: 18173},
 			expr: &actionExpr{
-				pos: position{line: 616, col: 5, offset: 18380},
+				pos: position{line: 611, col: 5, offset: 18184},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 616, col: 5, offset: 18380},
+					pos: position{line: 611, col: 5, offset: 18184},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 616, col: 5, offset: 18380},
+							pos:   position{line: 611, col: 5, offset: 18184},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 7, offset: 18382},
+								pos:  position{line: 611, col: 7, offset: 18186},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 616, col: 11, offset: 18386},
+							pos:        position{line: 611, col: 11, offset: 18190},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 616, col: 15, offset: 18390},
+							pos:   position{line: 611, col: 15, offset: 18194},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 616, col: 17, offset: 18392},
+								pos:  position{line: 611, col: 17, offset: 18196},
 								name: "UInt",
 							},
 						},
@@ -4686,15 +4674,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 620, col: 1, offset: 18455},
+			pos:  position{line: 615, col: 1, offset: 18259},
 			expr: &actionExpr{
-				pos: position{line: 621, col: 4, offset: 18463},
+				pos: position{line: 616, col: 4, offset: 18267},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 621, col: 4, offset: 18463},
+					pos:   position{line: 616, col: 4, offset: 18267},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 621, col: 6, offset: 18465},
+						pos:  position{line: 616, col: 6, offset: 18269},
 						name: "UIntString",
 					},
 				},
@@ -4702,16 +4690,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 623, col: 1, offset: 18505},
+			pos:  position{line: 618, col: 1, offset: 18309},
 			expr: &choiceExpr{
-				pos: position{line: 624, col: 5, offset: 18519},
+				pos: position{line: 619, col: 5, offset: 18323},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 624, col: 5, offset: 18519},
+						pos:  position{line: 619, col: 5, offset: 18323},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 625, col: 5, offset: 18534},
+						pos:  position{line: 620, col: 5, offset: 18338},
 						name: "MinusIntString",
 					},
 				},
@@ -4719,14 +4707,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 627, col: 1, offset: 18550},
+			pos:  position{line: 622, col: 1, offset: 18354},
 			expr: &actionExpr{
-				pos: position{line: 627, col: 14, offset: 18563},
+				pos: position{line: 622, col: 14, offset: 18367},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 627, col: 14, offset: 18563},
+					pos: position{line: 622, col: 14, offset: 18367},
 					expr: &charClassMatcher{
-						pos:        position{line: 627, col: 14, offset: 18563},
+						pos:        position{line: 622, col: 14, offset: 18367},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4737,20 +4725,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 629, col: 1, offset: 18602},
+			pos:  position{line: 624, col: 1, offset: 18406},
 			expr: &actionExpr{
-				pos: position{line: 630, col: 5, offset: 18621},
+				pos: position{line: 625, col: 5, offset: 18425},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 630, col: 5, offset: 18621},
+					pos: position{line: 625, col: 5, offset: 18425},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 630, col: 5, offset: 18621},
+							pos:        position{line: 625, col: 5, offset: 18425},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 630, col: 9, offset: 18625},
+							pos:  position{line: 625, col: 9, offset: 18429},
 							name: "UIntString",
 						},
 					},
@@ -4759,28 +4747,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 632, col: 1, offset: 18668},
+			pos:  position{line: 627, col: 1, offset: 18472},
 			expr: &choiceExpr{
-				pos: position{line: 633, col: 5, offset: 18684},
+				pos: position{line: 628, col: 5, offset: 18488},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 633, col: 5, offset: 18684},
+						pos: position{line: 628, col: 5, offset: 18488},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 633, col: 5, offset: 18684},
+							pos: position{line: 628, col: 5, offset: 18488},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 633, col: 5, offset: 18684},
+									pos: position{line: 628, col: 5, offset: 18488},
 									expr: &litMatcher{
-										pos:        position{line: 633, col: 5, offset: 18684},
+										pos:        position{line: 628, col: 5, offset: 18488},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 633, col: 10, offset: 18689},
+									pos: position{line: 628, col: 10, offset: 18493},
 									expr: &charClassMatcher{
-										pos:        position{line: 633, col: 10, offset: 18689},
+										pos:        position{line: 628, col: 10, offset: 18493},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -4788,14 +4776,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 633, col: 17, offset: 18696},
+									pos:        position{line: 628, col: 17, offset: 18500},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 633, col: 21, offset: 18700},
+									pos: position{line: 628, col: 21, offset: 18504},
 									expr: &charClassMatcher{
-										pos:        position{line: 633, col: 21, offset: 18700},
+										pos:        position{line: 628, col: 21, offset: 18504},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -4803,9 +4791,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 633, col: 28, offset: 18707},
+									pos: position{line: 628, col: 28, offset: 18511},
 									expr: &ruleRefExpr{
-										pos:  position{line: 633, col: 28, offset: 18707},
+										pos:  position{line: 628, col: 28, offset: 18511},
 										name: "ExponentPart",
 									},
 								},
@@ -4813,28 +4801,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 636, col: 5, offset: 18766},
+						pos: position{line: 631, col: 5, offset: 18570},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 636, col: 5, offset: 18766},
+							pos: position{line: 631, col: 5, offset: 18570},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 636, col: 5, offset: 18766},
+									pos: position{line: 631, col: 5, offset: 18570},
 									expr: &litMatcher{
-										pos:        position{line: 636, col: 5, offset: 18766},
+										pos:        position{line: 631, col: 5, offset: 18570},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 636, col: 10, offset: 18771},
+									pos:        position{line: 631, col: 10, offset: 18575},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 636, col: 14, offset: 18775},
+									pos: position{line: 631, col: 14, offset: 18579},
 									expr: &charClassMatcher{
-										pos:        position{line: 636, col: 14, offset: 18775},
+										pos:        position{line: 631, col: 14, offset: 18579},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -4842,9 +4830,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 636, col: 21, offset: 18782},
+									pos: position{line: 631, col: 21, offset: 18586},
 									expr: &ruleRefExpr{
-										pos:  position{line: 636, col: 21, offset: 18782},
+										pos:  position{line: 631, col: 21, offset: 18586},
 										name: "ExponentPart",
 									},
 								},
@@ -4856,19 +4844,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 640, col: 1, offset: 18838},
+			pos:  position{line: 635, col: 1, offset: 18642},
 			expr: &seqExpr{
-				pos: position{line: 640, col: 16, offset: 18853},
+				pos: position{line: 635, col: 16, offset: 18657},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 640, col: 16, offset: 18853},
+						pos:        position{line: 635, col: 16, offset: 18657},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 640, col: 21, offset: 18858},
+						pos: position{line: 635, col: 21, offset: 18662},
 						expr: &charClassMatcher{
-							pos:        position{line: 640, col: 21, offset: 18858},
+							pos:        position{line: 635, col: 21, offset: 18662},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -4876,7 +4864,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 640, col: 27, offset: 18864},
+						pos:  position{line: 635, col: 27, offset: 18668},
 						name: "UIntString",
 					},
 				},
@@ -4884,14 +4872,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 642, col: 1, offset: 18876},
+			pos:  position{line: 637, col: 1, offset: 18680},
 			expr: &actionExpr{
-				pos: position{line: 642, col: 7, offset: 18882},
+				pos: position{line: 637, col: 7, offset: 18686},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 642, col: 7, offset: 18882},
+					pos: position{line: 637, col: 7, offset: 18686},
 					expr: &ruleRefExpr{
-						pos:  position{line: 642, col: 7, offset: 18882},
+						pos:  position{line: 637, col: 7, offset: 18686},
 						name: "HexDigit",
 					},
 				},
@@ -4899,9 +4887,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 644, col: 1, offset: 18924},
+			pos:  position{line: 639, col: 1, offset: 18728},
 			expr: &charClassMatcher{
-				pos:        position{line: 644, col: 12, offset: 18935},
+				pos:        position{line: 639, col: 12, offset: 18739},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -4910,17 +4898,17 @@ var g = &grammar{
 		},
 		{
 			name: "SearchWord",
-			pos:  position{line: 646, col: 1, offset: 18948},
+			pos:  position{line: 641, col: 1, offset: 18752},
 			expr: &actionExpr{
-				pos: position{line: 647, col: 5, offset: 18963},
+				pos: position{line: 642, col: 5, offset: 18767},
 				run: (*parser).callonSearchWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 647, col: 5, offset: 18963},
+					pos:   position{line: 642, col: 5, offset: 18767},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 647, col: 11, offset: 18969},
+						pos: position{line: 642, col: 11, offset: 18773},
 						expr: &ruleRefExpr{
-							pos:  position{line: 647, col: 11, offset: 18969},
+							pos:  position{line: 642, col: 11, offset: 18773},
 							name: "SearchWordPart",
 						},
 					},
@@ -4929,33 +4917,33 @@ var g = &grammar{
 		},
 		{
 			name: "SearchWordPart",
-			pos:  position{line: 649, col: 1, offset: 19019},
+			pos:  position{line: 644, col: 1, offset: 18823},
 			expr: &choiceExpr{
-				pos: position{line: 650, col: 5, offset: 19038},
+				pos: position{line: 645, col: 5, offset: 18842},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 650, col: 5, offset: 19038},
+						pos: position{line: 645, col: 5, offset: 18842},
 						run: (*parser).callonSearchWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 650, col: 5, offset: 19038},
+							pos: position{line: 645, col: 5, offset: 18842},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 650, col: 5, offset: 19038},
+									pos:        position{line: 645, col: 5, offset: 18842},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 650, col: 10, offset: 19043},
+									pos:   position{line: 645, col: 10, offset: 18847},
 									label: "s",
 									expr: &choiceExpr{
-										pos: position{line: 650, col: 13, offset: 19046},
+										pos: position{line: 645, col: 13, offset: 18850},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 650, col: 13, offset: 19046},
+												pos:  position{line: 645, col: 13, offset: 18850},
 												name: "EscapeSequence",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 650, col: 30, offset: 19063},
+												pos:  position{line: 645, col: 30, offset: 18867},
 												name: "SearchEscape",
 											},
 										},
@@ -4965,18 +4953,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 651, col: 5, offset: 19100},
+						pos: position{line: 646, col: 5, offset: 18904},
 						run: (*parser).callonSearchWordPart9,
 						expr: &seqExpr{
-							pos: position{line: 651, col: 5, offset: 19100},
+							pos: position{line: 646, col: 5, offset: 18904},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 651, col: 5, offset: 19100},
+									pos: position{line: 646, col: 5, offset: 18904},
 									expr: &choiceExpr{
-										pos: position{line: 651, col: 7, offset: 19102},
+										pos: position{line: 646, col: 7, offset: 18906},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 651, col: 7, offset: 19102},
+												pos:        position{line: 646, col: 7, offset: 18906},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;:]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';', ':'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -4984,14 +4972,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 651, col: 43, offset: 19138},
+												pos:  position{line: 646, col: 43, offset: 18942},
 												name: "WhiteSpace",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 651, col: 55, offset: 19150,
+									line: 646, col: 55, offset: 18954,
 								},
 							},
 						},
@@ -5001,34 +4989,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 653, col: 1, offset: 19184},
+			pos:  position{line: 648, col: 1, offset: 18988},
 			expr: &choiceExpr{
-				pos: position{line: 654, col: 5, offset: 19201},
+				pos: position{line: 649, col: 5, offset: 19005},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 654, col: 5, offset: 19201},
+						pos: position{line: 649, col: 5, offset: 19005},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 654, col: 5, offset: 19201},
+							pos: position{line: 649, col: 5, offset: 19005},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 654, col: 5, offset: 19201},
+									pos:        position{line: 649, col: 5, offset: 19005},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 654, col: 9, offset: 19205},
+									pos:   position{line: 649, col: 9, offset: 19009},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 654, col: 11, offset: 19207},
+										pos: position{line: 649, col: 11, offset: 19011},
 										expr: &ruleRefExpr{
-											pos:  position{line: 654, col: 11, offset: 19207},
+											pos:  position{line: 649, col: 11, offset: 19011},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 654, col: 29, offset: 19225},
+									pos:        position{line: 649, col: 29, offset: 19029},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5036,29 +5024,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 655, col: 5, offset: 19262},
+						pos: position{line: 650, col: 5, offset: 19066},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 655, col: 5, offset: 19262},
+							pos: position{line: 650, col: 5, offset: 19066},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 655, col: 5, offset: 19262},
+									pos:        position{line: 650, col: 5, offset: 19066},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 655, col: 9, offset: 19266},
+									pos:   position{line: 650, col: 9, offset: 19070},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 655, col: 11, offset: 19268},
+										pos: position{line: 650, col: 11, offset: 19072},
 										expr: &ruleRefExpr{
-											pos:  position{line: 655, col: 11, offset: 19268},
+											pos:  position{line: 650, col: 11, offset: 19072},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 655, col: 29, offset: 19286},
+									pos:        position{line: 650, col: 29, offset: 19090},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5070,55 +5058,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 657, col: 1, offset: 19320},
+			pos:  position{line: 652, col: 1, offset: 19124},
 			expr: &choiceExpr{
-				pos: position{line: 658, col: 5, offset: 19341},
+				pos: position{line: 653, col: 5, offset: 19145},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 658, col: 5, offset: 19341},
+						pos: position{line: 653, col: 5, offset: 19145},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 658, col: 5, offset: 19341},
+							pos: position{line: 653, col: 5, offset: 19145},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 658, col: 5, offset: 19341},
+									pos: position{line: 653, col: 5, offset: 19145},
 									expr: &choiceExpr{
-										pos: position{line: 658, col: 7, offset: 19343},
+										pos: position{line: 653, col: 7, offset: 19147},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 658, col: 7, offset: 19343},
+												pos:        position{line: 653, col: 7, offset: 19147},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 658, col: 13, offset: 19349},
+												pos:  position{line: 653, col: 13, offset: 19153},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 658, col: 26, offset: 19362,
+									line: 653, col: 26, offset: 19166,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 19399},
+						pos: position{line: 654, col: 5, offset: 19203},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 19399},
+							pos: position{line: 654, col: 5, offset: 19203},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 659, col: 5, offset: 19399},
+									pos:        position{line: 654, col: 5, offset: 19203},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 659, col: 10, offset: 19404},
+									pos:   position{line: 654, col: 10, offset: 19208},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 659, col: 12, offset: 19406},
+										pos:  position{line: 654, col: 12, offset: 19210},
 										name: "EscapeSequence",
 									},
 								},
@@ -5130,55 +5118,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 661, col: 1, offset: 19440},
+			pos:  position{line: 656, col: 1, offset: 19244},
 			expr: &choiceExpr{
-				pos: position{line: 662, col: 5, offset: 19461},
+				pos: position{line: 657, col: 5, offset: 19265},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 662, col: 5, offset: 19461},
+						pos: position{line: 657, col: 5, offset: 19265},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 662, col: 5, offset: 19461},
+							pos: position{line: 657, col: 5, offset: 19265},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 662, col: 5, offset: 19461},
+									pos: position{line: 657, col: 5, offset: 19265},
 									expr: &choiceExpr{
-										pos: position{line: 662, col: 7, offset: 19463},
+										pos: position{line: 657, col: 7, offset: 19267},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 662, col: 7, offset: 19463},
+												pos:        position{line: 657, col: 7, offset: 19267},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 662, col: 13, offset: 19469},
+												pos:  position{line: 657, col: 13, offset: 19273},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 662, col: 26, offset: 19482,
+									line: 657, col: 26, offset: 19286,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 663, col: 5, offset: 19519},
+						pos: position{line: 658, col: 5, offset: 19323},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 663, col: 5, offset: 19519},
+							pos: position{line: 658, col: 5, offset: 19323},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 663, col: 5, offset: 19519},
+									pos:        position{line: 658, col: 5, offset: 19323},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 663, col: 10, offset: 19524},
+									pos:   position{line: 658, col: 10, offset: 19328},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 663, col: 12, offset: 19526},
+										pos:  position{line: 658, col: 12, offset: 19330},
 										name: "EscapeSequence",
 									},
 								},
@@ -5190,38 +5178,38 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 665, col: 1, offset: 19560},
+			pos:  position{line: 660, col: 1, offset: 19364},
 			expr: &choiceExpr{
-				pos: position{line: 666, col: 5, offset: 19579},
+				pos: position{line: 661, col: 5, offset: 19383},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 666, col: 5, offset: 19579},
+						pos: position{line: 661, col: 5, offset: 19383},
 						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 666, col: 5, offset: 19579},
+							pos: position{line: 661, col: 5, offset: 19383},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 666, col: 5, offset: 19579},
+									pos:        position{line: 661, col: 5, offset: 19383},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 666, col: 9, offset: 19583},
+									pos:  position{line: 661, col: 9, offset: 19387},
 									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 666, col: 18, offset: 19592},
+									pos:  position{line: 661, col: 18, offset: 19396},
 									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 667, col: 5, offset: 19643},
+						pos:  position{line: 662, col: 5, offset: 19447},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 668, col: 5, offset: 19664},
+						pos:  position{line: 663, col: 5, offset: 19468},
 						name: "UnicodeEscape",
 					},
 				},
@@ -5229,75 +5217,75 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 670, col: 1, offset: 19679},
+			pos:  position{line: 665, col: 1, offset: 19483},
 			expr: &choiceExpr{
-				pos: position{line: 671, col: 5, offset: 19700},
+				pos: position{line: 666, col: 5, offset: 19504},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 671, col: 5, offset: 19700},
+						pos:        position{line: 666, col: 5, offset: 19504},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 672, col: 5, offset: 19708},
+						pos:        position{line: 667, col: 5, offset: 19512},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 673, col: 5, offset: 19716},
+						pos:        position{line: 668, col: 5, offset: 19520},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 674, col: 5, offset: 19725},
+						pos: position{line: 669, col: 5, offset: 19529},
 						run: (*parser).callonSingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 674, col: 5, offset: 19725},
+							pos:        position{line: 669, col: 5, offset: 19529},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 675, col: 5, offset: 19754},
+						pos: position{line: 670, col: 5, offset: 19558},
 						run: (*parser).callonSingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 675, col: 5, offset: 19754},
+							pos:        position{line: 670, col: 5, offset: 19558},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 676, col: 5, offset: 19783},
+						pos: position{line: 671, col: 5, offset: 19587},
 						run: (*parser).callonSingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 676, col: 5, offset: 19783},
+							pos:        position{line: 671, col: 5, offset: 19587},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 677, col: 5, offset: 19812},
+						pos: position{line: 672, col: 5, offset: 19616},
 						run: (*parser).callonSingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 677, col: 5, offset: 19812},
+							pos:        position{line: 672, col: 5, offset: 19616},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 678, col: 5, offset: 19841},
+						pos: position{line: 673, col: 5, offset: 19645},
 						run: (*parser).callonSingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 678, col: 5, offset: 19841},
+							pos:        position{line: 673, col: 5, offset: 19645},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 679, col: 5, offset: 19870},
+						pos: position{line: 674, col: 5, offset: 19674},
 						run: (*parser).callonSingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 679, col: 5, offset: 19870},
+							pos:        position{line: 674, col: 5, offset: 19674},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5307,24 +5295,24 @@ var g = &grammar{
 		},
 		{
 			name: "SearchEscape",
-			pos:  position{line: 681, col: 1, offset: 19896},
+			pos:  position{line: 676, col: 1, offset: 19700},
 			expr: &choiceExpr{
-				pos: position{line: 682, col: 5, offset: 19913},
+				pos: position{line: 677, col: 5, offset: 19717},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 682, col: 5, offset: 19913},
+						pos: position{line: 677, col: 5, offset: 19717},
 						run: (*parser).callonSearchEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 682, col: 5, offset: 19913},
+							pos:        position{line: 677, col: 5, offset: 19717},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 683, col: 5, offset: 19941},
+						pos: position{line: 678, col: 5, offset: 19745},
 						run: (*parser).callonSearchEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 683, col: 5, offset: 19941},
+							pos:        position{line: 678, col: 5, offset: 19745},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -5334,41 +5322,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 685, col: 1, offset: 19968},
+			pos:  position{line: 680, col: 1, offset: 19772},
 			expr: &choiceExpr{
-				pos: position{line: 686, col: 5, offset: 19986},
+				pos: position{line: 681, col: 5, offset: 19790},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 686, col: 5, offset: 19986},
+						pos: position{line: 681, col: 5, offset: 19790},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 686, col: 5, offset: 19986},
+							pos: position{line: 681, col: 5, offset: 19790},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 686, col: 5, offset: 19986},
+									pos:        position{line: 681, col: 5, offset: 19790},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 686, col: 9, offset: 19990},
+									pos:   position{line: 681, col: 9, offset: 19794},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 686, col: 16, offset: 19997},
+										pos: position{line: 681, col: 16, offset: 19801},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 686, col: 16, offset: 19997},
+												pos:  position{line: 681, col: 16, offset: 19801},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 686, col: 25, offset: 20006},
+												pos:  position{line: 681, col: 25, offset: 19810},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 686, col: 34, offset: 20015},
+												pos:  position{line: 681, col: 34, offset: 19819},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 686, col: 43, offset: 20024},
+												pos:  position{line: 681, col: 43, offset: 19828},
 												name: "HexDigit",
 											},
 										},
@@ -5378,63 +5366,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 689, col: 5, offset: 20087},
+						pos: position{line: 684, col: 5, offset: 19891},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 689, col: 5, offset: 20087},
+							pos: position{line: 684, col: 5, offset: 19891},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 689, col: 5, offset: 20087},
+									pos:        position{line: 684, col: 5, offset: 19891},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 689, col: 9, offset: 20091},
+									pos:        position{line: 684, col: 9, offset: 19895},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 689, col: 13, offset: 20095},
+									pos:   position{line: 684, col: 13, offset: 19899},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 689, col: 20, offset: 20102},
+										pos: position{line: 684, col: 20, offset: 19906},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 689, col: 20, offset: 20102},
+												pos:  position{line: 684, col: 20, offset: 19906},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 689, col: 29, offset: 20111},
+												pos: position{line: 684, col: 29, offset: 19915},
 												expr: &ruleRefExpr{
-													pos:  position{line: 689, col: 29, offset: 20111},
+													pos:  position{line: 684, col: 29, offset: 19915},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 689, col: 39, offset: 20121},
+												pos: position{line: 684, col: 39, offset: 19925},
 												expr: &ruleRefExpr{
-													pos:  position{line: 689, col: 39, offset: 20121},
+													pos:  position{line: 684, col: 39, offset: 19925},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 689, col: 49, offset: 20131},
+												pos: position{line: 684, col: 49, offset: 19935},
 												expr: &ruleRefExpr{
-													pos:  position{line: 689, col: 49, offset: 20131},
+													pos:  position{line: 684, col: 49, offset: 19935},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 689, col: 59, offset: 20141},
+												pos: position{line: 684, col: 59, offset: 19945},
 												expr: &ruleRefExpr{
-													pos:  position{line: 689, col: 59, offset: 20141},
+													pos:  position{line: 684, col: 59, offset: 19945},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 689, col: 69, offset: 20151},
+												pos: position{line: 684, col: 69, offset: 19955},
 												expr: &ruleRefExpr{
-													pos:  position{line: 689, col: 69, offset: 20151},
+													pos:  position{line: 684, col: 69, offset: 19955},
 													name: "HexDigit",
 												},
 											},
@@ -5442,7 +5430,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 689, col: 80, offset: 20162},
+									pos:        position{line: 684, col: 80, offset: 19966},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5454,28 +5442,28 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 693, col: 1, offset: 20216},
+			pos:  position{line: 688, col: 1, offset: 20020},
 			expr: &actionExpr{
-				pos: position{line: 694, col: 5, offset: 20227},
+				pos: position{line: 689, col: 5, offset: 20031},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 694, col: 5, offset: 20227},
+					pos: position{line: 689, col: 5, offset: 20031},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 694, col: 5, offset: 20227},
+							pos:        position{line: 689, col: 5, offset: 20031},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 694, col: 9, offset: 20231},
+							pos:   position{line: 689, col: 9, offset: 20035},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 694, col: 14, offset: 20236},
+								pos:  position{line: 689, col: 14, offset: 20040},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 694, col: 25, offset: 20247},
+							pos:        position{line: 689, col: 25, offset: 20051},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5485,24 +5473,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 696, col: 1, offset: 20273},
+			pos:  position{line: 691, col: 1, offset: 20077},
 			expr: &actionExpr{
-				pos: position{line: 697, col: 5, offset: 20288},
+				pos: position{line: 692, col: 5, offset: 20092},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 697, col: 5, offset: 20288},
+					pos: position{line: 692, col: 5, offset: 20092},
 					expr: &choiceExpr{
-						pos: position{line: 697, col: 6, offset: 20289},
+						pos: position{line: 692, col: 6, offset: 20093},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 697, col: 6, offset: 20289},
+								pos:        position{line: 692, col: 6, offset: 20093},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 697, col: 13, offset: 20296},
+								pos:        position{line: 692, col: 13, offset: 20100},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -5513,9 +5501,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 699, col: 1, offset: 20336},
+			pos:  position{line: 694, col: 1, offset: 20140},
 			expr: &charClassMatcher{
-				pos:        position{line: 700, col: 5, offset: 20352},
+				pos:        position{line: 695, col: 5, offset: 20156},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5525,37 +5513,37 @@ var g = &grammar{
 		},
 		{
 			name: "WhiteSpace",
-			pos:  position{line: 702, col: 1, offset: 20367},
+			pos:  position{line: 697, col: 1, offset: 20171},
 			expr: &choiceExpr{
-				pos: position{line: 703, col: 5, offset: 20382},
+				pos: position{line: 698, col: 5, offset: 20186},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 703, col: 5, offset: 20382},
+						pos:        position{line: 698, col: 5, offset: 20186},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 704, col: 5, offset: 20391},
+						pos:        position{line: 699, col: 5, offset: 20195},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 705, col: 5, offset: 20400},
+						pos:        position{line: 700, col: 5, offset: 20204},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 706, col: 5, offset: 20409},
+						pos:        position{line: 701, col: 5, offset: 20213},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 707, col: 5, offset: 20417},
+						pos:        position{line: 702, col: 5, offset: 20221},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 708, col: 5, offset: 20430},
+						pos:        position{line: 703, col: 5, offset: 20234},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5564,33 +5552,33 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 710, col: 1, offset: 20440},
+			pos:  position{line: 705, col: 1, offset: 20244},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 710, col: 6, offset: 20445},
+				pos: position{line: 705, col: 6, offset: 20249},
 				expr: &ruleRefExpr{
-					pos:  position{line: 710, col: 6, offset: 20445},
+					pos:  position{line: 705, col: 6, offset: 20249},
 					name: "WhiteSpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 711, col: 1, offset: 20457},
+			pos:  position{line: 706, col: 1, offset: 20261},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 711, col: 6, offset: 20462},
+				pos: position{line: 706, col: 6, offset: 20266},
 				expr: &ruleRefExpr{
-					pos:  position{line: 711, col: 6, offset: 20462},
+					pos:  position{line: 706, col: 6, offset: 20266},
 					name: "WhiteSpace",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 713, col: 1, offset: 20475},
+			pos:  position{line: 708, col: 1, offset: 20279},
 			expr: &notExpr{
-				pos: position{line: 713, col: 7, offset: 20481},
+				pos: position{line: 708, col: 7, offset: 20285},
 				expr: &anyMatcher{
-					line: 713, col: 8, offset: 20482,
+					line: 708, col: 8, offset: 20286,
 				},
 			},
 		},
@@ -5632,18 +5620,6 @@ func (p *parser) callonQuery5() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onQuery5(stack["s"], stack["rest"])
-}
-
-func (c *current) onQuery13(s interface{}) (interface{}, error) {
-	// XXX does this ever match?  Rule above shoul;d match first
-	return map[string]interface{}{"op": "SequentialProc", "procs": []interface{}{s}}, nil
-
-}
-
-func (p *parser) callonQuery13() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onQuery13(stack["s"])
 }
 
 func (c *current) onSearch1(expr interface{}) (interface{}, error) {
@@ -5989,9 +5965,8 @@ func (p *parser) callonNullLiteral1() (interface{}, error) {
 func (c *current) onSequentialProcs1(first, rest interface{}) (interface{}, error) {
 	if rest != nil {
 		return append([]interface{}{first}, (rest.([]interface{}))...), nil
-	} else {
-		return []interface{}{first}, nil
 	}
+	return []interface{}{first}, nil
 
 }
 
@@ -6542,46 +6517,46 @@ func (p *parser) callonConditionalExpr2() (interface{}, error) {
 	return p.cur.onConditionalExpr2(stack["condition"], stack["thenClause"], stack["elseClause"])
 }
 
-func (c *current) onLogicalORExpr7(op, expr interface{}) (interface{}, error) {
+func (c *current) onLogicalOrExpr7(op, expr interface{}) (interface{}, error) {
 	return []interface{}{op, expr}, nil
 }
 
-func (p *parser) callonLogicalORExpr7() (interface{}, error) {
+func (p *parser) callonLogicalOrExpr7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLogicalORExpr7(stack["op"], stack["expr"])
+	return p.cur.onLogicalOrExpr7(stack["op"], stack["expr"])
 }
 
-func (c *current) onLogicalORExpr1(first, rest interface{}) (interface{}, error) {
+func (c *current) onLogicalOrExpr1(first, rest interface{}) (interface{}, error) {
 	return makeBinaryExprChain(first, rest), nil
 
 }
 
-func (p *parser) callonLogicalORExpr1() (interface{}, error) {
+func (p *parser) callonLogicalOrExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLogicalORExpr1(stack["first"], stack["rest"])
+	return p.cur.onLogicalOrExpr1(stack["first"], stack["rest"])
 }
 
-func (c *current) onLogicalANDExpr7(op, expr interface{}) (interface{}, error) {
+func (c *current) onLogicalAndExpr7(op, expr interface{}) (interface{}, error) {
 	return []interface{}{op, expr}, nil
 }
 
-func (p *parser) callonLogicalANDExpr7() (interface{}, error) {
+func (p *parser) callonLogicalAndExpr7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLogicalANDExpr7(stack["op"], stack["expr"])
+	return p.cur.onLogicalAndExpr7(stack["op"], stack["expr"])
 }
 
-func (c *current) onLogicalANDExpr1(first, rest interface{}) (interface{}, error) {
+func (c *current) onLogicalAndExpr1(first, rest interface{}) (interface{}, error) {
 	return makeBinaryExprChain(first, rest), nil
 
 }
 
-func (p *parser) callonLogicalANDExpr1() (interface{}, error) {
+func (p *parser) callonLogicalAndExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLogicalANDExpr1(stack["first"], stack["rest"])
+	return p.cur.onLogicalAndExpr1(stack["first"], stack["rest"])
 }
 
 func (c *current) onEqualityCompareExpr7(comp, expr interface{}) (interface{}, error) {
@@ -7109,15 +7084,15 @@ func (p *parser) callonHexColon1() (interface{}, error) {
 	return p.cur.onHexColon1(stack["v"])
 }
 
-func (c *current) onIPNet1(a, m interface{}) (interface{}, error) {
+func (c *current) onIP4Net1(a, m interface{}) (interface{}, error) {
 	return a.(string) + "/" + fmt.Sprintf("%v", m), nil
 
 }
 
-func (p *parser) callonIPNet1() (interface{}, error) {
+func (p *parser) callonIP4Net1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onIPNet1(stack["a"], stack["m"])
+	return p.cur.onIP4Net1(stack["a"], stack["m"])
 }
 
 func (c *current) onIP6Net1(a, m interface{}) (interface{}, error) {

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -39,7 +39,7 @@ var g = &grammar{
 							label: "ast",
 							expr: &ruleRefExpr{
 								pos:  position{line: 10, col: 16, offset: 41},
-								name: "query",
+								name: "Query",
 							},
 						},
 						&ruleRefExpr{
@@ -55,49 +55,49 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "query",
+			name: "Query",
 			pos:  position{line: 12, col: 1, offset: 75},
 			expr: &choiceExpr{
 				pos: position{line: 13, col: 5, offset: 85},
 				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 13, col: 5, offset: 85},
-						run: (*parser).callonquery2,
+						run: (*parser).callonQuery2,
 						expr: &labeledExpr{
 							pos:   position{line: 13, col: 5, offset: 85},
 							label: "procs",
 							expr: &ruleRefExpr{
 								pos:  position{line: 13, col: 11, offset: 91},
-								name: "procChain",
+								name: "SequentialProcs",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 17, col: 5, offset: 357},
-						run: (*parser).callonquery5,
+						pos: position{line: 17, col: 5, offset: 363},
+						run: (*parser).callonQuery5,
 						expr: &seqExpr{
-							pos: position{line: 17, col: 5, offset: 357},
+							pos: position{line: 17, col: 5, offset: 363},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 17, col: 5, offset: 357},
+									pos:   position{line: 17, col: 5, offset: 363},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 17, col: 7, offset: 359},
-										name: "search",
+										pos:  position{line: 17, col: 7, offset: 365},
+										name: "Search",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 17, col: 14, offset: 366},
+									pos:  position{line: 17, col: 14, offset: 372},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 17, col: 17, offset: 369},
+									pos:   position{line: 17, col: 17, offset: 375},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 17, col: 22, offset: 374},
+										pos: position{line: 17, col: 22, offset: 380},
 										expr: &ruleRefExpr{
-											pos:  position{line: 17, col: 22, offset: 374},
-											name: "chainedProc",
+											pos:  position{line: 17, col: 22, offset: 380},
+											name: "SequentialTail",
 										},
 									},
 								},
@@ -105,14 +105,14 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 24, col: 5, offset: 622},
-						run: (*parser).callonquery13,
+						pos: position{line: 24, col: 5, offset: 631},
+						run: (*parser).callonQuery13,
 						expr: &labeledExpr{
-							pos:   position{line: 24, col: 5, offset: 622},
+							pos:   position{line: 24, col: 5, offset: 631},
 							label: "s",
 							expr: &ruleRefExpr{
-								pos:  position{line: 24, col: 7, offset: 624},
-								name: "search",
+								pos:  position{line: 24, col: 7, offset: 633},
+								name: "Search",
 							},
 						},
 					},
@@ -120,112 +120,46 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "procChain",
-			pos:  position{line: 28, col: 1, offset: 732},
+			name: "Search",
+			pos:  position{line: 29, col: 1, offset: 808},
 			expr: &actionExpr{
-				pos: position{line: 29, col: 5, offset: 746},
-				run: (*parser).callonprocChain1,
-				expr: &seqExpr{
-					pos: position{line: 29, col: 5, offset: 746},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 29, col: 5, offset: 746},
-							label: "first",
-							expr: &ruleRefExpr{
-								pos:  position{line: 29, col: 11, offset: 752},
-								name: "proc",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 29, col: 16, offset: 757},
-							label: "rest",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 29, col: 21, offset: 762},
-								expr: &ruleRefExpr{
-									pos:  position{line: 29, col: 21, offset: 762},
-									name: "chainedProc",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "chainedProc",
-			pos:  position{line: 37, col: 1, offset: 948},
-			expr: &actionExpr{
-				pos: position{line: 37, col: 15, offset: 962},
-				run: (*parser).callonchainedProc1,
-				expr: &seqExpr{
-					pos: position{line: 37, col: 15, offset: 962},
-					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 37, col: 15, offset: 962},
-							name: "__",
-						},
-						&litMatcher{
-							pos:        position{line: 37, col: 18, offset: 965},
-							val:        "|",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 37, col: 22, offset: 969},
-							name: "__",
-						},
-						&labeledExpr{
-							pos:   position{line: 37, col: 25, offset: 972},
-							label: "p",
-							expr: &ruleRefExpr{
-								pos:  position{line: 37, col: 27, offset: 974},
-								name: "proc",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "search",
-			pos:  position{line: 39, col: 1, offset: 998},
-			expr: &actionExpr{
-				pos: position{line: 40, col: 5, offset: 1009},
-				run: (*parser).callonsearch1,
+				pos: position{line: 30, col: 5, offset: 819},
+				run: (*parser).callonSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 40, col: 5, offset: 1009},
+					pos:   position{line: 30, col: 5, offset: 819},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 40, col: 10, offset: 1014},
-						name: "searchExpr",
+						pos:  position{line: 30, col: 10, offset: 824},
+						name: "SearchExpr",
 					},
 				},
 			},
 		},
 		{
-			name: "searchExpr",
-			pos:  position{line: 44, col: 1, offset: 1111},
+			name: "SearchExpr",
+			pos:  position{line: 34, col: 1, offset: 921},
 			expr: &actionExpr{
-				pos: position{line: 45, col: 5, offset: 1126},
-				run: (*parser).callonsearchExpr1,
+				pos: position{line: 35, col: 5, offset: 936},
+				run: (*parser).callonSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 45, col: 5, offset: 1126},
+					pos: position{line: 35, col: 5, offset: 936},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 45, col: 5, offset: 1126},
+							pos:   position{line: 35, col: 5, offset: 936},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 45, col: 11, offset: 1132},
-								name: "searchTerm",
+								pos:  position{line: 35, col: 11, offset: 942},
+								name: "SearchTerm",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 45, col: 22, offset: 1143},
+							pos:   position{line: 35, col: 22, offset: 953},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 45, col: 27, offset: 1148},
+								pos: position{line: 35, col: 27, offset: 958},
 								expr: &ruleRefExpr{
-									pos:  position{line: 45, col: 27, offset: 1148},
-									name: "oredSearchTerm",
+									pos:  position{line: 35, col: 27, offset: 958},
+									name: "OredSearchTerm",
 								},
 							},
 						},
@@ -234,32 +168,32 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "oredSearchTerm",
-			pos:  position{line: 49, col: 1, offset: 1227},
+			name: "OredSearchTerm",
+			pos:  position{line: 39, col: 1, offset: 1037},
 			expr: &actionExpr{
-				pos: position{line: 49, col: 18, offset: 1244},
-				run: (*parser).callonoredSearchTerm1,
+				pos: position{line: 39, col: 18, offset: 1054},
+				run: (*parser).callonOredSearchTerm1,
 				expr: &seqExpr{
-					pos: position{line: 49, col: 18, offset: 1244},
+					pos: position{line: 39, col: 18, offset: 1054},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 49, col: 18, offset: 1244},
+							pos:  position{line: 39, col: 18, offset: 1054},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 49, col: 20, offset: 1246},
-							name: "orToken",
+							pos:  position{line: 39, col: 20, offset: 1056},
+							name: "OrToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 49, col: 28, offset: 1254},
+							pos:  position{line: 39, col: 28, offset: 1064},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 49, col: 30, offset: 1256},
+							pos:   position{line: 39, col: 30, offset: 1066},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 49, col: 32, offset: 1258},
-								name: "searchTerm",
+								pos:  position{line: 39, col: 32, offset: 1068},
+								name: "SearchTerm",
 							},
 						},
 					},
@@ -267,30 +201,30 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "searchTerm",
-			pos:  position{line: 51, col: 1, offset: 1288},
+			name: "SearchTerm",
+			pos:  position{line: 41, col: 1, offset: 1098},
 			expr: &actionExpr{
-				pos: position{line: 52, col: 5, offset: 1303},
-				run: (*parser).callonsearchTerm1,
+				pos: position{line: 42, col: 5, offset: 1113},
+				run: (*parser).callonSearchTerm1,
 				expr: &seqExpr{
-					pos: position{line: 52, col: 5, offset: 1303},
+					pos: position{line: 42, col: 5, offset: 1113},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 52, col: 5, offset: 1303},
+							pos:   position{line: 42, col: 5, offset: 1113},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 52, col: 11, offset: 1309},
-								name: "searchFactor",
+								pos:  position{line: 42, col: 11, offset: 1119},
+								name: "SearchFactor",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 52, col: 24, offset: 1322},
+							pos:   position{line: 42, col: 24, offset: 1132},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 52, col: 29, offset: 1327},
+								pos: position{line: 42, col: 29, offset: 1137},
 								expr: &ruleRefExpr{
-									pos:  position{line: 52, col: 29, offset: 1327},
-									name: "andedSearchTerm",
+									pos:  position{line: 42, col: 29, offset: 1137},
+									name: "AndedSearchTerm",
 								},
 							},
 						},
@@ -299,40 +233,40 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "andedSearchTerm",
-			pos:  position{line: 56, col: 1, offset: 1408},
+			name: "AndedSearchTerm",
+			pos:  position{line: 46, col: 1, offset: 1218},
 			expr: &actionExpr{
-				pos: position{line: 56, col: 19, offset: 1426},
-				run: (*parser).callonandedSearchTerm1,
+				pos: position{line: 46, col: 19, offset: 1236},
+				run: (*parser).callonAndedSearchTerm1,
 				expr: &seqExpr{
-					pos: position{line: 56, col: 19, offset: 1426},
+					pos: position{line: 46, col: 19, offset: 1236},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 56, col: 19, offset: 1426},
+							pos:  position{line: 46, col: 19, offset: 1236},
 							name: "_",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 56, col: 21, offset: 1428},
+							pos: position{line: 46, col: 21, offset: 1238},
 							expr: &seqExpr{
-								pos: position{line: 56, col: 22, offset: 1429},
+								pos: position{line: 46, col: 22, offset: 1239},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 56, col: 22, offset: 1429},
-										name: "andToken",
+										pos:  position{line: 46, col: 22, offset: 1239},
+										name: "AndToken",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 56, col: 31, offset: 1438},
+										pos:  position{line: 46, col: 31, offset: 1248},
 										name: "_",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 56, col: 35, offset: 1442},
+							pos:   position{line: 46, col: 35, offset: 1252},
 							label: "f",
 							expr: &ruleRefExpr{
-								pos:  position{line: 56, col: 37, offset: 1444},
-								name: "searchFactor",
+								pos:  position{line: 46, col: 37, offset: 1254},
+								name: "SearchFactor",
 							},
 						},
 					},
@@ -340,43 +274,43 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "searchFactor",
-			pos:  position{line: 58, col: 1, offset: 1476},
+			name: "SearchFactor",
+			pos:  position{line: 48, col: 1, offset: 1286},
 			expr: &choiceExpr{
-				pos: position{line: 59, col: 5, offset: 1493},
+				pos: position{line: 49, col: 5, offset: 1303},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 59, col: 5, offset: 1493},
-						run: (*parser).callonsearchFactor2,
+						pos: position{line: 49, col: 5, offset: 1303},
+						run: (*parser).callonSearchFactor2,
 						expr: &seqExpr{
-							pos: position{line: 59, col: 5, offset: 1493},
+							pos: position{line: 49, col: 5, offset: 1303},
 							exprs: []interface{}{
 								&choiceExpr{
-									pos: position{line: 59, col: 6, offset: 1494},
+									pos: position{line: 49, col: 6, offset: 1304},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 59, col: 6, offset: 1494},
+											pos: position{line: 49, col: 6, offset: 1304},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 59, col: 6, offset: 1494},
-													name: "notToken",
+													pos:  position{line: 49, col: 6, offset: 1304},
+													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 59, col: 15, offset: 1503},
+													pos:  position{line: 49, col: 15, offset: 1313},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 59, col: 19, offset: 1507},
+											pos: position{line: 49, col: 19, offset: 1317},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 59, col: 19, offset: 1507},
+													pos:        position{line: 49, col: 19, offset: 1317},
 													val:        "!",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 59, col: 23, offset: 1511},
+													pos:  position{line: 49, col: 23, offset: 1321},
 													name: "__",
 												},
 											},
@@ -384,70 +318,70 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 59, col: 27, offset: 1515},
+									pos:   position{line: 49, col: 27, offset: 1325},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 59, col: 29, offset: 1517},
-										name: "searchExpr",
+										pos:  position{line: 49, col: 29, offset: 1327},
+										name: "SearchExpr",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 62, col: 5, offset: 1612},
-						run: (*parser).callonsearchFactor13,
+						pos: position{line: 52, col: 5, offset: 1422},
+						run: (*parser).callonSearchFactor13,
 						expr: &seqExpr{
-							pos: position{line: 62, col: 5, offset: 1612},
+							pos: position{line: 52, col: 5, offset: 1422},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 62, col: 5, offset: 1612},
+									pos: position{line: 52, col: 5, offset: 1422},
 									expr: &litMatcher{
-										pos:        position{line: 62, col: 7, offset: 1614},
+										pos:        position{line: 52, col: 7, offset: 1424},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 62, col: 12, offset: 1619},
+									pos:   position{line: 52, col: 12, offset: 1429},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 62, col: 14, offset: 1621},
-										name: "searchPred",
+										pos:  position{line: 52, col: 14, offset: 1431},
+										name: "SearchPred",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 63, col: 5, offset: 1654},
-						run: (*parser).callonsearchFactor19,
+						pos: position{line: 53, col: 5, offset: 1464},
+						run: (*parser).callonSearchFactor19,
 						expr: &seqExpr{
-							pos: position{line: 63, col: 5, offset: 1654},
+							pos: position{line: 53, col: 5, offset: 1464},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 63, col: 5, offset: 1654},
+									pos:        position{line: 53, col: 5, offset: 1464},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 63, col: 9, offset: 1658},
+									pos:  position{line: 53, col: 9, offset: 1468},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 63, col: 12, offset: 1661},
+									pos:   position{line: 53, col: 12, offset: 1471},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 63, col: 17, offset: 1666},
-										name: "searchExpr",
+										pos:  position{line: 53, col: 17, offset: 1476},
+										name: "SearchExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 63, col: 28, offset: 1677},
+									pos:  position{line: 53, col: 28, offset: 1487},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 63, col: 31, offset: 1680},
+									pos:        position{line: 53, col: 31, offset: 1490},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -458,205 +392,205 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "searchPred",
-			pos:  position{line: 65, col: 1, offset: 1706},
+			name: "SearchPred",
+			pos:  position{line: 55, col: 1, offset: 1516},
 			expr: &choiceExpr{
-				pos: position{line: 66, col: 5, offset: 1721},
+				pos: position{line: 56, col: 5, offset: 1531},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 66, col: 5, offset: 1721},
-						run: (*parser).callonsearchPred2,
+						pos: position{line: 56, col: 5, offset: 1531},
+						run: (*parser).callonSearchPred2,
 						expr: &seqExpr{
-							pos: position{line: 66, col: 5, offset: 1721},
+							pos: position{line: 56, col: 5, offset: 1531},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 66, col: 5, offset: 1721},
+									pos:        position{line: 56, col: 5, offset: 1531},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 66, col: 9, offset: 1725},
+									pos:  position{line: 56, col: 9, offset: 1535},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 66, col: 12, offset: 1728},
+									pos:   position{line: 56, col: 12, offset: 1538},
 									label: "comp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 66, col: 17, offset: 1733},
-										name: "equalityToken",
+										pos:  position{line: 56, col: 17, offset: 1543},
+										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 66, col: 31, offset: 1747},
+									pos:  position{line: 56, col: 31, offset: 1557},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 66, col: 34, offset: 1750},
+									pos:   position{line: 56, col: 34, offset: 1560},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 66, col: 36, offset: 1752},
-										name: "searchValue",
+										pos:  position{line: 56, col: 36, offset: 1562},
+										name: "SearchValue",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 69, col: 5, offset: 1889},
-						run: (*parser).callonsearchPred11,
+						pos: position{line: 59, col: 5, offset: 1699},
+						run: (*parser).callonSearchPred11,
 						expr: &seqExpr{
-							pos: position{line: 69, col: 5, offset: 1889},
+							pos: position{line: 59, col: 5, offset: 1699},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 69, col: 5, offset: 1889},
+									pos:        position{line: 59, col: 5, offset: 1699},
 									val:        "**",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 69, col: 10, offset: 1894},
+									pos:  position{line: 59, col: 10, offset: 1704},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 69, col: 13, offset: 1897},
+									pos:   position{line: 59, col: 13, offset: 1707},
 									label: "comp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 69, col: 18, offset: 1902},
-										name: "equalityToken",
+										pos:  position{line: 59, col: 18, offset: 1712},
+										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 69, col: 32, offset: 1916},
+									pos:  position{line: 59, col: 32, offset: 1726},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 69, col: 35, offset: 1919},
+									pos:   position{line: 59, col: 35, offset: 1729},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 69, col: 37, offset: 1921},
-										name: "searchValue",
+										pos:  position{line: 59, col: 37, offset: 1731},
+										name: "SearchValue",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 72, col: 5, offset: 2057},
-						run: (*parser).callonsearchPred20,
+						pos: position{line: 62, col: 5, offset: 1867},
+						run: (*parser).callonSearchPred20,
 						expr: &seqExpr{
-							pos: position{line: 72, col: 5, offset: 2057},
+							pos: position{line: 62, col: 5, offset: 1867},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 72, col: 5, offset: 2057},
+									pos:   position{line: 62, col: 5, offset: 1867},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 72, col: 7, offset: 2059},
+										pos:  position{line: 62, col: 7, offset: 1869},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 72, col: 12, offset: 2064},
+									pos:  position{line: 62, col: 12, offset: 1874},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 72, col: 15, offset: 2067},
+									pos:   position{line: 62, col: 15, offset: 1877},
 									label: "comp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 72, col: 20, offset: 2072},
-										name: "equalityToken",
+										pos:  position{line: 62, col: 20, offset: 1882},
+										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 72, col: 34, offset: 2086},
+									pos:  position{line: 62, col: 34, offset: 1896},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 72, col: 37, offset: 2089},
+									pos:   position{line: 62, col: 37, offset: 1899},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 72, col: 39, offset: 2091},
-										name: "searchValue",
+										pos:  position{line: 62, col: 39, offset: 1901},
+										name: "SearchValue",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 79, col: 5, offset: 2545},
-						run: (*parser).callonsearchPred30,
+						pos: position{line: 69, col: 5, offset: 2355},
+						run: (*parser).callonSearchPred30,
 						expr: &seqExpr{
-							pos: position{line: 79, col: 5, offset: 2545},
+							pos: position{line: 69, col: 5, offset: 2355},
 							exprs: []interface{}{
 								&andExpr{
-									pos: position{line: 79, col: 5, offset: 2545},
+									pos: position{line: 69, col: 5, offset: 2355},
 									expr: &litMatcher{
-										pos:        position{line: 79, col: 6, offset: 2546},
+										pos:        position{line: 69, col: 6, offset: 2356},
 										val:        "len",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 79, col: 12, offset: 2552},
+									pos:   position{line: 69, col: 12, offset: 2362},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 79, col: 17, offset: 2557},
-										name: "FunctionExpr",
+										pos:  position{line: 69, col: 17, offset: 2367},
+										name: "Function",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 79, col: 30, offset: 2570},
+									pos:  position{line: 69, col: 26, offset: 2376},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 79, col: 33, offset: 2573},
+									pos:   position{line: 69, col: 29, offset: 2379},
 									label: "comp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 79, col: 38, offset: 2578},
-										name: "equalityToken",
+										pos:  position{line: 69, col: 34, offset: 2384},
+										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 79, col: 52, offset: 2592},
+									pos:  position{line: 69, col: 48, offset: 2398},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 79, col: 55, offset: 2595},
+									pos:   position{line: 69, col: 51, offset: 2401},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 79, col: 57, offset: 2597},
-										name: "searchValue",
+										pos:  position{line: 69, col: 53, offset: 2403},
+										name: "SearchValue",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 82, col: 5, offset: 2725},
-						run: (*parser).callonsearchPred42,
+						pos: position{line: 72, col: 5, offset: 2531},
+						run: (*parser).callonSearchPred42,
 						expr: &seqExpr{
-							pos: position{line: 82, col: 5, offset: 2725},
+							pos: position{line: 72, col: 5, offset: 2531},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 82, col: 5, offset: 2725},
+									pos:   position{line: 72, col: 5, offset: 2531},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 82, col: 7, offset: 2727},
-										name: "searchValue",
+										pos:  position{line: 72, col: 7, offset: 2533},
+										name: "SearchValue",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 82, col: 19, offset: 2739},
+									pos:  position{line: 72, col: 19, offset: 2545},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 82, col: 22, offset: 2742},
-									name: "inToken",
+									pos:  position{line: 72, col: 22, offset: 2548},
+									name: "InToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 82, col: 30, offset: 2750},
+									pos:  position{line: 72, col: 30, offset: 2556},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 82, col: 33, offset: 2753},
+									pos:        position{line: 72, col: 33, offset: 2559},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -664,82 +598,82 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 85, col: 5, offset: 2882},
-						run: (*parser).callonsearchPred50,
+						pos: position{line: 75, col: 5, offset: 2688},
+						run: (*parser).callonSearchPred50,
 						expr: &seqExpr{
-							pos: position{line: 85, col: 5, offset: 2882},
+							pos: position{line: 75, col: 5, offset: 2688},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 85, col: 5, offset: 2882},
+									pos:   position{line: 75, col: 5, offset: 2688},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 85, col: 7, offset: 2884},
-										name: "searchValue",
+										pos:  position{line: 75, col: 7, offset: 2690},
+										name: "SearchValue",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 85, col: 19, offset: 2896},
+									pos:  position{line: 75, col: 19, offset: 2702},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 85, col: 22, offset: 2899},
-									name: "inToken",
+									pos:  position{line: 75, col: 22, offset: 2705},
+									name: "InToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 85, col: 30, offset: 2907},
+									pos:  position{line: 75, col: 30, offset: 2713},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 85, col: 33, offset: 2910},
+									pos:   position{line: 75, col: 33, offset: 2716},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 85, col: 35, offset: 2912},
-										name: "fieldExpr",
+										pos:  position{line: 75, col: 35, offset: 2718},
+										name: "FieldExpr",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 88, col: 5, offset: 3041},
-						run: (*parser).callonsearchPred59,
+						pos: position{line: 78, col: 5, offset: 2847},
+						run: (*parser).callonSearchPred59,
 						expr: &labeledExpr{
-							pos:   position{line: 88, col: 5, offset: 3041},
+							pos:   position{line: 78, col: 5, offset: 2847},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 88, col: 7, offset: 3043},
-								name: "searchLiteral",
+								pos:  position{line: 78, col: 7, offset: 2849},
+								name: "SearchLiteral",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 91, col: 5, offset: 3162},
-						run: (*parser).callonsearchPred62,
+						pos: position{line: 81, col: 5, offset: 2968},
+						run: (*parser).callonSearchPred62,
 						expr: &seqExpr{
-							pos: position{line: 91, col: 5, offset: 3162},
+							pos: position{line: 81, col: 5, offset: 2968},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 91, col: 5, offset: 3162},
+									pos: position{line: 81, col: 5, offset: 2968},
 									expr: &seqExpr{
-										pos: position{line: 91, col: 7, offset: 3164},
+										pos: position{line: 81, col: 7, offset: 2970},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 91, col: 8, offset: 3165},
-												name: "searchKeywords",
+												pos:  position{line: 81, col: 8, offset: 2971},
+												name: "SearchKeywords",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 91, col: 24, offset: 3181},
+												pos:  position{line: 81, col: 24, offset: 2987},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 91, col: 28, offset: 3185},
+									pos:   position{line: 81, col: 28, offset: 2991},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 91, col: 30, offset: 3187},
-										name: "searchWord",
+										pos:  position{line: 81, col: 30, offset: 2993},
+										name: "SearchWord",
 									},
 								},
 							},
@@ -749,82 +683,149 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "searchLiteral",
-			pos:  position{line: 104, col: 1, offset: 3639},
+			name: "SearchValue",
+			pos:  position{line: 94, col: 1, offset: 3445},
 			expr: &choiceExpr{
-				pos: position{line: 105, col: 5, offset: 3657},
+				pos: position{line: 95, col: 5, offset: 3461},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 105, col: 5, offset: 3657},
-						name: "StringLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 106, col: 5, offset: 3675},
-						name: "RegexpLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 107, col: 5, offset: 3693},
-						name: "SubnetLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 108, col: 5, offset: 3711},
-						name: "AddressLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 109, col: 5, offset: 3730},
-						name: "FloatLiteral",
+						pos:  position{line: 95, col: 5, offset: 3461},
+						name: "SearchLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 113, col: 5, offset: 3897},
-						run: (*parser).callonsearchLiteral7,
+						pos: position{line: 96, col: 5, offset: 3479},
+						run: (*parser).callonSearchValue3,
 						expr: &seqExpr{
-							pos: position{line: 113, col: 5, offset: 3897},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 113, col: 5, offset: 3897},
-									label: "i",
-									expr: &ruleRefExpr{
-										pos:  position{line: 113, col: 7, offset: 3899},
-										name: "IntegerLiteral",
-									},
-								},
-								&notExpr{
-									pos: position{line: 113, col: 22, offset: 3914},
-									expr: &ruleRefExpr{
-										pos:  position{line: 113, col: 23, offset: 3915},
-										name: "searchWord",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 115, col: 5, offset: 3949},
-						run: (*parser).callonsearchLiteral13,
-						expr: &seqExpr{
-							pos: position{line: 115, col: 5, offset: 3949},
+							pos: position{line: 96, col: 5, offset: 3479},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 115, col: 5, offset: 3949},
+									pos: position{line: 96, col: 5, offset: 3479},
 									expr: &seqExpr{
-										pos: position{line: 115, col: 7, offset: 3951},
+										pos: position{line: 96, col: 7, offset: 3481},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 115, col: 7, offset: 3951},
-												name: "searchKeywords",
+												pos:  position{line: 96, col: 8, offset: 3482},
+												name: "SearchKeywords",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 115, col: 22, offset: 3966},
+												pos:  position{line: 96, col: 24, offset: 3498},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 115, col: 25, offset: 3969},
+									pos:   position{line: 96, col: 27, offset: 3501},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 115, col: 27, offset: 3971},
+										pos:  position{line: 96, col: 29, offset: 3503},
+										name: "SearchWord",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SearchKeywords",
+			pos:  position{line: 100, col: 1, offset: 3611},
+			expr: &choiceExpr{
+				pos: position{line: 101, col: 5, offset: 3630},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 101, col: 5, offset: 3630},
+						name: "AndToken",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 102, col: 5, offset: 3643},
+						name: "OrToken",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 103, col: 5, offset: 3655},
+						name: "InToken",
+					},
+				},
+			},
+		},
+		{
+			name: "SearchLiteral",
+			pos:  position{line: 105, col: 1, offset: 3664},
+			expr: &choiceExpr{
+				pos: position{line: 106, col: 5, offset: 3682},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 106, col: 5, offset: 3682},
+						name: "StringLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 107, col: 5, offset: 3700},
+						name: "RegexpLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 108, col: 5, offset: 3718},
+						name: "SubnetLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 109, col: 5, offset: 3736},
+						name: "AddressLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 110, col: 5, offset: 3755},
+						name: "FloatLiteral",
+					},
+					&actionExpr{
+						pos: position{line: 114, col: 5, offset: 3922},
+						run: (*parser).callonSearchLiteral7,
+						expr: &seqExpr{
+							pos: position{line: 114, col: 5, offset: 3922},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 114, col: 5, offset: 3922},
+									label: "i",
+									expr: &ruleRefExpr{
+										pos:  position{line: 114, col: 7, offset: 3924},
+										name: "IntegerLiteral",
+									},
+								},
+								&notExpr{
+									pos: position{line: 114, col: 22, offset: 3939},
+									expr: &ruleRefExpr{
+										pos:  position{line: 114, col: 23, offset: 3940},
+										name: "SearchWord",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 116, col: 5, offset: 3974},
+						run: (*parser).callonSearchLiteral13,
+						expr: &seqExpr{
+							pos: position{line: 116, col: 5, offset: 3974},
+							exprs: []interface{}{
+								&notExpr{
+									pos: position{line: 116, col: 5, offset: 3974},
+									expr: &seqExpr{
+										pos: position{line: 116, col: 7, offset: 3976},
+										exprs: []interface{}{
+											&ruleRefExpr{
+												pos:  position{line: 116, col: 7, offset: 3976},
+												name: "SearchKeywords",
+											},
+											&ruleRefExpr{
+												pos:  position{line: 116, col: 22, offset: 3991},
+												name: "_",
+											},
+										},
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 116, col: 25, offset: 3994},
+									label: "v",
+									expr: &ruleRefExpr{
+										pos:  position{line: 116, col: 27, offset: 3996},
 										name: "BooleanLiteral",
 									},
 								},
@@ -832,32 +833,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 116, col: 5, offset: 4008},
-						run: (*parser).callonsearchLiteral21,
+						pos: position{line: 117, col: 5, offset: 4033},
+						run: (*parser).callonSearchLiteral21,
 						expr: &seqExpr{
-							pos: position{line: 116, col: 5, offset: 4008},
+							pos: position{line: 117, col: 5, offset: 4033},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 116, col: 5, offset: 4008},
+									pos: position{line: 117, col: 5, offset: 4033},
 									expr: &seqExpr{
-										pos: position{line: 116, col: 7, offset: 4010},
+										pos: position{line: 117, col: 7, offset: 4035},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 116, col: 7, offset: 4010},
-												name: "searchKeywords",
+												pos:  position{line: 117, col: 7, offset: 4035},
+												name: "SearchKeywords",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 116, col: 22, offset: 4025},
+												pos:  position{line: 117, col: 22, offset: 4050},
 												name: "_",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 116, col: 25, offset: 4028},
+									pos:   position{line: 117, col: 25, offset: 4053},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 116, col: 27, offset: 4030},
+										pos:  position{line: 117, col: 27, offset: 4055},
 										name: "NullLiteral",
 									},
 								},
@@ -868,107 +869,61 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "searchValue",
-			pos:  position{line: 119, col: 1, offset: 4062},
-			expr: &choiceExpr{
-				pos: position{line: 120, col: 5, offset: 4078},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 120, col: 5, offset: 4078},
-						name: "searchLiteral",
-					},
-					&actionExpr{
-						pos: position{line: 121, col: 5, offset: 4096},
-						run: (*parser).callonsearchValue3,
-						expr: &seqExpr{
-							pos: position{line: 121, col: 5, offset: 4096},
-							exprs: []interface{}{
-								&notExpr{
-									pos: position{line: 121, col: 5, offset: 4096},
-									expr: &seqExpr{
-										pos: position{line: 121, col: 7, offset: 4098},
-										exprs: []interface{}{
-											&ruleRefExpr{
-												pos:  position{line: 121, col: 8, offset: 4099},
-												name: "searchKeywords",
-											},
-											&ruleRefExpr{
-												pos:  position{line: 121, col: 24, offset: 4115},
-												name: "_",
-											},
-										},
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 121, col: 27, offset: 4118},
-									label: "v",
-									expr: &ruleRefExpr{
-										pos:  position{line: 121, col: 29, offset: 4120},
-										name: "searchWord",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "StringLiteral",
-			pos:  position{line: 125, col: 1, offset: 4228},
+			pos:  position{line: 120, col: 1, offset: 4087},
 			expr: &actionExpr{
-				pos: position{line: 126, col: 5, offset: 4246},
+				pos: position{line: 121, col: 5, offset: 4105},
 				run: (*parser).callonStringLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 126, col: 5, offset: 4246},
+					pos:   position{line: 121, col: 5, offset: 4105},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 126, col: 7, offset: 4248},
-						name: "quotedString",
+						pos:  position{line: 121, col: 7, offset: 4107},
+						name: "QuotedString",
 					},
 				},
 			},
 		},
 		{
 			name: "RegexpLiteral",
-			pos:  position{line: 130, col: 1, offset: 4358},
+			pos:  position{line: 125, col: 1, offset: 4217},
 			expr: &actionExpr{
-				pos: position{line: 131, col: 5, offset: 4376},
+				pos: position{line: 126, col: 5, offset: 4235},
 				run: (*parser).callonRegexpLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 131, col: 5, offset: 4376},
+					pos:   position{line: 126, col: 5, offset: 4235},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 131, col: 7, offset: 4378},
-						name: "reString",
+						pos:  position{line: 126, col: 7, offset: 4237},
+						name: "Regexp",
 					},
 				},
 			},
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 135, col: 1, offset: 4484},
+			pos:  position{line: 130, col: 1, offset: 4341},
 			expr: &choiceExpr{
-				pos: position{line: 136, col: 5, offset: 4502},
+				pos: position{line: 131, col: 5, offset: 4359},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 136, col: 5, offset: 4502},
+						pos: position{line: 131, col: 5, offset: 4359},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 136, col: 5, offset: 4502},
+							pos: position{line: 131, col: 5, offset: 4359},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 136, col: 5, offset: 4502},
+									pos:   position{line: 131, col: 5, offset: 4359},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 136, col: 7, offset: 4504},
-										name: "ip6subnet",
+										pos:  position{line: 131, col: 7, offset: 4361},
+										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 136, col: 17, offset: 4514},
+									pos: position{line: 131, col: 14, offset: 4368},
 									expr: &ruleRefExpr{
-										pos:  position{line: 136, col: 18, offset: 4515},
+										pos:  position{line: 131, col: 15, offset: 4369},
 										name: "IdentifierRest",
 									},
 								},
@@ -976,14 +931,14 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 139, col: 5, offset: 4627},
+						pos: position{line: 134, col: 5, offset: 4481},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 139, col: 5, offset: 4627},
+							pos:   position{line: 134, col: 5, offset: 4481},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 139, col: 7, offset: 4629},
-								name: "subnet",
+								pos:  position{line: 134, col: 7, offset: 4483},
+								name: "IPNet",
 							},
 						},
 					},
@@ -992,28 +947,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 143, col: 1, offset: 4730},
+			pos:  position{line: 138, col: 1, offset: 4583},
 			expr: &choiceExpr{
-				pos: position{line: 144, col: 5, offset: 4749},
+				pos: position{line: 139, col: 5, offset: 4602},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 144, col: 5, offset: 4749},
+						pos: position{line: 139, col: 5, offset: 4602},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 144, col: 5, offset: 4749},
+							pos: position{line: 139, col: 5, offset: 4602},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 144, col: 5, offset: 4749},
+									pos:   position{line: 139, col: 5, offset: 4602},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 144, col: 7, offset: 4751},
-										name: "ip6addr",
+										pos:  position{line: 139, col: 7, offset: 4604},
+										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 144, col: 15, offset: 4759},
+									pos: position{line: 139, col: 11, offset: 4608},
 									expr: &ruleRefExpr{
-										pos:  position{line: 144, col: 16, offset: 4760},
+										pos:  position{line: 139, col: 12, offset: 4609},
 										name: "IdentifierRest",
 									},
 								},
@@ -1021,14 +976,14 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 147, col: 5, offset: 4871},
+						pos: position{line: 142, col: 5, offset: 4720},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 147, col: 5, offset: 4871},
+							pos:   position{line: 142, col: 5, offset: 4720},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 147, col: 7, offset: 4873},
-								name: "addr",
+								pos:  position{line: 142, col: 7, offset: 4722},
+								name: "IP",
 							},
 						},
 					},
@@ -1037,56 +992,56 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 151, col: 1, offset: 4971},
+			pos:  position{line: 146, col: 1, offset: 4818},
 			expr: &actionExpr{
-				pos: position{line: 152, col: 5, offset: 4988},
+				pos: position{line: 147, col: 5, offset: 4835},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 152, col: 5, offset: 4988},
+					pos:   position{line: 147, col: 5, offset: 4835},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 152, col: 7, offset: 4990},
-						name: "sdouble",
+						pos:  position{line: 147, col: 7, offset: 4837},
+						name: "FloatString",
 					},
 				},
 			},
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 156, col: 1, offset: 5096},
+			pos:  position{line: 151, col: 1, offset: 4947},
 			expr: &actionExpr{
-				pos: position{line: 157, col: 5, offset: 5115},
+				pos: position{line: 152, col: 5, offset: 4966},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 157, col: 5, offset: 5115},
+					pos:   position{line: 152, col: 5, offset: 4966},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 157, col: 7, offset: 5117},
-						name: "sinteger",
+						pos:  position{line: 152, col: 7, offset: 4968},
+						name: "IntString",
 					},
 				},
 			},
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 161, col: 1, offset: 5222},
+			pos:  position{line: 156, col: 1, offset: 5074},
 			expr: &choiceExpr{
-				pos: position{line: 162, col: 5, offset: 5241},
+				pos: position{line: 157, col: 5, offset: 5093},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 162, col: 5, offset: 5241},
+						pos: position{line: 157, col: 5, offset: 5093},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 162, col: 5, offset: 5241},
+							pos:        position{line: 157, col: 5, offset: 5093},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 163, col: 5, offset: 5351},
+						pos: position{line: 158, col: 5, offset: 5203},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 163, col: 5, offset: 5351},
+							pos:        position{line: 158, col: 5, offset: 5203},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -1096,63 +1051,42 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 165, col: 1, offset: 5459},
+			pos:  position{line: 160, col: 1, offset: 5311},
 			expr: &actionExpr{
-				pos: position{line: 166, col: 5, offset: 5475},
+				pos: position{line: 161, col: 5, offset: 5327},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 166, col: 5, offset: 5475},
+					pos:        position{line: 161, col: 5, offset: 5327},
 					val:        "null",
 					ignoreCase: false,
 				},
 			},
 		},
 		{
-			name: "searchKeywords",
-			pos:  position{line: 168, col: 1, offset: 5565},
-			expr: &choiceExpr{
-				pos: position{line: 169, col: 5, offset: 5584},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 169, col: 5, offset: 5584},
-						name: "andToken",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 170, col: 5, offset: 5597},
-						name: "orToken",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 171, col: 5, offset: 5609},
-						name: "inToken",
-					},
-				},
-			},
-		},
-		{
-			name: "procList",
-			pos:  position{line: 173, col: 1, offset: 5618},
+			name: "SequentialProcs",
+			pos:  position{line: 163, col: 1, offset: 5417},
 			expr: &actionExpr{
-				pos: position{line: 174, col: 5, offset: 5631},
-				run: (*parser).callonprocList1,
+				pos: position{line: 164, col: 5, offset: 5437},
+				run: (*parser).callonSequentialProcs1,
 				expr: &seqExpr{
-					pos: position{line: 174, col: 5, offset: 5631},
+					pos: position{line: 164, col: 5, offset: 5437},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 174, col: 5, offset: 5631},
+							pos:   position{line: 164, col: 5, offset: 5437},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 174, col: 11, offset: 5637},
-								name: "procChain",
+								pos:  position{line: 164, col: 11, offset: 5443},
+								name: "Proc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 174, col: 21, offset: 5647},
+							pos:   position{line: 164, col: 16, offset: 5448},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 174, col: 26, offset: 5652},
+								pos: position{line: 164, col: 21, offset: 5453},
 								expr: &ruleRefExpr{
-									pos:  position{line: 174, col: 26, offset: 5652},
-									name: "parallelChain",
+									pos:  position{line: 164, col: 21, offset: 5453},
+									name: "SequentialTail",
 								},
 							},
 						},
@@ -1161,33 +1095,33 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "parallelChain",
-			pos:  position{line: 183, col: 1, offset: 5952},
+			name: "SequentialTail",
+			pos:  position{line: 172, col: 1, offset: 5641},
 			expr: &actionExpr{
-				pos: position{line: 184, col: 5, offset: 5970},
-				run: (*parser).callonparallelChain1,
+				pos: position{line: 172, col: 18, offset: 5658},
+				run: (*parser).callonSequentialTail1,
 				expr: &seqExpr{
-					pos: position{line: 184, col: 5, offset: 5970},
+					pos: position{line: 172, col: 18, offset: 5658},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 5, offset: 5970},
+							pos:  position{line: 172, col: 18, offset: 5658},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 184, col: 8, offset: 5973},
-							val:        ";",
+							pos:        position{line: 172, col: 21, offset: 5661},
+							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 184, col: 12, offset: 5977},
+							pos:  position{line: 172, col: 25, offset: 5665},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 184, col: 15, offset: 5980},
-							label: "ch",
+							pos:   position{line: 172, col: 28, offset: 5668},
+							label: "p",
 							expr: &ruleRefExpr{
-								pos:  position{line: 184, col: 18, offset: 5983},
-								name: "procChain",
+								pos:  position{line: 172, col: 30, offset: 5670},
+								name: "Proc",
 							},
 						},
 					},
@@ -1195,48 +1129,48 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "proc",
-			pos:  position{line: 186, col: 1, offset: 6070},
+			name: "Proc",
+			pos:  position{line: 174, col: 1, offset: 5694},
 			expr: &choiceExpr{
-				pos: position{line: 187, col: 5, offset: 6079},
+				pos: position{line: 175, col: 5, offset: 5703},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 187, col: 5, offset: 6079},
-						name: "simpleProc",
+						pos:  position{line: 175, col: 5, offset: 5703},
+						name: "NamedProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 188, col: 5, offset: 6094},
-						name: "groupByProc",
+						pos:  position{line: 176, col: 5, offset: 5717},
+						name: "GroupByProc",
 					},
 					&actionExpr{
-						pos: position{line: 189, col: 5, offset: 6110},
-						run: (*parser).callonproc4,
+						pos: position{line: 177, col: 5, offset: 5733},
+						run: (*parser).callonProc4,
 						expr: &seqExpr{
-							pos: position{line: 189, col: 5, offset: 6110},
+							pos: position{line: 177, col: 5, offset: 5733},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 189, col: 5, offset: 6110},
+									pos:        position{line: 177, col: 5, offset: 5733},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 189, col: 9, offset: 6114},
+									pos:  position{line: 177, col: 9, offset: 5737},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 189, col: 12, offset: 6117},
+									pos:   position{line: 177, col: 12, offset: 5740},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 189, col: 17, offset: 6122},
-										name: "procList",
+										pos:  position{line: 177, col: 17, offset: 5745},
+										name: "Procs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 189, col: 26, offset: 6131},
+									pos:  position{line: 177, col: 23, offset: 5751},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 189, col: 29, offset: 6134},
+									pos:        position{line: 177, col: 26, offset: 5754},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1247,32 +1181,186 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "groupByKeys",
-			pos:  position{line: 193, col: 1, offset: 6170},
+			name: "Procs",
+			pos:  position{line: 181, col: 1, offset: 5790},
 			expr: &actionExpr{
-				pos: position{line: 194, col: 5, offset: 6186},
-				run: (*parser).callongroupByKeys1,
+				pos: position{line: 182, col: 5, offset: 5800},
+				run: (*parser).callonProcs1,
 				expr: &seqExpr{
-					pos: position{line: 194, col: 5, offset: 6186},
+					pos: position{line: 182, col: 5, offset: 5800},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 182, col: 5, offset: 5800},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 182, col: 11, offset: 5806},
+								name: "SequentialProcs",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 182, col: 27, offset: 5822},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 182, col: 32, offset: 5827},
+								expr: &ruleRefExpr{
+									pos:  position{line: 182, col: 32, offset: 5827},
+									name: "ParallelTail",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ParallelTail",
+			pos:  position{line: 191, col: 1, offset: 6126},
+			expr: &actionExpr{
+				pos: position{line: 192, col: 5, offset: 6143},
+				run: (*parser).callonParallelTail1,
+				expr: &seqExpr{
+					pos: position{line: 192, col: 5, offset: 6143},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 194, col: 5, offset: 6186},
+							pos:  position{line: 192, col: 5, offset: 6143},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 192, col: 8, offset: 6146},
+							val:        ";",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 192, col: 12, offset: 6150},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 192, col: 15, offset: 6153},
+							label: "ch",
+							expr: &ruleRefExpr{
+								pos:  position{line: 192, col: 18, offset: 6156},
+								name: "SequentialProcs",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "GroupByProc",
+			pos:  position{line: 194, col: 1, offset: 6249},
+			expr: &actionExpr{
+				pos: position{line: 195, col: 5, offset: 6265},
+				run: (*parser).callonGroupByProc1,
+				expr: &seqExpr{
+					pos: position{line: 195, col: 5, offset: 6265},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 195, col: 5, offset: 6265},
+							label: "every",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 195, col: 11, offset: 6271},
+								expr: &ruleRefExpr{
+									pos:  position{line: 195, col: 11, offset: 6271},
+									name: "EveryDur",
+								},
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 195, col: 21, offset: 6281},
+							label: "reducers",
+							expr: &ruleRefExpr{
+								pos:  position{line: 195, col: 30, offset: 6290},
+								name: "Reducers",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 195, col: 39, offset: 6299},
+							label: "keys",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 195, col: 44, offset: 6304},
+								expr: &ruleRefExpr{
+									pos:  position{line: 195, col: 44, offset: 6304},
+									name: "GroupByKeys",
+								},
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 195, col: 57, offset: 6317},
+							label: "limit",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 195, col: 63, offset: 6323},
+								expr: &ruleRefExpr{
+									pos:  position{line: 195, col: 63, offset: 6323},
+									name: "LimitArg",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "EveryDur",
+			pos:  position{line: 209, col: 1, offset: 6619},
+			expr: &actionExpr{
+				pos: position{line: 210, col: 5, offset: 6632},
+				run: (*parser).callonEveryDur1,
+				expr: &seqExpr{
+					pos: position{line: 210, col: 5, offset: 6632},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 210, col: 5, offset: 6632},
+							val:        "every",
+							ignoreCase: true,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 210, col: 14, offset: 6641},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 210, col: 16, offset: 6643},
+							label: "dur",
+							expr: &ruleRefExpr{
+								pos:  position{line: 210, col: 20, offset: 6647},
+								name: "Duration",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 210, col: 29, offset: 6656},
+							name: "_",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "GroupByKeys",
+			pos:  position{line: 212, col: 1, offset: 6679},
+			expr: &actionExpr{
+				pos: position{line: 213, col: 5, offset: 6695},
+				run: (*parser).callonGroupByKeys1,
+				expr: &seqExpr{
+					pos: position{line: 213, col: 5, offset: 6695},
+					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 213, col: 5, offset: 6695},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 194, col: 7, offset: 6188},
+							pos:        position{line: 213, col: 7, offset: 6697},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 194, col: 13, offset: 6194},
+							pos:  position{line: 213, col: 13, offset: 6703},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 194, col: 15, offset: 6196},
+							pos:   position{line: 213, col: 15, offset: 6705},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 194, col: 23, offset: 6204},
+								pos:  position{line: 213, col: 23, offset: 6713},
 								name: "FlexAssignments",
 							},
 						},
@@ -1281,24 +1369,67 @@ var g = &grammar{
 			},
 		},
 		{
+			name: "LimitArg",
+			pos:  position{line: 215, col: 1, offset: 6754},
+			expr: &actionExpr{
+				pos: position{line: 216, col: 5, offset: 6767},
+				run: (*parser).callonLimitArg1,
+				expr: &seqExpr{
+					pos: position{line: 216, col: 5, offset: 6767},
+					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 216, col: 5, offset: 6767},
+							name: "_",
+						},
+						&litMatcher{
+							pos:        position{line: 216, col: 7, offset: 6769},
+							val:        "with",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 216, col: 14, offset: 6776},
+							name: "_",
+						},
+						&litMatcher{
+							pos:        position{line: 216, col: 16, offset: 6778},
+							val:        "-limit",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 216, col: 25, offset: 6787},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 216, col: 27, offset: 6789},
+							label: "limit",
+							expr: &ruleRefExpr{
+								pos:  position{line: 216, col: 33, offset: 6795},
+								name: "UInt",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "FlexAssignment",
-			pos:  position{line: 199, col: 1, offset: 6483},
+			pos:  position{line: 221, col: 1, offset: 7061},
 			expr: &choiceExpr{
-				pos: position{line: 200, col: 5, offset: 6502},
+				pos: position{line: 222, col: 5, offset: 7080},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 200, col: 5, offset: 6502},
+						pos:  position{line: 222, col: 5, offset: 7080},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 201, col: 5, offset: 6517},
+						pos: position{line: 223, col: 5, offset: 7095},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 201, col: 5, offset: 6517},
+							pos:   position{line: 223, col: 5, offset: 7095},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 201, col: 10, offset: 6522},
-								name: "Expression",
+								pos:  position{line: 223, col: 10, offset: 7100},
+								name: "Expr",
 							},
 						},
 					},
@@ -1307,50 +1438,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 203, col: 1, offset: 6606},
+			pos:  position{line: 225, col: 1, offset: 7178},
 			expr: &actionExpr{
-				pos: position{line: 204, col: 5, offset: 6626},
+				pos: position{line: 226, col: 5, offset: 7198},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 204, col: 5, offset: 6626},
+					pos: position{line: 226, col: 5, offset: 7198},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 204, col: 5, offset: 6626},
+							pos:   position{line: 226, col: 5, offset: 7198},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 204, col: 11, offset: 6632},
+								pos:  position{line: 226, col: 11, offset: 7204},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 204, col: 26, offset: 6647},
+							pos:   position{line: 226, col: 26, offset: 7219},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 204, col: 31, offset: 6652},
+								pos: position{line: 226, col: 31, offset: 7224},
 								expr: &actionExpr{
-									pos: position{line: 204, col: 32, offset: 6653},
+									pos: position{line: 226, col: 32, offset: 7225},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 204, col: 32, offset: 6653},
+										pos: position{line: 226, col: 32, offset: 7225},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 204, col: 32, offset: 6653},
+												pos:  position{line: 226, col: 32, offset: 7225},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 204, col: 35, offset: 6656},
+												pos:        position{line: 226, col: 35, offset: 7228},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 204, col: 39, offset: 6660},
+												pos:  position{line: 226, col: 39, offset: 7232},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 204, col: 42, offset: 6663},
+												pos:   position{line: 226, col: 42, offset: 7235},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 204, col: 47, offset: 6668},
+													pos:  position{line: 226, col: 47, offset: 7240},
 													name: "FlexAssignment",
 												},
 											},
@@ -1364,619 +1495,54 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "everyDur",
-			pos:  position{line: 208, col: 1, offset: 6788},
-			expr: &actionExpr{
-				pos: position{line: 209, col: 5, offset: 6801},
-				run: (*parser).calloneveryDur1,
-				expr: &seqExpr{
-					pos: position{line: 209, col: 5, offset: 6801},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 209, col: 5, offset: 6801},
-							val:        "every",
-							ignoreCase: true,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 209, col: 14, offset: 6810},
-							name: "_",
-						},
-						&labeledExpr{
-							pos:   position{line: 209, col: 16, offset: 6812},
-							label: "dur",
-							expr: &ruleRefExpr{
-								pos:  position{line: 209, col: 20, offset: 6816},
-								name: "duration",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 209, col: 29, offset: 6825},
-							name: "_",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "equalityToken",
-			pos:  position{line: 211, col: 1, offset: 6848},
-			expr: &choiceExpr{
-				pos: position{line: 212, col: 5, offset: 6866},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 212, col: 5, offset: 6866},
-						name: "EqualityOperator",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 212, col: 24, offset: 6885},
-						name: "RelativeOperator",
-					},
-				},
-			},
-		},
-		{
-			name: "andToken",
-			pos:  position{line: 214, col: 1, offset: 6903},
-			expr: &actionExpr{
-				pos: position{line: 214, col: 12, offset: 6914},
-				run: (*parser).callonandToken1,
-				expr: &litMatcher{
-					pos:        position{line: 214, col: 12, offset: 6914},
-					val:        "and",
-					ignoreCase: true,
-				},
-			},
-		},
-		{
-			name: "orToken",
-			pos:  position{line: 215, col: 1, offset: 6952},
-			expr: &actionExpr{
-				pos: position{line: 215, col: 11, offset: 6962},
-				run: (*parser).callonorToken1,
-				expr: &litMatcher{
-					pos:        position{line: 215, col: 11, offset: 6962},
-					val:        "or",
-					ignoreCase: true,
-				},
-			},
-		},
-		{
-			name: "inToken",
-			pos:  position{line: 216, col: 1, offset: 6999},
-			expr: &actionExpr{
-				pos: position{line: 216, col: 11, offset: 7009},
-				run: (*parser).calloninToken1,
-				expr: &litMatcher{
-					pos:        position{line: 216, col: 11, offset: 7009},
-					val:        "in",
-					ignoreCase: true,
-				},
-			},
-		},
-		{
-			name: "notToken",
-			pos:  position{line: 217, col: 1, offset: 7046},
-			expr: &actionExpr{
-				pos: position{line: 217, col: 12, offset: 7057},
-				run: (*parser).callonnotToken1,
-				expr: &litMatcher{
-					pos:        position{line: 217, col: 12, offset: 7057},
-					val:        "not",
-					ignoreCase: true,
-				},
-			},
-		},
-		{
-			name: "IdentifierName",
-			pos:  position{line: 219, col: 1, offset: 7096},
-			expr: &actionExpr{
-				pos: position{line: 219, col: 18, offset: 7113},
-				run: (*parser).callonIdentifierName1,
-				expr: &seqExpr{
-					pos: position{line: 219, col: 18, offset: 7113},
-					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 219, col: 18, offset: 7113},
-							name: "IdentifierStart",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 219, col: 34, offset: 7129},
-							expr: &ruleRefExpr{
-								pos:  position{line: 219, col: 34, offset: 7129},
-								name: "IdentifierRest",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "IdentifierStart",
-			pos:  position{line: 221, col: 1, offset: 7177},
-			expr: &charClassMatcher{
-				pos:        position{line: 221, col: 19, offset: 7195},
-				val:        "[A-Za-z_$]",
-				chars:      []rune{'_', '$'},
-				ranges:     []rune{'A', 'Z', 'a', 'z'},
-				ignoreCase: false,
-				inverted:   false,
-			},
-		},
-		{
-			name: "IdentifierRest",
-			pos:  position{line: 222, col: 1, offset: 7206},
-			expr: &choiceExpr{
-				pos: position{line: 222, col: 18, offset: 7223},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 222, col: 18, offset: 7223},
-						name: "IdentifierStart",
-					},
-					&charClassMatcher{
-						pos:        position{line: 222, col: 36, offset: 7241},
-						val:        "[0-9]",
-						ranges:     []rune{'0', '9'},
-						ignoreCase: false,
-						inverted:   false,
-					},
-				},
-			},
-		},
-		{
-			name: "Identifier",
-			pos:  position{line: 224, col: 1, offset: 7248},
-			expr: &actionExpr{
-				pos: position{line: 225, col: 5, offset: 7263},
-				run: (*parser).callonIdentifier1,
-				expr: &seqExpr{
-					pos: position{line: 225, col: 5, offset: 7263},
-					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 225, col: 5, offset: 7263},
-							name: "IdentifierStart",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 225, col: 21, offset: 7279},
-							expr: &ruleRefExpr{
-								pos:  position{line: 225, col: 21, offset: 7279},
-								name: "IdentifierRest",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "RootField",
-			pos:  position{line: 227, col: 1, offset: 7379},
-			expr: &choiceExpr{
-				pos: position{line: 228, col: 5, offset: 7393},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 228, col: 5, offset: 7393},
-						run: (*parser).callonRootField2,
-						expr: &seqExpr{
-							pos: position{line: 228, col: 5, offset: 7393},
-							exprs: []interface{}{
-								&zeroOrOneExpr{
-									pos: position{line: 228, col: 5, offset: 7393},
-									expr: &litMatcher{
-										pos:        position{line: 228, col: 5, offset: 7393},
-										val:        ".",
-										ignoreCase: false,
-									},
-								},
-								&notExpr{
-									pos: position{line: 228, col: 10, offset: 7398},
-									expr: &choiceExpr{
-										pos: position{line: 228, col: 12, offset: 7400},
-										alternatives: []interface{}{
-											&ruleRefExpr{
-												pos:  position{line: 228, col: 12, offset: 7400},
-												name: "BooleanLiteral",
-											},
-											&ruleRefExpr{
-												pos:  position{line: 228, col: 29, offset: 7417},
-												name: "NullLiteral",
-											},
-										},
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 228, col: 42, offset: 7430},
-									label: "field",
-									expr: &ruleRefExpr{
-										pos:  position{line: 228, col: 48, offset: 7436},
-										name: "Identifier",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 229, col: 5, offset: 7589},
-						run: (*parser).callonRootField12,
-						expr: &seqExpr{
-							pos: position{line: 229, col: 5, offset: 7589},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 229, col: 5, offset: 7589},
-									val:        ".",
-									ignoreCase: false,
-								},
-								&notExpr{
-									pos: position{line: 229, col: 9, offset: 7593},
-									expr: &ruleRefExpr{
-										pos:  position{line: 229, col: 11, offset: 7595},
-										name: "Identifier",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Lval",
-			pos:  position{line: 231, col: 1, offset: 7668},
-			expr: &ruleRefExpr{
-				pos:  position{line: 231, col: 8, offset: 7675},
-				name: "DerefExpression",
-			},
-		},
-		{
-			name: "DerefExpression",
-			pos:  position{line: 233, col: 1, offset: 7692},
-			expr: &actionExpr{
-				pos: position{line: 234, col: 5, offset: 7712},
-				run: (*parser).callonDerefExpression1,
-				expr: &seqExpr{
-					pos: position{line: 234, col: 5, offset: 7712},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 234, col: 5, offset: 7712},
-							label: "first",
-							expr: &ruleRefExpr{
-								pos:  position{line: 234, col: 11, offset: 7718},
-								name: "RootField",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 234, col: 21, offset: 7728},
-							label: "rest",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 234, col: 26, offset: 7733},
-								expr: &ruleRefExpr{
-									pos:  position{line: 234, col: 27, offset: 7734},
-									name: "Deref",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Deref",
-			pos:  position{line: 238, col: 1, offset: 7799},
-			expr: &choiceExpr{
-				pos: position{line: 239, col: 5, offset: 7809},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 239, col: 5, offset: 7809},
-						run: (*parser).callonDeref2,
-						expr: &seqExpr{
-							pos: position{line: 239, col: 5, offset: 7809},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 239, col: 5, offset: 7809},
-									val:        "[",
-									ignoreCase: false,
-								},
-								&labeledExpr{
-									pos:   position{line: 239, col: 9, offset: 7813},
-									label: "expr",
-									expr: &ruleRefExpr{
-										pos:  position{line: 239, col: 14, offset: 7818},
-										name: "Expression",
-									},
-								},
-								&litMatcher{
-									pos:        position{line: 239, col: 25, offset: 7829},
-									val:        "]",
-									ignoreCase: false,
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 240, col: 5, offset: 7878},
-						run: (*parser).callonDeref8,
-						expr: &seqExpr{
-							pos: position{line: 240, col: 5, offset: 7878},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 240, col: 5, offset: 7878},
-									val:        ".",
-									ignoreCase: false,
-								},
-								&notExpr{
-									pos: position{line: 240, col: 9, offset: 7882},
-									expr: &litMatcher{
-										pos:        position{line: 240, col: 11, offset: 7884},
-										val:        ".",
-										ignoreCase: false,
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 240, col: 16, offset: 7889},
-									label: "id",
-									expr: &ruleRefExpr{
-										pos:  position{line: 240, col: 19, offset: 7892},
-										name: "Identifier",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "FunctionExpr",
-			pos:  position{line: 247, col: 1, offset: 8204},
-			expr: &actionExpr{
-				pos: position{line: 248, col: 7, offset: 8223},
-				run: (*parser).callonFunctionExpr1,
-				expr: &seqExpr{
-					pos: position{line: 248, col: 7, offset: 8223},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 248, col: 7, offset: 8223},
-							label: "fn",
-							expr: &ruleRefExpr{
-								pos:  position{line: 248, col: 10, offset: 8226},
-								name: "FunctionName",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 248, col: 23, offset: 8239},
-							name: "__",
-						},
-						&litMatcher{
-							pos:        position{line: 248, col: 26, offset: 8242},
-							val:        "(",
-							ignoreCase: false,
-						},
-						&labeledExpr{
-							pos:   position{line: 248, col: 30, offset: 8246},
-							label: "args",
-							expr: &ruleRefExpr{
-								pos:  position{line: 248, col: 35, offset: 8251},
-								name: "ArgumentList",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 248, col: 48, offset: 8264},
-							val:        ")",
-							ignoreCase: false,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "fieldExpr",
-			pos:  position{line: 252, col: 1, offset: 8376},
-			expr: &ruleRefExpr{
-				pos:  position{line: 252, col: 13, offset: 8388},
-				name: "Lval",
-			},
-		},
-		{
-			name: "fieldExprList",
-			pos:  position{line: 254, col: 1, offset: 8394},
-			expr: &actionExpr{
-				pos: position{line: 255, col: 5, offset: 8412},
-				run: (*parser).callonfieldExprList1,
-				expr: &seqExpr{
-					pos: position{line: 255, col: 5, offset: 8412},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 255, col: 5, offset: 8412},
-							label: "first",
-							expr: &ruleRefExpr{
-								pos:  position{line: 255, col: 11, offset: 8418},
-								name: "fieldExpr",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 255, col: 21, offset: 8428},
-							label: "rest",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 255, col: 26, offset: 8433},
-								expr: &seqExpr{
-									pos: position{line: 255, col: 27, offset: 8434},
-									exprs: []interface{}{
-										&ruleRefExpr{
-											pos:  position{line: 255, col: 27, offset: 8434},
-											name: "__",
-										},
-										&litMatcher{
-											pos:        position{line: 255, col: 30, offset: 8437},
-											val:        ",",
-											ignoreCase: false,
-										},
-										&ruleRefExpr{
-											pos:  position{line: 255, col: 34, offset: 8441},
-											name: "__",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 255, col: 37, offset: 8444},
-											name: "fieldExpr",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "ExprList",
-			pos:  position{line: 265, col: 1, offset: 8641},
-			expr: &actionExpr{
-				pos: position{line: 266, col: 5, offset: 8654},
-				run: (*parser).callonExprList1,
-				expr: &seqExpr{
-					pos: position{line: 266, col: 5, offset: 8654},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 266, col: 5, offset: 8654},
-							label: "first",
-							expr: &ruleRefExpr{
-								pos:  position{line: 266, col: 11, offset: 8660},
-								name: "Expression",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 266, col: 22, offset: 8671},
-							label: "rest",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 266, col: 27, offset: 8676},
-								expr: &seqExpr{
-									pos: position{line: 266, col: 28, offset: 8677},
-									exprs: []interface{}{
-										&ruleRefExpr{
-											pos:  position{line: 266, col: 28, offset: 8677},
-											name: "__",
-										},
-										&litMatcher{
-											pos:        position{line: 266, col: 31, offset: 8680},
-											val:        ",",
-											ignoreCase: false,
-										},
-										&ruleRefExpr{
-											pos:  position{line: 266, col: 35, offset: 8684},
-											name: "__",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 266, col: 38, offset: 8687},
-											name: "Expression",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "groupByProc",
-			pos:  position{line: 276, col: 1, offset: 8887},
-			expr: &actionExpr{
-				pos: position{line: 277, col: 5, offset: 8903},
-				run: (*parser).callongroupByProc1,
-				expr: &seqExpr{
-					pos: position{line: 277, col: 5, offset: 8903},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 277, col: 5, offset: 8903},
-							label: "every",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 277, col: 11, offset: 8909},
-								expr: &ruleRefExpr{
-									pos:  position{line: 277, col: 11, offset: 8909},
-									name: "everyDur",
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 277, col: 21, offset: 8919},
-							label: "reducers",
-							expr: &ruleRefExpr{
-								pos:  position{line: 277, col: 30, offset: 8928},
-								name: "reducerList",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 277, col: 42, offset: 8940},
-							label: "keys",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 277, col: 47, offset: 8945},
-								expr: &ruleRefExpr{
-									pos:  position{line: 277, col: 47, offset: 8945},
-									name: "groupByKeys",
-								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 277, col: 60, offset: 8958},
-							label: "limit",
-							expr: &zeroOrOneExpr{
-								pos: position{line: 277, col: 66, offset: 8964},
-								expr: &ruleRefExpr{
-									pos:  position{line: 277, col: 66, offset: 8964},
-									name: "procLimitArg",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "ReducerAssignment",
-			pos:  position{line: 291, col: 1, offset: 9240},
+			pos:  position{line: 230, col: 1, offset: 7362},
 			expr: &choiceExpr{
-				pos: position{line: 292, col: 5, offset: 9262},
+				pos: position{line: 231, col: 5, offset: 7384},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 292, col: 5, offset: 9262},
+						pos: position{line: 231, col: 5, offset: 7384},
 						run: (*parser).callonReducerAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 292, col: 5, offset: 9262},
+							pos: position{line: 231, col: 5, offset: 7384},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 292, col: 5, offset: 9262},
+									pos:   position{line: 231, col: 5, offset: 7384},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 292, col: 10, offset: 9267},
+										pos:  position{line: 231, col: 10, offset: 7389},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 292, col: 15, offset: 9272},
+									pos:  position{line: 231, col: 15, offset: 7394},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 292, col: 18, offset: 9275},
+									pos:        position{line: 231, col: 18, offset: 7397},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 292, col: 22, offset: 9279},
+									pos:   position{line: 231, col: 22, offset: 7401},
 									label: "reducer",
 									expr: &ruleRefExpr{
-										pos:  position{line: 292, col: 30, offset: 9287},
-										name: "reducer",
+										pos:  position{line: 231, col: 30, offset: 7409},
+										name: "Reducer",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 295, col: 5, offset: 9395},
+						pos: position{line: 234, col: 5, offset: 7519},
 						run: (*parser).callonReducerAssignment10,
 						expr: &labeledExpr{
-							pos:   position{line: 295, col: 5, offset: 9395},
+							pos:   position{line: 234, col: 5, offset: 7519},
 							label: "reducer",
 							expr: &ruleRefExpr{
-								pos:  position{line: 295, col: 13, offset: 9403},
-								name: "reducer",
+								pos:  position{line: 234, col: 13, offset: 7527},
+								name: "Reducer",
 							},
 						},
 					},
@@ -1984,26 +1550,26 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "reducer",
-			pos:  position{line: 299, col: 1, offset: 9495},
+			name: "Reducer",
+			pos:  position{line: 238, col: 1, offset: 7621},
 			expr: &actionExpr{
-				pos: position{line: 300, col: 5, offset: 9507},
-				run: (*parser).callonreducer1,
+				pos: position{line: 239, col: 5, offset: 7633},
+				run: (*parser).callonReducer1,
 				expr: &seqExpr{
-					pos: position{line: 300, col: 5, offset: 9507},
+					pos: position{line: 239, col: 5, offset: 7633},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 300, col: 5, offset: 9507},
+							pos: position{line: 239, col: 5, offset: 7633},
 							expr: &choiceExpr{
-								pos: position{line: 300, col: 7, offset: 9509},
+								pos: position{line: 239, col: 7, offset: 7635},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 300, col: 7, offset: 9509},
+										pos:        position{line: 239, col: 7, offset: 7635},
 										val:        "not",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 300, col: 13, offset: 9515},
+										pos:        position{line: 239, col: 13, offset: 7641},
 										val:        "len",
 										ignoreCase: false,
 									},
@@ -2011,54 +1577,54 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 300, col: 20, offset: 9522},
+							pos:   position{line: 239, col: 20, offset: 7648},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 300, col: 23, offset: 9525},
-								name: "FunctionName",
+								pos:  position{line: 239, col: 23, offset: 7651},
+								name: "FuncName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 300, col: 36, offset: 9538},
+							pos:  position{line: 239, col: 32, offset: 7660},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 300, col: 39, offset: 9541},
+							pos:        position{line: 239, col: 35, offset: 7663},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 300, col: 43, offset: 9545},
+							pos:  position{line: 239, col: 39, offset: 7667},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 300, col: 46, offset: 9548},
+							pos:   position{line: 239, col: 42, offset: 7670},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 300, col: 51, offset: 9553},
+								pos: position{line: 239, col: 47, offset: 7675},
 								expr: &ruleRefExpr{
-									pos:  position{line: 300, col: 51, offset: 9553},
-									name: "Expression",
+									pos:  position{line: 239, col: 47, offset: 7675},
+									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 300, col: 64, offset: 9566},
+							pos:  position{line: 239, col: 54, offset: 7682},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 300, col: 67, offset: 9569},
+							pos:        position{line: 239, col: 57, offset: 7685},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 300, col: 71, offset: 9573},
+							pos:   position{line: 239, col: 61, offset: 7689},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 300, col: 77, offset: 9579},
+								pos: position{line: 239, col: 67, offset: 7695},
 								expr: &ruleRefExpr{
-									pos:  position{line: 300, col: 77, offset: 9579},
-									name: "where",
+									pos:  position{line: 239, col: 67, offset: 7695},
+									name: "WhereClause",
 								},
 							},
 						},
@@ -2067,33 +1633,33 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "where",
-			pos:  position{line: 308, col: 1, offset: 9744},
+			name: "WhereClause",
+			pos:  position{line: 247, col: 1, offset: 7878},
 			expr: &actionExpr{
-				pos: position{line: 308, col: 9, offset: 9752},
-				run: (*parser).callonwhere1,
+				pos: position{line: 247, col: 15, offset: 7892},
+				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 308, col: 9, offset: 9752},
+					pos: position{line: 247, col: 15, offset: 7892},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 308, col: 9, offset: 9752},
+							pos:  position{line: 247, col: 15, offset: 7892},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 308, col: 11, offset: 9754},
+							pos:        position{line: 247, col: 17, offset: 7894},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 308, col: 19, offset: 9762},
+							pos:  position{line: 247, col: 25, offset: 7902},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 308, col: 21, offset: 9764},
+							pos:   position{line: 247, col: 27, offset: 7904},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 308, col: 26, offset: 9769},
-								name: "Expression",
+								pos:  position{line: 247, col: 32, offset: 7909},
+								name: "Expr",
 							},
 						},
 					},
@@ -2101,45 +1667,45 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "reducerList",
-			pos:  position{line: 310, col: 1, offset: 9802},
+			name: "Reducers",
+			pos:  position{line: 249, col: 1, offset: 7936},
 			expr: &actionExpr{
-				pos: position{line: 311, col: 5, offset: 9818},
-				run: (*parser).callonreducerList1,
+				pos: position{line: 250, col: 5, offset: 7949},
+				run: (*parser).callonReducers1,
 				expr: &seqExpr{
-					pos: position{line: 311, col: 5, offset: 9818},
+					pos: position{line: 250, col: 5, offset: 7949},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 311, col: 5, offset: 9818},
+							pos:   position{line: 250, col: 5, offset: 7949},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 311, col: 11, offset: 9824},
+								pos:  position{line: 250, col: 11, offset: 7955},
 								name: "ReducerAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 311, col: 29, offset: 9842},
+							pos:   position{line: 250, col: 29, offset: 7973},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 311, col: 34, offset: 9847},
+								pos: position{line: 250, col: 34, offset: 7978},
 								expr: &seqExpr{
-									pos: position{line: 311, col: 35, offset: 9848},
+									pos: position{line: 250, col: 35, offset: 7979},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 311, col: 35, offset: 9848},
+											pos:  position{line: 250, col: 35, offset: 7979},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 311, col: 38, offset: 9851},
+											pos:        position{line: 250, col: 38, offset: 7982},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 311, col: 42, offset: 9855},
+											pos:  position{line: 250, col: 42, offset: 7986},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 311, col: 45, offset: 9858},
+											pos:  position{line: 250, col: 45, offset: 7989},
 											name: "ReducerAssignment",
 										},
 									},
@@ -2151,97 +1717,97 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "simpleProc",
-			pos:  position{line: 319, col: 1, offset: 10063},
+			name: "NamedProc",
+			pos:  position{line: 258, col: 1, offset: 8194},
 			expr: &choiceExpr{
-				pos: position{line: 320, col: 5, offset: 10078},
+				pos: position{line: 259, col: 5, offset: 8208},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 5, offset: 10078},
-						name: "sort",
+						pos:  position{line: 259, col: 5, offset: 8208},
+						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 321, col: 5, offset: 10087},
-						name: "top",
+						pos:  position{line: 260, col: 5, offset: 8221},
+						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 322, col: 5, offset: 10095},
-						name: "cut",
+						pos:  position{line: 261, col: 5, offset: 8233},
+						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 323, col: 5, offset: 10103},
-						name: "head",
+						pos:  position{line: 262, col: 5, offset: 8245},
+						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 324, col: 5, offset: 10112},
-						name: "tail",
+						pos:  position{line: 263, col: 5, offset: 8258},
+						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 325, col: 5, offset: 10121},
-						name: "filter",
+						pos:  position{line: 264, col: 5, offset: 8271},
+						name: "FilterProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 326, col: 5, offset: 10132},
-						name: "uniq",
+						pos:  position{line: 265, col: 5, offset: 8286},
+						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 327, col: 5, offset: 10141},
-						name: "put",
+						pos:  position{line: 266, col: 5, offset: 8299},
+						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 328, col: 5, offset: 10149},
-						name: "rename",
+						pos:  position{line: 267, col: 5, offset: 8311},
+						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 329, col: 5, offset: 10160},
-						name: "fuse",
+						pos:  position{line: 268, col: 5, offset: 8326},
+						name: "FuseProc",
 					},
 				},
 			},
 		},
 		{
-			name: "sort",
-			pos:  position{line: 331, col: 1, offset: 10166},
+			name: "SortProc",
+			pos:  position{line: 270, col: 1, offset: 8336},
 			expr: &actionExpr{
-				pos: position{line: 332, col: 5, offset: 10175},
-				run: (*parser).callonsort1,
+				pos: position{line: 271, col: 5, offset: 8349},
+				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 332, col: 5, offset: 10175},
+					pos: position{line: 271, col: 5, offset: 8349},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 332, col: 5, offset: 10175},
+							pos:        position{line: 271, col: 5, offset: 8349},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 332, col: 13, offset: 10183},
+							pos:   position{line: 271, col: 13, offset: 8357},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 332, col: 18, offset: 10188},
-								name: "sortArgs",
+								pos:  position{line: 271, col: 18, offset: 8362},
+								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 332, col: 27, offset: 10197},
+							pos:   position{line: 271, col: 27, offset: 8371},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 332, col: 32, offset: 10202},
+								pos: position{line: 271, col: 32, offset: 8376},
 								expr: &actionExpr{
-									pos: position{line: 332, col: 33, offset: 10203},
-									run: (*parser).callonsort8,
+									pos: position{line: 271, col: 33, offset: 8377},
+									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 332, col: 33, offset: 10203},
+										pos: position{line: 271, col: 33, offset: 8377},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 332, col: 33, offset: 10203},
+												pos:  position{line: 271, col: 33, offset: 8377},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 332, col: 35, offset: 10205},
+												pos:   position{line: 271, col: 35, offset: 8379},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 332, col: 37, offset: 10207},
-													name: "ExprList",
+													pos:  position{line: 271, col: 37, offset: 8381},
+													name: "Exprs",
 												},
 											},
 										},
@@ -2254,32 +1820,32 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "sortArgs",
-			pos:  position{line: 346, col: 1, offset: 10605},
+			name: "SortArgs",
+			pos:  position{line: 285, col: 1, offset: 8800},
 			expr: &actionExpr{
-				pos: position{line: 346, col: 12, offset: 10616},
-				run: (*parser).callonsortArgs1,
+				pos: position{line: 285, col: 12, offset: 8811},
+				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 346, col: 12, offset: 10616},
+					pos:   position{line: 285, col: 12, offset: 8811},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 346, col: 17, offset: 10621},
+						pos: position{line: 285, col: 17, offset: 8816},
 						expr: &actionExpr{
-							pos: position{line: 346, col: 18, offset: 10622},
-							run: (*parser).callonsortArgs4,
+							pos: position{line: 285, col: 18, offset: 8817},
+							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 346, col: 18, offset: 10622},
+								pos: position{line: 285, col: 18, offset: 8817},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 346, col: 18, offset: 10622},
+										pos:  position{line: 285, col: 18, offset: 8817},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 346, col: 20, offset: 10624},
+										pos:   position{line: 285, col: 20, offset: 8819},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 346, col: 22, offset: 10626},
-											name: "sortArg",
+											pos:  position{line: 285, col: 22, offset: 8821},
+											name: "SortArg",
 										},
 									},
 								},
@@ -2290,51 +1856,51 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "sortArg",
-			pos:  position{line: 350, col: 1, offset: 10686},
+			name: "SortArg",
+			pos:  position{line: 287, col: 1, offset: 8877},
 			expr: &choiceExpr{
-				pos: position{line: 351, col: 5, offset: 10698},
+				pos: position{line: 288, col: 5, offset: 8889},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 351, col: 5, offset: 10698},
-						run: (*parser).callonsortArg2,
+						pos: position{line: 288, col: 5, offset: 8889},
+						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 351, col: 5, offset: 10698},
+							pos:        position{line: 288, col: 5, offset: 8889},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 352, col: 5, offset: 10773},
-						run: (*parser).callonsortArg4,
+						pos: position{line: 289, col: 5, offset: 8964},
+						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 352, col: 5, offset: 10773},
+							pos: position{line: 289, col: 5, offset: 8964},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 352, col: 5, offset: 10773},
+									pos:        position{line: 289, col: 5, offset: 8964},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 352, col: 14, offset: 10782},
+									pos:  position{line: 289, col: 14, offset: 8973},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 352, col: 16, offset: 10784},
+									pos:   position{line: 289, col: 16, offset: 8975},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 352, col: 23, offset: 10791},
-										run: (*parser).callonsortArg9,
+										pos: position{line: 289, col: 23, offset: 8982},
+										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 352, col: 24, offset: 10792},
+											pos: position{line: 289, col: 24, offset: 8983},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 352, col: 24, offset: 10792},
+													pos:        position{line: 289, col: 24, offset: 8983},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 352, col: 34, offset: 10802},
+													pos:        position{line: 289, col: 34, offset: 8993},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2349,40 +1915,40 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "top",
-			pos:  position{line: 354, col: 1, offset: 10916},
+			name: "TopProc",
+			pos:  position{line: 291, col: 1, offset: 9107},
 			expr: &actionExpr{
-				pos: position{line: 355, col: 5, offset: 10924},
-				run: (*parser).callontop1,
+				pos: position{line: 292, col: 5, offset: 9119},
+				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 355, col: 5, offset: 10924},
+					pos: position{line: 292, col: 5, offset: 9119},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 355, col: 5, offset: 10924},
+							pos:        position{line: 292, col: 5, offset: 9119},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 355, col: 12, offset: 10931},
+							pos:   position{line: 292, col: 12, offset: 9126},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 355, col: 18, offset: 10937},
+								pos: position{line: 292, col: 18, offset: 9132},
 								expr: &actionExpr{
-									pos: position{line: 355, col: 19, offset: 10938},
-									run: (*parser).callontop6,
+									pos: position{line: 292, col: 19, offset: 9133},
+									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 355, col: 19, offset: 10938},
+										pos: position{line: 292, col: 19, offset: 9133},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 355, col: 19, offset: 10938},
+												pos:  position{line: 292, col: 19, offset: 9133},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 355, col: 21, offset: 10940},
+												pos:   position{line: 292, col: 21, offset: 9135},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 355, col: 23, offset: 10942},
-													name: "unsignedInteger",
+													pos:  position{line: 292, col: 23, offset: 9137},
+													name: "UInt",
 												},
 											},
 										},
@@ -2391,19 +1957,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 355, col: 58, offset: 10977},
+							pos:   position{line: 292, col: 47, offset: 9161},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 355, col: 64, offset: 10983},
+								pos: position{line: 292, col: 53, offset: 9167},
 								expr: &seqExpr{
-									pos: position{line: 355, col: 65, offset: 10984},
+									pos: position{line: 292, col: 54, offset: 9168},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 355, col: 65, offset: 10984},
+											pos:  position{line: 292, col: 54, offset: 9168},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 355, col: 67, offset: 10986},
+											pos:        position{line: 292, col: 56, offset: 9170},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2412,26 +1978,26 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 355, col: 78, offset: 10997},
+							pos:   position{line: 292, col: 67, offset: 9181},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 355, col: 85, offset: 11004},
+								pos: position{line: 292, col: 74, offset: 9188},
 								expr: &actionExpr{
-									pos: position{line: 355, col: 86, offset: 11005},
-									run: (*parser).callontop18,
+									pos: position{line: 292, col: 75, offset: 9189},
+									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 355, col: 86, offset: 11005},
+										pos: position{line: 292, col: 75, offset: 9189},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 355, col: 86, offset: 11005},
+												pos:  position{line: 292, col: 75, offset: 9189},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 355, col: 88, offset: 11007},
+												pos:   position{line: 292, col: 77, offset: 9191},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 355, col: 90, offset: 11009},
-													name: "fieldExprList",
+													pos:  position{line: 292, col: 79, offset: 9193},
+													name: "FieldExprs",
 												},
 											},
 										},
@@ -2444,42 +2010,37 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "procLimitArg",
-			pos:  position{line: 369, col: 1, offset: 11296},
+			name: "CutProc",
+			pos:  position{line: 306, col: 1, offset: 9500},
 			expr: &actionExpr{
-				pos: position{line: 370, col: 5, offset: 11313},
-				run: (*parser).callonprocLimitArg1,
+				pos: position{line: 307, col: 5, offset: 9512},
+				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 370, col: 5, offset: 11313},
+					pos: position{line: 307, col: 5, offset: 9512},
 					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 370, col: 5, offset: 11313},
-							name: "_",
-						},
 						&litMatcher{
-							pos:        position{line: 370, col: 7, offset: 11315},
-							val:        "with",
-							ignoreCase: false,
+							pos:        position{line: 307, col: 5, offset: 9512},
+							val:        "cut",
+							ignoreCase: true,
+						},
+						&labeledExpr{
+							pos:   position{line: 307, col: 12, offset: 9519},
+							label: "args",
+							expr: &ruleRefExpr{
+								pos:  position{line: 307, col: 17, offset: 9524},
+								name: "CutArgs",
+							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 370, col: 14, offset: 11322},
-							name: "_",
-						},
-						&litMatcher{
-							pos:        position{line: 370, col: 16, offset: 11324},
-							val:        "-limit",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 370, col: 25, offset: 11333},
+							pos:  position{line: 307, col: 25, offset: 9532},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 370, col: 27, offset: 11335},
-							label: "limit",
+							pos:   position{line: 307, col: 27, offset: 9534},
+							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 370, col: 33, offset: 11341},
-								name: "unsignedInteger",
+								pos:  position{line: 307, col: 35, offset: 9542},
+								name: "FlexAssignments",
 							},
 						},
 					},
@@ -2487,28 +2048,28 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "cutArgs",
-			pos:  position{line: 372, col: 1, offset: 11380},
+			name: "CutArgs",
+			pos:  position{line: 316, col: 1, offset: 9811},
 			expr: &actionExpr{
-				pos: position{line: 373, col: 5, offset: 11392},
-				run: (*parser).calloncutArgs1,
+				pos: position{line: 317, col: 5, offset: 9823},
+				run: (*parser).callonCutArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 373, col: 5, offset: 11392},
+					pos:   position{line: 317, col: 5, offset: 9823},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 373, col: 10, offset: 11397},
+						pos: position{line: 317, col: 10, offset: 9828},
 						expr: &actionExpr{
-							pos: position{line: 373, col: 11, offset: 11398},
-							run: (*parser).calloncutArgs4,
+							pos: position{line: 317, col: 11, offset: 9829},
+							run: (*parser).callonCutArgs4,
 							expr: &seqExpr{
-								pos: position{line: 373, col: 11, offset: 11398},
+								pos: position{line: 317, col: 11, offset: 9829},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 373, col: 11, offset: 11398},
+										pos:  position{line: 317, col: 11, offset: 9829},
 										name: "_",
 									},
 									&litMatcher{
-										pos:        position{line: 373, col: 13, offset: 11400},
+										pos:        position{line: 317, col: 13, offset: 9831},
 										val:        "-c",
 										ignoreCase: false,
 									},
@@ -2520,80 +2081,42 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "cut",
-			pos:  position{line: 377, col: 1, offset: 11508},
-			expr: &actionExpr{
-				pos: position{line: 378, col: 5, offset: 11516},
-				run: (*parser).calloncut1,
-				expr: &seqExpr{
-					pos: position{line: 378, col: 5, offset: 11516},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 378, col: 5, offset: 11516},
-							val:        "cut",
-							ignoreCase: true,
-						},
-						&labeledExpr{
-							pos:   position{line: 378, col: 12, offset: 11523},
-							label: "args",
-							expr: &ruleRefExpr{
-								pos:  position{line: 378, col: 17, offset: 11528},
-								name: "cutArgs",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 378, col: 25, offset: 11536},
-							name: "_",
-						},
-						&labeledExpr{
-							pos:   position{line: 378, col: 27, offset: 11538},
-							label: "columns",
-							expr: &ruleRefExpr{
-								pos:  position{line: 378, col: 35, offset: 11546},
-								name: "FlexAssignments",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "head",
-			pos:  position{line: 388, col: 1, offset: 11802},
+			name: "HeadProc",
+			pos:  position{line: 321, col: 1, offset: 9943},
 			expr: &choiceExpr{
-				pos: position{line: 389, col: 5, offset: 11811},
+				pos: position{line: 322, col: 5, offset: 9956},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 389, col: 5, offset: 11811},
-						run: (*parser).callonhead2,
+						pos: position{line: 322, col: 5, offset: 9956},
+						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 389, col: 5, offset: 11811},
+							pos: position{line: 322, col: 5, offset: 9956},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 389, col: 5, offset: 11811},
+									pos:        position{line: 322, col: 5, offset: 9956},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 389, col: 13, offset: 11819},
+									pos:  position{line: 322, col: 13, offset: 9964},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 389, col: 15, offset: 11821},
+									pos:   position{line: 322, col: 15, offset: 9966},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 389, col: 21, offset: 11827},
-										name: "unsignedInteger",
+										pos:  position{line: 322, col: 21, offset: 9972},
+										name: "UInt",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 390, col: 5, offset: 11920},
-						run: (*parser).callonhead8,
+						pos: position{line: 323, col: 5, offset: 10054},
+						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 390, col: 5, offset: 11920},
+							pos:        position{line: 323, col: 5, offset: 10054},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2602,42 +2125,42 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "tail",
-			pos:  position{line: 391, col: 1, offset: 11997},
+			name: "TailProc",
+			pos:  position{line: 325, col: 1, offset: 10132},
 			expr: &choiceExpr{
-				pos: position{line: 392, col: 5, offset: 12006},
+				pos: position{line: 326, col: 5, offset: 10145},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 392, col: 5, offset: 12006},
-						run: (*parser).callontail2,
+						pos: position{line: 326, col: 5, offset: 10145},
+						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 392, col: 5, offset: 12006},
+							pos: position{line: 326, col: 5, offset: 10145},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 392, col: 5, offset: 12006},
+									pos:        position{line: 326, col: 5, offset: 10145},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 392, col: 13, offset: 12014},
+									pos:  position{line: 326, col: 13, offset: 10153},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 392, col: 15, offset: 12016},
+									pos:   position{line: 326, col: 15, offset: 10155},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 392, col: 21, offset: 12022},
-										name: "unsignedInteger",
+										pos:  position{line: 326, col: 21, offset: 10161},
+										name: "UInt",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 393, col: 5, offset: 12115},
-						run: (*parser).callontail8,
+						pos: position{line: 327, col: 5, offset: 10243},
+						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 393, col: 5, offset: 12115},
+							pos:        position{line: 327, col: 5, offset: 10243},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2646,29 +2169,29 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "filter",
-			pos:  position{line: 395, col: 1, offset: 12193},
+			name: "FilterProc",
+			pos:  position{line: 329, col: 1, offset: 10321},
 			expr: &actionExpr{
-				pos: position{line: 396, col: 5, offset: 12204},
-				run: (*parser).callonfilter1,
+				pos: position{line: 330, col: 5, offset: 10336},
+				run: (*parser).callonFilterProc1,
 				expr: &seqExpr{
-					pos: position{line: 396, col: 5, offset: 12204},
+					pos: position{line: 330, col: 5, offset: 10336},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 396, col: 5, offset: 12204},
+							pos:        position{line: 330, col: 5, offset: 10336},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 396, col: 15, offset: 12214},
+							pos:  position{line: 330, col: 15, offset: 10346},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 396, col: 17, offset: 12216},
+							pos:   position{line: 330, col: 17, offset: 10348},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 396, col: 22, offset: 12221},
-								name: "searchExpr",
+								pos:  position{line: 330, col: 22, offset: 10353},
+								name: "SearchExpr",
 							},
 						},
 					},
@@ -2676,28 +2199,28 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "uniq",
-			pos:  position{line: 399, col: 1, offset: 12317},
+			name: "UniqProc",
+			pos:  position{line: 334, col: 1, offset: 10450},
 			expr: &choiceExpr{
-				pos: position{line: 400, col: 5, offset: 12326},
+				pos: position{line: 335, col: 5, offset: 10463},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 400, col: 5, offset: 12326},
-						run: (*parser).callonuniq2,
+						pos: position{line: 335, col: 5, offset: 10463},
+						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 400, col: 5, offset: 12326},
+							pos: position{line: 335, col: 5, offset: 10463},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 400, col: 5, offset: 12326},
+									pos:        position{line: 335, col: 5, offset: 10463},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 400, col: 13, offset: 12334},
+									pos:  position{line: 335, col: 13, offset: 10471},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 400, col: 15, offset: 12336},
+									pos:        position{line: 335, col: 15, offset: 10473},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2705,10 +2228,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 403, col: 5, offset: 12427},
-						run: (*parser).callonuniq7,
+						pos: position{line: 338, col: 5, offset: 10564},
+						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 403, col: 5, offset: 12427},
+							pos:        position{line: 338, col: 5, offset: 10564},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2717,28 +2240,28 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "put",
-			pos:  position{line: 407, col: 1, offset: 12519},
+			name: "PutProc",
+			pos:  position{line: 342, col: 1, offset: 10656},
 			expr: &actionExpr{
-				pos: position{line: 408, col: 5, offset: 12527},
-				run: (*parser).callonput1,
+				pos: position{line: 343, col: 5, offset: 10668},
+				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 408, col: 5, offset: 12527},
+					pos: position{line: 343, col: 5, offset: 10668},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 408, col: 5, offset: 12527},
+							pos:        position{line: 343, col: 5, offset: 10668},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 408, col: 12, offset: 12534},
+							pos:  position{line: 343, col: 12, offset: 10675},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 408, col: 14, offset: 12536},
+							pos:   position{line: 343, col: 14, offset: 10677},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 408, col: 22, offset: 12544},
+								pos:  position{line: 343, col: 22, offset: 10685},
 								name: "FlexAssignments",
 							},
 						},
@@ -2747,60 +2270,60 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "rename",
-			pos:  position{line: 412, col: 1, offset: 12647},
+			name: "RenameProc",
+			pos:  position{line: 347, col: 1, offset: 10788},
 			expr: &actionExpr{
-				pos: position{line: 413, col: 5, offset: 12658},
-				run: (*parser).callonrename1,
+				pos: position{line: 348, col: 5, offset: 10803},
+				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 413, col: 5, offset: 12658},
+					pos: position{line: 348, col: 5, offset: 10803},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 413, col: 5, offset: 12658},
+							pos:        position{line: 348, col: 5, offset: 10803},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 413, col: 15, offset: 12668},
+							pos:  position{line: 348, col: 15, offset: 10813},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 413, col: 17, offset: 12670},
+							pos:   position{line: 348, col: 17, offset: 10815},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 413, col: 23, offset: 12676},
+								pos:  position{line: 348, col: 23, offset: 10821},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 413, col: 34, offset: 12687},
+							pos:   position{line: 348, col: 34, offset: 10832},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 413, col: 39, offset: 12692},
+								pos: position{line: 348, col: 39, offset: 10837},
 								expr: &actionExpr{
-									pos: position{line: 413, col: 40, offset: 12693},
-									run: (*parser).callonrename9,
+									pos: position{line: 348, col: 40, offset: 10838},
+									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 413, col: 40, offset: 12693},
+										pos: position{line: 348, col: 40, offset: 10838},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 413, col: 40, offset: 12693},
+												pos:  position{line: 348, col: 40, offset: 10838},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 413, col: 43, offset: 12696},
+												pos:        position{line: 348, col: 43, offset: 10841},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 413, col: 47, offset: 12700},
+												pos:  position{line: 348, col: 47, offset: 10845},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 413, col: 50, offset: 12703},
+												pos:   position{line: 348, col: 50, offset: 10848},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 413, col: 53, offset: 12706},
+													pos:  position{line: 348, col: 53, offset: 10851},
 													name: "Assignment",
 												},
 											},
@@ -2814,54 +2337,241 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "fuse",
-			pos:  position{line: 417, col: 1, offset: 12876},
+			name: "FuseProc",
+			pos:  position{line: 352, col: 1, offset: 11021},
 			expr: &actionExpr{
-				pos: position{line: 418, col: 5, offset: 12885},
-				run: (*parser).callonfuse1,
+				pos: position{line: 353, col: 5, offset: 11034},
+				run: (*parser).callonFuseProc1,
 				expr: &litMatcher{
-					pos:        position{line: 418, col: 5, offset: 12885},
+					pos:        position{line: 353, col: 5, offset: 11034},
 					val:        "fuse",
 					ignoreCase: true,
 				},
 			},
 		},
 		{
-			name: "Assignment",
-			pos:  position{line: 422, col: 1, offset: 12959},
+			name: "RootField",
+			pos:  position{line: 357, col: 1, offset: 11110},
+			expr: &choiceExpr{
+				pos: position{line: 358, col: 5, offset: 11124},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 358, col: 5, offset: 11124},
+						run: (*parser).callonRootField2,
+						expr: &seqExpr{
+							pos: position{line: 358, col: 5, offset: 11124},
+							exprs: []interface{}{
+								&zeroOrOneExpr{
+									pos: position{line: 358, col: 5, offset: 11124},
+									expr: &litMatcher{
+										pos:        position{line: 358, col: 5, offset: 11124},
+										val:        ".",
+										ignoreCase: false,
+									},
+								},
+								&notExpr{
+									pos: position{line: 358, col: 10, offset: 11129},
+									expr: &choiceExpr{
+										pos: position{line: 358, col: 12, offset: 11131},
+										alternatives: []interface{}{
+											&ruleRefExpr{
+												pos:  position{line: 358, col: 12, offset: 11131},
+												name: "BooleanLiteral",
+											},
+											&ruleRefExpr{
+												pos:  position{line: 358, col: 29, offset: 11148},
+												name: "NullLiteral",
+											},
+										},
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 358, col: 42, offset: 11161},
+									label: "field",
+									expr: &ruleRefExpr{
+										pos:  position{line: 358, col: 48, offset: 11167},
+										name: "Identifier",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 359, col: 5, offset: 11320},
+						run: (*parser).callonRootField12,
+						expr: &seqExpr{
+							pos: position{line: 359, col: 5, offset: 11320},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 359, col: 5, offset: 11320},
+									val:        ".",
+									ignoreCase: false,
+								},
+								&notExpr{
+									pos: position{line: 359, col: 9, offset: 11324},
+									expr: &ruleRefExpr{
+										pos:  position{line: 359, col: 11, offset: 11326},
+										name: "Identifier",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Lval",
+			pos:  position{line: 361, col: 1, offset: 11399},
+			expr: &ruleRefExpr{
+				pos:  position{line: 361, col: 8, offset: 11406},
+				name: "DerefExpr",
+			},
+		},
+		{
+			name: "FieldExpr",
+			pos:  position{line: 363, col: 1, offset: 11417},
+			expr: &ruleRefExpr{
+				pos:  position{line: 363, col: 13, offset: 11429},
+				name: "Lval",
+			},
+		},
+		{
+			name: "FieldExprs",
+			pos:  position{line: 365, col: 1, offset: 11435},
 			expr: &actionExpr{
-				pos: position{line: 423, col: 5, offset: 12974},
-				run: (*parser).callonAssignment1,
+				pos: position{line: 366, col: 5, offset: 11450},
+				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 423, col: 5, offset: 12974},
+					pos: position{line: 366, col: 5, offset: 11450},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 423, col: 5, offset: 12974},
+							pos:   position{line: 366, col: 5, offset: 11450},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 366, col: 11, offset: 11456},
+								name: "FieldExpr",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 366, col: 21, offset: 11466},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 366, col: 26, offset: 11471},
+								expr: &seqExpr{
+									pos: position{line: 366, col: 27, offset: 11472},
+									exprs: []interface{}{
+										&ruleRefExpr{
+											pos:  position{line: 366, col: 27, offset: 11472},
+											name: "__",
+										},
+										&litMatcher{
+											pos:        position{line: 366, col: 30, offset: 11475},
+											val:        ",",
+											ignoreCase: false,
+										},
+										&ruleRefExpr{
+											pos:  position{line: 366, col: 34, offset: 11479},
+											name: "__",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 366, col: 37, offset: 11482},
+											name: "FieldExpr",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Exprs",
+			pos:  position{line: 376, col: 1, offset: 11681},
+			expr: &actionExpr{
+				pos: position{line: 377, col: 5, offset: 11691},
+				run: (*parser).callonExprs1,
+				expr: &seqExpr{
+					pos: position{line: 377, col: 5, offset: 11691},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 377, col: 5, offset: 11691},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 377, col: 11, offset: 11697},
+								name: "Expr",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 377, col: 16, offset: 11702},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 377, col: 21, offset: 11707},
+								expr: &seqExpr{
+									pos: position{line: 377, col: 22, offset: 11708},
+									exprs: []interface{}{
+										&ruleRefExpr{
+											pos:  position{line: 377, col: 22, offset: 11708},
+											name: "__",
+										},
+										&litMatcher{
+											pos:        position{line: 377, col: 25, offset: 11711},
+											val:        ",",
+											ignoreCase: false,
+										},
+										&ruleRefExpr{
+											pos:  position{line: 377, col: 29, offset: 11715},
+											name: "__",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 377, col: 32, offset: 11718},
+											name: "Expr",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Assignment",
+			pos:  position{line: 387, col: 1, offset: 11912},
+			expr: &actionExpr{
+				pos: position{line: 388, col: 5, offset: 11927},
+				run: (*parser).callonAssignment1,
+				expr: &seqExpr{
+					pos: position{line: 388, col: 5, offset: 11927},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 388, col: 5, offset: 11927},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 423, col: 9, offset: 12978},
+								pos:  position{line: 388, col: 9, offset: 11931},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 423, col: 14, offset: 12983},
+							pos:  position{line: 388, col: 14, offset: 11936},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 423, col: 17, offset: 12986},
+							pos:        position{line: 388, col: 17, offset: 11939},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 423, col: 21, offset: 12990},
+							pos:  position{line: 388, col: 21, offset: 11943},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 423, col: 24, offset: 12993},
+							pos:   position{line: 388, col: 24, offset: 11946},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 423, col: 28, offset: 12997},
-								name: "Expression",
+								pos:  position{line: 388, col: 28, offset: 11950},
+								name: "Expr",
 							},
 						},
 					},
@@ -2869,211 +2579,135 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "Primary",
-			pos:  position{line: 425, col: 1, offset: 13072},
-			expr: &choiceExpr{
-				pos: position{line: 426, col: 5, offset: 13084},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 426, col: 5, offset: 13084},
-						name: "StringLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 427, col: 5, offset: 13102},
-						name: "RegexpLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 428, col: 5, offset: 13120},
-						name: "SubnetLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 429, col: 5, offset: 13138},
-						name: "AddressLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 430, col: 5, offset: 13157},
-						name: "FloatLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 431, col: 5, offset: 13174},
-						name: "IntegerLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 432, col: 5, offset: 13193},
-						name: "BooleanLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 433, col: 5, offset: 13212},
-						name: "NullLiteral",
-					},
-					&actionExpr{
-						pos: position{line: 434, col: 5, offset: 13228},
-						run: (*parser).callonPrimary10,
-						expr: &seqExpr{
-							pos: position{line: 434, col: 5, offset: 13228},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 434, col: 5, offset: 13228},
-									val:        "(",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 434, col: 9, offset: 13232},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 434, col: 12, offset: 13235},
-									label: "expr",
-									expr: &ruleRefExpr{
-										pos:  position{line: 434, col: 17, offset: 13240},
-										name: "Expression",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 434, col: 28, offset: 13251},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 434, col: 31, offset: 13254},
-									val:        ")",
-									ignoreCase: false,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Expression",
-			pos:  position{line: 442, col: 1, offset: 13456},
+			name: "Expr",
+			pos:  position{line: 390, col: 1, offset: 12019},
 			expr: &ruleRefExpr{
-				pos:  position{line: 442, col: 14, offset: 13469},
-				name: "ConditionalExpression",
+				pos:  position{line: 390, col: 8, offset: 12026},
+				name: "ConditionalExpr",
 			},
 		},
 		{
-			name: "ConditionalExpression",
-			pos:  position{line: 444, col: 1, offset: 13492},
+			name: "ConditionalExpr",
+			pos:  position{line: 392, col: 1, offset: 12043},
 			expr: &choiceExpr{
-				pos: position{line: 445, col: 5, offset: 13518},
+				pos: position{line: 393, col: 5, offset: 12063},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 445, col: 5, offset: 13518},
-						run: (*parser).callonConditionalExpression2,
+						pos: position{line: 393, col: 5, offset: 12063},
+						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 445, col: 5, offset: 13518},
+							pos: position{line: 393, col: 5, offset: 12063},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 445, col: 5, offset: 13518},
+									pos:   position{line: 393, col: 5, offset: 12063},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 445, col: 15, offset: 13528},
-										name: "LogicalORExpression",
+										pos:  position{line: 393, col: 15, offset: 12073},
+										name: "LogicalORExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 445, col: 35, offset: 13548},
+									pos:  position{line: 393, col: 29, offset: 12087},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 445, col: 38, offset: 13551},
+									pos:        position{line: 393, col: 32, offset: 12090},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 445, col: 42, offset: 13555},
+									pos:  position{line: 393, col: 36, offset: 12094},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 445, col: 45, offset: 13558},
+									pos:   position{line: 393, col: 39, offset: 12097},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 445, col: 56, offset: 13569},
-										name: "Expression",
+										pos:  position{line: 393, col: 50, offset: 12108},
+										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 445, col: 67, offset: 13580},
+									pos:  position{line: 393, col: 55, offset: 12113},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 445, col: 70, offset: 13583},
+									pos:        position{line: 393, col: 58, offset: 12116},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 445, col: 74, offset: 13587},
+									pos:  position{line: 393, col: 62, offset: 12120},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 445, col: 77, offset: 13590},
+									pos:   position{line: 393, col: 65, offset: 12123},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 445, col: 88, offset: 13601},
-										name: "Expression",
+										pos:  position{line: 393, col: 76, offset: 12134},
+										name: "Expr",
 									},
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 448, col: 5, offset: 13750},
-						name: "LogicalORExpression",
+						pos:  position{line: 396, col: 5, offset: 12281},
+						name: "LogicalORExpr",
 					},
 				},
 			},
 		},
 		{
-			name: "LogicalORExpression",
-			pos:  position{line: 450, col: 1, offset: 13771},
+			name: "LogicalORExpr",
+			pos:  position{line: 398, col: 1, offset: 12296},
 			expr: &actionExpr{
-				pos: position{line: 451, col: 5, offset: 13795},
-				run: (*parser).callonLogicalORExpression1,
+				pos: position{line: 399, col: 5, offset: 12314},
+				run: (*parser).callonLogicalORExpr1,
 				expr: &seqExpr{
-					pos: position{line: 451, col: 5, offset: 13795},
+					pos: position{line: 399, col: 5, offset: 12314},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 451, col: 5, offset: 13795},
+							pos:   position{line: 399, col: 5, offset: 12314},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 451, col: 11, offset: 13801},
-								name: "LogicalANDExpression",
+								pos:  position{line: 399, col: 11, offset: 12320},
+								name: "LogicalANDExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 452, col: 5, offset: 13826},
+							pos:   position{line: 400, col: 5, offset: 12339},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 452, col: 10, offset: 13831},
+								pos: position{line: 400, col: 10, offset: 12344},
 								expr: &actionExpr{
-									pos: position{line: 452, col: 11, offset: 13832},
-									run: (*parser).callonLogicalORExpression7,
+									pos: position{line: 400, col: 11, offset: 12345},
+									run: (*parser).callonLogicalORExpr7,
 									expr: &seqExpr{
-										pos: position{line: 452, col: 11, offset: 13832},
+										pos: position{line: 400, col: 11, offset: 12345},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 452, col: 11, offset: 13832},
+												pos:  position{line: 400, col: 11, offset: 12345},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 452, col: 14, offset: 13835},
+												pos:   position{line: 400, col: 14, offset: 12348},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 452, col: 17, offset: 13838},
-													name: "orToken",
+													pos:  position{line: 400, col: 17, offset: 12351},
+													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 452, col: 25, offset: 13846},
+												pos:  position{line: 400, col: 25, offset: 12359},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 452, col: 28, offset: 13849},
+												pos:   position{line: 400, col: 28, offset: 12362},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 452, col: 33, offset: 13854},
-													name: "LogicalANDExpression",
+													pos:  position{line: 400, col: 33, offset: 12367},
+													name: "LogicalANDExpr",
 												},
 											},
 										},
@@ -3086,55 +2720,55 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "LogicalANDExpression",
-			pos:  position{line: 456, col: 1, offset: 13978},
+			name: "LogicalANDExpr",
+			pos:  position{line: 404, col: 1, offset: 12485},
 			expr: &actionExpr{
-				pos: position{line: 457, col: 5, offset: 14003},
-				run: (*parser).callonLogicalANDExpression1,
+				pos: position{line: 405, col: 5, offset: 12504},
+				run: (*parser).callonLogicalANDExpr1,
 				expr: &seqExpr{
-					pos: position{line: 457, col: 5, offset: 14003},
+					pos: position{line: 405, col: 5, offset: 12504},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 457, col: 5, offset: 14003},
+							pos:   position{line: 405, col: 5, offset: 12504},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 457, col: 11, offset: 14009},
-								name: "EqualityCompareExpression",
+								pos:  position{line: 405, col: 11, offset: 12510},
+								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 458, col: 5, offset: 14039},
+							pos:   position{line: 406, col: 5, offset: 12534},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 458, col: 10, offset: 14044},
+								pos: position{line: 406, col: 10, offset: 12539},
 								expr: &actionExpr{
-									pos: position{line: 458, col: 11, offset: 14045},
-									run: (*parser).callonLogicalANDExpression7,
+									pos: position{line: 406, col: 11, offset: 12540},
+									run: (*parser).callonLogicalANDExpr7,
 									expr: &seqExpr{
-										pos: position{line: 458, col: 11, offset: 14045},
+										pos: position{line: 406, col: 11, offset: 12540},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 458, col: 11, offset: 14045},
+												pos:  position{line: 406, col: 11, offset: 12540},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 458, col: 14, offset: 14048},
+												pos:   position{line: 406, col: 14, offset: 12543},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 458, col: 17, offset: 14051},
-													name: "andToken",
+													pos:  position{line: 406, col: 17, offset: 12546},
+													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 458, col: 26, offset: 14060},
+												pos:  position{line: 406, col: 26, offset: 12555},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 458, col: 29, offset: 14063},
+												pos:   position{line: 406, col: 29, offset: 12558},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 458, col: 34, offset: 14068},
-													name: "EqualityCompareExpression",
+													pos:  position{line: 406, col: 34, offset: 12563},
+													name: "EqualityCompareExpr",
 												},
 											},
 										},
@@ -3147,55 +2781,55 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "EqualityCompareExpression",
-			pos:  position{line: 462, col: 1, offset: 14197},
+			name: "EqualityCompareExpr",
+			pos:  position{line: 410, col: 1, offset: 12686},
 			expr: &actionExpr{
-				pos: position{line: 463, col: 5, offset: 14227},
-				run: (*parser).callonEqualityCompareExpression1,
+				pos: position{line: 411, col: 5, offset: 12710},
+				run: (*parser).callonEqualityCompareExpr1,
 				expr: &seqExpr{
-					pos: position{line: 463, col: 5, offset: 14227},
+					pos: position{line: 411, col: 5, offset: 12710},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 463, col: 5, offset: 14227},
+							pos:   position{line: 411, col: 5, offset: 12710},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 463, col: 11, offset: 14233},
-								name: "RelativeExpression",
+								pos:  position{line: 411, col: 11, offset: 12716},
+								name: "RelativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 464, col: 5, offset: 14256},
+							pos:   position{line: 412, col: 5, offset: 12733},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 464, col: 10, offset: 14261},
+								pos: position{line: 412, col: 10, offset: 12738},
 								expr: &actionExpr{
-									pos: position{line: 464, col: 11, offset: 14262},
-									run: (*parser).callonEqualityCompareExpression7,
+									pos: position{line: 412, col: 11, offset: 12739},
+									run: (*parser).callonEqualityCompareExpr7,
 									expr: &seqExpr{
-										pos: position{line: 464, col: 11, offset: 14262},
+										pos: position{line: 412, col: 11, offset: 12739},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 464, col: 11, offset: 14262},
+												pos:  position{line: 412, col: 11, offset: 12739},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 464, col: 14, offset: 14265},
+												pos:   position{line: 412, col: 14, offset: 12742},
 												label: "comp",
 												expr: &ruleRefExpr{
-													pos:  position{line: 464, col: 19, offset: 14270},
+													pos:  position{line: 412, col: 19, offset: 12747},
 													name: "EqualityComparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 464, col: 38, offset: 14289},
+												pos:  position{line: 412, col: 38, offset: 12766},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 464, col: 41, offset: 14292},
+												pos:   position{line: 412, col: 41, offset: 12769},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 464, col: 46, offset: 14297},
-													name: "RelativeExpression",
+													pos:  position{line: 412, col: 46, offset: 12774},
+													name: "RelativeExpr",
 												},
 											},
 										},
@@ -3209,30 +2843,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 468, col: 1, offset: 14421},
+			pos:  position{line: 416, col: 1, offset: 12892},
 			expr: &actionExpr{
-				pos: position{line: 468, col: 20, offset: 14440},
+				pos: position{line: 416, col: 20, offset: 12911},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 468, col: 21, offset: 14441},
+					pos: position{line: 416, col: 21, offset: 12912},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 468, col: 21, offset: 14441},
+							pos:        position{line: 416, col: 21, offset: 12912},
 							val:        "=~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 468, col: 28, offset: 14448},
+							pos:        position{line: 416, col: 28, offset: 12919},
 							val:        "!~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 468, col: 35, offset: 14455},
+							pos:        position{line: 416, col: 35, offset: 12926},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 468, col: 41, offset: 14461},
+							pos:        position{line: 416, col: 41, offset: 12932},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3242,19 +2876,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 470, col: 1, offset: 14499},
+			pos:  position{line: 418, col: 1, offset: 12970},
 			expr: &choiceExpr{
-				pos: position{line: 471, col: 5, offset: 14522},
+				pos: position{line: 419, col: 5, offset: 12993},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 471, col: 5, offset: 14522},
+						pos:  position{line: 419, col: 5, offset: 12993},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 472, col: 5, offset: 14543},
+						pos: position{line: 420, col: 5, offset: 13014},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 472, col: 5, offset: 14543},
+							pos:        position{line: 420, col: 5, offset: 13014},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3263,55 +2897,55 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "RelativeExpression",
-			pos:  position{line: 474, col: 1, offset: 14580},
+			name: "RelativeExpr",
+			pos:  position{line: 422, col: 1, offset: 13051},
 			expr: &actionExpr{
-				pos: position{line: 475, col: 5, offset: 14603},
-				run: (*parser).callonRelativeExpression1,
+				pos: position{line: 423, col: 5, offset: 13068},
+				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 475, col: 5, offset: 14603},
+					pos: position{line: 423, col: 5, offset: 13068},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 475, col: 5, offset: 14603},
+							pos:   position{line: 423, col: 5, offset: 13068},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 475, col: 11, offset: 14609},
-								name: "AdditiveExpression",
+								pos:  position{line: 423, col: 11, offset: 13074},
+								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 476, col: 5, offset: 14632},
+							pos:   position{line: 424, col: 5, offset: 13091},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 476, col: 10, offset: 14637},
+								pos: position{line: 424, col: 10, offset: 13096},
 								expr: &actionExpr{
-									pos: position{line: 476, col: 11, offset: 14638},
-									run: (*parser).callonRelativeExpression7,
+									pos: position{line: 424, col: 11, offset: 13097},
+									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 476, col: 11, offset: 14638},
+										pos: position{line: 424, col: 11, offset: 13097},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 476, col: 11, offset: 14638},
+												pos:  position{line: 424, col: 11, offset: 13097},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 476, col: 14, offset: 14641},
+												pos:   position{line: 424, col: 14, offset: 13100},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 476, col: 17, offset: 14644},
+													pos:  position{line: 424, col: 17, offset: 13103},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 476, col: 34, offset: 14661},
+												pos:  position{line: 424, col: 34, offset: 13120},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 476, col: 37, offset: 14664},
+												pos:   position{line: 424, col: 37, offset: 13123},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 476, col: 42, offset: 14669},
-													name: "AdditiveExpression",
+													pos:  position{line: 424, col: 42, offset: 13128},
+													name: "AdditiveExpr",
 												},
 											},
 										},
@@ -3325,30 +2959,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 480, col: 1, offset: 14791},
+			pos:  position{line: 428, col: 1, offset: 13244},
 			expr: &actionExpr{
-				pos: position{line: 480, col: 20, offset: 14810},
+				pos: position{line: 428, col: 20, offset: 13263},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 480, col: 21, offset: 14811},
+					pos: position{line: 428, col: 21, offset: 13264},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 480, col: 21, offset: 14811},
+							pos:        position{line: 428, col: 21, offset: 13264},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 480, col: 28, offset: 14818},
+							pos:        position{line: 428, col: 28, offset: 13271},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 480, col: 34, offset: 14824},
+							pos:        position{line: 428, col: 34, offset: 13277},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 480, col: 41, offset: 14831},
+							pos:        position{line: 428, col: 41, offset: 13284},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -3357,55 +2991,55 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "AdditiveExpression",
-			pos:  position{line: 482, col: 1, offset: 14868},
+			name: "AdditiveExpr",
+			pos:  position{line: 430, col: 1, offset: 13321},
 			expr: &actionExpr{
-				pos: position{line: 483, col: 5, offset: 14891},
-				run: (*parser).callonAdditiveExpression1,
+				pos: position{line: 431, col: 5, offset: 13338},
+				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 483, col: 5, offset: 14891},
+					pos: position{line: 431, col: 5, offset: 13338},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 483, col: 5, offset: 14891},
+							pos:   position{line: 431, col: 5, offset: 13338},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 483, col: 11, offset: 14897},
-								name: "MultiplicativeExpression",
+								pos:  position{line: 431, col: 11, offset: 13344},
+								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 484, col: 5, offset: 14926},
+							pos:   position{line: 432, col: 5, offset: 13367},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 484, col: 10, offset: 14931},
+								pos: position{line: 432, col: 10, offset: 13372},
 								expr: &actionExpr{
-									pos: position{line: 484, col: 11, offset: 14932},
-									run: (*parser).callonAdditiveExpression7,
+									pos: position{line: 432, col: 11, offset: 13373},
+									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 484, col: 11, offset: 14932},
+										pos: position{line: 432, col: 11, offset: 13373},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 484, col: 11, offset: 14932},
+												pos:  position{line: 432, col: 11, offset: 13373},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 484, col: 14, offset: 14935},
+												pos:   position{line: 432, col: 14, offset: 13376},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 484, col: 17, offset: 14938},
+													pos:  position{line: 432, col: 17, offset: 13379},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 484, col: 34, offset: 14955},
+												pos:  position{line: 432, col: 34, offset: 13396},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 484, col: 37, offset: 14958},
+												pos:   position{line: 432, col: 37, offset: 13399},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 484, col: 42, offset: 14963},
-													name: "MultiplicativeExpression",
+													pos:  position{line: 432, col: 42, offset: 13404},
+													name: "MultiplicativeExpr",
 												},
 											},
 										},
@@ -3419,20 +3053,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 488, col: 1, offset: 15091},
+			pos:  position{line: 436, col: 1, offset: 13526},
 			expr: &actionExpr{
-				pos: position{line: 488, col: 20, offset: 15110},
+				pos: position{line: 436, col: 20, offset: 13545},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 488, col: 21, offset: 15111},
+					pos: position{line: 436, col: 21, offset: 13546},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 488, col: 21, offset: 15111},
+							pos:        position{line: 436, col: 21, offset: 13546},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 488, col: 27, offset: 15117},
+							pos:        position{line: 436, col: 27, offset: 13552},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3441,55 +3075,55 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "MultiplicativeExpression",
-			pos:  position{line: 490, col: 1, offset: 15154},
+			name: "MultiplicativeExpr",
+			pos:  position{line: 438, col: 1, offset: 13589},
 			expr: &actionExpr{
-				pos: position{line: 491, col: 5, offset: 15183},
-				run: (*parser).callonMultiplicativeExpression1,
+				pos: position{line: 439, col: 5, offset: 13612},
+				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 491, col: 5, offset: 15183},
+					pos: position{line: 439, col: 5, offset: 13612},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 491, col: 5, offset: 15183},
+							pos:   position{line: 439, col: 5, offset: 13612},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 491, col: 11, offset: 15189},
-								name: "NotExpression",
+								pos:  position{line: 439, col: 11, offset: 13618},
+								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 492, col: 5, offset: 15207},
+							pos:   position{line: 440, col: 5, offset: 13630},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 492, col: 10, offset: 15212},
+								pos: position{line: 440, col: 10, offset: 13635},
 								expr: &actionExpr{
-									pos: position{line: 492, col: 11, offset: 15213},
-									run: (*parser).callonMultiplicativeExpression7,
+									pos: position{line: 440, col: 11, offset: 13636},
+									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 492, col: 11, offset: 15213},
+										pos: position{line: 440, col: 11, offset: 13636},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 492, col: 11, offset: 15213},
+												pos:  position{line: 440, col: 11, offset: 13636},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 492, col: 14, offset: 15216},
+												pos:   position{line: 440, col: 14, offset: 13639},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 492, col: 17, offset: 15219},
+													pos:  position{line: 440, col: 17, offset: 13642},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 492, col: 40, offset: 15242},
+												pos:  position{line: 440, col: 40, offset: 13665},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 492, col: 43, offset: 15245},
+												pos:   position{line: 440, col: 43, offset: 13668},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 492, col: 48, offset: 15250},
-													name: "NotExpression",
+													pos:  position{line: 440, col: 48, offset: 13673},
+													name: "NotExpr",
 												},
 											},
 										},
@@ -3503,20 +3137,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 496, col: 1, offset: 15367},
+			pos:  position{line: 444, col: 1, offset: 13784},
 			expr: &actionExpr{
-				pos: position{line: 496, col: 26, offset: 15392},
+				pos: position{line: 444, col: 26, offset: 13809},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 496, col: 27, offset: 15393},
+					pos: position{line: 444, col: 27, offset: 13810},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 496, col: 27, offset: 15393},
+							pos:        position{line: 444, col: 27, offset: 13810},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 496, col: 33, offset: 15399},
+							pos:        position{line: 444, col: 33, offset: 13816},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -3525,83 +3159,83 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "NotExpression",
-			pos:  position{line: 498, col: 1, offset: 15436},
+			name: "NotExpr",
+			pos:  position{line: 446, col: 1, offset: 13853},
 			expr: &choiceExpr{
-				pos: position{line: 499, col: 5, offset: 15454},
+				pos: position{line: 447, col: 5, offset: 13865},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 499, col: 5, offset: 15454},
-						run: (*parser).callonNotExpression2,
+						pos: position{line: 447, col: 5, offset: 13865},
+						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 499, col: 5, offset: 15454},
+							pos: position{line: 447, col: 5, offset: 13865},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 499, col: 5, offset: 15454},
+									pos:        position{line: 447, col: 5, offset: 13865},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 499, col: 9, offset: 15458},
+									pos:  position{line: 447, col: 9, offset: 13869},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 499, col: 12, offset: 15461},
+									pos:   position{line: 447, col: 12, offset: 13872},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 499, col: 14, offset: 15463},
-										name: "NotExpression",
+										pos:  position{line: 447, col: 14, offset: 13874},
+										name: "NotExpr",
 									},
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 502, col: 5, offset: 15582},
-						name: "CastExpression",
+						pos:  position{line: 450, col: 5, offset: 13987},
+						name: "CastExpr",
 					},
 				},
 			},
 		},
 		{
-			name: "CastExpression",
-			pos:  position{line: 504, col: 1, offset: 15598},
+			name: "CastExpr",
+			pos:  position{line: 452, col: 1, offset: 13997},
 			expr: &choiceExpr{
-				pos: position{line: 505, col: 5, offset: 15617},
+				pos: position{line: 453, col: 5, offset: 14010},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 505, col: 5, offset: 15617},
-						run: (*parser).callonCastExpression2,
+						pos: position{line: 453, col: 5, offset: 14010},
+						run: (*parser).callonCastExpr2,
 						expr: &seqExpr{
-							pos: position{line: 505, col: 5, offset: 15617},
+							pos: position{line: 453, col: 5, offset: 14010},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 505, col: 5, offset: 15617},
+									pos:   position{line: 453, col: 5, offset: 14010},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 505, col: 7, offset: 15619},
-										name: "FuncExpression",
+										pos:  position{line: 453, col: 7, offset: 14012},
+										name: "FuncExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 505, col: 22, offset: 15634},
+									pos:   position{line: 453, col: 16, offset: 14021},
 									label: "typ",
 									expr: &actionExpr{
-										pos: position{line: 505, col: 28, offset: 15640},
-										run: (*parser).callonCastExpression7,
+										pos: position{line: 453, col: 22, offset: 14027},
+										run: (*parser).callonCastExpr7,
 										expr: &seqExpr{
-											pos: position{line: 505, col: 28, offset: 15640},
+											pos: position{line: 453, col: 22, offset: 14027},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 505, col: 28, offset: 15640},
+													pos:        position{line: 453, col: 22, offset: 14027},
 													val:        ":",
 													ignoreCase: false,
 												},
 												&labeledExpr{
-													pos:   position{line: 505, col: 32, offset: 15644},
+													pos:   position{line: 453, col: 26, offset: 14031},
 													label: "typ",
 													expr: &ruleRefExpr{
-														pos:  position{line: 505, col: 36, offset: 15648},
+														pos:  position{line: 453, col: 30, offset: 14035},
 														name: "PrimitiveType",
 													},
 												},
@@ -3613,123 +3247,123 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 508, col: 5, offset: 15774},
-						name: "FuncExpression",
+						pos:  position{line: 456, col: 5, offset: 14165},
+						name: "FuncExpr",
 					},
 				},
 			},
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 511, col: 1, offset: 15791},
+			pos:  position{line: 459, col: 1, offset: 14176},
 			expr: &actionExpr{
-				pos: position{line: 512, col: 5, offset: 15809},
+				pos: position{line: 460, col: 5, offset: 14194},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 512, col: 9, offset: 15813},
+					pos: position{line: 460, col: 9, offset: 14198},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 512, col: 9, offset: 15813},
+							pos:        position{line: 460, col: 9, offset: 14198},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 512, col: 19, offset: 15823},
+							pos:        position{line: 460, col: 19, offset: 14208},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 512, col: 29, offset: 15833},
+							pos:        position{line: 460, col: 29, offset: 14218},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 512, col: 40, offset: 15844},
+							pos:        position{line: 460, col: 40, offset: 14229},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 512, col: 51, offset: 15855},
+							pos:        position{line: 460, col: 51, offset: 14240},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 513, col: 9, offset: 15872},
+							pos:        position{line: 461, col: 9, offset: 14257},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 513, col: 18, offset: 15881},
+							pos:        position{line: 461, col: 18, offset: 14266},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 513, col: 28, offset: 15891},
+							pos:        position{line: 461, col: 28, offset: 14276},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 513, col: 38, offset: 15901},
+							pos:        position{line: 461, col: 38, offset: 14286},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 514, col: 9, offset: 15917},
+							pos:        position{line: 462, col: 9, offset: 14302},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 514, col: 22, offset: 15930},
+							pos:        position{line: 462, col: 22, offset: 14315},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 515, col: 9, offset: 15945},
+							pos:        position{line: 463, col: 9, offset: 14330},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 516, col: 9, offset: 15963},
+							pos:        position{line: 464, col: 9, offset: 14348},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 516, col: 18, offset: 15972},
+							pos:        position{line: 464, col: 18, offset: 14357},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 516, col: 28, offset: 15982},
+							pos:        position{line: 464, col: 28, offset: 14367},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 516, col: 39, offset: 15993},
+							pos:        position{line: 464, col: 39, offset: 14378},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 517, col: 9, offset: 16011},
+							pos:        position{line: 465, col: 9, offset: 14396},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 517, col: 16, offset: 16018},
+							pos:        position{line: 465, col: 16, offset: 14403},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 518, col: 9, offset: 16032},
+							pos:        position{line: 466, col: 9, offset: 14417},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 518, col: 18, offset: 16041},
+							pos:        position{line: 466, col: 18, offset: 14426},
 							val:        "error",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 518, col: 28, offset: 16051},
+							pos:        position{line: 466, col: 28, offset: 14436},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -3738,32 +3372,32 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "FuncExpression",
-			pos:  position{line: 520, col: 1, offset: 16092},
+			name: "FuncExpr",
+			pos:  position{line: 468, col: 1, offset: 14477},
 			expr: &choiceExpr{
-				pos: position{line: 521, col: 5, offset: 16111},
+				pos: position{line: 469, col: 5, offset: 14490},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 521, col: 5, offset: 16111},
-						run: (*parser).callonFuncExpression2,
+						pos: position{line: 469, col: 5, offset: 14490},
+						run: (*parser).callonFuncExpr2,
 						expr: &seqExpr{
-							pos: position{line: 521, col: 5, offset: 16111},
+							pos: position{line: 469, col: 5, offset: 14490},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 521, col: 5, offset: 16111},
+									pos:   position{line: 469, col: 5, offset: 14490},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 521, col: 11, offset: 16117},
-										name: "FunctionCall",
+										pos:  position{line: 469, col: 11, offset: 14496},
+										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 521, col: 24, offset: 16130},
+									pos:   position{line: 469, col: 20, offset: 14505},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 521, col: 29, offset: 16135},
+										pos: position{line: 469, col: 25, offset: 14510},
 										expr: &ruleRefExpr{
-											pos:  position{line: 521, col: 30, offset: 16136},
+											pos:  position{line: 469, col: 26, offset: 14511},
 											name: "Deref",
 										},
 									},
@@ -3772,52 +3406,52 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 524, col: 5, offset: 16203},
-						name: "DerefExpression",
+						pos:  position{line: 472, col: 5, offset: 14582},
+						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 525, col: 5, offset: 16223},
+						pos:  position{line: 473, col: 5, offset: 14596},
 						name: "Primary",
 					},
 				},
 			},
 		},
 		{
-			name: "FunctionCall",
-			pos:  position{line: 527, col: 1, offset: 16232},
+			name: "Function",
+			pos:  position{line: 475, col: 1, offset: 14605},
 			expr: &actionExpr{
-				pos: position{line: 528, col: 5, offset: 16249},
-				run: (*parser).callonFunctionCall1,
+				pos: position{line: 476, col: 5, offset: 14618},
+				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 528, col: 5, offset: 16249},
+					pos: position{line: 476, col: 5, offset: 14618},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 528, col: 5, offset: 16249},
+							pos:   position{line: 476, col: 5, offset: 14618},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 528, col: 8, offset: 16252},
-								name: "FunctionName",
+								pos:  position{line: 476, col: 8, offset: 14621},
+								name: "FuncName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 528, col: 21, offset: 16265},
+							pos:  position{line: 476, col: 17, offset: 14630},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 528, col: 24, offset: 16268},
+							pos:        position{line: 476, col: 20, offset: 14633},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 528, col: 28, offset: 16272},
+							pos:   position{line: 476, col: 24, offset: 14637},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 528, col: 33, offset: 16277},
+								pos:  position{line: 476, col: 29, offset: 14642},
 								name: "ArgumentList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 528, col: 46, offset: 16290},
+							pos:        position{line: 476, col: 42, offset: 14655},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -3826,23 +3460,23 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "FunctionName",
-			pos:  position{line: 532, col: 1, offset: 16398},
+			name: "FuncName",
+			pos:  position{line: 480, col: 1, offset: 14761},
 			expr: &actionExpr{
-				pos: position{line: 533, col: 5, offset: 16415},
-				run: (*parser).callonFunctionName1,
+				pos: position{line: 481, col: 5, offset: 14774},
+				run: (*parser).callonFuncName1,
 				expr: &seqExpr{
-					pos: position{line: 533, col: 5, offset: 16415},
+					pos: position{line: 481, col: 5, offset: 14774},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 533, col: 5, offset: 16415},
-							name: "FunctionNameStart",
+							pos:  position{line: 481, col: 5, offset: 14774},
+							name: "FuncNameStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 533, col: 23, offset: 16433},
+							pos: position{line: 481, col: 19, offset: 14788},
 							expr: &ruleRefExpr{
-								pos:  position{line: 533, col: 23, offset: 16433},
-								name: "FunctionNameRest",
+								pos:  position{line: 481, col: 19, offset: 14788},
+								name: "FuncNameRest",
 							},
 						},
 					},
@@ -3850,10 +3484,10 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "FunctionNameStart",
-			pos:  position{line: 535, col: 1, offset: 16483},
+			name: "FuncNameStart",
+			pos:  position{line: 483, col: 1, offset: 14834},
 			expr: &charClassMatcher{
-				pos:        position{line: 535, col: 21, offset: 16503},
+				pos:        position{line: 483, col: 17, offset: 14850},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -3861,17 +3495,17 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "FunctionNameRest",
-			pos:  position{line: 536, col: 1, offset: 16512},
+			name: "FuncNameRest",
+			pos:  position{line: 484, col: 1, offset: 14859},
 			expr: &choiceExpr{
-				pos: position{line: 536, col: 20, offset: 16531},
+				pos: position{line: 484, col: 16, offset: 14874},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 536, col: 20, offset: 16531},
-						name: "FunctionNameStart",
+						pos:  position{line: 484, col: 16, offset: 14874},
+						name: "FuncNameStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 536, col: 40, offset: 16551},
+						pos:        position{line: 484, col: 32, offset: 14890},
 						val:        "[.0-9]",
 						chars:      []rune{'.'},
 						ranges:     []rune{'0', '9'},
@@ -3883,54 +3517,54 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 538, col: 1, offset: 16559},
+			pos:  position{line: 486, col: 1, offset: 14898},
 			expr: &choiceExpr{
-				pos: position{line: 539, col: 5, offset: 16576},
+				pos: position{line: 487, col: 5, offset: 14915},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 539, col: 5, offset: 16576},
+						pos: position{line: 487, col: 5, offset: 14915},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 539, col: 5, offset: 16576},
+							pos: position{line: 487, col: 5, offset: 14915},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 539, col: 5, offset: 16576},
+									pos:   position{line: 487, col: 5, offset: 14915},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 539, col: 11, offset: 16582},
-										name: "Expression",
+										pos:  position{line: 487, col: 11, offset: 14921},
+										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 539, col: 22, offset: 16593},
+									pos:   position{line: 487, col: 16, offset: 14926},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 539, col: 27, offset: 16598},
+										pos: position{line: 487, col: 21, offset: 14931},
 										expr: &actionExpr{
-											pos: position{line: 539, col: 28, offset: 16599},
+											pos: position{line: 487, col: 22, offset: 14932},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 539, col: 28, offset: 16599},
+												pos: position{line: 487, col: 22, offset: 14932},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 539, col: 28, offset: 16599},
+														pos:  position{line: 487, col: 22, offset: 14932},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 539, col: 31, offset: 16602},
+														pos:        position{line: 487, col: 25, offset: 14935},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 539, col: 35, offset: 16606},
+														pos:  position{line: 487, col: 29, offset: 14939},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 539, col: 38, offset: 16609},
+														pos:   position{line: 487, col: 32, offset: 14942},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 539, col: 40, offset: 16611},
-															name: "Expression",
+															pos:  position{line: 487, col: 34, offset: 14944},
+															name: "Expr",
 														},
 													},
 												},
@@ -3942,10 +3576,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 542, col: 5, offset: 16727},
+						pos: position{line: 490, col: 5, offset: 15056},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 542, col: 5, offset: 16727},
+							pos:  position{line: 490, col: 5, offset: 15056},
 							name: "__",
 						},
 					},
@@ -3953,485 +3587,31 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "duration",
-			pos:  position{line: 544, col: 1, offset: 16763},
-			expr: &choiceExpr{
-				pos: position{line: 545, col: 5, offset: 16776},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 545, col: 5, offset: 16776},
-						name: "seconds",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 546, col: 5, offset: 16788},
-						name: "minutes",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 547, col: 5, offset: 16800},
-						name: "hours",
-					},
-					&seqExpr{
-						pos: position{line: 548, col: 5, offset: 16810},
-						exprs: []interface{}{
-							&ruleRefExpr{
-								pos:  position{line: 548, col: 5, offset: 16810},
-								name: "hours",
-							},
-							&ruleRefExpr{
-								pos:  position{line: 548, col: 11, offset: 16816},
-								name: "_",
-							},
-							&litMatcher{
-								pos:        position{line: 548, col: 13, offset: 16818},
-								val:        "and",
-								ignoreCase: false,
-							},
-							&ruleRefExpr{
-								pos:  position{line: 548, col: 19, offset: 16824},
-								name: "_",
-							},
-							&ruleRefExpr{
-								pos:  position{line: 548, col: 21, offset: 16826},
-								name: "minutes",
-							},
-						},
-					},
-					&ruleRefExpr{
-						pos:  position{line: 549, col: 5, offset: 16838},
-						name: "days",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 550, col: 5, offset: 16847},
-						name: "weeks",
-					},
-				},
-			},
-		},
-		{
-			name: "sec_abbrev",
-			pos:  position{line: 552, col: 1, offset: 16854},
-			expr: &choiceExpr{
-				pos: position{line: 553, col: 5, offset: 16869},
-				alternatives: []interface{}{
-					&litMatcher{
-						pos:        position{line: 553, col: 5, offset: 16869},
-						val:        "seconds",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 554, col: 5, offset: 16883},
-						val:        "second",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 555, col: 5, offset: 16896},
-						val:        "secs",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 556, col: 5, offset: 16907},
-						val:        "sec",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 557, col: 5, offset: 16917},
-						val:        "s",
-						ignoreCase: false,
-					},
-				},
-			},
-		},
-		{
-			name: "min_abbrev",
-			pos:  position{line: 559, col: 1, offset: 16922},
-			expr: &choiceExpr{
-				pos: position{line: 560, col: 5, offset: 16937},
-				alternatives: []interface{}{
-					&litMatcher{
-						pos:        position{line: 560, col: 5, offset: 16937},
-						val:        "minutes",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 561, col: 5, offset: 16951},
-						val:        "minute",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 562, col: 5, offset: 16964},
-						val:        "mins",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 563, col: 5, offset: 16975},
-						val:        "min",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 564, col: 5, offset: 16985},
-						val:        "m",
-						ignoreCase: false,
-					},
-				},
-			},
-		},
-		{
-			name: "hour_abbrev",
-			pos:  position{line: 566, col: 1, offset: 16990},
-			expr: &choiceExpr{
-				pos: position{line: 567, col: 5, offset: 17006},
-				alternatives: []interface{}{
-					&litMatcher{
-						pos:        position{line: 567, col: 5, offset: 17006},
-						val:        "hours",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 568, col: 5, offset: 17018},
-						val:        "hrs",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 569, col: 5, offset: 17028},
-						val:        "hr",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 570, col: 5, offset: 17037},
-						val:        "h",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 571, col: 5, offset: 17045},
-						val:        "hour",
-						ignoreCase: false,
-					},
-				},
-			},
-		},
-		{
-			name: "day_abbrev",
-			pos:  position{line: 573, col: 1, offset: 17053},
-			expr: &choiceExpr{
-				pos: position{line: 573, col: 14, offset: 17066},
-				alternatives: []interface{}{
-					&litMatcher{
-						pos:        position{line: 573, col: 14, offset: 17066},
-						val:        "days",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 573, col: 21, offset: 17073},
-						val:        "day",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 573, col: 27, offset: 17079},
-						val:        "d",
-						ignoreCase: false,
-					},
-				},
-			},
-		},
-		{
-			name: "week_abbrev",
-			pos:  position{line: 574, col: 1, offset: 17083},
-			expr: &choiceExpr{
-				pos: position{line: 574, col: 15, offset: 17097},
-				alternatives: []interface{}{
-					&litMatcher{
-						pos:        position{line: 574, col: 15, offset: 17097},
-						val:        "weeks",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 574, col: 23, offset: 17105},
-						val:        "week",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 574, col: 30, offset: 17112},
-						val:        "wks",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 574, col: 36, offset: 17118},
-						val:        "wk",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 574, col: 41, offset: 17123},
-						val:        "w",
-						ignoreCase: false,
-					},
-				},
-			},
-		},
-		{
-			name: "seconds",
-			pos:  position{line: 576, col: 1, offset: 17128},
-			expr: &choiceExpr{
-				pos: position{line: 577, col: 5, offset: 17140},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 577, col: 5, offset: 17140},
-						run: (*parser).callonseconds2,
-						expr: &litMatcher{
-							pos:        position{line: 577, col: 5, offset: 17140},
-							val:        "second",
-							ignoreCase: false,
-						},
-					},
-					&actionExpr{
-						pos: position{line: 578, col: 5, offset: 17226},
-						run: (*parser).callonseconds4,
-						expr: &seqExpr{
-							pos: position{line: 578, col: 5, offset: 17226},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 578, col: 5, offset: 17226},
-									label: "num",
-									expr: &ruleRefExpr{
-										pos:  position{line: 578, col: 9, offset: 17230},
-										name: "number",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 578, col: 16, offset: 17237},
-									name: "__",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 578, col: 19, offset: 17240},
-									name: "sec_abbrev",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "minutes",
-			pos:  position{line: 580, col: 1, offset: 17327},
-			expr: &choiceExpr{
-				pos: position{line: 581, col: 5, offset: 17339},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 581, col: 5, offset: 17339},
-						run: (*parser).callonminutes2,
-						expr: &litMatcher{
-							pos:        position{line: 581, col: 5, offset: 17339},
-							val:        "minute",
-							ignoreCase: false,
-						},
-					},
-					&actionExpr{
-						pos: position{line: 582, col: 5, offset: 17426},
-						run: (*parser).callonminutes4,
-						expr: &seqExpr{
-							pos: position{line: 582, col: 5, offset: 17426},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 582, col: 5, offset: 17426},
-									label: "num",
-									expr: &ruleRefExpr{
-										pos:  position{line: 582, col: 9, offset: 17430},
-										name: "number",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 582, col: 16, offset: 17437},
-									name: "__",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 582, col: 19, offset: 17440},
-									name: "min_abbrev",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "hours",
-			pos:  position{line: 584, col: 1, offset: 17536},
-			expr: &choiceExpr{
-				pos: position{line: 585, col: 5, offset: 17546},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 585, col: 5, offset: 17546},
-						run: (*parser).callonhours2,
-						expr: &litMatcher{
-							pos:        position{line: 585, col: 5, offset: 17546},
-							val:        "hour",
-							ignoreCase: false,
-						},
-					},
-					&actionExpr{
-						pos: position{line: 586, col: 5, offset: 17633},
-						run: (*parser).callonhours4,
-						expr: &seqExpr{
-							pos: position{line: 586, col: 5, offset: 17633},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 586, col: 5, offset: 17633},
-									label: "num",
-									expr: &ruleRefExpr{
-										pos:  position{line: 586, col: 9, offset: 17637},
-										name: "number",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 586, col: 16, offset: 17644},
-									name: "__",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 586, col: 19, offset: 17647},
-									name: "hour_abbrev",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "days",
-			pos:  position{line: 588, col: 1, offset: 17746},
-			expr: &choiceExpr{
-				pos: position{line: 589, col: 5, offset: 17755},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 589, col: 5, offset: 17755},
-						run: (*parser).callondays2,
-						expr: &litMatcher{
-							pos:        position{line: 589, col: 5, offset: 17755},
-							val:        "day",
-							ignoreCase: false,
-						},
-					},
-					&actionExpr{
-						pos: position{line: 590, col: 5, offset: 17844},
-						run: (*parser).callondays4,
-						expr: &seqExpr{
-							pos: position{line: 590, col: 5, offset: 17844},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 590, col: 5, offset: 17844},
-									label: "num",
-									expr: &ruleRefExpr{
-										pos:  position{line: 590, col: 9, offset: 17848},
-										name: "number",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 590, col: 16, offset: 17855},
-									name: "__",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 590, col: 19, offset: 17858},
-									name: "day_abbrev",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "weeks",
-			pos:  position{line: 592, col: 1, offset: 17961},
-			expr: &choiceExpr{
-				pos: position{line: 593, col: 5, offset: 17971},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 593, col: 5, offset: 17971},
-						run: (*parser).callonweeks2,
-						expr: &litMatcher{
-							pos:        position{line: 593, col: 5, offset: 17971},
-							val:        "week",
-							ignoreCase: false,
-						},
-					},
-					&actionExpr{
-						pos: position{line: 594, col: 5, offset: 18063},
-						run: (*parser).callonweeks4,
-						expr: &seqExpr{
-							pos: position{line: 594, col: 5, offset: 18063},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 594, col: 5, offset: 18063},
-									label: "num",
-									expr: &ruleRefExpr{
-										pos:  position{line: 594, col: 9, offset: 18067},
-										name: "number",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 594, col: 16, offset: 18074},
-									name: "__",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 594, col: 19, offset: 18077},
-									name: "week_abbrev",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "number",
-			pos:  position{line: 596, col: 1, offset: 18181},
-			expr: &ruleRefExpr{
-				pos:  position{line: 596, col: 10, offset: 18190},
-				name: "unsignedInteger",
-			},
-		},
-		{
-			name: "addr",
-			pos:  position{line: 600, col: 1, offset: 18236},
+			name: "DerefExpr",
+			pos:  position{line: 492, col: 1, offset: 15092},
 			expr: &actionExpr{
-				pos: position{line: 601, col: 5, offset: 18245},
-				run: (*parser).callonaddr1,
-				expr: &labeledExpr{
-					pos:   position{line: 601, col: 5, offset: 18245},
-					label: "a",
-					expr: &seqExpr{
-						pos: position{line: 601, col: 8, offset: 18248},
-						exprs: []interface{}{
-							&ruleRefExpr{
-								pos:  position{line: 601, col: 8, offset: 18248},
-								name: "unsignedInteger",
+				pos: position{line: 493, col: 5, offset: 15106},
+				run: (*parser).callonDerefExpr1,
+				expr: &seqExpr{
+					pos: position{line: 493, col: 5, offset: 15106},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 493, col: 5, offset: 15106},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 493, col: 11, offset: 15112},
+								name: "RootField",
 							},
-							&litMatcher{
-								pos:        position{line: 601, col: 24, offset: 18264},
-								val:        ".",
-								ignoreCase: false,
-							},
-							&ruleRefExpr{
-								pos:  position{line: 601, col: 28, offset: 18268},
-								name: "unsignedInteger",
-							},
-							&litMatcher{
-								pos:        position{line: 601, col: 44, offset: 18284},
-								val:        ".",
-								ignoreCase: false,
-							},
-							&ruleRefExpr{
-								pos:  position{line: 601, col: 48, offset: 18288},
-								name: "unsignedInteger",
-							},
-							&litMatcher{
-								pos:        position{line: 601, col: 64, offset: 18304},
-								val:        ".",
-								ignoreCase: false,
-							},
-							&ruleRefExpr{
-								pos:  position{line: 601, col: 68, offset: 18308},
-								name: "unsignedInteger",
+						},
+						&labeledExpr{
+							pos:   position{line: 493, col: 21, offset: 15122},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 493, col: 26, offset: 15127},
+								expr: &ruleRefExpr{
+									pos:  position{line: 493, col: 27, offset: 15128},
+									name: "Deref",
+								},
 							},
 						},
 					},
@@ -4439,206 +3619,234 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "ip6addr",
-			pos:  position{line: 605, col: 1, offset: 18488},
+			name: "Deref",
+			pos:  position{line: 497, col: 1, offset: 15196},
 			expr: &choiceExpr{
-				pos: position{line: 606, col: 5, offset: 18500},
+				pos: position{line: 498, col: 5, offset: 15206},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 606, col: 5, offset: 18500},
-						run: (*parser).callonip6addr2,
+						pos: position{line: 498, col: 5, offset: 15206},
+						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 606, col: 5, offset: 18500},
+							pos: position{line: 498, col: 5, offset: 15206},
 							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 606, col: 5, offset: 18500},
-									label: "a",
-									expr: &oneOrMoreExpr{
-										pos: position{line: 606, col: 7, offset: 18502},
-										expr: &ruleRefExpr{
-											pos:  position{line: 606, col: 8, offset: 18503},
-											name: "h_prepend",
-										},
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 606, col: 20, offset: 18515},
-									label: "b",
-									expr: &ruleRefExpr{
-										pos:  position{line: 606, col: 22, offset: 18517},
-										name: "ip6tail",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 609, col: 5, offset: 18581},
-						run: (*parser).callonip6addr9,
-						expr: &seqExpr{
-							pos: position{line: 609, col: 5, offset: 18581},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 609, col: 5, offset: 18581},
-									label: "a",
-									expr: &ruleRefExpr{
-										pos:  position{line: 609, col: 7, offset: 18583},
-										name: "h16",
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 609, col: 11, offset: 18587},
-									label: "b",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 609, col: 13, offset: 18589},
-										expr: &ruleRefExpr{
-											pos:  position{line: 609, col: 14, offset: 18590},
-											name: "h_append",
-										},
-									},
-								},
 								&litMatcher{
-									pos:        position{line: 609, col: 25, offset: 18601},
-									val:        "::",
+									pos:        position{line: 498, col: 5, offset: 15206},
+									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 609, col: 30, offset: 18606},
-									label: "d",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 609, col: 32, offset: 18608},
-										expr: &ruleRefExpr{
-											pos:  position{line: 609, col: 33, offset: 18609},
-											name: "h_prepend",
-										},
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 609, col: 45, offset: 18621},
-									label: "e",
+									pos:   position{line: 498, col: 9, offset: 15210},
+									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 609, col: 47, offset: 18623},
-										name: "ip6tail",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 612, col: 5, offset: 18722},
-						run: (*parser).callonip6addr22,
-						expr: &seqExpr{
-							pos: position{line: 612, col: 5, offset: 18722},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 612, col: 5, offset: 18722},
-									val:        "::",
-									ignoreCase: false,
-								},
-								&labeledExpr{
-									pos:   position{line: 612, col: 10, offset: 18727},
-									label: "a",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 612, col: 12, offset: 18729},
-										expr: &ruleRefExpr{
-											pos:  position{line: 612, col: 13, offset: 18730},
-											name: "h_prepend",
-										},
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 612, col: 25, offset: 18742},
-									label: "b",
-									expr: &ruleRefExpr{
-										pos:  position{line: 612, col: 27, offset: 18744},
-										name: "ip6tail",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 615, col: 5, offset: 18815},
-						run: (*parser).callonip6addr30,
-						expr: &seqExpr{
-							pos: position{line: 615, col: 5, offset: 18815},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 615, col: 5, offset: 18815},
-									label: "a",
-									expr: &ruleRefExpr{
-										pos:  position{line: 615, col: 7, offset: 18817},
-										name: "h16",
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 615, col: 11, offset: 18821},
-									label: "b",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 615, col: 13, offset: 18823},
-										expr: &ruleRefExpr{
-											pos:  position{line: 615, col: 14, offset: 18824},
-											name: "h_append",
-										},
+										pos:  position{line: 498, col: 14, offset: 15215},
+										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 615, col: 25, offset: 18835},
-									val:        "::",
+									pos:        position{line: 498, col: 19, offset: 15220},
+									val:        "]",
 									ignoreCase: false,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 618, col: 5, offset: 18903},
-						run: (*parser).callonip6addr38,
-						expr: &litMatcher{
-							pos:        position{line: 618, col: 5, offset: 18903},
-							val:        "::",
-							ignoreCase: false,
+						pos: position{line: 499, col: 5, offset: 15269},
+						run: (*parser).callonDeref8,
+						expr: &seqExpr{
+							pos: position{line: 499, col: 5, offset: 15269},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 499, col: 5, offset: 15269},
+									val:        ".",
+									ignoreCase: false,
+								},
+								&notExpr{
+									pos: position{line: 499, col: 9, offset: 15273},
+									expr: &litMatcher{
+										pos:        position{line: 499, col: 11, offset: 15275},
+										val:        ".",
+										ignoreCase: false,
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 499, col: 16, offset: 15280},
+									label: "id",
+									expr: &ruleRefExpr{
+										pos:  position{line: 499, col: 19, offset: 15283},
+										name: "Identifier",
+									},
+								},
+							},
 						},
 					},
 				},
 			},
 		},
 		{
-			name: "ip6tail",
-			pos:  position{line: 622, col: 1, offset: 18940},
+			name: "Primary",
+			pos:  position{line: 501, col: 1, offset: 15334},
 			expr: &choiceExpr{
-				pos: position{line: 623, col: 5, offset: 18952},
+				pos: position{line: 502, col: 5, offset: 15346},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 623, col: 5, offset: 18952},
-						name: "addr",
+						pos:  position{line: 502, col: 5, offset: 15346},
+						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 624, col: 5, offset: 18961},
-						name: "h16",
+						pos:  position{line: 503, col: 5, offset: 15364},
+						name: "RegexpLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 504, col: 5, offset: 15382},
+						name: "SubnetLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 505, col: 5, offset: 15400},
+						name: "AddressLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 506, col: 5, offset: 15419},
+						name: "FloatLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 507, col: 5, offset: 15436},
+						name: "IntegerLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 508, col: 5, offset: 15455},
+						name: "BooleanLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 509, col: 5, offset: 15474},
+						name: "NullLiteral",
+					},
+					&actionExpr{
+						pos: position{line: 510, col: 5, offset: 15490},
+						run: (*parser).callonPrimary10,
+						expr: &seqExpr{
+							pos: position{line: 510, col: 5, offset: 15490},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 510, col: 5, offset: 15490},
+									val:        "(",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 510, col: 9, offset: 15494},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 510, col: 12, offset: 15497},
+									label: "expr",
+									expr: &ruleRefExpr{
+										pos:  position{line: 510, col: 17, offset: 15502},
+										name: "Expr",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 510, col: 22, offset: 15507},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 510, col: 25, offset: 15510},
+									val:        ")",
+									ignoreCase: false,
+								},
+							},
+						},
 					},
 				},
 			},
 		},
 		{
-			name: "h_append",
-			pos:  position{line: 626, col: 1, offset: 18966},
+			name: "EqualityToken",
+			pos:  position{line: 512, col: 1, offset: 15536},
+			expr: &choiceExpr{
+				pos: position{line: 513, col: 5, offset: 15554},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 513, col: 5, offset: 15554},
+						name: "EqualityOperator",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 513, col: 24, offset: 15573},
+						name: "RelativeOperator",
+					},
+				},
+			},
+		},
+		{
+			name: "AndToken",
+			pos:  position{line: 515, col: 1, offset: 15591},
 			expr: &actionExpr{
-				pos: position{line: 626, col: 12, offset: 18977},
-				run: (*parser).callonh_append1,
+				pos: position{line: 515, col: 12, offset: 15602},
+				run: (*parser).callonAndToken1,
+				expr: &litMatcher{
+					pos:        position{line: 515, col: 12, offset: 15602},
+					val:        "and",
+					ignoreCase: true,
+				},
+			},
+		},
+		{
+			name: "OrToken",
+			pos:  position{line: 516, col: 1, offset: 15640},
+			expr: &actionExpr{
+				pos: position{line: 516, col: 11, offset: 15650},
+				run: (*parser).callonOrToken1,
+				expr: &litMatcher{
+					pos:        position{line: 516, col: 11, offset: 15650},
+					val:        "or",
+					ignoreCase: true,
+				},
+			},
+		},
+		{
+			name: "InToken",
+			pos:  position{line: 517, col: 1, offset: 15687},
+			expr: &actionExpr{
+				pos: position{line: 517, col: 11, offset: 15697},
+				run: (*parser).callonInToken1,
+				expr: &litMatcher{
+					pos:        position{line: 517, col: 11, offset: 15697},
+					val:        "in",
+					ignoreCase: true,
+				},
+			},
+		},
+		{
+			name: "NotToken",
+			pos:  position{line: 518, col: 1, offset: 15734},
+			expr: &actionExpr{
+				pos: position{line: 518, col: 12, offset: 15745},
+				run: (*parser).callonNotToken1,
+				expr: &litMatcher{
+					pos:        position{line: 518, col: 12, offset: 15745},
+					val:        "not",
+					ignoreCase: true,
+				},
+			},
+		},
+		{
+			name: "IdentifierName",
+			pos:  position{line: 520, col: 1, offset: 15784},
+			expr: &actionExpr{
+				pos: position{line: 520, col: 18, offset: 15801},
+				run: (*parser).callonIdentifierName1,
 				expr: &seqExpr{
-					pos: position{line: 626, col: 12, offset: 18977},
+					pos: position{line: 520, col: 18, offset: 15801},
 					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 626, col: 12, offset: 18977},
-							val:        ":",
-							ignoreCase: false,
+						&ruleRefExpr{
+							pos:  position{line: 520, col: 18, offset: 15801},
+							name: "IdentifierStart",
 						},
-						&labeledExpr{
-							pos:   position{line: 626, col: 16, offset: 18981},
-							label: "v",
+						&zeroOrMoreExpr{
+							pos: position{line: 520, col: 34, offset: 15817},
 							expr: &ruleRefExpr{
-								pos:  position{line: 626, col: 18, offset: 18983},
-								name: "h16",
+								pos:  position{line: 520, col: 34, offset: 15817},
+								name: "IdentifierRest",
 							},
 						},
 					},
@@ -4646,125 +3854,29 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "h_prepend",
-			pos:  position{line: 627, col: 1, offset: 19020},
-			expr: &actionExpr{
-				pos: position{line: 627, col: 13, offset: 19032},
-				run: (*parser).callonh_prepend1,
-				expr: &seqExpr{
-					pos: position{line: 627, col: 13, offset: 19032},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 627, col: 13, offset: 19032},
-							label: "v",
-							expr: &ruleRefExpr{
-								pos:  position{line: 627, col: 15, offset: 19034},
-								name: "h16",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 627, col: 19, offset: 19038},
-							val:        ":",
-							ignoreCase: false,
-						},
-					},
-				},
+			name: "IdentifierStart",
+			pos:  position{line: 522, col: 1, offset: 15865},
+			expr: &charClassMatcher{
+				pos:        position{line: 522, col: 19, offset: 15883},
+				val:        "[A-Za-z_$]",
+				chars:      []rune{'_', '$'},
+				ranges:     []rune{'A', 'Z', 'a', 'z'},
+				ignoreCase: false,
+				inverted:   false,
 			},
 		},
 		{
-			name: "subnet",
-			pos:  position{line: 629, col: 1, offset: 19076},
-			expr: &actionExpr{
-				pos: position{line: 630, col: 5, offset: 19087},
-				run: (*parser).callonsubnet1,
-				expr: &seqExpr{
-					pos: position{line: 630, col: 5, offset: 19087},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 630, col: 5, offset: 19087},
-							label: "a",
-							expr: &ruleRefExpr{
-								pos:  position{line: 630, col: 7, offset: 19089},
-								name: "addr",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 630, col: 12, offset: 19094},
-							val:        "/",
-							ignoreCase: false,
-						},
-						&labeledExpr{
-							pos:   position{line: 630, col: 16, offset: 19098},
-							label: "m",
-							expr: &ruleRefExpr{
-								pos:  position{line: 630, col: 18, offset: 19100},
-								name: "unsignedInteger",
-							},
-						},
+			name: "IdentifierRest",
+			pos:  position{line: 523, col: 1, offset: 15894},
+			expr: &choiceExpr{
+				pos: position{line: 523, col: 18, offset: 15911},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 523, col: 18, offset: 15911},
+						name: "IdentifierStart",
 					},
-				},
-			},
-		},
-		{
-			name: "ip6subnet",
-			pos:  position{line: 634, col: 1, offset: 19184},
-			expr: &actionExpr{
-				pos: position{line: 635, col: 5, offset: 19198},
-				run: (*parser).callonip6subnet1,
-				expr: &seqExpr{
-					pos: position{line: 635, col: 5, offset: 19198},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 635, col: 5, offset: 19198},
-							label: "a",
-							expr: &ruleRefExpr{
-								pos:  position{line: 635, col: 7, offset: 19200},
-								name: "ip6addr",
-							},
-						},
-						&litMatcher{
-							pos:        position{line: 635, col: 15, offset: 19208},
-							val:        "/",
-							ignoreCase: false,
-						},
-						&labeledExpr{
-							pos:   position{line: 635, col: 19, offset: 19212},
-							label: "m",
-							expr: &ruleRefExpr{
-								pos:  position{line: 635, col: 21, offset: 19214},
-								name: "unsignedInteger",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "unsignedInteger",
-			pos:  position{line: 639, col: 1, offset: 19288},
-			expr: &actionExpr{
-				pos: position{line: 640, col: 5, offset: 19308},
-				run: (*parser).callonunsignedInteger1,
-				expr: &labeledExpr{
-					pos:   position{line: 640, col: 5, offset: 19308},
-					label: "s",
-					expr: &ruleRefExpr{
-						pos:  position{line: 640, col: 7, offset: 19310},
-						name: "suint",
-					},
-				},
-			},
-		},
-		{
-			name: "suint",
-			pos:  position{line: 642, col: 1, offset: 19345},
-			expr: &actionExpr{
-				pos: position{line: 643, col: 5, offset: 19355},
-				run: (*parser).callonsuint1,
-				expr: &oneOrMoreExpr{
-					pos: position{line: 643, col: 5, offset: 19355},
-					expr: &charClassMatcher{
-						pos:        position{line: 643, col: 5, offset: 19355},
+					&charClassMatcher{
+						pos:        position{line: 523, col: 36, offset: 15929},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4774,146 +3886,23 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "integer",
-			pos:  position{line: 645, col: 1, offset: 19394},
+			name: "Identifier",
+			pos:  position{line: 525, col: 1, offset: 15936},
 			expr: &actionExpr{
-				pos: position{line: 646, col: 5, offset: 19406},
-				run: (*parser).calloninteger1,
-				expr: &labeledExpr{
-					pos:   position{line: 646, col: 5, offset: 19406},
-					label: "s",
-					expr: &ruleRefExpr{
-						pos:  position{line: 646, col: 7, offset: 19408},
-						name: "sinteger",
-					},
-				},
-			},
-		},
-		{
-			name: "sinteger",
-			pos:  position{line: 648, col: 1, offset: 19446},
-			expr: &actionExpr{
-				pos: position{line: 649, col: 5, offset: 19459},
-				run: (*parser).callonsinteger1,
+				pos: position{line: 526, col: 5, offset: 15951},
+				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 649, col: 5, offset: 19459},
+					pos: position{line: 526, col: 5, offset: 15951},
 					exprs: []interface{}{
-						&zeroOrOneExpr{
-							pos: position{line: 649, col: 5, offset: 19459},
-							expr: &charClassMatcher{
-								pos:        position{line: 649, col: 5, offset: 19459},
-								val:        "[+-]",
-								chars:      []rune{'+', '-'},
-								ignoreCase: false,
-								inverted:   false,
-							},
-						},
 						&ruleRefExpr{
-							pos:  position{line: 649, col: 11, offset: 19465},
-							name: "suint",
+							pos:  position{line: 526, col: 5, offset: 15951},
+							name: "IdentifierStart",
 						},
-					},
-				},
-			},
-		},
-		{
-			name: "double",
-			pos:  position{line: 651, col: 1, offset: 19503},
-			expr: &actionExpr{
-				pos: position{line: 652, col: 5, offset: 19514},
-				run: (*parser).callondouble1,
-				expr: &labeledExpr{
-					pos:   position{line: 652, col: 5, offset: 19514},
-					label: "s",
-					expr: &ruleRefExpr{
-						pos:  position{line: 652, col: 7, offset: 19516},
-						name: "sdouble",
-					},
-				},
-			},
-		},
-		{
-			name: "sdouble",
-			pos:  position{line: 656, col: 1, offset: 19563},
-			expr: &choiceExpr{
-				pos: position{line: 657, col: 5, offset: 19575},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 657, col: 5, offset: 19575},
-						run: (*parser).callonsdouble2,
-						expr: &seqExpr{
-							pos: position{line: 657, col: 5, offset: 19575},
-							exprs: []interface{}{
-								&zeroOrOneExpr{
-									pos: position{line: 657, col: 5, offset: 19575},
-									expr: &litMatcher{
-										pos:        position{line: 657, col: 5, offset: 19575},
-										val:        "-",
-										ignoreCase: false,
-									},
-								},
-								&oneOrMoreExpr{
-									pos: position{line: 657, col: 10, offset: 19580},
-									expr: &ruleRefExpr{
-										pos:  position{line: 657, col: 10, offset: 19580},
-										name: "doubleInteger",
-									},
-								},
-								&litMatcher{
-									pos:        position{line: 657, col: 25, offset: 19595},
-									val:        ".",
-									ignoreCase: false,
-								},
-								&oneOrMoreExpr{
-									pos: position{line: 657, col: 29, offset: 19599},
-									expr: &ruleRefExpr{
-										pos:  position{line: 657, col: 29, offset: 19599},
-										name: "doubleDigit",
-									},
-								},
-								&zeroOrOneExpr{
-									pos: position{line: 657, col: 42, offset: 19612},
-									expr: &ruleRefExpr{
-										pos:  position{line: 657, col: 42, offset: 19612},
-										name: "exponentPart",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 660, col: 5, offset: 19671},
-						run: (*parser).callonsdouble13,
-						expr: &seqExpr{
-							pos: position{line: 660, col: 5, offset: 19671},
-							exprs: []interface{}{
-								&zeroOrOneExpr{
-									pos: position{line: 660, col: 5, offset: 19671},
-									expr: &litMatcher{
-										pos:        position{line: 660, col: 5, offset: 19671},
-										val:        "-",
-										ignoreCase: false,
-									},
-								},
-								&litMatcher{
-									pos:        position{line: 660, col: 10, offset: 19676},
-									val:        ".",
-									ignoreCase: false,
-								},
-								&oneOrMoreExpr{
-									pos: position{line: 660, col: 14, offset: 19680},
-									expr: &ruleRefExpr{
-										pos:  position{line: 660, col: 14, offset: 19680},
-										name: "doubleDigit",
-									},
-								},
-								&zeroOrOneExpr{
-									pos: position{line: 660, col: 27, offset: 19693},
-									expr: &ruleRefExpr{
-										pos:  position{line: 660, col: 27, offset: 19693},
-										name: "exponentPart",
-									},
-								},
+						&zeroOrMoreExpr{
+							pos: position{line: 526, col: 21, offset: 15967},
+							expr: &ruleRefExpr{
+								pos:  position{line: 526, col: 21, offset: 15967},
+								name: "IdentifierRest",
 							},
 						},
 					},
@@ -4921,34 +3910,256 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "doubleInteger",
-			pos:  position{line: 664, col: 1, offset: 19749},
+			name: "Duration",
+			pos:  position{line: 528, col: 1, offset: 16067},
 			expr: &choiceExpr{
-				pos: position{line: 665, col: 5, offset: 19767},
+				pos: position{line: 529, col: 5, offset: 16080},
 				alternatives: []interface{}{
-					&litMatcher{
-						pos:        position{line: 665, col: 5, offset: 19767},
-						val:        "0",
-						ignoreCase: false,
+					&ruleRefExpr{
+						pos:  position{line: 529, col: 5, offset: 16080},
+						name: "Seconds",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 530, col: 5, offset: 16092},
+						name: "Minutes",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 531, col: 5, offset: 16104},
+						name: "Hours",
 					},
 					&seqExpr{
-						pos: position{line: 666, col: 5, offset: 19775},
+						pos: position{line: 532, col: 5, offset: 16114},
 						exprs: []interface{}{
-							&charClassMatcher{
-								pos:        position{line: 666, col: 5, offset: 19775},
-								val:        "[1-9]",
-								ranges:     []rune{'1', '9'},
-								ignoreCase: false,
-								inverted:   false,
+							&ruleRefExpr{
+								pos:  position{line: 532, col: 5, offset: 16114},
+								name: "Hours",
 							},
-							&zeroOrMoreExpr{
-								pos: position{line: 666, col: 11, offset: 19781},
-								expr: &charClassMatcher{
-									pos:        position{line: 666, col: 11, offset: 19781},
-									val:        "[0-9]",
-									ranges:     []rune{'0', '9'},
-									ignoreCase: false,
-									inverted:   false,
+							&ruleRefExpr{
+								pos:  position{line: 532, col: 11, offset: 16120},
+								name: "_",
+							},
+							&litMatcher{
+								pos:        position{line: 532, col: 13, offset: 16122},
+								val:        "and",
+								ignoreCase: false,
+							},
+							&ruleRefExpr{
+								pos:  position{line: 532, col: 19, offset: 16128},
+								name: "_",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 532, col: 21, offset: 16130},
+								name: "Minutes",
+							},
+						},
+					},
+					&ruleRefExpr{
+						pos:  position{line: 533, col: 5, offset: 16142},
+						name: "Days",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 534, col: 5, offset: 16151},
+						name: "Weeks",
+					},
+				},
+			},
+		},
+		{
+			name: "SecondsToken",
+			pos:  position{line: 536, col: 1, offset: 16158},
+			expr: &choiceExpr{
+				pos: position{line: 537, col: 5, offset: 16175},
+				alternatives: []interface{}{
+					&litMatcher{
+						pos:        position{line: 537, col: 5, offset: 16175},
+						val:        "seconds",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 538, col: 5, offset: 16189},
+						val:        "second",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 539, col: 5, offset: 16202},
+						val:        "secs",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 540, col: 5, offset: 16213},
+						val:        "sec",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 541, col: 5, offset: 16223},
+						val:        "s",
+						ignoreCase: false,
+					},
+				},
+			},
+		},
+		{
+			name: "MinutesToken",
+			pos:  position{line: 543, col: 1, offset: 16228},
+			expr: &choiceExpr{
+				pos: position{line: 544, col: 5, offset: 16245},
+				alternatives: []interface{}{
+					&litMatcher{
+						pos:        position{line: 544, col: 5, offset: 16245},
+						val:        "minutes",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 545, col: 5, offset: 16259},
+						val:        "minute",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 546, col: 5, offset: 16272},
+						val:        "mins",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 547, col: 5, offset: 16283},
+						val:        "min",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 548, col: 5, offset: 16293},
+						val:        "m",
+						ignoreCase: false,
+					},
+				},
+			},
+		},
+		{
+			name: "HoursToken",
+			pos:  position{line: 550, col: 1, offset: 16298},
+			expr: &choiceExpr{
+				pos: position{line: 551, col: 5, offset: 16313},
+				alternatives: []interface{}{
+					&litMatcher{
+						pos:        position{line: 551, col: 5, offset: 16313},
+						val:        "hours",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 552, col: 5, offset: 16325},
+						val:        "hrs",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 553, col: 5, offset: 16335},
+						val:        "hr",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 554, col: 5, offset: 16344},
+						val:        "h",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 555, col: 5, offset: 16352},
+						val:        "hour",
+						ignoreCase: false,
+					},
+				},
+			},
+		},
+		{
+			name: "DaysToken",
+			pos:  position{line: 557, col: 1, offset: 16360},
+			expr: &choiceExpr{
+				pos: position{line: 557, col: 13, offset: 16372},
+				alternatives: []interface{}{
+					&litMatcher{
+						pos:        position{line: 557, col: 13, offset: 16372},
+						val:        "days",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 557, col: 20, offset: 16379},
+						val:        "day",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 557, col: 26, offset: 16385},
+						val:        "d",
+						ignoreCase: false,
+					},
+				},
+			},
+		},
+		{
+			name: "WeeksToken",
+			pos:  position{line: 558, col: 1, offset: 16389},
+			expr: &choiceExpr{
+				pos: position{line: 558, col: 14, offset: 16402},
+				alternatives: []interface{}{
+					&litMatcher{
+						pos:        position{line: 558, col: 14, offset: 16402},
+						val:        "weeks",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 558, col: 22, offset: 16410},
+						val:        "week",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 558, col: 29, offset: 16417},
+						val:        "wks",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 558, col: 35, offset: 16423},
+						val:        "wk",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 558, col: 40, offset: 16428},
+						val:        "w",
+						ignoreCase: false,
+					},
+				},
+			},
+		},
+		{
+			name: "Seconds",
+			pos:  position{line: 560, col: 1, offset: 16433},
+			expr: &choiceExpr{
+				pos: position{line: 561, col: 5, offset: 16445},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 561, col: 5, offset: 16445},
+						run: (*parser).callonSeconds2,
+						expr: &litMatcher{
+							pos:        position{line: 561, col: 5, offset: 16445},
+							val:        "second",
+							ignoreCase: false,
+						},
+					},
+					&actionExpr{
+						pos: position{line: 562, col: 5, offset: 16531},
+						run: (*parser).callonSeconds4,
+						expr: &seqExpr{
+							pos: position{line: 562, col: 5, offset: 16531},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 562, col: 5, offset: 16531},
+									label: "num",
+									expr: &ruleRefExpr{
+										pos:  position{line: 562, col: 9, offset: 16535},
+										name: "UInt",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 562, col: 14, offset: 16540},
+									name: "__",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 562, col: 17, offset: 16543},
+									name: "SecondsToken",
 								},
 							},
 						},
@@ -4957,58 +4168,740 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "doubleDigit",
-			pos:  position{line: 668, col: 1, offset: 19789},
-			expr: &charClassMatcher{
-				pos:        position{line: 668, col: 15, offset: 19803},
-				val:        "[0-9]",
-				ranges:     []rune{'0', '9'},
-				ignoreCase: false,
-				inverted:   false,
+			name: "Minutes",
+			pos:  position{line: 564, col: 1, offset: 16632},
+			expr: &choiceExpr{
+				pos: position{line: 565, col: 5, offset: 16644},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 565, col: 5, offset: 16644},
+						run: (*parser).callonMinutes2,
+						expr: &litMatcher{
+							pos:        position{line: 565, col: 5, offset: 16644},
+							val:        "minute",
+							ignoreCase: false,
+						},
+					},
+					&actionExpr{
+						pos: position{line: 566, col: 5, offset: 16731},
+						run: (*parser).callonMinutes4,
+						expr: &seqExpr{
+							pos: position{line: 566, col: 5, offset: 16731},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 566, col: 5, offset: 16731},
+									label: "num",
+									expr: &ruleRefExpr{
+										pos:  position{line: 566, col: 9, offset: 16735},
+										name: "UInt",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 566, col: 14, offset: 16740},
+									name: "__",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 566, col: 17, offset: 16743},
+									name: "MinutesToken",
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 		{
-			name: "exponentPart",
-			pos:  position{line: 670, col: 1, offset: 19810},
+			name: "Hours",
+			pos:  position{line: 568, col: 1, offset: 16841},
+			expr: &choiceExpr{
+				pos: position{line: 569, col: 5, offset: 16851},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 569, col: 5, offset: 16851},
+						run: (*parser).callonHours2,
+						expr: &litMatcher{
+							pos:        position{line: 569, col: 5, offset: 16851},
+							val:        "hour",
+							ignoreCase: false,
+						},
+					},
+					&actionExpr{
+						pos: position{line: 570, col: 5, offset: 16938},
+						run: (*parser).callonHours4,
+						expr: &seqExpr{
+							pos: position{line: 570, col: 5, offset: 16938},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 570, col: 5, offset: 16938},
+									label: "num",
+									expr: &ruleRefExpr{
+										pos:  position{line: 570, col: 9, offset: 16942},
+										name: "UInt",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 570, col: 14, offset: 16947},
+									name: "__",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 570, col: 17, offset: 16950},
+									name: "HoursToken",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Days",
+			pos:  position{line: 572, col: 1, offset: 17048},
+			expr: &choiceExpr{
+				pos: position{line: 573, col: 5, offset: 17057},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 573, col: 5, offset: 17057},
+						run: (*parser).callonDays2,
+						expr: &litMatcher{
+							pos:        position{line: 573, col: 5, offset: 17057},
+							val:        "day",
+							ignoreCase: false,
+						},
+					},
+					&actionExpr{
+						pos: position{line: 574, col: 5, offset: 17146},
+						run: (*parser).callonDays4,
+						expr: &seqExpr{
+							pos: position{line: 574, col: 5, offset: 17146},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 574, col: 5, offset: 17146},
+									label: "num",
+									expr: &ruleRefExpr{
+										pos:  position{line: 574, col: 9, offset: 17150},
+										name: "UInt",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 574, col: 14, offset: 17155},
+									name: "__",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 574, col: 17, offset: 17158},
+									name: "DaysToken",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Weeks",
+			pos:  position{line: 576, col: 1, offset: 17260},
+			expr: &choiceExpr{
+				pos: position{line: 577, col: 5, offset: 17270},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 577, col: 5, offset: 17270},
+						run: (*parser).callonWeeks2,
+						expr: &litMatcher{
+							pos:        position{line: 577, col: 5, offset: 17270},
+							val:        "week",
+							ignoreCase: false,
+						},
+					},
+					&actionExpr{
+						pos: position{line: 578, col: 5, offset: 17362},
+						run: (*parser).callonWeeks4,
+						expr: &seqExpr{
+							pos: position{line: 578, col: 5, offset: 17362},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 578, col: 5, offset: 17362},
+									label: "num",
+									expr: &ruleRefExpr{
+										pos:  position{line: 578, col: 9, offset: 17366},
+										name: "UInt",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 578, col: 14, offset: 17371},
+									name: "__",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 578, col: 17, offset: 17374},
+									name: "WeeksToken",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "IP",
+			pos:  position{line: 581, col: 1, offset: 17505},
+			expr: &actionExpr{
+				pos: position{line: 582, col: 5, offset: 17512},
+				run: (*parser).callonIP1,
+				expr: &seqExpr{
+					pos: position{line: 582, col: 5, offset: 17512},
+					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 582, col: 5, offset: 17512},
+							name: "UInt",
+						},
+						&litMatcher{
+							pos:        position{line: 582, col: 10, offset: 17517},
+							val:        ".",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 582, col: 14, offset: 17521},
+							name: "UInt",
+						},
+						&litMatcher{
+							pos:        position{line: 582, col: 19, offset: 17526},
+							val:        ".",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 582, col: 23, offset: 17530},
+							name: "UInt",
+						},
+						&litMatcher{
+							pos:        position{line: 582, col: 28, offset: 17535},
+							val:        ".",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 582, col: 32, offset: 17539},
+							name: "UInt",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "IP6",
+			pos:  position{line: 586, col: 1, offset: 17707},
+			expr: &choiceExpr{
+				pos: position{line: 587, col: 5, offset: 17715},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 587, col: 5, offset: 17715},
+						run: (*parser).callonIP62,
+						expr: &seqExpr{
+							pos: position{line: 587, col: 5, offset: 17715},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 587, col: 5, offset: 17715},
+									label: "a",
+									expr: &oneOrMoreExpr{
+										pos: position{line: 587, col: 7, offset: 17717},
+										expr: &ruleRefExpr{
+											pos:  position{line: 587, col: 7, offset: 17717},
+											name: "HexColon",
+										},
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 587, col: 17, offset: 17727},
+									label: "b",
+									expr: &ruleRefExpr{
+										pos:  position{line: 587, col: 19, offset: 17729},
+										name: "IP6Tail",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 590, col: 5, offset: 17793},
+						run: (*parser).callonIP69,
+						expr: &seqExpr{
+							pos: position{line: 590, col: 5, offset: 17793},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 590, col: 5, offset: 17793},
+									label: "a",
+									expr: &ruleRefExpr{
+										pos:  position{line: 590, col: 7, offset: 17795},
+										name: "Hex",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 590, col: 11, offset: 17799},
+									label: "b",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 590, col: 13, offset: 17801},
+										expr: &ruleRefExpr{
+											pos:  position{line: 590, col: 13, offset: 17801},
+											name: "ColonHex",
+										},
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 590, col: 23, offset: 17811},
+									val:        "::",
+									ignoreCase: false,
+								},
+								&labeledExpr{
+									pos:   position{line: 590, col: 28, offset: 17816},
+									label: "d",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 590, col: 30, offset: 17818},
+										expr: &ruleRefExpr{
+											pos:  position{line: 590, col: 30, offset: 17818},
+											name: "HexColon",
+										},
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 590, col: 40, offset: 17828},
+									label: "e",
+									expr: &ruleRefExpr{
+										pos:  position{line: 590, col: 42, offset: 17830},
+										name: "IP6Tail",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 593, col: 5, offset: 17929},
+						run: (*parser).callonIP622,
+						expr: &seqExpr{
+							pos: position{line: 593, col: 5, offset: 17929},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 593, col: 5, offset: 17929},
+									val:        "::",
+									ignoreCase: false,
+								},
+								&labeledExpr{
+									pos:   position{line: 593, col: 10, offset: 17934},
+									label: "a",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 593, col: 12, offset: 17936},
+										expr: &ruleRefExpr{
+											pos:  position{line: 593, col: 12, offset: 17936},
+											name: "HexColon",
+										},
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 593, col: 22, offset: 17946},
+									label: "b",
+									expr: &ruleRefExpr{
+										pos:  position{line: 593, col: 24, offset: 17948},
+										name: "IP6Tail",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 596, col: 5, offset: 18019},
+						run: (*parser).callonIP630,
+						expr: &seqExpr{
+							pos: position{line: 596, col: 5, offset: 18019},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 596, col: 5, offset: 18019},
+									label: "a",
+									expr: &ruleRefExpr{
+										pos:  position{line: 596, col: 7, offset: 18021},
+										name: "Hex",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 596, col: 11, offset: 18025},
+									label: "b",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 596, col: 13, offset: 18027},
+										expr: &ruleRefExpr{
+											pos:  position{line: 596, col: 13, offset: 18027},
+											name: "ColonHex",
+										},
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 596, col: 23, offset: 18037},
+									val:        "::",
+									ignoreCase: false,
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 599, col: 5, offset: 18105},
+						run: (*parser).callonIP638,
+						expr: &litMatcher{
+							pos:        position{line: 599, col: 5, offset: 18105},
+							val:        "::",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "IP6Tail",
+			pos:  position{line: 603, col: 1, offset: 18142},
+			expr: &choiceExpr{
+				pos: position{line: 604, col: 5, offset: 18154},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 604, col: 5, offset: 18154},
+						name: "IP",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 605, col: 5, offset: 18161},
+						name: "Hex",
+					},
+				},
+			},
+		},
+		{
+			name: "ColonHex",
+			pos:  position{line: 607, col: 1, offset: 18166},
+			expr: &actionExpr{
+				pos: position{line: 607, col: 12, offset: 18177},
+				run: (*parser).callonColonHex1,
+				expr: &seqExpr{
+					pos: position{line: 607, col: 12, offset: 18177},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 607, col: 12, offset: 18177},
+							val:        ":",
+							ignoreCase: false,
+						},
+						&labeledExpr{
+							pos:   position{line: 607, col: 16, offset: 18181},
+							label: "v",
+							expr: &ruleRefExpr{
+								pos:  position{line: 607, col: 18, offset: 18183},
+								name: "Hex",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "HexColon",
+			pos:  position{line: 608, col: 1, offset: 18220},
+			expr: &actionExpr{
+				pos: position{line: 608, col: 12, offset: 18231},
+				run: (*parser).callonHexColon1,
+				expr: &seqExpr{
+					pos: position{line: 608, col: 12, offset: 18231},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 608, col: 12, offset: 18231},
+							label: "v",
+							expr: &ruleRefExpr{
+								pos:  position{line: 608, col: 14, offset: 18233},
+								name: "Hex",
+							},
+						},
+						&litMatcher{
+							pos:        position{line: 608, col: 18, offset: 18237},
+							val:        ":",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "IPNet",
+			pos:  position{line: 610, col: 1, offset: 18275},
+			expr: &actionExpr{
+				pos: position{line: 611, col: 5, offset: 18285},
+				run: (*parser).callonIPNet1,
+				expr: &seqExpr{
+					pos: position{line: 611, col: 5, offset: 18285},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 611, col: 5, offset: 18285},
+							label: "a",
+							expr: &ruleRefExpr{
+								pos:  position{line: 611, col: 7, offset: 18287},
+								name: "IP",
+							},
+						},
+						&litMatcher{
+							pos:        position{line: 611, col: 10, offset: 18290},
+							val:        "/",
+							ignoreCase: false,
+						},
+						&labeledExpr{
+							pos:   position{line: 611, col: 14, offset: 18294},
+							label: "m",
+							expr: &ruleRefExpr{
+								pos:  position{line: 611, col: 16, offset: 18296},
+								name: "UInt",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "IP6Net",
+			pos:  position{line: 615, col: 1, offset: 18369},
+			expr: &actionExpr{
+				pos: position{line: 616, col: 5, offset: 18380},
+				run: (*parser).callonIP6Net1,
+				expr: &seqExpr{
+					pos: position{line: 616, col: 5, offset: 18380},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 616, col: 5, offset: 18380},
+							label: "a",
+							expr: &ruleRefExpr{
+								pos:  position{line: 616, col: 7, offset: 18382},
+								name: "IP6",
+							},
+						},
+						&litMatcher{
+							pos:        position{line: 616, col: 11, offset: 18386},
+							val:        "/",
+							ignoreCase: false,
+						},
+						&labeledExpr{
+							pos:   position{line: 616, col: 15, offset: 18390},
+							label: "m",
+							expr: &ruleRefExpr{
+								pos:  position{line: 616, col: 17, offset: 18392},
+								name: "UInt",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "UInt",
+			pos:  position{line: 620, col: 1, offset: 18455},
+			expr: &actionExpr{
+				pos: position{line: 621, col: 4, offset: 18463},
+				run: (*parser).callonUInt1,
+				expr: &labeledExpr{
+					pos:   position{line: 621, col: 4, offset: 18463},
+					label: "s",
+					expr: &ruleRefExpr{
+						pos:  position{line: 621, col: 6, offset: 18465},
+						name: "UIntString",
+					},
+				},
+			},
+		},
+		{
+			name: "IntString",
+			pos:  position{line: 623, col: 1, offset: 18505},
+			expr: &choiceExpr{
+				pos: position{line: 624, col: 5, offset: 18519},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 624, col: 5, offset: 18519},
+						name: "UIntString",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 625, col: 5, offset: 18534},
+						name: "MinusIntString",
+					},
+				},
+			},
+		},
+		{
+			name: "UIntString",
+			pos:  position{line: 627, col: 1, offset: 18550},
+			expr: &actionExpr{
+				pos: position{line: 627, col: 14, offset: 18563},
+				run: (*parser).callonUIntString1,
+				expr: &oneOrMoreExpr{
+					pos: position{line: 627, col: 14, offset: 18563},
+					expr: &charClassMatcher{
+						pos:        position{line: 627, col: 14, offset: 18563},
+						val:        "[0-9]",
+						ranges:     []rune{'0', '9'},
+						ignoreCase: false,
+						inverted:   false,
+					},
+				},
+			},
+		},
+		{
+			name: "MinusIntString",
+			pos:  position{line: 629, col: 1, offset: 18602},
+			expr: &actionExpr{
+				pos: position{line: 630, col: 5, offset: 18621},
+				run: (*parser).callonMinusIntString1,
+				expr: &seqExpr{
+					pos: position{line: 630, col: 5, offset: 18621},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 630, col: 5, offset: 18621},
+							val:        "-",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 630, col: 9, offset: 18625},
+							name: "UIntString",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "FloatString",
+			pos:  position{line: 632, col: 1, offset: 18668},
+			expr: &choiceExpr{
+				pos: position{line: 633, col: 5, offset: 18684},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 633, col: 5, offset: 18684},
+						run: (*parser).callonFloatString2,
+						expr: &seqExpr{
+							pos: position{line: 633, col: 5, offset: 18684},
+							exprs: []interface{}{
+								&zeroOrOneExpr{
+									pos: position{line: 633, col: 5, offset: 18684},
+									expr: &litMatcher{
+										pos:        position{line: 633, col: 5, offset: 18684},
+										val:        "-",
+										ignoreCase: false,
+									},
+								},
+								&oneOrMoreExpr{
+									pos: position{line: 633, col: 10, offset: 18689},
+									expr: &charClassMatcher{
+										pos:        position{line: 633, col: 10, offset: 18689},
+										val:        "[0-9]",
+										ranges:     []rune{'0', '9'},
+										ignoreCase: false,
+										inverted:   false,
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 633, col: 17, offset: 18696},
+									val:        ".",
+									ignoreCase: false,
+								},
+								&oneOrMoreExpr{
+									pos: position{line: 633, col: 21, offset: 18700},
+									expr: &charClassMatcher{
+										pos:        position{line: 633, col: 21, offset: 18700},
+										val:        "[0-9]",
+										ranges:     []rune{'0', '9'},
+										ignoreCase: false,
+										inverted:   false,
+									},
+								},
+								&zeroOrOneExpr{
+									pos: position{line: 633, col: 28, offset: 18707},
+									expr: &ruleRefExpr{
+										pos:  position{line: 633, col: 28, offset: 18707},
+										name: "ExponentPart",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 636, col: 5, offset: 18766},
+						run: (*parser).callonFloatString13,
+						expr: &seqExpr{
+							pos: position{line: 636, col: 5, offset: 18766},
+							exprs: []interface{}{
+								&zeroOrOneExpr{
+									pos: position{line: 636, col: 5, offset: 18766},
+									expr: &litMatcher{
+										pos:        position{line: 636, col: 5, offset: 18766},
+										val:        "-",
+										ignoreCase: false,
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 636, col: 10, offset: 18771},
+									val:        ".",
+									ignoreCase: false,
+								},
+								&oneOrMoreExpr{
+									pos: position{line: 636, col: 14, offset: 18775},
+									expr: &charClassMatcher{
+										pos:        position{line: 636, col: 14, offset: 18775},
+										val:        "[0-9]",
+										ranges:     []rune{'0', '9'},
+										ignoreCase: false,
+										inverted:   false,
+									},
+								},
+								&zeroOrOneExpr{
+									pos: position{line: 636, col: 21, offset: 18782},
+									expr: &ruleRefExpr{
+										pos:  position{line: 636, col: 21, offset: 18782},
+										name: "ExponentPart",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ExponentPart",
+			pos:  position{line: 640, col: 1, offset: 18838},
 			expr: &seqExpr{
-				pos: position{line: 670, col: 16, offset: 19825},
+				pos: position{line: 640, col: 16, offset: 18853},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 670, col: 16, offset: 19825},
+						pos:        position{line: 640, col: 16, offset: 18853},
 						val:        "e",
 						ignoreCase: true,
 					},
-					&ruleRefExpr{
-						pos:  position{line: 670, col: 21, offset: 19830},
-						name: "sinteger",
-					},
-				},
-			},
-		},
-		{
-			name: "h16",
-			pos:  position{line: 672, col: 1, offset: 19840},
-			expr: &actionExpr{
-				pos: position{line: 672, col: 7, offset: 19846},
-				run: (*parser).callonh161,
-				expr: &labeledExpr{
-					pos:   position{line: 672, col: 7, offset: 19846},
-					label: "chars",
-					expr: &oneOrMoreExpr{
-						pos: position{line: 672, col: 13, offset: 19852},
-						expr: &ruleRefExpr{
-							pos:  position{line: 672, col: 13, offset: 19852},
-							name: "hexdigit",
+					&zeroOrOneExpr{
+						pos: position{line: 640, col: 21, offset: 18858},
+						expr: &charClassMatcher{
+							pos:        position{line: 640, col: 21, offset: 18858},
+							val:        "[+-]",
+							chars:      []rune{'+', '-'},
+							ignoreCase: false,
+							inverted:   false,
 						},
 					},
+					&ruleRefExpr{
+						pos:  position{line: 640, col: 27, offset: 18864},
+						name: "UIntString",
+					},
 				},
 			},
 		},
 		{
-			name: "hexdigit",
-			pos:  position{line: 674, col: 1, offset: 19894},
+			name: "Hex",
+			pos:  position{line: 642, col: 1, offset: 18876},
+			expr: &actionExpr{
+				pos: position{line: 642, col: 7, offset: 18882},
+				run: (*parser).callonHex1,
+				expr: &oneOrMoreExpr{
+					pos: position{line: 642, col: 7, offset: 18882},
+					expr: &ruleRefExpr{
+						pos:  position{line: 642, col: 7, offset: 18882},
+						name: "HexDigit",
+					},
+				},
+			},
+		},
+		{
+			name: "HexDigit",
+			pos:  position{line: 644, col: 1, offset: 18924},
 			expr: &charClassMatcher{
-				pos:        position{line: 674, col: 12, offset: 19905},
+				pos:        position{line: 644, col: 12, offset: 18935},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -5016,54 +4909,54 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "searchWord",
-			pos:  position{line: 676, col: 1, offset: 19918},
+			name: "SearchWord",
+			pos:  position{line: 646, col: 1, offset: 18948},
 			expr: &actionExpr{
-				pos: position{line: 677, col: 5, offset: 19933},
-				run: (*parser).callonsearchWord1,
+				pos: position{line: 647, col: 5, offset: 18963},
+				run: (*parser).callonSearchWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 677, col: 5, offset: 19933},
+					pos:   position{line: 647, col: 5, offset: 18963},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 677, col: 11, offset: 19939},
+						pos: position{line: 647, col: 11, offset: 18969},
 						expr: &ruleRefExpr{
-							pos:  position{line: 677, col: 11, offset: 19939},
-							name: "searchWordPart",
+							pos:  position{line: 647, col: 11, offset: 18969},
+							name: "SearchWordPart",
 						},
 					},
 				},
 			},
 		},
 		{
-			name: "searchWordPart",
-			pos:  position{line: 679, col: 1, offset: 19989},
+			name: "SearchWordPart",
+			pos:  position{line: 649, col: 1, offset: 19019},
 			expr: &choiceExpr{
-				pos: position{line: 680, col: 5, offset: 20008},
+				pos: position{line: 650, col: 5, offset: 19038},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 680, col: 5, offset: 20008},
-						run: (*parser).callonsearchWordPart2,
+						pos: position{line: 650, col: 5, offset: 19038},
+						run: (*parser).callonSearchWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 680, col: 5, offset: 20008},
+							pos: position{line: 650, col: 5, offset: 19038},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 680, col: 5, offset: 20008},
+									pos:        position{line: 650, col: 5, offset: 19038},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 680, col: 10, offset: 20013},
+									pos:   position{line: 650, col: 10, offset: 19043},
 									label: "s",
 									expr: &choiceExpr{
-										pos: position{line: 680, col: 13, offset: 20016},
+										pos: position{line: 650, col: 13, offset: 19046},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 680, col: 13, offset: 20016},
-												name: "escapeSequence",
+												pos:  position{line: 650, col: 13, offset: 19046},
+												name: "EscapeSequence",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 680, col: 30, offset: 20033},
-												name: "searchEscape",
+												pos:  position{line: 650, col: 30, offset: 19063},
+												name: "SearchEscape",
 											},
 										},
 									},
@@ -5072,18 +4965,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 681, col: 5, offset: 20070},
-						run: (*parser).callonsearchWordPart9,
+						pos: position{line: 651, col: 5, offset: 19100},
+						run: (*parser).callonSearchWordPart9,
 						expr: &seqExpr{
-							pos: position{line: 681, col: 5, offset: 20070},
+							pos: position{line: 651, col: 5, offset: 19100},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 681, col: 5, offset: 20070},
+									pos: position{line: 651, col: 5, offset: 19100},
 									expr: &choiceExpr{
-										pos: position{line: 681, col: 7, offset: 20072},
+										pos: position{line: 651, col: 7, offset: 19102},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 681, col: 7, offset: 20072},
+												pos:        position{line: 651, col: 7, offset: 19102},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;:]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';', ':'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -5091,14 +4984,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 681, col: 43, offset: 20108},
-												name: "ws",
+												pos:  position{line: 651, col: 43, offset: 19138},
+												name: "WhiteSpace",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 681, col: 47, offset: 20112,
+									line: 651, col: 55, offset: 19150,
 								},
 							},
 						},
@@ -5107,35 +5000,35 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "quotedString",
-			pos:  position{line: 683, col: 1, offset: 20146},
+			name: "QuotedString",
+			pos:  position{line: 653, col: 1, offset: 19184},
 			expr: &choiceExpr{
-				pos: position{line: 684, col: 5, offset: 20163},
+				pos: position{line: 654, col: 5, offset: 19201},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 684, col: 5, offset: 20163},
-						run: (*parser).callonquotedString2,
+						pos: position{line: 654, col: 5, offset: 19201},
+						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 684, col: 5, offset: 20163},
+							pos: position{line: 654, col: 5, offset: 19201},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 684, col: 5, offset: 20163},
+									pos:        position{line: 654, col: 5, offset: 19201},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 684, col: 9, offset: 20167},
+									pos:   position{line: 654, col: 9, offset: 19205},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 684, col: 11, offset: 20169},
+										pos: position{line: 654, col: 11, offset: 19207},
 										expr: &ruleRefExpr{
-											pos:  position{line: 684, col: 11, offset: 20169},
-											name: "doubleQuotedChar",
+											pos:  position{line: 654, col: 11, offset: 19207},
+											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 684, col: 29, offset: 20187},
+									pos:        position{line: 654, col: 29, offset: 19225},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5143,29 +5036,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 685, col: 5, offset: 20224},
-						run: (*parser).callonquotedString9,
+						pos: position{line: 655, col: 5, offset: 19262},
+						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 685, col: 5, offset: 20224},
+							pos: position{line: 655, col: 5, offset: 19262},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 685, col: 5, offset: 20224},
+									pos:        position{line: 655, col: 5, offset: 19262},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 685, col: 9, offset: 20228},
+									pos:   position{line: 655, col: 9, offset: 19266},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 685, col: 11, offset: 20230},
+										pos: position{line: 655, col: 11, offset: 19268},
 										expr: &ruleRefExpr{
-											pos:  position{line: 685, col: 11, offset: 20230},
-											name: "singleQuotedChar",
+											pos:  position{line: 655, col: 11, offset: 19268},
+											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 685, col: 29, offset: 20248},
+									pos:        position{line: 655, col: 29, offset: 19286},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5176,57 +5069,57 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "doubleQuotedChar",
-			pos:  position{line: 687, col: 1, offset: 20282},
+			name: "DoubleQuotedChar",
+			pos:  position{line: 657, col: 1, offset: 19320},
 			expr: &choiceExpr{
-				pos: position{line: 688, col: 5, offset: 20303},
+				pos: position{line: 658, col: 5, offset: 19341},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 688, col: 5, offset: 20303},
-						run: (*parser).callondoubleQuotedChar2,
+						pos: position{line: 658, col: 5, offset: 19341},
+						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 688, col: 5, offset: 20303},
+							pos: position{line: 658, col: 5, offset: 19341},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 688, col: 5, offset: 20303},
+									pos: position{line: 658, col: 5, offset: 19341},
 									expr: &choiceExpr{
-										pos: position{line: 688, col: 7, offset: 20305},
+										pos: position{line: 658, col: 7, offset: 19343},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 688, col: 7, offset: 20305},
+												pos:        position{line: 658, col: 7, offset: 19343},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 688, col: 13, offset: 20311},
-												name: "escapedChar",
+												pos:  position{line: 658, col: 13, offset: 19349},
+												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 688, col: 26, offset: 20324,
+									line: 658, col: 26, offset: 19362,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 689, col: 5, offset: 20361},
-						run: (*parser).callondoubleQuotedChar9,
+						pos: position{line: 659, col: 5, offset: 19399},
+						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 689, col: 5, offset: 20361},
+							pos: position{line: 659, col: 5, offset: 19399},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 689, col: 5, offset: 20361},
+									pos:        position{line: 659, col: 5, offset: 19399},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 689, col: 10, offset: 20366},
+									pos:   position{line: 659, col: 10, offset: 19404},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 689, col: 12, offset: 20368},
-										name: "escapeSequence",
+										pos:  position{line: 659, col: 12, offset: 19406},
+										name: "EscapeSequence",
 									},
 								},
 							},
@@ -5236,57 +5129,57 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "singleQuotedChar",
-			pos:  position{line: 691, col: 1, offset: 20402},
+			name: "SingleQuotedChar",
+			pos:  position{line: 661, col: 1, offset: 19440},
 			expr: &choiceExpr{
-				pos: position{line: 692, col: 5, offset: 20423},
+				pos: position{line: 662, col: 5, offset: 19461},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 692, col: 5, offset: 20423},
-						run: (*parser).callonsingleQuotedChar2,
+						pos: position{line: 662, col: 5, offset: 19461},
+						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 692, col: 5, offset: 20423},
+							pos: position{line: 662, col: 5, offset: 19461},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 692, col: 5, offset: 20423},
+									pos: position{line: 662, col: 5, offset: 19461},
 									expr: &choiceExpr{
-										pos: position{line: 692, col: 7, offset: 20425},
+										pos: position{line: 662, col: 7, offset: 19463},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 692, col: 7, offset: 20425},
+												pos:        position{line: 662, col: 7, offset: 19463},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 692, col: 13, offset: 20431},
-												name: "escapedChar",
+												pos:  position{line: 662, col: 13, offset: 19469},
+												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 692, col: 26, offset: 20444,
+									line: 662, col: 26, offset: 19482,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 693, col: 5, offset: 20481},
-						run: (*parser).callonsingleQuotedChar9,
+						pos: position{line: 663, col: 5, offset: 19519},
+						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 693, col: 5, offset: 20481},
+							pos: position{line: 663, col: 5, offset: 19519},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 693, col: 5, offset: 20481},
+									pos:        position{line: 663, col: 5, offset: 19519},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 693, col: 10, offset: 20486},
+									pos:   position{line: 663, col: 10, offset: 19524},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 693, col: 12, offset: 20488},
-										name: "escapeSequence",
+										pos:  position{line: 663, col: 12, offset: 19526},
+										name: "EscapeSequence",
 									},
 								},
 							},
@@ -5296,115 +5189,115 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "escapeSequence",
-			pos:  position{line: 695, col: 1, offset: 20522},
+			name: "EscapeSequence",
+			pos:  position{line: 665, col: 1, offset: 19560},
 			expr: &choiceExpr{
-				pos: position{line: 696, col: 5, offset: 20541},
+				pos: position{line: 666, col: 5, offset: 19579},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 696, col: 5, offset: 20541},
-						run: (*parser).callonescapeSequence2,
+						pos: position{line: 666, col: 5, offset: 19579},
+						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 696, col: 5, offset: 20541},
+							pos: position{line: 666, col: 5, offset: 19579},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 696, col: 5, offset: 20541},
+									pos:        position{line: 666, col: 5, offset: 19579},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 696, col: 9, offset: 20545},
-									name: "hexdigit",
+									pos:  position{line: 666, col: 9, offset: 19583},
+									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 696, col: 18, offset: 20554},
-									name: "hexdigit",
+									pos:  position{line: 666, col: 18, offset: 19592},
+									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 697, col: 5, offset: 20605},
-						name: "singleCharEscape",
+						pos:  position{line: 667, col: 5, offset: 19643},
+						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 698, col: 5, offset: 20626},
-						name: "unicodeEscape",
+						pos:  position{line: 668, col: 5, offset: 19664},
+						name: "UnicodeEscape",
 					},
 				},
 			},
 		},
 		{
-			name: "singleCharEscape",
-			pos:  position{line: 700, col: 1, offset: 20641},
+			name: "SingleCharEscape",
+			pos:  position{line: 670, col: 1, offset: 19679},
 			expr: &choiceExpr{
-				pos: position{line: 701, col: 5, offset: 20662},
+				pos: position{line: 671, col: 5, offset: 19700},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 701, col: 5, offset: 20662},
+						pos:        position{line: 671, col: 5, offset: 19700},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 702, col: 5, offset: 20670},
+						pos:        position{line: 672, col: 5, offset: 19708},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 703, col: 5, offset: 20678},
+						pos:        position{line: 673, col: 5, offset: 19716},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 704, col: 5, offset: 20687},
-						run: (*parser).callonsingleCharEscape5,
+						pos: position{line: 674, col: 5, offset: 19725},
+						run: (*parser).callonSingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 704, col: 5, offset: 20687},
+							pos:        position{line: 674, col: 5, offset: 19725},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 705, col: 5, offset: 20716},
-						run: (*parser).callonsingleCharEscape7,
+						pos: position{line: 675, col: 5, offset: 19754},
+						run: (*parser).callonSingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 705, col: 5, offset: 20716},
+							pos:        position{line: 675, col: 5, offset: 19754},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 706, col: 5, offset: 20745},
-						run: (*parser).callonsingleCharEscape9,
+						pos: position{line: 676, col: 5, offset: 19783},
+						run: (*parser).callonSingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 706, col: 5, offset: 20745},
+							pos:        position{line: 676, col: 5, offset: 19783},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 707, col: 5, offset: 20774},
-						run: (*parser).callonsingleCharEscape11,
+						pos: position{line: 677, col: 5, offset: 19812},
+						run: (*parser).callonSingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 707, col: 5, offset: 20774},
+							pos:        position{line: 677, col: 5, offset: 19812},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 708, col: 5, offset: 20803},
-						run: (*parser).callonsingleCharEscape13,
+						pos: position{line: 678, col: 5, offset: 19841},
+						run: (*parser).callonSingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 708, col: 5, offset: 20803},
+							pos:        position{line: 678, col: 5, offset: 19841},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 709, col: 5, offset: 20832},
-						run: (*parser).callonsingleCharEscape15,
+						pos: position{line: 679, col: 5, offset: 19870},
+						run: (*parser).callonSingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 709, col: 5, offset: 20832},
+							pos:        position{line: 679, col: 5, offset: 19870},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5413,25 +5306,25 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "searchEscape",
-			pos:  position{line: 711, col: 1, offset: 20858},
+			name: "SearchEscape",
+			pos:  position{line: 681, col: 1, offset: 19896},
 			expr: &choiceExpr{
-				pos: position{line: 712, col: 5, offset: 20875},
+				pos: position{line: 682, col: 5, offset: 19913},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 712, col: 5, offset: 20875},
-						run: (*parser).callonsearchEscape2,
+						pos: position{line: 682, col: 5, offset: 19913},
+						run: (*parser).callonSearchEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 712, col: 5, offset: 20875},
+							pos:        position{line: 682, col: 5, offset: 19913},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 713, col: 5, offset: 20903},
-						run: (*parser).callonsearchEscape4,
+						pos: position{line: 683, col: 5, offset: 19941},
+						run: (*parser).callonSearchEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 713, col: 5, offset: 20903},
+							pos:        position{line: 683, col: 5, offset: 19941},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -5440,43 +5333,43 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "unicodeEscape",
-			pos:  position{line: 715, col: 1, offset: 20930},
+			name: "UnicodeEscape",
+			pos:  position{line: 685, col: 1, offset: 19968},
 			expr: &choiceExpr{
-				pos: position{line: 716, col: 5, offset: 20948},
+				pos: position{line: 686, col: 5, offset: 19986},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 716, col: 5, offset: 20948},
-						run: (*parser).callonunicodeEscape2,
+						pos: position{line: 686, col: 5, offset: 19986},
+						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 716, col: 5, offset: 20948},
+							pos: position{line: 686, col: 5, offset: 19986},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 716, col: 5, offset: 20948},
+									pos:        position{line: 686, col: 5, offset: 19986},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 716, col: 9, offset: 20952},
+									pos:   position{line: 686, col: 9, offset: 19990},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 716, col: 16, offset: 20959},
+										pos: position{line: 686, col: 16, offset: 19997},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 716, col: 16, offset: 20959},
-												name: "hexdigit",
+												pos:  position{line: 686, col: 16, offset: 19997},
+												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 716, col: 25, offset: 20968},
-												name: "hexdigit",
+												pos:  position{line: 686, col: 25, offset: 20006},
+												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 716, col: 34, offset: 20977},
-												name: "hexdigit",
+												pos:  position{line: 686, col: 34, offset: 20015},
+												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 716, col: 43, offset: 20986},
-												name: "hexdigit",
+												pos:  position{line: 686, col: 43, offset: 20024},
+												name: "HexDigit",
 											},
 										},
 									},
@@ -5485,71 +5378,71 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 719, col: 5, offset: 21049},
-						run: (*parser).callonunicodeEscape11,
+						pos: position{line: 689, col: 5, offset: 20087},
+						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 719, col: 5, offset: 21049},
+							pos: position{line: 689, col: 5, offset: 20087},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 719, col: 5, offset: 21049},
+									pos:        position{line: 689, col: 5, offset: 20087},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 719, col: 9, offset: 21053},
+									pos:        position{line: 689, col: 9, offset: 20091},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 719, col: 13, offset: 21057},
+									pos:   position{line: 689, col: 13, offset: 20095},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 719, col: 20, offset: 21064},
+										pos: position{line: 689, col: 20, offset: 20102},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 719, col: 20, offset: 21064},
-												name: "hexdigit",
+												pos:  position{line: 689, col: 20, offset: 20102},
+												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 719, col: 29, offset: 21073},
+												pos: position{line: 689, col: 29, offset: 20111},
 												expr: &ruleRefExpr{
-													pos:  position{line: 719, col: 29, offset: 21073},
-													name: "hexdigit",
+													pos:  position{line: 689, col: 29, offset: 20111},
+													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 719, col: 39, offset: 21083},
+												pos: position{line: 689, col: 39, offset: 20121},
 												expr: &ruleRefExpr{
-													pos:  position{line: 719, col: 39, offset: 21083},
-													name: "hexdigit",
+													pos:  position{line: 689, col: 39, offset: 20121},
+													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 719, col: 49, offset: 21093},
+												pos: position{line: 689, col: 49, offset: 20131},
 												expr: &ruleRefExpr{
-													pos:  position{line: 719, col: 49, offset: 21093},
-													name: "hexdigit",
+													pos:  position{line: 689, col: 49, offset: 20131},
+													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 719, col: 59, offset: 21103},
+												pos: position{line: 689, col: 59, offset: 20141},
 												expr: &ruleRefExpr{
-													pos:  position{line: 719, col: 59, offset: 21103},
-													name: "hexdigit",
+													pos:  position{line: 689, col: 59, offset: 20141},
+													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 719, col: 69, offset: 21113},
+												pos: position{line: 689, col: 69, offset: 20151},
 												expr: &ruleRefExpr{
-													pos:  position{line: 719, col: 69, offset: 21113},
-													name: "hexdigit",
+													pos:  position{line: 689, col: 69, offset: 20151},
+													name: "HexDigit",
 												},
 											},
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 719, col: 80, offset: 21124},
+									pos:        position{line: 689, col: 80, offset: 20162},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5560,29 +5453,45 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "reString",
-			pos:  position{line: 723, col: 1, offset: 21178},
+			name: "Regexp",
+			pos:  position{line: 693, col: 1, offset: 20216},
 			expr: &actionExpr{
-				pos: position{line: 724, col: 5, offset: 21191},
-				run: (*parser).callonreString1,
+				pos: position{line: 694, col: 5, offset: 20227},
+				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 724, col: 5, offset: 21191},
+					pos: position{line: 694, col: 5, offset: 20227},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 724, col: 5, offset: 21191},
+							pos:        position{line: 694, col: 5, offset: 20227},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 724, col: 9, offset: 21195},
-							label: "v",
-							expr: &ruleRefExpr{
-								pos:  position{line: 724, col: 11, offset: 21197},
-								name: "reBody",
+							pos:   position{line: 694, col: 9, offset: 20231},
+							label: "body",
+							expr: &oneOrMoreExpr{
+								pos: position{line: 694, col: 14, offset: 20236},
+								expr: &choiceExpr{
+									pos: position{line: 694, col: 15, offset: 20237},
+									alternatives: []interface{}{
+										&charClassMatcher{
+											pos:        position{line: 694, col: 15, offset: 20237},
+											val:        "[^/\\\\]",
+											chars:      []rune{'/', '\\'},
+											ignoreCase: false,
+											inverted:   true,
+										},
+										&litMatcher{
+											pos:        position{line: 694, col: 22, offset: 20244},
+											val:        "\\/",
+											ignoreCase: false,
+										},
+									},
+								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 724, col: 18, offset: 21204},
+							pos:        position{line: 694, col: 30, offset: 20252},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5591,38 +5500,10 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "reBody",
-			pos:  position{line: 726, col: 1, offset: 21227},
-			expr: &actionExpr{
-				pos: position{line: 727, col: 5, offset: 21238},
-				run: (*parser).callonreBody1,
-				expr: &oneOrMoreExpr{
-					pos: position{line: 727, col: 5, offset: 21238},
-					expr: &choiceExpr{
-						pos: position{line: 727, col: 6, offset: 21239},
-						alternatives: []interface{}{
-							&charClassMatcher{
-								pos:        position{line: 727, col: 6, offset: 21239},
-								val:        "[^/\\\\]",
-								chars:      []rune{'/', '\\'},
-								ignoreCase: false,
-								inverted:   true,
-							},
-							&litMatcher{
-								pos:        position{line: 727, col: 13, offset: 21246},
-								val:        "\\/",
-								ignoreCase: false,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "escapedChar",
-			pos:  position{line: 729, col: 1, offset: 21286},
+			name: "EscapedChar",
+			pos:  position{line: 696, col: 1, offset: 20278},
 			expr: &charClassMatcher{
-				pos:        position{line: 730, col: 5, offset: 21302},
+				pos:        position{line: 697, col: 5, offset: 20294},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5631,38 +5512,38 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "ws",
-			pos:  position{line: 732, col: 1, offset: 21317},
+			name: "WhiteSpace",
+			pos:  position{line: 699, col: 1, offset: 20309},
 			expr: &choiceExpr{
-				pos: position{line: 733, col: 5, offset: 21324},
+				pos: position{line: 700, col: 5, offset: 20324},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 733, col: 5, offset: 21324},
+						pos:        position{line: 700, col: 5, offset: 20324},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 734, col: 5, offset: 21333},
+						pos:        position{line: 701, col: 5, offset: 20333},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 735, col: 5, offset: 21342},
+						pos:        position{line: 702, col: 5, offset: 20342},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 736, col: 5, offset: 21351},
+						pos:        position{line: 703, col: 5, offset: 20351},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 737, col: 5, offset: 21359},
+						pos:        position{line: 704, col: 5, offset: 20359},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 738, col: 5, offset: 21372},
+						pos:        position{line: 705, col: 5, offset: 20372},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5670,35 +5551,34 @@ var g = &grammar{
 			},
 		},
 		{
-			name:        "_",
-			displayName: "\"whitespace\"",
-			pos:         position{line: 740, col: 1, offset: 21382},
+			name: "_",
+			pos:  position{line: 707, col: 1, offset: 20382},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 740, col: 18, offset: 21399},
+				pos: position{line: 707, col: 6, offset: 20387},
 				expr: &ruleRefExpr{
-					pos:  position{line: 740, col: 18, offset: 21399},
-					name: "ws",
+					pos:  position{line: 707, col: 6, offset: 20387},
+					name: "WhiteSpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 741, col: 1, offset: 21403},
+			pos:  position{line: 708, col: 1, offset: 20399},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 741, col: 6, offset: 21408},
+				pos: position{line: 708, col: 6, offset: 20404},
 				expr: &ruleRefExpr{
-					pos:  position{line: 741, col: 6, offset: 21408},
-					name: "ws",
+					pos:  position{line: 708, col: 6, offset: 20404},
+					name: "WhiteSpace",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 743, col: 1, offset: 21413},
+			pos:  position{line: 710, col: 1, offset: 20417},
 			expr: &notExpr{
-				pos: position{line: 743, col: 7, offset: 21419},
+				pos: position{line: 710, col: 7, offset: 20423},
 				expr: &anyMatcher{
-					line: 743, col: 8, offset: 21420,
+					line: 710, col: 8, offset: 20424,
 				},
 			},
 		},
@@ -5715,19 +5595,19 @@ func (p *parser) callonstart1() (interface{}, error) {
 	return p.cur.onstart1(stack["ast"])
 }
 
-func (c *current) onquery2(procs interface{}) (interface{}, error) {
+func (c *current) onQuery2(procs interface{}) (interface{}, error) {
 	var filt = map[string]interface{}{"op": "FilterProc", "filter": map[string]interface{}{"op": "MatchAll"}}
 	return map[string]interface{}{"op": "SequentialProc", "procs": append([]interface{}{filt}, (procs.([]interface{}))...)}, nil
 
 }
 
-func (p *parser) callonquery2() (interface{}, error) {
+func (p *parser) callonQuery2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onquery2(stack["procs"])
+	return p.cur.onQuery2(stack["procs"])
 }
 
-func (c *current) onquery5(s, rest interface{}) (interface{}, error) {
+func (c *current) onQuery5(s, rest interface{}) (interface{}, error) {
 	if len(rest.([]interface{})) == 0 {
 		return s, nil
 	} else {
@@ -5736,210 +5616,186 @@ func (c *current) onquery5(s, rest interface{}) (interface{}, error) {
 
 }
 
-func (p *parser) callonquery5() (interface{}, error) {
+func (p *parser) callonQuery5() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onquery5(stack["s"], stack["rest"])
+	return p.cur.onQuery5(stack["s"], stack["rest"])
 }
 
-func (c *current) onquery13(s interface{}) (interface{}, error) {
+func (c *current) onQuery13(s interface{}) (interface{}, error) {
+	// XXX does this ever match?  Rule above shoul;d match first
 	return map[string]interface{}{"op": "SequentialProc", "procs": []interface{}{s}}, nil
 
 }
 
-func (p *parser) callonquery13() (interface{}, error) {
+func (p *parser) callonQuery13() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onquery13(stack["s"])
+	return p.cur.onQuery13(stack["s"])
 }
 
-func (c *current) onprocChain1(first, rest interface{}) (interface{}, error) {
-	if rest != nil {
-		return append([]interface{}{first}, (rest.([]interface{}))...), nil
-	} else {
-		return []interface{}{first}, nil
-	}
-
-}
-
-func (p *parser) callonprocChain1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onprocChain1(stack["first"], stack["rest"])
-}
-
-func (c *current) onchainedProc1(p interface{}) (interface{}, error) {
-	return p, nil
-}
-
-func (p *parser) callonchainedProc1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onchainedProc1(stack["p"])
-}
-
-func (c *current) onsearch1(expr interface{}) (interface{}, error) {
+func (c *current) onSearch1(expr interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "FilterProc", "filter": expr}, nil
 
 }
 
-func (p *parser) callonsearch1() (interface{}, error) {
+func (p *parser) callonSearch1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearch1(stack["expr"])
+	return p.cur.onSearch1(stack["expr"])
 }
 
-func (c *current) onsearchExpr1(first, rest interface{}) (interface{}, error) {
+func (c *current) onSearchExpr1(first, rest interface{}) (interface{}, error) {
 	return makeChain(first, rest, "LogicalOr"), nil
 
 }
 
-func (p *parser) callonsearchExpr1() (interface{}, error) {
+func (p *parser) callonSearchExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchExpr1(stack["first"], stack["rest"])
+	return p.cur.onSearchExpr1(stack["first"], stack["rest"])
 }
 
-func (c *current) onoredSearchTerm1(t interface{}) (interface{}, error) {
+func (c *current) onOredSearchTerm1(t interface{}) (interface{}, error) {
 	return t, nil
 }
 
-func (p *parser) callonoredSearchTerm1() (interface{}, error) {
+func (p *parser) callonOredSearchTerm1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onoredSearchTerm1(stack["t"])
+	return p.cur.onOredSearchTerm1(stack["t"])
 }
 
-func (c *current) onsearchTerm1(first, rest interface{}) (interface{}, error) {
+func (c *current) onSearchTerm1(first, rest interface{}) (interface{}, error) {
 	return makeChain(first, rest, "LogicalAnd"), nil
 
 }
 
-func (p *parser) callonsearchTerm1() (interface{}, error) {
+func (p *parser) callonSearchTerm1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchTerm1(stack["first"], stack["rest"])
+	return p.cur.onSearchTerm1(stack["first"], stack["rest"])
 }
 
-func (c *current) onandedSearchTerm1(f interface{}) (interface{}, error) {
+func (c *current) onAndedSearchTerm1(f interface{}) (interface{}, error) {
 	return f, nil
 }
 
-func (p *parser) callonandedSearchTerm1() (interface{}, error) {
+func (p *parser) callonAndedSearchTerm1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onandedSearchTerm1(stack["f"])
+	return p.cur.onAndedSearchTerm1(stack["f"])
 }
 
-func (c *current) onsearchFactor2(e interface{}) (interface{}, error) {
+func (c *current) onSearchFactor2(e interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "LogicalNot", "expr": e}, nil
 
 }
 
-func (p *parser) callonsearchFactor2() (interface{}, error) {
+func (p *parser) callonSearchFactor2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchFactor2(stack["e"])
+	return p.cur.onSearchFactor2(stack["e"])
 }
 
-func (c *current) onsearchFactor13(s interface{}) (interface{}, error) {
+func (c *current) onSearchFactor13(s interface{}) (interface{}, error) {
 	return s, nil
 }
 
-func (p *parser) callonsearchFactor13() (interface{}, error) {
+func (p *parser) callonSearchFactor13() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchFactor13(stack["s"])
+	return p.cur.onSearchFactor13(stack["s"])
 }
 
-func (c *current) onsearchFactor19(expr interface{}) (interface{}, error) {
+func (c *current) onSearchFactor19(expr interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonsearchFactor19() (interface{}, error) {
+func (p *parser) callonSearchFactor19() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchFactor19(stack["expr"])
+	return p.cur.onSearchFactor19(stack["expr"])
 }
 
-func (c *current) onsearchPred2(comp, v interface{}) (interface{}, error) {
+func (c *current) onSearchPred2(comp, v interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "CompareAny", "comparator": comp, "recursive": false, "value": v}, nil
 
 }
 
-func (p *parser) callonsearchPred2() (interface{}, error) {
+func (p *parser) callonSearchPred2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchPred2(stack["comp"], stack["v"])
+	return p.cur.onSearchPred2(stack["comp"], stack["v"])
 }
 
-func (c *current) onsearchPred11(comp, v interface{}) (interface{}, error) {
+func (c *current) onSearchPred11(comp, v interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "CompareAny", "comparator": comp, "recursive": true, "value": v}, nil
 
 }
 
-func (p *parser) callonsearchPred11() (interface{}, error) {
+func (p *parser) callonSearchPred11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchPred11(stack["comp"], stack["v"])
+	return p.cur.onSearchPred11(stack["comp"], stack["v"])
 }
 
-func (c *current) onsearchPred20(f, comp, v interface{}) (interface{}, error) {
+func (c *current) onSearchPred20(f, comp, v interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "CompareField", "comparator": comp, "field": f, "value": v}, nil
 
 }
 
-func (p *parser) callonsearchPred20() (interface{}, error) {
+func (p *parser) callonSearchPred20() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchPred20(stack["f"], stack["comp"], stack["v"])
+	return p.cur.onSearchPred20(stack["f"], stack["comp"], stack["v"])
 }
 
-func (c *current) onsearchPred30(expr, comp, v interface{}) (interface{}, error) {
+func (c *current) onSearchPred30(expr, comp, v interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "BinaryExpression", "operator": comp, "lhs": expr, "rhs": v}, nil
 
 }
 
-func (p *parser) callonsearchPred30() (interface{}, error) {
+func (p *parser) callonSearchPred30() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchPred30(stack["expr"], stack["comp"], stack["v"])
+	return p.cur.onSearchPred30(stack["expr"], stack["comp"], stack["v"])
 }
 
-func (c *current) onsearchPred42(v interface{}) (interface{}, error) {
+func (c *current) onSearchPred42(v interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "CompareAny", "comparator": "in", "recursive": false, "value": v}, nil
 
 }
 
-func (p *parser) callonsearchPred42() (interface{}, error) {
+func (p *parser) callonSearchPred42() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchPred42(stack["v"])
+	return p.cur.onSearchPred42(stack["v"])
 }
 
-func (c *current) onsearchPred50(v, f interface{}) (interface{}, error) {
+func (c *current) onSearchPred50(v, f interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "CompareField", "comparator": "in", "field": f, "value": v}, nil
 
 }
 
-func (p *parser) callonsearchPred50() (interface{}, error) {
+func (p *parser) callonSearchPred50() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchPred50(stack["v"], stack["f"])
+	return p.cur.onSearchPred50(stack["v"], stack["f"])
 }
 
-func (c *current) onsearchPred59(v interface{}) (interface{}, error) {
+func (c *current) onSearchPred59(v interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "Search", "text": string(c.text), "value": v}, nil
 
 }
 
-func (p *parser) callonsearchPred59() (interface{}, error) {
+func (p *parser) callonSearchPred59() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchPred59(stack["v"])
+	return p.cur.onSearchPred59(stack["v"])
 }
 
-func (c *current) onsearchPred62(v interface{}) (interface{}, error) {
+func (c *current) onSearchPred62(v interface{}) (interface{}, error) {
 	var str = v.(string)
 	if str == "*" {
 		return map[string]interface{}{"op": "MatchAll"}, nil
@@ -5953,51 +5809,51 @@ func (c *current) onsearchPred62(v interface{}) (interface{}, error) {
 
 }
 
-func (p *parser) callonsearchPred62() (interface{}, error) {
+func (p *parser) callonSearchPred62() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchPred62(stack["v"])
+	return p.cur.onSearchPred62(stack["v"])
 }
 
-func (c *current) onsearchLiteral7(i interface{}) (interface{}, error) {
-	return i, nil
-}
-
-func (p *parser) callonsearchLiteral7() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onsearchLiteral7(stack["i"])
-}
-
-func (c *current) onsearchLiteral13(v interface{}) (interface{}, error) {
-	return v, nil
-}
-
-func (p *parser) callonsearchLiteral13() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onsearchLiteral13(stack["v"])
-}
-
-func (c *current) onsearchLiteral21(v interface{}) (interface{}, error) {
-	return v, nil
-}
-
-func (p *parser) callonsearchLiteral21() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onsearchLiteral21(stack["v"])
-}
-
-func (c *current) onsearchValue3(v interface{}) (interface{}, error) {
+func (c *current) onSearchValue3(v interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "Literal", "type": "string", "value": v}, nil
 
 }
 
-func (p *parser) callonsearchValue3() (interface{}, error) {
+func (p *parser) callonSearchValue3() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchValue3(stack["v"])
+	return p.cur.onSearchValue3(stack["v"])
+}
+
+func (c *current) onSearchLiteral7(i interface{}) (interface{}, error) {
+	return i, nil
+}
+
+func (p *parser) callonSearchLiteral7() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSearchLiteral7(stack["i"])
+}
+
+func (c *current) onSearchLiteral13(v interface{}) (interface{}, error) {
+	return v, nil
+}
+
+func (p *parser) callonSearchLiteral13() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSearchLiteral13(stack["v"])
+}
+
+func (c *current) onSearchLiteral21(v interface{}) (interface{}, error) {
+	return v, nil
+}
+
+func (p *parser) callonSearchLiteral21() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSearchLiteral21(stack["v"])
 }
 
 func (c *current) onStringLiteral1(v interface{}) (interface{}, error) {
@@ -6118,7 +5974,43 @@ func (p *parser) callonNullLiteral1() (interface{}, error) {
 	return p.cur.onNullLiteral1()
 }
 
-func (c *current) onprocList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onSequentialProcs1(first, rest interface{}) (interface{}, error) {
+	if rest != nil {
+		return append([]interface{}{first}, (rest.([]interface{}))...), nil
+	} else {
+		return []interface{}{first}, nil
+	}
+
+}
+
+func (p *parser) callonSequentialProcs1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSequentialProcs1(stack["first"], stack["rest"])
+}
+
+func (c *current) onSequentialTail1(p interface{}) (interface{}, error) {
+	return p, nil
+}
+
+func (p *parser) callonSequentialTail1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSequentialTail1(stack["p"])
+}
+
+func (c *current) onProc4(proc interface{}) (interface{}, error) {
+	return proc, nil
+
+}
+
+func (p *parser) callonProc4() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onProc4(stack["proc"])
+}
+
+func (c *current) onProcs1(first, rest interface{}) (interface{}, error) {
 	var fp = map[string]interface{}{"op": "SequentialProc", "procs": first}
 	if rest != nil {
 		return map[string]interface{}{"op": "ParallelProc", "procs": append([]interface{}{fp}, (rest.([]interface{}))...)}, nil
@@ -6128,41 +6020,71 @@ func (c *current) onprocList1(first, rest interface{}) (interface{}, error) {
 
 }
 
-func (p *parser) callonprocList1() (interface{}, error) {
+func (p *parser) callonProcs1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onprocList1(stack["first"], stack["rest"])
+	return p.cur.onProcs1(stack["first"], stack["rest"])
 }
 
-func (c *current) onparallelChain1(ch interface{}) (interface{}, error) {
+func (c *current) onParallelTail1(ch interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "SequentialProc", "procs": ch}, nil
 }
 
-func (p *parser) callonparallelChain1() (interface{}, error) {
+func (p *parser) callonParallelTail1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onparallelChain1(stack["ch"])
+	return p.cur.onParallelTail1(stack["ch"])
 }
 
-func (c *current) onproc4(proc interface{}) (interface{}, error) {
-	return proc, nil
+func (c *current) onGroupByProc1(every, reducers, keys, limit interface{}) (interface{}, error) {
+	var p = map[string]interface{}{"op": "GroupByProc", "reducers": reducers}
+	if every != nil {
+		p["duration"] = every
+	}
+	if keys != nil {
+		p["keys"] = keys
+	}
+	if limit != nil {
+		p["limit"] = limit
+	}
+	return p, nil
 
 }
 
-func (p *parser) callonproc4() (interface{}, error) {
+func (p *parser) callonGroupByProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onproc4(stack["proc"])
+	return p.cur.onGroupByProc1(stack["every"], stack["reducers"], stack["keys"], stack["limit"])
 }
 
-func (c *current) ongroupByKeys1(columns interface{}) (interface{}, error) {
+func (c *current) onEveryDur1(dur interface{}) (interface{}, error) {
+	return dur, nil
+}
+
+func (p *parser) callonEveryDur1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onEveryDur1(stack["dur"])
+}
+
+func (c *current) onGroupByKeys1(columns interface{}) (interface{}, error) {
 	return columns, nil
 }
 
-func (p *parser) callongroupByKeys1() (interface{}, error) {
+func (p *parser) callonGroupByKeys1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.ongroupByKeys1(stack["columns"])
+	return p.cur.onGroupByKeys1(stack["columns"])
+}
+
+func (c *current) onLimitArg1(limit interface{}) (interface{}, error) {
+	return limit, nil
+}
+
+func (p *parser) callonLimitArg1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onLimitArg1(stack["limit"])
 }
 
 func (c *current) onFlexAssignment3(expr interface{}) (interface{}, error) {
@@ -6196,193 +6118,6 @@ func (p *parser) callonFlexAssignments1() (interface{}, error) {
 	return p.cur.onFlexAssignments1(stack["first"], stack["rest"])
 }
 
-func (c *current) oneveryDur1(dur interface{}) (interface{}, error) {
-	return dur, nil
-}
-
-func (p *parser) calloneveryDur1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.oneveryDur1(stack["dur"])
-}
-
-func (c *current) onandToken1() (interface{}, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) callonandToken1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onandToken1()
-}
-
-func (c *current) onorToken1() (interface{}, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) callonorToken1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onorToken1()
-}
-
-func (c *current) oninToken1() (interface{}, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) calloninToken1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.oninToken1()
-}
-
-func (c *current) onnotToken1() (interface{}, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) callonnotToken1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onnotToken1()
-}
-
-func (c *current) onIdentifierName1() (interface{}, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) callonIdentifierName1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onIdentifierName1()
-}
-
-func (c *current) onIdentifier1() (interface{}, error) {
-	return map[string]interface{}{"op": "Identifier", "name": string(c.text)}, nil
-}
-
-func (p *parser) callonIdentifier1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onIdentifier1()
-}
-
-func (c *current) onRootField2(field interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "BinaryExpr", "operator": ".", "lhs": map[string]interface{}{"op": "RootRecord"}, "rhs": field}, nil
-}
-
-func (p *parser) callonRootField2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRootField2(stack["field"])
-}
-
-func (c *current) onRootField12() (interface{}, error) {
-	return map[string]interface{}{"op": "RootRecord"}, nil
-}
-
-func (p *parser) callonRootField12() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRootField12()
-}
-
-func (c *current) onDerefExpression1(first, rest interface{}) (interface{}, error) {
-	return makeBinaryExprChain(first, rest), nil
-
-}
-
-func (p *parser) callonDerefExpression1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onDerefExpression1(stack["first"], stack["rest"])
-}
-
-func (c *current) onDeref2(expr interface{}) (interface{}, error) {
-	return []interface{}{"[", expr}, nil
-}
-
-func (p *parser) callonDeref2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onDeref2(stack["expr"])
-}
-
-func (c *current) onDeref8(id interface{}) (interface{}, error) {
-	return []interface{}{".", id}, nil
-}
-
-func (p *parser) callonDeref8() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onDeref8(stack["id"])
-}
-
-func (c *current) onFunctionExpr1(fn, args interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "FunctionCall", "function": fn, "args": args}, nil
-
-}
-
-func (p *parser) callonFunctionExpr1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onFunctionExpr1(stack["fn"], stack["args"])
-}
-
-func (c *current) onfieldExprList1(first, rest interface{}) (interface{}, error) {
-	var result = []interface{}{first}
-
-	for _, r := range rest.([]interface{}) {
-		result = append(result, r.([]interface{})[3])
-	}
-
-	return result, nil
-
-}
-
-func (p *parser) callonfieldExprList1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onfieldExprList1(stack["first"], stack["rest"])
-}
-
-func (c *current) onExprList1(first, rest interface{}) (interface{}, error) {
-	var result = []interface{}{first}
-
-	for _, r := range rest.([]interface{}) {
-		result = append(result, r.([]interface{})[3])
-	}
-
-	return result, nil
-
-}
-
-func (p *parser) callonExprList1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onExprList1(stack["first"], stack["rest"])
-}
-
-func (c *current) ongroupByProc1(every, reducers, keys, limit interface{}) (interface{}, error) {
-	var p = map[string]interface{}{"op": "GroupByProc", "reducers": reducers}
-	if keys != nil {
-		p["keys"] = keys
-	}
-	if every != nil {
-		p["duration"] = every
-	}
-	if limit != nil {
-		p["limit"] = limit
-	}
-	return p, nil
-
-}
-
-func (p *parser) callongroupByProc1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.ongroupByProc1(stack["every"], stack["reducers"], stack["keys"], stack["limit"])
-}
-
 func (c *current) onReducerAssignment2(lval, reducer interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "Assignment", "lhs": lval, "rhs": reducer}, nil
 
@@ -6405,7 +6140,7 @@ func (p *parser) callonReducerAssignment10() (interface{}, error) {
 	return p.cur.onReducerAssignment10(stack["reducer"])
 }
 
-func (c *current) onreducer1(op, expr, where interface{}) (interface{}, error) {
+func (c *current) onReducer1(op, expr, where interface{}) (interface{}, error) {
 	var r = map[string]interface{}{"op": "Reducer", "operator": op, "where": where}
 	if expr != nil {
 		r["expr"] = expr
@@ -6414,23 +6149,23 @@ func (c *current) onreducer1(op, expr, where interface{}) (interface{}, error) {
 
 }
 
-func (p *parser) callonreducer1() (interface{}, error) {
+func (p *parser) callonReducer1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onreducer1(stack["op"], stack["expr"], stack["where"])
+	return p.cur.onReducer1(stack["op"], stack["expr"], stack["where"])
 }
 
-func (c *current) onwhere1(expr interface{}) (interface{}, error) {
+func (c *current) onWhereClause1(expr interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonwhere1() (interface{}, error) {
+func (p *parser) callonWhereClause1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onwhere1(stack["expr"])
+	return p.cur.onWhereClause1(stack["expr"])
 }
 
-func (c *current) onreducerList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onReducers1(first, rest interface{}) (interface{}, error) {
 	var result = []interface{}{first}
 	for _, r := range rest.([]interface{}) {
 		result = append(result, r.([]interface{})[3])
@@ -6439,23 +6174,23 @@ func (c *current) onreducerList1(first, rest interface{}) (interface{}, error) {
 
 }
 
-func (p *parser) callonreducerList1() (interface{}, error) {
+func (p *parser) callonReducers1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onreducerList1(stack["first"], stack["rest"])
+	return p.cur.onReducers1(stack["first"], stack["rest"])
 }
 
-func (c *current) onsort8(l interface{}) (interface{}, error) {
+func (c *current) onSortProc8(l interface{}) (interface{}, error) {
 	return l, nil
 }
 
-func (p *parser) callonsort8() (interface{}, error) {
+func (p *parser) callonSortProc8() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsort8(stack["l"])
+	return p.cur.onSortProc8(stack["l"])
 }
 
-func (c *current) onsort1(args, list interface{}) (interface{}, error) {
+func (c *current) onSortProc1(args, list interface{}) (interface{}, error) {
 	var argm = args.(map[string]interface{})
 	var proc = map[string]interface{}{"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false}
 	if _, ok := argm["r"]; ok {
@@ -6470,83 +6205,83 @@ func (c *current) onsort1(args, list interface{}) (interface{}, error) {
 
 }
 
-func (p *parser) callonsort1() (interface{}, error) {
+func (p *parser) callonSortProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsort1(stack["args"], stack["list"])
+	return p.cur.onSortProc1(stack["args"], stack["list"])
 }
 
-func (c *current) onsortArgs4(a interface{}) (interface{}, error) {
+func (c *current) onSortArgs4(a interface{}) (interface{}, error) {
 	return a, nil
 }
 
-func (p *parser) callonsortArgs4() (interface{}, error) {
+func (p *parser) callonSortArgs4() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsortArgs4(stack["a"])
+	return p.cur.onSortArgs4(stack["a"])
 }
 
-func (c *current) onsortArgs1(args interface{}) (interface{}, error) {
+func (c *current) onSortArgs1(args interface{}) (interface{}, error) {
 	return makeArgMap(args)
 }
 
-func (p *parser) callonsortArgs1() (interface{}, error) {
+func (p *parser) callonSortArgs1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsortArgs1(stack["args"])
+	return p.cur.onSortArgs1(stack["args"])
 }
 
-func (c *current) onsortArg2() (interface{}, error) {
+func (c *current) onSortArg2() (interface{}, error) {
 	return map[string]interface{}{"name": "r", "value": nil}, nil
 }
 
-func (p *parser) callonsortArg2() (interface{}, error) {
+func (p *parser) callonSortArg2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsortArg2()
+	return p.cur.onSortArg2()
 }
 
-func (c *current) onsortArg9() (interface{}, error) {
+func (c *current) onSortArg9() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonsortArg9() (interface{}, error) {
+func (p *parser) callonSortArg9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsortArg9()
+	return p.cur.onSortArg9()
 }
 
-func (c *current) onsortArg4(where interface{}) (interface{}, error) {
+func (c *current) onSortArg4(where interface{}) (interface{}, error) {
 	return map[string]interface{}{"name": "nulls", "value": where}, nil
 }
 
-func (p *parser) callonsortArg4() (interface{}, error) {
+func (p *parser) callonSortArg4() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsortArg4(stack["where"])
+	return p.cur.onSortArg4(stack["where"])
 }
 
-func (c *current) ontop6(n interface{}) (interface{}, error) {
+func (c *current) onTopProc6(n interface{}) (interface{}, error) {
 	return n, nil
 }
 
-func (p *parser) callontop6() (interface{}, error) {
+func (p *parser) callonTopProc6() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.ontop6(stack["n"])
+	return p.cur.onTopProc6(stack["n"])
 }
 
-func (c *current) ontop18(f interface{}) (interface{}, error) {
+func (c *current) onTopProc18(f interface{}) (interface{}, error) {
 	return f, nil
 }
 
-func (p *parser) callontop18() (interface{}, error) {
+func (p *parser) callonTopProc18() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.ontop18(stack["f"])
+	return p.cur.onTopProc18(stack["f"])
 }
 
-func (c *current) ontop1(limit, flush, fields interface{}) (interface{}, error) {
+func (c *current) onTopProc1(limit, flush, fields interface{}) (interface{}, error) {
 	var proc = map[string]interface{}{"op": "TopProc"}
 	if limit != nil {
 		proc["limit"] = limit
@@ -6561,44 +6296,13 @@ func (c *current) ontop1(limit, flush, fields interface{}) (interface{}, error) 
 
 }
 
-func (p *parser) callontop1() (interface{}, error) {
+func (p *parser) callonTopProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.ontop1(stack["limit"], stack["flush"], stack["fields"])
+	return p.cur.onTopProc1(stack["limit"], stack["flush"], stack["fields"])
 }
 
-func (c *current) onprocLimitArg1(limit interface{}) (interface{}, error) {
-	return limit, nil
-}
-
-func (p *parser) callonprocLimitArg1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onprocLimitArg1(stack["limit"])
-}
-
-func (c *current) oncutArgs4() (interface{}, error) {
-	return map[string]interface{}{"name": "c", "value": nil}, nil
-}
-
-func (p *parser) calloncutArgs4() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.oncutArgs4()
-}
-
-func (c *current) oncutArgs1(args interface{}) (interface{}, error) {
-	return makeArgMap(args)
-
-}
-
-func (p *parser) calloncutArgs1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.oncutArgs1(stack["args"])
-}
-
-func (c *current) oncut1(args, columns interface{}) (interface{}, error) {
+func (c *current) onCutProc1(args, columns interface{}) (interface{}, error) {
 	var argm = args.(map[string]interface{})
 	var proc = map[string]interface{}{"op": "CutProc", "fields": columns, "complement": false}
 	if _, ok := argm["c"]; ok {
@@ -6608,126 +6312,201 @@ func (c *current) oncut1(args, columns interface{}) (interface{}, error) {
 
 }
 
-func (p *parser) calloncut1() (interface{}, error) {
+func (p *parser) callonCutProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.oncut1(stack["args"], stack["columns"])
+	return p.cur.onCutProc1(stack["args"], stack["columns"])
 }
 
-func (c *current) onhead2(count interface{}) (interface{}, error) {
+func (c *current) onCutArgs4() (interface{}, error) {
+	return map[string]interface{}{"name": "c", "value": nil}, nil
+}
+
+func (p *parser) callonCutArgs4() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onCutArgs4()
+}
+
+func (c *current) onCutArgs1(args interface{}) (interface{}, error) {
+	return makeArgMap(args)
+
+}
+
+func (p *parser) callonCutArgs1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onCutArgs1(stack["args"])
+}
+
+func (c *current) onHeadProc2(count interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "HeadProc", "count": count}, nil
 }
 
-func (p *parser) callonhead2() (interface{}, error) {
+func (p *parser) callonHeadProc2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onhead2(stack["count"])
+	return p.cur.onHeadProc2(stack["count"])
 }
 
-func (c *current) onhead8() (interface{}, error) {
+func (c *current) onHeadProc8() (interface{}, error) {
 	return map[string]interface{}{"op": "HeadProc", "count": 1}, nil
 }
 
-func (p *parser) callonhead8() (interface{}, error) {
+func (p *parser) callonHeadProc8() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onhead8()
+	return p.cur.onHeadProc8()
 }
 
-func (c *current) ontail2(count interface{}) (interface{}, error) {
+func (c *current) onTailProc2(count interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "TailProc", "count": count}, nil
 }
 
-func (p *parser) callontail2() (interface{}, error) {
+func (p *parser) callonTailProc2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.ontail2(stack["count"])
+	return p.cur.onTailProc2(stack["count"])
 }
 
-func (c *current) ontail8() (interface{}, error) {
+func (c *current) onTailProc8() (interface{}, error) {
 	return map[string]interface{}{"op": "TailProc", "count": 1}, nil
 }
 
-func (p *parser) callontail8() (interface{}, error) {
+func (p *parser) callonTailProc8() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.ontail8()
+	return p.cur.onTailProc8()
 }
 
-func (c *current) onfilter1(expr interface{}) (interface{}, error) {
+func (c *current) onFilterProc1(expr interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "FilterProc", "filter": expr}, nil
 
 }
 
-func (p *parser) callonfilter1() (interface{}, error) {
+func (p *parser) callonFilterProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onfilter1(stack["expr"])
+	return p.cur.onFilterProc1(stack["expr"])
 }
 
-func (c *current) onuniq2() (interface{}, error) {
+func (c *current) onUniqProc2() (interface{}, error) {
 	return map[string]interface{}{"op": "UniqProc", "cflag": true}, nil
 
 }
 
-func (p *parser) callonuniq2() (interface{}, error) {
+func (p *parser) callonUniqProc2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onuniq2()
+	return p.cur.onUniqProc2()
 }
 
-func (c *current) onuniq7() (interface{}, error) {
+func (c *current) onUniqProc7() (interface{}, error) {
 	return map[string]interface{}{"op": "UniqProc", "cflag": false}, nil
 
 }
 
-func (p *parser) callonuniq7() (interface{}, error) {
+func (p *parser) callonUniqProc7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onuniq7()
+	return p.cur.onUniqProc7()
 }
 
-func (c *current) onput1(columns interface{}) (interface{}, error) {
+func (c *current) onPutProc1(columns interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "PutProc", "clauses": columns}, nil
 
 }
 
-func (p *parser) callonput1() (interface{}, error) {
+func (p *parser) callonPutProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onput1(stack["columns"])
+	return p.cur.onPutProc1(stack["columns"])
 }
 
-func (c *current) onrename9(cl interface{}) (interface{}, error) {
+func (c *current) onRenameProc9(cl interface{}) (interface{}, error) {
 	return cl, nil
 }
 
-func (p *parser) callonrename9() (interface{}, error) {
+func (p *parser) callonRenameProc9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onrename9(stack["cl"])
+	return p.cur.onRenameProc9(stack["cl"])
 }
 
-func (c *current) onrename1(first, rest interface{}) (interface{}, error) {
+func (c *current) onRenameProc1(first, rest interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "RenameProc", "fields": append([]interface{}{first}, (rest.([]interface{}))...)}, nil
 
 }
 
-func (p *parser) callonrename1() (interface{}, error) {
+func (p *parser) callonRenameProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onrename1(stack["first"], stack["rest"])
+	return p.cur.onRenameProc1(stack["first"], stack["rest"])
 }
 
-func (c *current) onfuse1() (interface{}, error) {
+func (c *current) onFuseProc1() (interface{}, error) {
 	return map[string]interface{}{"op": "FuseProc"}, nil
 
 }
 
-func (p *parser) callonfuse1() (interface{}, error) {
+func (p *parser) callonFuseProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onfuse1()
+	return p.cur.onFuseProc1()
+}
+
+func (c *current) onRootField2(field interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "BinaryExpr", "operator": ".", "lhs": map[string]interface{}{"op": "RootRecord"}, "rhs": field}, nil
+}
+
+func (p *parser) callonRootField2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onRootField2(stack["field"])
+}
+
+func (c *current) onRootField12() (interface{}, error) {
+	return map[string]interface{}{"op": "RootRecord"}, nil
+}
+
+func (p *parser) callonRootField12() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onRootField12()
+}
+
+func (c *current) onFieldExprs1(first, rest interface{}) (interface{}, error) {
+	var result = []interface{}{first}
+
+	for _, r := range rest.([]interface{}) {
+		result = append(result, r.([]interface{})[3])
+	}
+
+	return result, nil
+
+}
+
+func (p *parser) callonFieldExprs1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onFieldExprs1(stack["first"], stack["rest"])
+}
+
+func (c *current) onExprs1(first, rest interface{}) (interface{}, error) {
+	var result = []interface{}{first}
+
+	for _, r := range rest.([]interface{}) {
+		result = append(result, r.([]interface{})[3])
+	}
+
+	return result, nil
+
+}
+
+func (p *parser) callonExprs1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onExprs1(stack["first"], stack["rest"])
 }
 
 func (c *current) onAssignment1(lhs, rhs interface{}) (interface{}, error) {
@@ -6740,88 +6519,78 @@ func (p *parser) callonAssignment1() (interface{}, error) {
 	return p.cur.onAssignment1(stack["lhs"], stack["rhs"])
 }
 
-func (c *current) onPrimary10(expr interface{}) (interface{}, error) {
-	return expr, nil
-}
-
-func (p *parser) callonPrimary10() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onPrimary10(stack["expr"])
-}
-
-func (c *current) onConditionalExpression2(condition, thenClause, elseClause interface{}) (interface{}, error) {
+func (c *current) onConditionalExpr2(condition, thenClause, elseClause interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}, nil
 
 }
 
-func (p *parser) callonConditionalExpression2() (interface{}, error) {
+func (p *parser) callonConditionalExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onConditionalExpression2(stack["condition"], stack["thenClause"], stack["elseClause"])
+	return p.cur.onConditionalExpr2(stack["condition"], stack["thenClause"], stack["elseClause"])
 }
 
-func (c *current) onLogicalORExpression7(op, expr interface{}) (interface{}, error) {
+func (c *current) onLogicalORExpr7(op, expr interface{}) (interface{}, error) {
 	return []interface{}{op, expr}, nil
 }
 
-func (p *parser) callonLogicalORExpression7() (interface{}, error) {
+func (p *parser) callonLogicalORExpr7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLogicalORExpression7(stack["op"], stack["expr"])
+	return p.cur.onLogicalORExpr7(stack["op"], stack["expr"])
 }
 
-func (c *current) onLogicalORExpression1(first, rest interface{}) (interface{}, error) {
+func (c *current) onLogicalORExpr1(first, rest interface{}) (interface{}, error) {
 	return makeBinaryExprChain(first, rest), nil
 
 }
 
-func (p *parser) callonLogicalORExpression1() (interface{}, error) {
+func (p *parser) callonLogicalORExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLogicalORExpression1(stack["first"], stack["rest"])
+	return p.cur.onLogicalORExpr1(stack["first"], stack["rest"])
 }
 
-func (c *current) onLogicalANDExpression7(op, expr interface{}) (interface{}, error) {
+func (c *current) onLogicalANDExpr7(op, expr interface{}) (interface{}, error) {
 	return []interface{}{op, expr}, nil
 }
 
-func (p *parser) callonLogicalANDExpression7() (interface{}, error) {
+func (p *parser) callonLogicalANDExpr7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLogicalANDExpression7(stack["op"], stack["expr"])
+	return p.cur.onLogicalANDExpr7(stack["op"], stack["expr"])
 }
 
-func (c *current) onLogicalANDExpression1(first, rest interface{}) (interface{}, error) {
+func (c *current) onLogicalANDExpr1(first, rest interface{}) (interface{}, error) {
 	return makeBinaryExprChain(first, rest), nil
 
 }
 
-func (p *parser) callonLogicalANDExpression1() (interface{}, error) {
+func (p *parser) callonLogicalANDExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLogicalANDExpression1(stack["first"], stack["rest"])
+	return p.cur.onLogicalANDExpr1(stack["first"], stack["rest"])
 }
 
-func (c *current) onEqualityCompareExpression7(comp, expr interface{}) (interface{}, error) {
+func (c *current) onEqualityCompareExpr7(comp, expr interface{}) (interface{}, error) {
 	return []interface{}{comp, expr}, nil
 }
 
-func (p *parser) callonEqualityCompareExpression7() (interface{}, error) {
+func (p *parser) callonEqualityCompareExpr7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onEqualityCompareExpression7(stack["comp"], stack["expr"])
+	return p.cur.onEqualityCompareExpr7(stack["comp"], stack["expr"])
 }
 
-func (c *current) onEqualityCompareExpression1(first, rest interface{}) (interface{}, error) {
+func (c *current) onEqualityCompareExpr1(first, rest interface{}) (interface{}, error) {
 	return makeBinaryExprChain(first, rest), nil
 
 }
 
-func (p *parser) callonEqualityCompareExpression1() (interface{}, error) {
+func (p *parser) callonEqualityCompareExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onEqualityCompareExpression1(stack["first"], stack["rest"])
+	return p.cur.onEqualityCompareExpr1(stack["first"], stack["rest"])
 }
 
 func (c *current) onEqualityOperator1() (interface{}, error) {
@@ -6844,25 +6613,25 @@ func (p *parser) callonEqualityComparator3() (interface{}, error) {
 	return p.cur.onEqualityComparator3()
 }
 
-func (c *current) onRelativeExpression7(op, expr interface{}) (interface{}, error) {
+func (c *current) onRelativeExpr7(op, expr interface{}) (interface{}, error) {
 	return []interface{}{op, expr}, nil
 }
 
-func (p *parser) callonRelativeExpression7() (interface{}, error) {
+func (p *parser) callonRelativeExpr7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onRelativeExpression7(stack["op"], stack["expr"])
+	return p.cur.onRelativeExpr7(stack["op"], stack["expr"])
 }
 
-func (c *current) onRelativeExpression1(first, rest interface{}) (interface{}, error) {
+func (c *current) onRelativeExpr1(first, rest interface{}) (interface{}, error) {
 	return makeBinaryExprChain(first, rest), nil
 
 }
 
-func (p *parser) callonRelativeExpression1() (interface{}, error) {
+func (p *parser) callonRelativeExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onRelativeExpression1(stack["first"], stack["rest"])
+	return p.cur.onRelativeExpr1(stack["first"], stack["rest"])
 }
 
 func (c *current) onRelativeOperator1() (interface{}, error) {
@@ -6875,25 +6644,25 @@ func (p *parser) callonRelativeOperator1() (interface{}, error) {
 	return p.cur.onRelativeOperator1()
 }
 
-func (c *current) onAdditiveExpression7(op, expr interface{}) (interface{}, error) {
+func (c *current) onAdditiveExpr7(op, expr interface{}) (interface{}, error) {
 	return []interface{}{op, expr}, nil
 }
 
-func (p *parser) callonAdditiveExpression7() (interface{}, error) {
+func (p *parser) callonAdditiveExpr7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAdditiveExpression7(stack["op"], stack["expr"])
+	return p.cur.onAdditiveExpr7(stack["op"], stack["expr"])
 }
 
-func (c *current) onAdditiveExpression1(first, rest interface{}) (interface{}, error) {
+func (c *current) onAdditiveExpr1(first, rest interface{}) (interface{}, error) {
 	return makeBinaryExprChain(first, rest), nil
 
 }
 
-func (p *parser) callonAdditiveExpression1() (interface{}, error) {
+func (p *parser) callonAdditiveExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAdditiveExpression1(stack["first"], stack["rest"])
+	return p.cur.onAdditiveExpr1(stack["first"], stack["rest"])
 }
 
 func (c *current) onAdditiveOperator1() (interface{}, error) {
@@ -6906,25 +6675,25 @@ func (p *parser) callonAdditiveOperator1() (interface{}, error) {
 	return p.cur.onAdditiveOperator1()
 }
 
-func (c *current) onMultiplicativeExpression7(op, expr interface{}) (interface{}, error) {
+func (c *current) onMultiplicativeExpr7(op, expr interface{}) (interface{}, error) {
 	return []interface{}{op, expr}, nil
 }
 
-func (p *parser) callonMultiplicativeExpression7() (interface{}, error) {
+func (p *parser) callonMultiplicativeExpr7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onMultiplicativeExpression7(stack["op"], stack["expr"])
+	return p.cur.onMultiplicativeExpr7(stack["op"], stack["expr"])
 }
 
-func (c *current) onMultiplicativeExpression1(first, rest interface{}) (interface{}, error) {
+func (c *current) onMultiplicativeExpr1(first, rest interface{}) (interface{}, error) {
 	return makeBinaryExprChain(first, rest), nil
 
 }
 
-func (p *parser) callonMultiplicativeExpression1() (interface{}, error) {
+func (p *parser) callonMultiplicativeExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onMultiplicativeExpression1(stack["first"], stack["rest"])
+	return p.cur.onMultiplicativeExpr1(stack["first"], stack["rest"])
 }
 
 func (c *current) onMultiplicativeOperator1() (interface{}, error) {
@@ -6937,36 +6706,36 @@ func (p *parser) callonMultiplicativeOperator1() (interface{}, error) {
 	return p.cur.onMultiplicativeOperator1()
 }
 
-func (c *current) onNotExpression2(e interface{}) (interface{}, error) {
+func (c *current) onNotExpr2(e interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "UnaryExpr", "operator": "!", "operand": e}, nil
 
 }
 
-func (p *parser) callonNotExpression2() (interface{}, error) {
+func (p *parser) callonNotExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onNotExpression2(stack["e"])
+	return p.cur.onNotExpr2(stack["e"])
 }
 
-func (c *current) onCastExpression7(typ interface{}) (interface{}, error) {
+func (c *current) onCastExpr7(typ interface{}) (interface{}, error) {
 	return typ, nil
 }
 
-func (p *parser) callonCastExpression7() (interface{}, error) {
+func (p *parser) callonCastExpr7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onCastExpression7(stack["typ"])
+	return p.cur.onCastExpr7(stack["typ"])
 }
 
-func (c *current) onCastExpression2(e, typ interface{}) (interface{}, error) {
+func (c *current) onCastExpr2(e, typ interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "CastExpr", "expr": e, "type": typ}, nil
 
 }
 
-func (p *parser) callonCastExpression2() (interface{}, error) {
+func (p *parser) callonCastExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onCastExpression2(stack["e"], stack["typ"])
+	return p.cur.onCastExpr2(stack["e"], stack["typ"])
 }
 
 func (c *current) onPrimitiveType1() (interface{}, error) {
@@ -6979,36 +6748,36 @@ func (p *parser) callonPrimitiveType1() (interface{}, error) {
 	return p.cur.onPrimitiveType1()
 }
 
-func (c *current) onFuncExpression2(first, rest interface{}) (interface{}, error) {
+func (c *current) onFuncExpr2(first, rest interface{}) (interface{}, error) {
 	return makeBinaryExprChain(first, rest), nil
 
 }
 
-func (p *parser) callonFuncExpression2() (interface{}, error) {
+func (p *parser) callonFuncExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFuncExpression2(stack["first"], stack["rest"])
+	return p.cur.onFuncExpr2(stack["first"], stack["rest"])
 }
 
-func (c *current) onFunctionCall1(fn, args interface{}) (interface{}, error) {
+func (c *current) onFunction1(fn, args interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "FunctionCall", "function": fn, "args": args}, nil
 
 }
 
-func (p *parser) callonFunctionCall1() (interface{}, error) {
+func (p *parser) callonFunction1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFunctionCall1(stack["fn"], stack["args"])
+	return p.cur.onFunction1(stack["fn"], stack["args"])
 }
 
-func (c *current) onFunctionName1() (interface{}, error) {
+func (c *current) onFuncName1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonFunctionName1() (interface{}, error) {
+func (p *parser) callonFuncName1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFunctionName1()
+	return p.cur.onFuncName1()
 }
 
 func (c *current) onArgumentList8(e interface{}) (interface{}, error) {
@@ -7042,516 +6811,586 @@ func (p *parser) callonArgumentList15() (interface{}, error) {
 	return p.cur.onArgumentList15()
 }
 
-func (c *current) onseconds2() (interface{}, error) {
-	return map[string]interface{}{"type": "Duration", "seconds": 1}, nil
+func (c *current) onDerefExpr1(first, rest interface{}) (interface{}, error) {
+	return makeBinaryExprChain(first, rest), nil
+
 }
 
-func (p *parser) callonseconds2() (interface{}, error) {
+func (p *parser) callonDerefExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onseconds2()
+	return p.cur.onDerefExpr1(stack["first"], stack["rest"])
 }
 
-func (c *current) onseconds4(num interface{}) (interface{}, error) {
-	return map[string]interface{}{"type": "Duration", "seconds": num}, nil
+func (c *current) onDeref2(expr interface{}) (interface{}, error) {
+	return []interface{}{"[", expr}, nil
 }
 
-func (p *parser) callonseconds4() (interface{}, error) {
+func (p *parser) callonDeref2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onseconds4(stack["num"])
+	return p.cur.onDeref2(stack["expr"])
 }
 
-func (c *current) onminutes2() (interface{}, error) {
-	return map[string]interface{}{"type": "Duration", "seconds": 60}, nil
+func (c *current) onDeref8(id interface{}) (interface{}, error) {
+	return []interface{}{".", id}, nil
 }
 
-func (p *parser) callonminutes2() (interface{}, error) {
+func (p *parser) callonDeref8() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onminutes2()
+	return p.cur.onDeref8(stack["id"])
 }
 
-func (c *current) onminutes4(num interface{}) (interface{}, error) {
-	return map[string]interface{}{"type": "Duration", "seconds": num.(int) * 60}, nil
+func (c *current) onPrimary10(expr interface{}) (interface{}, error) {
+	return expr, nil
 }
 
-func (p *parser) callonminutes4() (interface{}, error) {
+func (p *parser) callonPrimary10() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onminutes4(stack["num"])
+	return p.cur.onPrimary10(stack["expr"])
 }
 
-func (c *current) onhours2() (interface{}, error) {
-	return map[string]interface{}{"type": "Duration", "seconds": 3600}, nil
-}
-
-func (p *parser) callonhours2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onhours2()
-}
-
-func (c *current) onhours4(num interface{}) (interface{}, error) {
-	return map[string]interface{}{"type": "Duration", "seconds": num.(int) * 3600}, nil
-}
-
-func (p *parser) callonhours4() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onhours4(stack["num"])
-}
-
-func (c *current) ondays2() (interface{}, error) {
-	return map[string]interface{}{"type": "Duration", "seconds": 3600 * 24}, nil
-}
-
-func (p *parser) callondays2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.ondays2()
-}
-
-func (c *current) ondays4(num interface{}) (interface{}, error) {
-	return map[string]interface{}{"type": "Duration", "seconds": (num.(int) * 3600 * 24)}, nil
-}
-
-func (p *parser) callondays4() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.ondays4(stack["num"])
-}
-
-func (c *current) onweeks2() (interface{}, error) {
-	return map[string]interface{}{"type": "Duration", "seconds": 3600 * 24 * 7}, nil
-}
-
-func (p *parser) callonweeks2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onweeks2()
-}
-
-func (c *current) onweeks4(num interface{}) (interface{}, error) {
-	return map[string]interface{}{"type": "Duration", "seconds": num.(int) * 3600 * 24 * 7}, nil
-}
-
-func (p *parser) callonweeks4() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onweeks4(stack["num"])
-}
-
-func (c *current) onaddr1(a interface{}) (interface{}, error) {
+func (c *current) onAndToken1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonaddr1() (interface{}, error) {
+func (p *parser) callonAndToken1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onaddr1(stack["a"])
+	return p.cur.onAndToken1()
 }
 
-func (c *current) onip6addr2(a, b interface{}) (interface{}, error) {
+func (c *current) onOrToken1() (interface{}, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonOrToken1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onOrToken1()
+}
+
+func (c *current) onInToken1() (interface{}, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonInToken1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onInToken1()
+}
+
+func (c *current) onNotToken1() (interface{}, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonNotToken1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNotToken1()
+}
+
+func (c *current) onIdentifierName1() (interface{}, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonIdentifierName1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onIdentifierName1()
+}
+
+func (c *current) onIdentifier1() (interface{}, error) {
+	return map[string]interface{}{"op": "Identifier", "name": string(c.text)}, nil
+}
+
+func (p *parser) callonIdentifier1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onIdentifier1()
+}
+
+func (c *current) onSeconds2() (interface{}, error) {
+	return map[string]interface{}{"type": "Duration", "seconds": 1}, nil
+}
+
+func (p *parser) callonSeconds2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSeconds2()
+}
+
+func (c *current) onSeconds4(num interface{}) (interface{}, error) {
+	return map[string]interface{}{"type": "Duration", "seconds": num}, nil
+}
+
+func (p *parser) callonSeconds4() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSeconds4(stack["num"])
+}
+
+func (c *current) onMinutes2() (interface{}, error) {
+	return map[string]interface{}{"type": "Duration", "seconds": 60}, nil
+}
+
+func (p *parser) callonMinutes2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onMinutes2()
+}
+
+func (c *current) onMinutes4(num interface{}) (interface{}, error) {
+	return map[string]interface{}{"type": "Duration", "seconds": num.(int) * 60}, nil
+}
+
+func (p *parser) callonMinutes4() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onMinutes4(stack["num"])
+}
+
+func (c *current) onHours2() (interface{}, error) {
+	return map[string]interface{}{"type": "Duration", "seconds": 3600}, nil
+}
+
+func (p *parser) callonHours2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onHours2()
+}
+
+func (c *current) onHours4(num interface{}) (interface{}, error) {
+	return map[string]interface{}{"type": "Duration", "seconds": num.(int) * 3600}, nil
+}
+
+func (p *parser) callonHours4() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onHours4(stack["num"])
+}
+
+func (c *current) onDays2() (interface{}, error) {
+	return map[string]interface{}{"type": "Duration", "seconds": 3600 * 24}, nil
+}
+
+func (p *parser) callonDays2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onDays2()
+}
+
+func (c *current) onDays4(num interface{}) (interface{}, error) {
+	return map[string]interface{}{"type": "Duration", "seconds": (num.(int) * 3600 * 24)}, nil
+}
+
+func (p *parser) callonDays4() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onDays4(stack["num"])
+}
+
+func (c *current) onWeeks2() (interface{}, error) {
+	return map[string]interface{}{"type": "Duration", "seconds": 3600 * 24 * 7}, nil
+}
+
+func (p *parser) callonWeeks2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onWeeks2()
+}
+
+func (c *current) onWeeks4(num interface{}) (interface{}, error) {
+	return map[string]interface{}{"type": "Duration", "seconds": num.(int) * 3600 * 24 * 7}, nil
+}
+
+func (p *parser) callonWeeks4() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onWeeks4(stack["num"])
+}
+
+func (c *current) onIP1() (interface{}, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonIP1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onIP1()
+}
+
+func (c *current) onIP62(a, b interface{}) (interface{}, error) {
 	return joinChars(a) + b.(string), nil
 
 }
 
-func (p *parser) callonip6addr2() (interface{}, error) {
+func (p *parser) callonIP62() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onip6addr2(stack["a"], stack["b"])
+	return p.cur.onIP62(stack["a"], stack["b"])
 }
 
-func (c *current) onip6addr9(a, b, d, e interface{}) (interface{}, error) {
+func (c *current) onIP69(a, b, d, e interface{}) (interface{}, error) {
 	return a.(string) + joinChars(b) + "::" + joinChars(d) + e.(string), nil
 
 }
 
-func (p *parser) callonip6addr9() (interface{}, error) {
+func (p *parser) callonIP69() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onip6addr9(stack["a"], stack["b"], stack["d"], stack["e"])
+	return p.cur.onIP69(stack["a"], stack["b"], stack["d"], stack["e"])
 }
 
-func (c *current) onip6addr22(a, b interface{}) (interface{}, error) {
+func (c *current) onIP622(a, b interface{}) (interface{}, error) {
 	return "::" + joinChars(a) + b.(string), nil
 
 }
 
-func (p *parser) callonip6addr22() (interface{}, error) {
+func (p *parser) callonIP622() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onip6addr22(stack["a"], stack["b"])
+	return p.cur.onIP622(stack["a"], stack["b"])
 }
 
-func (c *current) onip6addr30(a, b interface{}) (interface{}, error) {
+func (c *current) onIP630(a, b interface{}) (interface{}, error) {
 	return a.(string) + joinChars(b) + "::", nil
 
 }
 
-func (p *parser) callonip6addr30() (interface{}, error) {
+func (p *parser) callonIP630() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onip6addr30(stack["a"], stack["b"])
+	return p.cur.onIP630(stack["a"], stack["b"])
 }
 
-func (c *current) onip6addr38() (interface{}, error) {
+func (c *current) onIP638() (interface{}, error) {
 	return "::", nil
 
 }
 
-func (p *parser) callonip6addr38() (interface{}, error) {
+func (p *parser) callonIP638() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onip6addr38()
+	return p.cur.onIP638()
 }
 
-func (c *current) onh_append1(v interface{}) (interface{}, error) {
+func (c *current) onColonHex1(v interface{}) (interface{}, error) {
 	return ":" + v.(string), nil
 }
 
-func (p *parser) callonh_append1() (interface{}, error) {
+func (p *parser) callonColonHex1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onh_append1(stack["v"])
+	return p.cur.onColonHex1(stack["v"])
 }
 
-func (c *current) onh_prepend1(v interface{}) (interface{}, error) {
+func (c *current) onHexColon1(v interface{}) (interface{}, error) {
 	return v.(string) + ":", nil
 }
 
-func (p *parser) callonh_prepend1() (interface{}, error) {
+func (p *parser) callonHexColon1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onh_prepend1(stack["v"])
+	return p.cur.onHexColon1(stack["v"])
 }
 
-func (c *current) onsubnet1(a, m interface{}) (interface{}, error) {
+func (c *current) onIPNet1(a, m interface{}) (interface{}, error) {
 	return a.(string) + "/" + fmt.Sprintf("%v", m), nil
 
 }
 
-func (p *parser) callonsubnet1() (interface{}, error) {
+func (p *parser) callonIPNet1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsubnet1(stack["a"], stack["m"])
+	return p.cur.onIPNet1(stack["a"], stack["m"])
 }
 
-func (c *current) onip6subnet1(a, m interface{}) (interface{}, error) {
+func (c *current) onIP6Net1(a, m interface{}) (interface{}, error) {
 	return a.(string) + "/" + m.(string), nil
 
 }
 
-func (p *parser) callonip6subnet1() (interface{}, error) {
+func (p *parser) callonIP6Net1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onip6subnet1(stack["a"], stack["m"])
+	return p.cur.onIP6Net1(stack["a"], stack["m"])
 }
 
-func (c *current) onunsignedInteger1(s interface{}) (interface{}, error) {
+func (c *current) onUInt1(s interface{}) (interface{}, error) {
 	return parseInt(s), nil
 }
 
-func (p *parser) callonunsignedInteger1() (interface{}, error) {
+func (p *parser) callonUInt1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onunsignedInteger1(stack["s"])
+	return p.cur.onUInt1(stack["s"])
 }
 
-func (c *current) onsuint1() (interface{}, error) {
+func (c *current) onUIntString1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonsuint1() (interface{}, error) {
+func (p *parser) callonUIntString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsuint1()
+	return p.cur.onUIntString1()
 }
 
-func (c *current) oninteger1(s interface{}) (interface{}, error) {
-	return parseInt(s), nil
-}
-
-func (p *parser) calloninteger1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.oninteger1(stack["s"])
-}
-
-func (c *current) onsinteger1() (interface{}, error) {
+func (c *current) onMinusIntString1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonsinteger1() (interface{}, error) {
+func (p *parser) callonMinusIntString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsinteger1()
+	return p.cur.onMinusIntString1()
 }
 
-func (c *current) ondouble1(s interface{}) (interface{}, error) {
-	return parseFloat(s), nil
-
-}
-
-func (p *parser) callondouble1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.ondouble1(stack["s"])
-}
-
-func (c *current) onsdouble2() (interface{}, error) {
+func (c *current) onFloatString2() (interface{}, error) {
 	return string(c.text), nil
 
 }
 
-func (p *parser) callonsdouble2() (interface{}, error) {
+func (p *parser) callonFloatString2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsdouble2()
+	return p.cur.onFloatString2()
 }
 
-func (c *current) onsdouble13() (interface{}, error) {
+func (c *current) onFloatString13() (interface{}, error) {
 	return string(c.text), nil
 
 }
 
-func (p *parser) callonsdouble13() (interface{}, error) {
+func (p *parser) callonFloatString13() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsdouble13()
+	return p.cur.onFloatString13()
 }
 
-func (c *current) onh161(chars interface{}) (interface{}, error) {
+func (c *current) onHex1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonh161() (interface{}, error) {
+func (p *parser) callonHex1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onh161(stack["chars"])
+	return p.cur.onHex1()
 }
 
-func (c *current) onsearchWord1(chars interface{}) (interface{}, error) {
+func (c *current) onSearchWord1(chars interface{}) (interface{}, error) {
 	return joinChars(chars), nil
 }
 
-func (p *parser) callonsearchWord1() (interface{}, error) {
+func (p *parser) callonSearchWord1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchWord1(stack["chars"])
+	return p.cur.onSearchWord1(stack["chars"])
 }
 
-func (c *current) onsearchWordPart2(s interface{}) (interface{}, error) {
+func (c *current) onSearchWordPart2(s interface{}) (interface{}, error) {
 	return s, nil
 }
 
-func (p *parser) callonsearchWordPart2() (interface{}, error) {
+func (p *parser) callonSearchWordPart2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchWordPart2(stack["s"])
+	return p.cur.onSearchWordPart2(stack["s"])
 }
 
-func (c *current) onsearchWordPart9() (interface{}, error) {
+func (c *current) onSearchWordPart9() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonsearchWordPart9() (interface{}, error) {
+func (p *parser) callonSearchWordPart9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchWordPart9()
+	return p.cur.onSearchWordPart9()
 }
 
-func (c *current) onquotedString2(v interface{}) (interface{}, error) {
+func (c *current) onQuotedString2(v interface{}) (interface{}, error) {
 	return joinChars(v), nil
 }
 
-func (p *parser) callonquotedString2() (interface{}, error) {
+func (p *parser) callonQuotedString2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onquotedString2(stack["v"])
+	return p.cur.onQuotedString2(stack["v"])
 }
 
-func (c *current) onquotedString9(v interface{}) (interface{}, error) {
+func (c *current) onQuotedString9(v interface{}) (interface{}, error) {
 	return joinChars(v), nil
 }
 
-func (p *parser) callonquotedString9() (interface{}, error) {
+func (p *parser) callonQuotedString9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onquotedString9(stack["v"])
+	return p.cur.onQuotedString9(stack["v"])
 }
 
-func (c *current) ondoubleQuotedChar2() (interface{}, error) {
+func (c *current) onDoubleQuotedChar2() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callondoubleQuotedChar2() (interface{}, error) {
+func (p *parser) callonDoubleQuotedChar2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.ondoubleQuotedChar2()
+	return p.cur.onDoubleQuotedChar2()
 }
 
-func (c *current) ondoubleQuotedChar9(s interface{}) (interface{}, error) {
+func (c *current) onDoubleQuotedChar9(s interface{}) (interface{}, error) {
 	return s, nil
 }
 
-func (p *parser) callondoubleQuotedChar9() (interface{}, error) {
+func (p *parser) callonDoubleQuotedChar9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.ondoubleQuotedChar9(stack["s"])
+	return p.cur.onDoubleQuotedChar9(stack["s"])
 }
 
-func (c *current) onsingleQuotedChar2() (interface{}, error) {
+func (c *current) onSingleQuotedChar2() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonsingleQuotedChar2() (interface{}, error) {
+func (p *parser) callonSingleQuotedChar2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsingleQuotedChar2()
+	return p.cur.onSingleQuotedChar2()
 }
 
-func (c *current) onsingleQuotedChar9(s interface{}) (interface{}, error) {
+func (c *current) onSingleQuotedChar9(s interface{}) (interface{}, error) {
 	return s, nil
 }
 
-func (p *parser) callonsingleQuotedChar9() (interface{}, error) {
+func (p *parser) callonSingleQuotedChar9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsingleQuotedChar9(stack["s"])
+	return p.cur.onSingleQuotedChar9(stack["s"])
 }
 
-func (c *current) onescapeSequence2() (interface{}, error) {
+func (c *current) onEscapeSequence2() (interface{}, error) {
 	return "\\" + string(c.text), nil
 }
 
-func (p *parser) callonescapeSequence2() (interface{}, error) {
+func (p *parser) callonEscapeSequence2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onescapeSequence2()
+	return p.cur.onEscapeSequence2()
 }
 
-func (c *current) onsingleCharEscape5() (interface{}, error) {
+func (c *current) onSingleCharEscape5() (interface{}, error) {
 	return "\b", nil
 }
 
-func (p *parser) callonsingleCharEscape5() (interface{}, error) {
+func (p *parser) callonSingleCharEscape5() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsingleCharEscape5()
+	return p.cur.onSingleCharEscape5()
 }
 
-func (c *current) onsingleCharEscape7() (interface{}, error) {
+func (c *current) onSingleCharEscape7() (interface{}, error) {
 	return "\f", nil
 }
 
-func (p *parser) callonsingleCharEscape7() (interface{}, error) {
+func (p *parser) callonSingleCharEscape7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsingleCharEscape7()
+	return p.cur.onSingleCharEscape7()
 }
 
-func (c *current) onsingleCharEscape9() (interface{}, error) {
+func (c *current) onSingleCharEscape9() (interface{}, error) {
 	return "\n", nil
 }
 
-func (p *parser) callonsingleCharEscape9() (interface{}, error) {
+func (p *parser) callonSingleCharEscape9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsingleCharEscape9()
+	return p.cur.onSingleCharEscape9()
 }
 
-func (c *current) onsingleCharEscape11() (interface{}, error) {
+func (c *current) onSingleCharEscape11() (interface{}, error) {
 	return "\r", nil
 }
 
-func (p *parser) callonsingleCharEscape11() (interface{}, error) {
+func (p *parser) callonSingleCharEscape11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsingleCharEscape11()
+	return p.cur.onSingleCharEscape11()
 }
 
-func (c *current) onsingleCharEscape13() (interface{}, error) {
+func (c *current) onSingleCharEscape13() (interface{}, error) {
 	return "\t", nil
 }
 
-func (p *parser) callonsingleCharEscape13() (interface{}, error) {
+func (p *parser) callonSingleCharEscape13() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsingleCharEscape13()
+	return p.cur.onSingleCharEscape13()
 }
 
-func (c *current) onsingleCharEscape15() (interface{}, error) {
+func (c *current) onSingleCharEscape15() (interface{}, error) {
 	return "\v", nil
 }
 
-func (p *parser) callonsingleCharEscape15() (interface{}, error) {
+func (p *parser) callonSingleCharEscape15() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsingleCharEscape15()
+	return p.cur.onSingleCharEscape15()
 }
 
-func (c *current) onsearchEscape2() (interface{}, error) {
+func (c *current) onSearchEscape2() (interface{}, error) {
 	return "=", nil
 }
 
-func (p *parser) callonsearchEscape2() (interface{}, error) {
+func (p *parser) callonSearchEscape2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchEscape2()
+	return p.cur.onSearchEscape2()
 }
 
-func (c *current) onsearchEscape4() (interface{}, error) {
+func (c *current) onSearchEscape4() (interface{}, error) {
 	return "\\*", nil
 }
 
-func (p *parser) callonsearchEscape4() (interface{}, error) {
+func (p *parser) callonSearchEscape4() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onsearchEscape4()
+	return p.cur.onSearchEscape4()
 }
 
-func (c *current) onunicodeEscape2(chars interface{}) (interface{}, error) {
+func (c *current) onUnicodeEscape2(chars interface{}) (interface{}, error) {
 	return makeUnicodeChar(chars), nil
 
 }
 
-func (p *parser) callonunicodeEscape2() (interface{}, error) {
+func (p *parser) callonUnicodeEscape2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onunicodeEscape2(stack["chars"])
+	return p.cur.onUnicodeEscape2(stack["chars"])
 }
 
-func (c *current) onunicodeEscape11(chars interface{}) (interface{}, error) {
+func (c *current) onUnicodeEscape11(chars interface{}) (interface{}, error) {
 	return makeUnicodeChar(chars), nil
 
 }
 
-func (p *parser) callonunicodeEscape11() (interface{}, error) {
+func (p *parser) callonUnicodeEscape11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onunicodeEscape11(stack["chars"])
+	return p.cur.onUnicodeEscape11(stack["chars"])
 }
 
-func (c *current) onreString1(v interface{}) (interface{}, error) {
-	return v, nil
+func (c *current) onRegexp1(body interface{}) (interface{}, error) {
+	return body, nil
 }
 
-func (p *parser) callonreString1() (interface{}, error) {
+func (p *parser) callonRegexp1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onreString1(stack["v"])
-}
-
-func (c *current) onreBody1() (interface{}, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) callonreBody1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onreBody1()
+	return p.cur.onRegexp1(stack["body"])
 }
 
 var (

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -5469,29 +5469,13 @@ var g = &grammar{
 						&labeledExpr{
 							pos:   position{line: 694, col: 9, offset: 20231},
 							label: "body",
-							expr: &oneOrMoreExpr{
-								pos: position{line: 694, col: 14, offset: 20236},
-								expr: &choiceExpr{
-									pos: position{line: 694, col: 15, offset: 20237},
-									alternatives: []interface{}{
-										&charClassMatcher{
-											pos:        position{line: 694, col: 15, offset: 20237},
-											val:        "[^/\\\\]",
-											chars:      []rune{'/', '\\'},
-											ignoreCase: false,
-											inverted:   true,
-										},
-										&litMatcher{
-											pos:        position{line: 694, col: 22, offset: 20244},
-											val:        "\\/",
-											ignoreCase: false,
-										},
-									},
-								},
+							expr: &ruleRefExpr{
+								pos:  position{line: 694, col: 14, offset: 20236},
+								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 694, col: 30, offset: 20252},
+							pos:        position{line: 694, col: 25, offset: 20247},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5500,10 +5484,38 @@ var g = &grammar{
 			},
 		},
 		{
+			name: "RegexpBody",
+			pos:  position{line: 696, col: 1, offset: 20273},
+			expr: &actionExpr{
+				pos: position{line: 697, col: 5, offset: 20288},
+				run: (*parser).callonRegexpBody1,
+				expr: &oneOrMoreExpr{
+					pos: position{line: 697, col: 5, offset: 20288},
+					expr: &choiceExpr{
+						pos: position{line: 697, col: 6, offset: 20289},
+						alternatives: []interface{}{
+							&charClassMatcher{
+								pos:        position{line: 697, col: 6, offset: 20289},
+								val:        "[^/\\\\]",
+								chars:      []rune{'/', '\\'},
+								ignoreCase: false,
+								inverted:   true,
+							},
+							&litMatcher{
+								pos:        position{line: 697, col: 13, offset: 20296},
+								val:        "\\/",
+								ignoreCase: false,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "EscapedChar",
-			pos:  position{line: 696, col: 1, offset: 20278},
+			pos:  position{line: 699, col: 1, offset: 20336},
 			expr: &charClassMatcher{
-				pos:        position{line: 697, col: 5, offset: 20294},
+				pos:        position{line: 700, col: 5, offset: 20352},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5513,37 +5525,37 @@ var g = &grammar{
 		},
 		{
 			name: "WhiteSpace",
-			pos:  position{line: 699, col: 1, offset: 20309},
+			pos:  position{line: 702, col: 1, offset: 20367},
 			expr: &choiceExpr{
-				pos: position{line: 700, col: 5, offset: 20324},
+				pos: position{line: 703, col: 5, offset: 20382},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 700, col: 5, offset: 20324},
+						pos:        position{line: 703, col: 5, offset: 20382},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 701, col: 5, offset: 20333},
+						pos:        position{line: 704, col: 5, offset: 20391},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 702, col: 5, offset: 20342},
+						pos:        position{line: 705, col: 5, offset: 20400},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 703, col: 5, offset: 20351},
+						pos:        position{line: 706, col: 5, offset: 20409},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 704, col: 5, offset: 20359},
+						pos:        position{line: 707, col: 5, offset: 20417},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 705, col: 5, offset: 20372},
+						pos:        position{line: 708, col: 5, offset: 20430},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5552,33 +5564,33 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 707, col: 1, offset: 20382},
+			pos:  position{line: 710, col: 1, offset: 20440},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 707, col: 6, offset: 20387},
+				pos: position{line: 710, col: 6, offset: 20445},
 				expr: &ruleRefExpr{
-					pos:  position{line: 707, col: 6, offset: 20387},
+					pos:  position{line: 710, col: 6, offset: 20445},
 					name: "WhiteSpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 708, col: 1, offset: 20399},
+			pos:  position{line: 711, col: 1, offset: 20457},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 708, col: 6, offset: 20404},
+				pos: position{line: 711, col: 6, offset: 20462},
 				expr: &ruleRefExpr{
-					pos:  position{line: 708, col: 6, offset: 20404},
+					pos:  position{line: 711, col: 6, offset: 20462},
 					name: "WhiteSpace",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 710, col: 1, offset: 20417},
+			pos:  position{line: 713, col: 1, offset: 20475},
 			expr: &notExpr{
-				pos: position{line: 710, col: 7, offset: 20423},
+				pos: position{line: 713, col: 7, offset: 20481},
 				expr: &anyMatcher{
-					line: 710, col: 8, offset: 20424,
+					line: 713, col: 8, offset: 20482,
 				},
 			},
 		},
@@ -7391,6 +7403,16 @@ func (p *parser) callonRegexp1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRegexp1(stack["body"])
+}
+
+func (c *current) onRegexpBody1() (interface{}, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonRegexpBody1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onRegexpBody1()
 }
 
 var (

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -153,62 +153,58 @@ function peg$parse(input, options) {
                 return {"op": "SequentialProc", "procs": [s, ... rest]}
             }
           },
-      peg$c3 = function(s) {
-            // XXX does this ever match?  Rule above shoul;d match first
-            return {"op": "SequentialProc", "procs": [s]}
-          },
-      peg$c4 = function(expr) {
+      peg$c3 = function(expr) {
             return {"op": "FilterProc", "filter": expr}
           },
-      peg$c5 = function(first, rest) {
+      peg$c4 = function(first, rest) {
             return makeChain(first, rest, "LogicalOr")
           },
-      peg$c6 = function(t) { return t },
-      peg$c7 = function(first, rest) {
+      peg$c5 = function(t) { return t },
+      peg$c6 = function(first, rest) {
             return makeChain(first, rest, "LogicalAnd")
           },
-      peg$c8 = function(f) { return f },
-      peg$c9 = "!",
-      peg$c10 = peg$literalExpectation("!", false),
-      peg$c11 = function(e) {
+      peg$c7 = function(f) { return f },
+      peg$c8 = "!",
+      peg$c9 = peg$literalExpectation("!", false),
+      peg$c10 = function(e) {
             return {"op": "LogicalNot", "expr": e}
           },
-      peg$c12 = "-",
-      peg$c13 = peg$literalExpectation("-", false),
-      peg$c14 = function(s) { return s },
-      peg$c15 = "(",
-      peg$c16 = peg$literalExpectation("(", false),
-      peg$c17 = ")",
-      peg$c18 = peg$literalExpectation(")", false),
-      peg$c19 = function(expr) { return expr },
-      peg$c20 = "*",
-      peg$c21 = peg$literalExpectation("*", false),
-      peg$c22 = function(comp, v) {
+      peg$c11 = "-",
+      peg$c12 = peg$literalExpectation("-", false),
+      peg$c13 = function(s) { return s },
+      peg$c14 = "(",
+      peg$c15 = peg$literalExpectation("(", false),
+      peg$c16 = ")",
+      peg$c17 = peg$literalExpectation(")", false),
+      peg$c18 = function(expr) { return expr },
+      peg$c19 = "*",
+      peg$c20 = peg$literalExpectation("*", false),
+      peg$c21 = function(comp, v) {
             return {"op": "CompareAny", "comparator": comp, "recursive": false, "value": v}
           },
-      peg$c23 = "**",
-      peg$c24 = peg$literalExpectation("**", false),
-      peg$c25 = function(comp, v) {
+      peg$c22 = "**",
+      peg$c23 = peg$literalExpectation("**", false),
+      peg$c24 = function(comp, v) {
             return {"op": "CompareAny", "comparator": comp, "recursive": true, "value": v}
           },
-      peg$c26 = function(f, comp, v) {
+      peg$c25 = function(f, comp, v) {
             return {"op": "CompareField", "comparator": comp, "field": f, "value": v}
           },
-      peg$c27 = "len",
-      peg$c28 = peg$literalExpectation("len", false),
-      peg$c29 = function(expr, comp, v) {
+      peg$c26 = "len",
+      peg$c27 = peg$literalExpectation("len", false),
+      peg$c28 = function(expr, comp, v) {
           return {"op": "BinaryExpression", "operator": comp, "lhs": expr, "rhs": v}
         },
-      peg$c30 = function(v) {
+      peg$c29 = function(v) {
             return {"op": "CompareAny", "comparator": "in", "recursive": false, "value": v}
           },
-      peg$c31 = function(v, f) {
+      peg$c30 = function(v, f) {
             return {"op": "CompareField", "comparator": "in", "field": f, "value": v}
           },
-      peg$c32 = function(v) {
+      peg$c31 = function(v) {
             return {"op": "Search", "text": text(), "value": v}
           },
-      peg$c33 = function(v) {
+      peg$c32 = function(v) {
             let str = v
             if (str == "*") {
               return {"op": "MatchAll"}
@@ -220,49 +216,48 @@ function peg$parse(input, options) {
             }
             return {"op": "Search", "text": text(), "value": literal}
           },
-      peg$c34 = function(v) {
+      peg$c33 = function(v) {
             return {"op": "Literal", "type": "string", "value": v}
           },
-      peg$c35 = function(i) { return i },
-      peg$c36 = function(v) { return v },
-      peg$c37 = function(v) {
+      peg$c34 = function(i) { return i },
+      peg$c35 = function(v) { return v },
+      peg$c36 = function(v) {
             return {"op": "Literal", "type": "regexp", "value": v}
           },
-      peg$c38 = function(v) {
+      peg$c37 = function(v) {
             return {"op": "Literal", "type": "net", "value": v}
           },
-      peg$c39 = function(v) {
+      peg$c38 = function(v) {
             return {"op": "Literal", "type": "ip", "value": v}
           },
-      peg$c40 = function(v) {
+      peg$c39 = function(v) {
             return {"op": "Literal", "type": "float64", "value": v}
           },
-      peg$c41 = function(v) {
+      peg$c40 = function(v) {
             return {"op": "Literal", "type": "int64", "value": v}
           },
-      peg$c42 = "true",
-      peg$c43 = peg$literalExpectation("true", false),
-      peg$c44 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
-      peg$c45 = "false",
-      peg$c46 = peg$literalExpectation("false", false),
-      peg$c47 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
-      peg$c48 = "null",
-      peg$c49 = peg$literalExpectation("null", false),
-      peg$c50 = function() { return {"op": "Literal", "type": "null"} },
-      peg$c51 = function(first, rest) {
+      peg$c41 = "true",
+      peg$c42 = peg$literalExpectation("true", false),
+      peg$c43 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
+      peg$c44 = "false",
+      peg$c45 = peg$literalExpectation("false", false),
+      peg$c46 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
+      peg$c47 = "null",
+      peg$c48 = peg$literalExpectation("null", false),
+      peg$c49 = function() { return {"op": "Literal", "type": "null"} },
+      peg$c50 = function(first, rest) {
            if (rest) {
               return [first, ... rest]
-            } else {
-              return [first]
             }
+            return [first]
           },
-      peg$c52 = "|",
-      peg$c53 = peg$literalExpectation("|", false),
-      peg$c54 = function(p) { return p },
-      peg$c55 = function(proc) {
+      peg$c51 = "|",
+      peg$c52 = peg$literalExpectation("|", false),
+      peg$c53 = function(p) { return p },
+      peg$c54 = function(proc) {
             return proc
           },
-      peg$c56 = function(first, rest) {
+      peg$c55 = function(first, rest) {
             let fp = {"op": "SequentialProc", "procs": first}
             if (rest) {
               return {"op": "ParallelProc", "procs": [fp, ... rest]}
@@ -270,10 +265,10 @@ function peg$parse(input, options) {
               return fp
             }
           },
-      peg$c57 = ";",
-      peg$c58 = peg$literalExpectation(";", false),
-      peg$c59 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
-      peg$c60 = function(every, reducers, keys, limit) {
+      peg$c56 = ";",
+      peg$c57 = peg$literalExpectation(";", false),
+      peg$c58 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
+      peg$c59 = function(every, reducers, keys, limit) {
             let p = {"op": "GroupByProc", "reducers": reducers}
             if (every) {
               p["duration"] = every
@@ -286,54 +281,54 @@ function peg$parse(input, options) {
             }
             return p
           },
-      peg$c61 = "every",
-      peg$c62 = peg$literalExpectation("every", true),
-      peg$c63 = function(dur) { return dur },
-      peg$c64 = "by",
-      peg$c65 = peg$literalExpectation("by", true),
-      peg$c66 = function(columns) { return columns },
-      peg$c67 = "with",
-      peg$c68 = peg$literalExpectation("with", false),
-      peg$c69 = "-limit",
-      peg$c70 = peg$literalExpectation("-limit", false),
-      peg$c71 = function(limit) { return limit },
-      peg$c72 = function(expr) { return {"op": "Assignment", "rhs": expr} },
-      peg$c73 = ",",
-      peg$c74 = peg$literalExpectation(",", false),
-      peg$c75 = function(first, expr) { return expr },
-      peg$c76 = function(first, rest) {
+      peg$c60 = "every",
+      peg$c61 = peg$literalExpectation("every", true),
+      peg$c62 = function(dur) { return dur },
+      peg$c63 = "by",
+      peg$c64 = peg$literalExpectation("by", true),
+      peg$c65 = function(columns) { return columns },
+      peg$c66 = "with",
+      peg$c67 = peg$literalExpectation("with", false),
+      peg$c68 = "-limit",
+      peg$c69 = peg$literalExpectation("-limit", false),
+      peg$c70 = function(limit) { return limit },
+      peg$c71 = function(expr) { return {"op": "Assignment", "rhs": expr} },
+      peg$c72 = ",",
+      peg$c73 = peg$literalExpectation(",", false),
+      peg$c74 = function(first, expr) { return expr },
+      peg$c75 = function(first, rest) {
             return [first, ... rest]
           },
-      peg$c77 = "=",
-      peg$c78 = peg$literalExpectation("=", false),
-      peg$c79 = function(lval, reducer) {
+      peg$c76 = "=",
+      peg$c77 = peg$literalExpectation("=", false),
+      peg$c78 = function(lval, reducer) {
             return {"op": "Assignment", "lhs": lval, "rhs": reducer}
           },
-      peg$c80 = function(reducer) {
+      peg$c79 = function(reducer) {
             return {"op": "Assignment", "rhs": reducer}
           },
-      peg$c81 = "not",
-      peg$c82 = peg$literalExpectation("not", false),
-      peg$c83 = function(op, expr, where) {
+      peg$c80 = "not",
+      peg$c81 = peg$literalExpectation("not", false),
+      peg$c82 = function(op, expr, where) {
             let r = {"op": "Reducer", "operator": op, "where":where}
             if (expr) {
               r["expr"] = expr
             }
             return r
           },
-      peg$c84 = "where",
-      peg$c85 = peg$literalExpectation("where", false),
-      peg$c86 = function(first, rest) {
+      peg$c83 = "where",
+      peg$c84 = peg$literalExpectation("where", false),
+      peg$c85 = function(first, rest) {
             let result = [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c87 = "sort",
-      peg$c88 = peg$literalExpectation("sort", true),
-      peg$c89 = function(args, l) { return l },
-      peg$c90 = function(args, list) {
+      peg$c86 = "sort",
+      peg$c87 = peg$literalExpectation("sort", true),
+      peg$c88 = function(args, l) { return l },
+      peg$c89 = function(args, list) {
             let argm = args
             let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false}
             if ( "r" in argm) {
@@ -346,26 +341,26 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c91 = function(a) { return a },
-      peg$c92 = function(args) { return makeArgMap(args) },
-      peg$c93 = "-r",
-      peg$c94 = peg$literalExpectation("-r", false),
-      peg$c95 = function() { return {"name": "r", "value": null} },
-      peg$c96 = "-nulls",
-      peg$c97 = peg$literalExpectation("-nulls", false),
-      peg$c98 = "first",
-      peg$c99 = peg$literalExpectation("first", false),
-      peg$c100 = "last",
-      peg$c101 = peg$literalExpectation("last", false),
-      peg$c102 = function() { return text() },
-      peg$c103 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c104 = "top",
-      peg$c105 = peg$literalExpectation("top", true),
-      peg$c106 = function(n) { return n},
-      peg$c107 = "-flush",
-      peg$c108 = peg$literalExpectation("-flush", false),
-      peg$c109 = function(limit, flush, f) { return f },
-      peg$c110 = function(limit, flush, fields) {
+      peg$c90 = function(a) { return a },
+      peg$c91 = function(args) { return makeArgMap(args) },
+      peg$c92 = "-r",
+      peg$c93 = peg$literalExpectation("-r", false),
+      peg$c94 = function() { return {"name": "r", "value": null} },
+      peg$c95 = "-nulls",
+      peg$c96 = peg$literalExpectation("-nulls", false),
+      peg$c97 = "first",
+      peg$c98 = peg$literalExpectation("first", false),
+      peg$c99 = "last",
+      peg$c100 = peg$literalExpectation("last", false),
+      peg$c101 = function() { return text() },
+      peg$c102 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c103 = "top",
+      peg$c104 = peg$literalExpectation("top", true),
+      peg$c105 = function(n) { return n},
+      peg$c106 = "-flush",
+      peg$c107 = peg$literalExpectation("-flush", false),
+      peg$c108 = function(limit, flush, f) { return f },
+      peg$c109 = function(limit, flush, fields) {
             let proc = {"op": "TopProc"}
             if (limit) {
               proc["limit"] = limit
@@ -374,13 +369,13 @@ function peg$parse(input, options) {
               proc["fields"] = fields
             }
             if (flush) {
-             proc["flush"] = true
+              proc["flush"] = true
             }
             return proc
           },
-      peg$c111 = "cut",
-      peg$c112 = peg$literalExpectation("cut", true),
-      peg$c113 = function(args, columns) {
+      peg$c110 = "cut",
+      peg$c111 = peg$literalExpectation("cut", true),
+      peg$c112 = function(args, columns) {
             let argm = args
             let proc = {"op": "CutProc", "fields": columns, "complement": false}
             if ( "c" in argm) {
@@ -388,51 +383,51 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c114 = "-c",
-      peg$c115 = peg$literalExpectation("-c", false),
-      peg$c116 = function() { return {"name": "c", "value": null} },
-      peg$c117 = function(args) {
+      peg$c113 = "-c",
+      peg$c114 = peg$literalExpectation("-c", false),
+      peg$c115 = function() { return {"name": "c", "value": null} },
+      peg$c116 = function(args) {
             return makeArgMap(args)
           },
-      peg$c118 = "head",
-      peg$c119 = peg$literalExpectation("head", true),
-      peg$c120 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c121 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c122 = "tail",
-      peg$c123 = peg$literalExpectation("tail", true),
-      peg$c124 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c125 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c126 = "filter",
-      peg$c127 = peg$literalExpectation("filter", true),
-      peg$c128 = "uniq",
-      peg$c129 = peg$literalExpectation("uniq", true),
-      peg$c130 = function() {
+      peg$c117 = "head",
+      peg$c118 = peg$literalExpectation("head", true),
+      peg$c119 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c120 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c121 = "tail",
+      peg$c122 = peg$literalExpectation("tail", true),
+      peg$c123 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c124 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c125 = "filter",
+      peg$c126 = peg$literalExpectation("filter", true),
+      peg$c127 = "uniq",
+      peg$c128 = peg$literalExpectation("uniq", true),
+      peg$c129 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c131 = function() {
+      peg$c130 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c132 = "put",
-      peg$c133 = peg$literalExpectation("put", true),
-      peg$c134 = function(columns) {
+      peg$c131 = "put",
+      peg$c132 = peg$literalExpectation("put", true),
+      peg$c133 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c135 = "rename",
-      peg$c136 = peg$literalExpectation("rename", true),
-      peg$c137 = function(first, cl) { return cl },
-      peg$c138 = function(first, rest) {
+      peg$c134 = "rename",
+      peg$c135 = peg$literalExpectation("rename", true),
+      peg$c136 = function(first, cl) { return cl },
+      peg$c137 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c139 = "fuse",
-      peg$c140 = peg$literalExpectation("fuse", true),
-      peg$c141 = function() {
+      peg$c138 = "fuse",
+      peg$c139 = peg$literalExpectation("fuse", true),
+      peg$c140 = function() {
             return {"op": "FuseProc"}
           },
-      peg$c142 = ".",
-      peg$c143 = peg$literalExpectation(".", false),
-      peg$c144 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
-      peg$c145 = function() { return {"op": "RootRecord"} },
-      peg$c146 = function(first, rest) {
+      peg$c141 = ".",
+      peg$c142 = peg$literalExpectation(".", false),
+      peg$c143 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
+      peg$c144 = function() { return {"op": "RootRecord"} },
+      peg$c145 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -441,267 +436,267 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c147 = function(lhs, rhs) { return {"lhs": lhs, "rhs": rhs} },
-      peg$c148 = "?",
-      peg$c149 = peg$literalExpectation("?", false),
-      peg$c150 = ":",
-      peg$c151 = peg$literalExpectation(":", false),
-      peg$c152 = function(condition, thenClause, elseClause) {
+      peg$c146 = function(lhs, rhs) { return {"lhs": lhs, "rhs": rhs} },
+      peg$c147 = "?",
+      peg$c148 = peg$literalExpectation("?", false),
+      peg$c149 = ":",
+      peg$c150 = peg$literalExpectation(":", false),
+      peg$c151 = function(condition, thenClause, elseClause) {
             return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c153 = function(first, op, expr) { return [op, expr] },
-      peg$c154 = function(first, rest) {
+      peg$c152 = function(first, op, expr) { return [op, expr] },
+      peg$c153 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c155 = function(first, comp, expr) { return [comp, expr] },
-      peg$c156 = "=~",
-      peg$c157 = peg$literalExpectation("=~", false),
-      peg$c158 = "!~",
-      peg$c159 = peg$literalExpectation("!~", false),
-      peg$c160 = "!=",
-      peg$c161 = peg$literalExpectation("!=", false),
-      peg$c162 = "in",
-      peg$c163 = peg$literalExpectation("in", false),
-      peg$c164 = "<=",
-      peg$c165 = peg$literalExpectation("<=", false),
-      peg$c166 = "<",
-      peg$c167 = peg$literalExpectation("<", false),
-      peg$c168 = ">=",
-      peg$c169 = peg$literalExpectation(">=", false),
-      peg$c170 = ">",
-      peg$c171 = peg$literalExpectation(">", false),
-      peg$c172 = "+",
-      peg$c173 = peg$literalExpectation("+", false),
-      peg$c174 = "/",
-      peg$c175 = peg$literalExpectation("/", false),
-      peg$c176 = function(e) {
+      peg$c154 = function(first, comp, expr) { return [comp, expr] },
+      peg$c155 = "=~",
+      peg$c156 = peg$literalExpectation("=~", false),
+      peg$c157 = "!~",
+      peg$c158 = peg$literalExpectation("!~", false),
+      peg$c159 = "!=",
+      peg$c160 = peg$literalExpectation("!=", false),
+      peg$c161 = "in",
+      peg$c162 = peg$literalExpectation("in", false),
+      peg$c163 = "<=",
+      peg$c164 = peg$literalExpectation("<=", false),
+      peg$c165 = "<",
+      peg$c166 = peg$literalExpectation("<", false),
+      peg$c167 = ">=",
+      peg$c168 = peg$literalExpectation(">=", false),
+      peg$c169 = ">",
+      peg$c170 = peg$literalExpectation(">", false),
+      peg$c171 = "+",
+      peg$c172 = peg$literalExpectation("+", false),
+      peg$c173 = "/",
+      peg$c174 = peg$literalExpectation("/", false),
+      peg$c175 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c177 = function(e, typ) { return typ },
-      peg$c178 = function(e, typ) {
+      peg$c176 = function(e, typ) { return typ },
+      peg$c177 = function(e, typ) {
             return {"op": "CastExpr", "expr": e, "type": typ}
           },
-      peg$c179 = "bytes",
-      peg$c180 = peg$literalExpectation("bytes", false),
-      peg$c181 = "uint8",
-      peg$c182 = peg$literalExpectation("uint8", false),
-      peg$c183 = "uint16",
-      peg$c184 = peg$literalExpectation("uint16", false),
-      peg$c185 = "uint32",
-      peg$c186 = peg$literalExpectation("uint32", false),
-      peg$c187 = "uint64",
-      peg$c188 = peg$literalExpectation("uint64", false),
-      peg$c189 = "int8",
-      peg$c190 = peg$literalExpectation("int8", false),
-      peg$c191 = "int16",
-      peg$c192 = peg$literalExpectation("int16", false),
-      peg$c193 = "int32",
-      peg$c194 = peg$literalExpectation("int32", false),
-      peg$c195 = "int64",
-      peg$c196 = peg$literalExpectation("int64", false),
-      peg$c197 = "duration",
-      peg$c198 = peg$literalExpectation("duration", false),
-      peg$c199 = "time",
-      peg$c200 = peg$literalExpectation("time", false),
-      peg$c201 = "float64",
-      peg$c202 = peg$literalExpectation("float64", false),
-      peg$c203 = "bool",
-      peg$c204 = peg$literalExpectation("bool", false),
-      peg$c205 = "string",
-      peg$c206 = peg$literalExpectation("string", false),
-      peg$c207 = "bstring",
-      peg$c208 = peg$literalExpectation("bstring", false),
-      peg$c209 = "ip",
-      peg$c210 = peg$literalExpectation("ip", false),
-      peg$c211 = "net",
-      peg$c212 = peg$literalExpectation("net", false),
-      peg$c213 = "type",
-      peg$c214 = peg$literalExpectation("type", false),
-      peg$c215 = "error",
-      peg$c216 = peg$literalExpectation("error", false),
-      peg$c217 = function(first, rest) {
+      peg$c178 = "bytes",
+      peg$c179 = peg$literalExpectation("bytes", false),
+      peg$c180 = "uint8",
+      peg$c181 = peg$literalExpectation("uint8", false),
+      peg$c182 = "uint16",
+      peg$c183 = peg$literalExpectation("uint16", false),
+      peg$c184 = "uint32",
+      peg$c185 = peg$literalExpectation("uint32", false),
+      peg$c186 = "uint64",
+      peg$c187 = peg$literalExpectation("uint64", false),
+      peg$c188 = "int8",
+      peg$c189 = peg$literalExpectation("int8", false),
+      peg$c190 = "int16",
+      peg$c191 = peg$literalExpectation("int16", false),
+      peg$c192 = "int32",
+      peg$c193 = peg$literalExpectation("int32", false),
+      peg$c194 = "int64",
+      peg$c195 = peg$literalExpectation("int64", false),
+      peg$c196 = "duration",
+      peg$c197 = peg$literalExpectation("duration", false),
+      peg$c198 = "time",
+      peg$c199 = peg$literalExpectation("time", false),
+      peg$c200 = "float64",
+      peg$c201 = peg$literalExpectation("float64", false),
+      peg$c202 = "bool",
+      peg$c203 = peg$literalExpectation("bool", false),
+      peg$c204 = "string",
+      peg$c205 = peg$literalExpectation("string", false),
+      peg$c206 = "bstring",
+      peg$c207 = peg$literalExpectation("bstring", false),
+      peg$c208 = "ip",
+      peg$c209 = peg$literalExpectation("ip", false),
+      peg$c210 = "net",
+      peg$c211 = peg$literalExpectation("net", false),
+      peg$c212 = "type",
+      peg$c213 = peg$literalExpectation("type", false),
+      peg$c214 = "error",
+      peg$c215 = peg$literalExpectation("error", false),
+      peg$c216 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c218 = function(fn, args) {
+      peg$c217 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c219 = /^[A-Za-z]/,
-      peg$c220 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
-      peg$c221 = /^[.0-9]/,
-      peg$c222 = peg$classExpectation([".", ["0", "9"]], false, false),
-      peg$c223 = function(first, e) { return e },
-      peg$c224 = function() { return [] },
-      peg$c225 = "[",
-      peg$c226 = peg$literalExpectation("[", false),
-      peg$c227 = "]",
-      peg$c228 = peg$literalExpectation("]", false),
-      peg$c229 = function(expr) { return ["[", expr] },
-      peg$c230 = function(id) { return [".", id] },
-      peg$c231 = "and",
-      peg$c232 = peg$literalExpectation("and", true),
-      peg$c233 = "or",
-      peg$c234 = peg$literalExpectation("or", true),
-      peg$c235 = peg$literalExpectation("in", true),
-      peg$c236 = peg$literalExpectation("not", true),
-      peg$c237 = /^[A-Za-z_$]/,
-      peg$c238 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c239 = /^[0-9]/,
-      peg$c240 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c241 = function() { return {"op": "Identifier", "name": text()} },
-      peg$c242 = peg$literalExpectation("and", false),
-      peg$c243 = "seconds",
-      peg$c244 = peg$literalExpectation("seconds", false),
-      peg$c245 = "second",
-      peg$c246 = peg$literalExpectation("second", false),
-      peg$c247 = "secs",
-      peg$c248 = peg$literalExpectation("secs", false),
-      peg$c249 = "sec",
-      peg$c250 = peg$literalExpectation("sec", false),
-      peg$c251 = "s",
-      peg$c252 = peg$literalExpectation("s", false),
-      peg$c253 = "minutes",
-      peg$c254 = peg$literalExpectation("minutes", false),
-      peg$c255 = "minute",
-      peg$c256 = peg$literalExpectation("minute", false),
-      peg$c257 = "mins",
-      peg$c258 = peg$literalExpectation("mins", false),
-      peg$c259 = "min",
-      peg$c260 = peg$literalExpectation("min", false),
-      peg$c261 = "m",
-      peg$c262 = peg$literalExpectation("m", false),
-      peg$c263 = "hours",
-      peg$c264 = peg$literalExpectation("hours", false),
-      peg$c265 = "hrs",
-      peg$c266 = peg$literalExpectation("hrs", false),
-      peg$c267 = "hr",
-      peg$c268 = peg$literalExpectation("hr", false),
-      peg$c269 = "h",
-      peg$c270 = peg$literalExpectation("h", false),
-      peg$c271 = "hour",
-      peg$c272 = peg$literalExpectation("hour", false),
-      peg$c273 = "days",
-      peg$c274 = peg$literalExpectation("days", false),
-      peg$c275 = "day",
-      peg$c276 = peg$literalExpectation("day", false),
-      peg$c277 = "d",
-      peg$c278 = peg$literalExpectation("d", false),
-      peg$c279 = "weeks",
-      peg$c280 = peg$literalExpectation("weeks", false),
-      peg$c281 = "week",
-      peg$c282 = peg$literalExpectation("week", false),
-      peg$c283 = "wks",
-      peg$c284 = peg$literalExpectation("wks", false),
-      peg$c285 = "wk",
-      peg$c286 = peg$literalExpectation("wk", false),
-      peg$c287 = "w",
-      peg$c288 = peg$literalExpectation("w", false),
-      peg$c289 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c290 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c291 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c292 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c293 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c294 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c295 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c296 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c297 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c298 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c299 = function(a, b) {
+      peg$c218 = /^[A-Za-z]/,
+      peg$c219 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
+      peg$c220 = /^[.0-9]/,
+      peg$c221 = peg$classExpectation([".", ["0", "9"]], false, false),
+      peg$c222 = function(first, e) { return e },
+      peg$c223 = function() { return [] },
+      peg$c224 = "[",
+      peg$c225 = peg$literalExpectation("[", false),
+      peg$c226 = "]",
+      peg$c227 = peg$literalExpectation("]", false),
+      peg$c228 = function(expr) { return ["[", expr] },
+      peg$c229 = function(id) { return [".", id] },
+      peg$c230 = "and",
+      peg$c231 = peg$literalExpectation("and", true),
+      peg$c232 = "or",
+      peg$c233 = peg$literalExpectation("or", true),
+      peg$c234 = peg$literalExpectation("in", true),
+      peg$c235 = peg$literalExpectation("not", true),
+      peg$c236 = /^[A-Za-z_$]/,
+      peg$c237 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c238 = /^[0-9]/,
+      peg$c239 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c240 = function() { return {"op": "Identifier", "name": text()} },
+      peg$c241 = peg$literalExpectation("and", false),
+      peg$c242 = "seconds",
+      peg$c243 = peg$literalExpectation("seconds", false),
+      peg$c244 = "second",
+      peg$c245 = peg$literalExpectation("second", false),
+      peg$c246 = "secs",
+      peg$c247 = peg$literalExpectation("secs", false),
+      peg$c248 = "sec",
+      peg$c249 = peg$literalExpectation("sec", false),
+      peg$c250 = "s",
+      peg$c251 = peg$literalExpectation("s", false),
+      peg$c252 = "minutes",
+      peg$c253 = peg$literalExpectation("minutes", false),
+      peg$c254 = "minute",
+      peg$c255 = peg$literalExpectation("minute", false),
+      peg$c256 = "mins",
+      peg$c257 = peg$literalExpectation("mins", false),
+      peg$c258 = "min",
+      peg$c259 = peg$literalExpectation("min", false),
+      peg$c260 = "m",
+      peg$c261 = peg$literalExpectation("m", false),
+      peg$c262 = "hours",
+      peg$c263 = peg$literalExpectation("hours", false),
+      peg$c264 = "hrs",
+      peg$c265 = peg$literalExpectation("hrs", false),
+      peg$c266 = "hr",
+      peg$c267 = peg$literalExpectation("hr", false),
+      peg$c268 = "h",
+      peg$c269 = peg$literalExpectation("h", false),
+      peg$c270 = "hour",
+      peg$c271 = peg$literalExpectation("hour", false),
+      peg$c272 = "days",
+      peg$c273 = peg$literalExpectation("days", false),
+      peg$c274 = "day",
+      peg$c275 = peg$literalExpectation("day", false),
+      peg$c276 = "d",
+      peg$c277 = peg$literalExpectation("d", false),
+      peg$c278 = "weeks",
+      peg$c279 = peg$literalExpectation("weeks", false),
+      peg$c280 = "week",
+      peg$c281 = peg$literalExpectation("week", false),
+      peg$c282 = "wks",
+      peg$c283 = peg$literalExpectation("wks", false),
+      peg$c284 = "wk",
+      peg$c285 = peg$literalExpectation("wk", false),
+      peg$c286 = "w",
+      peg$c287 = peg$literalExpectation("w", false),
+      peg$c288 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c289 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c290 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c291 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c292 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c293 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c294 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c295 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c296 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c297 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c298 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c300 = "::",
-      peg$c301 = peg$literalExpectation("::", false),
-      peg$c302 = function(a, b, d, e) {
+      peg$c299 = "::",
+      peg$c300 = peg$literalExpectation("::", false),
+      peg$c301 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c303 = function(a, b) {
+      peg$c302 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c304 = function(a, b) {
+      peg$c303 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c305 = function() {
+      peg$c304 = function() {
             return "::"
           },
-      peg$c306 = function(v) { return ":" + v },
-      peg$c307 = function(v) { return v + ":" },
-      peg$c308 = function(a, m) {
+      peg$c305 = function(v) { return ":" + v },
+      peg$c306 = function(v) { return v + ":" },
+      peg$c307 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c309 = function(a, m) {
+      peg$c308 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c310 = function(s) { return parseInt(s) },
-      peg$c311 = function() {
+      peg$c309 = function(s) { return parseInt(s) },
+      peg$c310 = function() {
             return text()
           },
-      peg$c312 = "e",
-      peg$c313 = peg$literalExpectation("e", true),
-      peg$c314 = /^[+\-]/,
-      peg$c315 = peg$classExpectation(["+", "-"], false, false),
-      peg$c316 = /^[0-9a-fA-F]/,
-      peg$c317 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c318 = function(chars) { return joinChars(chars) },
-      peg$c319 = "\\",
-      peg$c320 = peg$literalExpectation("\\", false),
-      peg$c321 = /^[\0-\x1F\\(),!><="|';:]/,
-      peg$c322 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
-      peg$c323 = peg$anyExpectation(),
-      peg$c324 = "\"",
-      peg$c325 = peg$literalExpectation("\"", false),
-      peg$c326 = function(v) { return joinChars(v) },
-      peg$c327 = "'",
-      peg$c328 = peg$literalExpectation("'", false),
-      peg$c329 = "x",
-      peg$c330 = peg$literalExpectation("x", false),
-      peg$c331 = function() { return "\\" + text() },
-      peg$c332 = "b",
-      peg$c333 = peg$literalExpectation("b", false),
-      peg$c334 = function() { return "\b" },
-      peg$c335 = "f",
-      peg$c336 = peg$literalExpectation("f", false),
-      peg$c337 = function() { return "\f" },
-      peg$c338 = "n",
-      peg$c339 = peg$literalExpectation("n", false),
-      peg$c340 = function() { return "\n" },
-      peg$c341 = "r",
-      peg$c342 = peg$literalExpectation("r", false),
-      peg$c343 = function() { return "\r" },
-      peg$c344 = "t",
-      peg$c345 = peg$literalExpectation("t", false),
-      peg$c346 = function() { return "\t" },
-      peg$c347 = "v",
-      peg$c348 = peg$literalExpectation("v", false),
-      peg$c349 = function() { return "\v" },
-      peg$c350 = function() { return "=" },
-      peg$c351 = function() { return "\\*" },
-      peg$c352 = "u",
-      peg$c353 = peg$literalExpectation("u", false),
-      peg$c354 = function(chars) {
+      peg$c311 = "e",
+      peg$c312 = peg$literalExpectation("e", true),
+      peg$c313 = /^[+\-]/,
+      peg$c314 = peg$classExpectation(["+", "-"], false, false),
+      peg$c315 = /^[0-9a-fA-F]/,
+      peg$c316 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c317 = function(chars) { return joinChars(chars) },
+      peg$c318 = "\\",
+      peg$c319 = peg$literalExpectation("\\", false),
+      peg$c320 = /^[\0-\x1F\\(),!><="|';:]/,
+      peg$c321 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
+      peg$c322 = peg$anyExpectation(),
+      peg$c323 = "\"",
+      peg$c324 = peg$literalExpectation("\"", false),
+      peg$c325 = function(v) { return joinChars(v) },
+      peg$c326 = "'",
+      peg$c327 = peg$literalExpectation("'", false),
+      peg$c328 = "x",
+      peg$c329 = peg$literalExpectation("x", false),
+      peg$c330 = function() { return "\\" + text() },
+      peg$c331 = "b",
+      peg$c332 = peg$literalExpectation("b", false),
+      peg$c333 = function() { return "\b" },
+      peg$c334 = "f",
+      peg$c335 = peg$literalExpectation("f", false),
+      peg$c336 = function() { return "\f" },
+      peg$c337 = "n",
+      peg$c338 = peg$literalExpectation("n", false),
+      peg$c339 = function() { return "\n" },
+      peg$c340 = "r",
+      peg$c341 = peg$literalExpectation("r", false),
+      peg$c342 = function() { return "\r" },
+      peg$c343 = "t",
+      peg$c344 = peg$literalExpectation("t", false),
+      peg$c345 = function() { return "\t" },
+      peg$c346 = "v",
+      peg$c347 = peg$literalExpectation("v", false),
+      peg$c348 = function() { return "\v" },
+      peg$c349 = function() { return "=" },
+      peg$c350 = function() { return "\\*" },
+      peg$c351 = "u",
+      peg$c352 = peg$literalExpectation("u", false),
+      peg$c353 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c355 = "{",
-      peg$c356 = peg$literalExpectation("{", false),
-      peg$c357 = "}",
-      peg$c358 = peg$literalExpectation("}", false),
-      peg$c359 = function(body) { return body },
-      peg$c360 = /^[^\/\\]/,
-      peg$c361 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c362 = "\\/",
-      peg$c363 = peg$literalExpectation("\\/", false),
-      peg$c364 = /^[\0-\x1F\\]/,
-      peg$c365 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c366 = "\t",
-      peg$c367 = peg$literalExpectation("\t", false),
-      peg$c368 = "\x0B",
-      peg$c369 = peg$literalExpectation("\x0B", false),
-      peg$c370 = "\f",
-      peg$c371 = peg$literalExpectation("\f", false),
-      peg$c372 = " ",
-      peg$c373 = peg$literalExpectation(" ", false),
-      peg$c374 = "\xA0",
-      peg$c375 = peg$literalExpectation("\xA0", false),
-      peg$c376 = "\uFEFF",
-      peg$c377 = peg$literalExpectation("\uFEFF", false),
+      peg$c354 = "{",
+      peg$c355 = peg$literalExpectation("{", false),
+      peg$c356 = "}",
+      peg$c357 = peg$literalExpectation("}", false),
+      peg$c358 = function(body) { return body },
+      peg$c359 = /^[^\/\\]/,
+      peg$c360 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c361 = "\\/",
+      peg$c362 = peg$literalExpectation("\\/", false),
+      peg$c363 = /^[\0-\x1F\\]/,
+      peg$c364 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c365 = "\t",
+      peg$c366 = peg$literalExpectation("\t", false),
+      peg$c367 = "\x0B",
+      peg$c368 = peg$literalExpectation("\x0B", false),
+      peg$c369 = "\f",
+      peg$c370 = peg$literalExpectation("\f", false),
+      peg$c371 = " ",
+      peg$c372 = peg$literalExpectation(" ", false),
+      peg$c373 = "\xA0",
+      peg$c374 = peg$literalExpectation("\xA0", false),
+      peg$c375 = "\uFEFF",
+      peg$c376 = peg$literalExpectation("\uFEFF", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -912,15 +907,6 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parseSearch();
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c3(s1);
-        }
-        s0 = s1;
-      }
     }
 
     return s0;
@@ -933,7 +919,7 @@ function peg$parse(input, options) {
     s1 = peg$parseSearchExpr();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c4(s1);
+      s1 = peg$c3(s1);
     }
     s0 = s1;
 
@@ -954,7 +940,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c5(s1, s2);
+        s1 = peg$c4(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -981,7 +967,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSearchTerm();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c6(s4);
+            s1 = peg$c5(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1017,7 +1003,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c7(s1, s2);
+        s1 = peg$c6(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1059,7 +1045,7 @@ function peg$parse(input, options) {
         s3 = peg$parseSearchFactor();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c8(s3);
+          s1 = peg$c7(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1099,11 +1085,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c9;
+        s2 = peg$c8;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c10); }
+        if (peg$silentFails === 0) { peg$fail(peg$c9); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -1123,7 +1109,7 @@ function peg$parse(input, options) {
       s2 = peg$parseSearchExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c11(s2);
+        s1 = peg$c10(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1138,11 +1124,11 @@ function peg$parse(input, options) {
       s1 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c12;
+        s2 = peg$c11;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c13); }
+        if (peg$silentFails === 0) { peg$fail(peg$c12); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -1155,7 +1141,7 @@ function peg$parse(input, options) {
         s2 = peg$parseSearchPred();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c14(s2);
+          s1 = peg$c13(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1168,11 +1154,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c15;
+          s1 = peg$c14;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          if (peg$silentFails === 0) { peg$fail(peg$c15); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -1182,15 +1168,15 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c17;
+                  s5 = peg$c16;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c17); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c19(s3);
+                  s1 = peg$c18(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1223,11 +1209,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c20;
+      s1 = peg$c19;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c21); }
+      if (peg$silentFails === 0) { peg$fail(peg$c20); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -1239,7 +1225,7 @@ function peg$parse(input, options) {
             s5 = peg$parseSearchValue();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c22(s3, s5);
+              s1 = peg$c21(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1263,12 +1249,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c23) {
-        s1 = peg$c23;
+      if (input.substr(peg$currPos, 2) === peg$c22) {
+        s1 = peg$c22;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c24); }
+        if (peg$silentFails === 0) { peg$fail(peg$c23); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -1280,7 +1266,7 @@ function peg$parse(input, options) {
               s5 = peg$parseSearchValue();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c25(s3, s5);
+                s1 = peg$c24(s3, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1315,7 +1301,7 @@ function peg$parse(input, options) {
                 s5 = peg$parseSearchValue();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c26(s1, s3, s5);
+                  s1 = peg$c25(s1, s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1341,12 +1327,12 @@ function peg$parse(input, options) {
           s0 = peg$currPos;
           s1 = peg$currPos;
           peg$silentFails++;
-          if (input.substr(peg$currPos, 3) === peg$c27) {
-            s2 = peg$c27;
+          if (input.substr(peg$currPos, 3) === peg$c26) {
+            s2 = peg$c26;
             peg$currPos += 3;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c28); }
+            if (peg$silentFails === 0) { peg$fail(peg$c27); }
           }
           peg$silentFails--;
           if (s2 !== peg$FAILED) {
@@ -1367,7 +1353,7 @@ function peg$parse(input, options) {
                     s6 = peg$parseSearchValue();
                     if (s6 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c29(s2, s4, s6);
+                      s1 = peg$c28(s2, s4, s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1404,15 +1390,15 @@ function peg$parse(input, options) {
                   s4 = peg$parse__();
                   if (s4 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 42) {
-                      s5 = peg$c20;
+                      s5 = peg$c19;
                       peg$currPos++;
                     } else {
                       s5 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c21); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c20); }
                     }
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c30(s1);
+                      s1 = peg$c29(s1);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1447,7 +1433,7 @@ function peg$parse(input, options) {
                       s5 = peg$parseDerefExpr();
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c31(s1, s5);
+                        s1 = peg$c30(s1, s5);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -1474,7 +1460,7 @@ function peg$parse(input, options) {
                 s1 = peg$parseSearchLiteral();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c32(s1);
+                  s1 = peg$c31(s1);
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
@@ -1507,7 +1493,7 @@ function peg$parse(input, options) {
                     s2 = peg$parseSearchWord();
                     if (s2 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c33(s2);
+                      s1 = peg$c32(s2);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1562,7 +1548,7 @@ function peg$parse(input, options) {
         s2 = peg$parseSearchWord();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c34(s2);
+          s1 = peg$c33(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1619,7 +1605,7 @@ function peg$parse(input, options) {
                 }
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c35(s1);
+                  s1 = peg$c34(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1659,7 +1645,7 @@ function peg$parse(input, options) {
                   s2 = peg$parseBooleanLiteral();
                   if (s2 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c36(s2);
+                    s1 = peg$c35(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1699,7 +1685,7 @@ function peg$parse(input, options) {
                     s2 = peg$parseNullLiteral();
                     if (s2 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c36(s2);
+                      s1 = peg$c35(s2);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1727,7 +1713,7 @@ function peg$parse(input, options) {
     s1 = peg$parseQuotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c34(s1);
+      s1 = peg$c33(s1);
     }
     s0 = s1;
 
@@ -1741,7 +1727,7 @@ function peg$parse(input, options) {
     s1 = peg$parseRegexp();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c37(s1);
+      s1 = peg$c36(s1);
     }
     s0 = s1;
 
@@ -1766,7 +1752,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c38(s1);
+        s1 = peg$c37(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1778,10 +1764,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseIPNet();
+      s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c38(s1);
+        s1 = peg$c37(s1);
       }
       s0 = s1;
     }
@@ -1807,7 +1793,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c39(s1);
+        s1 = peg$c38(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1822,7 +1808,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c39(s1);
+        s1 = peg$c38(s1);
       }
       s0 = s1;
     }
@@ -1837,7 +1823,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c40(s1);
+      s1 = peg$c39(s1);
     }
     s0 = s1;
 
@@ -1851,7 +1837,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c41(s1);
+      s1 = peg$c40(s1);
     }
     s0 = s1;
 
@@ -1862,30 +1848,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c42) {
-      s1 = peg$c42;
+    if (input.substr(peg$currPos, 4) === peg$c41) {
+      s1 = peg$c41;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c43); }
+      if (peg$silentFails === 0) { peg$fail(peg$c42); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c44();
+      s1 = peg$c43();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c45) {
-        s1 = peg$c45;
+      if (input.substr(peg$currPos, 5) === peg$c44) {
+        s1 = peg$c44;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c46); }
+        if (peg$silentFails === 0) { peg$fail(peg$c45); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c47();
+        s1 = peg$c46();
       }
       s0 = s1;
     }
@@ -1897,16 +1883,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c48) {
-      s1 = peg$c48;
+    if (input.substr(peg$currPos, 4) === peg$c47) {
+      s1 = peg$c47;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      if (peg$silentFails === 0) { peg$fail(peg$c48); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c50();
+      s1 = peg$c49();
     }
     s0 = s1;
 
@@ -1927,7 +1913,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c51(s1, s2);
+        s1 = peg$c50(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1948,11 +1934,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 124) {
-        s2 = peg$c52;
+        s2 = peg$c51;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c52); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -1960,7 +1946,7 @@ function peg$parse(input, options) {
           s4 = peg$parseProc();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c54(s4);
+            s1 = peg$c53(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1991,11 +1977,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c15;
+          s1 = peg$c14;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          if (peg$silentFails === 0) { peg$fail(peg$c15); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -2005,15 +1991,15 @@ function peg$parse(input, options) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c17;
+                  s5 = peg$c16;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c17); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c55(s3);
+                  s1 = peg$c54(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2055,7 +2041,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c56(s1, s2);
+        s1 = peg$c55(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2076,11 +2062,11 @@ function peg$parse(input, options) {
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 59) {
-        s2 = peg$c57;
+        s2 = peg$c56;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c58); }
+        if (peg$silentFails === 0) { peg$fail(peg$c57); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -2088,7 +2074,7 @@ function peg$parse(input, options) {
           s4 = peg$parseSequentialProcs();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c59(s4);
+            s1 = peg$c58(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2132,7 +2118,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c60(s1, s2, s3, s4);
+            s1 = peg$c59(s1, s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2158,12 +2144,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c61) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c60) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+      if (peg$silentFails === 0) { peg$fail(peg$c61); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2173,7 +2159,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c63(s3);
+            s1 = peg$c62(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2201,12 +2187,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c64) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c63) {
         s2 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c65); }
+        if (peg$silentFails === 0) { peg$fail(peg$c64); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -2214,7 +2200,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFlexAssignments();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c66(s4);
+            s1 = peg$c65(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2242,22 +2228,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c67) {
-        s2 = peg$c67;
+      if (input.substr(peg$currPos, 4) === peg$c66) {
+        s2 = peg$c66;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c67); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c69) {
-            s4 = peg$c69;
+          if (input.substr(peg$currPos, 6) === peg$c68) {
+            s4 = peg$c68;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c70); }
+            if (peg$silentFails === 0) { peg$fail(peg$c69); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -2265,7 +2251,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c71(s6);
+                s1 = peg$c70(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2304,7 +2290,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72(s1);
+        s1 = peg$c71(s1);
       }
       s0 = s1;
     }
@@ -2323,11 +2309,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2335,7 +2321,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c75(s1, s7);
+              s4 = peg$c74(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2359,11 +2345,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2371,7 +2357,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c75(s1, s7);
+                s4 = peg$c74(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2392,7 +2378,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c76(s1, s2);
+        s1 = peg$c75(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2415,17 +2401,17 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c77;
+          s3 = peg$c76;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c77); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseReducer();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c79(s1, s4);
+            s1 = peg$c78(s1, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2448,7 +2434,7 @@ function peg$parse(input, options) {
       s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1);
+        s1 = peg$c79(s1);
       }
       s0 = s1;
     }
@@ -2462,20 +2448,20 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
-    if (input.substr(peg$currPos, 3) === peg$c81) {
-      s2 = peg$c81;
+    if (input.substr(peg$currPos, 3) === peg$c80) {
+      s2 = peg$c80;
       peg$currPos += 3;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c82); }
+      if (peg$silentFails === 0) { peg$fail(peg$c81); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c27) {
-        s2 = peg$c27;
+      if (input.substr(peg$currPos, 3) === peg$c26) {
+        s2 = peg$c26;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c28); }
+        if (peg$silentFails === 0) { peg$fail(peg$c27); }
       }
     }
     peg$silentFails--;
@@ -2491,11 +2477,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c15;
+            s4 = peg$c14;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c16); }
+            if (peg$silentFails === 0) { peg$fail(peg$c15); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -2508,11 +2494,11 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c17;
+                    s8 = peg$c16;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c17); }
                   }
                   if (s8 !== peg$FAILED) {
                     s9 = peg$parseWhereClause();
@@ -2521,7 +2507,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c83(s2, s6, s9);
+                      s1 = peg$c82(s2, s6, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -2569,12 +2555,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c84) {
-        s2 = peg$c84;
+      if (input.substr(peg$currPos, 5) === peg$c83) {
+        s2 = peg$c83;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        if (peg$silentFails === 0) { peg$fail(peg$c84); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -2582,7 +2568,7 @@ function peg$parse(input, options) {
           s4 = peg$parseConditionalExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c19(s4);
+            s1 = peg$c18(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2615,11 +2601,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2650,11 +2636,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2682,7 +2668,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c86(s1, s2);
+        s1 = peg$c85(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2735,12 +2721,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c87) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c86) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c88); }
+      if (peg$silentFails === 0) { peg$fail(peg$c87); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -2751,7 +2737,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c89(s2, s5);
+            s4 = peg$c88(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2766,7 +2752,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c90(s2, s3);
+          s1 = peg$c89(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2795,7 +2781,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c91(s4);
+        s3 = peg$c90(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -2813,7 +2799,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c91(s4);
+          s3 = peg$c90(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -2826,7 +2812,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c92(s1);
+      s1 = peg$c91(s1);
     }
     s0 = s1;
 
@@ -2837,55 +2823,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c93) {
-      s1 = peg$c93;
+    if (input.substr(peg$currPos, 2) === peg$c92) {
+      s1 = peg$c92;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      if (peg$silentFails === 0) { peg$fail(peg$c93); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c95();
+      s1 = peg$c94();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c96) {
-        s1 = peg$c96;
+      if (input.substr(peg$currPos, 6) === peg$c95) {
+        s1 = peg$c95;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+        if (peg$silentFails === 0) { peg$fail(peg$c96); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c98) {
-            s4 = peg$c98;
+          if (input.substr(peg$currPos, 5) === peg$c97) {
+            s4 = peg$c97;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c99); }
+            if (peg$silentFails === 0) { peg$fail(peg$c98); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c100) {
-              s4 = peg$c100;
+            if (input.substr(peg$currPos, 4) === peg$c99) {
+              s4 = peg$c99;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c101); }
+              if (peg$silentFails === 0) { peg$fail(peg$c100); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c102();
+            s4 = peg$c101();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c103(s3);
+            s1 = peg$c102(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2908,12 +2894,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c104) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c103) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c105); }
+      if (peg$silentFails === 0) { peg$fail(peg$c104); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -2922,7 +2908,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c106(s4);
+          s3 = peg$c105(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -2939,12 +2925,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c107) {
-            s5 = peg$c107;
+          if (input.substr(peg$currPos, 6) === peg$c106) {
+            s5 = peg$c106;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c108); }
+            if (peg$silentFails === 0) { peg$fail(peg$c107); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -2967,7 +2953,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c109(s2, s3, s6);
+              s5 = peg$c108(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -2982,7 +2968,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c110(s2, s3, s4);
+            s1 = peg$c109(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3008,12 +2994,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c111) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c110) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c112); }
+      if (peg$silentFails === 0) { peg$fail(peg$c111); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseCutArgs();
@@ -3023,7 +3009,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFlexAssignments();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c113(s2, s4);
+            s1 = peg$c112(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3053,16 +3039,16 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     s3 = peg$parse_();
     if (s3 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c114) {
-        s4 = peg$c114;
+      if (input.substr(peg$currPos, 2) === peg$c113) {
+        s4 = peg$c113;
         peg$currPos += 2;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c116();
+        s3 = peg$c115();
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3077,16 +3063,16 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c114) {
-          s4 = peg$c114;
+        if (input.substr(peg$currPos, 2) === peg$c113) {
+          s4 = peg$c113;
           peg$currPos += 2;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c116();
+          s3 = peg$c115();
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3099,7 +3085,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c117(s1);
+      s1 = peg$c116(s1);
     }
     s0 = s1;
 
@@ -3110,12 +3096,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c118) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c117) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c119); }
+      if (peg$silentFails === 0) { peg$fail(peg$c118); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3123,7 +3109,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c120(s3);
+          s1 = peg$c119(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3139,16 +3125,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c118) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c117) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c119); }
+        if (peg$silentFails === 0) { peg$fail(peg$c118); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c121();
+        s1 = peg$c120();
       }
       s0 = s1;
     }
@@ -3160,12 +3146,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c122) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c121) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c123); }
+      if (peg$silentFails === 0) { peg$fail(peg$c122); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3173,7 +3159,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c124(s3);
+          s1 = peg$c123(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3189,16 +3175,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c122) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c121) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c123); }
+        if (peg$silentFails === 0) { peg$fail(peg$c122); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c125();
+        s1 = peg$c124();
       }
       s0 = s1;
     }
@@ -3210,12 +3196,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c126) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c125) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c127); }
+      if (peg$silentFails === 0) { peg$fail(peg$c126); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3223,7 +3209,7 @@ function peg$parse(input, options) {
         s3 = peg$parseSearchExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c4(s3);
+          s1 = peg$c3(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3245,26 +3231,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c127) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c129); }
+      if (peg$silentFails === 0) { peg$fail(peg$c128); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c114) {
-          s3 = peg$c114;
+        if (input.substr(peg$currPos, 2) === peg$c113) {
+          s3 = peg$c113;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c130();
+          s1 = peg$c129();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3280,16 +3266,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c127) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c129); }
+        if (peg$silentFails === 0) { peg$fail(peg$c128); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c131();
+        s1 = peg$c130();
       }
       s0 = s1;
     }
@@ -3301,12 +3287,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c132) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c131) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c133); }
+      if (peg$silentFails === 0) { peg$fail(peg$c132); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3314,7 +3300,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c134(s3);
+          s1 = peg$c133(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3336,12 +3322,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c135) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c134) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c136); }
+      if (peg$silentFails === 0) { peg$fail(peg$c135); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3353,11 +3339,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c73;
+              s7 = peg$c72;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c74); }
+              if (peg$silentFails === 0) { peg$fail(peg$c73); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -3365,7 +3351,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c137(s3, s9);
+                  s6 = peg$c136(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -3389,11 +3375,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c73;
+                s7 = peg$c72;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                if (peg$silentFails === 0) { peg$fail(peg$c73); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -3401,7 +3387,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c137(s3, s9);
+                    s6 = peg$c136(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -3422,7 +3408,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c138(s3, s4);
+            s1 = peg$c137(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3448,16 +3434,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c138) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c139); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c141();
+      s1 = peg$c140();
     }
     s0 = s1;
 
@@ -3469,11 +3455,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c142;
+      s1 = peg$c141;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      if (peg$silentFails === 0) { peg$fail(peg$c142); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -3496,7 +3482,7 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifier();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c144(s3);
+          s1 = peg$c143(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3513,11 +3499,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c142;
+        s1 = peg$c141;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
@@ -3532,7 +3518,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c145();
+          s1 = peg$c144();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3558,11 +3544,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3593,11 +3579,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3625,7 +3611,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c146(s1, s2);
+        s1 = peg$c145(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3650,11 +3636,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3685,11 +3671,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3717,7 +3703,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c146(s1, s2);
+        s1 = peg$c145(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3740,11 +3726,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c77;
+          s3 = peg$c76;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c77); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3752,7 +3738,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c147(s1, s5);
+              s1 = peg$c146(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3790,16 +3776,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    s1 = peg$parseLogicalORExpr();
+    s1 = peg$parseLogicalOrExpr();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c148;
+          s3 = peg$c147;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c149); }
+          if (peg$silentFails === 0) { peg$fail(peg$c148); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3809,11 +3795,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c150;
+                  s7 = peg$c149;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c151); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c150); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -3821,7 +3807,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c152(s1, s5, s9);
+                      s1 = peg$c151(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -3860,17 +3846,17 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$parseLogicalORExpr();
+      s0 = peg$parseLogicalOrExpr();
     }
 
     return s0;
   }
 
-  function peg$parseLogicalORExpr() {
+  function peg$parseLogicalOrExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    s1 = peg$parseLogicalANDExpr();
+    s1 = peg$parseLogicalAndExpr();
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
@@ -3880,10 +3866,10 @@ function peg$parse(input, options) {
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
-            s7 = peg$parseLogicalANDExpr();
+            s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c153(s1, s5, s7);
+              s4 = peg$c152(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3910,10 +3896,10 @@ function peg$parse(input, options) {
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
-              s7 = peg$parseLogicalANDExpr();
+              s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c153(s1, s5, s7);
+                s4 = peg$c152(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3934,7 +3920,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c154(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3948,7 +3934,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseLogicalANDExpr() {
+  function peg$parseLogicalAndExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
@@ -3965,7 +3951,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c153(s1, s5, s7);
+              s4 = peg$c152(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3995,7 +3981,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c153(s1, s5, s7);
+                s4 = peg$c152(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4016,7 +4002,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c154(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4047,7 +4033,7 @@ function peg$parse(input, options) {
             s7 = peg$parseRelativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c155(s1, s5, s7);
+              s4 = peg$c154(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4077,7 +4063,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c155(s1, s5, s7);
+                s4 = peg$c154(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4098,7 +4084,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c154(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4116,43 +4102,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c156) {
-      s1 = peg$c156;
+    if (input.substr(peg$currPos, 2) === peg$c155) {
+      s1 = peg$c155;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+      if (peg$silentFails === 0) { peg$fail(peg$c156); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c158) {
-        s1 = peg$c158;
+      if (input.substr(peg$currPos, 2) === peg$c157) {
+        s1 = peg$c157;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c159); }
+        if (peg$silentFails === 0) { peg$fail(peg$c158); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c77;
+          s1 = peg$c76;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c77); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c160) {
-            s1 = peg$c160;
+          if (input.substr(peg$currPos, 2) === peg$c159) {
+            s1 = peg$c159;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c161); }
+            if (peg$silentFails === 0) { peg$fail(peg$c160); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -4165,16 +4151,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c162) {
-        s1 = peg$c162;
+      if (input.substr(peg$currPos, 2) === peg$c161) {
+        s1 = peg$c161;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c162); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c101();
       }
       s0 = s1;
     }
@@ -4199,7 +4185,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c153(s1, s5, s7);
+              s4 = peg$c152(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4229,7 +4215,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c153(s1, s5, s7);
+                s4 = peg$c152(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4250,7 +4236,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c154(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4268,43 +4254,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c164) {
-      s1 = peg$c164;
+    if (input.substr(peg$currPos, 2) === peg$c163) {
+      s1 = peg$c163;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c165); }
+      if (peg$silentFails === 0) { peg$fail(peg$c164); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c166;
+        s1 = peg$c165;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c167); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c168) {
-          s1 = peg$c168;
+        if (input.substr(peg$currPos, 2) === peg$c167) {
+          s1 = peg$c167;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c169); }
+          if (peg$silentFails === 0) { peg$fail(peg$c168); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c170;
+            s1 = peg$c169;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c171); }
+            if (peg$silentFails === 0) { peg$fail(peg$c170); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -4328,7 +4314,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c153(s1, s5, s7);
+              s4 = peg$c152(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4358,7 +4344,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c153(s1, s5, s7);
+                s4 = peg$c152(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4379,7 +4365,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c154(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4398,24 +4384,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c172;
+      s1 = peg$c171;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c173); }
+      if (peg$silentFails === 0) { peg$fail(peg$c172); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c12;
+        s1 = peg$c11;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c13); }
+        if (peg$silentFails === 0) { peg$fail(peg$c12); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -4439,7 +4425,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c153(s1, s5, s7);
+              s4 = peg$c152(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4469,7 +4455,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c153(s1, s5, s7);
+                s4 = peg$c152(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4490,7 +4476,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c154(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4509,24 +4495,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c20;
+      s1 = peg$c19;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c21); }
+      if (peg$silentFails === 0) { peg$fail(peg$c20); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c174;
+        s1 = peg$c173;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+        if (peg$silentFails === 0) { peg$fail(peg$c174); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -4538,11 +4524,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c9;
+      s1 = peg$c8;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c10); }
+      if (peg$silentFails === 0) { peg$fail(peg$c9); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -4550,7 +4536,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s3);
+          s1 = peg$c175(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4579,17 +4565,17 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 58) {
-        s3 = peg$c150;
+        s3 = peg$c149;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c151); }
+        if (peg$silentFails === 0) { peg$fail(peg$c150); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parsePrimitiveType();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c177(s1, s4);
+          s3 = peg$c176(s1, s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4601,7 +4587,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c178(s1, s2);
+        s1 = peg$c177(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4622,172 +4608,172 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c179) {
-      s1 = peg$c179;
+    if (input.substr(peg$currPos, 5) === peg$c178) {
+      s1 = peg$c178;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c180); }
+      if (peg$silentFails === 0) { peg$fail(peg$c179); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c181) {
-        s1 = peg$c181;
+      if (input.substr(peg$currPos, 5) === peg$c180) {
+        s1 = peg$c180;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c182); }
+        if (peg$silentFails === 0) { peg$fail(peg$c181); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c183) {
-          s1 = peg$c183;
+        if (input.substr(peg$currPos, 6) === peg$c182) {
+          s1 = peg$c182;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c184); }
+          if (peg$silentFails === 0) { peg$fail(peg$c183); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c185) {
-            s1 = peg$c185;
+          if (input.substr(peg$currPos, 6) === peg$c184) {
+            s1 = peg$c184;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c186); }
+            if (peg$silentFails === 0) { peg$fail(peg$c185); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c187) {
-              s1 = peg$c187;
+            if (input.substr(peg$currPos, 6) === peg$c186) {
+              s1 = peg$c186;
               peg$currPos += 6;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c188); }
+              if (peg$silentFails === 0) { peg$fail(peg$c187); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4) === peg$c189) {
-                s1 = peg$c189;
+              if (input.substr(peg$currPos, 4) === peg$c188) {
+                s1 = peg$c188;
                 peg$currPos += 4;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c190); }
+                if (peg$silentFails === 0) { peg$fail(peg$c189); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c191) {
-                  s1 = peg$c191;
+                if (input.substr(peg$currPos, 5) === peg$c190) {
+                  s1 = peg$c190;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c192); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c191); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c193) {
-                    s1 = peg$c193;
+                  if (input.substr(peg$currPos, 5) === peg$c192) {
+                    s1 = peg$c192;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c194); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c193); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c195) {
-                      s1 = peg$c195;
+                    if (input.substr(peg$currPos, 5) === peg$c194) {
+                      s1 = peg$c194;
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c195); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 8) === peg$c197) {
-                        s1 = peg$c197;
+                      if (input.substr(peg$currPos, 8) === peg$c196) {
+                        s1 = peg$c196;
                         peg$currPos += 8;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c197); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c199) {
-                          s1 = peg$c199;
+                        if (input.substr(peg$currPos, 4) === peg$c198) {
+                          s1 = peg$c198;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c200); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c199); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 7) === peg$c201) {
-                            s1 = peg$c201;
+                          if (input.substr(peg$currPos, 7) === peg$c200) {
+                            s1 = peg$c200;
                             peg$currPos += 7;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c202); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c201); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 4) === peg$c203) {
-                              s1 = peg$c203;
+                            if (input.substr(peg$currPos, 4) === peg$c202) {
+                              s1 = peg$c202;
                               peg$currPos += 4;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c204); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c203); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 5) === peg$c179) {
-                                s1 = peg$c179;
+                              if (input.substr(peg$currPos, 5) === peg$c178) {
+                                s1 = peg$c178;
                                 peg$currPos += 5;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c180); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c179); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 6) === peg$c205) {
-                                  s1 = peg$c205;
+                                if (input.substr(peg$currPos, 6) === peg$c204) {
+                                  s1 = peg$c204;
                                   peg$currPos += 6;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c206); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c205); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 7) === peg$c207) {
-                                    s1 = peg$c207;
+                                  if (input.substr(peg$currPos, 7) === peg$c206) {
+                                    s1 = peg$c206;
                                     peg$currPos += 7;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c208); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c207); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c209) {
-                                      s1 = peg$c209;
+                                    if (input.substr(peg$currPos, 2) === peg$c208) {
+                                      s1 = peg$c208;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c210); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c209); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c211) {
-                                        s1 = peg$c211;
+                                      if (input.substr(peg$currPos, 3) === peg$c210) {
+                                        s1 = peg$c210;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c212); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c211); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c213) {
-                                          s1 = peg$c213;
+                                        if (input.substr(peg$currPos, 4) === peg$c212) {
+                                          s1 = peg$c212;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c214); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c213); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 5) === peg$c215) {
-                                            s1 = peg$c215;
+                                          if (input.substr(peg$currPos, 5) === peg$c214) {
+                                            s1 = peg$c214;
                                             peg$currPos += 5;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c215); }
                                           }
                                           if (s1 === peg$FAILED) {
-                                            if (input.substr(peg$currPos, 4) === peg$c48) {
-                                              s1 = peg$c48;
+                                            if (input.substr(peg$currPos, 4) === peg$c47) {
+                                              s1 = peg$c47;
                                               peg$currPos += 4;
                                             } else {
                                               s1 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                              if (peg$silentFails === 0) { peg$fail(peg$c48); }
                                             }
                                           }
                                         }
@@ -4811,7 +4797,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -4832,7 +4818,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c217(s1, s2);
+        s1 = peg$c216(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4861,25 +4847,25 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c15;
+          s3 = peg$c14;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c16); }
+          if (peg$silentFails === 0) { peg$fail(peg$c15); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parseArgumentList();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c17;
+              s5 = peg$c16;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c18); }
+              if (peg$silentFails === 0) { peg$fail(peg$c17); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c218(s1, s4);
+              s1 = peg$c217(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4919,7 +4905,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c101();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4936,12 +4922,12 @@ function peg$parse(input, options) {
   function peg$parseFuncNameStart() {
     var s0;
 
-    if (peg$c219.test(input.charAt(peg$currPos))) {
+    if (peg$c218.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c220); }
+      if (peg$silentFails === 0) { peg$fail(peg$c219); }
     }
 
     return s0;
@@ -4952,12 +4938,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseFuncNameStart();
     if (s0 === peg$FAILED) {
-      if (peg$c221.test(input.charAt(peg$currPos))) {
+      if (peg$c220.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c222); }
+        if (peg$silentFails === 0) { peg$fail(peg$c221); }
       }
     }
 
@@ -4975,11 +4961,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c72;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c73); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -4987,7 +4973,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c223(s1, s7);
+              s4 = peg$c222(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5011,11 +4997,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c72;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5023,7 +5009,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c223(s1, s7);
+                s4 = peg$c222(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5044,7 +5030,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c76(s1, s2);
+        s1 = peg$c75(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5059,7 +5045,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c224();
+        s1 = peg$c223();
       }
       s0 = s1;
     }
@@ -5081,7 +5067,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c217(s1, s2);
+        s1 = peg$c216(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5100,25 +5086,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c225;
+      s1 = peg$c224;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+      if (peg$silentFails === 0) { peg$fail(peg$c225); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseConditionalExpr();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c227;
+          s3 = peg$c226;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c228); }
+          if (peg$silentFails === 0) { peg$fail(peg$c227); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c229(s2);
+          s1 = peg$c228(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5135,21 +5121,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c142;
+        s1 = peg$c141;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c142;
+          s3 = peg$c141;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c143); }
+          if (peg$silentFails === 0) { peg$fail(peg$c142); }
         }
         peg$silentFails--;
         if (s3 === peg$FAILED) {
@@ -5162,7 +5148,7 @@ function peg$parse(input, options) {
           s3 = peg$parseIdentifier();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c230(s3);
+            s1 = peg$c229(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5202,11 +5188,11 @@ function peg$parse(input, options) {
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 40) {
-                      s1 = peg$c15;
+                      s1 = peg$c14;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c15); }
                     }
                     if (s1 !== peg$FAILED) {
                       s2 = peg$parse__();
@@ -5216,15 +5202,15 @@ function peg$parse(input, options) {
                           s4 = peg$parse__();
                           if (s4 !== peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 41) {
-                              s5 = peg$c17;
+                              s5 = peg$c16;
                               peg$currPos++;
                             } else {
                               s5 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c18); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c17); }
                             }
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c19(s3);
+                              s1 = peg$c18(s3);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -5273,16 +5259,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c231) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c230) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c232); }
+      if (peg$silentFails === 0) { peg$fail(peg$c231); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -5293,16 +5279,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c233) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c232) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
+      if (peg$silentFails === 0) { peg$fail(peg$c233); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -5313,16 +5299,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c162) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c161) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c234); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -5333,16 +5319,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c81) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c80) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c236); }
+      if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -5363,7 +5349,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c101();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5380,12 +5366,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c237.test(input.charAt(peg$currPos))) {
+    if (peg$c236.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c237); }
     }
 
     return s0;
@@ -5396,12 +5382,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c239.test(input.charAt(peg$currPos))) {
+      if (peg$c238.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c240); }
+        if (peg$silentFails === 0) { peg$fail(peg$c239); }
       }
     }
 
@@ -5422,7 +5408,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c241();
+        s1 = peg$c240();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5450,12 +5436,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c231) {
-                s3 = peg$c231;
+              if (input.substr(peg$currPos, 3) === peg$c230) {
+                s3 = peg$c230;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c242); }
+                if (peg$silentFails === 0) { peg$fail(peg$c241); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -5500,44 +5486,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c243) {
-      s0 = peg$c243;
+    if (input.substr(peg$currPos, 7) === peg$c242) {
+      s0 = peg$c242;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c243); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c245) {
-        s0 = peg$c245;
+      if (input.substr(peg$currPos, 6) === peg$c244) {
+        s0 = peg$c244;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c246); }
+        if (peg$silentFails === 0) { peg$fail(peg$c245); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c247) {
-          s0 = peg$c247;
+        if (input.substr(peg$currPos, 4) === peg$c246) {
+          s0 = peg$c246;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c248); }
+          if (peg$silentFails === 0) { peg$fail(peg$c247); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c249) {
-            s0 = peg$c249;
+          if (input.substr(peg$currPos, 3) === peg$c248) {
+            s0 = peg$c248;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c250); }
+            if (peg$silentFails === 0) { peg$fail(peg$c249); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c251;
+              s0 = peg$c250;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c252); }
+              if (peg$silentFails === 0) { peg$fail(peg$c251); }
             }
           }
         }
@@ -5550,44 +5536,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c253) {
-      s0 = peg$c253;
+    if (input.substr(peg$currPos, 7) === peg$c252) {
+      s0 = peg$c252;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c254); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c255) {
-        s0 = peg$c255;
+      if (input.substr(peg$currPos, 6) === peg$c254) {
+        s0 = peg$c254;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c256); }
+        if (peg$silentFails === 0) { peg$fail(peg$c255); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c257) {
-          s0 = peg$c257;
+        if (input.substr(peg$currPos, 4) === peg$c256) {
+          s0 = peg$c256;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c258); }
+          if (peg$silentFails === 0) { peg$fail(peg$c257); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c259) {
-            s0 = peg$c259;
+          if (input.substr(peg$currPos, 3) === peg$c258) {
+            s0 = peg$c258;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c260); }
+            if (peg$silentFails === 0) { peg$fail(peg$c259); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c261;
+              s0 = peg$c260;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c262); }
+              if (peg$silentFails === 0) { peg$fail(peg$c261); }
             }
           }
         }
@@ -5600,44 +5586,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c263) {
-      s0 = peg$c263;
+    if (input.substr(peg$currPos, 5) === peg$c262) {
+      s0 = peg$c262;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c263); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c265) {
-        s0 = peg$c265;
+      if (input.substr(peg$currPos, 3) === peg$c264) {
+        s0 = peg$c264;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+        if (peg$silentFails === 0) { peg$fail(peg$c265); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c267) {
-          s0 = peg$c267;
+        if (input.substr(peg$currPos, 2) === peg$c266) {
+          s0 = peg$c266;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c268); }
+          if (peg$silentFails === 0) { peg$fail(peg$c267); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c269;
+            s0 = peg$c268;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c270); }
+            if (peg$silentFails === 0) { peg$fail(peg$c269); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c271) {
-              s0 = peg$c271;
+            if (input.substr(peg$currPos, 4) === peg$c270) {
+              s0 = peg$c270;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c272); }
+              if (peg$silentFails === 0) { peg$fail(peg$c271); }
             }
           }
         }
@@ -5650,28 +5636,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c273) {
-      s0 = peg$c273;
+    if (input.substr(peg$currPos, 4) === peg$c272) {
+      s0 = peg$c272;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c274); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c275) {
-        s0 = peg$c275;
+      if (input.substr(peg$currPos, 3) === peg$c274) {
+        s0 = peg$c274;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c276); }
+        if (peg$silentFails === 0) { peg$fail(peg$c275); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c277;
+          s0 = peg$c276;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c278); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
       }
     }
@@ -5682,44 +5668,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c279) {
-      s0 = peg$c279;
+    if (input.substr(peg$currPos, 5) === peg$c278) {
+      s0 = peg$c278;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c281) {
-        s0 = peg$c281;
+      if (input.substr(peg$currPos, 4) === peg$c280) {
+        s0 = peg$c280;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c281); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c283) {
-          s0 = peg$c283;
+        if (input.substr(peg$currPos, 3) === peg$c282) {
+          s0 = peg$c282;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c284); }
+          if (peg$silentFails === 0) { peg$fail(peg$c283); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c285) {
-            s0 = peg$c285;
+          if (input.substr(peg$currPos, 2) === peg$c284) {
+            s0 = peg$c284;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c286); }
+            if (peg$silentFails === 0) { peg$fail(peg$c285); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c287;
+              s0 = peg$c286;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c288); }
+              if (peg$silentFails === 0) { peg$fail(peg$c287); }
             }
           }
         }
@@ -5733,16 +5719,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c245) {
-      s1 = peg$c245;
+    if (input.substr(peg$currPos, 6) === peg$c244) {
+      s1 = peg$c244;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c245); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c289();
+      s1 = peg$c288();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5754,7 +5740,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c290(s1);
+            s1 = peg$c289(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5777,16 +5763,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c255) {
-      s1 = peg$c255;
+    if (input.substr(peg$currPos, 6) === peg$c254) {
+      s1 = peg$c254;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c256); }
+      if (peg$silentFails === 0) { peg$fail(peg$c255); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c291();
+      s1 = peg$c290();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5798,7 +5784,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c292(s1);
+            s1 = peg$c291(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5821,16 +5807,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c271) {
-      s1 = peg$c271;
+    if (input.substr(peg$currPos, 4) === peg$c270) {
+      s1 = peg$c270;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c272); }
+      if (peg$silentFails === 0) { peg$fail(peg$c271); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c293();
+      s1 = peg$c292();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5842,7 +5828,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c294(s1);
+            s1 = peg$c293(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5865,16 +5851,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c275) {
-      s1 = peg$c275;
+    if (input.substr(peg$currPos, 3) === peg$c274) {
+      s1 = peg$c274;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c276); }
+      if (peg$silentFails === 0) { peg$fail(peg$c275); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c295();
+      s1 = peg$c294();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5886,7 +5872,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c296(s1);
+            s1 = peg$c295(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5909,16 +5895,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c281) {
-      s1 = peg$c281;
+    if (input.substr(peg$currPos, 4) === peg$c280) {
+      s1 = peg$c280;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c281); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c297();
+      s1 = peg$c296();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5930,7 +5916,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c298(s1);
+            s1 = peg$c297(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5956,37 +5942,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c142;
+        s2 = peg$c141;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c142;
+            s4 = peg$c141;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c143); }
+            if (peg$silentFails === 0) { peg$fail(peg$c142); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c142;
+                s6 = peg$c141;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c143); }
+                if (peg$silentFails === 0) { peg$fail(peg$c142); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c102();
+                  s1 = peg$c101();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6038,7 +6024,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c298(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6059,12 +6045,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c300) {
-            s3 = peg$c300;
+          if (input.substr(peg$currPos, 2) === peg$c299) {
+            s3 = peg$c299;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c301); }
+            if (peg$silentFails === 0) { peg$fail(peg$c300); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6077,7 +6063,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c302(s1, s2, s4, s5);
+                s1 = peg$c301(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6101,12 +6087,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c300) {
-          s1 = peg$c300;
+        if (input.substr(peg$currPos, 2) === peg$c299) {
+          s1 = peg$c299;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c301); }
+          if (peg$silentFails === 0) { peg$fail(peg$c300); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6119,7 +6105,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c303(s2, s3);
+              s1 = peg$c302(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6144,16 +6130,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c300) {
-                s3 = peg$c300;
+              if (input.substr(peg$currPos, 2) === peg$c299) {
+                s3 = peg$c299;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c301); }
+                if (peg$silentFails === 0) { peg$fail(peg$c300); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c304(s1, s2);
+                s1 = peg$c303(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6169,16 +6155,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c300) {
-              s1 = peg$c300;
+            if (input.substr(peg$currPos, 2) === peg$c299) {
+              s1 = peg$c299;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c301); }
+              if (peg$silentFails === 0) { peg$fail(peg$c300); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c305();
+              s1 = peg$c304();
             }
             s0 = s1;
           }
@@ -6205,17 +6191,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c150;
+      s1 = peg$c149;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      if (peg$silentFails === 0) { peg$fail(peg$c150); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c306(s2);
+        s1 = peg$c305(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6236,15 +6222,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c150;
+        s2 = peg$c149;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c151); }
+        if (peg$silentFails === 0) { peg$fail(peg$c150); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c307(s1);
+        s1 = peg$c306(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6258,24 +6244,24 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseIPNet() {
+  function peg$parseIP4Net() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c174;
+        s2 = peg$c173;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+        if (peg$silentFails === 0) { peg$fail(peg$c174); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c308(s1, s3);
+          s1 = peg$c307(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6300,17 +6286,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c174;
+        s2 = peg$c173;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+        if (peg$silentFails === 0) { peg$fail(peg$c174); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c309(s1, s3);
+          s1 = peg$c308(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6335,7 +6321,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c310(s1);
+      s1 = peg$c309(s1);
     }
     s0 = s1;
 
@@ -6358,22 +6344,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c239.test(input.charAt(peg$currPos))) {
+    if (peg$c238.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      if (peg$silentFails === 0) { peg$fail(peg$c239); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c239.test(input.charAt(peg$currPos))) {
+        if (peg$c238.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          if (peg$silentFails === 0) { peg$fail(peg$c239); }
         }
       }
     } else {
@@ -6381,7 +6367,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -6393,17 +6379,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c12;
+      s1 = peg$c11;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c13); }
+      if (peg$silentFails === 0) { peg$fail(peg$c12); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c101();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6422,33 +6408,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c12;
+      s1 = peg$c11;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c13); }
+      if (peg$silentFails === 0) { peg$fail(peg$c12); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c239.test(input.charAt(peg$currPos))) {
+      if (peg$c238.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c240); }
+        if (peg$silentFails === 0) { peg$fail(peg$c239); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c239.test(input.charAt(peg$currPos))) {
+          if (peg$c238.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c239); }
           }
         }
       } else {
@@ -6456,30 +6442,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c142;
+          s3 = peg$c141;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c143); }
+          if (peg$silentFails === 0) { peg$fail(peg$c142); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c239.test(input.charAt(peg$currPos))) {
+          if (peg$c238.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c239); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c239.test(input.charAt(peg$currPos))) {
+              if (peg$c238.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c240); }
+                if (peg$silentFails === 0) { peg$fail(peg$c239); }
               }
             }
           } else {
@@ -6492,7 +6478,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311();
+              s1 = peg$c310();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6517,41 +6503,41 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c12;
+        s1 = peg$c11;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c13); }
+        if (peg$silentFails === 0) { peg$fail(peg$c12); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c142;
+          s2 = peg$c141;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c143); }
+          if (peg$silentFails === 0) { peg$fail(peg$c142); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c239.test(input.charAt(peg$currPos))) {
+          if (peg$c238.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c239); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c239.test(input.charAt(peg$currPos))) {
+              if (peg$c238.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c240); }
+                if (peg$silentFails === 0) { peg$fail(peg$c239); }
               }
             }
           } else {
@@ -6564,7 +6550,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311();
+              s1 = peg$c310();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6591,20 +6577,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c312) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c311) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c313); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c314.test(input.charAt(peg$currPos))) {
+      if (peg$c313.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c315); }
+        if (peg$silentFails === 0) { peg$fail(peg$c314); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -6646,7 +6632,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -6656,12 +6642,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c316.test(input.charAt(peg$currPos))) {
+    if (peg$c315.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c317); }
+      if (peg$silentFails === 0) { peg$fail(peg$c316); }
     }
 
     return s0;
@@ -6683,7 +6669,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c318(s1);
+      s1 = peg$c317(s1);
     }
     s0 = s1;
 
@@ -6695,11 +6681,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c319;
+      s1 = peg$c318;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c320); }
+      if (peg$silentFails === 0) { peg$fail(peg$c319); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
@@ -6708,7 +6694,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c14(s2);
+        s1 = peg$c13(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6722,12 +6708,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c321.test(input.charAt(peg$currPos))) {
+      if (peg$c320.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        if (peg$silentFails === 0) { peg$fail(peg$c321); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseWhiteSpace();
@@ -6745,11 +6731,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c323); }
+          if (peg$silentFails === 0) { peg$fail(peg$c322); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c102();
+          s1 = peg$c101();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6769,11 +6755,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c324;
+      s1 = peg$c323;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c324); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -6784,15 +6770,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c324;
+          s3 = peg$c323;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c325); }
+          if (peg$silentFails === 0) { peg$fail(peg$c324); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c326(s2);
+          s1 = peg$c325(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6809,11 +6795,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c327;
+        s1 = peg$c326;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c328); }
+        if (peg$silentFails === 0) { peg$fail(peg$c327); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -6824,15 +6810,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c327;
+            s3 = peg$c326;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c328); }
+            if (peg$silentFails === 0) { peg$fail(peg$c327); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c326(s2);
+            s1 = peg$c325(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6858,11 +6844,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c324;
+      s2 = peg$c323;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c324); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -6880,11 +6866,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c323); }
+        if (peg$silentFails === 0) { peg$fail(peg$c322); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c101();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6897,17 +6883,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c319;
+        s1 = peg$c318;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c320); }
+        if (peg$silentFails === 0) { peg$fail(peg$c319); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c14(s2);
+          s1 = peg$c13(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6929,11 +6915,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c327;
+      s2 = peg$c326;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c327); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -6951,11 +6937,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c323); }
+        if (peg$silentFails === 0) { peg$fail(peg$c322); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c101();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6968,17 +6954,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c319;
+        s1 = peg$c318;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c320); }
+        if (peg$silentFails === 0) { peg$fail(peg$c319); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c14(s2);
+          s1 = peg$c13(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6998,11 +6984,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c329;
+      s1 = peg$c328;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c329); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -7010,7 +6996,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c331();
+          s1 = peg$c330();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7038,110 +7024,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c327;
+      s0 = peg$c326;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c327); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c324;
+        s0 = peg$c323;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c325); }
+        if (peg$silentFails === 0) { peg$fail(peg$c324); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c319;
+          s0 = peg$c318;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c320); }
+          if (peg$silentFails === 0) { peg$fail(peg$c319); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c332;
+            s1 = peg$c331;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c333); }
+            if (peg$silentFails === 0) { peg$fail(peg$c332); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c334();
+            s1 = peg$c333();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c335;
+              s1 = peg$c334;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c336); }
+              if (peg$silentFails === 0) { peg$fail(peg$c335); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c337();
+              s1 = peg$c336();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c338;
+                s1 = peg$c337;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c339); }
+                if (peg$silentFails === 0) { peg$fail(peg$c338); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c340();
+                s1 = peg$c339();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c341;
+                  s1 = peg$c340;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c342); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c341); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c343();
+                  s1 = peg$c342();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c344;
+                    s1 = peg$c343;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c345); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c344); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c346();
+                    s1 = peg$c345();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c347;
+                      s1 = peg$c346;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c347); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c349();
+                      s1 = peg$c348();
                     }
                     s0 = s1;
                   }
@@ -7161,29 +7147,29 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c77;
+      s1 = peg$c76;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c78); }
+      if (peg$silentFails === 0) { peg$fail(peg$c77); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c350();
+      s1 = peg$c349();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c20;
+        s1 = peg$c19;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c21); }
+        if (peg$silentFails === 0) { peg$fail(peg$c20); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c351();
+        s1 = peg$c350();
       }
       s0 = s1;
     }
@@ -7196,11 +7182,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c352;
+      s1 = peg$c351;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7232,7 +7218,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c354(s2);
+        s1 = peg$c353(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7245,19 +7231,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c352;
+        s1 = peg$c351;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c353); }
+        if (peg$silentFails === 0) { peg$fail(peg$c352); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c355;
+          s2 = peg$c354;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c356); }
+          if (peg$silentFails === 0) { peg$fail(peg$c355); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7316,15 +7302,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c357;
+              s4 = peg$c356;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c358); }
+              if (peg$silentFails === 0) { peg$fail(peg$c357); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c354(s3);
+              s1 = peg$c353(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7352,25 +7338,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c174;
+      s1 = peg$c173;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c175); }
+      if (peg$silentFails === 0) { peg$fail(peg$c174); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c174;
+          s3 = peg$c173;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c175); }
+          if (peg$silentFails === 0) { peg$fail(peg$c174); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c359(s2);
+          s1 = peg$c358(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7393,39 +7379,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c360.test(input.charAt(peg$currPos))) {
+    if (peg$c359.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c362) {
-        s2 = peg$c362;
+      if (input.substr(peg$currPos, 2) === peg$c361) {
+        s2 = peg$c361;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c363); }
+        if (peg$silentFails === 0) { peg$fail(peg$c362); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c360.test(input.charAt(peg$currPos))) {
+        if (peg$c359.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c361); }
+          if (peg$silentFails === 0) { peg$fail(peg$c360); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c362) {
-            s2 = peg$c362;
+          if (input.substr(peg$currPos, 2) === peg$c361) {
+            s2 = peg$c361;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c363); }
+            if (peg$silentFails === 0) { peg$fail(peg$c362); }
           }
         }
       }
@@ -7434,7 +7420,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c101();
     }
     s0 = s1;
 
@@ -7444,12 +7430,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c364.test(input.charAt(peg$currPos))) {
+    if (peg$c363.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c364); }
     }
 
     return s0;
@@ -7459,51 +7445,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c366;
+      s0 = peg$c365;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c367); }
+      if (peg$silentFails === 0) { peg$fail(peg$c366); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c368;
+        s0 = peg$c367;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c369); }
+        if (peg$silentFails === 0) { peg$fail(peg$c368); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c370;
+          s0 = peg$c369;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c371); }
+          if (peg$silentFails === 0) { peg$fail(peg$c370); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c372;
+            s0 = peg$c371;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c373); }
+            if (peg$silentFails === 0) { peg$fail(peg$c372); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c374;
+              s0 = peg$c373;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c375); }
+              if (peg$silentFails === 0) { peg$fail(peg$c374); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c376;
+                s0 = peg$c375;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c377); }
+                if (peg$silentFails === 0) { peg$fail(peg$c376); }
               }
             }
           }
@@ -7554,7 +7540,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c323); }
+      if (peg$silentFails === 0) { peg$fail(peg$c322); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -683,11 +683,11 @@ function peg$parse(input, options) {
       peg$c356 = peg$literalExpectation("{", false),
       peg$c357 = "}",
       peg$c358 = peg$literalExpectation("}", false),
-      peg$c359 = /^[^\/\\]/,
-      peg$c360 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c361 = "\\/",
-      peg$c362 = peg$literalExpectation("\\/", false),
-      peg$c363 = function(body) { return body },
+      peg$c359 = function(body) { return body },
+      peg$c360 = /^[^\/\\]/,
+      peg$c361 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c362 = "\\/",
+      peg$c363 = peg$literalExpectation("\\/", false),
       peg$c364 = /^[\0-\x1F\\]/,
       peg$c365 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
       peg$c366 = "\t",
@@ -7359,46 +7359,7 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      if (peg$c359.test(input.charAt(peg$currPos))) {
-        s3 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c360); }
-      }
-      if (s3 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c361) {
-          s3 = peg$c361;
-          peg$currPos += 2;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c362); }
-        }
-      }
-      if (s3 !== peg$FAILED) {
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          if (peg$c359.test(input.charAt(peg$currPos))) {
-            s3 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c360); }
-          }
-          if (s3 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c361) {
-              s3 = peg$c361;
-              peg$currPos += 2;
-            } else {
-              s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c362); }
-            }
-          }
-        }
-      } else {
-        s2 = peg$FAILED;
-      }
+      s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
           s3 = peg$c174;
@@ -7409,7 +7370,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c363(s2);
+          s1 = peg$c359(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7423,6 +7384,59 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+
+    return s0;
+  }
+
+  function peg$parseRegexpBody() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = [];
+    if (peg$c360.test(input.charAt(peg$currPos))) {
+      s2 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s2 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+    }
+    if (s2 === peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c362) {
+        s2 = peg$c362;
+        peg$currPos += 2;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c363); }
+      }
+    }
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        if (peg$c360.test(input.charAt(peg$currPos))) {
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c361); }
+        }
+        if (s2 === peg$FAILED) {
+          if (input.substr(peg$currPos, 2) === peg$c362) {
+            s2 = peg$c362;
+            peg$currPos += 2;
+          } else {
+            s2 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c363); }
+          }
+        }
+      }
+    } else {
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c102();
+    }
+    s0 = s1;
 
     return s0;
   }

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -138,7 +138,7 @@ function peg$parse(input, options) {
 
   var peg$FAILED = {},
 
-      peg$startRuleFunctions = { start: peg$parsestart, Expression: peg$parseExpression },
+      peg$startRuleFunctions = { start: peg$parsestart, Expr: peg$parseExpr },
       peg$startRuleFunction  = peg$parsestart,
 
       peg$c0 = function(ast) { return ast },
@@ -154,70 +154,61 @@ function peg$parse(input, options) {
             }
           },
       peg$c3 = function(s) {
+            // XXX does this ever match?  Rule above shoul;d match first
             return {"op": "SequentialProc", "procs": [s]}
           },
-      peg$c4 = function(first, rest) {
-            if (rest) {
-              return [first, ... rest]
-            } else {
-              return [first]
-            }
-          },
-      peg$c5 = "|",
-      peg$c6 = peg$literalExpectation("|", false),
-      peg$c7 = function(p) { return p },
-      peg$c8 = function(expr) {
+      peg$c4 = function(expr) {
             return {"op": "FilterProc", "filter": expr}
           },
-      peg$c9 = function(first, rest) {
+      peg$c5 = function(first, rest) {
             return makeChain(first, rest, "LogicalOr")
           },
-      peg$c10 = function(t) { return t },
-      peg$c11 = function(first, rest) {
+      peg$c6 = function(t) { return t },
+      peg$c7 = function(first, rest) {
             return makeChain(first, rest, "LogicalAnd")
           },
-      peg$c12 = function(f) { return f },
-      peg$c13 = "!",
-      peg$c14 = peg$literalExpectation("!", false),
-      peg$c15 = function(e) {
+      peg$c8 = function(f) { return f },
+      peg$c9 = "!",
+      peg$c10 = peg$literalExpectation("!", false),
+      peg$c11 = function(e) {
             return {"op": "LogicalNot", "expr": e}
           },
-      peg$c16 = "-",
-      peg$c17 = peg$literalExpectation("-", false),
-      peg$c18 = function(s) { return s },
-      peg$c19 = "(",
-      peg$c20 = peg$literalExpectation("(", false),
-      peg$c21 = ")",
-      peg$c22 = peg$literalExpectation(")", false),
-      peg$c23 = function(expr) { return expr },
-      peg$c24 = "*",
-      peg$c25 = peg$literalExpectation("*", false),
-      peg$c26 = function(comp, v) {
+      peg$c12 = "-",
+      peg$c13 = peg$literalExpectation("-", false),
+      peg$c14 = function(s) { return s },
+      peg$c15 = "(",
+      peg$c16 = peg$literalExpectation("(", false),
+      peg$c17 = ")",
+      peg$c18 = peg$literalExpectation(")", false),
+      peg$c19 = function(expr) { return expr },
+      peg$c20 = "*",
+      peg$c21 = peg$literalExpectation("*", false),
+      peg$c22 = function(comp, v) {
             return {"op": "CompareAny", "comparator": comp, "recursive": false, "value": v}
           },
-      peg$c27 = "**",
-      peg$c28 = peg$literalExpectation("**", false),
-      peg$c29 = function(comp, v) {
+      peg$c23 = "**",
+      peg$c24 = peg$literalExpectation("**", false),
+      peg$c25 = function(comp, v) {
             return {"op": "CompareAny", "comparator": comp, "recursive": true, "value": v}
           },
-      peg$c30 = function(f, comp, v) {
+      peg$c26 = function(f, comp, v) {
             return {"op": "CompareField", "comparator": comp, "field": f, "value": v}
           },
-      peg$c31 = "len",
-      peg$c32 = peg$literalExpectation("len", false),
-      peg$c33 = function(expr, comp, v) {
+      peg$c27 = "len",
+      peg$c28 = peg$literalExpectation("len", false),
+      peg$c29 = function(expr, comp, v) {
           return {"op": "BinaryExpression", "operator": comp, "lhs": expr, "rhs": v}
         },
-      peg$c34 = function(v) {
+      peg$c30 = function(v) {
             return {"op": "CompareAny", "comparator": "in", "recursive": false, "value": v}
           },
-      peg$c35 = function(v, f) {
+      peg$c31 = function(v, f) {
             return {"op": "CompareField", "comparator": "in", "field": f, "value": v}
           },
-      peg$c36 = function(v) {
+      peg$c32 = function(v) {
             return {"op": "Search", "text": text(), "value": v}
           },
-      peg$c37 = function(v) {
+      peg$c33 = function(v) {
             let str = v
             if (str == "*") {
               return {"op": "MatchAll"}
@@ -229,36 +220,49 @@ function peg$parse(input, options) {
             }
             return {"op": "Search", "text": text(), "value": literal}
           },
-      peg$c38 = function(i) { return i },
-      peg$c39 = function(v) { return v },
-      peg$c40 = function(v) {
+      peg$c34 = function(v) {
             return {"op": "Literal", "type": "string", "value": v}
           },
-      peg$c41 = function(v) {
+      peg$c35 = function(i) { return i },
+      peg$c36 = function(v) { return v },
+      peg$c37 = function(v) {
             return {"op": "Literal", "type": "regexp", "value": v}
           },
-      peg$c42 = function(v) {
+      peg$c38 = function(v) {
             return {"op": "Literal", "type": "net", "value": v}
           },
-      peg$c43 = function(v) {
+      peg$c39 = function(v) {
             return {"op": "Literal", "type": "ip", "value": v}
           },
-      peg$c44 = function(v) {
+      peg$c40 = function(v) {
             return {"op": "Literal", "type": "float64", "value": v}
           },
-      peg$c45 = function(v) {
+      peg$c41 = function(v) {
             return {"op": "Literal", "type": "int64", "value": v}
           },
-      peg$c46 = "true",
-      peg$c47 = peg$literalExpectation("true", false),
-      peg$c48 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
-      peg$c49 = "false",
-      peg$c50 = peg$literalExpectation("false", false),
-      peg$c51 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
-      peg$c52 = "null",
-      peg$c53 = peg$literalExpectation("null", false),
-      peg$c54 = function() { return {"op": "Literal", "type": "null"} },
-      peg$c55 = function(first, rest) {
+      peg$c42 = "true",
+      peg$c43 = peg$literalExpectation("true", false),
+      peg$c44 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
+      peg$c45 = "false",
+      peg$c46 = peg$literalExpectation("false", false),
+      peg$c47 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
+      peg$c48 = "null",
+      peg$c49 = peg$literalExpectation("null", false),
+      peg$c50 = function() { return {"op": "Literal", "type": "null"} },
+      peg$c51 = function(first, rest) {
+           if (rest) {
+              return [first, ... rest]
+            } else {
+              return [first]
+            }
+          },
+      peg$c52 = "|",
+      peg$c53 = peg$literalExpectation("|", false),
+      peg$c54 = function(p) { return p },
+      peg$c55 = function(proc) {
+            return proc
+          },
+      peg$c56 = function(first, rest) {
             let fp = {"op": "SequentialProc", "procs": first}
             if (rest) {
               return {"op": "ParallelProc", "procs": [fp, ... rest]}
@@ -266,467 +270,438 @@ function peg$parse(input, options) {
               return fp
             }
           },
-      peg$c56 = ";",
-      peg$c57 = peg$literalExpectation(";", false),
-      peg$c58 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
-      peg$c59 = function(proc) {
+      peg$c57 = ";",
+      peg$c58 = peg$literalExpectation(";", false),
+      peg$c59 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
+      peg$c60 = function(every, reducers, keys, limit) {
+            let p = {"op": "GroupByProc", "reducers": reducers}
+            if (every) {
+              p["duration"] = every
+            }
+            if (keys) {
+              p["keys"] = keys
+            }
+            if (limit) {
+              p["limit"] = limit
+            }
+            return p
+          },
+      peg$c61 = "every",
+      peg$c62 = peg$literalExpectation("every", true),
+      peg$c63 = function(dur) { return dur },
+      peg$c64 = "by",
+      peg$c65 = peg$literalExpectation("by", true),
+      peg$c66 = function(columns) { return columns },
+      peg$c67 = "with",
+      peg$c68 = peg$literalExpectation("with", false),
+      peg$c69 = "-limit",
+      peg$c70 = peg$literalExpectation("-limit", false),
+      peg$c71 = function(limit) { return limit },
+      peg$c72 = function(expr) { return {"op": "Assignment", "rhs": expr} },
+      peg$c73 = ",",
+      peg$c74 = peg$literalExpectation(",", false),
+      peg$c75 = function(first, expr) { return expr },
+      peg$c76 = function(first, rest) {
+            return [first, ... rest]
+          },
+      peg$c77 = "=",
+      peg$c78 = peg$literalExpectation("=", false),
+      peg$c79 = function(lval, reducer) {
+            return {"op": "Assignment", "lhs": lval, "rhs": reducer}
+          },
+      peg$c80 = function(reducer) {
+            return {"op": "Assignment", "rhs": reducer}
+          },
+      peg$c81 = "not",
+      peg$c82 = peg$literalExpectation("not", false),
+      peg$c83 = function(op, expr, where) {
+            let r = {"op": "Reducer", "operator": op, "where":where}
+            if (expr) {
+              r["expr"] = expr
+            }
+            return r
+          },
+      peg$c84 = "where",
+      peg$c85 = peg$literalExpectation("where", false),
+      peg$c86 = function(first, rest) {
+            let result = [first]
+            for(let  r of rest) {
+              result.push( r[3])
+            }
+            return result
+          },
+      peg$c87 = "sort",
+      peg$c88 = peg$literalExpectation("sort", true),
+      peg$c89 = function(args, l) { return l },
+      peg$c90 = function(args, list) {
+            let argm = args
+            let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false}
+            if ( "r" in argm) {
+              proc["sortdir"] = -1
+            }
+            if ( "nulls" in argm) {
+              if (argm["nulls"] == "first") {
+                proc["nullsfirst"] = true
+              }
+            }
             return proc
           },
-      peg$c60 = "by",
-      peg$c61 = peg$literalExpectation("by", true),
-      peg$c62 = function(columns) { return columns },
-      peg$c63 = function(expr) { return {"op": "Assignment", "rhs": expr} },
-      peg$c64 = ",",
-      peg$c65 = peg$literalExpectation(",", false),
-      peg$c66 = function(first, expr) { return expr },
-      peg$c67 = function(first, rest) {
-            return [first, ... rest]
-        },
-      peg$c68 = "every",
-      peg$c69 = peg$literalExpectation("every", true),
-      peg$c70 = function(dur) { return dur },
-      peg$c71 = "and",
-      peg$c72 = peg$literalExpectation("and", true),
-      peg$c73 = function() { return text() },
-      peg$c74 = "or",
-      peg$c75 = peg$literalExpectation("or", true),
-      peg$c76 = "in",
-      peg$c77 = peg$literalExpectation("in", true),
-      peg$c78 = "not",
-      peg$c79 = peg$literalExpectation("not", true),
-      peg$c80 = /^[A-Za-z_$]/,
-      peg$c81 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c82 = /^[0-9]/,
-      peg$c83 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c84 = function() { return {"op": "Identifier", "name": text()} },
-      peg$c85 = ".",
-      peg$c86 = peg$literalExpectation(".", false),
-      peg$c87 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
-      peg$c88 = function() { return {"op": "RootRecord"} },
-      peg$c89 = function(first, rest) {
-          return makeBinaryExprChain(first, rest)
-         },
-      peg$c90 = "[",
-      peg$c91 = peg$literalExpectation("[", false),
-      peg$c92 = "]",
-      peg$c93 = peg$literalExpectation("]", false),
-      peg$c94 = function(expr) { return ["[", expr] },
-      peg$c95 = function(id) { return [".", id] },
-      peg$c96 = function(fn, args) {
-                return {"op": "FunctionCall", "function": fn, "args": args}
-            },
-      peg$c97 = function(first, rest) {
-            let result = [first]
-
-            for(let  r of rest) {
-              result.push( r[3])
+      peg$c91 = function(a) { return a },
+      peg$c92 = function(args) { return makeArgMap(args) },
+      peg$c93 = "-r",
+      peg$c94 = peg$literalExpectation("-r", false),
+      peg$c95 = function() { return {"name": "r", "value": null} },
+      peg$c96 = "-nulls",
+      peg$c97 = peg$literalExpectation("-nulls", false),
+      peg$c98 = "first",
+      peg$c99 = peg$literalExpectation("first", false),
+      peg$c100 = "last",
+      peg$c101 = peg$literalExpectation("last", false),
+      peg$c102 = function() { return text() },
+      peg$c103 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c104 = "top",
+      peg$c105 = peg$literalExpectation("top", true),
+      peg$c106 = function(n) { return n},
+      peg$c107 = "-flush",
+      peg$c108 = peg$literalExpectation("-flush", false),
+      peg$c109 = function(limit, flush, f) { return f },
+      peg$c110 = function(limit, flush, fields) {
+            let proc = {"op": "TopProc"}
+            if (limit) {
+              proc["limit"] = limit
             }
-
-            return result
-        },
-      peg$c98 = function(first, rest) {
-            let result = [first]
-
-            for(let  r of rest) {
-              result.push( r[3])
+            if (fields) {
+              proc["fields"] = fields
             }
-
-            return result
+            if (flush) {
+             proc["flush"] = true
+            }
+            return proc
           },
-      peg$c99 = function(every, reducers, keys, limit) {
-          let p = {"op": "GroupByProc", "reducers": reducers}
-          if (keys) {
-            p["keys"] = keys
-          }
-          if (every) {
-            p["duration"] = every
-          }
-          if (limit) {
-            p["limit"] = limit
-          }
-          return p
-        },
-      peg$c100 = "=",
-      peg$c101 = peg$literalExpectation("=", false),
-      peg$c102 = function(lval, reducer) {
-            return {"op": "Assignment", "lhs": lval, "rhs": reducer}
-        },
-      peg$c103 = function(reducer) {
-            return {"op": "Assignment", "rhs": reducer}
-        },
-      peg$c104 = peg$literalExpectation("not", false),
-      peg$c105 = function(op, expr, where) {
-          let r = {"op": "Reducer", "operator": op, "where":where}
-          if (expr) {
-            r["expr"] = expr
-          }
-          return r
-        },
-      peg$c106 = "where",
-      peg$c107 = peg$literalExpectation("where", false),
-      peg$c108 = function(first, rest) {
-            let result = [first]
-            for(let  r of rest) {
-              result.push( r[3])
+      peg$c111 = "cut",
+      peg$c112 = peg$literalExpectation("cut", true),
+      peg$c113 = function(args, columns) {
+            let argm = args
+            let proc = {"op": "CutProc", "fields": columns, "complement": false}
+            if ( "c" in argm) {
+              proc["complement"] = true
             }
-            return result
+            return proc
           },
-      peg$c109 = "sort",
-      peg$c110 = peg$literalExpectation("sort", true),
-      peg$c111 = function(args, l) { return l },
-      peg$c112 = function(args, list) {
-          let argm = args
-          let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false}
-          if ( "r" in argm) {
-            proc["sortdir"] = -1
-          }
-          if ( "nulls" in argm) {
-            if (argm["nulls"] == "first") {
-              proc["nullsfirst"] = true
-            }
-          }
-          return proc
-        },
-      peg$c113 = function(a) { return a },
-      peg$c114 = function(args) {
-          return makeArgMap(args)
-      },
-      peg$c115 = "-r",
-      peg$c116 = peg$literalExpectation("-r", false),
-      peg$c117 = function() { return {"name": "r", "value": null} },
-      peg$c118 = "-nulls",
-      peg$c119 = peg$literalExpectation("-nulls", false),
-      peg$c120 = "first",
-      peg$c121 = peg$literalExpectation("first", false),
-      peg$c122 = "last",
-      peg$c123 = peg$literalExpectation("last", false),
-      peg$c124 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c125 = "top",
-      peg$c126 = peg$literalExpectation("top", true),
-      peg$c127 = function(n) { return n},
-      peg$c128 = "-flush",
-      peg$c129 = peg$literalExpectation("-flush", false),
-      peg$c130 = function(limit, flush, f) { return f },
-      peg$c131 = function(limit, flush, fields) {
-          let proc = {"op": "TopProc"}
-          if (limit) {
-            proc["limit"] = limit
-          }
-          if (fields) {
-            proc["fields"] = fields
-          }
-          if (flush) {
-            proc["flush"] = true
-          }
-          return proc
-        },
-      peg$c132 = "with",
-      peg$c133 = peg$literalExpectation("with", false),
-      peg$c134 = "-limit",
-      peg$c135 = peg$literalExpectation("-limit", false),
-      peg$c136 = function(limit) { return limit },
-      peg$c137 = "-c",
-      peg$c138 = peg$literalExpectation("-c", false),
-      peg$c139 = function() { return {"name": "c", "value": null} },
-      peg$c140 = function(args) {
-          return makeArgMap(args)
-        },
-      peg$c141 = "cut",
-      peg$c142 = peg$literalExpectation("cut", true),
-      peg$c143 = function(args, columns) {
-          let argm = args
-          let proc = {"op": "CutProc", "fields": columns, "complement": false}
-          if ( "c" in argm) {
-            proc["complement"] = true
-          }
-          return proc
-        },
-      peg$c144 = "head",
-      peg$c145 = peg$literalExpectation("head", true),
-      peg$c146 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c147 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c148 = "tail",
-      peg$c149 = peg$literalExpectation("tail", true),
-      peg$c150 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c151 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c152 = "filter",
-      peg$c153 = peg$literalExpectation("filter", true),
-      peg$c154 = "uniq",
-      peg$c155 = peg$literalExpectation("uniq", true),
-      peg$c156 = function() {
+      peg$c114 = "-c",
+      peg$c115 = peg$literalExpectation("-c", false),
+      peg$c116 = function() { return {"name": "c", "value": null} },
+      peg$c117 = function(args) {
+            return makeArgMap(args)
+          },
+      peg$c118 = "head",
+      peg$c119 = peg$literalExpectation("head", true),
+      peg$c120 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c121 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c122 = "tail",
+      peg$c123 = peg$literalExpectation("tail", true),
+      peg$c124 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c125 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c126 = "filter",
+      peg$c127 = peg$literalExpectation("filter", true),
+      peg$c128 = "uniq",
+      peg$c129 = peg$literalExpectation("uniq", true),
+      peg$c130 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c157 = function() {
+      peg$c131 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c158 = "put",
-      peg$c159 = peg$literalExpectation("put", true),
-      peg$c160 = function(columns) {
+      peg$c132 = "put",
+      peg$c133 = peg$literalExpectation("put", true),
+      peg$c134 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c161 = "rename",
-      peg$c162 = peg$literalExpectation("rename", true),
-      peg$c163 = function(first, cl) { return cl },
-      peg$c164 = function(first, rest) {
+      peg$c135 = "rename",
+      peg$c136 = peg$literalExpectation("rename", true),
+      peg$c137 = function(first, cl) { return cl },
+      peg$c138 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c165 = "fuse",
-      peg$c166 = peg$literalExpectation("fuse", true),
-      peg$c167 = function() {
+      peg$c139 = "fuse",
+      peg$c140 = peg$literalExpectation("fuse", true),
+      peg$c141 = function() {
             return {"op": "FuseProc"}
-        },
-      peg$c168 = function(lhs, rhs) { return {"lhs": lhs, "rhs": rhs} },
-      peg$c169 = "?",
-      peg$c170 = peg$literalExpectation("?", false),
-      peg$c171 = ":",
-      peg$c172 = peg$literalExpectation(":", false),
-      peg$c173 = function(condition, thenClause, elseClause) {
-          return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
-        },
-      peg$c174 = function(first, op, expr) { return [op, expr] },
-      peg$c175 = function(first, rest) {
+          },
+      peg$c142 = ".",
+      peg$c143 = peg$literalExpectation(".", false),
+      peg$c144 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
+      peg$c145 = function() { return {"op": "RootRecord"} },
+      peg$c146 = function(first, rest) {
+            let result = [first]
+
+            for(let  r of rest) {
+              result.push( r[3])
+            }
+
+            return result
+          },
+      peg$c147 = function(lhs, rhs) { return {"lhs": lhs, "rhs": rhs} },
+      peg$c148 = "?",
+      peg$c149 = peg$literalExpectation("?", false),
+      peg$c150 = ":",
+      peg$c151 = peg$literalExpectation(":", false),
+      peg$c152 = function(condition, thenClause, elseClause) {
+            return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
+          },
+      peg$c153 = function(first, op, expr) { return [op, expr] },
+      peg$c154 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c176 = function(first, comp, expr) { return [comp, expr] },
-      peg$c177 = "=~",
-      peg$c178 = peg$literalExpectation("=~", false),
-      peg$c179 = "!~",
-      peg$c180 = peg$literalExpectation("!~", false),
-      peg$c181 = "!=",
-      peg$c182 = peg$literalExpectation("!=", false),
-      peg$c183 = peg$literalExpectation("in", false),
-      peg$c184 = "<=",
-      peg$c185 = peg$literalExpectation("<=", false),
-      peg$c186 = "<",
-      peg$c187 = peg$literalExpectation("<", false),
-      peg$c188 = ">=",
-      peg$c189 = peg$literalExpectation(">=", false),
-      peg$c190 = ">",
-      peg$c191 = peg$literalExpectation(">", false),
-      peg$c192 = "+",
-      peg$c193 = peg$literalExpectation("+", false),
-      peg$c194 = "/",
-      peg$c195 = peg$literalExpectation("/", false),
-      peg$c196 = function(e) {
+      peg$c155 = function(first, comp, expr) { return [comp, expr] },
+      peg$c156 = "=~",
+      peg$c157 = peg$literalExpectation("=~", false),
+      peg$c158 = "!~",
+      peg$c159 = peg$literalExpectation("!~", false),
+      peg$c160 = "!=",
+      peg$c161 = peg$literalExpectation("!=", false),
+      peg$c162 = "in",
+      peg$c163 = peg$literalExpectation("in", false),
+      peg$c164 = "<=",
+      peg$c165 = peg$literalExpectation("<=", false),
+      peg$c166 = "<",
+      peg$c167 = peg$literalExpectation("<", false),
+      peg$c168 = ">=",
+      peg$c169 = peg$literalExpectation(">=", false),
+      peg$c170 = ">",
+      peg$c171 = peg$literalExpectation(">", false),
+      peg$c172 = "+",
+      peg$c173 = peg$literalExpectation("+", false),
+      peg$c174 = "/",
+      peg$c175 = peg$literalExpectation("/", false),
+      peg$c176 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c197 = function(e, typ) { return typ },
-      peg$c198 = function(e, typ) {
-          return {"op": "CastExpr", "expr": e, "type": typ}
-        },
-      peg$c199 = "bytes",
-      peg$c200 = peg$literalExpectation("bytes", false),
-      peg$c201 = "uint8",
-      peg$c202 = peg$literalExpectation("uint8", false),
-      peg$c203 = "uint16",
-      peg$c204 = peg$literalExpectation("uint16", false),
-      peg$c205 = "uint32",
-      peg$c206 = peg$literalExpectation("uint32", false),
-      peg$c207 = "uint64",
-      peg$c208 = peg$literalExpectation("uint64", false),
-      peg$c209 = "int8",
-      peg$c210 = peg$literalExpectation("int8", false),
-      peg$c211 = "int16",
-      peg$c212 = peg$literalExpectation("int16", false),
-      peg$c213 = "int32",
-      peg$c214 = peg$literalExpectation("int32", false),
-      peg$c215 = "int64",
-      peg$c216 = peg$literalExpectation("int64", false),
-      peg$c217 = "duration",
-      peg$c218 = peg$literalExpectation("duration", false),
-      peg$c219 = "time",
-      peg$c220 = peg$literalExpectation("time", false),
-      peg$c221 = "float64",
-      peg$c222 = peg$literalExpectation("float64", false),
-      peg$c223 = "bool",
-      peg$c224 = peg$literalExpectation("bool", false),
-      peg$c225 = "string",
-      peg$c226 = peg$literalExpectation("string", false),
-      peg$c227 = "bstring",
-      peg$c228 = peg$literalExpectation("bstring", false),
-      peg$c229 = "ip",
-      peg$c230 = peg$literalExpectation("ip", false),
-      peg$c231 = "net",
-      peg$c232 = peg$literalExpectation("net", false),
-      peg$c233 = "type",
-      peg$c234 = peg$literalExpectation("type", false),
-      peg$c235 = "error",
-      peg$c236 = peg$literalExpectation("error", false),
-      peg$c237 = function(first, rest) {
-          return makeBinaryExprChain(first, rest)
-        },
-      peg$c238 = function(fn, args) {
-              return {"op": "FunctionCall", "function": fn, "args": args}
+      peg$c177 = function(e, typ) { return typ },
+      peg$c178 = function(e, typ) {
+            return {"op": "CastExpr", "expr": e, "type": typ}
           },
-      peg$c239 = /^[A-Za-z]/,
-      peg$c240 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
-      peg$c241 = /^[.0-9]/,
-      peg$c242 = peg$classExpectation([".", ["0", "9"]], false, false),
-      peg$c243 = function(first, e) { return e },
-      peg$c244 = function() { return [] },
-      peg$c245 = peg$literalExpectation("and", false),
-      peg$c246 = "seconds",
-      peg$c247 = peg$literalExpectation("seconds", false),
-      peg$c248 = "second",
-      peg$c249 = peg$literalExpectation("second", false),
-      peg$c250 = "secs",
-      peg$c251 = peg$literalExpectation("secs", false),
-      peg$c252 = "sec",
-      peg$c253 = peg$literalExpectation("sec", false),
-      peg$c254 = "s",
-      peg$c255 = peg$literalExpectation("s", false),
-      peg$c256 = "minutes",
-      peg$c257 = peg$literalExpectation("minutes", false),
-      peg$c258 = "minute",
-      peg$c259 = peg$literalExpectation("minute", false),
-      peg$c260 = "mins",
-      peg$c261 = peg$literalExpectation("mins", false),
-      peg$c262 = "min",
-      peg$c263 = peg$literalExpectation("min", false),
-      peg$c264 = "m",
-      peg$c265 = peg$literalExpectation("m", false),
-      peg$c266 = "hours",
-      peg$c267 = peg$literalExpectation("hours", false),
-      peg$c268 = "hrs",
-      peg$c269 = peg$literalExpectation("hrs", false),
-      peg$c270 = "hr",
-      peg$c271 = peg$literalExpectation("hr", false),
-      peg$c272 = "h",
-      peg$c273 = peg$literalExpectation("h", false),
-      peg$c274 = "hour",
-      peg$c275 = peg$literalExpectation("hour", false),
-      peg$c276 = "days",
-      peg$c277 = peg$literalExpectation("days", false),
-      peg$c278 = "day",
-      peg$c279 = peg$literalExpectation("day", false),
-      peg$c280 = "d",
-      peg$c281 = peg$literalExpectation("d", false),
-      peg$c282 = "weeks",
-      peg$c283 = peg$literalExpectation("weeks", false),
-      peg$c284 = "week",
-      peg$c285 = peg$literalExpectation("week", false),
-      peg$c286 = "wks",
-      peg$c287 = peg$literalExpectation("wks", false),
-      peg$c288 = "wk",
-      peg$c289 = peg$literalExpectation("wk", false),
-      peg$c290 = "w",
-      peg$c291 = peg$literalExpectation("w", false),
-      peg$c292 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c293 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c294 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c295 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c296 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c297 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c298 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c299 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c300 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c301 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c302 = function(a) { return text() },
-      peg$c303 = function(a, b) {
+      peg$c179 = "bytes",
+      peg$c180 = peg$literalExpectation("bytes", false),
+      peg$c181 = "uint8",
+      peg$c182 = peg$literalExpectation("uint8", false),
+      peg$c183 = "uint16",
+      peg$c184 = peg$literalExpectation("uint16", false),
+      peg$c185 = "uint32",
+      peg$c186 = peg$literalExpectation("uint32", false),
+      peg$c187 = "uint64",
+      peg$c188 = peg$literalExpectation("uint64", false),
+      peg$c189 = "int8",
+      peg$c190 = peg$literalExpectation("int8", false),
+      peg$c191 = "int16",
+      peg$c192 = peg$literalExpectation("int16", false),
+      peg$c193 = "int32",
+      peg$c194 = peg$literalExpectation("int32", false),
+      peg$c195 = "int64",
+      peg$c196 = peg$literalExpectation("int64", false),
+      peg$c197 = "duration",
+      peg$c198 = peg$literalExpectation("duration", false),
+      peg$c199 = "time",
+      peg$c200 = peg$literalExpectation("time", false),
+      peg$c201 = "float64",
+      peg$c202 = peg$literalExpectation("float64", false),
+      peg$c203 = "bool",
+      peg$c204 = peg$literalExpectation("bool", false),
+      peg$c205 = "string",
+      peg$c206 = peg$literalExpectation("string", false),
+      peg$c207 = "bstring",
+      peg$c208 = peg$literalExpectation("bstring", false),
+      peg$c209 = "ip",
+      peg$c210 = peg$literalExpectation("ip", false),
+      peg$c211 = "net",
+      peg$c212 = peg$literalExpectation("net", false),
+      peg$c213 = "type",
+      peg$c214 = peg$literalExpectation("type", false),
+      peg$c215 = "error",
+      peg$c216 = peg$literalExpectation("error", false),
+      peg$c217 = function(first, rest) {
+            return makeBinaryExprChain(first, rest)
+          },
+      peg$c218 = function(fn, args) {
+            return {"op": "FunctionCall", "function": fn, "args": args}
+          },
+      peg$c219 = /^[A-Za-z]/,
+      peg$c220 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
+      peg$c221 = /^[.0-9]/,
+      peg$c222 = peg$classExpectation([".", ["0", "9"]], false, false),
+      peg$c223 = function(first, e) { return e },
+      peg$c224 = function() { return [] },
+      peg$c225 = "[",
+      peg$c226 = peg$literalExpectation("[", false),
+      peg$c227 = "]",
+      peg$c228 = peg$literalExpectation("]", false),
+      peg$c229 = function(expr) { return ["[", expr] },
+      peg$c230 = function(id) { return [".", id] },
+      peg$c231 = "and",
+      peg$c232 = peg$literalExpectation("and", true),
+      peg$c233 = "or",
+      peg$c234 = peg$literalExpectation("or", true),
+      peg$c235 = peg$literalExpectation("in", true),
+      peg$c236 = peg$literalExpectation("not", true),
+      peg$c237 = /^[A-Za-z_$]/,
+      peg$c238 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c239 = /^[0-9]/,
+      peg$c240 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c241 = function() { return {"op": "Identifier", "name": text()} },
+      peg$c242 = peg$literalExpectation("and", false),
+      peg$c243 = "seconds",
+      peg$c244 = peg$literalExpectation("seconds", false),
+      peg$c245 = "second",
+      peg$c246 = peg$literalExpectation("second", false),
+      peg$c247 = "secs",
+      peg$c248 = peg$literalExpectation("secs", false),
+      peg$c249 = "sec",
+      peg$c250 = peg$literalExpectation("sec", false),
+      peg$c251 = "s",
+      peg$c252 = peg$literalExpectation("s", false),
+      peg$c253 = "minutes",
+      peg$c254 = peg$literalExpectation("minutes", false),
+      peg$c255 = "minute",
+      peg$c256 = peg$literalExpectation("minute", false),
+      peg$c257 = "mins",
+      peg$c258 = peg$literalExpectation("mins", false),
+      peg$c259 = "min",
+      peg$c260 = peg$literalExpectation("min", false),
+      peg$c261 = "m",
+      peg$c262 = peg$literalExpectation("m", false),
+      peg$c263 = "hours",
+      peg$c264 = peg$literalExpectation("hours", false),
+      peg$c265 = "hrs",
+      peg$c266 = peg$literalExpectation("hrs", false),
+      peg$c267 = "hr",
+      peg$c268 = peg$literalExpectation("hr", false),
+      peg$c269 = "h",
+      peg$c270 = peg$literalExpectation("h", false),
+      peg$c271 = "hour",
+      peg$c272 = peg$literalExpectation("hour", false),
+      peg$c273 = "days",
+      peg$c274 = peg$literalExpectation("days", false),
+      peg$c275 = "day",
+      peg$c276 = peg$literalExpectation("day", false),
+      peg$c277 = "d",
+      peg$c278 = peg$literalExpectation("d", false),
+      peg$c279 = "weeks",
+      peg$c280 = peg$literalExpectation("weeks", false),
+      peg$c281 = "week",
+      peg$c282 = peg$literalExpectation("week", false),
+      peg$c283 = "wks",
+      peg$c284 = peg$literalExpectation("wks", false),
+      peg$c285 = "wk",
+      peg$c286 = peg$literalExpectation("wk", false),
+      peg$c287 = "w",
+      peg$c288 = peg$literalExpectation("w", false),
+      peg$c289 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c290 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c291 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c292 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c293 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c294 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c295 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c296 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c297 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c298 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c299 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c304 = "::",
-      peg$c305 = peg$literalExpectation("::", false),
-      peg$c306 = function(a, b, d, e) {
+      peg$c300 = "::",
+      peg$c301 = peg$literalExpectation("::", false),
+      peg$c302 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c307 = function(a, b) {
+      peg$c303 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c308 = function(a, b) {
+      peg$c304 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c309 = function() {
+      peg$c305 = function() {
             return "::"
           },
-      peg$c310 = function(v) { return ":" + v },
-      peg$c311 = function(v) { return v + ":" },
-      peg$c312 = function(a, m) {
+      peg$c306 = function(v) { return ":" + v },
+      peg$c307 = function(v) { return v + ":" },
+      peg$c308 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c313 = function(a, m) {
+      peg$c309 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c314 = function(s) { return parseInt(s) },
-      peg$c315 = /^[+\-]/,
-      peg$c316 = peg$classExpectation(["+", "-"], false, false),
-      peg$c317 = function(s) {
-            return parseFloat(s)
-        },
-      peg$c318 = function() {
+      peg$c310 = function(s) { return parseInt(s) },
+      peg$c311 = function() {
             return text()
           },
-      peg$c319 = "0",
-      peg$c320 = peg$literalExpectation("0", false),
-      peg$c321 = /^[1-9]/,
-      peg$c322 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c323 = "e",
-      peg$c324 = peg$literalExpectation("e", true),
-      peg$c325 = function(chars) { return text() },
-      peg$c326 = /^[0-9a-fA-F]/,
-      peg$c327 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c328 = function(chars) { return joinChars(chars) },
-      peg$c329 = "\\",
-      peg$c330 = peg$literalExpectation("\\", false),
-      peg$c331 = /^[\0-\x1F\\(),!><="|';:]/,
-      peg$c332 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
-      peg$c333 = peg$anyExpectation(),
-      peg$c334 = "\"",
-      peg$c335 = peg$literalExpectation("\"", false),
-      peg$c336 = function(v) { return joinChars(v) },
-      peg$c337 = "'",
-      peg$c338 = peg$literalExpectation("'", false),
-      peg$c339 = "x",
-      peg$c340 = peg$literalExpectation("x", false),
-      peg$c341 = function() { return "\\" + text() },
-      peg$c342 = "b",
-      peg$c343 = peg$literalExpectation("b", false),
-      peg$c344 = function() { return "\b" },
-      peg$c345 = "f",
-      peg$c346 = peg$literalExpectation("f", false),
-      peg$c347 = function() { return "\f" },
-      peg$c348 = "n",
-      peg$c349 = peg$literalExpectation("n", false),
-      peg$c350 = function() { return "\n" },
-      peg$c351 = "r",
-      peg$c352 = peg$literalExpectation("r", false),
-      peg$c353 = function() { return "\r" },
-      peg$c354 = "t",
-      peg$c355 = peg$literalExpectation("t", false),
-      peg$c356 = function() { return "\t" },
-      peg$c357 = "v",
-      peg$c358 = peg$literalExpectation("v", false),
-      peg$c359 = function() { return "\v" },
-      peg$c360 = function() { return "=" },
-      peg$c361 = function() { return "\\*" },
-      peg$c362 = "u",
-      peg$c363 = peg$literalExpectation("u", false),
-      peg$c364 = function(chars) {
+      peg$c312 = "e",
+      peg$c313 = peg$literalExpectation("e", true),
+      peg$c314 = /^[+\-]/,
+      peg$c315 = peg$classExpectation(["+", "-"], false, false),
+      peg$c316 = /^[0-9a-fA-F]/,
+      peg$c317 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c318 = function(chars) { return joinChars(chars) },
+      peg$c319 = "\\",
+      peg$c320 = peg$literalExpectation("\\", false),
+      peg$c321 = /^[\0-\x1F\\(),!><="|';:]/,
+      peg$c322 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
+      peg$c323 = peg$anyExpectation(),
+      peg$c324 = "\"",
+      peg$c325 = peg$literalExpectation("\"", false),
+      peg$c326 = function(v) { return joinChars(v) },
+      peg$c327 = "'",
+      peg$c328 = peg$literalExpectation("'", false),
+      peg$c329 = "x",
+      peg$c330 = peg$literalExpectation("x", false),
+      peg$c331 = function() { return "\\" + text() },
+      peg$c332 = "b",
+      peg$c333 = peg$literalExpectation("b", false),
+      peg$c334 = function() { return "\b" },
+      peg$c335 = "f",
+      peg$c336 = peg$literalExpectation("f", false),
+      peg$c337 = function() { return "\f" },
+      peg$c338 = "n",
+      peg$c339 = peg$literalExpectation("n", false),
+      peg$c340 = function() { return "\n" },
+      peg$c341 = "r",
+      peg$c342 = peg$literalExpectation("r", false),
+      peg$c343 = function() { return "\r" },
+      peg$c344 = "t",
+      peg$c345 = peg$literalExpectation("t", false),
+      peg$c346 = function() { return "\t" },
+      peg$c347 = "v",
+      peg$c348 = peg$literalExpectation("v", false),
+      peg$c349 = function() { return "\v" },
+      peg$c350 = function() { return "=" },
+      peg$c351 = function() { return "\\*" },
+      peg$c352 = "u",
+      peg$c353 = peg$literalExpectation("u", false),
+      peg$c354 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c365 = "{",
-      peg$c366 = peg$literalExpectation("{", false),
-      peg$c367 = "}",
-      peg$c368 = peg$literalExpectation("}", false),
-      peg$c369 = /^[^\/\\]/,
-      peg$c370 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c371 = "\\/",
-      peg$c372 = peg$literalExpectation("\\/", false),
-      peg$c373 = /^[\0-\x1F\\]/,
-      peg$c374 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c375 = "\t",
-      peg$c376 = peg$literalExpectation("\t", false),
-      peg$c377 = "\x0B",
-      peg$c378 = peg$literalExpectation("\x0B", false),
-      peg$c379 = "\f",
-      peg$c380 = peg$literalExpectation("\f", false),
-      peg$c381 = " ",
-      peg$c382 = peg$literalExpectation(" ", false),
-      peg$c383 = "\xA0",
-      peg$c384 = peg$literalExpectation("\xA0", false),
-      peg$c385 = "\uFEFF",
-      peg$c386 = peg$literalExpectation("\uFEFF", false),
-      peg$c387 = peg$otherExpectation("whitespace"),
+      peg$c355 = "{",
+      peg$c356 = peg$literalExpectation("{", false),
+      peg$c357 = "}",
+      peg$c358 = peg$literalExpectation("}", false),
+      peg$c359 = /^[^\/\\]/,
+      peg$c360 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c361 = "\\/",
+      peg$c362 = peg$literalExpectation("\\/", false),
+      peg$c363 = function(body) { return body },
+      peg$c364 = /^[\0-\x1F\\]/,
+      peg$c365 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c366 = "\t",
+      peg$c367 = peg$literalExpectation("\t", false),
+      peg$c368 = "\x0B",
+      peg$c369 = peg$literalExpectation("\x0B", false),
+      peg$c370 = "\f",
+      peg$c371 = peg$literalExpectation("\f", false),
+      peg$c372 = " ",
+      peg$c373 = peg$literalExpectation(" ", false),
+      peg$c374 = "\xA0",
+      peg$c375 = peg$literalExpectation("\xA0", false),
+      peg$c376 = "\uFEFF",
+      peg$c377 = peg$literalExpectation("\uFEFF", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -870,7 +845,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parsequery();
+      s2 = peg$parseQuery();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
@@ -899,11 +874,11 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsequery() {
+  function peg$parseQuery() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parseprocChain();
+    s1 = peg$parseSequentialProcs();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
       s1 = peg$c1(s1);
@@ -911,15 +886,15 @@ function peg$parse(input, options) {
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parsesearch();
+      s1 = peg$parseSearch();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
           s3 = [];
-          s4 = peg$parsechainedProc();
+          s4 = peg$parseSequentialTail();
           while (s4 !== peg$FAILED) {
             s3.push(s4);
-            s4 = peg$parsechainedProc();
+            s4 = peg$parseSequentialTail();
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
@@ -939,7 +914,7 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parsesearch();
+        s1 = peg$parseSearch();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$c3(s1);
@@ -951,104 +926,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseprocChain() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseproc();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parsechainedProc();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parsechainedProc();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c4(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsechainedProc() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parse__();
-    if (s1 !== peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 124) {
-        s2 = peg$c5;
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c6); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse__();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseproc();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c7(s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsesearch() {
+  function peg$parseSearch() {
     var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parsesearchExpr();
+    s1 = peg$parseSearchExpr();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c8(s1);
+      s1 = peg$c4(s1);
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsesearchExpr() {
+  function peg$parseSearchExpr() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parsesearchTerm();
+    s1 = peg$parseSearchTerm();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseoredSearchTerm();
+      s3 = peg$parseOredSearchTerm();
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$parseoredSearchTerm();
+        s3 = peg$parseOredSearchTerm();
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c9(s1, s2);
+        s1 = peg$c5(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1062,20 +968,20 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseoredSearchTerm() {
+  function peg$parseOredSearchTerm() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseorToken();
+      s2 = peg$parseOrToken();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parsesearchTerm();
+          s4 = peg$parseSearchTerm();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c10(s4);
+            s1 = peg$c6(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1097,21 +1003,21 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesearchTerm() {
+  function peg$parseSearchTerm() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parsesearchFactor();
+    s1 = peg$parseSearchFactor();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseandedSearchTerm();
+      s3 = peg$parseAndedSearchTerm();
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$parseandedSearchTerm();
+        s3 = peg$parseAndedSearchTerm();
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c11(s1, s2);
+        s1 = peg$c7(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1125,14 +1031,14 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseandedSearchTerm() {
+  function peg$parseAndedSearchTerm() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      s3 = peg$parseandToken();
+      s3 = peg$parseAndToken();
       if (s3 !== peg$FAILED) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
@@ -1150,10 +1056,10 @@ function peg$parse(input, options) {
         s2 = null;
       }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parsesearchFactor();
+        s3 = peg$parseSearchFactor();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c12(s3);
+          s1 = peg$c8(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1171,12 +1077,12 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesearchFactor() {
+  function peg$parseSearchFactor() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    s2 = peg$parsenotToken();
+    s2 = peg$parseNotToken();
     if (s2 !== peg$FAILED) {
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
@@ -1193,11 +1099,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c13;
+        s2 = peg$c9;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c14); }
+        if (peg$silentFails === 0) { peg$fail(peg$c10); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -1214,10 +1120,10 @@ function peg$parse(input, options) {
       }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parsesearchExpr();
+      s2 = peg$parseSearchExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c15(s2);
+        s1 = peg$c11(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1232,11 +1138,11 @@ function peg$parse(input, options) {
       s1 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c16;
+        s2 = peg$c12;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        if (peg$silentFails === 0) { peg$fail(peg$c13); }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -1246,10 +1152,10 @@ function peg$parse(input, options) {
         s1 = peg$FAILED;
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parsesearchPred();
+        s2 = peg$parseSearchPred();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c18(s2);
+          s1 = peg$c14(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1262,29 +1168,29 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c19;
+          s1 = peg$c15;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c20); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parsesearchExpr();
+            s3 = peg$parseSearchExpr();
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c21;
+                  s5 = peg$c17;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c22); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c23(s3);
+                  s1 = peg$c19(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1312,28 +1218,28 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesearchPred() {
+  function peg$parseSearchPred() {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c24;
+      s1 = peg$c20;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c25); }
+      if (peg$silentFails === 0) { peg$fail(peg$c21); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseequalityToken();
+        s3 = peg$parseEqualityToken();
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsesearchValue();
+            s5 = peg$parseSearchValue();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c26(s3, s5);
+              s1 = peg$c22(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1357,24 +1263,24 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c27) {
-        s1 = peg$c27;
+      if (input.substr(peg$currPos, 2) === peg$c23) {
+        s1 = peg$c23;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c28); }
+        if (peg$silentFails === 0) { peg$fail(peg$c24); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parseequalityToken();
+          s3 = peg$parseEqualityToken();
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
-              s5 = peg$parsesearchValue();
+              s5 = peg$parseSearchValue();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c29(s3, s5);
+                s1 = peg$c25(s3, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1398,18 +1304,18 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parseDerefExpression();
+        s1 = peg$parseDerefExpr();
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parseequalityToken();
+            s3 = peg$parseEqualityToken();
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                s5 = peg$parsesearchValue();
+                s5 = peg$parseSearchValue();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c30(s1, s3, s5);
+                  s1 = peg$c26(s1, s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1435,12 +1341,12 @@ function peg$parse(input, options) {
           s0 = peg$currPos;
           s1 = peg$currPos;
           peg$silentFails++;
-          if (input.substr(peg$currPos, 3) === peg$c31) {
-            s2 = peg$c31;
+          if (input.substr(peg$currPos, 3) === peg$c27) {
+            s2 = peg$c27;
             peg$currPos += 3;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c32); }
+            if (peg$silentFails === 0) { peg$fail(peg$c28); }
           }
           peg$silentFails--;
           if (s2 !== peg$FAILED) {
@@ -1450,18 +1356,18 @@ function peg$parse(input, options) {
             s1 = peg$FAILED;
           }
           if (s1 !== peg$FAILED) {
-            s2 = peg$parseFunctionExpr();
+            s2 = peg$parseFunction();
             if (s2 !== peg$FAILED) {
               s3 = peg$parse__();
               if (s3 !== peg$FAILED) {
-                s4 = peg$parseequalityToken();
+                s4 = peg$parseEqualityToken();
                 if (s4 !== peg$FAILED) {
                   s5 = peg$parse__();
                   if (s5 !== peg$FAILED) {
-                    s6 = peg$parsesearchValue();
+                    s6 = peg$parseSearchValue();
                     if (s6 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c33(s2, s4, s6);
+                      s1 = peg$c29(s2, s4, s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1489,24 +1395,24 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            s1 = peg$parsesearchValue();
+            s1 = peg$parseSearchValue();
             if (s1 !== peg$FAILED) {
               s2 = peg$parse__();
               if (s2 !== peg$FAILED) {
-                s3 = peg$parseinToken();
+                s3 = peg$parseInToken();
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse__();
                   if (s4 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 42) {
-                      s5 = peg$c24;
+                      s5 = peg$c20;
                       peg$currPos++;
                     } else {
                       s5 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c25); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c21); }
                     }
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c34(s1);
+                      s1 = peg$c30(s1);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1530,18 +1436,18 @@ function peg$parse(input, options) {
             }
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              s1 = peg$parsesearchValue();
+              s1 = peg$parseSearchValue();
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse__();
                 if (s2 !== peg$FAILED) {
-                  s3 = peg$parseinToken();
+                  s3 = peg$parseInToken();
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse__();
                     if (s4 !== peg$FAILED) {
-                      s5 = peg$parseDerefExpression();
+                      s5 = peg$parseDerefExpr();
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c35(s1, s5);
+                        s1 = peg$c31(s1, s5);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -1565,10 +1471,10 @@ function peg$parse(input, options) {
               }
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                s1 = peg$parsesearchLiteral();
+                s1 = peg$parseSearchLiteral();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c36(s1);
+                  s1 = peg$c32(s1);
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
@@ -1576,7 +1482,7 @@ function peg$parse(input, options) {
                   s1 = peg$currPos;
                   peg$silentFails++;
                   s2 = peg$currPos;
-                  s3 = peg$parsesearchKeywords();
+                  s3 = peg$parseSearchKeywords();
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse_();
                     if (s4 !== peg$FAILED) {
@@ -1598,10 +1504,10 @@ function peg$parse(input, options) {
                     s1 = peg$FAILED;
                   }
                   if (s1 !== peg$FAILED) {
-                    s2 = peg$parsesearchWord();
+                    s2 = peg$parseSearchWord();
                     if (s2 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c37(s2);
+                      s1 = peg$c33(s2);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1622,7 +1528,70 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesearchLiteral() {
+  function peg$parseSearchValue() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$parseSearchLiteral();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$currPos;
+      peg$silentFails++;
+      s2 = peg$currPos;
+      s3 = peg$parseSearchKeywords();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parse_();
+        if (s4 !== peg$FAILED) {
+          s3 = [s3, s4];
+          s2 = s3;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      peg$silentFails--;
+      if (s2 === peg$FAILED) {
+        s1 = void 0;
+      } else {
+        peg$currPos = s1;
+        s1 = peg$FAILED;
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseSearchWord();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c34(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchKeywords() {
+    var s0;
+
+    s0 = peg$parseAndToken();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseOrToken();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseInToken();
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchLiteral() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$parseStringLiteral();
@@ -1640,7 +1609,7 @@ function peg$parse(input, options) {
               if (s1 !== peg$FAILED) {
                 s2 = peg$currPos;
                 peg$silentFails++;
-                s3 = peg$parsesearchWord();
+                s3 = peg$parseSearchWord();
                 peg$silentFails--;
                 if (s3 === peg$FAILED) {
                   s2 = void 0;
@@ -1650,7 +1619,7 @@ function peg$parse(input, options) {
                 }
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c38(s1);
+                  s1 = peg$c35(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1665,7 +1634,7 @@ function peg$parse(input, options) {
                 s1 = peg$currPos;
                 peg$silentFails++;
                 s2 = peg$currPos;
-                s3 = peg$parsesearchKeywords();
+                s3 = peg$parseSearchKeywords();
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse_();
                   if (s4 !== peg$FAILED) {
@@ -1690,7 +1659,7 @@ function peg$parse(input, options) {
                   s2 = peg$parseBooleanLiteral();
                   if (s2 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c39(s2);
+                    s1 = peg$c36(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1705,7 +1674,7 @@ function peg$parse(input, options) {
                   s1 = peg$currPos;
                   peg$silentFails++;
                   s2 = peg$currPos;
-                  s3 = peg$parsesearchKeywords();
+                  s3 = peg$parseSearchKeywords();
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse_();
                     if (s4 !== peg$FAILED) {
@@ -1730,7 +1699,7 @@ function peg$parse(input, options) {
                     s2 = peg$parseNullLiteral();
                     if (s2 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c39(s2);
+                      s1 = peg$c36(s2);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1751,63 +1720,14 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesearchValue() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$parsesearchLiteral();
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$currPos;
-      peg$silentFails++;
-      s2 = peg$currPos;
-      s3 = peg$parsesearchKeywords();
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parse_();
-        if (s4 !== peg$FAILED) {
-          s3 = [s3, s4];
-          s2 = s3;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      peg$silentFails--;
-      if (s2 === peg$FAILED) {
-        s1 = void 0;
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parsesearchWord();
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c40(s2);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
   function peg$parseStringLiteral() {
     var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parsequotedString();
+    s1 = peg$parseQuotedString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c40(s1);
+      s1 = peg$c34(s1);
     }
     s0 = s1;
 
@@ -1818,10 +1738,10 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parsereString();
+    s1 = peg$parseRegexp();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c41(s1);
+      s1 = peg$c37(s1);
     }
     s0 = s1;
 
@@ -1832,7 +1752,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseip6subnet();
+    s1 = peg$parseIP6Net();
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
@@ -1846,7 +1766,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c42(s1);
+        s1 = peg$c38(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1858,10 +1778,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parsesubnet();
+      s1 = peg$parseIPNet();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c42(s1);
+        s1 = peg$c38(s1);
       }
       s0 = s1;
     }
@@ -1873,7 +1793,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseip6addr();
+    s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       peg$silentFails++;
@@ -1887,7 +1807,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c43(s1);
+        s1 = peg$c39(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1899,10 +1819,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseaddr();
+      s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c43(s1);
+        s1 = peg$c39(s1);
       }
       s0 = s1;
     }
@@ -1914,10 +1834,10 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parsesdouble();
+    s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c44(s1);
+      s1 = peg$c40(s1);
     }
     s0 = s1;
 
@@ -1928,10 +1848,10 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parsesinteger();
+    s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c45(s1);
+      s1 = peg$c41(s1);
     }
     s0 = s1;
 
@@ -1942,30 +1862,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c46) {
-      s1 = peg$c46;
+    if (input.substr(peg$currPos, 4) === peg$c42) {
+      s1 = peg$c42;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c47); }
+      if (peg$silentFails === 0) { peg$fail(peg$c43); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c48();
+      s1 = peg$c44();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c49) {
-        s1 = peg$c49;
+      if (input.substr(peg$currPos, 5) === peg$c45) {
+        s1 = peg$c45;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c50); }
+        if (peg$silentFails === 0) { peg$fail(peg$c46); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c51();
+        s1 = peg$c47();
       }
       s0 = s1;
     }
@@ -1977,51 +1897,37 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c52) {
-      s1 = peg$c52;
+    if (input.substr(peg$currPos, 4) === peg$c48) {
+      s1 = peg$c48;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c49); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c54();
+      s1 = peg$c50();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsesearchKeywords() {
-    var s0;
-
-    s0 = peg$parseandToken();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseorToken();
-      if (s0 === peg$FAILED) {
-        s0 = peg$parseinToken();
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseprocList() {
+  function peg$parseSequentialProcs() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseprocChain();
+    s1 = peg$parseProc();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseparallelChain();
+      s3 = peg$parseSequentialTail();
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$parseparallelChain();
+        s3 = peg$parseSequentialTail();
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c55(s1, s2);
+        s1 = peg$c51(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2035,26 +1941,26 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseparallelChain() {
+  function peg$parseSequentialTail() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 59) {
-        s2 = peg$c56;
+      if (input.charCodeAt(peg$currPos) === 124) {
+        s2 = peg$c52;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c57); }
+        if (peg$silentFails === 0) { peg$fail(peg$c53); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseprocChain();
+          s4 = peg$parseProc();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c58(s4);
+            s1 = peg$c54(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2076,38 +1982,38 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseproc() {
+  function peg$parseProc() {
     var s0, s1, s2, s3, s4, s5;
 
-    s0 = peg$parsesimpleProc();
+    s0 = peg$parseNamedProc();
     if (s0 === peg$FAILED) {
-      s0 = peg$parsegroupByProc();
+      s0 = peg$parseGroupByProc();
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c19;
+          s1 = peg$c15;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c20); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parseprocList();
+            s3 = peg$parseProcs();
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c21;
+                  s5 = peg$c17;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c22); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c18); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c59(s3);
+                  s1 = peg$c55(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -2135,18 +2041,172 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsegroupByKeys() {
+  function peg$parseProcs() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSequentialProcs();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseParallelTail();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseParallelTail();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c56(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseParallelTail() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parse__();
+    if (s1 !== peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 59) {
+        s2 = peg$c57;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c58); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse__();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseSequentialProcs();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c59(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseGroupByProc() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parseEveryDur();
+    if (s1 === peg$FAILED) {
+      s1 = null;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseReducers();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseGroupByKeys();
+        if (s3 === peg$FAILED) {
+          s3 = null;
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseLimitArg();
+          if (s4 === peg$FAILED) {
+            s4 = null;
+          }
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c60(s1, s2, s3, s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseEveryDur() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c61) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseDuration();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c63(s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseGroupByKeys() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c60) {
+      if (input.substr(peg$currPos, 2).toLowerCase() === peg$c64) {
         s2 = input.substr(peg$currPos, 2);
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+        if (peg$silentFails === 0) { peg$fail(peg$c65); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -2154,8 +2214,67 @@ function peg$parse(input, options) {
           s4 = peg$parseFlexAssignments();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c62(s4);
+            s1 = peg$c66(s4);
             s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseLimitArg() {
+    var s0, s1, s2, s3, s4, s5, s6;
+
+    s0 = peg$currPos;
+    s1 = peg$parse_();
+    if (s1 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 4) === peg$c67) {
+        s2 = peg$c67;
+        peg$currPos += 4;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse_();
+        if (s3 !== peg$FAILED) {
+          if (input.substr(peg$currPos, 6) === peg$c69) {
+            s4 = peg$c69;
+            peg$currPos += 6;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c70); }
+          }
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parse_();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parseUInt();
+              if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c71(s6);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -2182,10 +2301,10 @@ function peg$parse(input, options) {
     s0 = peg$parseAssignment();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseConditionalExpression();
+      s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c63(s1);
+        s1 = peg$c72(s1);
       }
       s0 = s1;
     }
@@ -2204,11 +2323,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c64;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2216,7 +2335,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c66(s1, s7);
+              s4 = peg$c75(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2240,11 +2359,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c64;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2252,7 +2371,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c66(s1, s7);
+                s4 = peg$c75(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2273,705 +2392,8 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c67(s1, s2);
+        s1 = peg$c76(s1, s2);
         s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseeveryDur() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c68) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseduration();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse_();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c70(s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseequalityToken() {
-    var s0;
-
-    s0 = peg$parseEqualityOperator();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseRelativeOperator();
-    }
-
-    return s0;
-  }
-
-  function peg$parseandToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c71) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c72); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseorToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c74) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c75); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseinToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c76) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c77); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parsenotToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c78) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c79); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseIdentifierName() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseIdentifierStart();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseIdentifierRest();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseIdentifierRest();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c73();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseIdentifierStart() {
-    var s0;
-
-    if (peg$c80.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c81); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseIdentifierRest() {
-    var s0;
-
-    s0 = peg$parseIdentifierStart();
-    if (s0 === peg$FAILED) {
-      if (peg$c82.test(input.charAt(peg$currPos))) {
-        s0 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c83); }
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseIdentifier() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseIdentifierStart();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseIdentifierRest();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseIdentifierRest();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c84();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseRootField() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c85;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c86); }
-    }
-    if (s1 === peg$FAILED) {
-      s1 = null;
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseBooleanLiteral();
-      if (s3 === peg$FAILED) {
-        s3 = peg$parseNullLiteral();
-      }
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseIdentifier();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c87(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c85;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$currPos;
-        peg$silentFails++;
-        s3 = peg$parseIdentifier();
-        peg$silentFails--;
-        if (s3 === peg$FAILED) {
-          s2 = void 0;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c88();
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseDerefExpression() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseRootField();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseDeref();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseDeref();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c89(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseDeref() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c90;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c91); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseConditionalExpression();
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c92;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c93); }
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c94(s2);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c85;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$currPos;
-        peg$silentFails++;
-        if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c85;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
-        }
-        peg$silentFails--;
-        if (s3 === peg$FAILED) {
-          s2 = void 0;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parseIdentifier();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c95(s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseFunctionExpr() {
-    var s0, s1, s2, s3, s4, s5;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFunctionName();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c19;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c20); }
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseArgumentList();
-          if (s4 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c21;
-              peg$currPos++;
-            } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c22); }
-            }
-            if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c96(s1, s4);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsefieldExprList() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseDerefExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c64;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseDerefExpression();
-            if (s7 !== peg$FAILED) {
-              s4 = [s4, s5, s6, s7];
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c64;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseDerefExpression();
-              if (s7 !== peg$FAILED) {
-                s4 = [s4, s5, s6, s7];
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c97(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseExprList() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseConditionalExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c64;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseConditionalExpression();
-            if (s7 !== peg$FAILED) {
-              s4 = [s4, s5, s6, s7];
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c64;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseConditionalExpression();
-              if (s7 !== peg$FAILED) {
-                s4 = [s4, s5, s6, s7];
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c98(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsegroupByProc() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parseeveryDur();
-    if (s1 === peg$FAILED) {
-      s1 = null;
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parsereducerList();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parsegroupByKeys();
-        if (s3 === peg$FAILED) {
-          s3 = null;
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseprocLimitArg();
-          if (s4 === peg$FAILED) {
-            s4 = null;
-          }
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c99(s1, s2, s3, s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2988,22 +2410,22 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parseDerefExpression();
+    s1 = peg$parseDerefExpr();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c100;
+          s3 = peg$c77;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c101); }
+          if (peg$silentFails === 0) { peg$fail(peg$c78); }
         }
         if (s3 !== peg$FAILED) {
-          s4 = peg$parsereducer();
+          s4 = peg$parseReducer();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c102(s1, s4);
+            s1 = peg$c79(s1, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3023,10 +2445,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parsereducer();
+      s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c103(s1);
+        s1 = peg$c80(s1);
       }
       s0 = s1;
     }
@@ -3034,26 +2456,26 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsereducer() {
+  function peg$parseReducer() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
-    if (input.substr(peg$currPos, 3) === peg$c78) {
-      s2 = peg$c78;
+    if (input.substr(peg$currPos, 3) === peg$c81) {
+      s2 = peg$c81;
       peg$currPos += 3;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c104); }
+      if (peg$silentFails === 0) { peg$fail(peg$c82); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c31) {
-        s2 = peg$c31;
+      if (input.substr(peg$currPos, 3) === peg$c27) {
+        s2 = peg$c27;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c32); }
+        if (peg$silentFails === 0) { peg$fail(peg$c28); }
       }
     }
     peg$silentFails--;
@@ -3064,21 +2486,21 @@ function peg$parse(input, options) {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseFunctionName();
+      s2 = peg$parseFuncName();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c19;
+            s4 = peg$c15;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c20); }
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parseConditionalExpression();
+              s6 = peg$parseConditionalExpr();
               if (s6 === peg$FAILED) {
                 s6 = null;
               }
@@ -3086,20 +2508,20 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c21;
+                    s8 = peg$c17;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c22); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c18); }
                   }
                   if (s8 !== peg$FAILED) {
-                    s9 = peg$parsewhere();
+                    s9 = peg$parseWhereClause();
                     if (s9 === peg$FAILED) {
                       s9 = null;
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c105(s2, s6, s9);
+                      s1 = peg$c83(s2, s6, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -3141,26 +2563,26 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsewhere() {
+  function peg$parseWhereClause() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c106) {
-        s2 = peg$c106;
+      if (input.substr(peg$currPos, 5) === peg$c84) {
+        s2 = peg$c84;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseConditionalExpression();
+          s4 = peg$parseConditionalExpr();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c23(s4);
+            s1 = peg$c19(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3182,7 +2604,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsereducerList() {
+  function peg$parseReducers() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
@@ -3193,11 +2615,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c64;
+          s5 = peg$c73;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3228,11 +2650,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c64;
+            s5 = peg$c73;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3260,7 +2682,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c108(s1, s2);
+        s1 = peg$c86(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3274,28 +2696,28 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesimpleProc() {
+  function peg$parseNamedProc() {
     var s0;
 
-    s0 = peg$parsesort();
+    s0 = peg$parseSortProc();
     if (s0 === peg$FAILED) {
-      s0 = peg$parsetop();
+      s0 = peg$parseTopProc();
       if (s0 === peg$FAILED) {
-        s0 = peg$parsecut();
+        s0 = peg$parseCutProc();
         if (s0 === peg$FAILED) {
-          s0 = peg$parsehead();
+          s0 = peg$parseHeadProc();
           if (s0 === peg$FAILED) {
-            s0 = peg$parsetail();
+            s0 = peg$parseTailProc();
             if (s0 === peg$FAILED) {
-              s0 = peg$parsefilter();
+              s0 = peg$parseFilterProc();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseuniq();
+                s0 = peg$parseUniqProc();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseput();
+                  s0 = peg$parsePutProc();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parserename();
+                    s0 = peg$parseRenameProc();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parsefuse();
+                      s0 = peg$parseFuseProc();
                     }
                   }
                 }
@@ -3309,27 +2731,27 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesort() {
+  function peg$parseSortProc() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c109) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c87) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c110); }
+      if (peg$silentFails === 0) { peg$fail(peg$c88); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parsesortArgs();
+      s2 = peg$parseSortArgs();
       if (s2 !== peg$FAILED) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          s5 = peg$parseExprList();
+          s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c111(s2, s5);
+            s4 = peg$c89(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -3344,7 +2766,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c112(s2, s3);
+          s1 = peg$c90(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3362,7 +2784,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesortArgs() {
+  function peg$parseSortArgs() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
@@ -3370,10 +2792,10 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     s3 = peg$parse_();
     if (s3 !== peg$FAILED) {
-      s4 = peg$parsesortArg();
+      s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c113(s4);
+        s3 = peg$c91(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3388,10 +2810,10 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        s4 = peg$parsesortArg();
+        s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c113(s4);
+          s3 = peg$c91(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3404,66 +2826,66 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c114(s1);
+      s1 = peg$c92(s1);
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsesortArg() {
+  function peg$parseSortArg() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c115) {
-      s1 = peg$c115;
+    if (input.substr(peg$currPos, 2) === peg$c93) {
+      s1 = peg$c93;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c116); }
+      if (peg$silentFails === 0) { peg$fail(peg$c94); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c117();
+      s1 = peg$c95();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c118) {
-        s1 = peg$c118;
+      if (input.substr(peg$currPos, 6) === peg$c96) {
+        s1 = peg$c96;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c119); }
+        if (peg$silentFails === 0) { peg$fail(peg$c97); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c120) {
-            s4 = peg$c120;
+          if (input.substr(peg$currPos, 5) === peg$c98) {
+            s4 = peg$c98;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c121); }
+            if (peg$silentFails === 0) { peg$fail(peg$c99); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c122) {
-              s4 = peg$c122;
+            if (input.substr(peg$currPos, 4) === peg$c100) {
+              s4 = peg$c100;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c123); }
+              if (peg$silentFails === 0) { peg$fail(peg$c101); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c73();
+            s4 = peg$c102();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c124(s3);
+            s1 = peg$c103(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3482,25 +2904,25 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsetop() {
+  function peg$parseTopProc() {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c125) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c104) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c126); }
+      if (peg$silentFails === 0) { peg$fail(peg$c105); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        s4 = peg$parseunsignedInteger();
+        s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c127(s4);
+          s3 = peg$c106(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3517,12 +2939,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c128) {
-            s5 = peg$c128;
+          if (input.substr(peg$currPos, 6) === peg$c107) {
+            s5 = peg$c107;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c129); }
+            if (peg$silentFails === 0) { peg$fail(peg$c108); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3542,10 +2964,10 @@ function peg$parse(input, options) {
           s4 = peg$currPos;
           s5 = peg$parse_();
           if (s5 !== peg$FAILED) {
-            s6 = peg$parsefieldExprList();
+            s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c130(s2, s3, s6);
+              s5 = peg$c109(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3560,7 +2982,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c131(s2, s3, s4);
+            s1 = peg$c110(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3582,37 +3004,837 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseprocLimitArg() {
-    var s0, s1, s2, s3, s4, s5, s6;
+  function peg$parseCutProc() {
+    var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parse_();
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c111) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c112); }
+    }
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c132) {
-        s2 = peg$c132;
-        peg$currPos += 4;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
-      }
+      s2 = peg$parseCutArgs();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c134) {
-            s4 = peg$c134;
-            peg$currPos += 6;
+          s4 = peg$parseFlexAssignments();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c113(s2, s4);
+            s0 = s1;
           } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c135); }
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseCutArgs() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parse_();
+    if (s3 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c114) {
+        s4 = peg$c114;
+        peg$currPos += 2;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+      }
+      if (s4 !== peg$FAILED) {
+        peg$savedPos = s2;
+        s3 = peg$c116();
+        s2 = s3;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$currPos;
+      s3 = peg$parse_();
+      if (s3 !== peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c114) {
+          s4 = peg$c114;
+          peg$currPos += 2;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        }
+        if (s4 !== peg$FAILED) {
+          peg$savedPos = s2;
+          s3 = peg$c116();
+          s2 = s3;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c117(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseHeadProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c118) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c119); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseUInt();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c120(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c118) {
+        s1 = input.substr(peg$currPos, 4);
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c121();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseTailProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c122) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c123); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseUInt();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c124(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c122) {
+        s1 = input.substr(peg$currPos, 4);
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c123); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c125();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseFilterProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c126) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c127); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseSearchExpr();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c4(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseUniqProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c129); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c114) {
+          s3 = peg$c114;
+          peg$currPos += 2;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c130();
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+        s1 = input.substr(peg$currPos, 4);
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c129); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c131();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parsePutProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c132) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c133); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseFlexAssignments();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c134(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseRenameProc() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c135) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c136); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseAssignment();
+        if (s3 !== peg$FAILED) {
+          s4 = [];
+          s5 = peg$currPos;
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 44) {
+              s7 = peg$c73;
+              peg$currPos++;
+            } else {
+              s7 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            }
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parse__();
+              if (s8 !== peg$FAILED) {
+                s9 = peg$parseAssignment();
+                if (s9 !== peg$FAILED) {
+                  peg$savedPos = s5;
+                  s6 = peg$c137(s3, s9);
+                  s5 = s6;
+                } else {
+                  peg$currPos = s5;
+                  s5 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s5;
+                s5 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+          while (s5 !== peg$FAILED) {
+            s4.push(s5);
+            s5 = peg$currPos;
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 44) {
+                s7 = peg$c73;
+                peg$currPos++;
+              } else {
+                s7 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c74); }
+              }
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parse__();
+                if (s8 !== peg$FAILED) {
+                  s9 = peg$parseAssignment();
+                  if (s9 !== peg$FAILED) {
+                    peg$savedPos = s5;
+                    s6 = peg$c137(s3, s9);
+                    s5 = s6;
+                  } else {
+                    peg$currPos = s5;
+                    s5 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s5;
+                  s5 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s5;
+                s5 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
           }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parse_();
+            peg$savedPos = s0;
+            s1 = peg$c138(s3, s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseFuseProc() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c141();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseRootField() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 46) {
+      s1 = peg$c142;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+    }
+    if (s1 === peg$FAILED) {
+      s1 = null;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseBooleanLiteral();
+      if (s3 === peg$FAILED) {
+        s3 = peg$parseNullLiteral();
+      }
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseIdentifier();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c144(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 46) {
+        s1 = peg$c142;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$currPos;
+        peg$silentFails++;
+        s3 = peg$parseIdentifier();
+        peg$silentFails--;
+        if (s3 === peg$FAILED) {
+          s2 = void 0;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c145();
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseFieldExprs() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseDerefExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c73;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseDerefExpr();
+            if (s7 !== peg$FAILED) {
+              s4 = [s4, s5, s6, s7];
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c73;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseDerefExpr();
+              if (s7 !== peg$FAILED) {
+                s4 = [s4, s5, s6, s7];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c146(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseExprs() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseConditionalExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c73;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseConditionalExpr();
+            if (s7 !== peg$FAILED) {
+              s4 = [s4, s5, s6, s7];
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c73;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseConditionalExpr();
+              if (s7 !== peg$FAILED) {
+                s4 = [s4, s5, s6, s7];
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c146(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAssignment() {
+    var s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    s1 = peg$parseDerefExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 61) {
+          s3 = peg$c77;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parseunsignedInteger();
+              peg$savedPos = s0;
+              s1 = peg$c147(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseExpr() {
+    var s0;
+
+    s0 = peg$parseConditionalExpr();
+
+    return s0;
+  }
+
+  function peg$parseConditionalExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    s0 = peg$currPos;
+    s1 = peg$parseLogicalORExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 63) {
+          s3 = peg$c148;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c149); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseConditionalExpr();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c136(s6);
-                s0 = s1;
+                if (input.charCodeAt(peg$currPos) === 58) {
+                  s7 = peg$c150;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c151); }
+                }
+                if (s7 !== peg$FAILED) {
+                  s8 = peg$parse__();
+                  if (s8 !== peg$FAILED) {
+                    s9 = peg$parseConditionalExpr();
+                    if (s9 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c152(s1, s5, s9);
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -3637,52 +3859,737 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseLogicalORExpr();
+    }
 
     return s0;
   }
 
-  function peg$parsecutArgs() {
+  function peg$parseLogicalORExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseLogicalANDExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseOrToken();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseLogicalANDExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c153(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseOrToken();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseLogicalANDExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c153(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c154(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseLogicalANDExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseEqualityCompareExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseAndToken();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseEqualityCompareExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c153(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseAndToken();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseEqualityCompareExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c153(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c154(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseEqualityCompareExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseRelativeExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseEqualityComparator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseRelativeExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c155(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseEqualityComparator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseRelativeExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c155(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c154(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseEqualityOperator() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2) === peg$c156) {
+      s1 = peg$c156;
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c158) {
+        s1 = peg$c158;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c159); }
+      }
+      if (s1 === peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 61) {
+          s1 = peg$c77;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+        }
+        if (s1 === peg$FAILED) {
+          if (input.substr(peg$currPos, 2) === peg$c160) {
+            s1 = peg$c160;
+            peg$currPos += 2;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c161); }
+          }
+        }
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c102();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseEqualityComparator() {
+    var s0, s1;
+
+    s0 = peg$parseEqualityOperator();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 2) === peg$c162) {
+        s1 = peg$c162;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c102();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseRelativeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseAdditiveExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseRelativeOperator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseAdditiveExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c153(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseRelativeOperator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseAdditiveExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c153(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c154(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseRelativeOperator() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2) === peg$c164) {
+      s1 = peg$c164;
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c165); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 60) {
+        s1 = peg$c166;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c167); }
+      }
+      if (s1 === peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c168) {
+          s1 = peg$c168;
+          peg$currPos += 2;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c169); }
+        }
+        if (s1 === peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 62) {
+            s1 = peg$c170;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c171); }
+          }
+        }
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c102();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseAdditiveExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseMultiplicativeExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseAdditiveOperator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseMultiplicativeExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c153(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseAdditiveOperator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseMultiplicativeExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c153(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c154(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAdditiveOperator() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 43) {
+      s1 = peg$c172;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c173); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 45) {
+        s1 = peg$c12;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c13); }
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c102();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseMultiplicativeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseNotExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseMultiplicativeOperator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseNotExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c153(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseMultiplicativeOperator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseNotExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c153(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c154(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseMultiplicativeOperator() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 42) {
+      s1 = peg$c20;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c21); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 47) {
+        s1 = peg$c174;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c102();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseNotExpr() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 33) {
+      s1 = peg$c9;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c10); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseNotExpr();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c176(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseCastExpr();
+    }
+
+    return s0;
+  }
+
+  function peg$parseCastExpr() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$currPos;
-    s3 = peg$parse_();
-    if (s3 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c137) {
-        s4 = peg$c137;
-        peg$currPos += 2;
-      } else {
-        s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c138); }
-      }
-      if (s4 !== peg$FAILED) {
-        peg$savedPos = s2;
-        s3 = peg$c139();
-        s2 = s3;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s2;
-      s2 = peg$FAILED;
-    }
-    while (s2 !== peg$FAILED) {
-      s1.push(s2);
+    s1 = peg$parseFuncExpr();
+    if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      s3 = peg$parse_();
+      if (input.charCodeAt(peg$currPos) === 58) {
+        s3 = peg$c150;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      }
       if (s3 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c137) {
-          s4 = peg$c137;
-          peg$currPos += 2;
-        } else {
-          s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c138); }
-        }
+        s4 = peg$parsePrimitiveType();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c139();
+          s3 = peg$c177(s1, s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3692,80 +4599,10 @@ function peg$parse(input, options) {
         peg$currPos = s2;
         s2 = peg$FAILED;
       }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c140(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parsecut() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c141) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c142); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parsecutArgs();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseFlexAssignments();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c143(s2, s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsehead() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c144) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c145); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseunsignedInteger();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c146(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+        peg$savedPos = s0;
+        s1 = peg$c178(s1, s2);
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3775,354 +4612,274 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c144) {
-        s1 = input.substr(peg$currPos, 4);
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c145); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c147();
-      }
-      s0 = s1;
+      s0 = peg$parseFuncExpr();
     }
 
     return s0;
   }
 
-  function peg$parsetail() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c148) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c149); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseunsignedInteger();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c150(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c148) {
-        s1 = input.substr(peg$currPos, 4);
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c149); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c151();
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parsefilter() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c152) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c153); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parsesearchExpr();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c8(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseuniq() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c137) {
-          s3 = peg$c137;
-          peg$currPos += 2;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c138); }
-        }
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c156();
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
-        s1 = input.substr(peg$currPos, 4);
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c157();
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseput() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c158) {
-      s1 = input.substr(peg$currPos, 3);
-      peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c159); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseFlexAssignments();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c160(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parserename() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c161) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c162); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseAssignment();
-        if (s3 !== peg$FAILED) {
-          s4 = [];
-          s5 = peg$currPos;
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c64;
-              peg$currPos++;
-            } else {
-              s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c65); }
-            }
-            if (s7 !== peg$FAILED) {
-              s8 = peg$parse__();
-              if (s8 !== peg$FAILED) {
-                s9 = peg$parseAssignment();
-                if (s9 !== peg$FAILED) {
-                  peg$savedPos = s5;
-                  s6 = peg$c163(s3, s9);
-                  s5 = s6;
-                } else {
-                  peg$currPos = s5;
-                  s5 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s5;
-                s5 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s5;
-              s5 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s5;
-            s5 = peg$FAILED;
-          }
-          while (s5 !== peg$FAILED) {
-            s4.push(s5);
-            s5 = peg$currPos;
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c64;
-                peg$currPos++;
-              } else {
-                s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c65); }
-              }
-              if (s7 !== peg$FAILED) {
-                s8 = peg$parse__();
-                if (s8 !== peg$FAILED) {
-                  s9 = peg$parseAssignment();
-                  if (s9 !== peg$FAILED) {
-                    peg$savedPos = s5;
-                    s6 = peg$c163(s3, s9);
-                    s5 = s6;
-                  } else {
-                    peg$currPos = s5;
-                    s5 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s5;
-                  s5 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s5;
-                s5 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s5;
-              s5 = peg$FAILED;
-            }
-          }
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c164(s3, s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsefuse() {
+  function peg$parsePrimitiveType() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c165) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
+    if (input.substr(peg$currPos, 5) === peg$c179) {
+      s1 = peg$c179;
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c166); }
+      if (peg$silentFails === 0) { peg$fail(peg$c180); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.substr(peg$currPos, 5) === peg$c181) {
+        s1 = peg$c181;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c182); }
+      }
+      if (s1 === peg$FAILED) {
+        if (input.substr(peg$currPos, 6) === peg$c183) {
+          s1 = peg$c183;
+          peg$currPos += 6;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c184); }
+        }
+        if (s1 === peg$FAILED) {
+          if (input.substr(peg$currPos, 6) === peg$c185) {
+            s1 = peg$c185;
+            peg$currPos += 6;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c186); }
+          }
+          if (s1 === peg$FAILED) {
+            if (input.substr(peg$currPos, 6) === peg$c187) {
+              s1 = peg$c187;
+              peg$currPos += 6;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c188); }
+            }
+            if (s1 === peg$FAILED) {
+              if (input.substr(peg$currPos, 4) === peg$c189) {
+                s1 = peg$c189;
+                peg$currPos += 4;
+              } else {
+                s1 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c190); }
+              }
+              if (s1 === peg$FAILED) {
+                if (input.substr(peg$currPos, 5) === peg$c191) {
+                  s1 = peg$c191;
+                  peg$currPos += 5;
+                } else {
+                  s1 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c192); }
+                }
+                if (s1 === peg$FAILED) {
+                  if (input.substr(peg$currPos, 5) === peg$c193) {
+                    s1 = peg$c193;
+                    peg$currPos += 5;
+                  } else {
+                    s1 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c194); }
+                  }
+                  if (s1 === peg$FAILED) {
+                    if (input.substr(peg$currPos, 5) === peg$c195) {
+                      s1 = peg$c195;
+                      peg$currPos += 5;
+                    } else {
+                      s1 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+                    }
+                    if (s1 === peg$FAILED) {
+                      if (input.substr(peg$currPos, 8) === peg$c197) {
+                        s1 = peg$c197;
+                        peg$currPos += 8;
+                      } else {
+                        s1 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+                      }
+                      if (s1 === peg$FAILED) {
+                        if (input.substr(peg$currPos, 4) === peg$c199) {
+                          s1 = peg$c199;
+                          peg$currPos += 4;
+                        } else {
+                          s1 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c200); }
+                        }
+                        if (s1 === peg$FAILED) {
+                          if (input.substr(peg$currPos, 7) === peg$c201) {
+                            s1 = peg$c201;
+                            peg$currPos += 7;
+                          } else {
+                            s1 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c202); }
+                          }
+                          if (s1 === peg$FAILED) {
+                            if (input.substr(peg$currPos, 4) === peg$c203) {
+                              s1 = peg$c203;
+                              peg$currPos += 4;
+                            } else {
+                              s1 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c204); }
+                            }
+                            if (s1 === peg$FAILED) {
+                              if (input.substr(peg$currPos, 5) === peg$c179) {
+                                s1 = peg$c179;
+                                peg$currPos += 5;
+                              } else {
+                                s1 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c180); }
+                              }
+                              if (s1 === peg$FAILED) {
+                                if (input.substr(peg$currPos, 6) === peg$c205) {
+                                  s1 = peg$c205;
+                                  peg$currPos += 6;
+                                } else {
+                                  s1 = peg$FAILED;
+                                  if (peg$silentFails === 0) { peg$fail(peg$c206); }
+                                }
+                                if (s1 === peg$FAILED) {
+                                  if (input.substr(peg$currPos, 7) === peg$c207) {
+                                    s1 = peg$c207;
+                                    peg$currPos += 7;
+                                  } else {
+                                    s1 = peg$FAILED;
+                                    if (peg$silentFails === 0) { peg$fail(peg$c208); }
+                                  }
+                                  if (s1 === peg$FAILED) {
+                                    if (input.substr(peg$currPos, 2) === peg$c209) {
+                                      s1 = peg$c209;
+                                      peg$currPos += 2;
+                                    } else {
+                                      s1 = peg$FAILED;
+                                      if (peg$silentFails === 0) { peg$fail(peg$c210); }
+                                    }
+                                    if (s1 === peg$FAILED) {
+                                      if (input.substr(peg$currPos, 3) === peg$c211) {
+                                        s1 = peg$c211;
+                                        peg$currPos += 3;
+                                      } else {
+                                        s1 = peg$FAILED;
+                                        if (peg$silentFails === 0) { peg$fail(peg$c212); }
+                                      }
+                                      if (s1 === peg$FAILED) {
+                                        if (input.substr(peg$currPos, 4) === peg$c213) {
+                                          s1 = peg$c213;
+                                          peg$currPos += 4;
+                                        } else {
+                                          s1 = peg$FAILED;
+                                          if (peg$silentFails === 0) { peg$fail(peg$c214); }
+                                        }
+                                        if (s1 === peg$FAILED) {
+                                          if (input.substr(peg$currPos, 5) === peg$c215) {
+                                            s1 = peg$c215;
+                                            peg$currPos += 5;
+                                          } else {
+                                            s1 = peg$FAILED;
+                                            if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                                          }
+                                          if (s1 === peg$FAILED) {
+                                            if (input.substr(peg$currPos, 4) === peg$c48) {
+                                              s1 = peg$c48;
+                                              peg$currPos += 4;
+                                            } else {
+                                              s1 = peg$FAILED;
+                                              if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c167();
+      s1 = peg$c102();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseAssignment() {
+  function peg$parseFuncExpr() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseFunction();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseDeref();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseDeref();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c217(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseDerefExpr();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parsePrimary();
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseFunction() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    s1 = peg$parseDerefExpression();
+    s1 = peg$parseFuncName();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c100;
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c15;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c101); }
+          if (peg$silentFails === 0) { peg$fail(peg$c16); }
         }
         if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
+          s4 = peg$parseArgumentList();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseConditionalExpression();
+            if (input.charCodeAt(peg$currPos) === 41) {
+              s5 = peg$c17;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c18); }
+            }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c168(s1, s5);
+              s1 = peg$c218(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4143,6 +4900,282 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseFuncName() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseFuncNameStart();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseFuncNameRest();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseFuncNameRest();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c102();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseFuncNameStart() {
+    var s0;
+
+    if (peg$c219.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c220); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseFuncNameRest() {
+    var s0;
+
+    s0 = peg$parseFuncNameStart();
+    if (s0 === peg$FAILED) {
+      if (peg$c221.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c222); }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseArgumentList() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseConditionalExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c73;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseConditionalExpr();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c223(s1, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c73;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseConditionalExpr();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c223(s1, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c76(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parse__();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c224();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseDerefExpr() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseRootField();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseDeref();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseDeref();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c217(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseDeref() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 91) {
+      s1 = peg$c225;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseConditionalExpr();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 93) {
+          s3 = peg$c227;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c228); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c229(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 46) {
+        s1 = peg$c142;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$currPos;
+        peg$silentFails++;
+        if (input.charCodeAt(peg$currPos) === 46) {
+          s3 = peg$c142;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c143); }
+        }
+        peg$silentFails--;
+        if (s3 === peg$FAILED) {
+          s2 = void 0;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseIdentifier();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c230(s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     }
 
     return s0;
@@ -4169,29 +5202,29 @@ function peg$parse(input, options) {
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 40) {
-                      s1 = peg$c19;
+                      s1 = peg$c15;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c20); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c16); }
                     }
                     if (s1 !== peg$FAILED) {
                       s2 = peg$parse__();
                       if (s2 !== peg$FAILED) {
-                        s3 = peg$parseConditionalExpression();
+                        s3 = peg$parseConditionalExpr();
                         if (s3 !== peg$FAILED) {
                           s4 = peg$parse__();
                           if (s4 !== peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 41) {
-                              s5 = peg$c21;
+                              s5 = peg$c17;
                               peg$currPos++;
                             } else {
                               s5 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c22); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c18); }
                             }
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c23(s3);
+                              s1 = peg$c19(s3);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4225,1148 +5258,112 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseExpression() {
+  function peg$parseEqualityToken() {
     var s0;
-
-    s0 = peg$parseConditionalExpression();
-
-    return s0;
-  }
-
-  function peg$parseConditionalExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
-
-    s0 = peg$currPos;
-    s1 = peg$parseLogicalORExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c169;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c170); }
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parse__();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseConditionalExpression();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
-              if (s6 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c171;
-                  peg$currPos++;
-                } else {
-                  s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c172); }
-                }
-                if (s7 !== peg$FAILED) {
-                  s8 = peg$parse__();
-                  if (s8 !== peg$FAILED) {
-                    s9 = peg$parseConditionalExpression();
-                    if (s9 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c173(s1, s5, s9);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseLogicalORExpression();
-    }
-
-    return s0;
-  }
-
-  function peg$parseLogicalORExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseLogicalANDExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseorToken();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseLogicalANDExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c174(s1, s5, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseorToken();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseLogicalANDExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c174(s1, s5, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c175(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseLogicalANDExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseEqualityCompareExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseandToken();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseEqualityCompareExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c174(s1, s5, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseandToken();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseEqualityCompareExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c174(s1, s5, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c175(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseEqualityCompareExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseRelativeExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseEqualityComparator();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseRelativeExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c176(s1, s5, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseEqualityComparator();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseRelativeExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c176(s1, s5, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c175(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseEqualityOperator() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c177) {
-      s1 = peg$c177;
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c178); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c179) {
-        s1 = peg$c179;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c180); }
-      }
-      if (s1 === peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c100;
-          peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c101); }
-        }
-        if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c181) {
-            s1 = peg$c181;
-            peg$currPos += 2;
-          } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c182); }
-          }
-        }
-      }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseEqualityComparator() {
-    var s0, s1;
 
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c76) {
-        s1 = peg$c76;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c73();
-      }
-      s0 = s1;
+      s0 = peg$parseRelativeOperator();
     }
 
     return s0;
   }
 
-  function peg$parseRelativeExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseAdditiveExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseRelativeOperator();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseAdditiveExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c174(s1, s5, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseRelativeOperator();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseAdditiveExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c174(s1, s5, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c175(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseRelativeOperator() {
+  function peg$parseAndToken() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c184) {
-      s1 = peg$c184;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c231) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c232); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c102();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseOrToken() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c233) {
+      s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c185); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c186;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c187); }
-      }
-      if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c188) {
-          s1 = peg$c188;
-          peg$currPos += 2;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c189); }
-        }
-        if (s1 === peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c190;
-            peg$currPos++;
-          } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c191); }
-          }
-        }
-      }
+      if (peg$silentFails === 0) { peg$fail(peg$c234); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c73();
+      s1 = peg$c102();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseAdditiveExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseMultiplicativeExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseAdditiveOperator();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseMultiplicativeExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c174(s1, s5, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseAdditiveOperator();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseMultiplicativeExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c174(s1, s5, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c175(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseAdditiveOperator() {
+  function peg$parseInToken() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c192;
-      peg$currPos++;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c162) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c193); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c16;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
-      }
+      if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c73();
+      s1 = peg$c102();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseMultiplicativeExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseNotExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        s5 = peg$parseMultiplicativeOperator();
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseNotExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c174(s1, s5, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          s5 = peg$parseMultiplicativeOperator();
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseNotExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c174(s1, s5, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c175(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseMultiplicativeOperator() {
+  function peg$parseNotToken() {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c24;
-      peg$currPos++;
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c81) {
+      s1 = input.substr(peg$currPos, 3);
+      peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c25); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c194;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c195); }
-      }
+      if (peg$silentFails === 0) { peg$fail(peg$c236); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c73();
+      s1 = peg$c102();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseNotExpression() {
+  function peg$parseIdentifierName() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c13;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c14); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseNotExpression();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c196(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseCastExpression();
-    }
-
-    return s0;
-  }
-
-  function peg$parseCastExpression() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFuncExpression();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      if (input.charCodeAt(peg$currPos) === 58) {
-        s3 = peg$c171;
-        peg$currPos++;
-      } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c172); }
-      }
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parsePrimitiveType();
-        if (s4 !== peg$FAILED) {
-          peg$savedPos = s2;
-          s3 = peg$c197(s1, s4);
-          s2 = s3;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c198(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseFuncExpression();
-    }
-
-    return s0;
-  }
-
-  function peg$parsePrimitiveType() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c199) {
-      s1 = peg$c199;
-      peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c200); }
-    }
-    if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c201) {
-        s1 = peg$c201;
-        peg$currPos += 5;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c202); }
-      }
-      if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c203) {
-          s1 = peg$c203;
-          peg$currPos += 6;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c204); }
-        }
-        if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c205) {
-            s1 = peg$c205;
-            peg$currPos += 6;
-          } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c206); }
-          }
-          if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c207) {
-              s1 = peg$c207;
-              peg$currPos += 6;
-            } else {
-              s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c208); }
-            }
-            if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4) === peg$c209) {
-                s1 = peg$c209;
-                peg$currPos += 4;
-              } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c210); }
-              }
-              if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c211) {
-                  s1 = peg$c211;
-                  peg$currPos += 5;
-                } else {
-                  s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c212); }
-                }
-                if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c213) {
-                    s1 = peg$c213;
-                    peg$currPos += 5;
-                  } else {
-                    s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c214); }
-                  }
-                  if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c215) {
-                      s1 = peg$c215;
-                      peg$currPos += 5;
-                    } else {
-                      s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c216); }
-                    }
-                    if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 8) === peg$c217) {
-                        s1 = peg$c217;
-                        peg$currPos += 8;
-                      } else {
-                        s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c218); }
-                      }
-                      if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c219) {
-                          s1 = peg$c219;
-                          peg$currPos += 4;
-                        } else {
-                          s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c220); }
-                        }
-                        if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 7) === peg$c221) {
-                            s1 = peg$c221;
-                            peg$currPos += 7;
-                          } else {
-                            s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c222); }
-                          }
-                          if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 4) === peg$c223) {
-                              s1 = peg$c223;
-                              peg$currPos += 4;
-                            } else {
-                              s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c224); }
-                            }
-                            if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 5) === peg$c199) {
-                                s1 = peg$c199;
-                                peg$currPos += 5;
-                              } else {
-                                s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c200); }
-                              }
-                              if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 6) === peg$c225) {
-                                  s1 = peg$c225;
-                                  peg$currPos += 6;
-                                } else {
-                                  s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c226); }
-                                }
-                                if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 7) === peg$c227) {
-                                    s1 = peg$c227;
-                                    peg$currPos += 7;
-                                  } else {
-                                    s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c228); }
-                                  }
-                                  if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c229) {
-                                      s1 = peg$c229;
-                                      peg$currPos += 2;
-                                    } else {
-                                      s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c230); }
-                                    }
-                                    if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c231) {
-                                        s1 = peg$c231;
-                                        peg$currPos += 3;
-                                      } else {
-                                        s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c232); }
-                                      }
-                                      if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c233) {
-                                          s1 = peg$c233;
-                                          peg$currPos += 4;
-                                        } else {
-                                          s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c234); }
-                                        }
-                                        if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 5) === peg$c235) {
-                                            s1 = peg$c235;
-                                            peg$currPos += 5;
-                                          } else {
-                                            s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c236); }
-                                          }
-                                          if (s1 === peg$FAILED) {
-                                            if (input.substr(peg$currPos, 4) === peg$c52) {
-                                              s1 = peg$c52;
-                                              peg$currPos += 4;
-                                            } else {
-                                              s1 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c53); }
-                                            }
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseFuncExpression() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFunctionCall();
+    s1 = peg$parseIdentifierStart();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseDeref();
+      s3 = peg$parseIdentifierRest();
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$parseDeref();
+        s3 = peg$parseIdentifierRest();
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c237(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseDerefExpression();
-      if (s0 === peg$FAILED) {
-        s0 = peg$parsePrimary();
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseFunctionCall() {
-    var s0, s1, s2, s3, s4, s5;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFunctionName();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
-      if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c19;
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c20); }
-        }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseArgumentList();
-          if (s4 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c21;
-              peg$currPos++;
-            } else {
-              s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c22); }
-            }
-            if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c238(s1, s4);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseFunctionName() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFunctionNameStart();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseFunctionNameRest();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseFunctionNameRest();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c73();
+        s1 = peg$c102();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5380,118 +5377,52 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseFunctionNameStart() {
+  function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c239.test(input.charAt(peg$currPos))) {
+    if (peg$c237.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
 
     return s0;
   }
 
-  function peg$parseFunctionNameRest() {
+  function peg$parseIdentifierRest() {
     var s0;
 
-    s0 = peg$parseFunctionNameStart();
+    s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c241.test(input.charAt(peg$currPos))) {
+      if (peg$c239.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c242); }
+        if (peg$silentFails === 0) { peg$fail(peg$c240); }
       }
     }
 
     return s0;
   }
 
-  function peg$parseArgumentList() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+  function peg$parseIdentifier() {
+    var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseConditionalExpression();
+    s1 = peg$parseIdentifierStart();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse__();
-      if (s4 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c64;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse__();
-          if (s6 !== peg$FAILED) {
-            s7 = peg$parseConditionalExpression();
-            if (s7 !== peg$FAILED) {
-              peg$savedPos = s3;
-              s4 = peg$c243(s1, s7);
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
+      s3 = peg$parseIdentifierRest();
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse__();
-        if (s4 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c64;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c65); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse__();
-            if (s6 !== peg$FAILED) {
-              s7 = peg$parseConditionalExpression();
-              if (s7 !== peg$FAILED) {
-                peg$savedPos = s3;
-                s4 = peg$c243(s1, s7);
-                s3 = s4;
-              } else {
-                peg$currPos = s3;
-                s3 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
+        s3 = peg$parseIdentifierRest();
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c67(s1, s2);
+        s1 = peg$c241();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5501,44 +5432,35 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parse__();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c244();
-      }
-      s0 = s1;
-    }
 
     return s0;
   }
 
-  function peg$parseduration() {
+  function peg$parseDuration() {
     var s0, s1, s2, s3, s4, s5;
 
-    s0 = peg$parseseconds();
+    s0 = peg$parseSeconds();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseminutes();
+      s0 = peg$parseMinutes();
       if (s0 === peg$FAILED) {
-        s0 = peg$parsehours();
+        s0 = peg$parseHours();
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parsehours();
+          s1 = peg$parseHours();
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c71) {
-                s3 = peg$c71;
+              if (input.substr(peg$currPos, 3) === peg$c231) {
+                s3 = peg$c231;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c245); }
+                if (peg$silentFails === 0) { peg$fail(peg$c242); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
                 if (s4 !== peg$FAILED) {
-                  s5 = peg$parseminutes();
+                  s5 = peg$parseMinutes();
                   if (s5 !== peg$FAILED) {
                     s1 = [s1, s2, s3, s4, s5];
                     s0 = s1;
@@ -5563,9 +5485,9 @@ function peg$parse(input, options) {
             s0 = peg$FAILED;
           }
           if (s0 === peg$FAILED) {
-            s0 = peg$parsedays();
+            s0 = peg$parseDays();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseweeks();
+              s0 = peg$parseWeeks();
             }
           }
         }
@@ -5575,47 +5497,47 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesec_abbrev() {
+  function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c246) {
-      s0 = peg$c246;
+    if (input.substr(peg$currPos, 7) === peg$c243) {
+      s0 = peg$c243;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c248) {
-        s0 = peg$c248;
+      if (input.substr(peg$currPos, 6) === peg$c245) {
+        s0 = peg$c245;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c249); }
+        if (peg$silentFails === 0) { peg$fail(peg$c246); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c250) {
-          s0 = peg$c250;
+        if (input.substr(peg$currPos, 4) === peg$c247) {
+          s0 = peg$c247;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c251); }
+          if (peg$silentFails === 0) { peg$fail(peg$c248); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c252) {
-            s0 = peg$c252;
+          if (input.substr(peg$currPos, 3) === peg$c249) {
+            s0 = peg$c249;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c253); }
+            if (peg$silentFails === 0) { peg$fail(peg$c250); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c254;
+              s0 = peg$c251;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c255); }
+              if (peg$silentFails === 0) { peg$fail(peg$c252); }
             }
           }
         }
@@ -5625,47 +5547,47 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsemin_abbrev() {
+  function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c256) {
-      s0 = peg$c256;
+    if (input.substr(peg$currPos, 7) === peg$c253) {
+      s0 = peg$c253;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c257); }
+      if (peg$silentFails === 0) { peg$fail(peg$c254); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c258) {
-        s0 = peg$c258;
+      if (input.substr(peg$currPos, 6) === peg$c255) {
+        s0 = peg$c255;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c259); }
+        if (peg$silentFails === 0) { peg$fail(peg$c256); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c260) {
-          s0 = peg$c260;
+        if (input.substr(peg$currPos, 4) === peg$c257) {
+          s0 = peg$c257;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c261); }
+          if (peg$silentFails === 0) { peg$fail(peg$c258); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c262) {
-            s0 = peg$c262;
+          if (input.substr(peg$currPos, 3) === peg$c259) {
+            s0 = peg$c259;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c263); }
+            if (peg$silentFails === 0) { peg$fail(peg$c260); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c264;
+              s0 = peg$c261;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c265); }
+              if (peg$silentFails === 0) { peg$fail(peg$c262); }
             }
           }
         }
@@ -5675,47 +5597,47 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsehour_abbrev() {
+  function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c266) {
-      s0 = peg$c266;
+    if (input.substr(peg$currPos, 5) === peg$c263) {
+      s0 = peg$c263;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c267); }
+      if (peg$silentFails === 0) { peg$fail(peg$c264); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c268) {
-        s0 = peg$c268;
+      if (input.substr(peg$currPos, 3) === peg$c265) {
+        s0 = peg$c265;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c269); }
+        if (peg$silentFails === 0) { peg$fail(peg$c266); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c270) {
-          s0 = peg$c270;
+        if (input.substr(peg$currPos, 2) === peg$c267) {
+          s0 = peg$c267;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c271); }
+          if (peg$silentFails === 0) { peg$fail(peg$c268); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c272;
+            s0 = peg$c269;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c273); }
+            if (peg$silentFails === 0) { peg$fail(peg$c270); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c274) {
-              s0 = peg$c274;
+            if (input.substr(peg$currPos, 4) === peg$c271) {
+              s0 = peg$c271;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c275); }
+              if (peg$silentFails === 0) { peg$fail(peg$c272); }
             }
           }
         }
@@ -5725,31 +5647,31 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseday_abbrev() {
+  function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c276) {
-      s0 = peg$c276;
+    if (input.substr(peg$currPos, 4) === peg$c273) {
+      s0 = peg$c273;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c274); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c278) {
-        s0 = peg$c278;
+      if (input.substr(peg$currPos, 3) === peg$c275) {
+        s0 = peg$c275;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c279); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c280;
+          s0 = peg$c277;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c281); }
+          if (peg$silentFails === 0) { peg$fail(peg$c278); }
         }
       }
     }
@@ -5757,47 +5679,47 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseweek_abbrev() {
+  function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c282) {
-      s0 = peg$c282;
+    if (input.substr(peg$currPos, 5) === peg$c279) {
+      s0 = peg$c279;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c283); }
+      if (peg$silentFails === 0) { peg$fail(peg$c280); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c284) {
-        s0 = peg$c284;
+      if (input.substr(peg$currPos, 4) === peg$c281) {
+        s0 = peg$c281;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c285); }
+        if (peg$silentFails === 0) { peg$fail(peg$c282); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c286) {
-          s0 = peg$c286;
+        if (input.substr(peg$currPos, 3) === peg$c283) {
+          s0 = peg$c283;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c287); }
+          if (peg$silentFails === 0) { peg$fail(peg$c284); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c288) {
-            s0 = peg$c288;
+          if (input.substr(peg$currPos, 2) === peg$c285) {
+            s0 = peg$c285;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c289); }
+            if (peg$silentFails === 0) { peg$fail(peg$c286); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c290;
+              s0 = peg$c287;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c291); }
+              if (peg$silentFails === 0) { peg$fail(peg$c288); }
             }
           }
         }
@@ -5807,32 +5729,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseseconds() {
+  function peg$parseSeconds() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c248) {
-      s1 = peg$c248;
+    if (input.substr(peg$currPos, 6) === peg$c245) {
+      s1 = peg$c245;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c249); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c292();
+      s1 = peg$c289();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseunsignedInteger();
+      s1 = peg$parseUInt();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parsesec_abbrev();
+          s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c293(s1);
+            s1 = peg$c290(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5851,32 +5773,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseminutes() {
+  function peg$parseMinutes() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c258) {
-      s1 = peg$c258;
+    if (input.substr(peg$currPos, 6) === peg$c255) {
+      s1 = peg$c255;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c259); }
+      if (peg$silentFails === 0) { peg$fail(peg$c256); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c294();
+      s1 = peg$c291();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseunsignedInteger();
+      s1 = peg$parseUInt();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parsemin_abbrev();
+          s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c295(s1);
+            s1 = peg$c292(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5895,32 +5817,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsehours() {
+  function peg$parseHours() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c274) {
-      s1 = peg$c274;
+    if (input.substr(peg$currPos, 4) === peg$c271) {
+      s1 = peg$c271;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c275); }
+      if (peg$silentFails === 0) { peg$fail(peg$c272); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c296();
+      s1 = peg$c293();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseunsignedInteger();
+      s1 = peg$parseUInt();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parsehour_abbrev();
+          s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c297(s1);
+            s1 = peg$c294(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5939,32 +5861,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsedays() {
+  function peg$parseDays() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c278) {
-      s1 = peg$c278;
+    if (input.substr(peg$currPos, 3) === peg$c275) {
+      s1 = peg$c275;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c298();
+      s1 = peg$c295();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseunsignedInteger();
+      s1 = peg$parseUInt();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parseday_abbrev();
+          s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c299(s1);
+            s1 = peg$c296(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5983,32 +5905,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseweeks() {
+  function peg$parseWeeks() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c284) {
-      s1 = peg$c284;
+    if (input.substr(peg$currPos, 4) === peg$c281) {
+      s1 = peg$c281;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c285); }
+      if (peg$silentFails === 0) { peg$fail(peg$c282); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c300();
+      s1 = peg$c297();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseunsignedInteger();
+      s1 = peg$parseUInt();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parseweek_abbrev();
+          s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c301(s1);
+            s1 = peg$c298(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6027,101 +5949,96 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseaddr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+  function peg$parseIP() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    s1 = peg$currPos;
-    s2 = peg$parseunsignedInteger();
-    if (s2 !== peg$FAILED) {
+    s1 = peg$parseUInt();
+    if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c85;
+        s2 = peg$c142;
         peg$currPos++;
       } else {
-        s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c143); }
       }
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parseunsignedInteger();
-        if (s4 !== peg$FAILED) {
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseUInt();
+        if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s5 = peg$c85;
+            s4 = peg$c142;
             peg$currPos++;
           } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c86); }
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c143); }
           }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parseunsignedInteger();
-            if (s6 !== peg$FAILED) {
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseUInt();
+            if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s7 = peg$c85;
+                s6 = peg$c142;
                 peg$currPos++;
               } else {
-                s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c86); }
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c143); }
               }
-              if (s7 !== peg$FAILED) {
-                s8 = peg$parseunsignedInteger();
-                if (s8 !== peg$FAILED) {
-                  s2 = [s2, s3, s4, s5, s6, s7, s8];
-                  s1 = s2;
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseUInt();
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c102();
+                  s0 = s1;
                 } else {
-                  peg$currPos = s1;
-                  s1 = peg$FAILED;
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
                 }
               } else {
-                peg$currPos = s1;
-                s1 = peg$FAILED;
+                peg$currPos = s0;
+                s0 = peg$FAILED;
               }
             } else {
-              peg$currPos = s1;
-              s1 = peg$FAILED;
+              peg$currPos = s0;
+              s0 = peg$FAILED;
             }
           } else {
-            peg$currPos = s1;
-            s1 = peg$FAILED;
+            peg$currPos = s0;
+            s0 = peg$FAILED;
           }
         } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
       } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
+        peg$currPos = s0;
+        s0 = peg$FAILED;
       }
     } else {
-      peg$currPos = s1;
-      s1 = peg$FAILED;
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c302(s1);
-    }
-    s0 = s1;
 
     return s0;
   }
 
-  function peg$parseip6addr() {
+  function peg$parseIP6() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     s1 = [];
-    s2 = peg$parseh_prepend();
+    s2 = peg$parseHexColon();
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        s2 = peg$parseh_prepend();
+        s2 = peg$parseHexColon();
       }
     } else {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseip6tail();
+      s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c303(s1, s2);
+        s1 = peg$c299(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6133,34 +6050,34 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseh16();
+      s1 = peg$parseHex();
       if (s1 !== peg$FAILED) {
         s2 = [];
-        s3 = peg$parseh_append();
+        s3 = peg$parseColonHex();
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          s3 = peg$parseh_append();
+          s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c304) {
-            s3 = peg$c304;
+          if (input.substr(peg$currPos, 2) === peg$c300) {
+            s3 = peg$c300;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c305); }
+            if (peg$silentFails === 0) { peg$fail(peg$c301); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
-            s5 = peg$parseh_prepend();
+            s5 = peg$parseHexColon();
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              s5 = peg$parseh_prepend();
+              s5 = peg$parseHexColon();
             }
             if (s4 !== peg$FAILED) {
-              s5 = peg$parseip6tail();
+              s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c306(s1, s2, s4, s5);
+                s1 = peg$c302(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6184,25 +6101,25 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c304) {
-          s1 = peg$c304;
+        if (input.substr(peg$currPos, 2) === peg$c300) {
+          s1 = peg$c300;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c305); }
+          if (peg$silentFails === 0) { peg$fail(peg$c301); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
-          s3 = peg$parseh_prepend();
+          s3 = peg$parseHexColon();
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            s3 = peg$parseh_prepend();
+            s3 = peg$parseHexColon();
           }
           if (s2 !== peg$FAILED) {
-            s3 = peg$parseip6tail();
+            s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c307(s2, s3);
+              s1 = peg$c303(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6218,25 +6135,25 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parseh16();
+          s1 = peg$parseHex();
           if (s1 !== peg$FAILED) {
             s2 = [];
-            s3 = peg$parseh_append();
+            s3 = peg$parseColonHex();
             while (s3 !== peg$FAILED) {
               s2.push(s3);
-              s3 = peg$parseh_append();
+              s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c304) {
-                s3 = peg$c304;
+              if (input.substr(peg$currPos, 2) === peg$c300) {
+                s3 = peg$c300;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c305); }
+                if (peg$silentFails === 0) { peg$fail(peg$c301); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c308(s1, s2);
+                s1 = peg$c304(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6252,16 +6169,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c304) {
-              s1 = peg$c304;
+            if (input.substr(peg$currPos, 2) === peg$c300) {
+              s1 = peg$c300;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c301); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c309();
+              s1 = peg$c305();
             }
             s0 = s1;
           }
@@ -6272,33 +6189,33 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseip6tail() {
+  function peg$parseIP6Tail() {
     var s0;
 
-    s0 = peg$parseaddr();
+    s0 = peg$parseIP();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseh16();
+      s0 = peg$parseHex();
     }
 
     return s0;
   }
 
-  function peg$parseh_append() {
+  function peg$parseColonHex() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c171;
+      s1 = peg$c150;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c172); }
+      if (peg$silentFails === 0) { peg$fail(peg$c151); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseh16();
+      s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c310(s2);
+        s1 = peg$c306(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6312,22 +6229,22 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseh_prepend() {
+  function peg$parseHexColon() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    s1 = peg$parseh16();
+    s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c171;
+        s2 = peg$c150;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c172); }
+        if (peg$silentFails === 0) { peg$fail(peg$c151); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c311(s1);
+        s1 = peg$c307(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6341,24 +6258,24 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesubnet() {
+  function peg$parseIPNet() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseaddr();
+    s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c194;
+        s2 = peg$c174;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c195); }
+        if (peg$silentFails === 0) { peg$fail(peg$c175); }
       }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseunsignedInteger();
+        s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c312(s1, s3);
+          s1 = peg$c308(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6376,24 +6293,24 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseip6subnet() {
+  function peg$parseIP6Net() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseip6addr();
+    s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c194;
+        s2 = peg$c174;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c195); }
+        if (peg$silentFails === 0) { peg$fail(peg$c175); }
       }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseunsignedInteger();
+        s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c313(s1, s3);
+          s1 = peg$c309(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6411,41 +6328,52 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseunsignedInteger() {
+  function peg$parseUInt() {
     var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parsesuint();
+    s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c314(s1);
+      s1 = peg$c310(s1);
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsesuint() {
+  function peg$parseIntString() {
+    var s0;
+
+    s0 = peg$parseUIntString();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseMinusIntString();
+    }
+
+    return s0;
+  }
+
+  function peg$parseUIntString() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c82.test(input.charAt(peg$currPos))) {
+    if (peg$c239.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c83); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c82.test(input.charAt(peg$currPos))) {
+        if (peg$c239.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c83); }
+          if (peg$silentFails === 0) { peg$fail(peg$c240); }
         }
       }
     } else {
@@ -6453,46 +6381,29 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c73();
+      s1 = peg$c102();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseinteger() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parsesinteger();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c314(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parsesinteger() {
+  function peg$parseMinusIntString() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c315.test(input.charAt(peg$currPos))) {
-      s1 = input.charAt(peg$currPos);
+    if (input.charCodeAt(peg$currPos) === 45) {
+      s1 = peg$c12;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
-    }
-    if (s1 === peg$FAILED) {
-      s1 = null;
+      if (peg$silentFails === 0) { peg$fail(peg$c13); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parsesuint();
+      s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c73();
+        s1 = peg$c102();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6506,72 +6417,82 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsedouble() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parsesdouble();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c317(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parsesdouble() {
+  function peg$parseFloatString() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c16;
+      s1 = peg$c12;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c17); }
+      if (peg$silentFails === 0) { peg$fail(peg$c13); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parsedoubleInteger();
+      if (peg$c239.test(input.charAt(peg$currPos))) {
+        s3 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          s3 = peg$parsedoubleInteger();
+          if (peg$c239.test(input.charAt(peg$currPos))) {
+            s3 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          }
         }
       } else {
         s2 = peg$FAILED;
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c85;
+          s3 = peg$c142;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+          if (peg$silentFails === 0) { peg$fail(peg$c143); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          s5 = peg$parsedoubleDigit();
+          if (peg$c239.test(input.charAt(peg$currPos))) {
+            s5 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              s5 = peg$parsedoubleDigit();
+              if (peg$c239.test(input.charAt(peg$currPos))) {
+                s5 = input.charAt(peg$currPos);
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c240); }
+              }
             }
           } else {
             s4 = peg$FAILED;
           }
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseexponentPart();
+            s5 = peg$parseExponentPart();
             if (s5 === peg$FAILED) {
               s5 = null;
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c318();
+              s1 = peg$c311();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6596,42 +6517,54 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c16;
+        s1 = peg$c12;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+        if (peg$silentFails === 0) { peg$fail(peg$c13); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c85;
+          s2 = peg$c142;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c86); }
+          if (peg$silentFails === 0) { peg$fail(peg$c143); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          s4 = peg$parsedoubleDigit();
+          if (peg$c239.test(input.charAt(peg$currPos))) {
+            s4 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              s4 = peg$parsedoubleDigit();
+              if (peg$c239.test(input.charAt(peg$currPos))) {
+                s4 = input.charAt(peg$currPos);
+                peg$currPos++;
+              } else {
+                s4 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c240); }
+              }
             }
           } else {
             s3 = peg$FAILED;
           }
           if (s3 !== peg$FAILED) {
-            s4 = peg$parseexponentPart();
+            s4 = peg$parseExponentPart();
             if (s4 === peg$FAILED) {
               s4 = null;
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c318();
+              s1 = peg$c311();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6654,90 +6587,37 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsedoubleInteger() {
+  function peg$parseExponentPart() {
     var s0, s1, s2, s3;
 
-    if (input.charCodeAt(peg$currPos) === 48) {
-      s0 = peg$c319;
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c312) {
+      s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c320); }
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c313); }
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (peg$c321.test(input.charAt(peg$currPos))) {
-        s1 = input.charAt(peg$currPos);
+    if (s1 !== peg$FAILED) {
+      if (peg$c314.test(input.charAt(peg$currPos))) {
+        s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c315); }
       }
-      if (s1 !== peg$FAILED) {
-        s2 = [];
-        if (peg$c82.test(input.charAt(peg$currPos))) {
-          s3 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c83); }
-        }
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          if (peg$c82.test(input.charAt(peg$currPos))) {
-            s3 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c83); }
-          }
-        }
-        if (s2 !== peg$FAILED) {
-          s1 = [s1, s2];
+      if (s2 === peg$FAILED) {
+        s2 = null;
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseUIntString();
+        if (s3 !== peg$FAILED) {
+          s1 = [s1, s2, s3];
           s0 = s1;
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parsedoubleDigit() {
-    var s0;
-
-    if (peg$c82.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c83); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseexponentPart() {
-    var s0, s1, s2;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c323) {
-      s1 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c324); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parsesinteger();
-      if (s2 !== peg$FAILED) {
-        s1 = [s1, s2];
-        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -6750,85 +6630,85 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseh16() {
+  function peg$parseHex() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = [];
-    s2 = peg$parsehexdigit();
+    s2 = peg$parseHexDigit();
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        s2 = peg$parsehexdigit();
+        s2 = peg$parseHexDigit();
       }
     } else {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c325(s1);
+      s1 = peg$c102();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsehexdigit() {
+  function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c326.test(input.charAt(peg$currPos))) {
+    if (peg$c316.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c327); }
+      if (peg$silentFails === 0) { peg$fail(peg$c317); }
     }
 
     return s0;
   }
 
-  function peg$parsesearchWord() {
+  function peg$parseSearchWord() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = [];
-    s2 = peg$parsesearchWordPart();
+    s2 = peg$parseSearchWordPart();
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        s2 = peg$parsesearchWordPart();
+        s2 = peg$parseSearchWordPart();
       }
     } else {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c328(s1);
+      s1 = peg$c318(s1);
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parsesearchWordPart() {
+  function peg$parseSearchWordPart() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c329;
+      s1 = peg$c319;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c320); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseescapeSequence();
+      s2 = peg$parseEscapeSequence();
       if (s2 === peg$FAILED) {
-        s2 = peg$parsesearchEscape();
+        s2 = peg$parseSearchEscape();
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c18(s2);
+        s1 = peg$c14(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6842,15 +6722,15 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c331.test(input.charAt(peg$currPos))) {
+      if (peg$c321.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c332); }
+        if (peg$silentFails === 0) { peg$fail(peg$c322); }
       }
       if (s2 === peg$FAILED) {
-        s2 = peg$parsews();
+        s2 = peg$parseWhiteSpace();
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
@@ -6865,11 +6745,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c333); }
+          if (peg$silentFails === 0) { peg$fail(peg$c323); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c73();
+          s1 = peg$c102();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6884,35 +6764,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsequotedString() {
+  function peg$parseQuotedString() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c334;
+      s1 = peg$c324;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parsedoubleQuotedChar();
+      s3 = peg$parseDoubleQuotedChar();
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$parsedoubleQuotedChar();
+        s3 = peg$parseDoubleQuotedChar();
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c334;
+          s3 = peg$c324;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c335); }
+          if (peg$silentFails === 0) { peg$fail(peg$c325); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c336(s2);
+          s1 = peg$c326(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6929,30 +6809,30 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c337;
+        s1 = peg$c327;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c338); }
+        if (peg$silentFails === 0) { peg$fail(peg$c328); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        s3 = peg$parsesingleQuotedChar();
+        s3 = peg$parseSingleQuotedChar();
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          s3 = peg$parsesingleQuotedChar();
+          s3 = peg$parseSingleQuotedChar();
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c337;
+            s3 = peg$c327;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c338); }
+            if (peg$silentFails === 0) { peg$fail(peg$c328); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c336(s2);
+            s1 = peg$c326(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6971,21 +6851,21 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsedoubleQuotedChar() {
+  function peg$parseDoubleQuotedChar() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c334;
+      s2 = peg$c324;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s2 === peg$FAILED) {
-      s2 = peg$parseescapedChar();
+      s2 = peg$parseEscapedChar();
     }
     peg$silentFails--;
     if (s2 === peg$FAILED) {
@@ -7000,11 +6880,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c333); }
+        if (peg$silentFails === 0) { peg$fail(peg$c323); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c73();
+        s1 = peg$c102();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7017,17 +6897,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c329;
+        s1 = peg$c319;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c330); }
+        if (peg$silentFails === 0) { peg$fail(peg$c320); }
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseescapeSequence();
+        s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c18(s2);
+          s1 = peg$c14(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7042,21 +6922,21 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesingleQuotedChar() {
+  function peg$parseSingleQuotedChar() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c337;
+      s2 = peg$c327;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c328); }
     }
     if (s2 === peg$FAILED) {
-      s2 = peg$parseescapedChar();
+      s2 = peg$parseEscapedChar();
     }
     peg$silentFails--;
     if (s2 === peg$FAILED) {
@@ -7071,11 +6951,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c333); }
+        if (peg$silentFails === 0) { peg$fail(peg$c323); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c73();
+        s1 = peg$c102();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7088,17 +6968,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c329;
+        s1 = peg$c319;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c330); }
+        if (peg$silentFails === 0) { peg$fail(peg$c320); }
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseescapeSequence();
+        s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c18(s2);
+          s1 = peg$c14(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7113,24 +6993,24 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseescapeSequence() {
+  function peg$parseEscapeSequence() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c339;
+      s1 = peg$c329;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c340); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parsehexdigit();
+      s2 = peg$parseHexDigit();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parsehexdigit();
+        s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c341();
+          s1 = peg$c331();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7145,123 +7025,123 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$parsesingleCharEscape();
+      s0 = peg$parseSingleCharEscape();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseunicodeEscape();
+        s0 = peg$parseUnicodeEscape();
       }
     }
 
     return s0;
   }
 
-  function peg$parsesingleCharEscape() {
+  function peg$parseSingleCharEscape() {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c337;
+      s0 = peg$c327;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c328); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c334;
+        s0 = peg$c324;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c335); }
+        if (peg$silentFails === 0) { peg$fail(peg$c325); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c329;
+          s0 = peg$c319;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c330); }
+          if (peg$silentFails === 0) { peg$fail(peg$c320); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c342;
+            s1 = peg$c332;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c343); }
+            if (peg$silentFails === 0) { peg$fail(peg$c333); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c344();
+            s1 = peg$c334();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c345;
+              s1 = peg$c335;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c346); }
+              if (peg$silentFails === 0) { peg$fail(peg$c336); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c347();
+              s1 = peg$c337();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c348;
+                s1 = peg$c338;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c349); }
+                if (peg$silentFails === 0) { peg$fail(peg$c339); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c350();
+                s1 = peg$c340();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c351;
+                  s1 = peg$c341;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c352); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c342); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c353();
+                  s1 = peg$c343();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c354;
+                    s1 = peg$c344;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c355); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c345); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c356();
+                    s1 = peg$c346();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c357;
+                      s1 = peg$c347;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c358); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c348); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c359();
+                      s1 = peg$c349();
                     }
                     s0 = s1;
                   }
@@ -7276,34 +7156,34 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsesearchEscape() {
+  function peg$parseSearchEscape() {
     var s0, s1;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c100;
+      s1 = peg$c77;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c101); }
+      if (peg$silentFails === 0) { peg$fail(peg$c78); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c360();
+      s1 = peg$c350();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c24;
+        s1 = peg$c20;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c25); }
+        if (peg$silentFails === 0) { peg$fail(peg$c21); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c361();
+        s1 = peg$c351();
       }
       s0 = s1;
     }
@@ -7311,26 +7191,26 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseunicodeEscape() {
+  function peg$parseUnicodeEscape() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c362;
+      s1 = peg$c352;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c363); }
+      if (peg$silentFails === 0) { peg$fail(peg$c353); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      s3 = peg$parsehexdigit();
+      s3 = peg$parseHexDigit();
       if (s3 !== peg$FAILED) {
-        s4 = peg$parsehexdigit();
+        s4 = peg$parseHexDigit();
         if (s4 !== peg$FAILED) {
-          s5 = peg$parsehexdigit();
+          s5 = peg$parseHexDigit();
           if (s5 !== peg$FAILED) {
-            s6 = peg$parsehexdigit();
+            s6 = peg$parseHexDigit();
             if (s6 !== peg$FAILED) {
               s3 = [s3, s4, s5, s6];
               s2 = s3;
@@ -7352,7 +7232,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c364(s2);
+        s1 = peg$c354(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7365,45 +7245,45 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c362;
+        s1 = peg$c352;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c363); }
+        if (peg$silentFails === 0) { peg$fail(peg$c353); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c365;
+          s2 = peg$c355;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c366); }
+          if (peg$silentFails === 0) { peg$fail(peg$c356); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          s4 = peg$parsehexdigit();
+          s4 = peg$parseHexDigit();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsehexdigit();
+            s5 = peg$parseHexDigit();
             if (s5 === peg$FAILED) {
               s5 = null;
             }
             if (s5 !== peg$FAILED) {
-              s6 = peg$parsehexdigit();
+              s6 = peg$parseHexDigit();
               if (s6 === peg$FAILED) {
                 s6 = null;
               }
               if (s6 !== peg$FAILED) {
-                s7 = peg$parsehexdigit();
+                s7 = peg$parseHexDigit();
                 if (s7 === peg$FAILED) {
                   s7 = null;
                 }
                 if (s7 !== peg$FAILED) {
-                  s8 = peg$parsehexdigit();
+                  s8 = peg$parseHexDigit();
                   if (s8 === peg$FAILED) {
                     s8 = null;
                   }
                   if (s8 !== peg$FAILED) {
-                    s9 = peg$parsehexdigit();
+                    s9 = peg$parseHexDigit();
                     if (s9 === peg$FAILED) {
                       s9 = null;
                     }
@@ -7436,15 +7316,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c367;
+              s4 = peg$c357;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c368); }
+              if (peg$silentFails === 0) { peg$fail(peg$c358); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c364(s3);
+              s1 = peg$c354(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7467,30 +7347,69 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsereString() {
+  function peg$parseRegexp() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c194;
+      s1 = peg$c174;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c195); }
+      if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parsereBody();
+      s2 = [];
+      if (peg$c359.test(input.charAt(peg$currPos))) {
+        s3 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c360); }
+      }
+      if (s3 === peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c361) {
+          s3 = peg$c361;
+          peg$currPos += 2;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c362); }
+        }
+      }
+      if (s3 !== peg$FAILED) {
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          if (peg$c359.test(input.charAt(peg$currPos))) {
+            s3 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c360); }
+          }
+          if (s3 === peg$FAILED) {
+            if (input.substr(peg$currPos, 2) === peg$c361) {
+              s3 = peg$c361;
+              peg$currPos += 2;
+            } else {
+              s3 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c362); }
+            }
+          }
+        }
+      } else {
+        s2 = peg$FAILED;
+      }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c194;
+          s3 = peg$c174;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c195); }
+          if (peg$silentFails === 0) { peg$fail(peg$c175); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c39(s2);
+          s1 = peg$c363(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7508,122 +7427,69 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsereBody() {
-    var s0, s1, s2;
-
-    s0 = peg$currPos;
-    s1 = [];
-    if (peg$c369.test(input.charAt(peg$currPos))) {
-      s2 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c370); }
-    }
-    if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c371) {
-        s2 = peg$c371;
-        peg$currPos += 2;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c372); }
-      }
-    }
-    if (s2 !== peg$FAILED) {
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        if (peg$c369.test(input.charAt(peg$currPos))) {
-          s2 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c370); }
-        }
-        if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c371) {
-            s2 = peg$c371;
-            peg$currPos += 2;
-          } else {
-            s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c372); }
-          }
-        }
-      }
-    } else {
-      s1 = peg$FAILED;
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c73();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseescapedChar() {
+  function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c373.test(input.charAt(peg$currPos))) {
+    if (peg$c364.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c374); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
 
     return s0;
   }
 
-  function peg$parsews() {
+  function peg$parseWhiteSpace() {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c375;
+      s0 = peg$c366;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c376); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c377;
+        s0 = peg$c368;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c378); }
+        if (peg$silentFails === 0) { peg$fail(peg$c369); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c379;
+          s0 = peg$c370;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c380); }
+          if (peg$silentFails === 0) { peg$fail(peg$c371); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c381;
+            s0 = peg$c372;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c382); }
+            if (peg$silentFails === 0) { peg$fail(peg$c373); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c383;
+              s0 = peg$c374;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c384); }
+              if (peg$silentFails === 0) { peg$fail(peg$c375); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c385;
+                s0 = peg$c376;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c386); }
+                if (peg$silentFails === 0) { peg$fail(peg$c377); }
               }
             }
           }
@@ -7637,21 +7503,15 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    peg$silentFails++;
     s0 = [];
-    s1 = peg$parsews();
+    s1 = peg$parseWhiteSpace();
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        s1 = peg$parsews();
+        s1 = peg$parseWhiteSpace();
       }
     } else {
       s0 = peg$FAILED;
-    }
-    peg$silentFails--;
-    if (s0 === peg$FAILED) {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c387); }
     }
 
     return s0;
@@ -7661,10 +7521,10 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = [];
-    s1 = peg$parsews();
+    s1 = peg$parseWhiteSpace();
     while (s1 !== peg$FAILED) {
       s0.push(s1);
-      s1 = peg$parsews();
+      s1 = peg$parseWhiteSpace();
     }
 
     return s0;
@@ -7680,7 +7540,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c333); }
+      if (peg$silentFails === 0) { peg$fail(peg$c323); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -61,10 +61,6 @@ Query
           RETURN(MAP("op": "SequentialProc", "procs": PREPEND(s, rest)))
       }
     }
-  / s:Search {
-      // XXX does this ever match?  Rule above shoul;d match first
-      RETURN(MAP("op": "SequentialProc", "procs": ARRAY(s)))
-    }
 
 Search
   = expr:SearchExpr {
@@ -118,7 +114,7 @@ SearchPred
   / v:SearchLiteral {
       RETURN(MAP("op": "Search", "text": TEXT, "value": v))
     }
-  / !((SearchKeywords) _ ) v:SearchWord {
+  / !(SearchKeywords _ ) v:SearchWord {
       VAR(str) = ASSERT_STRING(v)
       if (str == "*") {
         RETURN(MAP("op": "MatchAll"))
@@ -171,7 +167,7 @@ SubnetLiteral
   = v:IP6Net !IdentifierRest {
       RETURN(MAP("op": "Literal", "type": "net", "value": v))
     }
-  / v:IPNet {
+  / v:IP4Net {
       RETURN(MAP("op": "Literal", "type": "net", "value": v))
     }
 
@@ -204,9 +200,8 @@ SequentialProcs
   = first:Proc rest:SequentialTail* {
      if ISNOTNULL(rest) {
         RETURN(PREPEND(first, rest))
-      } else {
-        RETURN(ARRAY(first))
       }
+      RETURN(ARRAY(first))
     }
 
 SequentialTail = __ "|" __ p:Proc { RETURN(p) }
@@ -338,7 +333,7 @@ TopProc
         proc["fields"] = fields
       }
       if ISNOTNULL(flush) {
-       proc["flush"] = true
+        proc["flush"] = true
       }
       RETURN(proc)
     }
@@ -430,18 +425,18 @@ Assignment
 Expr = ConditionalExpr
 
 ConditionalExpr
-  = condition:LogicalORExpr __ "?" __ thenClause:Expr __ ":" __ elseClause:Expr {
+  = condition:LogicalOrExpr __ "?" __ thenClause:Expr __ ":" __ elseClause:Expr {
       RETURN(MAP("op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause))
     }
-  / LogicalORExpr
+  / LogicalOrExpr
 
-LogicalORExpr
-  = first:LogicalANDExpr
-    rest:(__ op:OrToken __ expr:LogicalANDExpr{ RETURN(ARRAY(op, expr)) })* {
+LogicalOrExpr
+  = first:LogicalAndExpr
+    rest:(__ op:OrToken __ expr:LogicalAndExpr{ RETURN(ARRAY(op, expr)) })* {
         RETURN(makeBinaryExprChain(first, rest))
     }
 
-LogicalANDExpr
+LogicalAndExpr
   = first:EqualityCompareExpr
     rest:(__ op:AndToken __ expr:EqualityCompareExpr{ RETURN(ARRAY(op, expr)) })* {
         RETURN(makeBinaryExprChain(first, rest))
@@ -647,7 +642,7 @@ IP6Tail
 ColonHex = ":" v:Hex { RETURN(":" + ASSERT_STRING(v)) }
 HexColon = v:Hex ":" { RETURN(ASSERT_STRING(v) + ":") }
 
-IPNet
+IP4Net
   = a:IP '/' m:UInt {
       RETURN(ASSERT_STRING(a) + "/" + TOSTRING(m));
     }

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -731,7 +731,10 @@ UnicodeEscape
     }
 
 Regexp
-  = "/" body:([^/\\]/"\\/")+ "/" { RETURN(body) }
+  = "/" body:RegexpBody "/" { RETURN(body) }
+
+RegexpBody
+  = ([^/\\]/"\\/")+ { RETURN(TEXT) }
 
 EscapedChar
   = [\x00-\x1f\\]

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -66,17 +66,6 @@ Query
       RETURN(MAP("op": "SequentialProc", "procs": ARRAY(s)))
     }
 
-SequentialProcs
-  = first:Proc rest:SequentialTail* {
-      if ISNOTNULL(rest) {
-        RETURN(PREPEND(first, rest))
-      } else {
-        RETURN(ARRAY(first))
-      }
-    }
-
-SequentialTail = __ "|" __ p:Proc { RETURN(p) }
-
 Search
   = expr:SearchExpr {
       RETURN(MAP("op": "FilterProc", "filter": expr))
@@ -142,6 +131,17 @@ SearchPred
       RETURN(MAP("op": "Search", "text": TEXT, "value": literal))
     }
 
+SearchValue
+  = SearchLiteral
+  / !((SearchKeywords) _) v:SearchWord {
+      RETURN(MAP("op": "Literal", "type": "string", "value": v))
+    }
+
+SearchKeywords
+  = AndToken
+  / OrToken
+  / InToken
+
 SearchLiteral
   = StringLiteral
   / RegexpLiteral
@@ -156,12 +156,6 @@ SearchLiteral
   / !(SearchKeywords _) v:BooleanLiteral { RETURN(v) }
   / !(SearchKeywords _) v:NullLiteral { RETURN(v) }
 
-
-SearchValue
-  = SearchLiteral
-  / !((SearchKeywords) _) v:SearchWord {
-      RETURN(MAP("op": "Literal", "type": "string", "value": v))
-    }
 
 StringLiteral
   = v:QuotedString {
@@ -206,10 +200,23 @@ BooleanLiteral
 NullLiteral
   = "null"           { RETURN(MAP("op": "Literal", "type": "null")) }
 
-SearchKeywords
-  = AndToken
-  / OrToken
-  / InToken
+SequentialProcs
+  = first:Proc rest:SequentialTail* {
+     if ISNOTNULL(rest) {
+        RETURN(PREPEND(first, rest))
+      } else {
+        RETURN(ARRAY(first))
+      }
+    }
+
+SequentialTail = __ "|" __ p:Proc { RETURN(p) }
+
+Proc
+  = NamedProc
+  / GroupByProc
+  / "(" __ proc:Procs __ ")" {
+      RETURN(proc)
+    }
 
 Procs
   = first:SequentialProcs rest:ParallelTail* {
@@ -224,86 +231,6 @@ Procs
 ParallelTail
   = __ ";" __ ch:SequentialProcs { RETURN(MAP("op": "SequentialProc", "procs": ch)) }
 
-Proc
-  = NamedProc
-  / GroupByProc
-  / "(" __ proc:Procs __ ")" {
-      RETURN(proc)
-    }
-
-GroupByKeys
-  = _ "by"i _ columns:FlexAssignments { RETURN(columns) }
-
-// A FlexAssignment is like an Assignment but it can optionally omit the lhs,
-// in which case the semantic pass will infer a name from the rhs, e.g., for
-// an expression like "count() by foo", the rhs is Field "foo" and the lhs is nil.
-FlexAssignment
-  = Assignment
-  / expr:Expr { RETURN(MAP("op": "Assignment", "rhs": expr)) }
-
-FlexAssignments
-  = first:FlexAssignment rest:(__ "," __ expr:FlexAssignment { RETURN(expr) })* {
-      RETURN(PREPEND(first, rest))
-  }
-
-EveryDur
-  = "every"i _ dur:Duration _ { RETURN(dur) }
-
-EqualityToken
-  = EqualityOperator / RelativeOperator
-
-AndToken = "and"i { RETURN(TEXT) }
-OrToken = "or"i { RETURN(TEXT) }
-InToken = "in"i { RETURN(TEXT) }
-NotToken = "not"i { RETURN(TEXT) }
-
-IdentifierName = IdentifierStart IdentifierRest* { RETURN(TEXT) }
-
-IdentifierStart = [A-Za-z_$]
-IdentifierRest = IdentifierStart / [0-9]
-
-Identifier
-  = IdentifierStart IdentifierRest* { RETURN(MAP("op": "Identifier", "name": TEXT)) }
-
-RootField
-  = "."? !(BooleanLiteral / NullLiteral) field:Identifier { RETURN(MAP("op": "BinaryExpr", "operator":".", "lhs":MAP("op":"RootRecord"), "rhs": field)) }
-  / "." !(Identifier)  { RETURN(MAP("op": "RootRecord")) }
-
-Lval = DerefExpr
-
-DerefExpr
-  = first:RootField rest:(Deref)* {
-      RETURN(makeBinaryExprChain(first, rest))
-    }
-
-Deref
-  = "[" expr:Expr "]" { RETURN(ARRAY("[", expr)) }
-  / "." !(".") id:Identifier { RETURN(ARRAY(".", id)) }
-
-FieldExpr = Lval
-
-FieldExprs
-  = first:FieldExpr rest:(__ "," __ FieldExpr)* {
-      VAR(result) = ARRAY(first)
-
-      FOREACH(ASSERT_ARRAY(rest), r) {
-        APPEND(result, ASSERT_ARRAY(r)[3])
-      }
-
-      RETURN(result)
-    }
-
-Exprs
-  = first:Expr rest:(__ "," __ Expr)* {
-      VAR(result) = ARRAY(first)
-
-      FOREACH(ASSERT_ARRAY(rest), r) {
-        APPEND(result, ASSERT_ARRAY(r)[3])
-      }
-
-      RETURN(result)
-    }
-
 GroupByProc
   = every:EveryDur? reducers:Reducers keys:GroupByKeys? limit:LimitArg? {
       VAR(p) = MAP("op": "GroupByProc", "reducers": reducers)
@@ -317,6 +244,27 @@ GroupByProc
         p["limit"] = limit
       }
       RETURN(p)
+    }
+
+EveryDur
+  = "every"i _ dur:Duration _ { RETURN(dur) }
+
+GroupByKeys
+  = _ "by"i _ columns:FlexAssignments { RETURN(columns) }
+
+LimitArg
+  = _ "with" _ "-limit" _ limit:UInt { RETURN(limit) }
+
+// A FlexAssignment is like an Assignment but it can optionally omit the lhs,
+// in which case the semantic pass will infer a name from the rhs, e.g., for
+// an expression like "count() by foo", the rhs is Field "foo" and the lhs is nil.
+FlexAssignment
+  = Assignment
+  / expr:Expr { RETURN(MAP("op": "Assignment", "rhs": expr)) }
+
+FlexAssignments
+  = first:FlexAssignment rest:(__ "," __ expr:FlexAssignment { RETURN(expr) })* {
+      RETURN(PREPEND(first, rest))
     }
 
 ReducerAssignment
@@ -395,14 +343,6 @@ TopProc
       RETURN(proc)
     }
 
-LimitArg
-  = _ "with" _ "-limit" _ limit:UInt { RETURN(limit) }
-
-CutArgs
-  = args:(_ "-c" { RETURN(MAP("name": "c", "value": NULL)) })* {
-      return makeArgMap(args)
-    }
-
 CutProc
   = "cut"i args:CutArgs _ columns:FlexAssignments {
       VAR(argm) = ASSERT_MAP(args)
@@ -411,6 +351,11 @@ CutProc
         proc["complement"] = true
       }
       RETURN(proc)
+    }
+
+CutArgs
+  = args:(_ "-c" { RETURN(MAP("name": "c", "value": NULL)) })* {
+      return makeArgMap(args)
     }
 
 HeadProc
@@ -449,25 +394,38 @@ FuseProc
       RETURN(MAP("op": "FuseProc"))
     }
 
+RootField
+  = "."? !(BooleanLiteral / NullLiteral) field:Identifier { RETURN(MAP("op": "BinaryExpr", "operator":".", "lhs":MAP("op":"RootRecord"), "rhs": field)) }
+  / "." !(Identifier)  { RETURN(MAP("op": "RootRecord")) }
+
+Lval = DerefExpr
+
+FieldExpr = Lval
+
+FieldExprs
+  = first:FieldExpr rest:(__ "," __ FieldExpr)* {
+      VAR(result) = ARRAY(first)
+
+      FOREACH(ASSERT_ARRAY(rest), r) {
+        APPEND(result, ASSERT_ARRAY(r)[3])
+      }
+
+      RETURN(result)
+    }
+
+Exprs
+  = first:Expr rest:(__ "," __ Expr)* {
+      VAR(result) = ARRAY(first)
+
+      FOREACH(ASSERT_ARRAY(rest), r) {
+        APPEND(result, ASSERT_ARRAY(r)[3])
+      }
+
+      RETURN(result)
+    }
+
 Assignment
   = lhs:Lval __ "=" __ rhs:Expr { RETURN(MAP("lhs": lhs, "rhs": rhs)) }
-
-Primary
-  = StringLiteral
-  / RegexpLiteral
-  / SubnetLiteral
-  / AddressLiteral
-  / FloatLiteral
-  / IntegerLiteral
-  / BooleanLiteral
-  / NullLiteral
-  / "(" __ expr:Expr __ ")" { RETURN(expr) }
-
-//
-// Rules for parsing expressions.  Following standard practice, each
-// level of operator precedence has a rule that references the next
-// highest level of precedence.
-//
 
 Expr = ConditionalExpr
 
@@ -570,6 +528,42 @@ ArgumentList
       RETURN(PREPEND(first, rest))
     }
   / __ { RETURN(ARRAY()) }
+
+DerefExpr
+  = first:RootField rest:(Deref)* {
+      RETURN(makeBinaryExprChain(first, rest))
+    }
+
+Deref
+  = "[" expr:Expr "]" { RETURN(ARRAY("[", expr)) }
+  / "." !(".") id:Identifier { RETURN(ARRAY(".", id)) }
+
+Primary
+  = StringLiteral
+  / RegexpLiteral
+  / SubnetLiteral
+  / AddressLiteral
+  / FloatLiteral
+  / IntegerLiteral
+  / BooleanLiteral
+  / NullLiteral
+  / "(" __ expr:Expr __ ")" { RETURN(expr) }
+
+EqualityToken
+  = EqualityOperator / RelativeOperator
+
+AndToken = "and"i { RETURN(TEXT) }
+OrToken = "or"i { RETURN(TEXT) }
+InToken = "in"i { RETURN(TEXT) }
+NotToken = "not"i { RETURN(TEXT) }
+
+IdentifierName = IdentifierStart IdentifierRest* { RETURN(TEXT) }
+
+IdentifierStart = [A-Za-z_$]
+IdentifierRest = IdentifierStart / [0-9]
+
+Identifier
+  = IdentifierStart IdentifierRest* { RETURN(MAP("op": "Identifier", "name": TEXT)) }
 
 Duration
   = Seconds

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -47,26 +47,27 @@
 #define PRINT(...) console.log(__VAR_ARGS__)
 #endif
 
-start = __ ast:query __ EOF { RETURN(ast) }
+start = __ ast:Query __ EOF { RETURN(ast) }
 
-query
-  = procs:procChain {
+Query
+  = procs:SequentialProcs {
       VAR(filt) = MAP("op": "FilterProc", "filter": MAP("op": "MatchAll"))
       RETURN(MAP("op": "SequentialProc", "procs": PREPEND(filt, procs)))
     }
-  / s:search __ rest:chainedProc* {
+  / s:Search __ rest:SequentialTail* {
       if (ARRAY_LEN(rest) == 0) {
           RETURN(s)
       } else {
           RETURN(MAP("op": "SequentialProc", "procs": PREPEND(s, rest)))
       }
     }
-  / s:search {
+  / s:Search {
+      // XXX does this ever match?  Rule above shoul;d match first
       RETURN(MAP("op": "SequentialProc", "procs": ARRAY(s)))
     }
 
-procChain
-  = first:proc rest:chainedProc* {
+SequentialProcs
+  = first:Proc rest:SequentialTail* {
       if ISNOTNULL(rest) {
         RETURN(PREPEND(first, rest))
       } else {
@@ -74,61 +75,61 @@ procChain
       }
     }
 
-chainedProc = __ "|" __ p:proc { RETURN(p) }
+SequentialTail = __ "|" __ p:Proc { RETURN(p) }
 
-search
-  = expr:searchExpr {
+Search
+  = expr:SearchExpr {
       RETURN(MAP("op": "FilterProc", "filter": expr))
     }
 
-searchExpr
-  = first:searchTerm rest:oredSearchTerm* {
+SearchExpr
+  = first:SearchTerm rest:OredSearchTerm* {
       RETURN(makeChain(first, rest, "LogicalOr"))
     }
 
-oredSearchTerm = _ orToken _ t:searchTerm { RETURN(t) }
+OredSearchTerm = _ OrToken _ t:SearchTerm { RETURN(t) }
 
-searchTerm
-  = first:searchFactor rest:andedSearchTerm* {
+SearchTerm
+  = first:SearchFactor rest:AndedSearchTerm* {
       RETURN(makeChain(first, rest, "LogicalAnd"))
     }
 
-andedSearchTerm = _ (andToken _)? f:searchFactor { RETURN(f) }
+AndedSearchTerm = _ (AndToken _)? f:SearchFactor { RETURN(f) }
 
-searchFactor
-  = (notToken _ / "!" __) e:searchExpr {
+SearchFactor
+  = (NotToken _ / "!" __) e:SearchExpr {
       RETURN(MAP("op": "LogicalNot", "expr": e))
     }
-  / !("-") s:searchPred { RETURN(s) }
-  / "(" __ expr:searchExpr __ ")" { RETURN(expr) }
+  / !("-") s:SearchPred { RETURN(s) }
+  / "(" __ expr:SearchExpr __ ")" { RETURN(expr) }
 
-searchPred
-  = "*" __ comp:equalityToken __ v:searchValue {
+SearchPred
+  = "*" __ comp:EqualityToken __ v:SearchValue {
       RETURN(MAP("op": "CompareAny", "comparator": comp, "recursive": false, "value": v))
     }
-  / "**" __ comp:equalityToken __ v:searchValue {
+  / "**" __ comp:EqualityToken __ v:SearchValue {
       RETURN(MAP("op": "CompareAny", "comparator": comp, "recursive": true, "value": v))
     }
-  / f:Lval __ comp:equalityToken __ v:searchValue {
+  / f:Lval __ comp:EqualityToken __ v:SearchValue {
       RETURN(MAP("op": "CompareField", "comparator": comp, "field": f, "value": v))
     }
   // XXX this is here for now to let "len(array)" be matched now that we have
   // made reducer names generic (which will be far easier to add to and maintain),
   // and a better fix awaits the language tweaks coming in issue #1371.  At that
   // point this peg rule will be subsumed by a unified search/expression syntax.
-  / &"len" expr:FunctionExpr __ comp:equalityToken __ v:searchValue {
+  / &"len" expr:Function __ comp:EqualityToken __ v:SearchValue {
     RETURN(MAP("op": "BinaryExpression", "operator": comp, "lhs": expr, "rhs": v))
   }
-  / v:searchValue __ inToken __ "*" {
+  / v:SearchValue __ InToken __ "*" {
       RETURN(MAP("op": "CompareAny", "comparator": "in", "recursive": false, "value": v))
     }
-  / v:searchValue __ inToken __ f:fieldExpr {
+  / v:SearchValue __ InToken __ f:FieldExpr {
       RETURN(MAP("op": "CompareField", "comparator": "in", "field": f, "value": v))
     }
-  / v:searchLiteral {
+  / v:SearchLiteral {
       RETURN(MAP("op": "Search", "text": TEXT, "value": v))
     }
-  / !((searchKeywords) _ ) v:searchWord {
+  / !((SearchKeywords) _ ) v:SearchWord {
       VAR(str) = ASSERT_STRING(v)
       if (str == "*") {
         RETURN(MAP("op": "MatchAll"))
@@ -141,7 +142,7 @@ searchPred
       RETURN(MAP("op": "Search", "text": TEXT, "value": literal))
     }
 
-searchLiteral
+SearchLiteral
   = StringLiteral
   / RegexpLiteral
   / SubnetLiteral
@@ -150,51 +151,51 @@ searchLiteral
 
   // Careful not to use IntegerLiteral unconditionally or it will consume
   // the beginning of something like 1234abcd which is a valid search word
-  / i:IntegerLiteral !searchWord { RETURN(i) }
+  / i:IntegerLiteral !SearchWord { RETURN(i) }
 
-  / !(searchKeywords _) v:BooleanLiteral { RETURN(v) }
-  / !(searchKeywords _) v:NullLiteral { RETURN(v) }
+  / !(SearchKeywords _) v:BooleanLiteral { RETURN(v) }
+  / !(SearchKeywords _) v:NullLiteral { RETURN(v) }
 
 
-searchValue
-  = searchLiteral
-  / !((searchKeywords) _) v:searchWord {
+SearchValue
+  = SearchLiteral
+  / !((SearchKeywords) _) v:SearchWord {
       RETURN(MAP("op": "Literal", "type": "string", "value": v))
     }
 
 StringLiteral
-  = v:quotedString {
+  = v:QuotedString {
       RETURN(MAP("op": "Literal", "type": "string", "value": v))
     }
 
 RegexpLiteral
-  = v:reString {
+  = v:Regexp {
       RETURN(MAP("op": "Literal", "type": "regexp", "value": v))
     }
 
 SubnetLiteral
-  = v:ip6subnet !IdentifierRest {
+  = v:IP6Net !IdentifierRest {
       RETURN(MAP("op": "Literal", "type": "net", "value": v))
     }
-  / v:subnet {
+  / v:IPNet {
       RETURN(MAP("op": "Literal", "type": "net", "value": v))
     }
 
 AddressLiteral
-  = v:ip6addr !IdentifierRest {
+  = v:IP6 !IdentifierRest {
       RETURN(MAP("op": "Literal", "type": "ip", "value": v))
     }
-  / v:addr {
+  / v:IP {
       RETURN(MAP("op": "Literal", "type": "ip", "value": v))
     }
 
 FloatLiteral
-  = v:sdouble {
+  = v:FloatString {
       RETURN(MAP("op": "Literal", "type": "float64", "value": v))
     }
 
 IntegerLiteral
-  = v:sinteger {
+  = v:IntString {
       RETURN(MAP("op": "Literal", "type": "int64", "value": v))
     }
 
@@ -205,13 +206,13 @@ BooleanLiteral
 NullLiteral
   = "null"           { RETURN(MAP("op": "Literal", "type": "null")) }
 
-searchKeywords
-  = andToken
-  / orToken
-  / inToken
+SearchKeywords
+  = AndToken
+  / OrToken
+  / InToken
 
-procList
-  = first:procChain rest:parallelChain* {
+Procs
+  = first:SequentialProcs rest:ParallelTail* {
       VAR(fp) = MAP("op": "SequentialProc", "procs": first)
       if ISNOTNULL(rest) {
         RETURN(MAP("op": "ParallelProc", "procs": PREPEND(fp, rest)))
@@ -220,17 +221,17 @@ procList
       }
     }
 
-parallelChain
-  = __ ";" __ ch:procChain { RETURN(MAP("op": "SequentialProc", "procs": ch)) }
+ParallelTail
+  = __ ";" __ ch:SequentialProcs { RETURN(MAP("op": "SequentialProc", "procs": ch)) }
 
-proc
-  = simpleProc
-  / groupByProc
-  / "(" __ proc:procList __ ")" {
+Proc
+  = NamedProc
+  / GroupByProc
+  / "(" __ proc:Procs __ ")" {
       RETURN(proc)
     }
 
-groupByKeys
+GroupByKeys
   = _ "by"i _ columns:FlexAssignments { RETURN(columns) }
 
 // A FlexAssignment is like an Assignment but it can optionally omit the lhs,
@@ -238,23 +239,23 @@ groupByKeys
 // an expression like "count() by foo", the rhs is Field "foo" and the lhs is nil.
 FlexAssignment
   = Assignment
-  / expr:Expression { RETURN(MAP("op": "Assignment", "rhs": expr)) }
+  / expr:Expr { RETURN(MAP("op": "Assignment", "rhs": expr)) }
 
 FlexAssignments
   = first:FlexAssignment rest:(__ "," __ expr:FlexAssignment { RETURN(expr) })* {
       RETURN(PREPEND(first, rest))
   }
 
-everyDur
-  = "every"i _ dur:duration _ { RETURN(dur) }
+EveryDur
+  = "every"i _ dur:Duration _ { RETURN(dur) }
 
-equalityToken
+EqualityToken
   = EqualityOperator / RelativeOperator
 
-andToken = "and"i { RETURN(TEXT) }
-orToken = "or"i { RETURN(TEXT) }
-inToken = "in"i { RETURN(TEXT) }
-notToken = "not"i { RETURN(TEXT) }
+AndToken = "and"i { RETURN(TEXT) }
+OrToken = "or"i { RETURN(TEXT) }
+InToken = "in"i { RETURN(TEXT) }
+NotToken = "not"i { RETURN(TEXT) }
 
 IdentifierName = IdentifierStart IdentifierRest* { RETURN(TEXT) }
 
@@ -268,42 +269,21 @@ RootField
   = "."? !(BooleanLiteral / NullLiteral) field:Identifier { RETURN(MAP("op": "BinaryExpr", "operator":".", "lhs":MAP("op":"RootRecord"), "rhs": field)) }
   / "." !(Identifier)  { RETURN(MAP("op": "RootRecord")) }
 
-Lval = DerefExpression
+Lval = DerefExpr
 
-DerefExpression
+DerefExpr
   = first:RootField rest:(Deref)* {
-    RETURN(makeBinaryExprChain(first, rest))
-   }
+      RETURN(makeBinaryExprChain(first, rest))
+    }
 
 Deref
-  = "[" expr:Expression "]" { RETURN(ARRAY("[", expr)) }
+  = "[" expr:Expr "]" { RETURN(ARRAY("[", expr)) }
   / "." !(".") id:Identifier { RETURN(ARRAY(".", id)) }
 
+FieldExpr = Lval
 
-// XXX this is here to support the function call stuff that used to live
-// inside of FieldCall.  This will be replaced by a subset of the expression
-// syntax in a subsequent PR (which is tricky due to mixin keyword search
-// concantenation with expressions)
-FunctionExpr
-    = fn:FunctionName __ "(" args:ArgumentList ")" {
-          RETURN(MAP("op": "FunctionCall", "function": fn, "args": args))
-      }
-
-fieldExpr = Lval
-
-fieldExprList
-  = first:fieldExpr rest:(__ "," __ fieldExpr)* {
-      VAR(result) = ARRAY(first)
-
-      FOREACH(ASSERT_ARRAY(rest), r) {
-        APPEND(result, ASSERT_ARRAY(r)[3])
-      }
-
-      RETURN(result)
-  }
-
-ExprList
-  = first:Expression rest:(__ "," __ Expression)* {
+FieldExprs
+  = first:FieldExpr rest:(__ "," __ FieldExpr)* {
       VAR(result) = ARRAY(first)
 
       FOREACH(ASSERT_ARRAY(rest), r) {
@@ -313,41 +293,52 @@ ExprList
       RETURN(result)
     }
 
-groupByProc
-  = every:everyDur? reducers:reducerList keys:groupByKeys? limit:procLimitArg? {
-    VAR(p) = MAP("op": "GroupByProc", "reducers": reducers)
-    if ISNOTNULL(every) {
-      p["duration"] = every
+Exprs
+  = first:Expr rest:(__ "," __ Expr)* {
+      VAR(result) = ARRAY(first)
+
+      FOREACH(ASSERT_ARRAY(rest), r) {
+        APPEND(result, ASSERT_ARRAY(r)[3])
+      }
+
+      RETURN(result)
     }
-    if ISNOTNULL(keys) {
-      p["keys"] = keys
+
+GroupByProc
+  = every:EveryDur? reducers:Reducers keys:GroupByKeys? limit:LimitArg? {
+      VAR(p) = MAP("op": "GroupByProc", "reducers": reducers)
+      if ISNOTNULL(every) {
+        p["duration"] = every
+      }
+      if ISNOTNULL(keys) {
+        p["keys"] = keys
+      }
+      if ISNOTNULL(limit) {
+        p["limit"] = limit
+      }
+      RETURN(p)
     }
-    if ISNOTNULL(limit) {
-      p["limit"] = limit
-    }
-    RETURN(p)
-  }
 
 ReducerAssignment
-  = lval:Lval __ "=" reducer:reducer {
+  = lval:Lval __ "=" reducer:Reducer {
       RETURN(MAP("op": "Assignment", "lhs": lval, "rhs": reducer))
-  }
-  / reducer:reducer {
-      RETURN(MAP("op": "Assignment", "rhs": reducer))
-  }
-
-reducer
-  = !("not"/"len") op:FunctionName __ "(" __ expr:Expression?  __ ")" where:where? {
-    VAR(r) = MAP("op": "Reducer", "operator": op, "where":where)
-    if ISNOTNULL(expr) {
-      r["expr"] = expr
     }
-    RETURN(r)
-  }
+  / reducer:Reducer {
+      RETURN(MAP("op": "Assignment", "rhs": reducer))
+    }
 
-where = _ "where" _ expr:Expression { RETURN(expr) }
+Reducer
+  = !("not"/"len") op:FuncName __ "(" __ expr:Expr?  __ ")" where:WhereClause? {
+      VAR(r) = MAP("op": "Reducer", "operator": op, "where":where)
+      if ISNOTNULL(expr) {
+        r["expr"] = expr
+      }
+      RETURN(r)
+    }
 
-reducerList
+WhereClause = _ "where" _ expr:Expr { RETURN(expr) }
+
+Reducers
   = first:ReducerAssignment rest:(__ "," __ ReducerAssignment)* {
       VAR(result) = ARRAY(first)
       FOREACH(ASSERT_ARRAY(rest), r) {
@@ -356,87 +347,86 @@ reducerList
       RETURN(result)
     }
 
-simpleProc
-  = sort
-  / top
-  / cut
-  / head
-  / tail
-  / filter
-  / uniq
-  / put
-  / rename
-  / fuse
+NamedProc
+  = SortProc
+  / TopProc
+  / CutProc
+  / HeadProc
+  / TailProc
+  / FilterProc
+  / UniqProc
+  / PutProc
+  / RenameProc
+  / FuseProc
 
-sort
-  = "sort"i args:sortArgs list:(_ l:ExprList { RETURN(l) })? {
-    VAR(argm) = ASSERT_MAP(args)
-    VAR(proc) = MAP("op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false)
-    if HAS(argm, "r") {
-      proc["sortdir"] = -1
-    }
-    if HAS(argm, "nulls") {
-      if (argm["nulls"] == "first") {
-        proc["nullsfirst"] = true
+SortProc
+  = "sort"i args:SortArgs list:(_ l:Exprs { RETURN(l) })? {
+      VAR(argm) = ASSERT_MAP(args)
+      VAR(proc) = MAP("op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false)
+      if HAS(argm, "r") {
+        proc["sortdir"] = -1
       }
+      if HAS(argm, "nulls") {
+        if (argm["nulls"] == "first") {
+          proc["nullsfirst"] = true
+        }
+      }
+      RETURN(proc)
     }
-    RETURN(proc)
-  }
 
-sortArgs = args:(_ a:sortArg{ RETURN(a) })* {
-    return makeArgMap(args)
-}
+SortArgs = args:(_ a:SortArg{ RETURN(a) })* { return makeArgMap(args) }
 
-sortArg
+SortArg
   = "-r" { RETURN(MAP("name": "r", "value": NULL)) }
   / "-nulls" _ where:(("first" / "last") { RETURN(TEXT) } ) { RETURN(MAP("name": "nulls", "value": where)) }
 
-top
-  = "top"i limit:(_ n:unsignedInteger { RETURN(n)})? flush:(_ "-flush")? fields:(_ f:fieldExprList { RETURN(f) })? {
-    VAR(proc) = MAP("op": "TopProc")
-    if ISNOTNULL(limit) {
-      proc["limit"] = limit
+TopProc
+  = "top"i limit:(_ n:UInt { RETURN(n)})? flush:(_ "-flush")? fields:(_ f:FieldExprs { RETURN(f) })? {
+      VAR(proc) = MAP("op": "TopProc")
+      if ISNOTNULL(limit) {
+        proc["limit"] = limit
+      }
+      if ISNOTNULL(fields) {
+        proc["fields"] = fields
+      }
+      if ISNOTNULL(flush) {
+       proc["flush"] = true
+      }
+      RETURN(proc)
     }
-    if ISNOTNULL(fields) {
-      proc["fields"] = fields
-    }
-    if ISNOTNULL(flush) {
-      proc["flush"] = true
-    }
-    RETURN(proc)
-  }
 
-procLimitArg
-  = _ "with" _ "-limit" _ limit:unsignedInteger { RETURN(limit) }
+LimitArg
+  = _ "with" _ "-limit" _ limit:UInt { RETURN(limit) }
 
-cutArgs
+CutArgs
   = args:(_ "-c" { RETURN(MAP("name": "c", "value": NULL)) })* {
-    return makeArgMap(args)
-  }
-
-cut
-  = "cut"i args:cutArgs _ columns:FlexAssignments {
-    VAR(argm) = ASSERT_MAP(args)
-    VAR(proc) = MAP("op": "CutProc", "fields": columns, "complement": false)
-    if HAS(argm, "c") {
-      proc["complement"] = true
+      return makeArgMap(args)
     }
-    RETURN(proc)
-  }
 
+CutProc
+  = "cut"i args:CutArgs _ columns:FlexAssignments {
+      VAR(argm) = ASSERT_MAP(args)
+      VAR(proc) = MAP("op": "CutProc", "fields": columns, "complement": false)
+      if HAS(argm, "c") {
+        proc["complement"] = true
+      }
+      RETURN(proc)
+    }
 
-head
-  = "head"i _ count:unsignedInteger { RETURN(MAP("op": "HeadProc", "count": count)) }
+HeadProc
+  = "head"i _ count:UInt { RETURN(MAP("op": "HeadProc", "count": count)) }
   / "head"i { RETURN(MAP("op": "HeadProc", "count": 1)) }
-tail
-  = "tail"i _ count:unsignedInteger { RETURN(MAP("op": "TailProc", "count": count)) }
+
+TailProc
+  = "tail"i _ count:UInt { RETURN(MAP("op": "TailProc", "count": count)) }
   / "tail"i { RETURN(MAP("op": "TailProc", "count": 1)) }
 
-filter
-  = "filter"i _ expr:searchExpr {
+FilterProc
+  = "filter"i _ expr:SearchExpr {
       RETURN(MAP("op": "FilterProc", "filter": expr))
     }
-uniq
+
+UniqProc
   = "uniq"i _ "-c" {
       RETURN(MAP("op": "UniqProc", "cflag": true))
     }
@@ -444,23 +434,23 @@ uniq
       RETURN(MAP("op": "UniqProc", "cflag": false))
     }
 
-put
+PutProc
   = "put"i _ columns:FlexAssignments {
       RETURN(MAP("op": "PutProc", "clauses": columns))
     }
 
-rename
+RenameProc
   = "rename"i _ first:Assignment rest:(__ "," __ cl:Assignment { RETURN(cl) })* {
       RETURN(MAP("op": "RenameProc", "fields": PREPEND(first, rest)))
     }
 
-fuse
+FuseProc
   = "fuse"i {
       RETURN(MAP("op": "FuseProc"))
-  }
+    }
 
 Assignment
-  = lhs:Lval __ "=" __ rhs:Expression { RETURN(MAP("lhs": lhs, "rhs": rhs)) }
+  = lhs:Lval __ "=" __ rhs:Expr { RETURN(MAP("lhs": lhs, "rhs": rhs)) }
 
 Primary
   = StringLiteral
@@ -471,7 +461,7 @@ Primary
   / IntegerLiteral
   / BooleanLiteral
   / NullLiteral
-  / "(" __ expr:Expression __ ")" { RETURN(expr) }
+  / "(" __ expr:Expr __ ")" { RETURN(expr) }
 
 //
 // Rules for parsing expressions.  Following standard practice, each
@@ -479,29 +469,29 @@ Primary
 // highest level of precedence.
 //
 
-Expression = ConditionalExpression
+Expr = ConditionalExpr
 
-ConditionalExpression
-  = condition:LogicalORExpression __ "?" __ thenClause:Expression __ ":" __ elseClause:Expression {
-    RETURN(MAP("op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause))
-  }
-  / LogicalORExpression
+ConditionalExpr
+  = condition:LogicalORExpr __ "?" __ thenClause:Expr __ ":" __ elseClause:Expr {
+      RETURN(MAP("op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause))
+    }
+  / LogicalORExpr
 
-LogicalORExpression
-  = first:LogicalANDExpression
-    rest:(__ op:orToken __ expr:LogicalANDExpression{ RETURN(ARRAY(op, expr)) })* {
+LogicalORExpr
+  = first:LogicalANDExpr
+    rest:(__ op:OrToken __ expr:LogicalANDExpr{ RETURN(ARRAY(op, expr)) })* {
         RETURN(makeBinaryExprChain(first, rest))
     }
 
-LogicalANDExpression
-  = first:EqualityCompareExpression
-    rest:(__ op:andToken __ expr:EqualityCompareExpression{ RETURN(ARRAY(op, expr)) })* {
+LogicalANDExpr
+  = first:EqualityCompareExpr
+    rest:(__ op:AndToken __ expr:EqualityCompareExpr{ RETURN(ARRAY(op, expr)) })* {
         RETURN(makeBinaryExprChain(first, rest))
     }
 
-EqualityCompareExpression
-  = first:RelativeExpression
-    rest:(__ comp:EqualityComparator __ expr:RelativeExpression{ RETURN(ARRAY(comp, expr)) })* {
+EqualityCompareExpr
+  = first:RelativeExpr
+    rest:(__ comp:EqualityComparator __ expr:RelativeExpr{ RETURN(ARRAY(comp, expr)) })* {
         RETURN(makeBinaryExprChain(first, rest))
     }
 
@@ -511,41 +501,41 @@ EqualityComparator
   = EqualityOperator
   / "in" { RETURN(TEXT) }
 
-RelativeExpression
-  = first:AdditiveExpression
-    rest:(__ op:RelativeOperator __ expr:AdditiveExpression{ RETURN(ARRAY(op, expr)) })* {
+RelativeExpr
+  = first:AdditiveExpr
+    rest:(__ op:RelativeOperator __ expr:AdditiveExpr{ RETURN(ARRAY(op, expr)) })* {
         RETURN(makeBinaryExprChain(first, rest))
     }
 
 RelativeOperator = ("<=" / "<" / ">=" / ">") { RETURN(TEXT) }
 
-AdditiveExpression
-  = first:MultiplicativeExpression
-    rest:(__ op:AdditiveOperator __ expr:MultiplicativeExpression{ RETURN(ARRAY(op, expr)) })* {
+AdditiveExpr
+  = first:MultiplicativeExpr
+    rest:(__ op:AdditiveOperator __ expr:MultiplicativeExpr{ RETURN(ARRAY(op, expr)) })* {
         RETURN(makeBinaryExprChain(first, rest))
     }
 
 AdditiveOperator = ("+" / "-") { RETURN(TEXT) }
 
-MultiplicativeExpression
-  = first:NotExpression
-    rest:(__ op:MultiplicativeOperator __ expr:NotExpression{ RETURN(ARRAY(op, expr)) })* {
+MultiplicativeExpr
+  = first:NotExpr
+    rest:(__ op:MultiplicativeOperator __ expr:NotExpr{ RETURN(ARRAY(op, expr)) })* {
         RETURN(makeBinaryExprChain(first, rest))
     }
 
 MultiplicativeOperator = ("*" / "/") { RETURN(TEXT) }
 
-NotExpression
-  = "!" __ e:NotExpression {
+NotExpr
+  = "!" __ e:NotExpr {
         RETURN(MAP("op": "UnaryExpr", "operator": "!", "operand": e))
     }
-  / CastExpression
+  / CastExpr
 
-CastExpression
-  = e:FuncExpression typ:( ":" typ:PrimitiveType { RETURN(typ) }) {
-    RETURN(MAP("op": "CastExpr", "expr": e, "type": typ))
-  }
-  / FuncExpression
+CastExpr
+  = e:FuncExpr typ:( ":" typ:PrimitiveType { RETURN(typ) }) {
+      RETURN(MAP("op": "CastExpr", "expr": e, "type": typ))
+    }
+  / FuncExpr
 
 
 PrimitiveType
@@ -557,187 +547,173 @@ PrimitiveType
       / "ip" / "net"
       / "type" / "error" / "null" ) { RETURN(TEXT) }
 
-FuncExpression
-  = first:FunctionCall rest:(Deref)* {
-    RETURN(makeBinaryExprChain(first, rest))
-  }
-  / DerefExpression
+FuncExpr
+  = first:Function rest:(Deref)* {
+      RETURN(makeBinaryExprChain(first, rest))
+    }
+  / DerefExpr
   / Primary
 
-FunctionCall
-  = fn:FunctionName __ "(" args:ArgumentList ")" {
-        RETURN(MAP("op": "FunctionCall", "function": fn, "args": args))
+Function
+  = fn:FuncName __ "(" args:ArgumentList ")" {
+      RETURN(MAP("op": "FunctionCall", "function": fn, "args": args))
     }
 
-FunctionName
-  = FunctionNameStart FunctionNameRest* { RETURN(TEXT) }
+FuncName
+  = FuncNameStart FuncNameRest* { RETURN(TEXT) }
 
-FunctionNameStart = [A-Za-z]
-FunctionNameRest = FunctionNameStart / [.0-9]
+FuncNameStart = [A-Za-z]
+FuncNameRest = FuncNameStart / [.0-9]
 
 ArgumentList
-  = first:Expression rest:(__ "," __ e:Expression { RETURN(e) })* {
+  = first:Expr rest:(__ "," __ e:Expr { RETURN(e) })* {
       RETURN(PREPEND(first, rest))
-  }
+    }
   / __ { RETURN(ARRAY()) }
 
-duration
-  = seconds
-  / minutes
-  / hours
-  / hours _ "and" _ minutes
-  / days
-  / weeks
+Duration
+  = Seconds
+  / Minutes
+  / Hours
+  / Hours _ "and" _ Minutes
+  / Days
+  / Weeks
 
-sec_abbrev
+SecondsToken
   = "seconds"
   / "second"
   / "secs"
   / "sec"
   / "s"
 
-min_abbrev
+MinutesToken
   = "minutes"
   / "minute"
   / "mins"
   / "min"
   / "m"
 
-hour_abbrev
+HoursToken
   = "hours"
   / "hrs"
   / "hr"
   / "h"
   / "hour"
 
-day_abbrev = "days"/"day"/"d"
-week_abbrev = "weeks"/"week"/"wks"/"wk"/"w"
+DaysToken = "days"/"day"/"d"
+WeeksToken = "weeks"/"week"/"wks"/"wk"/"w"
 
-seconds
+Seconds
   = "second" { RETURN(MAP("type": "Duration", "seconds": 1)) }
-  / num:number __ sec_abbrev { RETURN(MAP("type": "Duration", "seconds": num)) }
+  / num:UInt __ SecondsToken { RETURN(MAP("type": "Duration", "seconds": num)) }
 
-minutes
+Minutes
   = "minute" { RETURN(MAP("type": "Duration", "seconds": 60)) }
-  / num:number __ min_abbrev { RETURN(MAP("type": "Duration", "seconds": ASSERT_INT(num)*60)) }
+  / num:UInt __ MinutesToken { RETURN(MAP("type": "Duration", "seconds": ASSERT_INT(num)*60)) }
 
-hours
+Hours
   = "hour" { RETURN(MAP("type": "Duration", "seconds": 3600)) }
-  / num:number __ hour_abbrev { RETURN(MAP("type": "Duration", "seconds": ASSERT_INT(num)*3600)) }
+  / num:UInt __ HoursToken { RETURN(MAP("type": "Duration", "seconds": ASSERT_INT(num)*3600)) }
 
-days
+Days
   = "day" { RETURN(MAP("type": "Duration", "seconds": 3600*24)) }
-  / num:number __ day_abbrev { RETURN(MAP("type": "Duration", "seconds": (ASSERT_INT(num)*3600*24))) }
+  / num:UInt __ DaysToken { RETURN(MAP("type": "Duration", "seconds": (ASSERT_INT(num)*3600*24))) }
 
-weeks
+Weeks
   = "week" { RETURN(MAP("type": "Duration", "seconds": 3600*24*7)) }
-  / num:number __ week_abbrev { RETURN(MAP("type": "Duration", "seconds": ASSERT_INT(num)*3600*24*7)) }
-
-number = unsignedInteger
-
+  / num:UInt __ WeeksToken { RETURN(MAP("type": "Duration", "seconds": ASSERT_INT(num)*3600*24*7)) }
 
 //XXX what about mac addrs?
-addr
-  = a:(unsignedInteger "." unsignedInteger "." unsignedInteger "." unsignedInteger) { RETURN(TEXT) }
+IP
+  = UInt "." UInt "." UInt "." UInt { RETURN(TEXT) }
 
 // this matches a superset of legal syntax for ip6 addresses but the compiler
 // will catch any errors when translating the filter
-ip6addr
-  = a:(h_prepend)+ b:ip6tail {
+IP6
+  = a:HexColon+ b:IP6Tail {
       RETURN(joinChars(a) + ASSERT_STRING(b))
     }
-  / a:h16 b:(h_append)* "::" d:(h_prepend)* e:ip6tail {
+  / a:Hex b:ColonHex* "::" d:HexColon* e:IP6Tail {
       RETURN(ASSERT_STRING(a) + joinChars(b) + "::" + joinChars(d) + ASSERT_STRING(e))
     }
-  / "::" a:(h_prepend)* b:ip6tail {
+  / "::" a:HexColon* b:IP6Tail {
       RETURN("::" + joinChars(a) + ASSERT_STRING(b))
     }
-  / a:h16 b:(h_append)* "::" {
+  / a:Hex b:ColonHex* "::" {
       RETURN(ASSERT_STRING(a) + joinChars(b) + "::")
     }
   / "::" {
       RETURN("::")
     }
 
-ip6tail
-  = addr
-  / h16
+IP6Tail
+  = IP
+  / Hex
 
-h_append = ":" v:h16 { RETURN(":" + ASSERT_STRING(v)) }
-h_prepend = v:h16 ":" { RETURN(ASSERT_STRING(v) + ":") }
+ColonHex = ":" v:Hex { RETURN(":" + ASSERT_STRING(v)) }
+HexColon = v:Hex ":" { RETURN(ASSERT_STRING(v) + ":") }
 
-subnet
-  = a:addr '/' m:unsignedInteger {
+IPNet
+  = a:IP '/' m:UInt {
       RETURN(ASSERT_STRING(a) + "/" + TOSTRING(m));
     }
 
-ip6subnet
-  = a:ip6addr '/' m:unsignedInteger {
+IP6Net
+  = a:IP6 '/' m:UInt {
       RETURN(ASSERT_STRING(a) + "/" + ASSERT_STRING(m));
     }
 
-unsignedInteger
-  = s:suint { RETURN(parseInt(s)) }
+UInt
+ = s:UIntString { RETURN(parseInt(s)) }
 
-suint
-  = [0-9]+ { RETURN(TEXT) }
+IntString
+  = UIntString
+  / MinusIntString
 
-integer
-  = s:sinteger { RETURN(parseInt(s)) }
+UIntString = [0-9]+ { RETURN(TEXT) }
 
-sinteger
-  = [+-]? suint { RETURN(TEXT) }
+MinusIntString
+  = "-" UIntString { RETURN(TEXT) }
 
-double
-  = s:sdouble {
-      RETURN(parseFloat(s))
-  }
-
-sdouble
-  = "-"? doubleInteger+ "." doubleDigit+ exponentPart? {
+FloatString
+  = "-"? [0-9]+ "." [0-9]+ ExponentPart? {
       RETURN(TEXT)
     }
-  / "-"? "." doubleDigit+ exponentPart? {
+  / "-"? "." [0-9]+ ExponentPart? {
       RETURN(TEXT)
     }
 
-doubleInteger
-  = "0"
-  / [1-9] [0-9]*
+ExponentPart = "e"i [+-]? UIntString
 
-doubleDigit = [0-9]
+Hex = HexDigit+ { RETURN(TEXT) }
 
-exponentPart = "e"i sinteger
+HexDigit = [0-9a-fA-F]
 
-h16 = chars:hexdigit+ { RETURN(TEXT) }
+SearchWord
+  = chars:SearchWordPart+ { RETURN(joinChars(chars)) }
 
-hexdigit = [0-9a-fA-F]
+SearchWordPart
+  = "\\" s:(EscapeSequence / SearchEscape)  { RETURN(s) }
+  / !([\x00-\x1F\x5C(),!><=DQUOTE|SQUOTE;:] / WhiteSpace) . { RETURN(TEXT) }
 
-searchWord
-  = chars:searchWordPart+ { RETURN(joinChars(chars)) }
+QuotedString
+  = '"' v:DoubleQuotedChar* '"' { RETURN(joinChars(v)) }
+  / "'" v:SingleQuotedChar* "'" { RETURN(joinChars(v)) }
 
-searchWordPart
-  = "\\" s:(escapeSequence / searchEscape)  { RETURN(s) }
-  / !([\x00-\x1F\x5C(),!><=DQUOTE|SQUOTE;:] / ws) . { RETURN(TEXT) }
+DoubleQuotedChar
+  = !('"' / EscapedChar) . { RETURN(TEXT) }
+  / "\\" s:EscapeSequence { RETURN(s) }
 
-quotedString
-  = '"' v:doubleQuotedChar* '"' { RETURN(joinChars(v)) }
-  / "'" v:singleQuotedChar* "'" { RETURN(joinChars(v)) }
+SingleQuotedChar
+  = !("'" / EscapedChar) . { RETURN(TEXT) }
+  / "\\" s:EscapeSequence { RETURN(s) }
 
-doubleQuotedChar
-  = !('"' / escapedChar) . { RETURN(TEXT) }
-  / "\\" s:escapeSequence { RETURN(s) }
+EscapeSequence
+  = "x" HexDigit HexDigit { RETURN("\\" + TEXT) }
+  / SingleCharEscape
+  / UnicodeEscape
 
-singleQuotedChar
-  = !("'" / escapedChar) . { RETURN(TEXT) }
-  / "\\" s:escapeSequence { RETURN(s) }
-
-escapeSequence
-  = "x" hexdigit hexdigit { RETURN("\\" + TEXT) }
-  / singleCharEscape
-  / unicodeEscape
-
-singleCharEscape
+SingleCharEscape
   = "'"
   / '"'
   / "\\"
@@ -748,28 +724,25 @@ singleCharEscape
   / "t" { RETURN("\t") }
   / "v" { RETURN("\v") }
 
-searchEscape
+SearchEscape
   = "=" { RETURN("=") }
   / "*" { RETURN("\\*") }
 
-unicodeEscape
-  = "u" chars:(hexdigit hexdigit hexdigit hexdigit) {
+UnicodeEscape
+  = "u" chars:(HexDigit HexDigit HexDigit HexDigit) {
       RETURN(makeUnicodeChar(chars))
     }
-  / "u" "{" chars:(hexdigit hexdigit? hexdigit? hexdigit? hexdigit? hexdigit?) "}" {
+  / "u" "{" chars:(HexDigit HexDigit? HexDigit? HexDigit? HexDigit? HexDigit?) "}" {
       RETURN(makeUnicodeChar(chars))
     }
 
-reString
-  = '/' v:reBody '/' { RETURN(v) }
+Regexp
+  = "/" body:([^/\\]/"\\/")+ "/" { RETURN(body) }
 
-reBody
-  = ([^/\\]/"\\/")+ { RETURN(TEXT) }
-
-escapedChar
+EscapedChar
   = [\x00-\x1f\\]
 
-ws
+WhiteSpace
   = "\t"
   / "\v"
   / "\f"
@@ -777,7 +750,7 @@ ws
   / "\u00A0"
   / "\uFEFF"
 
-_ "whitespace" = ws+
-__ = ws*
+_  = WhiteSpace+
+__ = WhiteSpace*
 
 EOF = !.


### PR DESCRIPTION
This commit updates the coding style in the peg grammar to follow
the CamelCase convention.  Also, a few names were changed and
some rules were moved around to improve readability.  Some unused
rules were removed.  This is a style change only and does not include
any semantic changes.

This PR is arranged in three commits.  The first one is the name change,
the second one moves some peg rules around, and the third one is 
the auto-generated peg parsers.
