### PR TITLE
Advance Zeek pointer and fix tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export GO111MODULE=on
 VERSION = $(shell git describe --tags --dirty --always)
 ECR_VERSION = $(VERSION)-$(ZQD_K8S_USER)
 LDFLAGS = -s -X github.com/brimsec/zq/cli.Version=$(VERSION)
-ZEEKTAG = v3.2.1-brim2
+ZEEKTAG = v3.2.1-brim4
 ZEEKPATH = zeek-$(ZEEKTAG)
 SURICATATAG = v5.0.3-brim8
 SURICATAPATH = suricata-$(SURICATATAG)

--- a/ztests/suite/zqd/archivestore/postpcap.yaml
+++ b/ztests/suite/zqd/archivestore/postpcap.yaml
@@ -1,7 +1,7 @@
 script: |
   source services.sh
   zapi -h $ZQD_HOST -s testsp postpcap -k archivestore -f ng.pcap >/dev/null
-  zapi -h $ZQD_HOST -s testsp get -f tzng "_path != stats | cut -c uid | sort -r ts, _path"
+  zapi -h $ZQD_HOST -s testsp get -f tzng "_path != stats | cut -c uid,geo | sort -r ts, _path"
   echo ===
   zapi -h $ZQD_HOST -s testsp get -f tzng "count()"
 
@@ -18,13 +18,13 @@ outputs:
       0:[capture_loss;1425568893.736974;0.001192;zeek;0;0;0;]
       #port=uint16
       #zenum=string
-      #1:record[_path:string,ts:time,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port],proto:zenum,service:bstring,duration:duration,orig_bytes:uint64,resp_bytes:uint64,conn_state:bstring,local_orig:bool,local_resp:bool,missed_bytes:uint64,history:bstring,orig_pkts:uint64,orig_ip_bytes:uint64,resp_pkts:uint64,resp_ip_bytes:uint64,tunnel_parents:set[bstring],geo:record[orig:record[country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64],resp:record[country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64]],community_id:bstring]
-      1:[conn;1425568893.735782;[192.168.0.2;34446;130.236.100.79;80;]tcp;-;0.001192;0;2776;OTH;-;-;0;Ad;1;52;2;2880;-;[[-;-;-;-;-;][SE;E;Linköping;58.4167;15.6167;]]1:tOxXSQENCvoWlZaDPdf9YgwpshQ=;]
+      #1:record[_path:string,ts:time,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port],proto:zenum,service:bstring,duration:duration,orig_bytes:uint64,resp_bytes:uint64,conn_state:bstring,local_orig:bool,local_resp:bool,missed_bytes:uint64,history:bstring,orig_pkts:uint64,orig_ip_bytes:uint64,resp_pkts:uint64,resp_ip_bytes:uint64,tunnel_parents:set[bstring],community_id:bstring]
+      1:[conn;1425568893.735782;[192.168.0.2;34446;130.236.100.79;80;]tcp;-;0.001192;0;2776;OTH;-;-;0;Ad;1;52;2;2880;-;1:tOxXSQENCvoWlZaDPdf9YgwpshQ=;]
       0:[capture_loss;1425568893.735782;1460.943301;zeek;0;0;0;]
