### PR TITLE
Move Zeek and Suricata version tags into package.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export GO111MODULE=on
 VERSION = $(shell git describe --tags --dirty --always)
 ECR_VERSION = $(VERSION)-$(ZQD_K8S_USER)
 LDFLAGS = -s -X github.com/brimsec/zq/cli.Version=$(VERSION)
-ZEEKTAG = $(shell python -c 'import json,sys;print(json.load(open("package.json","rt"))["brimdependencies"]["zeektag"])')
+ZEEKTAG := $(shell python -c 'import json ;print(json.load(open("package.json"))["brimDependencies"]["zeekTag"])')
 ZEEKPATH = zeek-$(ZEEKTAG)
 SURICATATAG = $(shell python -c 'import json,sys;print(json.load(open("package.json","rt"))["brimdependencies"]["suricatatag"])')
 SURICATAPATH = suricata-$(SURICATATAG)

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ export GO111MODULE=on
 VERSION = $(shell git describe --tags --dirty --always)
 ECR_VERSION = $(VERSION)-$(ZQD_K8S_USER)
 LDFLAGS = -s -X github.com/brimsec/zq/cli.Version=$(VERSION)
-ZEEKTAG = v3.2.1-brim2
+ZEEKTAG = $(shell jq -r '."brim-dependencies".zeektag' package.json)
 ZEEKPATH = zeek-$(ZEEKTAG)
-SURICATATAG = v5.0.3-brim8
+SURICATATAG = $(shell jq -r '."brim-dependencies".suricatatag' package.json)
 SURICATAPATH = suricata-$(SURICATATAG)
 
 # This enables a shortcut to run a single test from the ./ztests suite, e.g.:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ECR_VERSION = $(VERSION)-$(ZQD_K8S_USER)
 LDFLAGS = -s -X github.com/brimsec/zq/cli.Version=$(VERSION)
 ZEEKTAG := $(shell python -c 'import json ;print(json.load(open("package.json"))["brimDependencies"]["zeekTag"])')
 ZEEKPATH = zeek-$(ZEEKTAG)
-SURICATATAG = $(shell python -c 'import json,sys;print(json.load(open("package.json","rt"))["brimdependencies"]["suricatatag"])')
+SURICATATAG := $(shell python -c 'import json; print(json.load(open("package.json"))["brimDependencies"]["suricataTag"])')
 SURICATAPATH = suricata-$(SURICATATAG)
 
 # This enables a shortcut to run a single test from the ./ztests suite, e.g.:

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ export GO111MODULE=on
 VERSION = $(shell git describe --tags --dirty --always)
 ECR_VERSION = $(VERSION)-$(ZQD_K8S_USER)
 LDFLAGS = -s -X github.com/brimsec/zq/cli.Version=$(VERSION)
-ZEEKTAG = $(shell python3 -c 'import json,sys;print(json.load(open("package.json","rt"))["brimdependencies"]["zeektag"])')
+ZEEKTAG = $(shell python -c 'import json,sys;print(json.load(open("package.json","rt"))["brimdependencies"]["zeektag"])')
 ZEEKPATH = zeek-$(ZEEKTAG)
-SURICATATAG = $(shell python3 -c 'import json,sys;print(json.load(open("package.json","rt"))["brimdependencies"]["suricatatag"])')
+SURICATATAG = $(shell python -c 'import json,sys;print(json.load(open("package.json","rt"))["brimdependencies"]["suricatatag"])')
 SURICATAPATH = suricata-$(SURICATATAG)
 
 # This enables a shortcut to run a single test from the ./ztests suite, e.g.:

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ export GO111MODULE=on
 VERSION = $(shell git describe --tags --dirty --always)
 ECR_VERSION = $(VERSION)-$(ZQD_K8S_USER)
 LDFLAGS = -s -X github.com/brimsec/zq/cli.Version=$(VERSION)
-ZEEKTAG = $(shell jq -r '."brim-dependencies".zeektag' package.json)
+ZEEKTAG = $(shell jq -r '.brimdependencies.zeektag' package.json)
 ZEEKPATH = zeek-$(ZEEKTAG)
-SURICATATAG = $(shell jq -r '."brim-dependencies".suricatatag' package.json)
+SURICATATAG = $(shell jq -r '.brimdependencies.suricatatag' package.json)
 SURICATAPATH = suricata-$(SURICATATAG)
 
 # This enables a shortcut to run a single test from the ./ztests suite, e.g.:

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ export GO111MODULE=on
 VERSION = $(shell git describe --tags --dirty --always)
 ECR_VERSION = $(VERSION)-$(ZQD_K8S_USER)
 LDFLAGS = -s -X github.com/brimsec/zq/cli.Version=$(VERSION)
-ZEEKTAG = $(shell jq -r '.brimdependencies.zeektag' package.json)
+ZEEKTAG = $(shell python3 -c 'import json,sys;print(json.load(open("package.json","rt"))["brimdependencies"]["zeektag"])')
 ZEEKPATH = zeek-$(ZEEKTAG)
-SURICATATAG = $(shell jq -r '.brimdependencies.suricatatag' package.json)
+SURICATATAG = $(shell python3 -c 'import json,sys;print(json.load(open("package.json","rt"))["brimdependencies"]["suricatatag"])')
 SURICATAPATH = suricata-$(SURICATATAG)
 
 # This enables a shortcut to run a single test from the ./ztests suite, e.g.:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "directories": {
       "bin": "dist"
   },
-  "brim-dependencies": {
+  "brimdependencies": {
       "zeektag": "v3.2.1-brim4",
       "suricatatag": "v5.0.3-brim8"
   }

--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
   ],
   "directories": {
       "bin": "dist"
+  },
+  "brim-dependencies": {
+      "zeektag": "v3.2.1-brim4",
+      "suricatatag": "v5.0.3-brim8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "directories": {
       "bin": "dist"
   },
-  "brimdependencies": {
-      "zeektag": "v3.2.1-brim4",
-      "suricatatag": "v5.0.3-brim8"
+  "brimDependencies": {
+      "suricataTag": "v5.0.3-brim8",
+      "zeekTag": "v3.2.1-brim4"
   }
 }


### PR DESCRIPTION
(This is a companion PR to https://github.com/brimsec/brim/pull/1215.)

Currently zq's `make test-system` depends on specific Zeek and Suricata artifacts to ensure pcaps posted to `zqd` produce expected log outputs. Similar artifacts are also needed by Brim since Zeek and Suricata are bundled with the app such that users can generate similar logs on the desktop.

Up until now, this all has meant updating the Zeek & Suricata tags in each repo separately, ideally keeping them always in sync. However, we already have linkage between the repos in the form of the [notify-brim-merge.yml Action](https://github.com/brimsec/zq/blob/master/.github/workflows/notify-brim-merge.yml) that triggers a run of Brim's test automation against a new zq commit hash as soon as it's merged to master, ultimately committing the advanced zq pointer in Brim if the tests pass. By piggybacking on that same approach, we can maintain the Zeek/Suricata tags on just the zq side and ensure they start being used as long as triggered Brim-side tests pass.

The implementation of the zq build on the Brim side uses `npm`. Therefore, here I've taken the approach of moving the Zeek/Suricata tags out of the Makefile and into `package.json`, which is already used by this cross-repo build process. I'd done some poking around online and found a [StackOverflow thread](https://stackoverflow.com/questions/10065564/add-custom-metadata-or-config-to-package-json-is-it-valid/27232456#27232456) indicating that it's kosher to add custom metadata to `package.json` like I'm doing here, so I've opted for that route rather than creating some new separate config file.