### PR TITLE
Avoid sharing a filter.Filter across scanner.Scanners

### DIFF
--- a/driver/multisource.go
+++ b/driver/multisource.go
@@ -7,7 +7,6 @@ import (
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/field"
-	"github.com/brimsec/zq/filter"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zng/resolver"
@@ -45,7 +44,6 @@ type ScannerCloser interface {
 }
 
 type SourceFilter struct {
-	Filter     filter.Filter
 	FilterExpr ast.BooleanExpr
 	Span       nano.Span
 }

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -8,7 +8,6 @@ import (
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/api/client"
 	"github.com/brimsec/zq/ast"
-	"github.com/brimsec/zq/filter"
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/scanner"
 	"github.com/brimsec/zq/zbuf"
@@ -151,7 +150,7 @@ func (pg *parallelGroup) nextSourceForConn(conn *client.Connection) (ScannerClos
 			return nil, err
 		}
 		search := client.NewZngSearch(rc)
-		s, err := scanner.NewScanner(pg.pctx.Context, search, nil, nil, req.Span)
+		s, err := scanner.NewScanner(pg.pctx.Context, search, nil, req.Span)
 		if err != nil {
 			return nil, err
 		}
@@ -209,11 +208,10 @@ func (pg *parallelGroup) run() {
 	close(pg.sourceChan)
 }
 
-func createParallelGroup(pctx *proc.Context, filt filter.Filter, filterExpr ast.BooleanExpr, msrc MultiSource, mcfg MultiConfig, workerURLs []string) ([]proc.Interface, *parallelGroup, error) {
+func createParallelGroup(pctx *proc.Context, filterExpr ast.BooleanExpr, msrc MultiSource, mcfg MultiConfig, workerURLs []string) ([]proc.Interface, *parallelGroup, error) {
 	pg := &parallelGroup{
 		pctx: pctx,
 		filter: SourceFilter{
-			Filter:     filt,
 			FilterExpr: filterExpr,
 			Span:       mcfg.Span,
 		},

--- a/driver/parallel_test.go
+++ b/driver/parallel_test.go
@@ -85,7 +85,7 @@ func (m *orderedmsrc) SendSources(ctx context.Context, span nano.Span, srcChan c
 		i := i
 		opener := func(zctx *resolver.Context, sf SourceFilter) (ScannerCloser, error) {
 			rdr := tzngio.NewReader(strings.NewReader(parallelTestInputs[i]), zctx)
-			sn, err := scanner.NewScanner(ctx, rdr, sf.Filter, sf.FilterExpr, sf.Span)
+			sn, err := scanner.NewScanner(ctx, rdr, sf.FilterExpr, sf.Span)
 			if err != nil {
 				return nil, err
 			}

--- a/ppl/archive/multisource.go
+++ b/ppl/archive/multisource.go
@@ -58,9 +58,9 @@ func newSpanScanner(ctx context.Context, ark *Archive, zctx *resolver.Context, s
 	}
 	var scn scanner.Scanner
 	if len(readers) == 1 {
-		scn, err = scanner.NewScanner(ctx, readers[0], sf.Filter, sf.FilterExpr, si.Span)
+		scn, err = scanner.NewScanner(ctx, readers[0], sf.FilterExpr, si.Span)
 	} else {
-		scn, err = scanner.NewCombiner(ctx, readers, zbuf.RecordCompare(ark.DataOrder), sf.Filter, sf.FilterExpr, si.Span)
+		scn, err = scanner.NewCombiner(ctx, readers, zbuf.RecordCompare(ark.DataOrder), sf.FilterExpr, si.Span)
 	}
 	if err != nil {
 		closers.Close()
@@ -211,7 +211,7 @@ func (s *chunkSource) Open(ctx context.Context, zctx *resolver.Context, sf drive
 		paths[i] = u.String()
 	}
 	rc := detector.MultiFileReader(zctx, paths, zio.ReaderOpts{Format: "zng"})
-	sn, err := scanner.NewScanner(ctx, rc, sf.Filter, sf.FilterExpr, sf.Span)
+	sn, err := scanner.NewScanner(ctx, rc, sf.FilterExpr, sf.Span)
 	if err != nil {
 		rc.Close()
 		return nil, err

--- a/scanner/combiner.go
+++ b/scanner/combiner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/brimsec/zq/ast"
-	"github.com/brimsec/zq/filter"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
 )
@@ -16,11 +15,11 @@ type combiner struct {
 
 // NewCombiner returns a Scanner that combines the records scanned from
 // a set of filtered readers.
-func NewCombiner(ctx context.Context, readers []zbuf.Reader, cmp zbuf.RecordCmpFn, f filter.Filter, filterExpr ast.BooleanExpr, span nano.Span) (Scanner, error) {
+func NewCombiner(ctx context.Context, readers []zbuf.Reader, cmp zbuf.RecordCmpFn, filterExpr ast.BooleanExpr, span nano.Span) (Scanner, error) {
 	scanners := make([]Scanner, len(readers))
 	scanReaders := make([]zbuf.Reader, len(readers))
 	for i, r := range readers {
-		s, err := NewScanner(ctx, r, f, filterExpr, span)
+		s, err := NewScanner(ctx, r, filterExpr, span)
 		if err != nil {
 			return nil, err
 		}

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/brimsec/zq/ast"
-	"github.com/brimsec/zq/filter"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/scanner"
@@ -168,11 +167,10 @@ func (r *multiFileReader) Close() (err error) {
 	return
 }
 
-func (r *multiFileReader) NewScanner(ctx context.Context, f filter.Filter, filterExpr ast.BooleanExpr, s nano.Span) (scanner.Scanner, error) {
+func (r *multiFileReader) NewScanner(ctx context.Context, filterExpr ast.BooleanExpr, s nano.Span) (scanner.Scanner, error) {
 	return &multiFileScanner{
 		multiFileReader: r,
 		ctx:             ctx,
-		filter:          f,
 		filterExpr:      filterExpr,
 		span:            s,
 	}, nil
@@ -181,7 +179,6 @@ func (r *multiFileReader) NewScanner(ctx context.Context, f filter.Filter, filte
 type multiFileScanner struct {
 	*multiFileReader
 	ctx        context.Context
-	filter     filter.Filter
 	filterExpr ast.BooleanExpr
 	span       nano.Span
 
@@ -198,7 +195,7 @@ func (s *multiFileScanner) Pull() (zbuf.Batch, error) {
 			return nil, err
 		}
 		if s.scanner == nil {
-			sn, err := scanner.NewScanner(s.ctx, s.reader, s.filter, s.filterExpr, s.span)
+			sn, err := scanner.NewScanner(s.ctx, s.reader, s.filterExpr, s.span)
 			if err != nil {
 				return nil, err
 			}

--- a/zio/detector/file_test.go
+++ b/zio/detector/file_test.go
@@ -60,7 +60,7 @@ func TestMultiFileScanner(t *testing.T) {
 	defer os.Remove(f2)
 
 	mfr := MultiFileReader(resolver.NewContext(), []string{f1, f2}, zio.ReaderOpts{})
-	sn, err := scanner.NewScanner(context.Background(), mfr, nil, nil, nano.MaxSpan)
+	sn, err := scanner.NewScanner(context.Background(), mfr, nil, nano.MaxSpan)
 	require.NoError(t, err)
 	_, ok := sn.(*multiFileScanner)
 	assert.True(t, ok)

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -495,11 +495,16 @@ func (r *Reader) parseValue(rec *zng.Record, id int, b []byte) (*zng.Record, err
 
 var _ scanner.ScannerAble = (*Reader)(nil)
 
-func (r *Reader) NewScanner(ctx context.Context, f filter.Filter, filterExpr ast.BooleanExpr, s nano.Span) (scanner.Scanner, error) {
+func (r *Reader) NewScanner(ctx context.Context, filterExpr ast.BooleanExpr, s nano.Span) (scanner.Scanner, error) {
 	var bf *filter.BufferFilter
+	var f filter.Filter
 	if filterExpr != nil {
 		var err error
 		bf, err = filter.NewBufferFilter(filterExpr)
+		if err != nil {
+			return nil, err
+		}
+		f, err = filter.Compile(resolver.NewContext(), filterExpr)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
A filter.Filter is not safe for concurrent execution, so avoid sharing
them across multiple scanner.Scanners.

Fixes #1589.