### PR TITLE
deprecate package-style function names

### DIFF
--- a/driver/compile.go
+++ b/driver/compile.go
@@ -216,7 +216,7 @@ func ReplaceGroupByProcDurationWithKey(p ast.Proc) {
 				LHS: ast.NewDotExpr(field.New("ts")),
 				RHS: &ast.FunctionCall{
 					Node:     ast.Node{"FunctionCall"},
-					Function: "Time.trunc",
+					Function: "trunc",
 					Args: []ast.Expression{
 						ast.NewDotExpr(field.New("ts")),
 						&ast.Literal{
@@ -276,7 +276,7 @@ func setGroupByProcInputSortDir(p ast.Proc, inputSortField field.Static, inputSo
 			}
 			if expr, ok := p.Keys[0].RHS.(*ast.FunctionCall); ok {
 				switch expr.Function {
-				case "Math.ceil", "Math.floor", "Math.round", "Time.trunc":
+				case "ceil", "floor", "round", "trunc":
 					if len(expr.Args) == 0 {
 						return false
 					}

--- a/driver/compile_test.go
+++ b/driver/compile_test.go
@@ -52,7 +52,7 @@ func TestComputeColumns(t *testing.T) {
 			[]string{"ts", "x", "y"},
 		},
 		{
-			"every 1s count(y) by foo=String.replace(x, y, z)",
+			"every 1s count(y) by foo=replace(x, y, z)",
 			[]string{"ts", "x", "y", "z"},
 		},
 		{
@@ -68,7 +68,7 @@ func TestComputeColumns(t *testing.T) {
 			[]string{"ts", "x", "y", "z"},
 		},
 		{
-			"*>1 | every 1s count(y) by foo=String.replace(x, y, z) | (head 1; tail 1)",
+			"*>1 | every 1s count(y) by foo=replace(x, y, z) | (head 1; tail 1)",
 			nil,
 		},
 	}
@@ -128,19 +128,19 @@ func TestExpressionFields(t *testing.T) {
 			fields("a", "b", "c", "d"),
 		},
 		{
-			"Time.trunc(ts, 10)",
+			"trunc(ts, 10)",
 			fields("ts"),
 		},
 		{
-			"Math.max(a, b, c, d)",
+			"max(a, b, c, d)",
 			fields("a", "b", "c", "d"),
 		},
 		{
-			"String.replace(a, b, c)",
+			"replace(a, b, c)",
 			fields("a", "b", "c"),
 		},
 		{
-			"String.replace(a, 'b', c)",
+			"replace(a, 'b', c)",
 			fields("a", "c"),
 		},
 		{

--- a/expr/coerce/coerce.go
+++ b/expr/coerce/coerce.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"math"
+	"strconv"
 
 	"github.com/brimsec/zq/expr/result"
 	"github.com/brimsec/zq/pkg/nano"
@@ -158,6 +159,10 @@ func ToFloat(zv zng.Value) (float64, bool) {
 		v, _ := zng.DecodeInt(zv.Bytes)
 		return 1e-9 * float64(v), true
 	}
+	if zng.IsStringy(id) {
+		v, err := strconv.ParseFloat(string(zv.Bytes), 64)
+		return v, err == nil
+	}
 	return 0, false
 }
 
@@ -183,6 +188,10 @@ func ToUint(zv zng.Value) (uint64, bool) {
 		v, _ := zng.DecodeInt(zv.Bytes)
 		return uint64(v / 1_000_000_000), true
 	}
+	if zng.IsStringy(id) {
+		v, err := strconv.ParseUint(string(zv.Bytes), 10, 64)
+		return v, err == nil
+	}
 	return 0, false
 }
 
@@ -205,6 +214,10 @@ func ToInt(zv zng.Value) (int64, bool) {
 	if id == zng.IdDuration {
 		v, _ := zng.DecodeInt(zv.Bytes)
 		return int64(v / 1_000_000_000), true
+	}
+	if zng.IsStringy(id) {
+		v, err := strconv.ParseInt(string(zv.Bytes), 10, 64)
+		return v, err == nil
 	}
 	return 0, false
 }

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -1005,7 +1005,7 @@ func (t *TimeCast) Eval(rec *zng.Record) (zng.Value, error) {
 	if !ok {
 		return zng.Value{}, ErrBadCast
 	}
-	return zng.Value{zng.TypeTime, zng.EncodeTime(nano.Ts(ns * 1_000_000_000))}, nil
+	return zng.Value{zng.TypeTime, zng.EncodeTime(nano.Ts(ns))}, nil
 }
 
 type StringCast struct {
@@ -1029,7 +1029,12 @@ func (s *StringCast) Eval(rec *zng.Record) (zng.Value, error) {
 		}
 		return zng.Value{s.typ, zng.EncodeString(element.Name)}, nil
 	}
-	return zng.Value{s.typ, zng.EncodeString(zv.String())}, nil
+	//XXX here, we need to create a human-readable string rep
+	// rather than a tzng encoding, e.g., for time, an iso date instead of
+	// ns int.  For now, this works for numbers and IPs.  We will fix in a
+	// subsequent PR (see issue #1603).
+	result := zv.Type.StringOf(zv.Bytes, zng.OutFormatUnescaped, false)
+	return zng.Value{s.typ, zng.EncodeString(result)}, nil
 }
 
 type BytesCast struct {

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -738,3 +738,18 @@ func a(t *testing.T) {
 	testSuccessful(t, "1589126400 :time", nil, ts)
 	testError(t, `"1234" :time`, nil, expr.ErrBadCast, "cannot cast string to time")
 }
+
+func TestCasts(t *testing.T) {
+	testSuccessful(t, "1.2:string", nil, zstring("1.2"))
+	testSuccessful(t, "5:string", nil, zstring("5"))
+	testSuccessful(t, "1.2.3.4:string", nil, zstring("1.2.3.4"))
+	testSuccessful(t, `"1":int64`, nil, zint64(1))
+	testSuccessful(t, `"-1":int64`, nil, zint64(-1))
+	testSuccessful(t, `"5.5":float64`, nil, zfloat64(5.5))
+	testSuccessful(t, `"1.2.3.4":ip`, nil, zaddr("1.2.3.4"))
+
+	testError(t, "1:ip", nil, expr.ErrBadCast, "ip cast non-ip arg")
+	testError(t, `"abc":int64`, nil, expr.ErrBadCast, "int64 cast with non-parseable string")
+	testError(t, `"abc":float64`, nil, expr.ErrBadCast, "float64 cast with non-parseable string")
+	testError(t, `"abc":ip`, nil, expr.ErrBadCast, "ip cast with non-parseable string")
+}

--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -162,7 +162,7 @@ func (l *lenFn) Call(args []zng.Value) (zng.Value, error) {
 		}
 		return zng.Value{zng.TypeInt64, l.Int(int64(len))}, nil
 	case *zng.TypeOfString, *zng.TypeOfBstring:
-		v := len(string(args[0].Bytes))
+		v := len(args[0].Bytes)
 		return zng.Value{zng.TypeInt64, l.Int(int64(v))}, nil
 	default:
 		return badarg("len")

--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -20,7 +20,50 @@ type Interface interface {
 	Call([]zng.Value) (zng.Value, error)
 }
 
+var deprecated = map[string]string{
+	"Math.abs":              "abs",
+	"Math.ceil":             "ceil",
+	"Math.floor":            "floor",
+	"Math.log":              "log",
+	"Math.max":              "max",
+	"Math.min":              "min",
+	"Math.mod":              "mod",
+	"Math.round":            "round",
+	"Math.pow":              "pow",
+	"Math.sqrt":             "sqrt",
+	"String.byteLen":        "len",
+	"String.formatFloat":    "type cast, e.g., <float-value>:string",
+	"String.formatInt":      "type cast, e.g., <int-value>:string",
+	"String.formatIp":       "type cast, e.g., <ip-value>:string",
+	"String.parseFloat":     "type cast, e.g., <string-value>:float64",
+	"String.parseInt":       "type cast, e.g., <string-value>:int64",
+	"String.parseIp":        "type cast, e.g., <string-value>:ip",
+	"String.replace":        "replace",
+	"String.runeLen":        "rune_len",
+	"String.toLower":        "to_lower",
+	"String.toUpper":        "to_upper",
+	"String.trim":           "trim",
+	"Time.fromISO":          "iso",
+	"Time.fromMilliseconds": "msec and ype cast, e.g., msec(<msec-value>):time",
+	"Time.fromMicroseconds": "usec and type cast, e.g., usec(<usec-value>):time",
+	"Time.fromNanoseconds":  "type cast, e.g., <nsec-value>:time",
+	"Time.trunc":            "trunc",
+	"toBase64":              "to_base64",
+	"fromBase64":            "from_base64",
+}
+
+func isDeprecated(name string) error {
+	msg, ok := deprecated[name]
+	if ok {
+		return fmt.Errorf("function is deprecated: use %s", msg)
+	}
+	return nil
+}
+
 func New(name string, narg int) (Interface, error) {
+	if err := isDeprecated(name); err != nil {
+		return nil, err
+	}
 	argmin := 1
 	argmax := 1
 	var f Interface
@@ -29,73 +72,53 @@ func New(name string, narg int) (Interface, error) {
 		return nil, ErrNoSuchFunction
 	case "len":
 		f = &lenFn{}
-	case "Math.abs", "abs":
+	case "abs":
 		f = &abs{}
-	case "Math.ceil", "ceil":
+	case "ceil":
 		f = &ceil{}
-	case "Math.floor", "floor":
+	case "floor":
 		f = &floor{}
-	case "Math.log", "log":
+	case "log":
 		f = &log{}
-	case "Math.max", "max":
+	case "max":
 		argmax = -1
 		f = &reducer{fn: anymath.Max}
-	case "Math.min", "min":
+	case "min":
 		argmax = -1
 		f = &reducer{fn: anymath.Min}
-	case "Math.mod", "mod":
+	case "mod":
 		argmin = 2
 		argmax = 2
 		f = &mod{}
-	case "Math.round", "round":
+	case "round":
 		f = &round{}
-	case "Math.pow", "pow":
+	case "pow":
 		argmin = 2
 		argmax = 2
 		f = &pow{}
-	case "Math.sqrt", "sqrt":
+	case "sqrt":
 		f = &sqrt{}
-	case "String.byteLen":
-		f = &bytelen{}
-	case "String.formatFloat":
-		// deprecated by <float-val>:string
-		f = &stringFormatFloat{}
-	case "String.formatInt":
-		// deprecated by <int-val>:string
-		f = &stringFormatInt{}
-	case "String.formatIp":
-		// deprecated by <ip-val>:string
-		f = &stringFormatIp{}
-	case "String.parseFloat":
-		// deprecated by <string-val>:float
-		f = &stringParseFloat{}
-	case "String.parseInt":
-		// deprecated by <string-val>:int<n>
-		f = &stringParseInt{}
-	case "String.parseIp":
-		// deprecated by <string-val>:ip
-		f = &stringParseIp{}
-	case "String.replace", "replace":
+	case "replace":
 		argmin = 3
 		argmax = 3
 		f = &replace{}
-	case "String.runeLen", "rune_len":
+	case "rune_len":
 		f = &runeLen{}
-	case "String.toLower", "to_lower":
+	case "to_lower":
 		f = &toLower{}
-	case "String.toUpper", "to_upper":
+	case "to_upper":
 		f = &toUpper{}
-	case "String.trim", "trim":
+	case "trim":
 		f = &trim{}
-	case "Time.fromISO", "iso":
+	case "iso":
 		f = &iso{}
-	case "Time.fromMilliseconds", "ms":
-		f = &ms{}
-	case "Time.fromMicroseconds", "us":
-		f = &us{}
-	case "Time.fromNanoseconds", "ns":
-		f = &ns{}
-	case "Time.trunc", "trunc":
+	case "sec":
+		f = &sec{}
+	case "msec":
+		f = &msec{}
+	case "usec":
+		f = &usec{}
+	case "trunc":
 		argmin = 2
 		argmax = 2
 		f = &trunc{}
@@ -103,9 +126,9 @@ func New(name string, narg int) (Interface, error) {
 		f = &typeOf{}
 	case "iserr":
 		f = &isErr{}
-	case "toBase64", "to_base64":
+	case "to_base64":
 		f = &toBase64{}
-	case "fromBase64", "from_base64":
+	case "from_base64":
 		f = &fromBase64{}
 	}
 	if argmin != -1 && narg < argmin {
@@ -138,6 +161,9 @@ func (l *lenFn) Call(args []zng.Value) (zng.Value, error) {
 			return zng.Value{}, err
 		}
 		return zng.Value{zng.TypeInt64, l.Int(int64(len))}, nil
+	case *zng.TypeOfString, *zng.TypeOfBstring:
+		v := len(string(args[0].Bytes))
+		return zng.Value{zng.TypeInt64, l.Int(int64(v))}, nil
 	default:
 		return badarg("len")
 	}

--- a/expr/function/string.go
+++ b/expr/function/string.go
@@ -10,21 +10,6 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
-type bytelen struct {
-	result.Buffer
-}
-
-// XXX we should just have a len function that applies to different types
-// and a way to get unicode char len, charlen()?
-func (b *bytelen) Call(args []zng.Value) (zng.Value, error) {
-	zv := args[0]
-	if !zv.IsStringy() {
-		return badarg("Strings.byteLen")
-	}
-	v := len(string(zv.Bytes))
-	return zng.Value{zng.TypeInt64, b.Int(int64(v))}, nil
-}
-
 // XXX these string format functions should be handlded by :string cast
 
 type stringFormatFloat struct{}
@@ -171,7 +156,7 @@ type runeLen struct {
 func (s *runeLen) Call(args []zng.Value) (zng.Value, error) {
 	zv := args[0]
 	if !zv.IsStringy() {
-		return badarg("Strings.byteLen")
+		return badarg("rune_len")
 	}
 	in, err := zng.DecodeString(zv.Bytes)
 	if err != nil {

--- a/expr/function/time.go
+++ b/expr/function/time.go
@@ -25,43 +25,61 @@ func (i *iso) Call(args []zng.Value) (zng.Value, error) {
 	return zng.Value{zng.TypeTime, i.Time(nano.Ts(ts.UnixNano()))}, nil
 }
 
-type ms struct {
+type sec struct {
 	result.Buffer
 }
 
-func (m *ms) Call(args []zng.Value) (zng.Value, error) {
-	zv := args[0]
-	ms, ok := coerce.ToInt(zv)
-	if !ok {
-		return badarg("ms")
-	}
-	return zng.Value{zng.TypeTime, m.Time(nano.Ts(ms * 1_000_000))}, nil
-}
-
-type us struct {
-	result.Buffer
-}
-
-func (u *us) Call(args []zng.Value) (zng.Value, error) {
-	zv := args[0]
-	us, ok := coerce.ToInt(zv)
-	if !ok {
-		return badarg("us")
-	}
-	return zng.Value{zng.TypeTime, u.Time(nano.Ts(us * 1000))}, nil
-}
-
-type ns struct {
-	result.Buffer
-}
-
-func (n *ns) Call(args []zng.Value) (zng.Value, error) {
+func (s *sec) Call(args []zng.Value) (zng.Value, error) {
 	zv := args[0]
 	ns, ok := coerce.ToInt(zv)
 	if !ok {
-		return badarg("ns")
+		sec, ok := coerce.ToFloat(zv)
+		if !ok {
+			return badarg("sec")
+		}
+		ns = int64(1e9 * sec)
+	} else {
+		ns *= 1_000_000_000
 	}
-	return zng.Value{zng.TypeTime, n.Time(nano.Ts(ns))}, nil
+	return zng.Value{zng.TypeInt64, s.Int(ns)}, nil
+}
+
+type msec struct {
+	result.Buffer
+}
+
+func (m *msec) Call(args []zng.Value) (zng.Value, error) {
+	zv := args[0]
+	ns, ok := coerce.ToInt(zv)
+	if !ok {
+		ms, ok := coerce.ToFloat(zv)
+		if !ok {
+			return badarg("msec")
+		}
+		ns = int64(1e6 * ms)
+	} else {
+		ns *= 1_000_000
+	}
+	return zng.Value{zng.TypeInt64, m.Int(ns)}, nil
+}
+
+type usec struct {
+	result.Buffer
+}
+
+func (u *usec) Call(args []zng.Value) (zng.Value, error) {
+	zv := args[0]
+	ns, ok := coerce.ToInt(zv)
+	if !ok {
+		us, ok := coerce.ToFloat(zv)
+		if !ok {
+			return badarg("usec")
+		}
+		ns = int64(1000. * us)
+	} else {
+		ns *= 1000
+	}
+	return zng.Value{zng.TypeInt64, u.Int(ns)}, nil
 }
 
 type trunc struct {

--- a/expr/functions_test.go
+++ b/expr/functions_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/expr/function"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zng"
@@ -142,36 +141,6 @@ func TestMod(t *testing.T) {
 	testError(t, "mod(3.2, 2)", record, function.ErrBadArgument, "mod() with float64 arg")
 }
 
-func TestStrFormat(t *testing.T) {
-	testSuccessful(t, "1.2:string", nil, zstring("1.2"))
-	//testError(t, "String.formatFloat()", nil, function.ErrTooFewArgs, "formatFloat() with no args")
-	//testError(t, "String.formatFloat(1.2, 3.4)", nil, function.ErrTooManyArgs, "formatFloat() with too many args")
-	//testError(t, "String.formatFloat(1)", nil, function.ErrBadArgument, "formatFloat() with non-float arg")
-
-	testSuccessful(t, "5:string", nil, zstring("5"))
-	//testError(t, "String.formatInt()", nil, function.ErrTooFewArgs, "formatInt() with no args")
-	//testError(t, "String.formatInt(3, 4)", nil, function.ErrTooManyArgs, "formatInt() with too many args")
-	//testError(t, "String.formatInt(1.5)", nil, function.ErrBadArgument, "formatInt() with non-int arg")
-
-	testSuccessful(t, "1.2.3.4:string", nil, zstring("1.2.3.4"))
-	//testError(t, "String.formatIp()", nil, function.ErrTooFewArgs, "formatIp() with no args")
-	//testError(t, "String.formatIp(1.2, 3.4)", nil, function.ErrTooManyArgs, "formatIp() with too many args")
-	testError(t, "1:ip", nil, expr.ErrBadCast, "formatIp() with non-ip arg")
-}
-
-func TestCastStrings(t *testing.T) {
-	testSuccessful(t, `"1":int64`, nil, zint64(1))
-	testSuccessful(t, `"-1":int64`, nil, zint64(-1))
-
-	testError(t, `"abc":int64`, nil, expr.ErrBadCast, "parseInt() with non-parseable string")
-
-	testSuccessful(t, `"5.5":float64`, nil, zfloat64(5.5))
-	testError(t, `"abc":float64`, nil, expr.ErrBadCast, "parseFloat() with non-parseable string")
-
-	testSuccessful(t, `"1.2.3.4":ip`, nil, zaddr("1.2.3.4"))
-	testError(t, `"abc":ip`, nil, expr.ErrBadCast, "parseIp() with non-parseable string")
-}
-
 func TestOtherStrFuncs(t *testing.T) {
 	testSuccessful(t, `replace("bann", "n", "na")`, nil, zstring("banana"))
 	testError(t, `replace("foo", "bar")`, nil, function.ErrTooFewArgs, "replace() with too few args")
@@ -202,7 +171,6 @@ func TestLen(t *testing.T) {
 
 	testError(t, "len()", record, function.ErrTooFewArgs, "len() with no args")
 	testError(t, `len("foo", "bar")`, record, function.ErrTooManyArgs, "len() with too many args")
-	//testError(t, `len("foo")`, record, function.ErrBadArgument, "len() with string arg")
 	testError(t, "len(5)", record, function.ErrBadArgument, "len() with non-container arg")
 
 	record, err = parseOneRecord(`

--- a/expr/functions_test.go
+++ b/expr/functions_test.go
@@ -3,9 +3,9 @@ package expr_test
 import (
 	"fmt"
 	"net"
-	"strconv"
 	"testing"
 
+	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/expr/function"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zng"
@@ -27,15 +27,15 @@ func TestAbs(t *testing.T) {
 0:[50;]`)
 	require.NoError(t, err)
 
-	testSuccessful(t, "Math.abs(-5)", record, zint64(5))
-	testSuccessful(t, "Math.abs(5)", record, zint64(5))
-	testSuccessful(t, "Math.abs(-3.2)", record, zfloat64(3.2))
-	testSuccessful(t, "Math.abs(3.2)", record, zfloat64(3.2))
-	testSuccessful(t, "Math.abs(u)", record, zuint64(50))
+	testSuccessful(t, "abs(-5)", record, zint64(5))
+	testSuccessful(t, "abs(5)", record, zint64(5))
+	testSuccessful(t, "abs(-3.2)", record, zfloat64(3.2))
+	testSuccessful(t, "abs(3.2)", record, zfloat64(3.2))
+	testSuccessful(t, "abs(u)", record, zuint64(50))
 
-	testError(t, "Math.abs()", record, function.ErrTooFewArgs, "abs with no args")
-	testError(t, "Math.abs(1, 2)", record, function.ErrTooManyArgs, "abs with too many args")
-	testError(t, `Math.abs("hello")`, record, function.ErrBadArgument, "abs with non-number")
+	testError(t, "abs()", record, function.ErrTooFewArgs, "abs with no args")
+	testError(t, "abs(1, 2)", record, function.ErrTooManyArgs, "abs with too many args")
+	testError(t, `abs("hello")`, record, function.ErrBadArgument, "abs with non-number")
 }
 
 func TestSqrt(t *testing.T) {
@@ -44,13 +44,13 @@ func TestSqrt(t *testing.T) {
 0:[6.25;9;]`)
 	require.NoError(t, err)
 
-	testSuccessful(t, "Math.sqrt(4.0)", record, zfloat64(2.0))
-	testSuccessful(t, "Math.sqrt(f)", record, zfloat64(2.5))
-	testSuccessful(t, "Math.sqrt(i)", record, zfloat64(3.0))
+	testSuccessful(t, "sqrt(4.0)", record, zfloat64(2.0))
+	testSuccessful(t, "sqrt(f)", record, zfloat64(2.5))
+	testSuccessful(t, "sqrt(i)", record, zfloat64(3.0))
 
-	testError(t, "Math.sqrt()", record, function.ErrTooFewArgs, "sqrt with no args")
-	testError(t, "Math.sqrt(1, 2)", record, function.ErrTooManyArgs, "sqrt with too many args")
-	testError(t, "Math.sqrt(-1)", record, function.ErrBadArgument, "sqrt of negative")
+	testError(t, "sqrt()", record, function.ErrTooFewArgs, "sqrt with no args")
+	testError(t, "sqrt(1, 2)", record, function.ErrTooManyArgs, "sqrt with too many args")
+	testError(t, "sqrt(-1)", record, function.ErrBadArgument, "sqrt of negative")
 }
 
 func TestMinMax(t *testing.T) {
@@ -60,70 +60,70 @@ func TestMinMax(t *testing.T) {
 	require.NoError(t, err)
 
 	// Simple cases
-	testSuccessful(t, "Math.min(1)", record, zint64(1))
-	testSuccessful(t, "Math.max(1)", record, zint64(1))
-	testSuccessful(t, "Math.min(1, 2, 3)", record, zint64(1))
-	testSuccessful(t, "Math.max(1, 2, 3)", record, zint64(3))
-	testSuccessful(t, "Math.min(3, 2, 1)", record, zint64(1))
-	testSuccessful(t, "Math.max(3, 2, 1)", record, zint64(3))
+	testSuccessful(t, "min(1)", record, zint64(1))
+	testSuccessful(t, "max(1)", record, zint64(1))
+	testSuccessful(t, "min(1, 2, 3)", record, zint64(1))
+	testSuccessful(t, "max(1, 2, 3)", record, zint64(3))
+	testSuccessful(t, "min(3, 2, 1)", record, zint64(1))
+	testSuccessful(t, "max(3, 2, 1)", record, zint64(3))
 
 	// Fails with no arguments
-	testError(t, "Math.min()", record, function.ErrTooFewArgs, "min with no args")
-	testError(t, "Math.max()", record, function.ErrTooFewArgs, "max with no args")
+	testError(t, "min()", record, function.ErrTooFewArgs, "min with no args")
+	testError(t, "max()", record, function.ErrTooFewArgs, "max with no args")
 
 	// Mixed types work
-	testSuccessful(t, "Math.min(i, 2, 3)", record, zuint64(1))
-	testSuccessful(t, "Math.min(2, 3, i)", record, zint64(1))
-	testSuccessful(t, "Math.max(i, 2, 3)", record, zuint64(3))
-	testSuccessful(t, "Math.max(2, 3, i)", record, zint64(3))
-	testSuccessful(t, "Math.min(1, -2.0)", record, zint64(-2))
-	testSuccessful(t, "Math.min(-2.0, 1)", record, zfloat64(-2))
-	testSuccessful(t, "Math.max(-1, 2.0)", record, zint64(2))
-	testSuccessful(t, "Math.max(2.0, -1)", record, zfloat64(2))
+	testSuccessful(t, "min(i, 2, 3)", record, zuint64(1))
+	testSuccessful(t, "min(2, 3, i)", record, zint64(1))
+	testSuccessful(t, "max(i, 2, 3)", record, zuint64(3))
+	testSuccessful(t, "max(2, 3, i)", record, zint64(3))
+	testSuccessful(t, "min(1, -2.0)", record, zint64(-2))
+	testSuccessful(t, "min(-2.0, 1)", record, zfloat64(-2))
+	testSuccessful(t, "max(-1, 2.0)", record, zint64(2))
+	testSuccessful(t, "max(2.0, -1)", record, zfloat64(2))
 
 	// Fails on invalid types
-	testError(t, `Math.min("hello", 2)`, record, function.ErrBadArgument, "min() on string")
-	testError(t, `Math.max("hello", 2)`, record, function.ErrBadArgument, "max() on string")
-	testError(t, `Math.min(1.2.3.4, 2)`, record, function.ErrBadArgument, "min() on ip")
-	testError(t, `Math.max(1.2.3.4, 2)`, record, function.ErrBadArgument, "max() on ip")
+	testError(t, `min("hello", 2)`, record, function.ErrBadArgument, "min() on string")
+	testError(t, `max("hello", 2)`, record, function.ErrBadArgument, "max() on string")
+	testError(t, `min(1.2.3.4, 2)`, record, function.ErrBadArgument, "min() on ip")
+	testError(t, `max(1.2.3.4, 2)`, record, function.ErrBadArgument, "max() on ip")
 
 }
 
 func TestCeilFloorRound(t *testing.T) {
-	testSuccessful(t, "Math.ceil(1.5)", nil, zfloat64(2))
-	testSuccessful(t, "Math.floor(1.5)", nil, zfloat64(1))
-	testSuccessful(t, "Math.round(1.5)", nil, zfloat64(2))
+	testSuccessful(t, "ceil(1.5)", nil, zfloat64(2))
+	testSuccessful(t, "floor(1.5)", nil, zfloat64(1))
+	testSuccessful(t, "round(1.5)", nil, zfloat64(2))
 
-	testSuccessful(t, "Math.ceil(5)", nil, zint64(5))
-	testSuccessful(t, "Math.floor(5)", nil, zint64(5))
-	testSuccessful(t, "Math.round(5)", nil, zint64(5))
+	testSuccessful(t, "ceil(5)", nil, zint64(5))
+	testSuccessful(t, "floor(5)", nil, zint64(5))
+	testSuccessful(t, "round(5)", nil, zint64(5))
 
-	testError(t, "Math.ceil()", nil, function.ErrTooFewArgs, "ceil() with no args")
-	testError(t, "Math.ceil(1, 2)", nil, function.ErrTooManyArgs, "ceil() with too many args")
-	testError(t, "Math.floor()", nil, function.ErrTooFewArgs, "floor() with no args")
-	testError(t, "Math.floor(1, 2)", nil, function.ErrTooManyArgs, "floor() with too many args")
-	testError(t, "Math.round()", nil, function.ErrTooFewArgs, "round() with no args")
-	testError(t, "Math.round(1, 2)", nil, function.ErrTooManyArgs, "round() with too many args")
+	testError(t, "ceil()", nil, function.ErrTooFewArgs, "ceil() with no args")
+	testError(t, "ceil(1, 2)", nil, function.ErrTooManyArgs, "ceil() with too many args")
+	testError(t, "floor()", nil, function.ErrTooFewArgs, "floor() with no args")
+	testError(t, "floor(1, 2)", nil, function.ErrTooManyArgs, "floor() with too many args")
+	testError(t, "round()", nil, function.ErrTooFewArgs, "round() with no args")
+	testError(t, "round(1, 2)", nil, function.ErrTooManyArgs, "round() with too many args")
 }
 
 func TestLogPow(t *testing.T) {
 	// Math.log() computes natural logarithm.  Rather than writing
 	// out long floating point numbers in the parameters or results,
 	// use more complex expressions that evaluate to simpler values.
-	testSuccessful(t, "Math.log(32) / Math.log(2)", nil, zfloat64(5))
-	testSuccessful(t, "Math.log(32.0) / Math.log(2.0)", nil, zfloat64(5))
+	testSuccessful(t, "log(32) / log(2)", nil, zfloat64(5))
+	testSuccessful(t, "log(32.0) / log(2.0)", nil, zfloat64(5))
 
-	testSuccessful(t, "Math.pow(10, 2)", nil, zfloat64(100))
-	testSuccessful(t, "Math.pow(4.0, 1.5)", nil, zfloat64(8))
+	testSuccessful(t, "pow(10, 2)", nil, zfloat64(100))
+	testSuccessful(t, "pow(4.0, 1.5)", nil, zfloat64(8))
 
-	testError(t, "Math.log()", nil, function.ErrTooFewArgs, "log() with no args")
-	testError(t, "Math.log(2, 3)", nil, function.ErrTooManyArgs, "log() with too many args")
-	testError(t, "Math.log(0)", nil, function.ErrBadArgument, "log() of 0")
-	testError(t, "Math.log(-1)", nil, function.ErrBadArgument, "log() of negative number")
+	testError(t, "log()", nil, function.ErrTooFewArgs, "log() with no args")
+	testError(t, "log(2, 3)", nil, function.ErrTooManyArgs, "log() with too many args")
+	testError(t, "log(0)", nil, function.ErrBadArgument, "log() of 0")
+	testError(t, "log(-1)", nil, function.ErrBadArgument, "log() of negative number")
 
-	testError(t, "Math.pow()", nil, function.ErrTooFewArgs, "pow() with no args")
-	testError(t, "Math.pow(2, 3, r)", nil, function.ErrTooManyArgs, "pow() with too many args")
-	testError(t, "Math.pow(-1, 0.5)", nil, function.ErrBadArgument, "pow() with invalid arguments")
+	testError(t, "pow()", nil, function.ErrTooFewArgs, "pow() with no args")
+	testError(t, "pow(2, 3, r)", nil, function.ErrTooManyArgs, "pow() with too many args")
+	testError(t, "pow(-1, 0.5)", nil, function.ErrBadArgument, "pow() with invalid arguments")
 }
 
 func TestMod(t *testing.T) {
@@ -132,68 +132,63 @@ func TestMod(t *testing.T) {
 0:[5;]`)
 	require.NoError(t, err)
 
-	testSuccessful(t, "Math.mod(5, 3)", record, zint64(2))
-	testSuccessful(t, "Math.mod(u, 3)", record, zuint64(2))
-	testSuccessful(t, "Math.mod(8, 5)", record, zint64(3))
-	testSuccessful(t, "Math.mod(8, u)", record, zint64(3))
+	testSuccessful(t, "mod(5, 3)", record, zint64(2))
+	testSuccessful(t, "mod(u, 3)", record, zuint64(2))
+	testSuccessful(t, "mod(8, 5)", record, zint64(3))
+	testSuccessful(t, "mod(8, u)", record, zint64(3))
 
-	testError(t, "Math.mod()", record, function.ErrTooFewArgs, "mod() with no args")
-	testError(t, "Math.mod(1, 2, 3)", record, function.ErrTooManyArgs, "mod() with too many args")
-	testError(t, "Math.mod(3.2, 2)", record, function.ErrBadArgument, "mod() with float64 arg")
+	testError(t, "mod()", record, function.ErrTooFewArgs, "mod() with no args")
+	testError(t, "mod(1, 2, 3)", record, function.ErrTooManyArgs, "mod() with too many args")
+	testError(t, "mod(3.2, 2)", record, function.ErrBadArgument, "mod() with float64 arg")
 }
 
 func TestStrFormat(t *testing.T) {
-	testSuccessful(t, "String.formatFloat(1.2)", nil, zstring("1.2"))
-	testError(t, "String.formatFloat()", nil, function.ErrTooFewArgs, "formatFloat() with no args")
-	testError(t, "String.formatFloat(1.2, 3.4)", nil, function.ErrTooManyArgs, "formatFloat() with too many args")
-	testError(t, "String.formatFloat(1)", nil, function.ErrBadArgument, "formatFloat() with non-float arg")
+	testSuccessful(t, "1.2:string", nil, zstring("1.2"))
+	//testError(t, "String.formatFloat()", nil, function.ErrTooFewArgs, "formatFloat() with no args")
+	//testError(t, "String.formatFloat(1.2, 3.4)", nil, function.ErrTooManyArgs, "formatFloat() with too many args")
+	//testError(t, "String.formatFloat(1)", nil, function.ErrBadArgument, "formatFloat() with non-float arg")
 
-	testSuccessful(t, "String.formatInt(5)", nil, zstring("5"))
-	testError(t, "String.formatInt()", nil, function.ErrTooFewArgs, "formatInt() with no args")
-	testError(t, "String.formatInt(3, 4)", nil, function.ErrTooManyArgs, "formatInt() with too many args")
-	testError(t, "String.formatInt(1.5)", nil, function.ErrBadArgument, "formatInt() with non-int arg")
+	testSuccessful(t, "5:string", nil, zstring("5"))
+	//testError(t, "String.formatInt()", nil, function.ErrTooFewArgs, "formatInt() with no args")
+	//testError(t, "String.formatInt(3, 4)", nil, function.ErrTooManyArgs, "formatInt() with too many args")
+	//testError(t, "String.formatInt(1.5)", nil, function.ErrBadArgument, "formatInt() with non-int arg")
 
-	testSuccessful(t, "String.formatIp(1.2.3.4)", nil, zstring("1.2.3.4"))
-	testError(t, "String.formatIp()", nil, function.ErrTooFewArgs, "formatIp() with no args")
-	testError(t, "String.formatIp(1.2, 3.4)", nil, function.ErrTooManyArgs, "formatIp() with too many args")
-	testError(t, "String.formatIp(1)", nil, function.ErrBadArgument, "formatIp() with non-ip arg")
+	testSuccessful(t, "1.2.3.4:string", nil, zstring("1.2.3.4"))
+	//testError(t, "String.formatIp()", nil, function.ErrTooFewArgs, "formatIp() with no args")
+	//testError(t, "String.formatIp(1.2, 3.4)", nil, function.ErrTooManyArgs, "formatIp() with too many args")
+	testError(t, "1:ip", nil, expr.ErrBadCast, "formatIp() with non-ip arg")
 }
 
-func TestStrParse(t *testing.T) {
-	testSuccessful(t, `String.parseInt("1")`, nil, zint64(1))
-	testSuccessful(t, `String.parseInt("-1")`, nil, zint64(-1))
-	testError(t, `String.parseInt()`, nil, function.ErrTooFewArgs, "parseInt() with no args")
-	testError(t, `String.parseInt("a", "b")`, nil, function.ErrTooManyArgs, "parseInt() with too many args")
-	testError(t, `String.parseInt("abc")`, nil, strconv.ErrSyntax, "parseInt() with non-parseable string")
+func TestCastStrings(t *testing.T) {
+	testSuccessful(t, `"1":int64`, nil, zint64(1))
+	testSuccessful(t, `"-1":int64`, nil, zint64(-1))
 
-	testSuccessful(t, `String.parseFloat("5.5")`, nil, zfloat64(5.5))
-	testError(t, `String.parseFloat()`, nil, function.ErrTooFewArgs, "parseFloat() with no args")
-	testError(t, `String.parseFloat("a", "b")`, nil, function.ErrTooManyArgs, "parseFloat() with too many args")
-	testError(t, `String.parseFloat("abc")`, nil, strconv.ErrSyntax, "parseFloat() with non-parseable string")
+	testError(t, `"abc":int64`, nil, expr.ErrBadCast, "parseInt() with non-parseable string")
 
-	testSuccessful(t, `String.parseIp("1.2.3.4")`, nil, zaddr("1.2.3.4"))
-	testError(t, `String.parseIp()`, nil, function.ErrTooFewArgs, "parseIp() with no args")
-	testError(t, `String.parseIp("a", "b")`, nil, function.ErrTooManyArgs, "parseIp() with too many args")
-	testError(t, `String.parseIp("abc")`, nil, function.ErrBadArgument, "parseIp() with non-parseable string")
+	testSuccessful(t, `"5.5":float64`, nil, zfloat64(5.5))
+	testError(t, `"abc":float64`, nil, expr.ErrBadCast, "parseFloat() with non-parseable string")
+
+	testSuccessful(t, `"1.2.3.4":ip`, nil, zaddr("1.2.3.4"))
+	testError(t, `"abc":ip`, nil, expr.ErrBadCast, "parseIp() with non-parseable string")
 }
 
 func TestOtherStrFuncs(t *testing.T) {
-	testSuccessful(t, `String.replace("bann", "n", "na")`, nil, zstring("banana"))
-	testError(t, `String.replace("foo", "bar")`, nil, function.ErrTooFewArgs, "replace() with too few args")
-	testError(t, `String.replace("foo", "bar", "baz", "blort")`, nil, function.ErrTooManyArgs, "replace() with too many args")
-	testError(t, `String.replace("foo", "o", 5)`, nil, function.ErrBadArgument, "replace() with non-string arg")
+	testSuccessful(t, `replace("bann", "n", "na")`, nil, zstring("banana"))
+	testError(t, `replace("foo", "bar")`, nil, function.ErrTooFewArgs, "replace() with too few args")
+	testError(t, `replace("foo", "bar", "baz", "blort")`, nil, function.ErrTooManyArgs, "replace() with too many args")
+	testError(t, `replace("foo", "o", 5)`, nil, function.ErrBadArgument, "replace() with non-string arg")
 
-	testSuccessful(t, `String.toLower("BOO")`, nil, zstring("boo"))
-	testError(t, `String.toLower()`, nil, function.ErrTooFewArgs, "toLower() with no args")
-	testError(t, `String.toLower("BOO", "HOO")`, nil, function.ErrTooManyArgs, "toLower() with too many args")
+	testSuccessful(t, `to_lower("BOO")`, nil, zstring("boo"))
+	testError(t, `to_lower()`, nil, function.ErrTooFewArgs, "toLower() with no args")
+	testError(t, `to_lower("BOO", "HOO")`, nil, function.ErrTooManyArgs, "toLower() with too many args")
 
-	testSuccessful(t, `String.toUpper("boo")`, nil, zstring("BOO"))
-	testError(t, `String.toUpper()`, nil, function.ErrTooFewArgs, "toUpper() with no args")
-	testError(t, `String.toUpper("boo", "hoo")`, nil, function.ErrTooManyArgs, "toUpper() with too many args")
+	testSuccessful(t, `to_upper("boo")`, nil, zstring("BOO"))
+	testError(t, `to_upper()`, nil, function.ErrTooFewArgs, "toUpper() with no args")
+	testError(t, `to_upper("boo", "hoo")`, nil, function.ErrTooManyArgs, "toUpper() with too many args")
 
-	testSuccessful(t, `String.trim("  hi  there   ")`, nil, zstring("hi  there"))
-	testError(t, `String.trim()`, nil, function.ErrTooFewArgs, "trim() with no args")
-	testError(t, `String.trim("  hi  ", "  there  ")`, nil, function.ErrTooManyArgs, "trim() with too many args")
+	testSuccessful(t, `trim("  hi  there   ")`, nil, zstring("hi  there"))
+	testError(t, `trim()`, nil, function.ErrTooFewArgs, "trim() with no args")
+	testError(t, `trim("  hi  ", "  there  ")`, nil, function.ErrTooManyArgs, "trim() with too many args")
 }
 
 func TestLen(t *testing.T) {
@@ -207,7 +202,7 @@ func TestLen(t *testing.T) {
 
 	testError(t, "len()", record, function.ErrTooFewArgs, "len() with no args")
 	testError(t, `len("foo", "bar")`, record, function.ErrTooManyArgs, "len() with too many args")
-	testError(t, `len("foo")`, record, function.ErrBadArgument, "len() with string arg")
+	//testError(t, `len("foo")`, record, function.ErrBadArgument, "len() with string arg")
 	testError(t, "len(5)", record, function.ErrBadArgument, "len() with non-container arg")
 
 	record, err = parseOneRecord(`
@@ -215,15 +210,15 @@ func TestLen(t *testing.T) {
 0:[🍺;\xf0\x9f\x8d\xba;\xba\x8d\x9f\xf0;]`)
 	require.NoError(t, err)
 
-	testSuccessful(t, `String.byteLen("foo")`, record, zint64(3))
-	testSuccessful(t, `String.byteLen(s)`, record, zint64(4))
-	testSuccessful(t, `String.byteLen(bs)`, record, zint64(4))
-	testSuccessful(t, `String.byteLen(bs2)`, record, zint64(4))
+	testSuccessful(t, `len("foo")`, record, zint64(3))
+	testSuccessful(t, `len(s)`, record, zint64(4))
+	testSuccessful(t, `len(bs)`, record, zint64(4))
+	testSuccessful(t, `len(bs2)`, record, zint64(4))
 
-	testSuccessful(t, `String.runeLen("foo")`, record, zint64(3))
-	testSuccessful(t, `String.runeLen(s)`, record, zint64(1))
-	testSuccessful(t, `String.runeLen(bs)`, record, zint64(1))
-	testSuccessful(t, `String.runeLen(bs2)`, record, zint64(4))
+	testSuccessful(t, `rune_len("foo")`, record, zint64(3))
+	testSuccessful(t, `rune_len(s)`, record, zint64(1))
+	testSuccessful(t, `rune_len(bs)`, record, zint64(1))
+	testSuccessful(t, `rune_len(bs2)`, record, zint64(4))
 }
 
 func TestTime(t *testing.T) {
@@ -233,33 +228,34 @@ func TestTime(t *testing.T) {
 	nsec := msec * 1_000_000
 	zval := zng.Value{zng.TypeTime, zng.EncodeTime(nano.Ts(nsec))}
 
-	exp := fmt.Sprintf(`Time.fromISO("%s")`, iso)
+	exp := fmt.Sprintf(`iso("%s")`, iso)
+	//testSuccessful(t, exp, nil, zval)
+	exp = fmt.Sprintf("msec(%d):time", msec)
 	testSuccessful(t, exp, nil, zval)
-	exp = fmt.Sprintf("Time.fromMilliseconds(%d)", msec)
+	return
+	exp = fmt.Sprintf("msec(%d.0):time", msec)
 	testSuccessful(t, exp, nil, zval)
-	exp = fmt.Sprintf("Time.fromMilliseconds(%d.0)", msec)
+	exp = fmt.Sprintf("usec(%d):time", msec*1000)
 	testSuccessful(t, exp, nil, zval)
-	exp = fmt.Sprintf("Time.fromMicroseconds(%d)", msec*1000)
+	exp = fmt.Sprintf("usec(%d.0):time", msec*1000)
 	testSuccessful(t, exp, nil, zval)
-	exp = fmt.Sprintf("Time.fromMicroseconds(%d.0)", msec*1000)
+	exp = fmt.Sprintf("%d:time", nsec)
 	testSuccessful(t, exp, nil, zval)
-	exp = fmt.Sprintf("Time.fromNanoseconds(%d)", nsec)
-	testSuccessful(t, exp, nil, zval)
-	testSuccessful(t, "Time.trunc(1590506867.967, 1)", nil, zng.Value{zng.TypeTime, zng.EncodeTime(nano.Ts(1590506867 * 1_000_000_000))})
+	testSuccessful(t, "trunc(1590506867.967, 1)", nil, zng.Value{zng.TypeTime, zng.EncodeTime(nano.Ts(1590506867 * 1_000_000_000))})
 
-	testError(t, "Time.fromISO()", nil, function.ErrTooFewArgs, "Time.fromISO() with no args")
-	testError(t, `Time.fromISO("abc", "def")`, nil, function.ErrTooManyArgs, "Time.fromISO() with too many args")
-	testError(t, "Time.fromISO(1234)", nil, function.ErrBadArgument, "Time.fromISO() with wrong argument type")
+	testError(t, "iso()", nil, function.ErrTooFewArgs, "Time.fromISO() with no args")
+	testError(t, `iso("abc", "def")`, nil, function.ErrTooManyArgs, "Time.fromISO() with too many args")
+	testError(t, "iso(1234)", nil, function.ErrBadArgument, "Time.fromISO() with wrong argument type")
 
-	testError(t, "Time.fromMilliseconds()", nil, function.ErrTooFewArgs, "Time.fromMilliseconds() with no args")
-	testError(t, "Time.fromMilliseconds(123, 456)", nil, function.ErrTooManyArgs, "Time.fromMilliseconds() with too many args")
-	testError(t, `Time.fromMilliseconds("1234")`, nil, function.ErrBadArgument, "Time.fromMilliseconds() with wrong argument type")
+	testError(t, "msec()", nil, function.ErrTooFewArgs, "Time.fromMilliseconds() with no args")
+	testError(t, "msec(123, 456)", nil, function.ErrTooManyArgs, "Time.fromMilliseconds() with too many args")
+	//testError(t, `Time.fromMilliseconds("1234")`, nil, function.ErrBadArgument, "Time.fromMilliseconds() with wrong argument type")
 
-	testError(t, "Time.fromMicroseconds()", nil, function.ErrTooFewArgs, "Time.fromMicroseconds() with no args")
-	testError(t, "Time.fromMicroseconds(123, 456)", nil, function.ErrTooManyArgs, "Time.fromMicroseconds() with too many args")
-	testError(t, `Time.fromMicroseconds("1234")`, nil, function.ErrBadArgument, "Time.fromMicroseconds() with wrong argument type")
+	testError(t, "usec()", nil, function.ErrTooFewArgs, "Time.fromMicroseconds() with no args")
+	testError(t, "usec(123, 456)", nil, function.ErrTooManyArgs, "Time.fromMicroseconds() with too many args")
+	//testError(t, `Time.fromMicroseconds("1234")`, nil, function.ErrBadArgument, "Time.fromMicroseconds() with wrong argument type")
 
-	testError(t, "Time.fromNanoseconds()", nil, function.ErrTooFewArgs, "Time.fromNanoseconds() with no args")
-	testError(t, "Time.fromNanoseconds(123, 456)", nil, function.ErrTooManyArgs, "Time.fromNanoseconds() with too many args")
-	testError(t, `Time.fromNanoseconds("1234")`, nil, function.ErrBadArgument, "Time.fromNanoseconds() with wrong argument type")
+	testError(t, "nsec()", nil, function.ErrTooFewArgs, "Time.fromNanoseconds() with no args")
+	testError(t, "nsec(123, 456)", nil, function.ErrTooManyArgs, "Time.fromNanoseconds() with too many args")
+	//testError(t, `Time.fromNanoseconds("1234")`, nil, function.ErrBadArgument, "Time.fromNanoseconds() with wrong argument type")
 }

--- a/expr/functions_test.go
+++ b/expr/functions_test.go
@@ -229,10 +229,9 @@ func TestTime(t *testing.T) {
 	zval := zng.Value{zng.TypeTime, zng.EncodeTime(nano.Ts(nsec))}
 
 	exp := fmt.Sprintf(`iso("%s")`, iso)
-	//testSuccessful(t, exp, nil, zval)
+	testSuccessful(t, exp, nil, zval)
 	exp = fmt.Sprintf("msec(%d):time", msec)
 	testSuccessful(t, exp, nil, zval)
-	return
 	exp = fmt.Sprintf("msec(%d.0):time", msec)
 	testSuccessful(t, exp, nil, zval)
 	exp = fmt.Sprintf("usec(%d):time", msec*1000)
@@ -249,13 +248,7 @@ func TestTime(t *testing.T) {
 
 	testError(t, "msec()", nil, function.ErrTooFewArgs, "Time.fromMilliseconds() with no args")
 	testError(t, "msec(123, 456)", nil, function.ErrTooManyArgs, "Time.fromMilliseconds() with too many args")
-	//testError(t, `Time.fromMilliseconds("1234")`, nil, function.ErrBadArgument, "Time.fromMilliseconds() with wrong argument type")
 
 	testError(t, "usec()", nil, function.ErrTooFewArgs, "Time.fromMicroseconds() with no args")
 	testError(t, "usec(123, 456)", nil, function.ErrTooManyArgs, "Time.fromMicroseconds() with too many args")
-	//testError(t, `Time.fromMicroseconds("1234")`, nil, function.ErrBadArgument, "Time.fromMicroseconds() with wrong argument type")
-
-	testError(t, "nsec()", nil, function.ErrTooFewArgs, "Time.fromNanoseconds() with no args")
-	testError(t, "nsec(123, 456)", nil, function.ErrTooManyArgs, "Time.fromNanoseconds() with too many args")
-	//testError(t, `Time.fromNanoseconds("1234")`, nil, function.ErrBadArgument, "Time.fromNanoseconds() with wrong argument type")
 }

--- a/proc/cut/ztests/cut.yaml
+++ b/proc/cut/ztests/cut.yaml
@@ -1,4 +1,4 @@
-zql: 'cut y=x+1,a=String.toLower(s),typeof(s)'
+zql: 'cut y=x+1,a=to_lower(s),typeof(s)'
 
 input: |
   #0:record[a:array[int32],x:int32,s:string,b:bytes]

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -264,12 +264,12 @@ func tests(decomposable bool) suite {
 	s.add(New("aliases", aliasIn, aliasOut, "count() by host | sort host"))
 
 	// Tests with assignments and computed keys
-	s.add(New("unset-keys-computed", in+unsetKeyIn, groupSingleOut_unsetOut, "count() by key1=String.toLower(String.toUpper(key1)) | sort key1"))
+	s.add(New("unset-keys-computed", in+unsetKeyIn, groupSingleOut_unsetOut, "count() by key1=to_lower(to_upper(key1)) | sort key1"))
 	s.add(New("unset-keys-assign", in+unsetKeyIn, strings.ReplaceAll(groupSingleOut_unsetOut, "key1", "newkey"), "count() by newkey=key1 | sort newkey"))
 	s.add(New("unset-keys-at-start-assign", unsetKeyIn+in, strings.ReplaceAll(groupSingleOut_unsetOut, "key1", "newkey"), "count() by newkey=key1 | sort newkey"))
 	s.add(New("multiple-fields-assign", in, strings.ReplaceAll(groupMultiOut, "key2", "newkey"), "count() by key1,newkey=key2 | sort key1, newkey"))
 	s.add(New("key-in-record-assign", nestedKeyIn, nestedKeyAssignedOut, "count() by newkey=rec.i | sort newkey"))
-	s.add(New("computed-key", computedKeyIn, computedKeyOut, "count() by s=String.toLower(s), ij=i+j | sort"))
+	s.add(New("computed-key", computedKeyIn, computedKeyOut, "count() by s=to_lower(s), ij=i+j | sort"))
 	return s
 }
 

--- a/proc/put/ztests/implied.yaml
+++ b/proc/put/ztests/implied.yaml
@@ -1,4 +1,4 @@
-zql: 'put y=x+1,String.toLower(s),typeof(s)'
+zql: 'put y=x+1,to_lower(s),typeof(s)'
 
 input: |
   #0:record[a:array[int32],x:int32,s:string,b:bytes]
@@ -6,6 +6,6 @@ input: |
   0:[[1;]2;Bar;dGhlcmUK;]
 
 output: |
-  #0:record[a:array[int32],x:int32,s:string,b:bytes,y:int64,[String.toLower]:string,typeof:type]
+  #0:record[a:array[int32],x:int32,s:string,b:bytes,y:int64,to_lower:string,typeof:type]
   0:[[]1;foo;aGVsbG8K;2;foo;string;]
   0:[[1;]2;Bar;dGhlcmUK;3;bar;string;]

--- a/proc/sort/ztests/expr.yaml
+++ b/proc/sort/ztests/expr.yaml
@@ -1,4 +1,4 @@
-zql: 'sort String.toLower(s)'
+zql: 'sort to_lower(s)'
 
 input: |
   #0:record[s:string]

--- a/zng/ztests/bytes.yaml
+++ b/zng/ztests/bytes.yaml
@@ -1,4 +1,4 @@
-zql: put c=b:string | put d=toBase64(c),f=toBase64(c):bytes | put e=fromBase64(d):string
+zql: put c=b:string | put d=to_base64(c),f=to_base64(c):bytes | put e=from_base64(d):string
 
 input: |
   #0:record[b:bytes]

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -664,183 +664,179 @@ function peg$parse(input, options) {
       peg$c217 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c218 = /^[A-Za-z]/,
-      peg$c219 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
-      peg$c220 = /^[.0-9]/,
-      peg$c221 = peg$classExpectation([".", ["0", "9"]], false, false),
-      peg$c222 = function(first, e) { return e },
-      peg$c223 = function() { return [] },
-      peg$c224 = "[",
-      peg$c225 = peg$literalExpectation("[", false),
-      peg$c226 = "]",
-      peg$c227 = peg$literalExpectation("]", false),
-      peg$c228 = function(expr) { return ["[", expr] },
-      peg$c229 = function(id) { return [".", id] },
-      peg$c230 = "and",
-      peg$c231 = peg$literalExpectation("and", true),
-      peg$c232 = "or",
-      peg$c233 = peg$literalExpectation("or", true),
-      peg$c234 = peg$literalExpectation("in", true),
-      peg$c235 = peg$literalExpectation("not", true),
-      peg$c236 = /^[A-Za-z_$]/,
-      peg$c237 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c238 = /^[0-9]/,
-      peg$c239 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c240 = function() { return {"op": "Identifier", "name": text()} },
-      peg$c241 = peg$literalExpectation("and", false),
-      peg$c242 = "seconds",
-      peg$c243 = peg$literalExpectation("seconds", false),
-      peg$c244 = "second",
-      peg$c245 = peg$literalExpectation("second", false),
-      peg$c246 = "secs",
-      peg$c247 = peg$literalExpectation("secs", false),
-      peg$c248 = "sec",
-      peg$c249 = peg$literalExpectation("sec", false),
-      peg$c250 = "s",
-      peg$c251 = peg$literalExpectation("s", false),
-      peg$c252 = "minutes",
-      peg$c253 = peg$literalExpectation("minutes", false),
-      peg$c254 = "minute",
-      peg$c255 = peg$literalExpectation("minute", false),
-      peg$c256 = "mins",
-      peg$c257 = peg$literalExpectation("mins", false),
-      peg$c258 = "min",
-      peg$c259 = peg$literalExpectation("min", false),
-      peg$c260 = "m",
-      peg$c261 = peg$literalExpectation("m", false),
-      peg$c262 = "hours",
-      peg$c263 = peg$literalExpectation("hours", false),
-      peg$c264 = "hrs",
-      peg$c265 = peg$literalExpectation("hrs", false),
-      peg$c266 = "hr",
-      peg$c267 = peg$literalExpectation("hr", false),
-      peg$c268 = "h",
-      peg$c269 = peg$literalExpectation("h", false),
-      peg$c270 = "hour",
-      peg$c271 = peg$literalExpectation("hour", false),
-      peg$c272 = "days",
-      peg$c273 = peg$literalExpectation("days", false),
-      peg$c274 = "day",
-      peg$c275 = peg$literalExpectation("day", false),
-      peg$c276 = "d",
-      peg$c277 = peg$literalExpectation("d", false),
-      peg$c278 = "weeks",
-      peg$c279 = peg$literalExpectation("weeks", false),
-      peg$c280 = "week",
-      peg$c281 = peg$literalExpectation("week", false),
-      peg$c282 = "wks",
-      peg$c283 = peg$literalExpectation("wks", false),
-      peg$c284 = "wk",
-      peg$c285 = peg$literalExpectation("wk", false),
-      peg$c286 = "w",
-      peg$c287 = peg$literalExpectation("w", false),
-      peg$c288 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c289 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c290 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c291 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c292 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c293 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c294 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c295 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c296 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c297 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c298 = function(a, b) {
+      peg$c218 = function(first, e) { return e },
+      peg$c219 = function() { return [] },
+      peg$c220 = "[",
+      peg$c221 = peg$literalExpectation("[", false),
+      peg$c222 = "]",
+      peg$c223 = peg$literalExpectation("]", false),
+      peg$c224 = function(expr) { return ["[", expr] },
+      peg$c225 = function(id) { return [".", id] },
+      peg$c226 = "and",
+      peg$c227 = peg$literalExpectation("and", true),
+      peg$c228 = "or",
+      peg$c229 = peg$literalExpectation("or", true),
+      peg$c230 = peg$literalExpectation("in", true),
+      peg$c231 = peg$literalExpectation("not", true),
+      peg$c232 = /^[A-Za-z_$]/,
+      peg$c233 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c234 = /^[0-9]/,
+      peg$c235 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c236 = function() { return {"op": "Identifier", "name": text()} },
+      peg$c237 = peg$literalExpectation("and", false),
+      peg$c238 = "seconds",
+      peg$c239 = peg$literalExpectation("seconds", false),
+      peg$c240 = "second",
+      peg$c241 = peg$literalExpectation("second", false),
+      peg$c242 = "secs",
+      peg$c243 = peg$literalExpectation("secs", false),
+      peg$c244 = "sec",
+      peg$c245 = peg$literalExpectation("sec", false),
+      peg$c246 = "s",
+      peg$c247 = peg$literalExpectation("s", false),
+      peg$c248 = "minutes",
+      peg$c249 = peg$literalExpectation("minutes", false),
+      peg$c250 = "minute",
+      peg$c251 = peg$literalExpectation("minute", false),
+      peg$c252 = "mins",
+      peg$c253 = peg$literalExpectation("mins", false),
+      peg$c254 = "min",
+      peg$c255 = peg$literalExpectation("min", false),
+      peg$c256 = "m",
+      peg$c257 = peg$literalExpectation("m", false),
+      peg$c258 = "hours",
+      peg$c259 = peg$literalExpectation("hours", false),
+      peg$c260 = "hrs",
+      peg$c261 = peg$literalExpectation("hrs", false),
+      peg$c262 = "hr",
+      peg$c263 = peg$literalExpectation("hr", false),
+      peg$c264 = "h",
+      peg$c265 = peg$literalExpectation("h", false),
+      peg$c266 = "hour",
+      peg$c267 = peg$literalExpectation("hour", false),
+      peg$c268 = "days",
+      peg$c269 = peg$literalExpectation("days", false),
+      peg$c270 = "day",
+      peg$c271 = peg$literalExpectation("day", false),
+      peg$c272 = "d",
+      peg$c273 = peg$literalExpectation("d", false),
+      peg$c274 = "weeks",
+      peg$c275 = peg$literalExpectation("weeks", false),
+      peg$c276 = "week",
+      peg$c277 = peg$literalExpectation("week", false),
+      peg$c278 = "wks",
+      peg$c279 = peg$literalExpectation("wks", false),
+      peg$c280 = "wk",
+      peg$c281 = peg$literalExpectation("wk", false),
+      peg$c282 = "w",
+      peg$c283 = peg$literalExpectation("w", false),
+      peg$c284 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c285 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c286 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c287 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c288 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c289 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c290 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c291 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c292 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c293 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c294 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c299 = "::",
-      peg$c300 = peg$literalExpectation("::", false),
-      peg$c301 = function(a, b, d, e) {
+      peg$c295 = "::",
+      peg$c296 = peg$literalExpectation("::", false),
+      peg$c297 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c302 = function(a, b) {
+      peg$c298 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c303 = function(a, b) {
+      peg$c299 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c304 = function() {
+      peg$c300 = function() {
             return "::"
           },
-      peg$c305 = function(v) { return ":" + v },
-      peg$c306 = function(v) { return v + ":" },
-      peg$c307 = function(a, m) {
+      peg$c301 = function(v) { return ":" + v },
+      peg$c302 = function(v) { return v + ":" },
+      peg$c303 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c308 = function(a, m) {
+      peg$c304 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c309 = function(s) { return parseInt(s) },
-      peg$c310 = function() {
+      peg$c305 = function(s) { return parseInt(s) },
+      peg$c306 = function() {
             return text()
           },
-      peg$c311 = "e",
-      peg$c312 = peg$literalExpectation("e", true),
-      peg$c313 = /^[+\-]/,
-      peg$c314 = peg$classExpectation(["+", "-"], false, false),
-      peg$c315 = /^[0-9a-fA-F]/,
-      peg$c316 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c317 = function(chars) { return joinChars(chars) },
-      peg$c318 = "\\",
-      peg$c319 = peg$literalExpectation("\\", false),
-      peg$c320 = /^[\0-\x1F\\(),!><="|';:]/,
-      peg$c321 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
-      peg$c322 = peg$anyExpectation(),
-      peg$c323 = "\"",
-      peg$c324 = peg$literalExpectation("\"", false),
-      peg$c325 = function(v) { return joinChars(v) },
-      peg$c326 = "'",
-      peg$c327 = peg$literalExpectation("'", false),
-      peg$c328 = "x",
-      peg$c329 = peg$literalExpectation("x", false),
-      peg$c330 = function() { return "\\" + text() },
-      peg$c331 = "b",
-      peg$c332 = peg$literalExpectation("b", false),
-      peg$c333 = function() { return "\b" },
-      peg$c334 = "f",
-      peg$c335 = peg$literalExpectation("f", false),
-      peg$c336 = function() { return "\f" },
-      peg$c337 = "n",
-      peg$c338 = peg$literalExpectation("n", false),
-      peg$c339 = function() { return "\n" },
-      peg$c340 = "r",
-      peg$c341 = peg$literalExpectation("r", false),
-      peg$c342 = function() { return "\r" },
-      peg$c343 = "t",
-      peg$c344 = peg$literalExpectation("t", false),
-      peg$c345 = function() { return "\t" },
-      peg$c346 = "v",
-      peg$c347 = peg$literalExpectation("v", false),
-      peg$c348 = function() { return "\v" },
-      peg$c349 = function() { return "=" },
-      peg$c350 = function() { return "\\*" },
-      peg$c351 = "u",
-      peg$c352 = peg$literalExpectation("u", false),
-      peg$c353 = function(chars) {
+      peg$c307 = "e",
+      peg$c308 = peg$literalExpectation("e", true),
+      peg$c309 = /^[+\-]/,
+      peg$c310 = peg$classExpectation(["+", "-"], false, false),
+      peg$c311 = /^[0-9a-fA-F]/,
+      peg$c312 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c313 = function(chars) { return joinChars(chars) },
+      peg$c314 = "\\",
+      peg$c315 = peg$literalExpectation("\\", false),
+      peg$c316 = /^[\0-\x1F\\(),!><="|';:]/,
+      peg$c317 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
+      peg$c318 = peg$anyExpectation(),
+      peg$c319 = "\"",
+      peg$c320 = peg$literalExpectation("\"", false),
+      peg$c321 = function(v) { return joinChars(v) },
+      peg$c322 = "'",
+      peg$c323 = peg$literalExpectation("'", false),
+      peg$c324 = "x",
+      peg$c325 = peg$literalExpectation("x", false),
+      peg$c326 = function() { return "\\" + text() },
+      peg$c327 = "b",
+      peg$c328 = peg$literalExpectation("b", false),
+      peg$c329 = function() { return "\b" },
+      peg$c330 = "f",
+      peg$c331 = peg$literalExpectation("f", false),
+      peg$c332 = function() { return "\f" },
+      peg$c333 = "n",
+      peg$c334 = peg$literalExpectation("n", false),
+      peg$c335 = function() { return "\n" },
+      peg$c336 = "r",
+      peg$c337 = peg$literalExpectation("r", false),
+      peg$c338 = function() { return "\r" },
+      peg$c339 = "t",
+      peg$c340 = peg$literalExpectation("t", false),
+      peg$c341 = function() { return "\t" },
+      peg$c342 = "v",
+      peg$c343 = peg$literalExpectation("v", false),
+      peg$c344 = function() { return "\v" },
+      peg$c345 = function() { return "=" },
+      peg$c346 = function() { return "\\*" },
+      peg$c347 = "u",
+      peg$c348 = peg$literalExpectation("u", false),
+      peg$c349 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c354 = "{",
-      peg$c355 = peg$literalExpectation("{", false),
-      peg$c356 = "}",
-      peg$c357 = peg$literalExpectation("}", false),
-      peg$c358 = function(body) { return body },
-      peg$c359 = /^[^\/\\]/,
-      peg$c360 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c361 = "\\/",
-      peg$c362 = peg$literalExpectation("\\/", false),
-      peg$c363 = /^[\0-\x1F\\]/,
-      peg$c364 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c365 = "\t",
-      peg$c366 = peg$literalExpectation("\t", false),
-      peg$c367 = "\x0B",
-      peg$c368 = peg$literalExpectation("\x0B", false),
-      peg$c369 = "\f",
-      peg$c370 = peg$literalExpectation("\f", false),
-      peg$c371 = " ",
-      peg$c372 = peg$literalExpectation(" ", false),
-      peg$c373 = "\xA0",
-      peg$c374 = peg$literalExpectation("\xA0", false),
-      peg$c375 = "\uFEFF",
-      peg$c376 = peg$literalExpectation("\uFEFF", false),
+      peg$c350 = "{",
+      peg$c351 = peg$literalExpectation("{", false),
+      peg$c352 = "}",
+      peg$c353 = peg$literalExpectation("}", false),
+      peg$c354 = function(body) { return body },
+      peg$c355 = /^[^\/\\]/,
+      peg$c356 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c357 = "\\/",
+      peg$c358 = peg$literalExpectation("\\/", false),
+      peg$c359 = /^[\0-\x1F\\]/,
+      peg$c360 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c361 = "\t",
+      peg$c362 = peg$literalExpectation("\t", false),
+      peg$c363 = "\x0B",
+      peg$c364 = peg$literalExpectation("\x0B", false),
+      peg$c365 = "\f",
+      peg$c366 = peg$literalExpectation("\f", false),
+      peg$c367 = " ",
+      peg$c368 = peg$literalExpectation(" ", false),
+      peg$c369 = "\xA0",
+      peg$c370 = peg$literalExpectation("\xA0", false),
+      peg$c371 = "\uFEFF",
+      peg$c372 = peg$literalExpectation("\uFEFF", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -2588,7 +2584,7 @@ function peg$parse(input, options) {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseFuncName();
+      s2 = peg$parseIdentifierName();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
@@ -4958,7 +4954,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    s1 = peg$parseFuncName();
+    s1 = peg$parseDeprecatedName();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
@@ -5007,17 +5003,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseFuncName() {
+  function peg$parseDeprecatedName() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseFuncNameStart();
+    s1 = peg$parseIdentifierStart();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseFuncNameRest();
+      s3 = peg$parseIdentifierRest();
+      if (s3 === peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 46) {
+          s3 = peg$c141;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c142); }
+        }
+      }
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$parseFuncNameRest();
+        s3 = peg$parseIdentifierRest();
+        if (s3 === peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 46) {
+            s3 = peg$c141;
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c142); }
+          }
+        }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -5030,37 +5044,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseFuncNameStart() {
-    var s0;
-
-    if (peg$c218.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c219); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseFuncNameRest() {
-    var s0;
-
-    s0 = peg$parseFuncNameStart();
-    if (s0 === peg$FAILED) {
-      if (peg$c220.test(input.charAt(peg$currPos))) {
-        s0 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c221); }
-      }
     }
 
     return s0;
@@ -5089,7 +5072,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c222(s1, s7);
+              s4 = peg$c218(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5125,7 +5108,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c222(s1, s7);
+                s4 = peg$c218(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5161,7 +5144,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c223();
+        s1 = peg$c219();
       }
       s0 = s1;
     }
@@ -5202,25 +5185,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c224;
+      s1 = peg$c220;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c225); }
+      if (peg$silentFails === 0) { peg$fail(peg$c221); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseConditionalExpr();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c226;
+          s3 = peg$c222;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c227); }
+          if (peg$silentFails === 0) { peg$fail(peg$c223); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c228(s2);
+          s1 = peg$c224(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5264,7 +5247,7 @@ function peg$parse(input, options) {
           s3 = peg$parseIdentifier();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c229(s3);
+            s1 = peg$c225(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5375,12 +5358,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c230) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c226) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c231); }
+      if (peg$silentFails === 0) { peg$fail(peg$c227); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -5395,12 +5378,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c232) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c228) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c233); }
+      if (peg$silentFails === 0) { peg$fail(peg$c229); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -5420,7 +5403,7 @@ function peg$parse(input, options) {
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
+      if (peg$silentFails === 0) { peg$fail(peg$c230); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -5440,7 +5423,7 @@ function peg$parse(input, options) {
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c231); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -5451,15 +5434,43 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseIdentifierName() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseIdentifierStart();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseIdentifierRest();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseIdentifierRest();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c101();
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c236.test(input.charAt(peg$currPos))) {
+    if (peg$c232.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c237); }
+      if (peg$silentFails === 0) { peg$fail(peg$c233); }
     }
 
     return s0;
@@ -5470,12 +5481,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c238.test(input.charAt(peg$currPos))) {
+      if (peg$c234.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c239); }
+        if (peg$silentFails === 0) { peg$fail(peg$c235); }
       }
     }
 
@@ -5496,7 +5507,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c240();
+        s1 = peg$c236();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5524,12 +5535,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c230) {
-                s3 = peg$c230;
+              if (input.substr(peg$currPos, 3) === peg$c226) {
+                s3 = peg$c226;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c241); }
+                if (peg$silentFails === 0) { peg$fail(peg$c237); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -5574,44 +5585,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c242) {
-      s0 = peg$c242;
+    if (input.substr(peg$currPos, 7) === peg$c238) {
+      s0 = peg$c238;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c243); }
+      if (peg$silentFails === 0) { peg$fail(peg$c239); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c244) {
-        s0 = peg$c244;
+      if (input.substr(peg$currPos, 6) === peg$c240) {
+        s0 = peg$c240;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c245); }
+        if (peg$silentFails === 0) { peg$fail(peg$c241); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c246) {
-          s0 = peg$c246;
+        if (input.substr(peg$currPos, 4) === peg$c242) {
+          s0 = peg$c242;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c247); }
+          if (peg$silentFails === 0) { peg$fail(peg$c243); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c248) {
-            s0 = peg$c248;
+          if (input.substr(peg$currPos, 3) === peg$c244) {
+            s0 = peg$c244;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c249); }
+            if (peg$silentFails === 0) { peg$fail(peg$c245); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c250;
+              s0 = peg$c246;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c251); }
+              if (peg$silentFails === 0) { peg$fail(peg$c247); }
             }
           }
         }
@@ -5624,44 +5635,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c252) {
-      s0 = peg$c252;
+    if (input.substr(peg$currPos, 7) === peg$c248) {
+      s0 = peg$c248;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c249); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c254) {
-        s0 = peg$c254;
+      if (input.substr(peg$currPos, 6) === peg$c250) {
+        s0 = peg$c250;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c255); }
+        if (peg$silentFails === 0) { peg$fail(peg$c251); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c256) {
-          s0 = peg$c256;
+        if (input.substr(peg$currPos, 4) === peg$c252) {
+          s0 = peg$c252;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c257); }
+          if (peg$silentFails === 0) { peg$fail(peg$c253); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c258) {
-            s0 = peg$c258;
+          if (input.substr(peg$currPos, 3) === peg$c254) {
+            s0 = peg$c254;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c259); }
+            if (peg$silentFails === 0) { peg$fail(peg$c255); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c260;
+              s0 = peg$c256;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c261); }
+              if (peg$silentFails === 0) { peg$fail(peg$c257); }
             }
           }
         }
@@ -5674,44 +5685,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c262) {
-      s0 = peg$c262;
+    if (input.substr(peg$currPos, 5) === peg$c258) {
+      s0 = peg$c258;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c263); }
+      if (peg$silentFails === 0) { peg$fail(peg$c259); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c264) {
-        s0 = peg$c264;
+      if (input.substr(peg$currPos, 3) === peg$c260) {
+        s0 = peg$c260;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c265); }
+        if (peg$silentFails === 0) { peg$fail(peg$c261); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c266) {
-          s0 = peg$c266;
+        if (input.substr(peg$currPos, 2) === peg$c262) {
+          s0 = peg$c262;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c267); }
+          if (peg$silentFails === 0) { peg$fail(peg$c263); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c268;
+            s0 = peg$c264;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c269); }
+            if (peg$silentFails === 0) { peg$fail(peg$c265); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c270) {
-              s0 = peg$c270;
+            if (input.substr(peg$currPos, 4) === peg$c266) {
+              s0 = peg$c266;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c271); }
+              if (peg$silentFails === 0) { peg$fail(peg$c267); }
             }
           }
         }
@@ -5724,28 +5735,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c272) {
-      s0 = peg$c272;
+    if (input.substr(peg$currPos, 4) === peg$c268) {
+      s0 = peg$c268;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c273); }
+      if (peg$silentFails === 0) { peg$fail(peg$c269); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c274) {
-        s0 = peg$c274;
+      if (input.substr(peg$currPos, 3) === peg$c270) {
+        s0 = peg$c270;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c275); }
+        if (peg$silentFails === 0) { peg$fail(peg$c271); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c276;
+          s0 = peg$c272;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c277); }
+          if (peg$silentFails === 0) { peg$fail(peg$c273); }
         }
       }
     }
