### PR TITLE
fix memory bug in collect aggregation

### DIFF
--- a/reducer/collect.go
+++ b/reducer/collect.go
@@ -36,9 +36,12 @@ func (c *Collect) Consume(r *zng.Record) {
 }
 
 func (c *Collect) update(b zcode.Bytes) {
-	c.val = append(c.val, b)
+	stash := make(zcode.Bytes, len(b))
+	copy(stash, b)
+	c.val = append(c.val, stash)
 	c.size += len(b)
 	for c.size > MaxValueSize {
+		c.MemExceeded++
 		c.size -= len(c.val[0])
 		c.val = c.val[1:]
 	}


### PR DESCRIPTION
This commit fixes a memory bug where the values in the collect
aggregator needed to be copied since the passed-in byte slice
points into a volatile buffer.

This is not easy to reproduce so I haven't added a test as the
test case provided in the bug/issue is a very large data file.
I think we should create a scanner that deliberately corrupts
its scanner buffer (as an option to zq) so we can run system
tests across the board that detect this sort of bug rather than
adding a go unit test everywhere we can think of (issue #1597).

Also, I noticed the collect aggregator was not bumping the error
counter when its memory limit was exceeded so I fixed that too.