### PR TITLE
Rename zbuf.RecordCmpFn to zbuf.RecordLessFn

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -141,7 +141,7 @@ func (c *Command) Run(args []string) error {
 			readers[i] = zbuf.NewWarningReader(r, wch)
 		}
 	}
-	reader := zbuf.NewCombiner(readers, zbuf.CmpTimeForward)
+	reader := zbuf.NewCombiner(readers, zbuf.RecordLessTsForward)
 	defer reader.Close()
 
 	writer, err := c.outputFlags.Open()

--- a/cmd/zst/create/command.go
+++ b/cmd/zst/create/command.go
@@ -72,7 +72,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	reader := zbuf.NewCombiner(readers, zbuf.CmpTimeForward)
+	reader := zbuf.NewCombiner(readers, zbuf.RecordLessTsForward)
 	defer reader.Close()
 	writer, err := c.outputFlags.Open()
 	if err != nil {

--- a/ppl/archive/multisource.go
+++ b/ppl/archive/multisource.go
@@ -60,7 +60,7 @@ func newSpanScanner(ctx context.Context, ark *Archive, zctx *resolver.Context, s
 	if len(readers) == 1 {
 		scn, err = scanner.NewScanner(ctx, readers[0], sf.FilterExpr, si.Span)
 	} else {
-		scn, err = scanner.NewCombiner(ctx, readers, zbuf.RecordCompare(ark.DataOrder), sf.FilterExpr, si.Span)
+		scn, err = scanner.NewCombiner(ctx, readers, ark.DataOrder.RecordLess(), sf.FilterExpr, si.Span)
 	}
 	if err != nil {
 		closers.Close()

--- a/ppl/cmd/zar/import/command.go
+++ b/ppl/cmd/zar/import/command.go
@@ -105,12 +105,7 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	var reader zbuf.ReadCloser
-	if ark.DataOrder == zbuf.OrderAsc {
-		reader = zbuf.NewCombiner(readers, zbuf.CmpTimeForward)
-	} else {
-		reader = zbuf.NewCombiner(readers, zbuf.CmpTimeReverse)
-	}
+	reader := zbuf.NewCombiner(readers, ark.DataOrder.RecordLess())
 	defer reader.Close()
 
 	ctx, cancel := signalctx.New(os.Interrupt)

--- a/ppl/zqd/ingest/archivepcap.go
+++ b/ppl/zqd/ingest/archivepcap.go
@@ -100,7 +100,7 @@ func (p *archivePcapOp) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	combiner := zbuf.NewCombiner(zreaders, zbuf.RecordCompare(p.store.NativeOrder()))
+	combiner := zbuf.NewCombiner(zreaders, p.store.NativeOrder().RecordLess())
 	defer combiner.Close()
 
 	if err := zbuf.CopyWithContext(ctx, p.writer, combiner); err != nil {

--- a/ppl/zqd/ingest/log.go
+++ b/ppl/zqd/ingest/log.go
@@ -141,7 +141,7 @@ func (p *LogOp) start(ctx context.Context, store storage.Storage) {
 	for _, warning := range p.warnings {
 		p.warningCh <- warning
 	}
-	rc := zbuf.NewCombiner(p.readers, zbuf.RecordCompare(store.NativeOrder()))
+	rc := zbuf.NewCombiner(p.readers, store.NativeOrder().RecordLess())
 	defer rc.Close()
 	p.err = store.Write(ctx, p.zctx, rc)
 	if err := p.closeFiles(); err != nil && p.err != nil {

--- a/ppl/zqd/ingest/pcap.go
+++ b/ppl/zqd/ingest/pcap.go
@@ -22,7 +22,6 @@ import (
 	"github.com/brimsec/zq/ppl/zqd/space"
 	"github.com/brimsec/zq/ppl/zqd/storage"
 	"github.com/brimsec/zq/ppl/zqd/storage/archivestore"
-	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zio/ndjsonio"
@@ -290,7 +289,7 @@ func (p *legacyPcapOp) createSnapshot(ctx context.Context) error {
 	}
 	// convert logs into sorted zng
 	zctx := resolver.NewContext()
-	zr, err := detector.OpenFiles(ctx, zctx, zbuf.RecordCompare(p.store.NativeOrder()), files...)
+	zr, err := detector.OpenFiles(ctx, zctx, p.store.NativeOrder().RecordLess(), files...)
 	if err != nil {
 		return err
 	}

--- a/scanner/combiner.go
+++ b/scanner/combiner.go
@@ -15,7 +15,7 @@ type combiner struct {
 
 // NewCombiner returns a Scanner that combines the records scanned from
 // a set of filtered readers.
-func NewCombiner(ctx context.Context, readers []zbuf.Reader, cmp zbuf.RecordCmpFn, filterExpr ast.BooleanExpr, span nano.Span) (Scanner, error) {
+func NewCombiner(ctx context.Context, readers []zbuf.Reader, less zbuf.RecordLessFn, filterExpr ast.BooleanExpr, span nano.Span) (Scanner, error) {
 	scanners := make([]Scanner, len(readers))
 	scanReaders := make([]zbuf.Reader, len(readers))
 	for i, r := range readers {
@@ -27,7 +27,7 @@ func NewCombiner(ctx context.Context, readers []zbuf.Reader, cmp zbuf.RecordCmpF
 		scanReaders[i] = zbuf.PullerReader(s)
 	}
 	return &combiner{
-		reader:   zbuf.NewCombiner(scanReaders, cmp),
+		reader:   zbuf.NewCombiner(scanReaders, less),
 		scanners: scanners,
 	}, nil
 }

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -86,7 +86,7 @@ func OpenFromNamedReadCloser(zctx *resolver.Context, rc io.ReadCloser, path stri
 	return zbuf.NewFile(zr, rc, path), nil
 }
 
-func OpenFiles(ctx context.Context, zctx *resolver.Context, dir zbuf.RecordCmpFn, paths ...string) (zbuf.ReadCloser, error) {
+func OpenFiles(ctx context.Context, zctx *resolver.Context, less zbuf.RecordLessFn, paths ...string) (zbuf.ReadCloser, error) {
 	var readers []zbuf.Reader
 	for _, path := range paths {
 		reader, err := OpenFileWithContext(ctx, zctx, path, zio.ReaderOpts{})
@@ -95,7 +95,7 @@ func OpenFiles(ctx context.Context, zctx *resolver.Context, dir zbuf.RecordCmpFn
 		}
 		readers = append(readers, reader)
 	}
-	return zbuf.NewCombiner(readers, dir), nil
+	return zbuf.NewCombiner(readers, less), nil
 }
 
 type multiFileReader struct {

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -618,7 +618,7 @@ func loadInputs(inputs []string, zctx *resolver.Context) (zbuf.ReadCloser, error
 		}
 		readers = append(readers, zr)
 	}
-	return zbuf.NewCombiner(readers, zbuf.CmpTimeForward), nil
+	return zbuf.NewCombiner(readers, zbuf.RecordLessTsForward), nil
 }
 
 func tmpInputFiles(inputs []string) (string, []string, error) {


### PR DESCRIPTION
A zbuf.RecordCmpFn is a less function (like sort.Interface.Less) rather
than a comparision function (like bytes.Compare).  Rename it to
zbuf.RecordLessFn to reflect that, and rename functions and variables
accordingly.