@@ -5756,44 +5767,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c278) {
-      s0 = peg$c278;
+    if (input.substr(peg$currPos, 5) === peg$c274) {
+      s0 = peg$c274;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c275); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c280) {
-        s0 = peg$c280;
+      if (input.substr(peg$currPos, 4) === peg$c276) {
+        s0 = peg$c276;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c281); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c282) {
-          s0 = peg$c282;
+        if (input.substr(peg$currPos, 3) === peg$c278) {
+          s0 = peg$c278;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c283); }
+          if (peg$silentFails === 0) { peg$fail(peg$c279); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c284) {
-            s0 = peg$c284;
+          if (input.substr(peg$currPos, 2) === peg$c280) {
+            s0 = peg$c280;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c285); }
+            if (peg$silentFails === 0) { peg$fail(peg$c281); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c286;
+              s0 = peg$c282;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c287); }
+              if (peg$silentFails === 0) { peg$fail(peg$c283); }
             }
           }
         }
@@ -5807,16 +5818,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c244) {
-      s1 = peg$c244;
+    if (input.substr(peg$currPos, 6) === peg$c240) {
+      s1 = peg$c240;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c245); }
+      if (peg$silentFails === 0) { peg$fail(peg$c241); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c288();
+      s1 = peg$c284();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5828,7 +5839,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c289(s1);
+            s1 = peg$c285(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5851,16 +5862,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c254) {
-      s1 = peg$c254;
+    if (input.substr(peg$currPos, 6) === peg$c250) {
+      s1 = peg$c250;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c255); }
+      if (peg$silentFails === 0) { peg$fail(peg$c251); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c290();
+      s1 = peg$c286();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5872,7 +5883,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c291(s1);
+            s1 = peg$c287(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5895,16 +5906,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c270) {
-      s1 = peg$c270;
+    if (input.substr(peg$currPos, 4) === peg$c266) {
+      s1 = peg$c266;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c271); }
+      if (peg$silentFails === 0) { peg$fail(peg$c267); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c292();
+      s1 = peg$c288();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5916,7 +5927,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c293(s1);
+            s1 = peg$c289(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5939,16 +5950,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c274) {
-      s1 = peg$c274;
+    if (input.substr(peg$currPos, 3) === peg$c270) {
+      s1 = peg$c270;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c275); }
+      if (peg$silentFails === 0) { peg$fail(peg$c271); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c294();
+      s1 = peg$c290();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5960,7 +5971,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c295(s1);
+            s1 = peg$c291(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5983,16 +5994,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c280) {
-      s1 = peg$c280;
+    if (input.substr(peg$currPos, 4) === peg$c276) {
+      s1 = peg$c276;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c281); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c296();
+      s1 = peg$c292();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6004,7 +6015,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c297(s1);
+            s1 = peg$c293(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6112,7 +6123,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c298(s1, s2);
+        s1 = peg$c294(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6133,12 +6144,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c299) {
-            s3 = peg$c299;
+          if (input.substr(peg$currPos, 2) === peg$c295) {
+            s3 = peg$c295;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c300); }
+            if (peg$silentFails === 0) { peg$fail(peg$c296); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6151,7 +6162,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c301(s1, s2, s4, s5);
+                s1 = peg$c297(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6175,12 +6186,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c299) {
-          s1 = peg$c299;
+        if (input.substr(peg$currPos, 2) === peg$c295) {
+          s1 = peg$c295;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c300); }
+          if (peg$silentFails === 0) { peg$fail(peg$c296); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6193,7 +6204,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c302(s2, s3);
+              s1 = peg$c298(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6218,16 +6229,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c299) {
-                s3 = peg$c299;
+              if (input.substr(peg$currPos, 2) === peg$c295) {
+                s3 = peg$c295;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c300); }
+                if (peg$silentFails === 0) { peg$fail(peg$c296); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c303(s1, s2);
+                s1 = peg$c299(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6243,16 +6254,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c299) {
-              s1 = peg$c299;
+            if (input.substr(peg$currPos, 2) === peg$c295) {
+              s1 = peg$c295;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c300); }
+              if (peg$silentFails === 0) { peg$fail(peg$c296); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c304();
+              s1 = peg$c300();
             }
             s0 = s1;
           }
@@ -6289,7 +6300,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c305(s2);
+        s1 = peg$c301(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6318,7 +6329,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c306(s1);
+        s1 = peg$c302(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6349,7 +6360,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c307(s1, s3);
+          s1 = peg$c303(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6384,7 +6395,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c308(s1, s3);
+          s1 = peg$c304(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6409,7 +6420,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c309(s1);
+      s1 = peg$c305(s1);
     }
     s0 = s1;
 
@@ -6432,22 +6443,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c238.test(input.charAt(peg$currPos))) {
+    if (peg$c234.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c239); }
+      if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c238.test(input.charAt(peg$currPos))) {
+        if (peg$c234.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c239); }
+          if (peg$silentFails === 0) { peg$fail(peg$c235); }
         }
       }
     } else {
@@ -6507,22 +6518,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c238.test(input.charAt(peg$currPos))) {
+      if (peg$c234.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c239); }
+        if (peg$silentFails === 0) { peg$fail(peg$c235); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c238.test(input.charAt(peg$currPos))) {
+          if (peg$c234.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c239); }
+            if (peg$silentFails === 0) { peg$fail(peg$c235); }
           }
         }
       } else {
@@ -6538,22 +6549,22 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c238.test(input.charAt(peg$currPos))) {
+          if (peg$c234.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c239); }
+            if (peg$silentFails === 0) { peg$fail(peg$c235); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c238.test(input.charAt(peg$currPos))) {
+              if (peg$c234.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c239); }
+                if (peg$silentFails === 0) { peg$fail(peg$c235); }
               }
             }
           } else {
@@ -6566,7 +6577,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c310();
+              s1 = peg$c306();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6610,22 +6621,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c238.test(input.charAt(peg$currPos))) {
+          if (peg$c234.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c239); }
+            if (peg$silentFails === 0) { peg$fail(peg$c235); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c238.test(input.charAt(peg$currPos))) {
+              if (peg$c234.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c239); }
+                if (peg$silentFails === 0) { peg$fail(peg$c235); }
               }
             }
           } else {
@@ -6638,7 +6649,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c310();
+              s1 = peg$c306();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6665,20 +6676,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c311) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c307) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c312); }
+      if (peg$silentFails === 0) { peg$fail(peg$c308); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c313.test(input.charAt(peg$currPos))) {
+      if (peg$c309.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c314); }
+        if (peg$silentFails === 0) { peg$fail(peg$c310); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -6730,12 +6741,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c315.test(input.charAt(peg$currPos))) {
+    if (peg$c311.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
 
     return s0;
@@ -6757,7 +6768,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c317(s1);
+      s1 = peg$c313(s1);
     }
     s0 = s1;
 
@@ -6769,11 +6780,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c318;
+      s1 = peg$c314;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c319); }
+      if (peg$silentFails === 0) { peg$fail(peg$c315); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
@@ -6796,12 +6807,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c320.test(input.charAt(peg$currPos))) {
+      if (peg$c316.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c321); }
+        if (peg$silentFails === 0) { peg$fail(peg$c317); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseWhiteSpace();
@@ -6819,7 +6830,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c322); }
+          if (peg$silentFails === 0) { peg$fail(peg$c318); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -6843,11 +6854,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c323;
+      s1 = peg$c319;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c324); }
+      if (peg$silentFails === 0) { peg$fail(peg$c320); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -6858,15 +6869,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c323;
+          s3 = peg$c319;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c324); }
+          if (peg$silentFails === 0) { peg$fail(peg$c320); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c325(s2);
+          s1 = peg$c321(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6883,11 +6894,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c326;
+        s1 = peg$c322;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c327); }
+        if (peg$silentFails === 0) { peg$fail(peg$c323); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -6898,15 +6909,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c326;
+            s3 = peg$c322;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c327); }
+            if (peg$silentFails === 0) { peg$fail(peg$c323); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c325(s2);
+            s1 = peg$c321(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6932,11 +6943,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c323;
+      s2 = peg$c319;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c324); }
+      if (peg$silentFails === 0) { peg$fail(peg$c320); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -6954,7 +6965,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        if (peg$silentFails === 0) { peg$fail(peg$c318); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -6971,11 +6982,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c318;
+        s1 = peg$c314;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c319); }
+        if (peg$silentFails === 0) { peg$fail(peg$c315); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -7003,11 +7014,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c326;
+      s2 = peg$c322;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c327); }
+      if (peg$silentFails === 0) { peg$fail(peg$c323); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -7025,7 +7036,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        if (peg$silentFails === 0) { peg$fail(peg$c318); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -7042,11 +7053,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c318;
+        s1 = peg$c314;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c319); }
+        if (peg$silentFails === 0) { peg$fail(peg$c315); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -7072,11 +7083,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c328;
+      s1 = peg$c324;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c329); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -7084,7 +7095,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c330();
+          s1 = peg$c326();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7112,110 +7123,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c326;
+      s0 = peg$c322;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c327); }
+      if (peg$silentFails === 0) { peg$fail(peg$c323); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c323;
+        s0 = peg$c319;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c324); }
+        if (peg$silentFails === 0) { peg$fail(peg$c320); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c318;
+          s0 = peg$c314;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c319); }
+          if (peg$silentFails === 0) { peg$fail(peg$c315); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c331;
+            s1 = peg$c327;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c332); }
+            if (peg$silentFails === 0) { peg$fail(peg$c328); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c333();
+            s1 = peg$c329();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c334;
+              s1 = peg$c330;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c335); }
+              if (peg$silentFails === 0) { peg$fail(peg$c331); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c336();
+              s1 = peg$c332();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c337;
+                s1 = peg$c333;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c338); }
+                if (peg$silentFails === 0) { peg$fail(peg$c334); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c339();
+                s1 = peg$c335();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c340;
+                  s1 = peg$c336;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c341); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c337); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c342();
+                  s1 = peg$c338();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c343;
+                    s1 = peg$c339;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c344); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c340); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c345();
+                    s1 = peg$c341();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c346;
+                      s1 = peg$c342;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c343); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c348();
+                      s1 = peg$c344();
                     }
                     s0 = s1;
                   }