-      1:[conn;1425567432.792481;[192.168.0.51;50858;192.168.0.1;80;]tcp;-;0.00074;338;0;OTH;-;-;0;ADa;2;418;1;40;-;[[-;-;-;-;-;][-;-;-;-;-;]]1:YrhsMQd8siqxEOoc6A5E/gKZDgY=;]
-      1:[conn;1425567047.804914;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;[[-;-;-;-;-;][-;-;-;47;8;]]1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
-      1:[conn;1425567047.804906;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;[[-;-;-;-;-;][-;-;-;47;8;]]1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
-      1:[conn;1425567047.803929;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;[[-;-;-;-;-;][-;-;-;47;8;]]1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
+      1:[conn;1425567432.792481;[192.168.0.51;50858;192.168.0.1;80;]tcp;-;0.00074;338;0;OTH;-;-;0;ADa;2;418;1;40;-;1:YrhsMQd8siqxEOoc6A5E/gKZDgY=;]
+      1:[conn;1425567047.804914;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
+      1:[conn;1425567047.804906;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
+      1:[conn;1425567047.803929;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
       ===
       #0:record[count:uint64]
       0:[10;]

--- a/ztests/suite/zqd/postpcap.yaml
+++ b/ztests/suite/zqd/postpcap.yaml
@@ -1,7 +1,7 @@
 script: |
   source services.sh
   zapi -h $ZQD_HOST -s testsp postpcap -f ng.pcap >/dev/null
-  zapi -h $ZQD_HOST -s testsp get -f tzng "_path != stats | cut -c uid | sort -r ts, _path"
+  zapi -h $ZQD_HOST -s testsp get -f tzng "_path != stats | cut -c uid,geo | sort -r ts, _path"
   echo ===
   zapi -h $ZQD_HOST -s testsp get -f tzng "count()"
 
@@ -18,13 +18,13 @@ outputs:
       0:[capture_loss;1425568893.736974;0.001192;zeek;0;0;0;]
       #port=uint16
       #zenum=string
-      #1:record[_path:string,ts:time,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port],proto:zenum,service:bstring,duration:duration,orig_bytes:uint64,resp_bytes:uint64,conn_state:bstring,local_orig:bool,local_resp:bool,missed_bytes:uint64,history:bstring,orig_pkts:uint64,orig_ip_bytes:uint64,resp_pkts:uint64,resp_ip_bytes:uint64,tunnel_parents:set[bstring],geo:record[orig:record[country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64],resp:record[country_code:bstring,region:bstring,city:bstring,latitude:float64,longitude:float64]],community_id:bstring]
-      1:[conn;1425568893.735782;[192.168.0.2;34446;130.236.100.79;80;]tcp;-;0.001192;0;2776;OTH;-;-;0;Ad;1;52;2;2880;-;[[-;-;-;-;-;][SE;E;Linköping;58.4167;15.6167;]]1:tOxXSQENCvoWlZaDPdf9YgwpshQ=;]
+      #1:record[_path:string,ts:time,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port],proto:zenum,service:bstring,duration:duration,orig_bytes:uint64,resp_bytes:uint64,conn_state:bstring,local_orig:bool,local_resp:bool,missed_bytes:uint64,history:bstring,orig_pkts:uint64,orig_ip_bytes:uint64,resp_pkts:uint64,resp_ip_bytes:uint64,tunnel_parents:set[bstring],community_id:bstring]
+      1:[conn;1425568893.735782;[192.168.0.2;34446;130.236.100.79;80;]tcp;-;0.001192;0;2776;OTH;-;-;0;Ad;1;52;2;2880;-;1:tOxXSQENCvoWlZaDPdf9YgwpshQ=;]
       0:[capture_loss;1425568893.735782;1460.943301;zeek;0;0;0;]
-      1:[conn;1425567432.792481;[192.168.0.51;50858;192.168.0.1;80;]tcp;-;0.00074;338;0;OTH;-;-;0;ADa;2;418;1;40;-;[[-;-;-;-;-;][-;-;-;-;-;]]1:YrhsMQd8siqxEOoc6A5E/gKZDgY=;]
-      1:[conn;1425567047.804914;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;[[-;-;-;-;-;][-;-;-;47;8;]]1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
-      1:[conn;1425567047.804906;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;[[-;-;-;-;-;][-;-;-;47;8;]]1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
-      1:[conn;1425567047.803929;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;[[-;-;-;-;-;][-;-;-;47;8;]]1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
+      1:[conn;1425567432.792481;[192.168.0.51;50858;192.168.0.1;80;]tcp;-;0.00074;338;0;OTH;-;-;0;ADa;2;418;1;40;-;1:YrhsMQd8siqxEOoc6A5E/gKZDgY=;]
+      1:[conn;1425567047.804914;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
+      1:[conn;1425567047.804906;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
+      1:[conn;1425567047.803929;[192.168.0.51;33773;80.239.174.91;443;]tcp;-;-;-;-;OTH;-;-;0;^d;0;0;1;1440;-;1:wPP6HnEPl0F9QDVCQ+E0du2PUi8=;]
       ===
       #0:record[count:uint64]
       0:[10;]


### PR DESCRIPTION
We'd not advanced our Zeek pointer for the `zq` system tests in a while, so I've done that here.

Doing so revealed a couple tests that needed to be fixed. A connection that previously lacked a match in the geolocation database now has an entry, leading to different output. Much like we do for Zeek `uid` values that change on every run, here I've excluded the `geo` field so the tests won't be sensitive to this going forward. We already have decent upstream test coverage of the geolocation support in that the [smoketest Action in geoip-conn](https://github.com/brimsec/geoip-conn/blob/master/.github/workflows/smoketest.yml) ensures that each time we update the Zeek package it still outputs a location for a known location that we've never seen change/disappear.

This work is a prerequisite to a PR I'll put up next with a proposal to have a single set of tags for Zeek/Suricata dependencies in the zq repo and have those ripple to Brim when that gets built. I wanted to get everything current and passing before I go varying the implementation.