### PR TITLE
Improve developer doc links

### DIFF
--- a/zql/docs/aggregate-functions/README.md
+++ b/zql/docs/aggregate-functions/README.md
@@ -109,7 +109,7 @@ TS                   SHORT_RTT            SHORT_COUNT LONG_RTT             LONG_
 | **Syntax**                | `and(<expression>)`                                            |
 | **Required<br>arguments** | `<expression>`<br>A valid ZQL [expression](../expressions/README.md). |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer               |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Logical       |
 
 #### Example:
 
@@ -400,7 +400,7 @@ MIN
 | **Syntax**                | `or(<expression>)`                                             |
 | **Required<br>arguments** | `<expression>`<br>A valid ZQL [expression](../expressions/README.md). |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer               |
+| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Logical       |
 
 #### Example:
 


### PR DESCRIPTION
There were a couple links to developer docs for the new aggregate functions that I could only update after the new tagged `v0.23.0` release went out and the destinations appeared on pkg.go.dev.