@@ -7243,7 +7254,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c349();
+      s1 = peg$c345();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7257,7 +7268,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c350();
+        s1 = peg$c346();
       }
       s0 = s1;
     }
@@ -7270,11 +7281,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c351;
+      s1 = peg$c347;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c352); }
+      if (peg$silentFails === 0) { peg$fail(peg$c348); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7306,7 +7317,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c353(s2);
+        s1 = peg$c349(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7319,19 +7330,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c351;
+        s1 = peg$c347;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c352); }
+        if (peg$silentFails === 0) { peg$fail(peg$c348); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c354;
+          s2 = peg$c350;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c355); }
+          if (peg$silentFails === 0) { peg$fail(peg$c351); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7390,15 +7401,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c356;
+              s4 = peg$c352;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c357); }
+              if (peg$silentFails === 0) { peg$fail(peg$c353); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c353(s3);
+              s1 = peg$c349(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7444,7 +7455,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c358(s2);
+          s1 = peg$c354(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7467,39 +7478,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c359.test(input.charAt(peg$currPos))) {
+    if (peg$c355.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+      if (peg$silentFails === 0) { peg$fail(peg$c356); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c361) {
-        s2 = peg$c361;
+      if (input.substr(peg$currPos, 2) === peg$c357) {
+        s2 = peg$c357;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c362); }
+        if (peg$silentFails === 0) { peg$fail(peg$c358); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c359.test(input.charAt(peg$currPos))) {
+        if (peg$c355.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c360); }
+          if (peg$silentFails === 0) { peg$fail(peg$c356); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c361) {
-            s2 = peg$c361;
+          if (input.substr(peg$currPos, 2) === peg$c357) {
+            s2 = peg$c357;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c362); }
+            if (peg$silentFails === 0) { peg$fail(peg$c358); }
           }
         }
       }
@@ -7518,12 +7529,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c363.test(input.charAt(peg$currPos))) {
+    if (peg$c359.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
 
     return s0;
@@ -7533,51 +7544,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c365;
+      s0 = peg$c361;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
+      if (peg$silentFails === 0) { peg$fail(peg$c362); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c367;
+        s0 = peg$c363;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c368); }
+        if (peg$silentFails === 0) { peg$fail(peg$c364); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c369;
+          s0 = peg$c365;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c370); }
+          if (peg$silentFails === 0) { peg$fail(peg$c366); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c371;
+            s0 = peg$c367;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c372); }
+            if (peg$silentFails === 0) { peg$fail(peg$c368); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c373;
+              s0 = peg$c369;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c374); }
+              if (peg$silentFails === 0) { peg$fail(peg$c370); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c375;
+                s0 = peg$c371;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c376); }
+                if (peg$silentFails === 0) { peg$fail(peg$c372); }
               }
             }
           }
@@ -7628,7 +7639,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c318); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -1569,49 +1569,49 @@ var g = &grammar{
 							label: "op",
 							expr: &ruleRefExpr{
 								pos:  position{line: 234, col: 23, offset: 7453},
-								name: "FuncName",
+								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 234, col: 32, offset: 7462},
+							pos:  position{line: 234, col: 38, offset: 7468},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 234, col: 35, offset: 7465},
+							pos:        position{line: 234, col: 41, offset: 7471},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 234, col: 39, offset: 7469},
+							pos:  position{line: 234, col: 45, offset: 7475},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 234, col: 42, offset: 7472},
+							pos:   position{line: 234, col: 48, offset: 7478},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 234, col: 47, offset: 7477},
+								pos: position{line: 234, col: 53, offset: 7483},
 								expr: &ruleRefExpr{
-									pos:  position{line: 234, col: 47, offset: 7477},
+									pos:  position{line: 234, col: 53, offset: 7483},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 234, col: 54, offset: 7484},
+							pos:  position{line: 234, col: 60, offset: 7490},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 234, col: 57, offset: 7487},
+							pos:        position{line: 234, col: 63, offset: 7493},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 234, col: 61, offset: 7491},
+							pos:   position{line: 234, col: 67, offset: 7497},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 234, col: 67, offset: 7497},
+								pos: position{line: 234, col: 73, offset: 7503},
 								expr: &ruleRefExpr{
-									pos:  position{line: 234, col: 67, offset: 7497},
+									pos:  position{line: 234, col: 73, offset: 7503},
 									name: "WhereClause",
 								},
 							},
@@ -1622,31 +1622,31 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 242, col: 1, offset: 7680},
+			pos:  position{line: 242, col: 1, offset: 7686},
 			expr: &actionExpr{
-				pos: position{line: 242, col: 15, offset: 7694},
+				pos: position{line: 242, col: 15, offset: 7700},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 242, col: 15, offset: 7694},
+					pos: position{line: 242, col: 15, offset: 7700},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 242, col: 15, offset: 7694},
+							pos:  position{line: 242, col: 15, offset: 7700},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 242, col: 17, offset: 7696},
+							pos:        position{line: 242, col: 17, offset: 7702},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 242, col: 25, offset: 7704},
+							pos:  position{line: 242, col: 25, offset: 7710},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 242, col: 27, offset: 7706},
+							pos:   position{line: 242, col: 27, offset: 7712},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 242, col: 32, offset: 7711},
+								pos:  position{line: 242, col: 32, offset: 7717},
 								name: "Expr",
 							},
 						},
@@ -1656,44 +1656,44 @@ var g = &grammar{
 		},
 		{
 			name: "Reducers",
-			pos:  position{line: 244, col: 1, offset: 7738},
+			pos:  position{line: 244, col: 1, offset: 7744},
 			expr: &actionExpr{
-				pos: position{line: 245, col: 5, offset: 7751},
+				pos: position{line: 245, col: 5, offset: 7757},
 				run: (*parser).callonReducers1,
 				expr: &seqExpr{
-					pos: position{line: 245, col: 5, offset: 7751},
+					pos: position{line: 245, col: 5, offset: 7757},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 245, col: 5, offset: 7751},
+							pos:   position{line: 245, col: 5, offset: 7757},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 245, col: 11, offset: 7757},
+								pos:  position{line: 245, col: 11, offset: 7763},
 								name: "ReducerAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 245, col: 29, offset: 7775},
+							pos:   position{line: 245, col: 29, offset: 7781},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 245, col: 34, offset: 7780},
+								pos: position{line: 245, col: 34, offset: 7786},
 								expr: &seqExpr{
-									pos: position{line: 245, col: 35, offset: 7781},
+									pos: position{line: 245, col: 35, offset: 7787},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 245, col: 35, offset: 7781},
+											pos:  position{line: 245, col: 35, offset: 7787},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 245, col: 38, offset: 7784},
+											pos:        position{line: 245, col: 38, offset: 7790},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 245, col: 42, offset: 7788},
+											pos:  position{line: 245, col: 42, offset: 7794},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 245, col: 45, offset: 7791},
+											pos:  position{line: 245, col: 45, offset: 7797},
 											name: "ReducerAssignment",
 										},
 									},
