### PR TITLE
Add example Prometheus metrics in zqd

### DIFF
--- a/ppl/zqd/handler.go
+++ b/ppl/zqd/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 )
 
@@ -29,6 +30,7 @@ func NewHandler(core *Core, logger *zap.Logger) http.Handler {
 	h.Use(accessLogMiddleware(logger))
 	h.Use(panicCatchMiddleware(logger))
 	h.Handle("/ast", handleASTPost).Methods("POST")
+	h.Router.Handle("/metrics", promhttp.HandlerFor(core.registry, promhttp.HandlerOpts{}))
 	h.Handle("/space", handleSpaceList).Methods("GET")
 	h.Handle("/space", handleSpacePost).Methods("POST")
 	h.Handle("/space/{space}", handleSpaceGet).Methods("GET")

--- a/ppl/zqd/handlers_test.go
+++ b/ppl/zqd/handlers_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"

--- a/ppl/zqd/handlers_test.go
+++ b/ppl/zqd/handlers_test.go
@@ -357,7 +357,7 @@ func TestSpacePut(t *testing.T) {
 
 func TestSpaceDelete(t *testing.T) {
 	ctx := context.Background()
-	_, conn := newCore(t)
+	c, conn := newCore(t)
 	sp, err := conn.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
 	err = conn.SpaceDelete(ctx, sp.ID)
@@ -365,6 +365,9 @@ func TestSpaceDelete(t *testing.T) {
 	list, err := conn.SpaceList(ctx)
 	require.NoError(t, err)
 	require.Equal(t, []api.SpaceInfo{}, list)
+
+	require.Equal(t, 1.0, promCounterValue(c.Registry(), "spaces_created_total"))
+	require.Equal(t, 1.0, promCounterValue(c.Registry(), "spaces_deleted_total"))
 }
 
 func TestSpaceDeleteDataDir(t *testing.T) {
@@ -1082,6 +1085,19 @@ func newCoreWithConfig(t *testing.T, conf zqd.Config) (*zqd.Core, *client.Connec
 	srv := httptest.NewServer(zqd.NewHandler(core, conf.Logger))
 	t.Cleanup(srv.Close)
 	return core, client.NewConnectionTo(srv.URL)
+}
+
+func promCounterValue(g prometheus.Gatherer, name string) interface{} {
+	metricFamilies, err := g.Gather()
+	if err != nil {
+		return err
+	}
+	for _, mf := range metricFamilies {
+		if mf.GetName() == name {
+			return mf.GetMetric()[0].GetCounter().GetValue()
+		}
+	}
+	return errors.New("metric not found")
 }
 
 func testLauncher(start, wait procFn) pcapanalyzer.Launcher {

--- a/ppl/zqd/space/manager_test.go
+++ b/ppl/zqd/space/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/brimsec/zq/pcap"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -25,7 +26,7 @@ func TestConfigCurrentVersion(t *testing.T) {
 	u, err := iosrc.ParseURI(root)
 	require.NoError(t, err)
 	ctx := context.Background()
-	m, err := NewManager(ctx, u, zap.NewNop())
+	m, err := NewManager(ctx, zap.NewNop(), prometheus.NewRegistry(), u)
 	require.NoError(t, err)
 	s, err := m.Create(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
@@ -163,7 +164,7 @@ func (tm *testMigration) initRoot() {
 
 func (tm *testMigration) manager() *Manager {
 	if tm.mgr == nil {
-		mgr, err := NewManager(context.Background(), tm.root, zap.NewNop())
+		mgr, err := NewManager(context.Background(), zap.NewNop(), prometheus.NewRegistry(), tm.root)
 		require.NoError(tm.T, err)
 		tm.mgr = mgr
 	}


### PR DESCRIPTION
* Add a prometheus.Registry to zqd.Core.

* Always add an http.Handler for the Regsitry at /metrics.

* Remove zqd listen's -prom flag since /metrics is always handled.

* Add space.Manager.created and .deleted metrics as
  examples for future metrics.

Closes #1554.