### PR TITLE
Make zar import work with volatile records

### DIFF
--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -192,7 +192,7 @@ func (dw *tsDirWriter) writeOne(rec *zng.Record) error {
 	// and slow down import. We should instead copy the raw record bytes into a
 	// recycled buffer and keep around an array of ts + byte-slice structs for
 	// sorting.
-	rec = rec.Keep()
+	rec.CopyBody()
 	dw.records = append(dw.records, rec)
 	dw.addBufSize(int64(len(rec.Raw)))
 	if dw.chunkSizeEstimate() > dw.ark.LogSizeThreshold {

--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -188,6 +188,11 @@ func (dw *tsDirWriter) chunkSizeEstimate() int64 {
 }
 
 func (dw *tsDirWriter) writeOne(rec *zng.Record) error {
+	// XXX This call leads to a ton of one-off allocations that burden the GC
+	// and slow down import. We should instead copy the raw record bytes into a
+	// recycled buffer and keep around an array of ts + byte-slice structs for
+	// sorting.
+	rec = rec.Keep()
 	dw.records = append(dw.records, rec)
 	dw.addBufSize(int64(len(rec.Raw)))
 	if dw.chunkSizeEstimate() > dw.ark.LogSizeThreshold {

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -121,8 +121,8 @@ func (r *Reader) reset() {
 	r.sos = r.peekerOffset
 }
 
-var startBatch = errors.New("start of uncmompressed batch")
-var endBatch = errors.New("end of uncmmpressed batch encountered while parsing data")
+var startBatch = errors.New("start of uncompressed batch")
+var endBatch = errors.New("end of uncompressed batch encountered while parsing data")
 
 // ReadPayload returns either data values as zbuf.Record or app-specific
 // messages .  The record or message is volatile so they must be


### PR DESCRIPTION
Fix issue where zar import would end up with corrupted records when
importing data from zng data sources.

Part of #1579