@@ -1706,48 +1706,48 @@ var g = &grammar{
 		},
 		{
 			name: "NamedProc",
-			pos:  position{line: 253, col: 1, offset: 7996},
+			pos:  position{line: 253, col: 1, offset: 8002},
 			expr: &choiceExpr{
-				pos: position{line: 254, col: 5, offset: 8010},
+				pos: position{line: 254, col: 5, offset: 8016},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 254, col: 5, offset: 8010},
+						pos:  position{line: 254, col: 5, offset: 8016},
 						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 255, col: 5, offset: 8023},
+						pos:  position{line: 255, col: 5, offset: 8029},
 						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 256, col: 5, offset: 8035},
+						pos:  position{line: 256, col: 5, offset: 8041},
 						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 5, offset: 8047},
+						pos:  position{line: 257, col: 5, offset: 8053},
 						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 258, col: 5, offset: 8060},
+						pos:  position{line: 258, col: 5, offset: 8066},
 						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 259, col: 5, offset: 8073},
+						pos:  position{line: 259, col: 5, offset: 8079},
 						name: "FilterProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 260, col: 5, offset: 8088},
+						pos:  position{line: 260, col: 5, offset: 8094},
 						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 261, col: 5, offset: 8101},
+						pos:  position{line: 261, col: 5, offset: 8107},
 						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 262, col: 5, offset: 8113},
+						pos:  position{line: 262, col: 5, offset: 8119},
 						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 263, col: 5, offset: 8128},
+						pos:  position{line: 263, col: 5, offset: 8134},
 						name: "FuseProc",
 					},
 				},
@@ -1755,46 +1755,46 @@ var g = &grammar{
 		},
 		{
 			name: "SortProc",
-			pos:  position{line: 265, col: 1, offset: 8138},
+			pos:  position{line: 265, col: 1, offset: 8144},
 			expr: &actionExpr{
-				pos: position{line: 266, col: 5, offset: 8151},
+				pos: position{line: 266, col: 5, offset: 8157},
 				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 266, col: 5, offset: 8151},
+					pos: position{line: 266, col: 5, offset: 8157},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 266, col: 5, offset: 8151},
+							pos:        position{line: 266, col: 5, offset: 8157},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 266, col: 13, offset: 8159},
+							pos:   position{line: 266, col: 13, offset: 8165},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 266, col: 18, offset: 8164},
+								pos:  position{line: 266, col: 18, offset: 8170},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 266, col: 27, offset: 8173},
+							pos:   position{line: 266, col: 27, offset: 8179},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 266, col: 32, offset: 8178},
+								pos: position{line: 266, col: 32, offset: 8184},
 								expr: &actionExpr{
-									pos: position{line: 266, col: 33, offset: 8179},
+									pos: position{line: 266, col: 33, offset: 8185},
 									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 266, col: 33, offset: 8179},
+										pos: position{line: 266, col: 33, offset: 8185},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 266, col: 33, offset: 8179},
+												pos:  position{line: 266, col: 33, offset: 8185},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 266, col: 35, offset: 8181},
+												pos:   position{line: 266, col: 35, offset: 8187},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 266, col: 37, offset: 8183},
+													pos:  position{line: 266, col: 37, offset: 8189},
 													name: "Exprs",
 												},
 											},
@@ -1809,30 +1809,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 280, col: 1, offset: 8602},
+			pos:  position{line: 280, col: 1, offset: 8608},
 			expr: &actionExpr{
-				pos: position{line: 280, col: 12, offset: 8613},
+				pos: position{line: 280, col: 12, offset: 8619},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 280, col: 12, offset: 8613},
+					pos:   position{line: 280, col: 12, offset: 8619},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 280, col: 17, offset: 8618},
+						pos: position{line: 280, col: 17, offset: 8624},
 						expr: &actionExpr{
-							pos: position{line: 280, col: 18, offset: 8619},
+							pos: position{line: 280, col: 18, offset: 8625},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 280, col: 18, offset: 8619},
+								pos: position{line: 280, col: 18, offset: 8625},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 280, col: 18, offset: 8619},
+										pos:  position{line: 280, col: 18, offset: 8625},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 280, col: 20, offset: 8621},
+										pos:   position{line: 280, col: 20, offset: 8627},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 280, col: 22, offset: 8623},
+											pos:  position{line: 280, col: 22, offset: 8629},
 											name: "SortArg",
 										},
 									},
@@ -1845,50 +1845,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 282, col: 1, offset: 8679},
+			pos:  position{line: 282, col: 1, offset: 8685},
 			expr: &choiceExpr{
-				pos: position{line: 283, col: 5, offset: 8691},
+				pos: position{line: 283, col: 5, offset: 8697},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 283, col: 5, offset: 8691},
+						pos: position{line: 283, col: 5, offset: 8697},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 283, col: 5, offset: 8691},
+							pos:        position{line: 283, col: 5, offset: 8697},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 284, col: 5, offset: 8766},
+						pos: position{line: 284, col: 5, offset: 8772},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 284, col: 5, offset: 8766},
+							pos: position{line: 284, col: 5, offset: 8772},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 284, col: 5, offset: 8766},
+									pos:        position{line: 284, col: 5, offset: 8772},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 284, col: 14, offset: 8775},
+									pos:  position{line: 284, col: 14, offset: 8781},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 284, col: 16, offset: 8777},
+									pos:   position{line: 284, col: 16, offset: 8783},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 284, col: 23, offset: 8784},
+										pos: position{line: 284, col: 23, offset: 8790},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 284, col: 24, offset: 8785},
+											pos: position{line: 284, col: 24, offset: 8791},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 284, col: 24, offset: 8785},
+													pos:        position{line: 284, col: 24, offset: 8791},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 284, col: 34, offset: 8795},
+													pos:        position{line: 284, col: 34, offset: 8801},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -1904,38 +1904,38 @@ var g = &grammar{
 		},
 		{
 			name: "TopProc",
-			pos:  position{line: 286, col: 1, offset: 8909},
+			pos:  position{line: 286, col: 1, offset: 8915},
 			expr: &actionExpr{
-				pos: position{line: 287, col: 5, offset: 8921},
+				pos: position{line: 287, col: 5, offset: 8927},
 				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 287, col: 5, offset: 8921},
+					pos: position{line: 287, col: 5, offset: 8927},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 287, col: 5, offset: 8921},
+							pos:        position{line: 287, col: 5, offset: 8927},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 287, col: 12, offset: 8928},
+							pos:   position{line: 287, col: 12, offset: 8934},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 287, col: 18, offset: 8934},
+								pos: position{line: 287, col: 18, offset: 8940},
 								expr: &actionExpr{
-									pos: position{line: 287, col: 19, offset: 8935},
+									pos: position{line: 287, col: 19, offset: 8941},
 									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 287, col: 19, offset: 8935},
+										pos: position{line: 287, col: 19, offset: 8941},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 287, col: 19, offset: 8935},
+												pos:  position{line: 287, col: 19, offset: 8941},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 287, col: 21, offset: 8937},
+												pos:   position{line: 287, col: 21, offset: 8943},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 287, col: 23, offset: 8939},
+													pos:  position{line: 287, col: 23, offset: 8945},
 													name: "UInt",
 												},
 											},
@@ -1945,19 +1945,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 287, col: 47, offset: 8963},
+							pos:   position{line: 287, col: 47, offset: 8969},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 287, col: 53, offset: 8969},
+								pos: position{line: 287, col: 53, offset: 8975},
 								expr: &seqExpr{
-									pos: position{line: 287, col: 54, offset: 8970},
+									pos: position{line: 287, col: 54, offset: 8976},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 287, col: 54, offset: 8970},
+											pos:  position{line: 287, col: 54, offset: 8976},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 287, col: 56, offset: 8972},
+											pos:        position{line: 287, col: 56, offset: 8978},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -1966,25 +1966,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 287, col: 67, offset: 8983},
+							pos:   position{line: 287, col: 67, offset: 8989},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 287, col: 74, offset: 8990},
+								pos: position{line: 287, col: 74, offset: 8996},
 								expr: &actionExpr{
-									pos: position{line: 287, col: 75, offset: 8991},
+									pos: position{line: 287, col: 75, offset: 8997},
 									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 287, col: 75, offset: 8991},
+										pos: position{line: 287, col: 75, offset: 8997},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 287, col: 75, offset: 8991},
+												pos:  position{line: 287, col: 75, offset: 8997},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 287, col: 77, offset: 8993},
+												pos:   position{line: 287, col: 77, offset: 8999},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 287, col: 79, offset: 8995},
+													pos:  position{line: 287, col: 79, offset: 9001},
 													name: "FieldExprs",
 												},
 											},
@@ -1999,35 +1999,35 @@ var g = &grammar{
 		},
 		{
 			name: "CutProc",
-			pos:  position{line: 301, col: 1, offset: 9303},
+			pos:  position{line: 301, col: 1, offset: 9309},
 			expr: &actionExpr{
-				pos: position{line: 302, col: 5, offset: 9315},
+				pos: position{line: 302, col: 5, offset: 9321},
 				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 302, col: 5, offset: 9315},
+					pos: position{line: 302, col: 5, offset: 9321},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 302, col: 5, offset: 9315},
+							pos:        position{line: 302, col: 5, offset: 9321},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 302, col: 12, offset: 9322},
+							pos:   position{line: 302, col: 12, offset: 9328},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 302, col: 17, offset: 9327},
+								pos:  position{line: 302, col: 17, offset: 9333},
 								name: "CutArgs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 302, col: 25, offset: 9335},
+							pos:  position{line: 302, col: 25, offset: 9341},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 302, col: 27, offset: 9337},
+							pos:   position{line: 302, col: 27, offset: 9343},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 302, col: 35, offset: 9345},
+								pos:  position{line: 302, col: 35, offset: 9351},
 								name: "FlexAssignments",
 							},
 						},
@@ -2037,27 +2037,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutArgs",
-			pos:  position{line: 311, col: 1, offset: 9614},
+			pos:  position{line: 311, col: 1, offset: 9620},
 			expr: &actionExpr{
-				pos: position{line: 312, col: 5, offset: 9626},
+				pos: position{line: 312, col: 5, offset: 9632},
 				run: (*parser).callonCutArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 312, col: 5, offset: 9626},
+					pos:   position{line: 312, col: 5, offset: 9632},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 312, col: 10, offset: 9631},
+						pos: position{line: 312, col: 10, offset: 9637},
 						expr: &actionExpr{
-							pos: position{line: 312, col: 11, offset: 9632},
+							pos: position{line: 312, col: 11, offset: 9638},
 							run: (*parser).callonCutArgs4,
 							expr: &seqExpr{
-								pos: position{line: 312, col: 11, offset: 9632},
+								pos: position{line: 312, col: 11, offset: 9638},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 312, col: 11, offset: 9632},
+										pos:  position{line: 312, col: 11, offset: 9638},
 										name: "_",
 									},
 									&litMatcher{
-										pos:        position{line: 312, col: 13, offset: 9634},
+										pos:        position{line: 312, col: 13, offset: 9640},
 										val:        "-c",
 										ignoreCase: false,
 									},
@@ -2070,30 +2070,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadProc",
-			pos:  position{line: 316, col: 1, offset: 9746},
+			pos:  position{line: 316, col: 1, offset: 9752},
 			expr: &choiceExpr{
-				pos: position{line: 317, col: 5, offset: 9759},
+				pos: position{line: 317, col: 5, offset: 9765},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 317, col: 5, offset: 9759},
+						pos: position{line: 317, col: 5, offset: 9765},
 						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 317, col: 5, offset: 9759},
+							pos: position{line: 317, col: 5, offset: 9765},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 317, col: 5, offset: 9759},
+									pos:        position{line: 317, col: 5, offset: 9765},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 317, col: 13, offset: 9767},
+									pos:  position{line: 317, col: 13, offset: 9773},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 317, col: 15, offset: 9769},
+									pos:   position{line: 317, col: 15, offset: 9775},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 317, col: 21, offset: 9775},
+										pos:  position{line: 317, col: 21, offset: 9781},
 										name: "UInt",
 									},
 								},
@@ -2101,10 +2101,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 318, col: 5, offset: 9857},
+						pos: position{line: 318, col: 5, offset: 9863},
 						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 318, col: 5, offset: 9857},
+							pos:        position{line: 318, col: 5, offset: 9863},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2114,30 +2114,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailProc",
-			pos:  position{line: 320, col: 1, offset: 9935},
+			pos:  position{line: 320, col: 1, offset: 9941},
 			expr: &choiceExpr{
-				pos: position{line: 321, col: 5, offset: 9948},
+				pos: position{line: 321, col: 5, offset: 9954},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 321, col: 5, offset: 9948},
+						pos: position{line: 321, col: 5, offset: 9954},
 						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 321, col: 5, offset: 9948},
+							pos: position{line: 321, col: 5, offset: 9954},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 321, col: 5, offset: 9948},
+									pos:        position{line: 321, col: 5, offset: 9954},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 321, col: 13, offset: 9956},
+									pos:  position{line: 321, col: 13, offset: 9962},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 321, col: 15, offset: 9958},
+									pos:   position{line: 321, col: 15, offset: 9964},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 321, col: 21, offset: 9964},
+										pos:  position{line: 321, col: 21, offset: 9970},
 										name: "UInt",
 									},
 								},
@@ -2145,10 +2145,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 322, col: 5, offset: 10046},
+						pos: position{line: 322, col: 5, offset: 10052},
 						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 322, col: 5, offset: 10046},
+							pos:        position{line: 322, col: 5, offset: 10052},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2158,27 +2158,27 @@ var g = &grammar{
 		},
 		{
 			name: "FilterProc",
-			pos:  position{line: 324, col: 1, offset: 10124},
+			pos:  position{line: 324, col: 1, offset: 10130},
 			expr: &actionExpr{
-				pos: position{line: 325, col: 5, offset: 10139},
+				pos: position{line: 325, col: 5, offset: 10145},
 				run: (*parser).callonFilterProc1,
 				expr: &seqExpr{
-					pos: position{line: 325, col: 5, offset: 10139},
+					pos: position{line: 325, col: 5, offset: 10145},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 325, col: 5, offset: 10139},
+							pos:        position{line: 325, col: 5, offset: 10145},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 325, col: 15, offset: 10149},
+							pos:  position{line: 325, col: 15, offset: 10155},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 325, col: 17, offset: 10151},
+							pos:   position{line: 325, col: 17, offset: 10157},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 325, col: 22, offset: 10156},
+								pos:  position{line: 325, col: 22, offset: 10162},
 								name: "SearchExpr",
 							},
 						},
@@ -2188,27 +2188,27 @@ var g = &grammar{
 		},
 		{
 			name: "UniqProc",
-			pos:  position{line: 329, col: 1, offset: 10253},
+			pos:  position{line: 329, col: 1, offset: 10259},
 			expr: &choiceExpr{
-				pos: position{line: 330, col: 5, offset: 10266},
+				pos: position{line: 330, col: 5, offset: 10272},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 330, col: 5, offset: 10266},
+						pos: position{line: 330, col: 5, offset: 10272},
 						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 330, col: 5, offset: 10266},
+							pos: position{line: 330, col: 5, offset: 10272},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 330, col: 5, offset: 10266},
+									pos:        position{line: 330, col: 5, offset: 10272},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 330, col: 13, offset: 10274},
+									pos:  position{line: 330, col: 13, offset: 10280},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 330, col: 15, offset: 10276},
+									pos:        position{line: 330, col: 15, offset: 10282},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2216,10 +2216,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 333, col: 5, offset: 10367},
+						pos: position{line: 333, col: 5, offset: 10373},
 						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 333, col: 5, offset: 10367},
+							pos:        position{line: 333, col: 5, offset: 10373},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2229,27 +2229,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutProc",
-			pos:  position{line: 337, col: 1, offset: 10459},
+			pos:  position{line: 337, col: 1, offset: 10465},
 			expr: &actionExpr{
-				pos: position{line: 338, col: 5, offset: 10471},
+				pos: position{line: 338, col: 5, offset: 10477},
 				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 338, col: 5, offset: 10471},
+					pos: position{line: 338, col: 5, offset: 10477},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 338, col: 5, offset: 10471},
+							pos:        position{line: 338, col: 5, offset: 10477},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 338, col: 12, offset: 10478},
+							pos:  position{line: 338, col: 12, offset: 10484},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 338, col: 14, offset: 10480},
+							pos:   position{line: 338, col: 14, offset: 10486},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 338, col: 22, offset: 10488},
+								pos:  position{line: 338, col: 22, offset: 10494},
 								name: "FlexAssignments",
 							},
 						},
@@ -2259,59 +2259,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameProc",
-			pos:  position{line: 342, col: 1, offset: 10591},
+			pos:  position{line: 342, col: 1, offset: 10597},
 			expr: &actionExpr{
-				pos: position{line: 343, col: 5, offset: 10606},
+				pos: position{line: 343, col: 5, offset: 10612},
 				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 343, col: 5, offset: 10606},
+					pos: position{line: 343, col: 5, offset: 10612},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 343, col: 5, offset: 10606},
+							pos:        position{line: 343, col: 5, offset: 10612},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 343, col: 15, offset: 10616},
+							pos:  position{line: 343, col: 15, offset: 10622},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 343, col: 17, offset: 10618},
+							pos:   position{line: 343, col: 17, offset: 10624},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 343, col: 23, offset: 10624},
+								pos:  position{line: 343, col: 23, offset: 10630},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 343, col: 34, offset: 10635},
+							pos:   position{line: 343, col: 34, offset: 10641},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 343, col: 39, offset: 10640},
+								pos: position{line: 343, col: 39, offset: 10646},
 								expr: &actionExpr{
-									pos: position{line: 343, col: 40, offset: 10641},
+									pos: position{line: 343, col: 40, offset: 10647},
 									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 343, col: 40, offset: 10641},
+										pos: position{line: 343, col: 40, offset: 10647},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 343, col: 40, offset: 10641},
+												pos:  position{line: 343, col: 40, offset: 10647},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 343, col: 43, offset: 10644},
+												pos:        position{line: 343, col: 43, offset: 10650},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 343, col: 47, offset: 10648},
+												pos:  position{line: 343, col: 47, offset: 10654},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 343, col: 50, offset: 10651},
+												pos:   position{line: 343, col: 50, offset: 10657},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 343, col: 53, offset: 10654},
+													pos:  position{line: 343, col: 53, offset: 10660},
 													name: "Assignment",
 												},
 											},
@@ -2326,12 +2326,12 @@ var g = &grammar{
 		},
 		{
 			name: "FuseProc",
-			pos:  position{line: 347, col: 1, offset: 10824},
+			pos:  position{line: 347, col: 1, offset: 10830},
 			expr: &actionExpr{
-				pos: position{line: 348, col: 5, offset: 10837},
+				pos: position{line: 348, col: 5, offset: 10843},
 				run: (*parser).callonFuseProc1,
 				expr: &litMatcher{
-					pos:        position{line: 348, col: 5, offset: 10837},
+					pos:        position{line: 348, col: 5, offset: 10843},
 					val:        "fuse",
 					ignoreCase: true,
 				},
@@ -2339,45 +2339,45 @@ var g = &grammar{
 		},
 		{
 			name: "RootField",
-			pos:  position{line: 352, col: 1, offset: 10913},
+			pos:  position{line: 352, col: 1, offset: 10919},
 			expr: &choiceExpr{
-				pos: position{line: 353, col: 5, offset: 10927},
+				pos: position{line: 353, col: 5, offset: 10933},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 353, col: 5, offset: 10927},
+						pos: position{line: 353, col: 5, offset: 10933},
 						run: (*parser).callonRootField2,
 						expr: &seqExpr{
-							pos: position{line: 353, col: 5, offset: 10927},
+							pos: position{line: 353, col: 5, offset: 10933},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 353, col: 5, offset: 10927},
+									pos: position{line: 353, col: 5, offset: 10933},
 									expr: &litMatcher{
-										pos:        position{line: 353, col: 5, offset: 10927},
+										pos:        position{line: 353, col: 5, offset: 10933},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&notExpr{
-									pos: position{line: 353, col: 10, offset: 10932},
+									pos: position{line: 353, col: 10, offset: 10938},
 									expr: &choiceExpr{
-										pos: position{line: 353, col: 12, offset: 10934},
+										pos: position{line: 353, col: 12, offset: 10940},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 353, col: 12, offset: 10934},
+												pos:  position{line: 353, col: 12, offset: 10940},
 												name: "BooleanLiteral",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 353, col: 29, offset: 10951},
+												pos:  position{line: 353, col: 29, offset: 10957},
 												name: "NullLiteral",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 353, col: 42, offset: 10964},
+									pos:   position{line: 353, col: 42, offset: 10970},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 353, col: 48, offset: 10970},
+										pos:  position{line: 353, col: 48, offset: 10976},
 										name: "Identifier",
 									},
 								},
@@ -2385,20 +2385,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 354, col: 5, offset: 11123},
+						pos: position{line: 354, col: 5, offset: 11129},
 						run: (*parser).callonRootField12,
 						expr: &seqExpr{
-							pos: position{line: 354, col: 5, offset: 11123},
+							pos: position{line: 354, col: 5, offset: 11129},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 354, col: 5, offset: 11123},
+									pos:        position{line: 354, col: 5, offset: 11129},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 354, col: 9, offset: 11127},
+									pos: position{line: 354, col: 9, offset: 11133},
 									expr: &ruleRefExpr{
-										pos:  position{line: 354, col: 11, offset: 11129},
+										pos:  position{line: 354, col: 11, offset: 11135},
 										name: "Identifier",
 									},
 								},
@@ -2410,60 +2410,60 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 356, col: 1, offset: 11202},
+			pos:  position{line: 356, col: 1, offset: 11208},
 			expr: &ruleRefExpr{
-				pos:  position{line: 356, col: 8, offset: 11209},
+				pos:  position{line: 356, col: 8, offset: 11215},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 358, col: 1, offset: 11220},
+			pos:  position{line: 358, col: 1, offset: 11226},
 			expr: &ruleRefExpr{
-				pos:  position{line: 358, col: 13, offset: 11232},
+				pos:  position{line: 358, col: 13, offset: 11238},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 360, col: 1, offset: 11238},
+			pos:  position{line: 360, col: 1, offset: 11244},
 			expr: &actionExpr{
-				pos: position{line: 361, col: 5, offset: 11253},
+				pos: position{line: 361, col: 5, offset: 11259},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 361, col: 5, offset: 11253},
+					pos: position{line: 361, col: 5, offset: 11259},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 361, col: 5, offset: 11253},
+							pos:   position{line: 361, col: 5, offset: 11259},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 361, col: 11, offset: 11259},
+								pos:  position{line: 361, col: 11, offset: 11265},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 361, col: 21, offset: 11269},
+							pos:   position{line: 361, col: 21, offset: 11275},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 361, col: 26, offset: 11274},
+								pos: position{line: 361, col: 26, offset: 11280},
 								expr: &seqExpr{
-									pos: position{line: 361, col: 27, offset: 11275},
+									pos: position{line: 361, col: 27, offset: 11281},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 361, col: 27, offset: 11275},
+											pos:  position{line: 361, col: 27, offset: 11281},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 361, col: 30, offset: 11278},
+											pos:        position{line: 361, col: 30, offset: 11284},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 361, col: 34, offset: 11282},
+											pos:  position{line: 361, col: 34, offset: 11288},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 361, col: 37, offset: 11285},
+											pos:  position{line: 361, col: 37, offset: 11291},
 											name: "FieldExpr",
 										},
 									},
@@ -2476,44 +2476,44 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 371, col: 1, offset: 11484},
+			pos:  position{line: 371, col: 1, offset: 11490},
 			expr: &actionExpr{
-				pos: position{line: 372, col: 5, offset: 11494},
+				pos: position{line: 372, col: 5, offset: 11500},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 372, col: 5, offset: 11494},
+					pos: position{line: 372, col: 5, offset: 11500},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 372, col: 5, offset: 11494},
+							pos:   position{line: 372, col: 5, offset: 11500},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 372, col: 11, offset: 11500},
+								pos:  position{line: 372, col: 11, offset: 11506},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 372, col: 16, offset: 11505},
+							pos:   position{line: 372, col: 16, offset: 11511},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 372, col: 21, offset: 11510},
+								pos: position{line: 372, col: 21, offset: 11516},
 								expr: &seqExpr{
-									pos: position{line: 372, col: 22, offset: 11511},
+									pos: position{line: 372, col: 22, offset: 11517},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 372, col: 22, offset: 11511},
+											pos:  position{line: 372, col: 22, offset: 11517},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 372, col: 25, offset: 11514},
+											pos:        position{line: 372, col: 25, offset: 11520},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 372, col: 29, offset: 11518},
+											pos:  position{line: 372, col: 29, offset: 11524},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 372, col: 32, offset: 11521},
+											pos:  position{line: 372, col: 32, offset: 11527},
 											name: "Expr",
 										},
 									},
@@ -2526,39 +2526,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 382, col: 1, offset: 11715},
+			pos:  position{line: 382, col: 1, offset: 11721},
 			expr: &actionExpr{
-				pos: position{line: 383, col: 5, offset: 11730},
+				pos: position{line: 383, col: 5, offset: 11736},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 383, col: 5, offset: 11730},
+					pos: position{line: 383, col: 5, offset: 11736},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 383, col: 5, offset: 11730},
+							pos:   position{line: 383, col: 5, offset: 11736},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 383, col: 9, offset: 11734},
+								pos:  position{line: 383, col: 9, offset: 11740},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 383, col: 14, offset: 11739},
+							pos:  position{line: 383, col: 14, offset: 11745},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 383, col: 17, offset: 11742},
+							pos:        position{line: 383, col: 17, offset: 11748},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 383, col: 21, offset: 11746},
+							pos:  position{line: 383, col: 21, offset: 11752},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 383, col: 24, offset: 11749},
+							pos:   position{line: 383, col: 24, offset: 11755},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 383, col: 28, offset: 11753},
+								pos:  position{line: 383, col: 28, offset: 11759},
 								name: "Expr",
 							},
 						},
@@ -2568,71 +2568,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 385, col: 1, offset: 11822},
+			pos:  position{line: 385, col: 1, offset: 11828},
 			expr: &ruleRefExpr{
-				pos:  position{line: 385, col: 8, offset: 11829},
+				pos:  position{line: 385, col: 8, offset: 11835},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 387, col: 1, offset: 11846},
+			pos:  position{line: 387, col: 1, offset: 11852},
 			expr: &choiceExpr{
-				pos: position{line: 388, col: 5, offset: 11866},
+				pos: position{line: 388, col: 5, offset: 11872},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 388, col: 5, offset: 11866},
+						pos: position{line: 388, col: 5, offset: 11872},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 388, col: 5, offset: 11866},
+							pos: position{line: 388, col: 5, offset: 11872},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 388, col: 5, offset: 11866},
+									pos:   position{line: 388, col: 5, offset: 11872},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 388, col: 15, offset: 11876},
+										pos:  position{line: 388, col: 15, offset: 11882},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 388, col: 29, offset: 11890},
+									pos:  position{line: 388, col: 29, offset: 11896},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 388, col: 32, offset: 11893},
+									pos:        position{line: 388, col: 32, offset: 11899},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 388, col: 36, offset: 11897},
+									pos:  position{line: 388, col: 36, offset: 11903},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 388, col: 39, offset: 11900},
+									pos:   position{line: 388, col: 39, offset: 11906},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 388, col: 50, offset: 11911},
+										pos:  position{line: 388, col: 50, offset: 11917},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 388, col: 55, offset: 11916},
+									pos:  position{line: 388, col: 55, offset: 11922},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 388, col: 58, offset: 11919},
+									pos:        position{line: 388, col: 58, offset: 11925},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 388, col: 62, offset: 11923},
+									pos:  position{line: 388, col: 62, offset: 11929},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 388, col: 65, offset: 11926},
+									pos:   position{line: 388, col: 65, offset: 11932},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 388, col: 76, offset: 11937},
+										pos:  position{line: 388, col: 76, offset: 11943},
 										name: "Expr",
 									},
 								},
@@ -2640,7 +2640,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 391, col: 5, offset: 12084},
+						pos:  position{line: 391, col: 5, offset: 12090},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -2648,53 +2648,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 393, col: 1, offset: 12099},
+			pos:  position{line: 393, col: 1, offset: 12105},
 			expr: &actionExpr{
-				pos: position{line: 394, col: 5, offset: 12117},
+				pos: position{line: 394, col: 5, offset: 12123},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 394, col: 5, offset: 12117},
+					pos: position{line: 394, col: 5, offset: 12123},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 394, col: 5, offset: 12117},
+							pos:   position{line: 394, col: 5, offset: 12123},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 394, col: 11, offset: 12123},
+								pos:  position{line: 394, col: 11, offset: 12129},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 395, col: 5, offset: 12142},
+							pos:   position{line: 395, col: 5, offset: 12148},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 395, col: 10, offset: 12147},
+								pos: position{line: 395, col: 10, offset: 12153},
 								expr: &actionExpr{
-									pos: position{line: 395, col: 11, offset: 12148},
+									pos: position{line: 395, col: 11, offset: 12154},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 395, col: 11, offset: 12148},
+										pos: position{line: 395, col: 11, offset: 12154},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 395, col: 11, offset: 12148},
+												pos:  position{line: 395, col: 11, offset: 12154},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 395, col: 14, offset: 12151},
+												pos:   position{line: 395, col: 14, offset: 12157},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 395, col: 17, offset: 12154},
+													pos:  position{line: 395, col: 17, offset: 12160},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 395, col: 25, offset: 12162},
+												pos:  position{line: 395, col: 25, offset: 12168},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 395, col: 28, offset: 12165},
+												pos:   position{line: 395, col: 28, offset: 12171},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 395, col: 33, offset: 12170},
+													pos:  position{line: 395, col: 33, offset: 12176},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -2709,53 +2709,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 399, col: 1, offset: 12288},
+			pos:  position{line: 399, col: 1, offset: 12294},
 			expr: &actionExpr{
-				pos: position{line: 400, col: 5, offset: 12307},
+				pos: position{line: 400, col: 5, offset: 12313},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 400, col: 5, offset: 12307},
+					pos: position{line: 400, col: 5, offset: 12313},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 400, col: 5, offset: 12307},
+							pos:   position{line: 400, col: 5, offset: 12313},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 400, col: 11, offset: 12313},
+								pos:  position{line: 400, col: 11, offset: 12319},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 401, col: 5, offset: 12337},
+							pos:   position{line: 401, col: 5, offset: 12343},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 401, col: 10, offset: 12342},
+								pos: position{line: 401, col: 10, offset: 12348},
 								expr: &actionExpr{
-									pos: position{line: 401, col: 11, offset: 12343},
+									pos: position{line: 401, col: 11, offset: 12349},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 401, col: 11, offset: 12343},
+										pos: position{line: 401, col: 11, offset: 12349},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 401, col: 11, offset: 12343},
+												pos:  position{line: 401, col: 11, offset: 12349},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 401, col: 14, offset: 12346},
+												pos:   position{line: 401, col: 14, offset: 12352},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 401, col: 17, offset: 12349},
+													pos:  position{line: 401, col: 17, offset: 12355},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 401, col: 26, offset: 12358},
+												pos:  position{line: 401, col: 26, offset: 12364},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 401, col: 29, offset: 12361},
+												pos:   position{line: 401, col: 29, offset: 12367},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 401, col: 34, offset: 12366},
+													pos:  position{line: 401, col: 34, offset: 12372},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -2770,53 +2770,53 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 405, col: 1, offset: 12489},
+			pos:  position{line: 405, col: 1, offset: 12495},
 			expr: &actionExpr{
-				pos: position{line: 406, col: 5, offset: 12513},
+				pos: position{line: 406, col: 5, offset: 12519},
 				run: (*parser).callonEqualityCompareExpr1,
 				expr: &seqExpr{
-					pos: position{line: 406, col: 5, offset: 12513},
+					pos: position{line: 406, col: 5, offset: 12519},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 406, col: 5, offset: 12513},
+							pos:   position{line: 406, col: 5, offset: 12519},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 406, col: 11, offset: 12519},
+								pos:  position{line: 406, col: 11, offset: 12525},
 								name: "RelativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 407, col: 5, offset: 12536},
