### PR TITLE
Fix seekindex lookups for descending order indices

### DIFF
--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -267,10 +267,10 @@ type chunkWriter struct {
 	dataFileWriter *zngio.Writer
 	firstTs        nano.Ts
 	id             ksuid.KSUID
-	seekIndex      *seekindex.Builder
 	lastTs         nano.Ts
 	masks          []ksuid.KSUID
 	needIndexWrite bool
+	seekIndex      *seekindex.Builder
 	tsd            tsDir
 	wroteFirst     bool
 }

--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -3,16 +3,13 @@ package archive
 import (
 	"context"
 	"io"
-	"io/ioutil"
-	"os"
 	"sync/atomic"
 
 	"github.com/brimsec/zq/expr"
-	"github.com/brimsec/zq/microindex"
 	"github.com/brimsec/zq/pkg/bufwriter"
-	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/ppl/archive/seekindex"
 	"github.com/brimsec/zq/proc/sort"
 	"github.com/brimsec/zq/proc/spill"
 	"github.com/brimsec/zq/zbuf"
@@ -264,20 +261,18 @@ func (dw *tsDirWriter) flush() error {
 // chunkWriter is a zbuf.Writer that writes a stream of sorted records into an
 // archive chunk file.
 type chunkWriter struct {
-	ark             *Archive
-	byteCounter     *writeCounter
-	count           uint64
-	dataFileWriter  *zngio.Writer
-	firstTs         nano.Ts
-	id              ksuid.KSUID
-	indexBuilder    *zng.Builder
-	indexTempPath   string
-	indexTempWriter *zngio.Writer
-	lastTs          nano.Ts
-	masks           []ksuid.KSUID
-	needIndexWrite  bool
-	tsd             tsDir
-	wroteFirst      bool
+	ark            *Archive
+	byteCounter    *writeCounter
+	count          uint64
+	dataFileWriter *zngio.Writer
+	firstTs        nano.Ts
+	id             ksuid.KSUID
+	seekIndex      *seekindex.Builder
+	lastTs         nano.Ts
+	masks          []ksuid.KSUID
+	needIndexWrite bool
+	tsd            tsDir
+	wroteFirst     bool
 }
 
 func newChunkWriter(ctx context.Context, ark *Archive, tsd tsDir, masks []ksuid.KSUID) (*chunkWriter, error) {
@@ -291,29 +286,20 @@ func newChunkWriter(ctx context.Context, ark *Archive, tsd tsDir, masks []ksuid.
 		LZ4BlockSize:     importLZ4BlockSize,
 		StreamRecordsMax: ImportStreamRecordsMax,
 	})
-	// Create the temporary index key file
-	idxTemp, err := ioutil.TempFile("", "archive-import-index-key-")
+	seekIndexPath := chunkSeekIndexPath(ark, tsd, id)
+	seekIndex, err := seekindex.NewBuilder(ctx, seekIndexPath.String(), ark.DataOrder)
 	if err != nil {
 		return nil, err
 	}
-	indexTempPath := idxTemp.Name()
-	indexTempWriter := zngio.NewWriter(bufwriter.New(idxTemp), zngio.WriterOpts{})
-	zctx := resolver.NewContext()
-	indexBuilder := zng.NewBuilder(zctx.MustLookupTypeRecord([]zng.Column{
-		{"ts", zng.TypeTime},
-		{"offset", zng.TypeInt64},
-	}))
 	return &chunkWriter{
-		ark:             ark,
-		byteCounter:     counter,
-		dataFileWriter:  dataFileWriter,
-		id:              id,
-		indexBuilder:    indexBuilder,
-		indexTempPath:   indexTempPath,
-		indexTempWriter: indexTempWriter,
-		masks:           masks,
-		needIndexWrite:  true,
-		tsd:             tsd,
+		ark:            ark,
+		byteCounter:    counter,
+		dataFileWriter: dataFileWriter,
+		id:             id,
+		seekIndex:      seekIndex,
+		masks:          masks,
+		needIndexWrite: true,
+		tsd:            tsd,
 	}, nil
 }
 
@@ -330,8 +316,7 @@ func (cw *chunkWriter) Write(rec *zng.Record) error {
 		return err
 	}
 	if cw.needIndexWrite {
-		out := cw.indexBuilder.Build(zng.EncodeTime(rec.Ts()), zng.EncodeInt(sos))
-		if err := cw.indexTempWriter.Write(out); err != nil {
+		if err := cw.seekIndex.Enter(rec.Ts(), sos); err != nil {
 			return err
 		}
 		cw.needIndexWrite = false
@@ -353,8 +338,7 @@ func (cw *chunkWriter) Write(rec *zng.Record) error {
 // because the write error will be more informative and should be returned.
 func (cw *chunkWriter) abort() {
 	cw.dataFileWriter.Close()
-	cw.indexTempWriter.Close()
-	os.Remove(cw.indexTempPath)
+	cw.seekIndex.Abort()
 }
 
 func (cw *chunkWriter) close(ctx context.Context) (Chunk, error) {
@@ -363,10 +347,8 @@ func (cw *chunkWriter) close(ctx context.Context) (Chunk, error) {
 
 func (cw *chunkWriter) closeWithTs(ctx context.Context, firstTs, lastTs nano.Ts) (Chunk, error) {
 	err := cw.dataFileWriter.Close()
-	if closeErr := cw.indexTempWriter.Close(); err == nil {
-		err = closeErr
-	}
 	if err != nil {
+		cw.seekIndex.Abort()
 		return Chunk{}, err
 	}
 	metadata := chunkMetadata{
@@ -377,38 +359,17 @@ func (cw *chunkWriter) closeWithTs(ctx context.Context, firstTs, lastTs nano.Ts)
 		Size:        cw.dataFileWriter.Position(),
 	}
 	if err := writeChunkMetadata(ctx, chunkMetadataPath(cw.ark, cw.tsd, cw.id), metadata); err != nil {
+		cw.seekIndex.Abort()
 		return Chunk{}, err
 	}
-	// Write the time seek index into the archive, feeding it the key/offset
-	// records written to indexTempPath.
-	tf, err := fs.Open(cw.indexTempPath)
-	if err != nil {
-		return Chunk{}, err
-	}
-	defer func() {
-		tf.Close()
-		os.Remove(tf.Name())
-	}()
-	zctx := resolver.NewContext()
-	tfr := zngio.NewReader(tf, zctx)
-	chunk := metadata.Chunk(cw.id)
-	idxURI := chunk.seekIndexPath(cw.ark)
-	idxWriter, err := microindex.NewWriter(zctx, idxURI.String(),
-		microindex.Keys("ts"),
-		microindex.FrameThresh(framesize),
-		microindex.Order(cw.ark.DataOrder),
-	)
-	if err != nil {
-		return Chunk{}, err
-	}
-	if err = zbuf.CopyWithContext(ctx, idxWriter, tfr); err != nil {
-		idxWriter.Abort()
+	if err := cw.seekIndex.Close(); err != nil {
+		cw.seekIndex.Abort()
 		return Chunk{}, err
 	}
 	// TODO: zq#1264
 	// Add an entry to the update log for S3 backed stores containing the
 	// location of the just added data & index file.
-	return chunk, idxWriter.Close()
+	return metadata.Chunk(cw.id), nil
 }
 
 type writeCounter struct {

--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -363,7 +363,6 @@ func (cw *chunkWriter) closeWithTs(ctx context.Context, firstTs, lastTs nano.Ts)
 		return Chunk{}, err
 	}
 	if err := cw.seekIndex.Close(); err != nil {
-		cw.seekIndex.Abort()
 		return Chunk{}, err
 	}
 	// TODO: zq#1264

--- a/ppl/archive/seekindex/builder.go
+++ b/ppl/archive/seekindex/builder.go
@@ -1,0 +1,44 @@
+package seekindex
+
+import (
+	"context"
+
+	"github.com/brimsec/zq/microindex"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type Builder struct {
+	builder *zng.Builder
+	path    string
+	writer  *microindex.Writer
+}
+
+func NewBuilder(ctx context.Context, path string, order zbuf.Order) (*Builder, error) {
+	zctx := resolver.NewContext()
+	writer, err := microindex.NewWriterWithContext(ctx, zctx, path, microindex.Order(order), microindex.Keys("ts"))
+	if err != nil {
+		return nil, err
+	}
+	builder := zng.NewBuilder(zctx.MustLookupTypeRecord(Schema))
+	return &Builder{
+		builder: builder,
+		path:    path,
+		writer:  writer,
+	}, nil
+}
+
+func (b *Builder) Enter(ts nano.Ts, offset int64) error {
+	rec := b.builder.Build(zng.EncodeTime(ts), zng.EncodeInt(offset))
+	return b.writer.Write(rec)
+}
+
+func (b *Builder) Abort() error {
+	return b.writer.Abort()
+}
+
+func (b *Builder) Close() error {
+	return b.writer.Close()
+}

--- a/ppl/archive/seekindex/builder.go
+++ b/ppl/archive/seekindex/builder.go
@@ -38,7 +38,7 @@ func (b *Builder) Abort() error {
 }
 
 // Close closes the underlying microindex.Writer. Should an error occur the
-// microindex will be deleted via a call to abort.
+// microindex will be deleted via a call to Abort.
 func (b *Builder) Close() error {
 	err := b.writer.Close()
 	if err != nil {

--- a/ppl/archive/seekindex/builder.go
+++ b/ppl/archive/seekindex/builder.go
@@ -12,7 +12,6 @@ import (
 
 type Builder struct {
 	builder *zng.Builder
-	path    string
 	writer  *microindex.Writer
 }
 
@@ -25,7 +24,6 @@ func NewBuilder(ctx context.Context, path string, order zbuf.Order) (*Builder, e
 	builder := zng.NewBuilder(zctx.MustLookupTypeRecord(Schema))
 	return &Builder{
 		builder: builder,
-		path:    path,
 		writer:  writer,
 	}, nil
 }
@@ -39,6 +37,12 @@ func (b *Builder) Abort() error {
 	return b.writer.Abort()
 }
 
+// Close closes the underlying microindex.Writer. Should an error occur the
+// microindex will be deleted via a call to abort.
 func (b *Builder) Close() error {
-	return b.writer.Close()
+	err := b.writer.Close()
+	if err != nil {
+		b.Abort()
+	}
+	return err
 }

--- a/ppl/archive/seekindex/builder.go
+++ b/ppl/archive/seekindex/builder.go
@@ -21,9 +21,8 @@ func NewBuilder(ctx context.Context, path string, order zbuf.Order) (*Builder, e
 	if err != nil {
 		return nil, err
 	}
-	builder := zng.NewBuilder(zctx.MustLookupTypeRecord(Schema))
 	return &Builder{
-		builder: builder,
+		builder: zng.NewBuilder(zctx.MustLookupTypeRecord(Schema)),
 		writer:  writer,
 	}, nil
 }

--- a/ppl/archive/seekindex/builder.go
+++ b/ppl/archive/seekindex/builder.go
@@ -10,6 +10,11 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 )
 
+var schema = []zng.Column{
+	{"ts", zng.TypeTime},
+	{"offset", zng.TypeInt64},
+}
+
 type Builder struct {
 	builder *zng.Builder
 	writer  *microindex.Writer
@@ -22,7 +27,7 @@ func NewBuilder(ctx context.Context, path string, order zbuf.Order) (*Builder, e
 		return nil, err
 	}
 	return &Builder{
-		builder: zng.NewBuilder(zctx.MustLookupTypeRecord(Schema)),
+		builder: zng.NewBuilder(zctx.MustLookupTypeRecord(schema)),
 		writer:  writer,
 	}, nil
 }

--- a/ppl/archive/seekindex/range.go
+++ b/ppl/archive/seekindex/range.go
@@ -1,0 +1,27 @@
+package seekindex
+
+import "io"
+
+type Range struct {
+	Start, End int64
+}
+
+func (r Range) TrimEnd(end int64) Range {
+	if r.End > end {
+		r.End = end
+	}
+	return r
+}
+
+func (r Range) Size() int64 {
+	return r.End - r.Start
+}
+
+func (r Range) LimitReader(reader io.ReadSeeker) (io.Reader, error) {
+	if r.Start > 0 {
+		if _, err := reader.Seek(r.Start, io.SeekStart); err != nil {
+			return nil, err
+		}
+	}
+	return io.LimitReader(reader, r.Size()), nil
+}

--- a/ppl/archive/seekindex/seekindex.go
+++ b/ppl/archive/seekindex/seekindex.go
@@ -12,11 +12,6 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-var Schema = []zng.Column{
-	{"ts", zng.TypeTime},
-	{"offset", zng.TypeInt64},
-}
-
 type SeekIndex struct {
 	finder *microindex.Finder
 }

--- a/ppl/archive/seekindex/seekindex.go
+++ b/ppl/archive/seekindex/seekindex.go
@@ -1,0 +1,88 @@
+package seekindex
+
+import (
+	"context"
+	"math"
+
+	"github.com/brimsec/zq/microindex"
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+var Schema = []zng.Column{
+	{"ts", zng.TypeTime},
+	{"offset", zng.TypeInt64},
+}
+
+type SeekIndex struct {
+	finder *microindex.Finder
+}
+
+func Open(ctx context.Context, uri iosrc.URI) (*SeekIndex, error) {
+	finder, err := microindex.NewFinder(ctx, resolver.NewContext(), uri)
+	if err != nil {
+		return nil, err
+	}
+	return &SeekIndex{finder: finder}, nil
+}
+
+func (s *SeekIndex) Lookup(ctx context.Context, span nano.Span) (rg Range, err error) {
+	if s.finder.Order() == zbuf.OrderDesc {
+		rg, err = s.lookupDesc(ctx, span)
+	} else {
+		rg, err = s.lookupAsc(ctx, span)
+	}
+	if err != nil {
+		return
+	}
+	if rg.Start == -1 {
+		rg.Start = 0
+	}
+	if rg.End == -1 {
+		rg.End = math.MaxInt64
+	}
+	return
+}
+
+func (s *SeekIndex) lookupAsc(ctx context.Context, span nano.Span) (rg Range, err error) {
+	rg.Start, err = s.offsetAt(ctx, span.Ts, true)
+	if err != nil {
+		return
+	}
+	rg.End, err = s.offsetAt(ctx, span.End(), false)
+	return
+}
+
+func (s *SeekIndex) lookupDesc(ctx context.Context, span nano.Span) (rg Range, err error) {
+	rg.Start, err = s.offsetAt(ctx, span.End()-1, false)
+	if err != nil {
+		return
+	}
+	rg.End, err = s.offsetAt(ctx, span.Ts-1, true)
+	return
+}
+
+func (s *SeekIndex) offsetAt(ctx context.Context, ts nano.Ts, less bool) (int64, error) {
+	key, err := s.finder.ParseKeys(ts.StringFloat())
+	if err != nil {
+		return -1, err
+	}
+	var rec *zng.Record
+	// XXX These calls to finder should have the ability to pass context.
+	if less {
+		rec, err = s.finder.ClosestLTE(key)
+	} else {
+		rec, err = s.finder.ClosestGTE(key)
+	}
+	if rec == nil || err != nil {
+		return -1, err
+	}
+	return rec.AccessInt("offset")
+}
+
+func (s *SeekIndex) Close() error {
+	return s.finder.Close()
+}

--- a/ppl/archive/seekindex/seekindex_test.go
+++ b/ppl/archive/seekindex/seekindex_test.go
@@ -1,0 +1,103 @@
+package seekindex
+
+import (
+	"context"
+	"io/ioutil"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAscending(t *testing.T) {
+	var entries = []entry{
+		{1490469784771872000, 0},
+		{1490469786286912000, 215367},
+		{1490469787357005000, 438514},
+		{1490469788607068000, 680477},
+		{1490469790128032000, 904528},
+		{1490469791268206000, 1139588},
+		{1490469792684029000, 1355498},
+		{1490469794231011000, 1564211},
+		{1490469795517324000, 1776965},
+		{1490469796974189000, 1992947},
+	}
+	s := newTestSeekIndex(t, entries)
+	s.Lookup(nano.Span{Ts: 1490469784771872000, Dur: 1}, Range{0, 215367})
+	s.Lookup(nano.Span{Ts: 1490469784771871999, Dur: 1}, Range{0, 0})
+	s.Lookup(nano.Span{Ts: 1490469791268206000, Dur: 1}, Range{1139588, 1355498})
+	s.Lookup(nano.Span{Ts: 1490469796974189000, Dur: 1}, Range{1992947, math.MaxInt64})
+}
+
+func TestDescending(t *testing.T) {
+	var entries = []entry{
+		{900, 0},
+		{800, 215367},
+		{700, 438514},
+		{600, 680477},
+		{500, 904528},
+		{400, 1139588},
+		{300, 1355498},
+		{200, 1564211},
+		{100, 1776965},
+	}
+	s := newTestSeekIndex(t, entries)
+	s.Lookup(nano.Span{Ts: 900, Dur: 1}, Range{0, 215367})
+	s.Lookup(nano.Span{Ts: 700, Dur: 1}, Range{438514, 680477})
+	s.Lookup(nano.Span{Ts: 750, Dur: 100}, Range{0, 438514})
+	s.Lookup(nano.Span{Ts: 100, Dur: 1}, Range{1776965, math.MaxInt64})
+
+}
+
+type entry struct {
+	ts     nano.Ts
+	offset int64
+}
+
+type entries []entry
+
+func (e entries) Order() zbuf.Order {
+	if len(e) < 2 || e[0].ts < e[1].ts {
+		return zbuf.OrderAsc
+	}
+	return zbuf.OrderDesc
+}
+
+type testSeekIndex struct {
+	*SeekIndex
+	*testing.T
+}
+
+func (t *testSeekIndex) Lookup(span nano.Span, expected Range) {
+	rg, err := t.SeekIndex.Lookup(context.Background(), span)
+	require.NoError(t, err)
+	assert.Equal(t, expected, rg)
+}
+
+func newTestSeekIndex(t *testing.T, entries []entry) *testSeekIndex {
+	path := build(t, entries)
+	s, err := Open(context.Background(), iosrc.MustParseURI(path))
+	require.NoError(t, err)
+	return &testSeekIndex{s, t}
+}
+
+func build(t *testing.T, entries entries) string {
+	dir, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Remove(dir) })
+	path := filepath.Join(dir, "seekindex.zng")
+	builder, err := NewBuilder(context.Background(), path, entries.Order())
+	require.NoError(t, err)
+	for _, entry := range entries {
+		err = builder.Enter(entry.ts, entry.offset)
+		require.NoError(t, err)
+	}
+	require.NoError(t, builder.Close())
+	return path
+}

--- a/ppl/archive/seekindex/seekindex_test.go
+++ b/ppl/archive/seekindex/seekindex_test.go
@@ -17,22 +17,22 @@ import (
 
 func TestAscending(t *testing.T) {
 	var entries = []entry{
-		{1490469784771872000, 0},
-		{1490469786286912000, 215367},
-		{1490469787357005000, 438514},
-		{1490469788607068000, 680477},
-		{1490469790128032000, 904528},
-		{1490469791268206000, 1139588},
-		{1490469792684029000, 1355498},
-		{1490469794231011000, 1564211},
-		{1490469795517324000, 1776965},
-		{1490469796974189000, 1992947},
+		{100, 0},
+		{200, 215367},
+		{300, 438514},
+		{400, 680477},
+		{500, 904528},
+		{600, 1139588},
+		{700, 1355498},
+		{800, 1564211},
+		{900, 1776965},
+		{1000, 1992947},
 	}
 	s := newTestSeekIndex(t, entries)
-	s.Lookup(nano.Span{Ts: 1490469784771872000, Dur: 1}, Range{0, 215367})
-	s.Lookup(nano.Span{Ts: 1490469784771871999, Dur: 1}, Range{0, 0})
-	s.Lookup(nano.Span{Ts: 1490469791268206000, Dur: 1}, Range{1139588, 1355498})
-	s.Lookup(nano.Span{Ts: 1490469796974189000, Dur: 1}, Range{1992947, math.MaxInt64})
+	s.Lookup(nano.Span{Ts: 100, Dur: 1}, Range{0, 215367})
+	s.Lookup(nano.Span{Ts: 99, Dur: 1}, Range{0, 0})
+	s.Lookup(nano.Span{Ts: 600, Dur: 1}, Range{1139588, 1355498})
+	s.Lookup(nano.Span{Ts: 1000, Dur: 1}, Range{1992947, math.MaxInt64})
 }
 
 func TestDescending(t *testing.T) {
@@ -83,6 +83,7 @@ func (t *testSeekIndex) Lookup(span nano.Span, expected Range) {
 func newTestSeekIndex(t *testing.T, entries []entry) *testSeekIndex {
 	path := build(t, entries)
 	s, err := Open(context.Background(), iosrc.MustParseURI(path))
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
 	require.NoError(t, err)
 	return &testSeekIndex{s, t}
 }


### PR DESCRIPTION
Fix an off-by-one error one descending seek indexes that was causing missed
records in certain circumstances.

Additionally: The way the seek index was written, made it difficult to isolate
issues. As such I moved seekindex into its own package that includes both
builder and reader functionality.

Closes #1579