+							pos:   position{line: 407, col: 5, offset: 12542},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 407, col: 10, offset: 12541},
+								pos: position{line: 407, col: 10, offset: 12547},
 								expr: &actionExpr{
-									pos: position{line: 407, col: 11, offset: 12542},
+									pos: position{line: 407, col: 11, offset: 12548},
 									run: (*parser).callonEqualityCompareExpr7,
 									expr: &seqExpr{
-										pos: position{line: 407, col: 11, offset: 12542},
+										pos: position{line: 407, col: 11, offset: 12548},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 407, col: 11, offset: 12542},
+												pos:  position{line: 407, col: 11, offset: 12548},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 407, col: 14, offset: 12545},
+												pos:   position{line: 407, col: 14, offset: 12551},
 												label: "comp",
 												expr: &ruleRefExpr{
-													pos:  position{line: 407, col: 19, offset: 12550},
+													pos:  position{line: 407, col: 19, offset: 12556},
 													name: "EqualityComparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 407, col: 38, offset: 12569},
+												pos:  position{line: 407, col: 38, offset: 12575},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 407, col: 41, offset: 12572},
+												pos:   position{line: 407, col: 41, offset: 12578},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 407, col: 46, offset: 12577},
+													pos:  position{line: 407, col: 46, offset: 12583},
 													name: "RelativeExpr",
 												},
 											},
@@ -2831,30 +2831,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 411, col: 1, offset: 12695},
+			pos:  position{line: 411, col: 1, offset: 12701},
 			expr: &actionExpr{
-				pos: position{line: 411, col: 20, offset: 12714},
+				pos: position{line: 411, col: 20, offset: 12720},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 411, col: 21, offset: 12715},
+					pos: position{line: 411, col: 21, offset: 12721},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 411, col: 21, offset: 12715},
+							pos:        position{line: 411, col: 21, offset: 12721},
 							val:        "=~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 411, col: 28, offset: 12722},
+							pos:        position{line: 411, col: 28, offset: 12728},
 							val:        "!~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 411, col: 35, offset: 12729},
+							pos:        position{line: 411, col: 35, offset: 12735},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 411, col: 41, offset: 12735},
+							pos:        position{line: 411, col: 41, offset: 12741},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -2864,19 +2864,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 413, col: 1, offset: 12773},
+			pos:  position{line: 413, col: 1, offset: 12779},
 			expr: &choiceExpr{
-				pos: position{line: 414, col: 5, offset: 12796},
+				pos: position{line: 414, col: 5, offset: 12802},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 414, col: 5, offset: 12796},
+						pos:  position{line: 414, col: 5, offset: 12802},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 415, col: 5, offset: 12817},
+						pos: position{line: 415, col: 5, offset: 12823},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 415, col: 5, offset: 12817},
+							pos:        position{line: 415, col: 5, offset: 12823},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -2886,53 +2886,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 417, col: 1, offset: 12854},
+			pos:  position{line: 417, col: 1, offset: 12860},
 			expr: &actionExpr{
-				pos: position{line: 418, col: 5, offset: 12871},
+				pos: position{line: 418, col: 5, offset: 12877},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 418, col: 5, offset: 12871},
+					pos: position{line: 418, col: 5, offset: 12877},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 418, col: 5, offset: 12871},
+							pos:   position{line: 418, col: 5, offset: 12877},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 418, col: 11, offset: 12877},
+								pos:  position{line: 418, col: 11, offset: 12883},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 419, col: 5, offset: 12894},
+							pos:   position{line: 419, col: 5, offset: 12900},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 419, col: 10, offset: 12899},
+								pos: position{line: 419, col: 10, offset: 12905},
 								expr: &actionExpr{
-									pos: position{line: 419, col: 11, offset: 12900},
+									pos: position{line: 419, col: 11, offset: 12906},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 419, col: 11, offset: 12900},
+										pos: position{line: 419, col: 11, offset: 12906},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 419, col: 11, offset: 12900},
+												pos:  position{line: 419, col: 11, offset: 12906},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 419, col: 14, offset: 12903},
+												pos:   position{line: 419, col: 14, offset: 12909},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 419, col: 17, offset: 12906},
+													pos:  position{line: 419, col: 17, offset: 12912},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 419, col: 34, offset: 12923},
+												pos:  position{line: 419, col: 34, offset: 12929},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 419, col: 37, offset: 12926},
+												pos:   position{line: 419, col: 37, offset: 12932},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 419, col: 42, offset: 12931},
+													pos:  position{line: 419, col: 42, offset: 12937},
 													name: "AdditiveExpr",
 												},
 											},
@@ -2947,30 +2947,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 423, col: 1, offset: 13047},
+			pos:  position{line: 423, col: 1, offset: 13053},
 			expr: &actionExpr{
-				pos: position{line: 423, col: 20, offset: 13066},
+				pos: position{line: 423, col: 20, offset: 13072},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 423, col: 21, offset: 13067},
+					pos: position{line: 423, col: 21, offset: 13073},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 423, col: 21, offset: 13067},
+							pos:        position{line: 423, col: 21, offset: 13073},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 423, col: 28, offset: 13074},
+							pos:        position{line: 423, col: 28, offset: 13080},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 423, col: 34, offset: 13080},
+							pos:        position{line: 423, col: 34, offset: 13086},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 423, col: 41, offset: 13087},
+							pos:        position{line: 423, col: 41, offset: 13093},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -2980,53 +2980,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 425, col: 1, offset: 13124},
+			pos:  position{line: 425, col: 1, offset: 13130},
 			expr: &actionExpr{
-				pos: position{line: 426, col: 5, offset: 13141},
+				pos: position{line: 426, col: 5, offset: 13147},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 426, col: 5, offset: 13141},
+					pos: position{line: 426, col: 5, offset: 13147},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 426, col: 5, offset: 13141},
+							pos:   position{line: 426, col: 5, offset: 13147},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 426, col: 11, offset: 13147},
+								pos:  position{line: 426, col: 11, offset: 13153},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 427, col: 5, offset: 13170},
+							pos:   position{line: 427, col: 5, offset: 13176},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 427, col: 10, offset: 13175},
+								pos: position{line: 427, col: 10, offset: 13181},
 								expr: &actionExpr{
-									pos: position{line: 427, col: 11, offset: 13176},
+									pos: position{line: 427, col: 11, offset: 13182},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 427, col: 11, offset: 13176},
+										pos: position{line: 427, col: 11, offset: 13182},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 427, col: 11, offset: 13176},
+												pos:  position{line: 427, col: 11, offset: 13182},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 427, col: 14, offset: 13179},
+												pos:   position{line: 427, col: 14, offset: 13185},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 427, col: 17, offset: 13182},
+													pos:  position{line: 427, col: 17, offset: 13188},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 427, col: 34, offset: 13199},
+												pos:  position{line: 427, col: 34, offset: 13205},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 427, col: 37, offset: 13202},
+												pos:   position{line: 427, col: 37, offset: 13208},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 427, col: 42, offset: 13207},
+													pos:  position{line: 427, col: 42, offset: 13213},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -3041,20 +3041,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 431, col: 1, offset: 13329},
+			pos:  position{line: 431, col: 1, offset: 13335},
 			expr: &actionExpr{
-				pos: position{line: 431, col: 20, offset: 13348},
+				pos: position{line: 431, col: 20, offset: 13354},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 431, col: 21, offset: 13349},
+					pos: position{line: 431, col: 21, offset: 13355},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 431, col: 21, offset: 13349},
+							pos:        position{line: 431, col: 21, offset: 13355},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 431, col: 27, offset: 13355},
+							pos:        position{line: 431, col: 27, offset: 13361},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3064,53 +3064,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 433, col: 1, offset: 13392},
+			pos:  position{line: 433, col: 1, offset: 13398},
 			expr: &actionExpr{
-				pos: position{line: 434, col: 5, offset: 13415},
+				pos: position{line: 434, col: 5, offset: 13421},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 434, col: 5, offset: 13415},
+					pos: position{line: 434, col: 5, offset: 13421},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 434, col: 5, offset: 13415},
+							pos:   position{line: 434, col: 5, offset: 13421},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 434, col: 11, offset: 13421},
+								pos:  position{line: 434, col: 11, offset: 13427},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 435, col: 5, offset: 13433},
+							pos:   position{line: 435, col: 5, offset: 13439},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 435, col: 10, offset: 13438},
+								pos: position{line: 435, col: 10, offset: 13444},
 								expr: &actionExpr{
-									pos: position{line: 435, col: 11, offset: 13439},
+									pos: position{line: 435, col: 11, offset: 13445},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 435, col: 11, offset: 13439},
+										pos: position{line: 435, col: 11, offset: 13445},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 435, col: 11, offset: 13439},
+												pos:  position{line: 435, col: 11, offset: 13445},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 435, col: 14, offset: 13442},
+												pos:   position{line: 435, col: 14, offset: 13448},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 435, col: 17, offset: 13445},
+													pos:  position{line: 435, col: 17, offset: 13451},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 435, col: 40, offset: 13468},
+												pos:  position{line: 435, col: 40, offset: 13474},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 435, col: 43, offset: 13471},
+												pos:   position{line: 435, col: 43, offset: 13477},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 435, col: 48, offset: 13476},
+													pos:  position{line: 435, col: 48, offset: 13482},
 													name: "NotExpr",
 												},
 											},
@@ -3125,20 +3125,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 439, col: 1, offset: 13587},
+			pos:  position{line: 439, col: 1, offset: 13593},
 			expr: &actionExpr{
-				pos: position{line: 439, col: 26, offset: 13612},
+				pos: position{line: 439, col: 26, offset: 13618},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 439, col: 27, offset: 13613},
+					pos: position{line: 439, col: 27, offset: 13619},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 439, col: 27, offset: 13613},
+							pos:        position{line: 439, col: 27, offset: 13619},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 439, col: 33, offset: 13619},
+							pos:        position{line: 439, col: 33, offset: 13625},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -3148,30 +3148,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 441, col: 1, offset: 13656},
+			pos:  position{line: 441, col: 1, offset: 13662},
 			expr: &choiceExpr{
-				pos: position{line: 442, col: 5, offset: 13668},
+				pos: position{line: 442, col: 5, offset: 13674},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 442, col: 5, offset: 13668},
+						pos: position{line: 442, col: 5, offset: 13674},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 442, col: 5, offset: 13668},
+							pos: position{line: 442, col: 5, offset: 13674},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 442, col: 5, offset: 13668},
+									pos:        position{line: 442, col: 5, offset: 13674},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 442, col: 9, offset: 13672},
+									pos:  position{line: 442, col: 9, offset: 13678},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 442, col: 12, offset: 13675},
+									pos:   position{line: 442, col: 12, offset: 13681},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 442, col: 14, offset: 13677},
+										pos:  position{line: 442, col: 14, offset: 13683},
 										name: "NotExpr",
 									},
 								},
@@ -3179,7 +3179,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 445, col: 5, offset: 13790},
+						pos:  position{line: 445, col: 5, offset: 13796},
 						name: "CastExpr",
 					},
 				},
@@ -3187,43 +3187,43 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpr",
-			pos:  position{line: 447, col: 1, offset: 13800},
+			pos:  position{line: 447, col: 1, offset: 13806},
 			expr: &choiceExpr{
-				pos: position{line: 448, col: 5, offset: 13813},
+				pos: position{line: 448, col: 5, offset: 13819},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 448, col: 5, offset: 13813},
+						pos: position{line: 448, col: 5, offset: 13819},
 						run: (*parser).callonCastExpr2,
 						expr: &seqExpr{
-							pos: position{line: 448, col: 5, offset: 13813},
+							pos: position{line: 448, col: 5, offset: 13819},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 448, col: 5, offset: 13813},
+									pos:   position{line: 448, col: 5, offset: 13819},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 448, col: 7, offset: 13815},
+										pos:  position{line: 448, col: 7, offset: 13821},
 										name: "FuncExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 448, col: 16, offset: 13824},
+									pos:   position{line: 448, col: 16, offset: 13830},
 									label: "typ",
 									expr: &actionExpr{
-										pos: position{line: 448, col: 22, offset: 13830},
+										pos: position{line: 448, col: 22, offset: 13836},
 										run: (*parser).callonCastExpr7,
 										expr: &seqExpr{
-											pos: position{line: 448, col: 22, offset: 13830},
+											pos: position{line: 448, col: 22, offset: 13836},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 448, col: 22, offset: 13830},
+													pos:        position{line: 448, col: 22, offset: 13836},
 													val:        ":",
 													ignoreCase: false,
 												},
 												&labeledExpr{
-													pos:   position{line: 448, col: 26, offset: 13834},
+													pos:   position{line: 448, col: 26, offset: 13840},
 													label: "typ",
 													expr: &ruleRefExpr{
-														pos:  position{line: 448, col: 30, offset: 13838},
+														pos:  position{line: 448, col: 30, offset: 13844},
 														name: "PrimitiveType",
 													},
 												},
@@ -3235,7 +3235,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 451, col: 5, offset: 13968},
+						pos:  position{line: 451, col: 5, offset: 13974},
 						name: "FuncExpr",
 					},
 				},
@@ -3243,115 +3243,115 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 454, col: 1, offset: 13979},
+			pos:  position{line: 454, col: 1, offset: 13985},
 			expr: &actionExpr{
-				pos: position{line: 455, col: 5, offset: 13997},
+				pos: position{line: 455, col: 5, offset: 14003},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 455, col: 9, offset: 14001},
+					pos: position{line: 455, col: 9, offset: 14007},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 455, col: 9, offset: 14001},
+							pos:        position{line: 455, col: 9, offset: 14007},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 455, col: 19, offset: 14011},
+							pos:        position{line: 455, col: 19, offset: 14017},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 455, col: 29, offset: 14021},
+							pos:        position{line: 455, col: 29, offset: 14027},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 455, col: 40, offset: 14032},
+							pos:        position{line: 455, col: 40, offset: 14038},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 455, col: 51, offset: 14043},
+							pos:        position{line: 455, col: 51, offset: 14049},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 9, offset: 14060},
+							pos:        position{line: 456, col: 9, offset: 14066},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 18, offset: 14069},
+							pos:        position{line: 456, col: 18, offset: 14075},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 28, offset: 14079},
+							pos:        position{line: 456, col: 28, offset: 14085},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 456, col: 38, offset: 14089},
+							pos:        position{line: 456, col: 38, offset: 14095},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 457, col: 9, offset: 14105},
+							pos:        position{line: 457, col: 9, offset: 14111},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 457, col: 22, offset: 14118},
+							pos:        position{line: 457, col: 22, offset: 14124},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 458, col: 9, offset: 14133},
+							pos:        position{line: 458, col: 9, offset: 14139},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 459, col: 9, offset: 14151},
+							pos:        position{line: 459, col: 9, offset: 14157},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 459, col: 18, offset: 14160},
+							pos:        position{line: 459, col: 18, offset: 14166},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 459, col: 28, offset: 14170},
+							pos:        position{line: 459, col: 28, offset: 14176},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 459, col: 39, offset: 14181},
+							pos:        position{line: 459, col: 39, offset: 14187},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 460, col: 9, offset: 14199},
+							pos:        position{line: 460, col: 9, offset: 14205},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 460, col: 16, offset: 14206},
+							pos:        position{line: 460, col: 16, offset: 14212},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 461, col: 9, offset: 14220},
+							pos:        position{line: 461, col: 9, offset: 14226},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 461, col: 18, offset: 14229},
+							pos:        position{line: 461, col: 18, offset: 14235},
 							val:        "error",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 461, col: 28, offset: 14239},
+							pos:        position{line: 461, col: 28, offset: 14245},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -3361,31 +3361,31 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 463, col: 1, offset: 14280},
+			pos:  position{line: 463, col: 1, offset: 14286},
 			expr: &choiceExpr{
-				pos: position{line: 464, col: 5, offset: 14293},
+				pos: position{line: 464, col: 5, offset: 14299},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 464, col: 5, offset: 14293},
+						pos: position{line: 464, col: 5, offset: 14299},
 						run: (*parser).callonFuncExpr2,
 						expr: &seqExpr{
-							pos: position{line: 464, col: 5, offset: 14293},
+							pos: position{line: 464, col: 5, offset: 14299},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 464, col: 5, offset: 14293},
+									pos:   position{line: 464, col: 5, offset: 14299},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 464, col: 11, offset: 14299},
+										pos:  position{line: 464, col: 11, offset: 14305},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 464, col: 20, offset: 14308},
+									pos:   position{line: 464, col: 20, offset: 14314},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 464, col: 25, offset: 14313},
+										pos: position{line: 464, col: 25, offset: 14319},
 										expr: &ruleRefExpr{
-											pos:  position{line: 464, col: 26, offset: 14314},
+											pos:  position{line: 464, col: 26, offset: 14320},
 											name: "Deref",
 										},
 									},
@@ -3394,11 +3394,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 467, col: 5, offset: 14385},
+						pos:  position{line: 467, col: 5, offset: 14391},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 468, col: 5, offset: 14399},
+						pos:  position{line: 468, col: 5, offset: 14405},
 						name: "Primary",
 					},
 				},
@@ -3406,40 +3406,40 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 470, col: 1, offset: 14408},
+			pos:  position{line: 470, col: 1, offset: 14414},
 			expr: &actionExpr{
-				pos: position{line: 471, col: 5, offset: 14421},
+				pos: position{line: 471, col: 5, offset: 14427},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 471, col: 5, offset: 14421},
+					pos: position{line: 471, col: 5, offset: 14427},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 471, col: 5, offset: 14421},
+							pos:   position{line: 471, col: 5, offset: 14427},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 471, col: 8, offset: 14424},
-								name: "FuncName",
+								pos:  position{line: 471, col: 8, offset: 14430},
+								name: "DeprecatedName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 471, col: 17, offset: 14433},
+							pos:  position{line: 471, col: 23, offset: 14445},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 471, col: 20, offset: 14436},
+							pos:        position{line: 471, col: 26, offset: 14448},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 471, col: 24, offset: 14440},
+							pos:   position{line: 471, col: 30, offset: 14452},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 471, col: 29, offset: 14445},
+								pos:  position{line: 471, col: 35, offset: 14457},
 								name: "ArgumentList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 471, col: 42, offset: 14458},
+							pos:        position{line: 471, col: 48, offset: 14470},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -3448,23 +3448,33 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "FuncName",
-			pos:  position{line: 475, col: 1, offset: 14564},
+			name: "DeprecatedName",
+			pos:  position{line: 477, col: 1, offset: 14702},
 			expr: &actionExpr{
-				pos: position{line: 476, col: 5, offset: 14577},
-				run: (*parser).callonFuncName1,
+				pos: position{line: 477, col: 18, offset: 14719},
+				run: (*parser).callonDeprecatedName1,
 				expr: &seqExpr{
-					pos: position{line: 476, col: 5, offset: 14577},
+					pos: position{line: 477, col: 18, offset: 14719},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 476, col: 5, offset: 14577},
-							name: "FuncNameStart",
+							pos:  position{line: 477, col: 18, offset: 14719},
+							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 476, col: 19, offset: 14591},
-							expr: &ruleRefExpr{
-								pos:  position{line: 476, col: 19, offset: 14591},
-								name: "FuncNameRest",
+							pos: position{line: 477, col: 34, offset: 14735},
+							expr: &choiceExpr{
+								pos: position{line: 477, col: 35, offset: 14736},
+								alternatives: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 477, col: 35, offset: 14736},
+										name: "IdentifierRest",
+									},
+									&litMatcher{
+										pos:        position{line: 477, col: 52, offset: 14753},
+										val:        ".",
+										ignoreCase: false,
+									},
+								},
 							},
 						},
 					},
@@ -3472,86 +3482,54 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "FuncNameStart",
-			pos:  position{line: 478, col: 1, offset: 14637},
-			expr: &charClassMatcher{
-				pos:        position{line: 478, col: 17, offset: 14653},
-				val:        "[A-Za-z]",
-				ranges:     []rune{'A', 'Z', 'a', 'z'},
-				ignoreCase: false,
-				inverted:   false,
-			},
-		},
-		{
-			name: "FuncNameRest",
-			pos:  position{line: 479, col: 1, offset: 14662},
-			expr: &choiceExpr{
-				pos: position{line: 479, col: 16, offset: 14677},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 479, col: 16, offset: 14677},
-						name: "FuncNameStart",
-					},
-					&charClassMatcher{
-						pos:        position{line: 479, col: 32, offset: 14693},
-						val:        "[.0-9]",
-						chars:      []rune{'.'},
-						ranges:     []rune{'0', '9'},
-						ignoreCase: false,
-						inverted:   false,
-					},
-				},
-			},
-		},
-		{
 			name: "ArgumentList",
-			pos:  position{line: 481, col: 1, offset: 14701},
+			pos:  position{line: 479, col: 1, offset: 14791},
 			expr: &choiceExpr{
-				pos: position{line: 482, col: 5, offset: 14718},
+				pos: position{line: 480, col: 5, offset: 14808},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 482, col: 5, offset: 14718},
+						pos: position{line: 480, col: 5, offset: 14808},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 482, col: 5, offset: 14718},
+							pos: position{line: 480, col: 5, offset: 14808},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 482, col: 5, offset: 14718},
+									pos:   position{line: 480, col: 5, offset: 14808},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 482, col: 11, offset: 14724},
+										pos:  position{line: 480, col: 11, offset: 14814},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 482, col: 16, offset: 14729},
+									pos:   position{line: 480, col: 16, offset: 14819},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 482, col: 21, offset: 14734},
+										pos: position{line: 480, col: 21, offset: 14824},
 										expr: &actionExpr{
-											pos: position{line: 482, col: 22, offset: 14735},
+											pos: position{line: 480, col: 22, offset: 14825},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 482, col: 22, offset: 14735},
+												pos: position{line: 480, col: 22, offset: 14825},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 482, col: 22, offset: 14735},
+														pos:  position{line: 480, col: 22, offset: 14825},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 482, col: 25, offset: 14738},
+														pos:        position{line: 480, col: 25, offset: 14828},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 482, col: 29, offset: 14742},
+														pos:  position{line: 480, col: 29, offset: 14832},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 482, col: 32, offset: 14745},
+														pos:   position{line: 480, col: 32, offset: 14835},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 482, col: 34, offset: 14747},
+															pos:  position{line: 480, col: 34, offset: 14837},
 															name: "Expr",
 														},
 													},
@@ -3564,10 +3542,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 485, col: 5, offset: 14859},
+						pos: position{line: 483, col: 5, offset: 14949},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 485, col: 5, offset: 14859},
+							pos:  position{line: 483, col: 5, offset: 14949},
 							name: "__",
 						},
 					},
@@ -3576,28 +3554,28 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 487, col: 1, offset: 14895},
+			pos:  position{line: 485, col: 1, offset: 14985},
 			expr: &actionExpr{
-				pos: position{line: 488, col: 5, offset: 14909},
+				pos: position{line: 486, col: 5, offset: 14999},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 488, col: 5, offset: 14909},
+					pos: position{line: 486, col: 5, offset: 14999},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 488, col: 5, offset: 14909},
+							pos:   position{line: 486, col: 5, offset: 14999},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 488, col: 11, offset: 14915},
+								pos:  position{line: 486, col: 11, offset: 15005},
 								name: "RootField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 488, col: 21, offset: 14925},
+							pos:   position{line: 486, col: 21, offset: 15015},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 488, col: 26, offset: 14930},
+								pos: position{line: 486, col: 26, offset: 15020},
 								expr: &ruleRefExpr{
-									pos:  position{line: 488, col: 27, offset: 14931},
+									pos:  position{line: 486, col: 27, offset: 15021},
 									name: "Deref",
 								},
 							},
@@ -3608,31 +3586,31 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 492, col: 1, offset: 14999},
+			pos:  position{line: 490, col: 1, offset: 15089},
 			expr: &choiceExpr{
-				pos: position{line: 493, col: 5, offset: 15009},
+				pos: position{line: 491, col: 5, offset: 15099},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 493, col: 5, offset: 15009},
+						pos: position{line: 491, col: 5, offset: 15099},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 493, col: 5, offset: 15009},
+							pos: position{line: 491, col: 5, offset: 15099},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 493, col: 5, offset: 15009},
+									pos:        position{line: 491, col: 5, offset: 15099},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 493, col: 9, offset: 15013},
+									pos:   position{line: 491, col: 9, offset: 15103},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 493, col: 14, offset: 15018},
+										pos:  position{line: 491, col: 14, offset: 15108},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 493, col: 19, offset: 15023},
+									pos:        position{line: 491, col: 19, offset: 15113},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -3640,29 +3618,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 494, col: 5, offset: 15072},
+						pos: position{line: 492, col: 5, offset: 15162},
 						run: (*parser).callonDeref8,
 						expr: &seqExpr{
-							pos: position{line: 494, col: 5, offset: 15072},
+							pos: position{line: 492, col: 5, offset: 15162},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 494, col: 5, offset: 15072},
+									pos:        position{line: 492, col: 5, offset: 15162},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 494, col: 9, offset: 15076},
+									pos: position{line: 492, col: 9, offset: 15166},
 									expr: &litMatcher{
-										pos:        position{line: 494, col: 11, offset: 15078},
+										pos:        position{line: 492, col: 11, offset: 15168},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 494, col: 16, offset: 15083},
+									pos:   position{line: 492, col: 16, offset: 15173},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 494, col: 19, offset: 15086},
+										pos:  position{line: 492, col: 19, offset: 15176},
 										name: "Identifier",
 									},
 								},
@@ -3674,71 +3652,71 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 496, col: 1, offset: 15137},
+			pos:  position{line: 494, col: 1, offset: 15227},
 			expr: &choiceExpr{
-				pos: position{line: 497, col: 5, offset: 15149},
+				pos: position{line: 495, col: 5, offset: 15239},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 497, col: 5, offset: 15149},
+						pos:  position{line: 495, col: 5, offset: 15239},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 498, col: 5, offset: 15167},
+						pos:  position{line: 496, col: 5, offset: 15257},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 499, col: 5, offset: 15185},
+						pos:  position{line: 497, col: 5, offset: 15275},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 500, col: 5, offset: 15203},
+						pos:  position{line: 498, col: 5, offset: 15293},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 501, col: 5, offset: 15222},
+						pos:  position{line: 499, col: 5, offset: 15312},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 502, col: 5, offset: 15239},
+						pos:  position{line: 500, col: 5, offset: 15329},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 503, col: 5, offset: 15258},
+						pos:  position{line: 501, col: 5, offset: 15348},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 504, col: 5, offset: 15277},
+						pos:  position{line: 502, col: 5, offset: 15367},
 						name: "NullLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 505, col: 5, offset: 15293},
+						pos: position{line: 503, col: 5, offset: 15383},
 						run: (*parser).callonPrimary10,
 						expr: &seqExpr{
-							pos: position{line: 505, col: 5, offset: 15293},
+							pos: position{line: 503, col: 5, offset: 15383},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 505, col: 5, offset: 15293},
+									pos:        position{line: 503, col: 5, offset: 15383},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 505, col: 9, offset: 15297},
+									pos:  position{line: 503, col: 9, offset: 15387},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 505, col: 12, offset: 15300},
+									pos:   position{line: 503, col: 12, offset: 15390},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 505, col: 17, offset: 15305},
+										pos:  position{line: 503, col: 17, offset: 15395},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 505, col: 22, offset: 15310},
+									pos:  position{line: 503, col: 22, offset: 15400},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 505, col: 25, offset: 15313},
+									pos:        position{line: 503, col: 25, offset: 15403},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3750,16 +3728,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 507, col: 1, offset: 15339},
+			pos:  position{line: 505, col: 1, offset: 15429},
 			expr: &choiceExpr{
-				pos: position{line: 508, col: 5, offset: 15357},
+				pos: position{line: 506, col: 5, offset: 15447},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 508, col: 5, offset: 15357},
+						pos:  position{line: 506, col: 5, offset: 15447},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 508, col: 24, offset: 15376},
+						pos:  position{line: 506, col: 24, offset: 15466},
 						name: "RelativeOperator",
 					},
 				},
@@ -3767,12 +3745,12 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 510, col: 1, offset: 15394},
+			pos:  position{line: 508, col: 1, offset: 15484},
 			expr: &actionExpr{
-				pos: position{line: 510, col: 12, offset: 15405},
+				pos: position{line: 508, col: 12, offset: 15495},
 				run: (*parser).callonAndToken1,
 				expr: &litMatcher{
-					pos:        position{line: 510, col: 12, offset: 15405},
+					pos:        position{line: 508, col: 12, offset: 15495},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -3780,12 +3758,12 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 511, col: 1, offset: 15443},
+			pos:  position{line: 509, col: 1, offset: 15533},
 			expr: &actionExpr{
-				pos: position{line: 511, col: 11, offset: 15453},
+				pos: position{line: 509, col: 11, offset: 15543},
 				run: (*parser).callonOrToken1,
 				expr: &litMatcher{
-					pos:        position{line: 511, col: 11, offset: 15453},
+					pos:        position{line: 509, col: 11, offset: 15543},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -3793,12 +3771,12 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 512, col: 1, offset: 15490},
+			pos:  position{line: 510, col: 1, offset: 15580},
 			expr: &actionExpr{
-				pos: position{line: 512, col: 11, offset: 15500},
+				pos: position{line: 510, col: 11, offset: 15590},
 				run: (*parser).callonInToken1,
 				expr: &litMatcher{
-					pos:        position{line: 512, col: 11, offset: 15500},
+					pos:        position{line: 510, col: 11, offset: 15590},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -3806,12 +3784,12 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 513, col: 1, offset: 15537},
+			pos:  position{line: 511, col: 1, offset: 15627},
 			expr: &actionExpr{
-				pos: position{line: 513, col: 12, offset: 15548},
+				pos: position{line: 511, col: 12, offset: 15638},
 				run: (*parser).callonNotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 513, col: 12, offset: 15548},
+					pos:        position{line: 511, col: 12, offset: 15638},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -3819,21 +3797,21 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 515, col: 1, offset: 15587},
+			pos:  position{line: 513, col: 1, offset: 15677},
 			expr: &actionExpr{
-				pos: position{line: 515, col: 18, offset: 15604},
+				pos: position{line: 513, col: 18, offset: 15694},
 				run: (*parser).callonIdentifierName1,
 				expr: &seqExpr{
-					pos: position{line: 515, col: 18, offset: 15604},
+					pos: position{line: 513, col: 18, offset: 15694},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 515, col: 18, offset: 15604},
+							pos:  position{line: 513, col: 18, offset: 15694},
 							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 515, col: 34, offset: 15620},
+							pos: position{line: 513, col: 34, offset: 15710},
 							expr: &ruleRefExpr{
-								pos:  position{line: 515, col: 34, offset: 15620},
+								pos:  position{line: 513, col: 34, offset: 15710},
 								name: "IdentifierRest",
 							},
 						},
@@ -3843,9 +3821,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 517, col: 1, offset: 15668},
+			pos:  position{line: 515, col: 1, offset: 15758},
 			expr: &charClassMatcher{
-				pos:        position{line: 517, col: 19, offset: 15686},
+				pos:        position{line: 515, col: 19, offset: 15776},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -3855,16 +3833,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 518, col: 1, offset: 15697},
+			pos:  position{line: 516, col: 1, offset: 15787},
 			expr: &choiceExpr{
-				pos: position{line: 518, col: 18, offset: 15714},
+				pos: position{line: 516, col: 18, offset: 15804},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 518, col: 18, offset: 15714},
+						pos:  position{line: 516, col: 18, offset: 15804},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 518, col: 36, offset: 15732},
+						pos:        position{line: 516, col: 36, offset: 15822},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -3875,21 +3853,21 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 520, col: 1, offset: 15739},
+			pos:  position{line: 518, col: 1, offset: 15829},
 			expr: &actionExpr{
-				pos: position{line: 521, col: 5, offset: 15754},
+				pos: position{line: 519, col: 5, offset: 15844},
 				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 521, col: 5, offset: 15754},
+					pos: position{line: 519, col: 5, offset: 15844},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 521, col: 5, offset: 15754},
+							pos:  position{line: 519, col: 5, offset: 15844},
 							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 521, col: 21, offset: 15770},
+							pos: position{line: 519, col: 21, offset: 15860},
 							expr: &ruleRefExpr{
-								pos:  position{line: 521, col: 21, offset: 15770},
+								pos:  position{line: 519, col: 21, offset: 15860},
 								name: "IdentifierRest",
 							},
 						},
@@ -3899,54 +3877,54 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 523, col: 1, offset: 15870},
+			pos:  position{line: 521, col: 1, offset: 15960},
 			expr: &choiceExpr{
-				pos: position{line: 524, col: 5, offset: 15883},
+				pos: position{line: 522, col: 5, offset: 15973},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 524, col: 5, offset: 15883},
+						pos:  position{line: 522, col: 5, offset: 15973},
 						name: "Seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 525, col: 5, offset: 15895},
+						pos:  position{line: 523, col: 5, offset: 15985},
 						name: "Minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 526, col: 5, offset: 15907},
+						pos:  position{line: 524, col: 5, offset: 15997},
 						name: "Hours",
 					},
 					&seqExpr{
-						pos: position{line: 527, col: 5, offset: 15917},
+						pos: position{line: 525, col: 5, offset: 16007},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 527, col: 5, offset: 15917},
+								pos:  position{line: 525, col: 5, offset: 16007},
 								name: "Hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 527, col: 11, offset: 15923},
+								pos:  position{line: 525, col: 11, offset: 16013},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 527, col: 13, offset: 15925},
+								pos:        position{line: 525, col: 13, offset: 16015},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 527, col: 19, offset: 15931},
+								pos:  position{line: 525, col: 19, offset: 16021},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 527, col: 21, offset: 15933},
+								pos:  position{line: 525, col: 21, offset: 16023},
 								name: "Minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 528, col: 5, offset: 15945},
+						pos:  position{line: 526, col: 5, offset: 16035},
 						name: "Days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 529, col: 5, offset: 15954},
+						pos:  position{line: 527, col: 5, offset: 16044},
 						name: "Weeks",
 					},
 				},
@@ -3954,32 +3932,32 @@ var g = &grammar{
 		},
 		{
 			name: "SecondsToken",
-			pos:  position{line: 531, col: 1, offset: 15961},
+			pos:  position{line: 529, col: 1, offset: 16051},
 			expr: &choiceExpr{
-				pos: position{line: 532, col: 5, offset: 15978},
+				pos: position{line: 530, col: 5, offset: 16068},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 532, col: 5, offset: 15978},
+						pos:        position{line: 530, col: 5, offset: 16068},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 533, col: 5, offset: 15992},
+						pos:        position{line: 531, col: 5, offset: 16082},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 534, col: 5, offset: 16005},
+						pos:        position{line: 532, col: 5, offset: 16095},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 535, col: 5, offset: 16016},
+						pos:        position{line: 533, col: 5, offset: 16106},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 536, col: 5, offset: 16026},
+						pos:        position{line: 534, col: 5, offset: 16116},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -3988,32 +3966,32 @@ var g = &grammar{
 		},
 		{
 			name: "MinutesToken",
-			pos:  position{line: 538, col: 1, offset: 16031},
+			pos:  position{line: 536, col: 1, offset: 16121},
 			expr: &choiceExpr{
-				pos: position{line: 539, col: 5, offset: 16048},
+				pos: position{line: 537, col: 5, offset: 16138},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 539, col: 5, offset: 16048},
+						pos:        position{line: 537, col: 5, offset: 16138},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 540, col: 5, offset: 16062},
+						pos:        position{line: 538, col: 5, offset: 16152},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 541, col: 5, offset: 16075},
+						pos:        position{line: 539, col: 5, offset: 16165},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 542, col: 5, offset: 16086},
+						pos:        position{line: 540, col: 5, offset: 16176},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 543, col: 5, offset: 16096},
+						pos:        position{line: 541, col: 5, offset: 16186},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -4022,32 +4000,32 @@ var g = &grammar{
 		},
 		{
 			name: "HoursToken",
-			pos:  position{line: 545, col: 1, offset: 16101},
+			pos:  position{line: 543, col: 1, offset: 16191},
 			expr: &choiceExpr{
-				pos: position{line: 546, col: 5, offset: 16116},
+				pos: position{line: 544, col: 5, offset: 16206},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 546, col: 5, offset: 16116},
+						pos:        position{line: 544, col: 5, offset: 16206},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 547, col: 5, offset: 16128},
+						pos:        position{line: 545, col: 5, offset: 16218},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 548, col: 5, offset: 16138},
+						pos:        position{line: 546, col: 5, offset: 16228},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 549, col: 5, offset: 16147},
+						pos:        position{line: 547, col: 5, offset: 16237},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 550, col: 5, offset: 16155},
+						pos:        position{line: 548, col: 5, offset: 16245},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -4056,22 +4034,22 @@ var g = &grammar{
 		},
 		{
 			name: "DaysToken",
-			pos:  position{line: 552, col: 1, offset: 16163},
+			pos:  position{line: 550, col: 1, offset: 16253},
 			expr: &choiceExpr{
-				pos: position{line: 552, col: 13, offset: 16175},
+				pos: position{line: 550, col: 13, offset: 16265},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 552, col: 13, offset: 16175},
+						pos:        position{line: 550, col: 13, offset: 16265},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 552, col: 20, offset: 16182},
+						pos:        position{line: 550, col: 20, offset: 16272},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 552, col: 26, offset: 16188},
+						pos:        position{line: 550, col: 26, offset: 16278},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -4080,32 +4058,32 @@ var g = &grammar{
 		},
 		{
 			name: "WeeksToken",
-			pos:  position{line: 553, col: 1, offset: 16192},
+			pos:  position{line: 551, col: 1, offset: 16282},
 			expr: &choiceExpr{
-				pos: position{line: 553, col: 14, offset: 16205},
+				pos: position{line: 551, col: 14, offset: 16295},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 553, col: 14, offset: 16205},
+						pos:        position{line: 551, col: 14, offset: 16295},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 553, col: 22, offset: 16213},
+						pos:        position{line: 551, col: 22, offset: 16303},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 553, col: 29, offset: 16220},
+						pos:        position{line: 551, col: 29, offset: 16310},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 553, col: 35, offset: 16226},
+						pos:        position{line: 551, col: 35, offset: 16316},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 553, col: 40, offset: 16231},
+						pos:        position{line: 551, col: 40, offset: 16321},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -4114,39 +4092,39 @@ var g = &grammar{
 		},
 		{
 			name: "Seconds",
-			pos:  position{line: 555, col: 1, offset: 16236},
+			pos:  position{line: 553, col: 1, offset: 16326},
 			expr: &choiceExpr{
-				pos: position{line: 556, col: 5, offset: 16248},
+				pos: position{line: 554, col: 5, offset: 16338},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 556, col: 5, offset: 16248},
+						pos: position{line: 554, col: 5, offset: 16338},
 						run: (*parser).callonSeconds2,
 						expr: &litMatcher{
-							pos:        position{line: 556, col: 5, offset: 16248},
+							pos:        position{line: 554, col: 5, offset: 16338},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 557, col: 5, offset: 16334},
+						pos: position{line: 555, col: 5, offset: 16424},
 						run: (*parser).callonSeconds4,
 						expr: &seqExpr{
-							pos: position{line: 557, col: 5, offset: 16334},
+							pos: position{line: 555, col: 5, offset: 16424},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 557, col: 5, offset: 16334},
+									pos:   position{line: 555, col: 5, offset: 16424},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 557, col: 9, offset: 16338},
+										pos:  position{line: 555, col: 9, offset: 16428},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 557, col: 14, offset: 16343},
+									pos:  position{line: 555, col: 14, offset: 16433},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 557, col: 17, offset: 16346},
+									pos:  position{line: 555, col: 17, offset: 16436},
 									name: "SecondsToken",
 								},
 							},
@@ -4157,39 +4135,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minutes",
-			pos:  position{line: 559, col: 1, offset: 16435},
+			pos:  position{line: 557, col: 1, offset: 16525},
 			expr: &choiceExpr{
-				pos: position{line: 560, col: 5, offset: 16447},
+				pos: position{line: 558, col: 5, offset: 16537},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 560, col: 5, offset: 16447},
+						pos: position{line: 558, col: 5, offset: 16537},
 						run: (*parser).callonMinutes2,
 						expr: &litMatcher{
-							pos:        position{line: 560, col: 5, offset: 16447},
+							pos:        position{line: 558, col: 5, offset: 16537},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 561, col: 5, offset: 16534},
+						pos: position{line: 559, col: 5, offset: 16624},
 						run: (*parser).callonMinutes4,
 						expr: &seqExpr{
-							pos: position{line: 561, col: 5, offset: 16534},
+							pos: position{line: 559, col: 5, offset: 16624},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 561, col: 5, offset: 16534},
+									pos:   position{line: 559, col: 5, offset: 16624},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 561, col: 9, offset: 16538},
+										pos:  position{line: 559, col: 9, offset: 16628},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 561, col: 14, offset: 16543},
+									pos:  position{line: 559, col: 14, offset: 16633},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 561, col: 17, offset: 16546},
+									pos:  position{line: 559, col: 17, offset: 16636},
 									name: "MinutesToken",
 								},
 							},
@@ -4200,39 +4178,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hours",
-			pos:  position{line: 563, col: 1, offset: 16644},
+			pos:  position{line: 561, col: 1, offset: 16734},
 			expr: &choiceExpr{
-				pos: position{line: 564, col: 5, offset: 16654},
+				pos: position{line: 562, col: 5, offset: 16744},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 564, col: 5, offset: 16654},
+						pos: position{line: 562, col: 5, offset: 16744},
 						run: (*parser).callonHours2,
 						expr: &litMatcher{
-							pos:        position{line: 564, col: 5, offset: 16654},
+							pos:        position{line: 562, col: 5, offset: 16744},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 565, col: 5, offset: 16741},
+						pos: position{line: 563, col: 5, offset: 16831},
 						run: (*parser).callonHours4,
 						expr: &seqExpr{
-							pos: position{line: 565, col: 5, offset: 16741},
+							pos: position{line: 563, col: 5, offset: 16831},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 565, col: 5, offset: 16741},
+									pos:   position{line: 563, col: 5, offset: 16831},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 565, col: 9, offset: 16745},
+										pos:  position{line: 563, col: 9, offset: 16835},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 565, col: 14, offset: 16750},
+									pos:  position{line: 563, col: 14, offset: 16840},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 565, col: 17, offset: 16753},
+									pos:  position{line: 563, col: 17, offset: 16843},
 									name: "HoursToken",
 								},
 							},
@@ -4243,39 +4221,39 @@ var g = &grammar{
 		},
 		{
 			name: "Days",
-			pos:  position{line: 567, col: 1, offset: 16851},
+			pos:  position{line: 565, col: 1, offset: 16941},
 			expr: &choiceExpr{
-				pos: position{line: 568, col: 5, offset: 16860},
+				pos: position{line: 566, col: 5, offset: 16950},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 568, col: 5, offset: 16860},
+						pos: position{line: 566, col: 5, offset: 16950},
 						run: (*parser).callonDays2,
 						expr: &litMatcher{
-							pos:        position{line: 568, col: 5, offset: 16860},
+							pos:        position{line: 566, col: 5, offset: 16950},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 569, col: 5, offset: 16949},
+						pos: position{line: 567, col: 5, offset: 17039},
 						run: (*parser).callonDays4,
 						expr: &seqExpr{
-							pos: position{line: 569, col: 5, offset: 16949},
+							pos: position{line: 567, col: 5, offset: 17039},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 569, col: 5, offset: 16949},
+									pos:   position{line: 567, col: 5, offset: 17039},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 569, col: 9, offset: 16953},
+										pos:  position{line: 567, col: 9, offset: 17043},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 569, col: 14, offset: 16958},
+									pos:  position{line: 567, col: 14, offset: 17048},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 569, col: 17, offset: 16961},
+									pos:  position{line: 567, col: 17, offset: 17051},
 									name: "DaysToken",
 								},
 							},
@@ -4286,39 +4264,39 @@ var g = &grammar{
 		},
 		{
 			name: "Weeks",
-			pos:  position{line: 571, col: 1, offset: 17063},
+			pos:  position{line: 569, col: 1, offset: 17153},
 			expr: &choiceExpr{
-				pos: position{line: 572, col: 5, offset: 17073},
+				pos: position{line: 570, col: 5, offset: 17163},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 572, col: 5, offset: 17073},
+						pos: position{line: 570, col: 5, offset: 17163},
 						run: (*parser).callonWeeks2,
 						expr: &litMatcher{
-							pos:        position{line: 572, col: 5, offset: 17073},
+							pos:        position{line: 570, col: 5, offset: 17163},
 							val:        "week",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 573, col: 5, offset: 17165},
+						pos: position{line: 571, col: 5, offset: 17255},
 						run: (*parser).callonWeeks4,
 						expr: &seqExpr{
-							pos: position{line: 573, col: 5, offset: 17165},
+							pos: position{line: 571, col: 5, offset: 17255},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 573, col: 5, offset: 17165},
+									pos:   position{line: 571, col: 5, offset: 17255},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 573, col: 9, offset: 17169},
+										pos:  position{line: 571, col: 9, offset: 17259},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 573, col: 14, offset: 17174},
+									pos:  position{line: 571, col: 14, offset: 17264},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 573, col: 17, offset: 17177},
+									pos:  position{line: 571, col: 17, offset: 17267},
 									name: "WeeksToken",
 								},
 							},
@@ -4329,42 +4307,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 576, col: 1, offset: 17308},
+			pos:  position{line: 574, col: 1, offset: 17398},
 			expr: &actionExpr{
-				pos: position{line: 577, col: 5, offset: 17315},
+				pos: position{line: 575, col: 5, offset: 17405},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 577, col: 5, offset: 17315},
+					pos: position{line: 575, col: 5, offset: 17405},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 577, col: 5, offset: 17315},
+							pos:  position{line: 575, col: 5, offset: 17405},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 577, col: 10, offset: 17320},
+							pos:        position{line: 575, col: 10, offset: 17410},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 577, col: 14, offset: 17324},
+							pos:  position{line: 575, col: 14, offset: 17414},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 577, col: 19, offset: 17329},
+							pos:        position{line: 575, col: 19, offset: 17419},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 577, col: 23, offset: 17333},
+							pos:  position{line: 575, col: 23, offset: 17423},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 577, col: 28, offset: 17338},
+							pos:        position{line: 575, col: 28, offset: 17428},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 577, col: 32, offset: 17342},
+							pos:  position{line: 575, col: 32, offset: 17432},
 							name: "UInt",
 						},
 					},
@@ -4373,32 +4351,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 581, col: 1, offset: 17510},
+			pos:  position{line: 579, col: 1, offset: 17600},
 			expr: &choiceExpr{
-				pos: position{line: 582, col: 5, offset: 17518},
+				pos: position{line: 580, col: 5, offset: 17608},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 582, col: 5, offset: 17518},
+						pos: position{line: 580, col: 5, offset: 17608},
 						run: (*parser).callonIP62,
 						expr: &seqExpr{
-							pos: position{line: 582, col: 5, offset: 17518},
+							pos: position{line: 580, col: 5, offset: 17608},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 582, col: 5, offset: 17518},
+									pos:   position{line: 580, col: 5, offset: 17608},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 582, col: 7, offset: 17520},
+										pos: position{line: 580, col: 7, offset: 17610},
 										expr: &ruleRefExpr{
-											pos:  position{line: 582, col: 7, offset: 17520},
+											pos:  position{line: 580, col: 7, offset: 17610},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 582, col: 17, offset: 17530},
+									pos:   position{line: 580, col: 17, offset: 17620},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 582, col: 19, offset: 17532},
+										pos:  position{line: 580, col: 19, offset: 17622},
 										name: "IP6Tail",
 									},
 								},
@@ -4406,51 +4384,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 585, col: 5, offset: 17596},
+						pos: position{line: 583, col: 5, offset: 17686},
 						run: (*parser).callonIP69,
 						expr: &seqExpr{
-							pos: position{line: 585, col: 5, offset: 17596},
+							pos: position{line: 583, col: 5, offset: 17686},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 585, col: 5, offset: 17596},
+									pos:   position{line: 583, col: 5, offset: 17686},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 585, col: 7, offset: 17598},
+										pos:  position{line: 583, col: 7, offset: 17688},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 585, col: 11, offset: 17602},
+									pos:   position{line: 583, col: 11, offset: 17692},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 585, col: 13, offset: 17604},
+										pos: position{line: 583, col: 13, offset: 17694},
 										expr: &ruleRefExpr{
-											pos:  position{line: 585, col: 13, offset: 17604},
+											pos:  position{line: 583, col: 13, offset: 17694},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 585, col: 23, offset: 17614},
+									pos:        position{line: 583, col: 23, offset: 17704},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 585, col: 28, offset: 17619},
+									pos:   position{line: 583, col: 28, offset: 17709},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 585, col: 30, offset: 17621},
+										pos: position{line: 583, col: 30, offset: 17711},
 										expr: &ruleRefExpr{
-											pos:  position{line: 585, col: 30, offset: 17621},
+											pos:  position{line: 583, col: 30, offset: 17711},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 585, col: 40, offset: 17631},
+									pos:   position{line: 583, col: 40, offset: 17721},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 585, col: 42, offset: 17633},
+										pos:  position{line: 583, col: 42, offset: 17723},
 										name: "IP6Tail",
 									},
 								},
@@ -4458,32 +4436,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 588, col: 5, offset: 17732},
+						pos: position{line: 586, col: 5, offset: 17822},
 						run: (*parser).callonIP622,
 						expr: &seqExpr{
-							pos: position{line: 588, col: 5, offset: 17732},
+							pos: position{line: 586, col: 5, offset: 17822},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 588, col: 5, offset: 17732},
+									pos:        position{line: 586, col: 5, offset: 17822},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 588, col: 10, offset: 17737},
+									pos:   position{line: 586, col: 10, offset: 17827},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 588, col: 12, offset: 17739},
+										pos: position{line: 586, col: 12, offset: 17829},
 										expr: &ruleRefExpr{
-											pos:  position{line: 588, col: 12, offset: 17739},
+											pos:  position{line: 586, col: 12, offset: 17829},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 588, col: 22, offset: 17749},
+									pos:   position{line: 586, col: 22, offset: 17839},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 588, col: 24, offset: 17751},
+										pos:  position{line: 586, col: 24, offset: 17841},
 										name: "IP6Tail",
 									},
 								},
@@ -4491,32 +4469,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 591, col: 5, offset: 17822},
+						pos: position{line: 589, col: 5, offset: 17912},
 						run: (*parser).callonIP630,
 						expr: &seqExpr{
-							pos: position{line: 591, col: 5, offset: 17822},
+							pos: position{line: 589, col: 5, offset: 17912},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 591, col: 5, offset: 17822},
+									pos:   position{line: 589, col: 5, offset: 17912},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 591, col: 7, offset: 17824},
+										pos:  position{line: 589, col: 7, offset: 17914},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 591, col: 11, offset: 17828},
+									pos:   position{line: 589, col: 11, offset: 17918},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 591, col: 13, offset: 17830},
+										pos: position{line: 589, col: 13, offset: 17920},
 										expr: &ruleRefExpr{
-											pos:  position{line: 591, col: 13, offset: 17830},
+											pos:  position{line: 589, col: 13, offset: 17920},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 591, col: 23, offset: 17840},
+									pos:        position{line: 589, col: 23, offset: 17930},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -4524,10 +4502,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 594, col: 5, offset: 17908},
+						pos: position{line: 592, col: 5, offset: 17998},
 						run: (*parser).callonIP638,
 						expr: &litMatcher{
-							pos:        position{line: 594, col: 5, offset: 17908},
+							pos:        position{line: 592, col: 5, offset: 17998},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -4537,16 +4515,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 598, col: 1, offset: 17945},
+			pos:  position{line: 596, col: 1, offset: 18035},
 			expr: &choiceExpr{
-				pos: position{line: 599, col: 5, offset: 17957},
+				pos: position{line: 597, col: 5, offset: 18047},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 599, col: 5, offset: 17957},
+						pos:  position{line: 597, col: 5, offset: 18047},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 600, col: 5, offset: 17964},
+						pos:  position{line: 598, col: 5, offset: 18054},
 						name: "Hex",
 					},
 				},
@@ -4554,23 +4532,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 602, col: 1, offset: 17969},
+			pos:  position{line: 600, col: 1, offset: 18059},
 			expr: &actionExpr{
-				pos: position{line: 602, col: 12, offset: 17980},
+				pos: position{line: 600, col: 12, offset: 18070},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 602, col: 12, offset: 17980},
+					pos: position{line: 600, col: 12, offset: 18070},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 602, col: 12, offset: 17980},
+							pos:        position{line: 600, col: 12, offset: 18070},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 602, col: 16, offset: 17984},
+							pos:   position{line: 600, col: 16, offset: 18074},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 602, col: 18, offset: 17986},
+								pos:  position{line: 600, col: 18, offset: 18076},
 								name: "Hex",
 							},
 						},
@@ -4580,23 +4558,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 603, col: 1, offset: 18023},
+			pos:  position{line: 601, col: 1, offset: 18113},
 			expr: &actionExpr{
-				pos: position{line: 603, col: 12, offset: 18034},
+				pos: position{line: 601, col: 12, offset: 18124},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 603, col: 12, offset: 18034},
+					pos: position{line: 601, col: 12, offset: 18124},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 603, col: 12, offset: 18034},
+							pos:   position{line: 601, col: 12, offset: 18124},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 603, col: 14, offset: 18036},
+								pos:  position{line: 601, col: 14, offset: 18126},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 603, col: 18, offset: 18040},
+							pos:        position{line: 601, col: 18, offset: 18130},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -4606,31 +4584,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 605, col: 1, offset: 18078},
+			pos:  position{line: 603, col: 1, offset: 18168},
 			expr: &actionExpr{
-				pos: position{line: 606, col: 5, offset: 18089},
+				pos: position{line: 604, col: 5, offset: 18179},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 606, col: 5, offset: 18089},
+					pos: position{line: 604, col: 5, offset: 18179},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 606, col: 5, offset: 18089},
+							pos:   position{line: 604, col: 5, offset: 18179},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 606, col: 7, offset: 18091},
+								pos:  position{line: 604, col: 7, offset: 18181},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 606, col: 10, offset: 18094},
+							pos:        position{line: 604, col: 10, offset: 18184},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 606, col: 14, offset: 18098},
+							pos:   position{line: 604, col: 14, offset: 18188},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 606, col: 16, offset: 18100},
+								pos:  position{line: 604, col: 16, offset: 18190},
 								name: "UInt",
 							},
 						},
@@ -4640,31 +4618,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 610, col: 1, offset: 18173},
+			pos:  position{line: 608, col: 1, offset: 18263},
 			expr: &actionExpr{
-				pos: position{line: 611, col: 5, offset: 18184},
+				pos: position{line: 609, col: 5, offset: 18274},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 611, col: 5, offset: 18184},
+					pos: position{line: 609, col: 5, offset: 18274},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 611, col: 5, offset: 18184},
+							pos:   position{line: 609, col: 5, offset: 18274},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 611, col: 7, offset: 18186},
+								pos:  position{line: 609, col: 7, offset: 18276},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 611, col: 11, offset: 18190},
+							pos:        position{line: 609, col: 11, offset: 18280},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 611, col: 15, offset: 18194},
+							pos:   position{line: 609, col: 15, offset: 18284},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 611, col: 17, offset: 18196},
+								pos:  position{line: 609, col: 17, offset: 18286},
 								name: "UInt",
 							},
 						},
@@ -4674,15 +4652,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 615, col: 1, offset: 18259},
+			pos:  position{line: 613, col: 1, offset: 18349},
 			expr: &actionExpr{
-				pos: position{line: 616, col: 4, offset: 18267},
+				pos: position{line: 614, col: 4, offset: 18357},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 616, col: 4, offset: 18267},
+					pos:   position{line: 614, col: 4, offset: 18357},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 616, col: 6, offset: 18269},
+						pos:  position{line: 614, col: 6, offset: 18359},
 						name: "UIntString",
 					},
 				},
@@ -4690,16 +4668,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 618, col: 1, offset: 18309},
+			pos:  position{line: 616, col: 1, offset: 18399},
 			expr: &choiceExpr{
-				pos: position{line: 619, col: 5, offset: 18323},
+				pos: position{line: 617, col: 5, offset: 18413},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 619, col: 5, offset: 18323},
+						pos:  position{line: 617, col: 5, offset: 18413},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 620, col: 5, offset: 18338},
+						pos:  position{line: 618, col: 5, offset: 18428},
 						name: "MinusIntString",
 					},
 				},
@@ -4707,14 +4685,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 622, col: 1, offset: 18354},
+			pos:  position{line: 620, col: 1, offset: 18444},
 			expr: &actionExpr{
-				pos: position{line: 622, col: 14, offset: 18367},
+				pos: position{line: 620, col: 14, offset: 18457},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 622, col: 14, offset: 18367},
+					pos: position{line: 620, col: 14, offset: 18457},
 					expr: &charClassMatcher{
-						pos:        position{line: 622, col: 14, offset: 18367},
+						pos:        position{line: 620, col: 14, offset: 18457},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4725,20 +4703,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 624, col: 1, offset: 18406},
+			pos:  position{line: 622, col: 1, offset: 18496},
 			expr: &actionExpr{
-				pos: position{line: 625, col: 5, offset: 18425},
+				pos: position{line: 623, col: 5, offset: 18515},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 625, col: 5, offset: 18425},
+					pos: position{line: 623, col: 5, offset: 18515},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 625, col: 5, offset: 18425},
+							pos:        position{line: 623, col: 5, offset: 18515},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 625, col: 9, offset: 18429},
+							pos:  position{line: 623, col: 9, offset: 18519},
 							name: "UIntString",
 						},
 					},
@@ -4747,28 +4725,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 627, col: 1, offset: 18472},
+			pos:  position{line: 625, col: 1, offset: 18562},
 			expr: &choiceExpr{
-				pos: position{line: 628, col: 5, offset: 18488},
+				pos: position{line: 626, col: 5, offset: 18578},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 628, col: 5, offset: 18488},
+						pos: position{line: 626, col: 5, offset: 18578},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 628, col: 5, offset: 18488},
+							pos: position{line: 626, col: 5, offset: 18578},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 628, col: 5, offset: 18488},
+									pos: position{line: 626, col: 5, offset: 18578},
 									expr: &litMatcher{
-										pos:        position{line: 628, col: 5, offset: 18488},
+										pos:        position{line: 626, col: 5, offset: 18578},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 628, col: 10, offset: 18493},
+									pos: position{line: 626, col: 10, offset: 18583},
 									expr: &charClassMatcher{
-										pos:        position{line: 628, col: 10, offset: 18493},
+										pos:        position{line: 626, col: 10, offset: 18583},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -4776,14 +4754,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 628, col: 17, offset: 18500},
+									pos:        position{line: 626, col: 17, offset: 18590},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 628, col: 21, offset: 18504},
+									pos: position{line: 626, col: 21, offset: 18594},
 									expr: &charClassMatcher{
-										pos:        position{line: 628, col: 21, offset: 18504},
+										pos:        position{line: 626, col: 21, offset: 18594},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -4791,9 +4769,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 628, col: 28, offset: 18511},
+									pos: position{line: 626, col: 28, offset: 18601},
 									expr: &ruleRefExpr{
-										pos:  position{line: 628, col: 28, offset: 18511},
+										pos:  position{line: 626, col: 28, offset: 18601},
 										name: "ExponentPart",
 									},
 								},
@@ -4801,28 +4779,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 631, col: 5, offset: 18570},
+						pos: position{line: 629, col: 5, offset: 18660},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 631, col: 5, offset: 18570},
+							pos: position{line: 629, col: 5, offset: 18660},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 631, col: 5, offset: 18570},
+									pos: position{line: 629, col: 5, offset: 18660},
 									expr: &litMatcher{
-										pos:        position{line: 631, col: 5, offset: 18570},
+										pos:        position{line: 629, col: 5, offset: 18660},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 631, col: 10, offset: 18575},
+									pos:        position{line: 629, col: 10, offset: 18665},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 631, col: 14, offset: 18579},
+									pos: position{line: 629, col: 14, offset: 18669},
 									expr: &charClassMatcher{
-										pos:        position{line: 631, col: 14, offset: 18579},
+										pos:        position{line: 629, col: 14, offset: 18669},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -4830,9 +4808,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 631, col: 21, offset: 18586},
+									pos: position{line: 629, col: 21, offset: 18676},
 									expr: &ruleRefExpr{
-										pos:  position{line: 631, col: 21, offset: 18586},
+										pos:  position{line: 629, col: 21, offset: 18676},
 										name: "ExponentPart",
 									},
 								},
@@ -4844,19 +4822,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 635, col: 1, offset: 18642},
+			pos:  position{line: 633, col: 1, offset: 18732},
 			expr: &seqExpr{
-				pos: position{line: 635, col: 16, offset: 18657},
+				pos: position{line: 633, col: 16, offset: 18747},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 635, col: 16, offset: 18657},
+						pos:        position{line: 633, col: 16, offset: 18747},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 635, col: 21, offset: 18662},
+						pos: position{line: 633, col: 21, offset: 18752},
 						expr: &charClassMatcher{
-							pos:        position{line: 635, col: 21, offset: 18662},
+							pos:        position{line: 633, col: 21, offset: 18752},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -4864,7 +4842,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 635, col: 27, offset: 18668},
+						pos:  position{line: 633, col: 27, offset: 18758},
 						name: "UIntString",
 					},
 				},
@@ -4872,14 +4850,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 637, col: 1, offset: 18680},
+			pos:  position{line: 635, col: 1, offset: 18770},
 			expr: &actionExpr{
-				pos: position{line: 637, col: 7, offset: 18686},
+				pos: position{line: 635, col: 7, offset: 18776},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 637, col: 7, offset: 18686},
+					pos: position{line: 635, col: 7, offset: 18776},
 					expr: &ruleRefExpr{
-						pos:  position{line: 637, col: 7, offset: 18686},
+						pos:  position{line: 635, col: 7, offset: 18776},
 						name: "HexDigit",
 					},
 				},
@@ -4887,9 +4865,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 639, col: 1, offset: 18728},
+			pos:  position{line: 637, col: 1, offset: 18818},
 			expr: &charClassMatcher{
-				pos:        position{line: 639, col: 12, offset: 18739},
+				pos:        position{line: 637, col: 12, offset: 18829},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -4898,17 +4876,17 @@ var g = &grammar{
 		},
 		{
 			name: "SearchWord",
-			pos:  position{line: 641, col: 1, offset: 18752},
+			pos:  position{line: 639, col: 1, offset: 18842},
 			expr: &actionExpr{
-				pos: position{line: 642, col: 5, offset: 18767},
+				pos: position{line: 640, col: 5, offset: 18857},
 				run: (*parser).callonSearchWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 642, col: 5, offset: 18767},
+					pos:   position{line: 640, col: 5, offset: 18857},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 642, col: 11, offset: 18773},
+						pos: position{line: 640, col: 11, offset: 18863},
 						expr: &ruleRefExpr{
-							pos:  position{line: 642, col: 11, offset: 18773},
+							pos:  position{line: 640, col: 11, offset: 18863},
 							name: "SearchWordPart",
 						},
 					},
@@ -4917,33 +4895,33 @@ var g = &grammar{
 		},
 		{
 			name: "SearchWordPart",
-			pos:  position{line: 644, col: 1, offset: 18823},
+			pos:  position{line: 642, col: 1, offset: 18913},
 			expr: &choiceExpr{
-				pos: position{line: 645, col: 5, offset: 18842},
+				pos: position{line: 643, col: 5, offset: 18932},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 645, col: 5, offset: 18842},
+						pos: position{line: 643, col: 5, offset: 18932},
 						run: (*parser).callonSearchWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 645, col: 5, offset: 18842},
+							pos: position{line: 643, col: 5, offset: 18932},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 645, col: 5, offset: 18842},
+									pos:        position{line: 643, col: 5, offset: 18932},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 645, col: 10, offset: 18847},
+									pos:   position{line: 643, col: 10, offset: 18937},
 									label: "s",
 									expr: &choiceExpr{
-										pos: position{line: 645, col: 13, offset: 18850},
+										pos: position{line: 643, col: 13, offset: 18940},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 645, col: 13, offset: 18850},
+												pos:  position{line: 643, col: 13, offset: 18940},
 												name: "EscapeSequence",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 645, col: 30, offset: 18867},
+												pos:  position{line: 643, col: 30, offset: 18957},
 												name: "SearchEscape",
 											},
 										},
@@ -4953,18 +4931,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 646, col: 5, offset: 18904},
+						pos: position{line: 644, col: 5, offset: 18994},
 						run: (*parser).callonSearchWordPart9,
 						expr: &seqExpr{
-							pos: position{line: 646, col: 5, offset: 18904},
+							pos: position{line: 644, col: 5, offset: 18994},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 646, col: 5, offset: 18904},
+									pos: position{line: 644, col: 5, offset: 18994},
 									expr: &choiceExpr{
-										pos: position{line: 646, col: 7, offset: 18906},
+										pos: position{line: 644, col: 7, offset: 18996},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 646, col: 7, offset: 18906},
+												pos:        position{line: 644, col: 7, offset: 18996},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;:]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';', ':'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -4972,14 +4950,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 646, col: 43, offset: 18942},
+												pos:  position{line: 644, col: 43, offset: 19032},
 												name: "WhiteSpace",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 646, col: 55, offset: 18954,
+									line: 644, col: 55, offset: 19044,
 								},
 							},
 						},
@@ -4989,34 +4967,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 648, col: 1, offset: 18988},
+			pos:  position{line: 646, col: 1, offset: 19078},
 			expr: &choiceExpr{
-				pos: position{line: 649, col: 5, offset: 19005},
+				pos: position{line: 647, col: 5, offset: 19095},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 649, col: 5, offset: 19005},
+						pos: position{line: 647, col: 5, offset: 19095},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 649, col: 5, offset: 19005},
+							pos: position{line: 647, col: 5, offset: 19095},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 649, col: 5, offset: 19005},
+									pos:        position{line: 647, col: 5, offset: 19095},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 649, col: 9, offset: 19009},
+									pos:   position{line: 647, col: 9, offset: 19099},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 649, col: 11, offset: 19011},
+										pos: position{line: 647, col: 11, offset: 19101},
 										expr: &ruleRefExpr{
-											pos:  position{line: 649, col: 11, offset: 19011},
+											pos:  position{line: 647, col: 11, offset: 19101},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 649, col: 29, offset: 19029},
+									pos:        position{line: 647, col: 29, offset: 19119},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5024,29 +5002,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 650, col: 5, offset: 19066},
+						pos: position{line: 648, col: 5, offset: 19156},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 650, col: 5, offset: 19066},
+							pos: position{line: 648, col: 5, offset: 19156},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 650, col: 5, offset: 19066},
+									pos:        position{line: 648, col: 5, offset: 19156},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 650, col: 9, offset: 19070},
+									pos:   position{line: 648, col: 9, offset: 19160},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 650, col: 11, offset: 19072},
+										pos: position{line: 648, col: 11, offset: 19162},
 										expr: &ruleRefExpr{
-											pos:  position{line: 650, col: 11, offset: 19072},
+											pos:  position{line: 648, col: 11, offset: 19162},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 650, col: 29, offset: 19090},
+									pos:        position{line: 648, col: 29, offset: 19180},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5058,55 +5036,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 652, col: 1, offset: 19124},
+			pos:  position{line: 650, col: 1, offset: 19214},
 			expr: &choiceExpr{
-				pos: position{line: 653, col: 5, offset: 19145},
+				pos: position{line: 651, col: 5, offset: 19235},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 653, col: 5, offset: 19145},
+						pos: position{line: 651, col: 5, offset: 19235},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 653, col: 5, offset: 19145},
+							pos: position{line: 651, col: 5, offset: 19235},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 653, col: 5, offset: 19145},
+									pos: position{line: 651, col: 5, offset: 19235},
 									expr: &choiceExpr{
-										pos: position{line: 653, col: 7, offset: 19147},
+										pos: position{line: 651, col: 7, offset: 19237},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 653, col: 7, offset: 19147},
+												pos:        position{line: 651, col: 7, offset: 19237},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 653, col: 13, offset: 19153},
+												pos:  position{line: 651, col: 13, offset: 19243},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 653, col: 26, offset: 19166,
+									line: 651, col: 26, offset: 19256,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 654, col: 5, offset: 19203},
+						pos: position{line: 652, col: 5, offset: 19293},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 654, col: 5, offset: 19203},
+							pos: position{line: 652, col: 5, offset: 19293},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 654, col: 5, offset: 19203},
+									pos:        position{line: 652, col: 5, offset: 19293},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 654, col: 10, offset: 19208},
+									pos:   position{line: 652, col: 10, offset: 19298},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 654, col: 12, offset: 19210},
+										pos:  position{line: 652, col: 12, offset: 19300},
 										name: "EscapeSequence",
 									},
 								},
@@ -5118,55 +5096,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 656, col: 1, offset: 19244},
+			pos:  position{line: 654, col: 1, offset: 19334},
 			expr: &choiceExpr{
-				pos: position{line: 657, col: 5, offset: 19265},
+				pos: position{line: 655, col: 5, offset: 19355},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 657, col: 5, offset: 19265},
+						pos: position{line: 655, col: 5, offset: 19355},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 657, col: 5, offset: 19265},
+							pos: position{line: 655, col: 5, offset: 19355},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 657, col: 5, offset: 19265},
+									pos: position{line: 655, col: 5, offset: 19355},
 									expr: &choiceExpr{
-										pos: position{line: 657, col: 7, offset: 19267},
+										pos: position{line: 655, col: 7, offset: 19357},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 657, col: 7, offset: 19267},
+												pos:        position{line: 655, col: 7, offset: 19357},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 657, col: 13, offset: 19273},
+												pos:  position{line: 655, col: 13, offset: 19363},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 657, col: 26, offset: 19286,
+									line: 655, col: 26, offset: 19376,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 658, col: 5, offset: 19323},
+						pos: position{line: 656, col: 5, offset: 19413},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 658, col: 5, offset: 19323},
+							pos: position{line: 656, col: 5, offset: 19413},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 658, col: 5, offset: 19323},
+									pos:        position{line: 656, col: 5, offset: 19413},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 658, col: 10, offset: 19328},
+									pos:   position{line: 656, col: 10, offset: 19418},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 658, col: 12, offset: 19330},
+										pos:  position{line: 656, col: 12, offset: 19420},
 										name: "EscapeSequence",
 									},
 								},
@@ -5178,38 +5156,38 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 660, col: 1, offset: 19364},
+			pos:  position{line: 658, col: 1, offset: 19454},
 			expr: &choiceExpr{
-				pos: position{line: 661, col: 5, offset: 19383},
+				pos: position{line: 659, col: 5, offset: 19473},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 661, col: 5, offset: 19383},
+						pos: position{line: 659, col: 5, offset: 19473},
 						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 661, col: 5, offset: 19383},
+							pos: position{line: 659, col: 5, offset: 19473},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 661, col: 5, offset: 19383},
+									pos:        position{line: 659, col: 5, offset: 19473},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 661, col: 9, offset: 19387},
+									pos:  position{line: 659, col: 9, offset: 19477},
 									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 661, col: 18, offset: 19396},
+									pos:  position{line: 659, col: 18, offset: 19486},
 									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 662, col: 5, offset: 19447},
+						pos:  position{line: 660, col: 5, offset: 19537},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 663, col: 5, offset: 19468},
+						pos:  position{line: 661, col: 5, offset: 19558},
 						name: "UnicodeEscape",
 					},
 				},
@@ -5217,75 +5195,75 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 665, col: 1, offset: 19483},
+			pos:  position{line: 663, col: 1, offset: 19573},
 			expr: &choiceExpr{
-				pos: position{line: 666, col: 5, offset: 19504},
+				pos: position{line: 664, col: 5, offset: 19594},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 666, col: 5, offset: 19504},
+						pos:        position{line: 664, col: 5, offset: 19594},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 667, col: 5, offset: 19512},
+						pos:        position{line: 665, col: 5, offset: 19602},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 668, col: 5, offset: 19520},
+						pos:        position{line: 666, col: 5, offset: 19610},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 669, col: 5, offset: 19529},
+						pos: position{line: 667, col: 5, offset: 19619},
 						run: (*parser).callonSingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 669, col: 5, offset: 19529},
+							pos:        position{line: 667, col: 5, offset: 19619},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 670, col: 5, offset: 19558},
+						pos: position{line: 668, col: 5, offset: 19648},
 						run: (*parser).callonSingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 670, col: 5, offset: 19558},
+							pos:        position{line: 668, col: 5, offset: 19648},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 671, col: 5, offset: 19587},
+						pos: position{line: 669, col: 5, offset: 19677},
 						run: (*parser).callonSingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 671, col: 5, offset: 19587},
+							pos:        position{line: 669, col: 5, offset: 19677},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 672, col: 5, offset: 19616},
+						pos: position{line: 670, col: 5, offset: 19706},
 						run: (*parser).callonSingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 672, col: 5, offset: 19616},
+							pos:        position{line: 670, col: 5, offset: 19706},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 673, col: 5, offset: 19645},
+						pos: position{line: 671, col: 5, offset: 19735},
 						run: (*parser).callonSingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 673, col: 5, offset: 19645},
+							pos:        position{line: 671, col: 5, offset: 19735},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 674, col: 5, offset: 19674},
+						pos: position{line: 672, col: 5, offset: 19764},
 						run: (*parser).callonSingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 674, col: 5, offset: 19674},
+							pos:        position{line: 672, col: 5, offset: 19764},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5295,24 +5273,24 @@ var g = &grammar{
 		},
 		{
 			name: "SearchEscape",
-			pos:  position{line: 676, col: 1, offset: 19700},
+			pos:  position{line: 674, col: 1, offset: 19790},
 			expr: &choiceExpr{
-				pos: position{line: 677, col: 5, offset: 19717},
+				pos: position{line: 675, col: 5, offset: 19807},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 677, col: 5, offset: 19717},
+						pos: position{line: 675, col: 5, offset: 19807},
 						run: (*parser).callonSearchEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 677, col: 5, offset: 19717},
+							pos:        position{line: 675, col: 5, offset: 19807},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 678, col: 5, offset: 19745},
+						pos: position{line: 676, col: 5, offset: 19835},
 						run: (*parser).callonSearchEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 678, col: 5, offset: 19745},
+							pos:        position{line: 676, col: 5, offset: 19835},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -5322,41 +5300,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 680, col: 1, offset: 19772},
+			pos:  position{line: 678, col: 1, offset: 19862},
 			expr: &choiceExpr{
-				pos: position{line: 681, col: 5, offset: 19790},
+				pos: position{line: 679, col: 5, offset: 19880},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 681, col: 5, offset: 19790},
+						pos: position{line: 679, col: 5, offset: 19880},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 681, col: 5, offset: 19790},
+							pos: position{line: 679, col: 5, offset: 19880},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 681, col: 5, offset: 19790},
+									pos:        position{line: 679, col: 5, offset: 19880},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 681, col: 9, offset: 19794},
+									pos:   position{line: 679, col: 9, offset: 19884},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 681, col: 16, offset: 19801},
+										pos: position{line: 679, col: 16, offset: 19891},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 681, col: 16, offset: 19801},
+												pos:  position{line: 679, col: 16, offset: 19891},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 681, col: 25, offset: 19810},
+												pos:  position{line: 679, col: 25, offset: 19900},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 681, col: 34, offset: 19819},
+												pos:  position{line: 679, col: 34, offset: 19909},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 681, col: 43, offset: 19828},
+												pos:  position{line: 679, col: 43, offset: 19918},
 												name: "HexDigit",
 											},
 										},
@@ -5366,63 +5344,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 684, col: 5, offset: 19891},
+						pos: position{line: 682, col: 5, offset: 19981},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 684, col: 5, offset: 19891},
+							pos: position{line: 682, col: 5, offset: 19981},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 684, col: 5, offset: 19891},
+									pos:        position{line: 682, col: 5, offset: 19981},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 684, col: 9, offset: 19895},
+									pos:        position{line: 682, col: 9, offset: 19985},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 684, col: 13, offset: 19899},
+									pos:   position{line: 682, col: 13, offset: 19989},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 684, col: 20, offset: 19906},
+										pos: position{line: 682, col: 20, offset: 19996},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 684, col: 20, offset: 19906},
+												pos:  position{line: 682, col: 20, offset: 19996},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 684, col: 29, offset: 19915},
+												pos: position{line: 682, col: 29, offset: 20005},
 												expr: &ruleRefExpr{
-													pos:  position{line: 684, col: 29, offset: 19915},
+													pos:  position{line: 682, col: 29, offset: 20005},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 684, col: 39, offset: 19925},
+												pos: position{line: 682, col: 39, offset: 20015},
 												expr: &ruleRefExpr{
-													pos:  position{line: 684, col: 39, offset: 19925},
+													pos:  position{line: 682, col: 39, offset: 20015},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 684, col: 49, offset: 19935},
+												pos: position{line: 682, col: 49, offset: 20025},
 												expr: &ruleRefExpr{
-													pos:  position{line: 684, col: 49, offset: 19935},
+													pos:  position{line: 682, col: 49, offset: 20025},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 684, col: 59, offset: 19945},
+												pos: position{line: 682, col: 59, offset: 20035},
 												expr: &ruleRefExpr{
-													pos:  position{line: 684, col: 59, offset: 19945},
+													pos:  position{line: 682, col: 59, offset: 20035},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 684, col: 69, offset: 19955},
+												pos: position{line: 682, col: 69, offset: 20045},
 												expr: &ruleRefExpr{
-													pos:  position{line: 684, col: 69, offset: 19955},
+													pos:  position{line: 682, col: 69, offset: 20045},
 													name: "HexDigit",
 												},
 											},
@@ -5430,7 +5408,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 684, col: 80, offset: 19966},
+									pos:        position{line: 682, col: 80, offset: 20056},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5442,28 +5420,28 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 688, col: 1, offset: 20020},
+			pos:  position{line: 686, col: 1, offset: 20110},
 			expr: &actionExpr{
-				pos: position{line: 689, col: 5, offset: 20031},
+				pos: position{line: 687, col: 5, offset: 20121},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 689, col: 5, offset: 20031},
+					pos: position{line: 687, col: 5, offset: 20121},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 689, col: 5, offset: 20031},
+							pos:        position{line: 687, col: 5, offset: 20121},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 689, col: 9, offset: 20035},
+							pos:   position{line: 687, col: 9, offset: 20125},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 689, col: 14, offset: 20040},
+								pos:  position{line: 687, col: 14, offset: 20130},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 689, col: 25, offset: 20051},
+							pos:        position{line: 687, col: 25, offset: 20141},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5473,24 +5451,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 691, col: 1, offset: 20077},
+			pos:  position{line: 689, col: 1, offset: 20167},
 			expr: &actionExpr{
-				pos: position{line: 692, col: 5, offset: 20092},
+				pos: position{line: 690, col: 5, offset: 20182},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 692, col: 5, offset: 20092},
+					pos: position{line: 690, col: 5, offset: 20182},
 					expr: &choiceExpr{
-						pos: position{line: 692, col: 6, offset: 20093},
+						pos: position{line: 690, col: 6, offset: 20183},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 692, col: 6, offset: 20093},
+								pos:        position{line: 690, col: 6, offset: 20183},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 692, col: 13, offset: 20100},
+								pos:        position{line: 690, col: 13, offset: 20190},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -5501,9 +5479,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 694, col: 1, offset: 20140},
+			pos:  position{line: 692, col: 1, offset: 20230},
 			expr: &charClassMatcher{
-				pos:        position{line: 695, col: 5, offset: 20156},
+				pos:        position{line: 693, col: 5, offset: 20246},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5513,37 +5491,37 @@ var g = &grammar{
 		},
 		{
 			name: "WhiteSpace",
-			pos:  position{line: 697, col: 1, offset: 20171},
+			pos:  position{line: 695, col: 1, offset: 20261},
 			expr: &choiceExpr{
-				pos: position{line: 698, col: 5, offset: 20186},
+				pos: position{line: 696, col: 5, offset: 20276},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 698, col: 5, offset: 20186},
+						pos:        position{line: 696, col: 5, offset: 20276},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 699, col: 5, offset: 20195},
+						pos:        position{line: 697, col: 5, offset: 20285},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 700, col: 5, offset: 20204},
+						pos:        position{line: 698, col: 5, offset: 20294},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 701, col: 5, offset: 20213},
+						pos:        position{line: 699, col: 5, offset: 20303},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 702, col: 5, offset: 20221},
+						pos:        position{line: 700, col: 5, offset: 20311},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 703, col: 5, offset: 20234},
+						pos:        position{line: 701, col: 5, offset: 20324},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5552,33 +5530,33 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 705, col: 1, offset: 20244},
+			pos:  position{line: 703, col: 1, offset: 20334},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 705, col: 6, offset: 20249},
+				pos: position{line: 703, col: 6, offset: 20339},
 				expr: &ruleRefExpr{
-					pos:  position{line: 705, col: 6, offset: 20249},
+					pos:  position{line: 703, col: 6, offset: 20339},
 					name: "WhiteSpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 706, col: 1, offset: 20261},
+			pos:  position{line: 704, col: 1, offset: 20351},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 706, col: 6, offset: 20266},
+				pos: position{line: 704, col: 6, offset: 20356},
 				expr: &ruleRefExpr{
-					pos:  position{line: 706, col: 6, offset: 20266},
+					pos:  position{line: 704, col: 6, offset: 20356},
 					name: "WhiteSpace",
 				},
 			},
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 708, col: 1, offset: 20279},
+			pos:  position{line: 706, col: 1, offset: 20369},
 			expr: &notExpr{
-				pos: position{line: 708, col: 7, offset: 20285},
+				pos: position{line: 706, col: 7, offset: 20375},
 				expr: &anyMatcher{
-					line: 708, col: 8, offset: 20286,
+					line: 706, col: 8, offset: 20376,
 				},
 			},
 		},
@@ -6757,14 +6735,14 @@ func (p *parser) callonFunction1() (interface{}, error) {
 	return p.cur.onFunction1(stack["fn"], stack["args"])
 }
 
-func (c *current) onFuncName1() (interface{}, error) {
+func (c *current) onDeprecatedName1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonFuncName1() (interface{}, error) {
+func (p *parser) callonDeprecatedName1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFuncName1()
+	return p.cur.onDeprecatedName1()
 }
 
 func (c *current) onArgumentList8(e interface{}) (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -520,183 +520,179 @@ function peg$parse(input, options) {
       peg$c217 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c218 = /^[A-Za-z]/,
-      peg$c219 = peg$classExpectation([["A", "Z"], ["a", "z"]], false, false),
-      peg$c220 = /^[.0-9]/,
-      peg$c221 = peg$classExpectation([".", ["0", "9"]], false, false),
-      peg$c222 = function(first, e) { return e },
-      peg$c223 = function() { return [] },
-      peg$c224 = "[",
-      peg$c225 = peg$literalExpectation("[", false),
-      peg$c226 = "]",
-      peg$c227 = peg$literalExpectation("]", false),
-      peg$c228 = function(expr) { return ["[", expr] },
-      peg$c229 = function(id) { return [".", id] },
-      peg$c230 = "and",
-      peg$c231 = peg$literalExpectation("and", true),
-      peg$c232 = "or",
-      peg$c233 = peg$literalExpectation("or", true),
-      peg$c234 = peg$literalExpectation("in", true),
-      peg$c235 = peg$literalExpectation("not", true),
-      peg$c236 = /^[A-Za-z_$]/,
-      peg$c237 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c238 = /^[0-9]/,
-      peg$c239 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c240 = function() { return {"op": "Identifier", "name": text()} },
-      peg$c241 = peg$literalExpectation("and", false),
-      peg$c242 = "seconds",
-      peg$c243 = peg$literalExpectation("seconds", false),
-      peg$c244 = "second",
-      peg$c245 = peg$literalExpectation("second", false),
-      peg$c246 = "secs",
-      peg$c247 = peg$literalExpectation("secs", false),
-      peg$c248 = "sec",
-      peg$c249 = peg$literalExpectation("sec", false),
-      peg$c250 = "s",
-      peg$c251 = peg$literalExpectation("s", false),
-      peg$c252 = "minutes",
-      peg$c253 = peg$literalExpectation("minutes", false),
-      peg$c254 = "minute",
-      peg$c255 = peg$literalExpectation("minute", false),
-      peg$c256 = "mins",
-      peg$c257 = peg$literalExpectation("mins", false),
-      peg$c258 = "min",
-      peg$c259 = peg$literalExpectation("min", false),
-      peg$c260 = "m",
-      peg$c261 = peg$literalExpectation("m", false),
-      peg$c262 = "hours",
-      peg$c263 = peg$literalExpectation("hours", false),
-      peg$c264 = "hrs",
-      peg$c265 = peg$literalExpectation("hrs", false),
-      peg$c266 = "hr",
-      peg$c267 = peg$literalExpectation("hr", false),
-      peg$c268 = "h",
-      peg$c269 = peg$literalExpectation("h", false),
-      peg$c270 = "hour",
-      peg$c271 = peg$literalExpectation("hour", false),
-      peg$c272 = "days",
-      peg$c273 = peg$literalExpectation("days", false),
-      peg$c274 = "day",
-      peg$c275 = peg$literalExpectation("day", false),
-      peg$c276 = "d",
-      peg$c277 = peg$literalExpectation("d", false),
-      peg$c278 = "weeks",
-      peg$c279 = peg$literalExpectation("weeks", false),
-      peg$c280 = "week",
-      peg$c281 = peg$literalExpectation("week", false),
-      peg$c282 = "wks",
-      peg$c283 = peg$literalExpectation("wks", false),
-      peg$c284 = "wk",
-      peg$c285 = peg$literalExpectation("wk", false),
-      peg$c286 = "w",
-      peg$c287 = peg$literalExpectation("w", false),
-      peg$c288 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c289 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c290 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c291 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c292 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c293 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c294 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c295 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c296 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c297 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c298 = function(a, b) {
+      peg$c218 = function(first, e) { return e },
+      peg$c219 = function() { return [] },
+      peg$c220 = "[",
+      peg$c221 = peg$literalExpectation("[", false),
+      peg$c222 = "]",
+      peg$c223 = peg$literalExpectation("]", false),
+      peg$c224 = function(expr) { return ["[", expr] },
+      peg$c225 = function(id) { return [".", id] },
+      peg$c226 = "and",
+      peg$c227 = peg$literalExpectation("and", true),
+      peg$c228 = "or",
+      peg$c229 = peg$literalExpectation("or", true),
+      peg$c230 = peg$literalExpectation("in", true),
+      peg$c231 = peg$literalExpectation("not", true),
+      peg$c232 = /^[A-Za-z_$]/,
+      peg$c233 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c234 = /^[0-9]/,
+      peg$c235 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c236 = function() { return {"op": "Identifier", "name": text()} },
+      peg$c237 = peg$literalExpectation("and", false),
+      peg$c238 = "seconds",
+      peg$c239 = peg$literalExpectation("seconds", false),
+      peg$c240 = "second",
+      peg$c241 = peg$literalExpectation("second", false),
+      peg$c242 = "secs",
+      peg$c243 = peg$literalExpectation("secs", false),
+      peg$c244 = "sec",
+      peg$c245 = peg$literalExpectation("sec", false),
+      peg$c246 = "s",
+      peg$c247 = peg$literalExpectation("s", false),
+      peg$c248 = "minutes",
+      peg$c249 = peg$literalExpectation("minutes", false),
+      peg$c250 = "minute",
+      peg$c251 = peg$literalExpectation("minute", false),
+      peg$c252 = "mins",
+      peg$c253 = peg$literalExpectation("mins", false),
+      peg$c254 = "min",
+      peg$c255 = peg$literalExpectation("min", false),
+      peg$c256 = "m",
+      peg$c257 = peg$literalExpectation("m", false),
+      peg$c258 = "hours",
+      peg$c259 = peg$literalExpectation("hours", false),
+      peg$c260 = "hrs",
+      peg$c261 = peg$literalExpectation("hrs", false),
+      peg$c262 = "hr",
+      peg$c263 = peg$literalExpectation("hr", false),
+      peg$c264 = "h",
+      peg$c265 = peg$literalExpectation("h", false),
+      peg$c266 = "hour",
+      peg$c267 = peg$literalExpectation("hour", false),
+      peg$c268 = "days",
+      peg$c269 = peg$literalExpectation("days", false),
+      peg$c270 = "day",
+      peg$c271 = peg$literalExpectation("day", false),
+      peg$c272 = "d",
+      peg$c273 = peg$literalExpectation("d", false),
+      peg$c274 = "weeks",
+      peg$c275 = peg$literalExpectation("weeks", false),
+      peg$c276 = "week",
+      peg$c277 = peg$literalExpectation("week", false),
+      peg$c278 = "wks",
+      peg$c279 = peg$literalExpectation("wks", false),
+      peg$c280 = "wk",
+      peg$c281 = peg$literalExpectation("wk", false),
+      peg$c282 = "w",
+      peg$c283 = peg$literalExpectation("w", false),
+      peg$c284 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c285 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c286 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c287 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c288 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c289 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c290 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c291 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c292 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c293 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c294 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c299 = "::",
-      peg$c300 = peg$literalExpectation("::", false),
-      peg$c301 = function(a, b, d, e) {
+      peg$c295 = "::",
+      peg$c296 = peg$literalExpectation("::", false),
+      peg$c297 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c302 = function(a, b) {
+      peg$c298 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c303 = function(a, b) {
+      peg$c299 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c304 = function() {
+      peg$c300 = function() {
             return "::"
           },
-      peg$c305 = function(v) { return ":" + v },
-      peg$c306 = function(v) { return v + ":" },
-      peg$c307 = function(a, m) {
+      peg$c301 = function(v) { return ":" + v },
+      peg$c302 = function(v) { return v + ":" },
+      peg$c303 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c308 = function(a, m) {
+      peg$c304 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c309 = function(s) { return parseInt(s) },
-      peg$c310 = function() {
+      peg$c305 = function(s) { return parseInt(s) },
+      peg$c306 = function() {
             return text()
           },
-      peg$c311 = "e",
-      peg$c312 = peg$literalExpectation("e", true),
-      peg$c313 = /^[+\-]/,
-      peg$c314 = peg$classExpectation(["+", "-"], false, false),
-      peg$c315 = /^[0-9a-fA-F]/,
-      peg$c316 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c317 = function(chars) { return joinChars(chars) },
-      peg$c318 = "\\",
-      peg$c319 = peg$literalExpectation("\\", false),
-      peg$c320 = /^[\0-\x1F\\(),!><="|';:]/,
-      peg$c321 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
-      peg$c322 = peg$anyExpectation(),
-      peg$c323 = "\"",
-      peg$c324 = peg$literalExpectation("\"", false),
-      peg$c325 = function(v) { return joinChars(v) },
-      peg$c326 = "'",
-      peg$c327 = peg$literalExpectation("'", false),
-      peg$c328 = "x",
-      peg$c329 = peg$literalExpectation("x", false),
-      peg$c330 = function() { return "\\" + text() },
-      peg$c331 = "b",
-      peg$c332 = peg$literalExpectation("b", false),
-      peg$c333 = function() { return "\b" },
-      peg$c334 = "f",
-      peg$c335 = peg$literalExpectation("f", false),
-      peg$c336 = function() { return "\f" },
-      peg$c337 = "n",
-      peg$c338 = peg$literalExpectation("n", false),
-      peg$c339 = function() { return "\n" },
-      peg$c340 = "r",
-      peg$c341 = peg$literalExpectation("r", false),
-      peg$c342 = function() { return "\r" },
-      peg$c343 = "t",
-      peg$c344 = peg$literalExpectation("t", false),
-      peg$c345 = function() { return "\t" },
-      peg$c346 = "v",
-      peg$c347 = peg$literalExpectation("v", false),
-      peg$c348 = function() { return "\v" },
-      peg$c349 = function() { return "=" },
-      peg$c350 = function() { return "\\*" },
-      peg$c351 = "u",
-      peg$c352 = peg$literalExpectation("u", false),
-      peg$c353 = function(chars) {
+      peg$c307 = "e",
+      peg$c308 = peg$literalExpectation("e", true),
+      peg$c309 = /^[+\-]/,
+      peg$c310 = peg$classExpectation(["+", "-"], false, false),
+      peg$c311 = /^[0-9a-fA-F]/,
+      peg$c312 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c313 = function(chars) { return joinChars(chars) },
+      peg$c314 = "\\",
+      peg$c315 = peg$literalExpectation("\\", false),
+      peg$c316 = /^[\0-\x1F\\(),!><="|';:]/,
+      peg$c317 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
+      peg$c318 = peg$anyExpectation(),
+      peg$c319 = "\"",
+      peg$c320 = peg$literalExpectation("\"", false),
+      peg$c321 = function(v) { return joinChars(v) },
+      peg$c322 = "'",
+      peg$c323 = peg$literalExpectation("'", false),
+      peg$c324 = "x",
+      peg$c325 = peg$literalExpectation("x", false),
+      peg$c326 = function() { return "\\" + text() },
+      peg$c327 = "b",
+      peg$c328 = peg$literalExpectation("b", false),
+      peg$c329 = function() { return "\b" },
+      peg$c330 = "f",
+      peg$c331 = peg$literalExpectation("f", false),
+      peg$c332 = function() { return "\f" },
+      peg$c333 = "n",
+      peg$c334 = peg$literalExpectation("n", false),
+      peg$c335 = function() { return "\n" },
+      peg$c336 = "r",
+      peg$c337 = peg$literalExpectation("r", false),
+      peg$c338 = function() { return "\r" },
+      peg$c339 = "t",
+      peg$c340 = peg$literalExpectation("t", false),
+      peg$c341 = function() { return "\t" },
+      peg$c342 = "v",
+      peg$c343 = peg$literalExpectation("v", false),
+      peg$c344 = function() { return "\v" },
+      peg$c345 = function() { return "=" },
+      peg$c346 = function() { return "\\*" },
+      peg$c347 = "u",
+      peg$c348 = peg$literalExpectation("u", false),
+      peg$c349 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c354 = "{",
-      peg$c355 = peg$literalExpectation("{", false),
-      peg$c356 = "}",
-      peg$c357 = peg$literalExpectation("}", false),
-      peg$c358 = function(body) { return body },
-      peg$c359 = /^[^\/\\]/,
-      peg$c360 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c361 = "\\/",
-      peg$c362 = peg$literalExpectation("\\/", false),
-      peg$c363 = /^[\0-\x1F\\]/,
-      peg$c364 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c365 = "\t",
-      peg$c366 = peg$literalExpectation("\t", false),
-      peg$c367 = "\x0B",
-      peg$c368 = peg$literalExpectation("\x0B", false),
-      peg$c369 = "\f",
-      peg$c370 = peg$literalExpectation("\f", false),
-      peg$c371 = " ",
-      peg$c372 = peg$literalExpectation(" ", false),
-      peg$c373 = "\xA0",
-      peg$c374 = peg$literalExpectation("\xA0", false),
-      peg$c375 = "\uFEFF",
-      peg$c376 = peg$literalExpectation("\uFEFF", false),
+      peg$c350 = "{",
+      peg$c351 = peg$literalExpectation("{", false),
+      peg$c352 = "}",
+      peg$c353 = peg$literalExpectation("}", false),
+      peg$c354 = function(body) { return body },
+      peg$c355 = /^[^\/\\]/,
+      peg$c356 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c357 = "\\/",
+      peg$c358 = peg$literalExpectation("\\/", false),
+      peg$c359 = /^[\0-\x1F\\]/,
+      peg$c360 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c361 = "\t",
+      peg$c362 = peg$literalExpectation("\t", false),
+      peg$c363 = "\x0B",
+      peg$c364 = peg$literalExpectation("\x0B", false),
+      peg$c365 = "\f",
+      peg$c366 = peg$literalExpectation("\f", false),
+      peg$c367 = " ",
+      peg$c368 = peg$literalExpectation(" ", false),
+      peg$c369 = "\xA0",
+      peg$c370 = peg$literalExpectation("\xA0", false),
+      peg$c371 = "\uFEFF",
+      peg$c372 = peg$literalExpectation("\uFEFF", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -2472,7 +2468,7 @@ function peg$parse(input, options) {
       s1 = peg$FAILED;
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseFuncName();
+      s2 = peg$parseIdentifierName();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
@@ -4842,7 +4838,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    s1 = peg$parseFuncName();
+    s1 = peg$parseDeprecatedName();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
@@ -4891,17 +4887,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseFuncName() {
+  function peg$parseDeprecatedName() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseFuncNameStart();
+    s1 = peg$parseIdentifierStart();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseFuncNameRest();
+      s3 = peg$parseIdentifierRest();
+      if (s3 === peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 46) {
+          s3 = peg$c141;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c142); }
+        }
+      }
       while (s3 !== peg$FAILED) {
         s2.push(s3);
-        s3 = peg$parseFuncNameRest();
+        s3 = peg$parseIdentifierRest();
+        if (s3 === peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 46) {
+            s3 = peg$c141;
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c142); }
+          }
+        }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -4914,37 +4928,6 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseFuncNameStart() {
-    var s0;
-
-    if (peg$c218.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c219); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseFuncNameRest() {
-    var s0;
-
-    s0 = peg$parseFuncNameStart();
-    if (s0 === peg$FAILED) {
-      if (peg$c220.test(input.charAt(peg$currPos))) {
-        s0 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c221); }
-      }
     }
 
     return s0;
@@ -4973,7 +4956,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c222(s1, s7);
+              s4 = peg$c218(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5009,7 +4992,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c222(s1, s7);
+                s4 = peg$c218(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5045,7 +5028,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c223();
+        s1 = peg$c219();
       }
       s0 = s1;
     }
@@ -5086,25 +5069,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c224;
+      s1 = peg$c220;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c225); }
+      if (peg$silentFails === 0) { peg$fail(peg$c221); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseConditionalExpr();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c226;
+          s3 = peg$c222;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c227); }
+          if (peg$silentFails === 0) { peg$fail(peg$c223); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c228(s2);
+          s1 = peg$c224(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5148,7 +5131,7 @@ function peg$parse(input, options) {
           s3 = peg$parseIdentifier();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c229(s3);
+            s1 = peg$c225(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5259,12 +5242,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c230) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c226) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c231); }
+      if (peg$silentFails === 0) { peg$fail(peg$c227); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -5279,12 +5262,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c232) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c228) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c233); }
+      if (peg$silentFails === 0) { peg$fail(peg$c229); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -5304,7 +5287,7 @@ function peg$parse(input, options) {
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
+      if (peg$silentFails === 0) { peg$fail(peg$c230); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -5324,7 +5307,7 @@ function peg$parse(input, options) {
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c231); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -5366,12 +5349,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c236.test(input.charAt(peg$currPos))) {
+    if (peg$c232.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c237); }
+      if (peg$silentFails === 0) { peg$fail(peg$c233); }
     }
 
     return s0;
@@ -5382,12 +5365,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c238.test(input.charAt(peg$currPos))) {
+      if (peg$c234.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c239); }
+        if (peg$silentFails === 0) { peg$fail(peg$c235); }
       }
     }
 
@@ -5408,7 +5391,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c240();
+        s1 = peg$c236();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5436,12 +5419,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c230) {
-                s3 = peg$c230;
+              if (input.substr(peg$currPos, 3) === peg$c226) {
+                s3 = peg$c226;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c241); }
+                if (peg$silentFails === 0) { peg$fail(peg$c237); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -5486,44 +5469,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c242) {
-      s0 = peg$c242;
+    if (input.substr(peg$currPos, 7) === peg$c238) {
+      s0 = peg$c238;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c243); }
+      if (peg$silentFails === 0) { peg$fail(peg$c239); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c244) {
-        s0 = peg$c244;
+      if (input.substr(peg$currPos, 6) === peg$c240) {
+        s0 = peg$c240;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c245); }
+        if (peg$silentFails === 0) { peg$fail(peg$c241); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c246) {
-          s0 = peg$c246;
+        if (input.substr(peg$currPos, 4) === peg$c242) {
+          s0 = peg$c242;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c247); }
+          if (peg$silentFails === 0) { peg$fail(peg$c243); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c248) {
-            s0 = peg$c248;
+          if (input.substr(peg$currPos, 3) === peg$c244) {
+            s0 = peg$c244;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c249); }
+            if (peg$silentFails === 0) { peg$fail(peg$c245); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c250;
+              s0 = peg$c246;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c251); }
+              if (peg$silentFails === 0) { peg$fail(peg$c247); }
             }
           }
         }
@@ -5536,44 +5519,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c252) {
-      s0 = peg$c252;
+    if (input.substr(peg$currPos, 7) === peg$c248) {
+      s0 = peg$c248;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c249); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c254) {
-        s0 = peg$c254;
+      if (input.substr(peg$currPos, 6) === peg$c250) {
+        s0 = peg$c250;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c255); }
+        if (peg$silentFails === 0) { peg$fail(peg$c251); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c256) {
-          s0 = peg$c256;
+        if (input.substr(peg$currPos, 4) === peg$c252) {
+          s0 = peg$c252;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c257); }
+          if (peg$silentFails === 0) { peg$fail(peg$c253); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c258) {
-            s0 = peg$c258;
+          if (input.substr(peg$currPos, 3) === peg$c254) {
+            s0 = peg$c254;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c259); }
+            if (peg$silentFails === 0) { peg$fail(peg$c255); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c260;
+              s0 = peg$c256;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c261); }
+              if (peg$silentFails === 0) { peg$fail(peg$c257); }
             }
           }
         }
@@ -5586,44 +5569,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c262) {
-      s0 = peg$c262;
+    if (input.substr(peg$currPos, 5) === peg$c258) {
+      s0 = peg$c258;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c263); }
+      if (peg$silentFails === 0) { peg$fail(peg$c259); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c264) {
-        s0 = peg$c264;
+      if (input.substr(peg$currPos, 3) === peg$c260) {
+        s0 = peg$c260;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c265); }
+        if (peg$silentFails === 0) { peg$fail(peg$c261); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c266) {
-          s0 = peg$c266;
+        if (input.substr(peg$currPos, 2) === peg$c262) {
+          s0 = peg$c262;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c267); }
+          if (peg$silentFails === 0) { peg$fail(peg$c263); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c268;
+            s0 = peg$c264;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c269); }
+            if (peg$silentFails === 0) { peg$fail(peg$c265); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c270) {
-              s0 = peg$c270;
+            if (input.substr(peg$currPos, 4) === peg$c266) {
+              s0 = peg$c266;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c271); }
+              if (peg$silentFails === 0) { peg$fail(peg$c267); }
             }
           }
         }
@@ -5636,28 +5619,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c272) {
-      s0 = peg$c272;
+    if (input.substr(peg$currPos, 4) === peg$c268) {
+      s0 = peg$c268;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c273); }
+      if (peg$silentFails === 0) { peg$fail(peg$c269); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c274) {
-        s0 = peg$c274;
+      if (input.substr(peg$currPos, 3) === peg$c270) {
+        s0 = peg$c270;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c275); }
+        if (peg$silentFails === 0) { peg$fail(peg$c271); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c276;
+          s0 = peg$c272;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c277); }
+          if (peg$silentFails === 0) { peg$fail(peg$c273); }
         }
       }
     }
@@ -5668,44 +5651,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c278) {
-      s0 = peg$c278;
+    if (input.substr(peg$currPos, 5) === peg$c274) {
+      s0 = peg$c274;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c279); }
+      if (peg$silentFails === 0) { peg$fail(peg$c275); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c280) {
-        s0 = peg$c280;
+      if (input.substr(peg$currPos, 4) === peg$c276) {
+        s0 = peg$c276;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c281); }
+        if (peg$silentFails === 0) { peg$fail(peg$c277); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c282) {
-          s0 = peg$c282;
+        if (input.substr(peg$currPos, 3) === peg$c278) {
+          s0 = peg$c278;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c283); }
+          if (peg$silentFails === 0) { peg$fail(peg$c279); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c284) {
-            s0 = peg$c284;
+          if (input.substr(peg$currPos, 2) === peg$c280) {
+            s0 = peg$c280;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c285); }
+            if (peg$silentFails === 0) { peg$fail(peg$c281); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c286;
+              s0 = peg$c282;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c287); }
+              if (peg$silentFails === 0) { peg$fail(peg$c283); }
             }
           }
         }
@@ -5719,16 +5702,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c244) {
-      s1 = peg$c244;
+    if (input.substr(peg$currPos, 6) === peg$c240) {
+      s1 = peg$c240;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c245); }
+      if (peg$silentFails === 0) { peg$fail(peg$c241); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c288();
+      s1 = peg$c284();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5740,7 +5723,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c289(s1);
+            s1 = peg$c285(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5763,16 +5746,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c254) {
-      s1 = peg$c254;
+    if (input.substr(peg$currPos, 6) === peg$c250) {
+      s1 = peg$c250;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c255); }
+      if (peg$silentFails === 0) { peg$fail(peg$c251); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c290();
+      s1 = peg$c286();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5784,7 +5767,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c291(s1);
+            s1 = peg$c287(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5807,16 +5790,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c270) {
-      s1 = peg$c270;
+    if (input.substr(peg$currPos, 4) === peg$c266) {
+      s1 = peg$c266;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c271); }
+      if (peg$silentFails === 0) { peg$fail(peg$c267); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c292();
+      s1 = peg$c288();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5828,7 +5811,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c293(s1);
+            s1 = peg$c289(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5851,16 +5834,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c274) {
-      s1 = peg$c274;
+    if (input.substr(peg$currPos, 3) === peg$c270) {
+      s1 = peg$c270;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c275); }
+      if (peg$silentFails === 0) { peg$fail(peg$c271); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c294();
+      s1 = peg$c290();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5872,7 +5855,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c295(s1);
+            s1 = peg$c291(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5895,16 +5878,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c280) {
-      s1 = peg$c280;
+    if (input.substr(peg$currPos, 4) === peg$c276) {
+      s1 = peg$c276;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c281); }
+      if (peg$silentFails === 0) { peg$fail(peg$c277); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c296();
+      s1 = peg$c292();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5916,7 +5899,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c297(s1);
+            s1 = peg$c293(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6024,7 +6007,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c298(s1, s2);
+        s1 = peg$c294(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6045,12 +6028,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c299) {
-            s3 = peg$c299;
+          if (input.substr(peg$currPos, 2) === peg$c295) {
+            s3 = peg$c295;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c300); }
+            if (peg$silentFails === 0) { peg$fail(peg$c296); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6063,7 +6046,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c301(s1, s2, s4, s5);
+                s1 = peg$c297(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6087,12 +6070,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c299) {
-          s1 = peg$c299;
+        if (input.substr(peg$currPos, 2) === peg$c295) {
+          s1 = peg$c295;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c300); }
+          if (peg$silentFails === 0) { peg$fail(peg$c296); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6105,7 +6088,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c302(s2, s3);
+              s1 = peg$c298(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6130,16 +6113,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c299) {
-                s3 = peg$c299;
+              if (input.substr(peg$currPos, 2) === peg$c295) {
+                s3 = peg$c295;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c300); }
+                if (peg$silentFails === 0) { peg$fail(peg$c296); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c303(s1, s2);
+                s1 = peg$c299(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6155,16 +6138,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c299) {
-              s1 = peg$c299;
+            if (input.substr(peg$currPos, 2) === peg$c295) {
+              s1 = peg$c295;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c300); }
+              if (peg$silentFails === 0) { peg$fail(peg$c296); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c304();
+              s1 = peg$c300();
             }
             s0 = s1;
           }
@@ -6201,7 +6184,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c305(s2);
+        s1 = peg$c301(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6230,7 +6213,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c306(s1);
+        s1 = peg$c302(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6261,7 +6244,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c307(s1, s3);
+          s1 = peg$c303(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6296,7 +6279,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c308(s1, s3);
+          s1 = peg$c304(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6321,7 +6304,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c309(s1);
+      s1 = peg$c305(s1);
     }
     s0 = s1;
 
@@ -6344,22 +6327,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c238.test(input.charAt(peg$currPos))) {
+    if (peg$c234.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c239); }
+      if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c238.test(input.charAt(peg$currPos))) {
+        if (peg$c234.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c239); }
+          if (peg$silentFails === 0) { peg$fail(peg$c235); }
         }
       }
     } else {
@@ -6419,22 +6402,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c238.test(input.charAt(peg$currPos))) {
+      if (peg$c234.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c239); }
+        if (peg$silentFails === 0) { peg$fail(peg$c235); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c238.test(input.charAt(peg$currPos))) {
+          if (peg$c234.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c239); }
+            if (peg$silentFails === 0) { peg$fail(peg$c235); }
           }
         }
       } else {
@@ -6450,22 +6433,22 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c238.test(input.charAt(peg$currPos))) {
+          if (peg$c234.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c239); }
+            if (peg$silentFails === 0) { peg$fail(peg$c235); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c238.test(input.charAt(peg$currPos))) {
+              if (peg$c234.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c239); }
+                if (peg$silentFails === 0) { peg$fail(peg$c235); }
               }
             }
           } else {
@@ -6478,7 +6461,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c310();
+              s1 = peg$c306();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6522,22 +6505,22 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c238.test(input.charAt(peg$currPos))) {
+          if (peg$c234.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c239); }
+            if (peg$silentFails === 0) { peg$fail(peg$c235); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c238.test(input.charAt(peg$currPos))) {
+              if (peg$c234.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c239); }
+                if (peg$silentFails === 0) { peg$fail(peg$c235); }
               }
             }
           } else {
@@ -6550,7 +6533,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c310();
+              s1 = peg$c306();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6577,20 +6560,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c311) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c307) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c312); }
+      if (peg$silentFails === 0) { peg$fail(peg$c308); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c313.test(input.charAt(peg$currPos))) {
+      if (peg$c309.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c314); }
+        if (peg$silentFails === 0) { peg$fail(peg$c310); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -6642,12 +6625,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c315.test(input.charAt(peg$currPos))) {
+    if (peg$c311.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
 
     return s0;
@@ -6669,7 +6652,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c317(s1);
+      s1 = peg$c313(s1);
     }
     s0 = s1;
 
@@ -6681,11 +6664,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c318;
+      s1 = peg$c314;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c319); }
+      if (peg$silentFails === 0) { peg$fail(peg$c315); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
@@ -6708,12 +6691,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c320.test(input.charAt(peg$currPos))) {
+      if (peg$c316.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c321); }
+        if (peg$silentFails === 0) { peg$fail(peg$c317); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseWhiteSpace();
@@ -6731,7 +6714,7 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c322); }
+          if (peg$silentFails === 0) { peg$fail(peg$c318); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
@@ -6755,11 +6738,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c323;
+      s1 = peg$c319;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c324); }
+      if (peg$silentFails === 0) { peg$fail(peg$c320); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -6770,15 +6753,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c323;
+          s3 = peg$c319;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c324); }
+          if (peg$silentFails === 0) { peg$fail(peg$c320); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c325(s2);
+          s1 = peg$c321(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6795,11 +6778,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c326;
+        s1 = peg$c322;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c327); }
+        if (peg$silentFails === 0) { peg$fail(peg$c323); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -6810,15 +6793,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c326;
+            s3 = peg$c322;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c327); }
+            if (peg$silentFails === 0) { peg$fail(peg$c323); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c325(s2);
+            s1 = peg$c321(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6844,11 +6827,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c323;
+      s2 = peg$c319;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c324); }
+      if (peg$silentFails === 0) { peg$fail(peg$c320); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -6866,7 +6849,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        if (peg$silentFails === 0) { peg$fail(peg$c318); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -6883,11 +6866,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c318;
+        s1 = peg$c314;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c319); }
+        if (peg$silentFails === 0) { peg$fail(peg$c315); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -6915,11 +6898,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c326;
+      s2 = peg$c322;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c327); }
+      if (peg$silentFails === 0) { peg$fail(peg$c323); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -6937,7 +6920,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        if (peg$silentFails === 0) { peg$fail(peg$c318); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -6954,11 +6937,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c318;
+        s1 = peg$c314;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c319); }
+        if (peg$silentFails === 0) { peg$fail(peg$c315); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -6984,11 +6967,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c328;
+      s1 = peg$c324;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c329); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -6996,7 +6979,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c330();
+          s1 = peg$c326();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7024,110 +7007,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c326;
+      s0 = peg$c322;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c327); }
+      if (peg$silentFails === 0) { peg$fail(peg$c323); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c323;
+        s0 = peg$c319;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c324); }
+        if (peg$silentFails === 0) { peg$fail(peg$c320); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c318;
+          s0 = peg$c314;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c319); }
+          if (peg$silentFails === 0) { peg$fail(peg$c315); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c331;
+            s1 = peg$c327;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c332); }
+            if (peg$silentFails === 0) { peg$fail(peg$c328); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c333();
+            s1 = peg$c329();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c334;
+              s1 = peg$c330;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c335); }
+              if (peg$silentFails === 0) { peg$fail(peg$c331); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c336();
+              s1 = peg$c332();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c337;
+                s1 = peg$c333;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c338); }
+                if (peg$silentFails === 0) { peg$fail(peg$c334); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c339();
+                s1 = peg$c335();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c340;
+                  s1 = peg$c336;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c341); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c337); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c342();
+                  s1 = peg$c338();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c343;
+                    s1 = peg$c339;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c344); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c340); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c345();
+                    s1 = peg$c341();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c346;
+                      s1 = peg$c342;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c343); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c348();
+                      s1 = peg$c344();
                     }
                     s0 = s1;
                   }
@@ -7155,7 +7138,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c349();
+      s1 = peg$c345();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7169,7 +7152,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c350();
+        s1 = peg$c346();
       }
       s0 = s1;
     }
@@ -7182,11 +7165,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c351;
+      s1 = peg$c347;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c352); }
+      if (peg$silentFails === 0) { peg$fail(peg$c348); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7218,7 +7201,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c353(s2);
+        s1 = peg$c349(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7231,19 +7214,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c351;
+        s1 = peg$c347;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c352); }
+        if (peg$silentFails === 0) { peg$fail(peg$c348); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c354;
+          s2 = peg$c350;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c355); }
+          if (peg$silentFails === 0) { peg$fail(peg$c351); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7302,15 +7285,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c356;
+              s4 = peg$c352;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c357); }
+              if (peg$silentFails === 0) { peg$fail(peg$c353); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c353(s3);
+              s1 = peg$c349(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7356,7 +7339,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c358(s2);
+          s1 = peg$c354(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7379,39 +7362,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c359.test(input.charAt(peg$currPos))) {
+    if (peg$c355.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+      if (peg$silentFails === 0) { peg$fail(peg$c356); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c361) {
-        s2 = peg$c361;
+      if (input.substr(peg$currPos, 2) === peg$c357) {
+        s2 = peg$c357;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c362); }
+        if (peg$silentFails === 0) { peg$fail(peg$c358); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c359.test(input.charAt(peg$currPos))) {
+        if (peg$c355.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c360); }
+          if (peg$silentFails === 0) { peg$fail(peg$c356); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c361) {
-            s2 = peg$c361;
+          if (input.substr(peg$currPos, 2) === peg$c357) {
+            s2 = peg$c357;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c362); }
+            if (peg$silentFails === 0) { peg$fail(peg$c358); }
           }
         }
       }
@@ -7430,12 +7413,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c363.test(input.charAt(peg$currPos))) {
+    if (peg$c359.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c364); }
+      if (peg$silentFails === 0) { peg$fail(peg$c360); }
     }
 
     return s0;
@@ -7445,51 +7428,51 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c365;
+      s0 = peg$c361;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
+      if (peg$silentFails === 0) { peg$fail(peg$c362); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c367;
+        s0 = peg$c363;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c368); }
+        if (peg$silentFails === 0) { peg$fail(peg$c364); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c369;
+          s0 = peg$c365;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c370); }
+          if (peg$silentFails === 0) { peg$fail(peg$c366); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c371;
+            s0 = peg$c367;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c372); }
+            if (peg$silentFails === 0) { peg$fail(peg$c368); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c373;
+              s0 = peg$c369;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c374); }
+              if (peg$silentFails === 0) { peg$fail(peg$c370); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c375;
+                s0 = peg$c371;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c376); }
+                if (peg$silentFails === 0) { peg$fail(peg$c372); }
               }
             }
           }
@@ -7540,7 +7523,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c318); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -271,7 +271,7 @@ ReducerAssignment
     }
 
 Reducer
-  = !("not"/"len") op:FuncName __ "(" __ expr:Expr?  __ ")" where:WhereClause? {
+  = !("not"/"len") op:IdentifierName __ "(" __ expr:Expr?  __ ")" where:WhereClause? {
       VAR(r) = MAP("op": "Reducer", "operator": op, "where":where)
       if ISNOTNULL(expr) {
         r["expr"] = expr
@@ -508,15 +508,13 @@ FuncExpr
   / Primary
 
 Function
-  = fn:FuncName __ "(" args:ArgumentList ")" {
+  = fn:DeprecatedName __ "(" args:ArgumentList ")" {
       RETURN(MAP("op": "FunctionCall", "function": fn, "args": args))
     }
 
-FuncName
-  = FuncNameStart FuncNameRest* { RETURN(TEXT) }
-
-FuncNameStart = [A-Za-z]
-FuncNameRest = FuncNameStart / [.0-9]
+//XXX change Function names to IdentifierName once we completely
+// get rid of deprecated package-style function name errors.
+DeprecatedName = IdentifierStart (IdentifierRest / ".")* { RETURN(TEXT) }
 
 ArgumentList
   = first:Expr rest:(__ "," __ e:Expr { RETURN(e) })* {

--- a/ztests/suite/put/put-error.yaml
+++ b/ztests/suite/put/put-error.yaml
@@ -1,6 +1,6 @@
 # Tests that warnings are propagated and that we only warn once
 # for a given error.
-zql: put y = Math.sqrt(x)
+zql: put y = sqrt(x)
 
 input: |
   #0:record[x:int32]


### PR DESCRIPTION
This commit deprecates package-style function names by raising
an error with a helpful message for the alternative use.
We also eliminated some of the string functions in favor
of a type cast style, and extended the semantics of
numeric casts to accept strings (and parse the string
to a numeric value).  We also got rid of several of the
time conversion functions in favor of casts and adopted
the convention that a numeric value cast to time is in
units of nanosecond and added helper functions to convert
sec, msec, and usec to nanoseconds.

Closes #1379 