### PR TITLE
add -P flag to zq

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -419,3 +419,14 @@ func NewReducerAssignment(op string, lval field.Static, arg field.Static) Assign
 	}
 	return Assignment{LHS: NewDotExpr(lhs), RHS: reducer}
 }
+
+func FanIn(p Proc) int {
+	first := p
+	if seq, ok := first.(*SequentialProc); ok {
+		first = seq.Procs[0]
+	}
+	if p, ok := first.(*ParallelProc); ok {
+		return len(p.Procs)
+	}
+	return 1
+}

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -107,6 +107,45 @@ func compileSingle(ctx context.Context, program ast.Proc, zctx *resolver.Context
 	return newMuxOutput(pctx, leaves, sn), nil
 }
 
+func compileParallel(ctx context.Context, program ast.Proc, zctx *resolver.Context, readers []zbuf.Reader, cfg Config) (*muxOutput, error) {
+	if cfg.Logger == nil {
+		cfg.Logger = zap.NewNop()
+	}
+	if cfg.Span.Dur == 0 {
+		cfg.Span = nano.MaxSpan
+	}
+	if cfg.Warnings == nil {
+		cfg.Warnings = make(chan string, 5)
+	}
+
+	filterExpr, program := programPrep(program, field.Dotted(cfg.ReaderSortKey), cfg.ReaderSortReverse)
+	procs := make([]proc.Interface, 0, len(readers))
+	scanners := make([]zbuf.Scanner, 0, len(readers))
+	for _, r := range readers {
+		sn, err := zbuf.NewScanner(ctx, r, filterExpr, cfg.Span)
+		if err != nil {
+			return nil, err
+		}
+		if stringer, ok := r.(fmt.Stringer); ok {
+			sn = &namedScanner{sn, stringer.String()}
+		}
+		scanners = append(scanners, sn)
+		procs = append(procs, &scannerProc{sn})
+	}
+
+	pctx := &proc.Context{
+		Context:     ctx,
+		TypeContext: zctx,
+		Logger:      cfg.Logger,
+		Warnings:    cfg.Warnings,
+	}
+	leaves, err := compiler.Compile(cfg.Custom, program, pctx, procs)
+	if err != nil {
+		return nil, err
+	}
+	return newMuxOutput(pctx, leaves, zbuf.MultiStats(scanners)), nil
+}
+
 type MultiConfig struct {
 	Custom      compiler.Hook
 	Order       zbuf.Order

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -74,11 +74,7 @@ func (n *namedScanner) Pull() (zbuf.Batch, error) {
 	return b, err
 }
 
-func compileSingle(ctx context.Context, program ast.Proc, zctx *resolver.Context, r zbuf.Reader, cfg Config) (*muxOutput, error) {
-	return compileParallel(ctx, program, zctx, []zbuf.Reader{r}, cfg)
-}
-
-func compileParallel(ctx context.Context, program ast.Proc, zctx *resolver.Context, readers []zbuf.Reader, cfg Config) (*muxOutput, error) {
+func compile(ctx context.Context, program ast.Proc, zctx *resolver.Context, readers []zbuf.Reader, cfg Config) (*muxOutput, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = zap.NewNop()
 	}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -25,7 +25,7 @@ func Run(ctx context.Context, d Driver, program ast.Proc, zctx *resolver.Context
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	mux, err := compileSingle(ctx, program, zctx, reader, cfg)
+	mux, err := compile(ctx, program, zctx, []zbuf.Reader{reader}, cfg)
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func RunParallel(ctx context.Context, d Driver, program ast.Proc, zctx *resolver
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	mux, err := compileParallel(ctx, program, zctx, readers, cfg)
+	mux, err := compile(ctx, program, zctx, readers, cfg)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func (mr *muxReader) Close() error {
 
 func NewReader(ctx context.Context, program ast.Proc, zctx *resolver.Context, reader zbuf.Reader) (zbuf.ReadCloser, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	mux, err := compileSingle(ctx, program, zctx, reader, Config{})
+	mux, err := compile(ctx, program, zctx, []zbuf.Reader{reader}, Config{})
 	if err != nil {
 		cancel()
 		return nil, err

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -32,6 +32,20 @@ func Run(ctx context.Context, d Driver, program ast.Proc, zctx *resolver.Context
 	return runMux(mux, d, cfg.StatsTick)
 }
 
+func RunParallel(ctx context.Context, d Driver, program ast.Proc, zctx *resolver.Context, readers []zbuf.Reader, cfg Config) error {
+	if len(readers) != ast.FanIn(program) {
+		return errors.New("number of input sources must match number of parallel inputs in zql query")
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	mux, err := compileParallel(ctx, program, zctx, readers, cfg)
+	if err != nil {
+		return err
+	}
+	return runMux(mux, d, cfg.StatsTick)
+}
+
 func MultiRun(ctx context.Context, d Driver, program ast.Proc, zctx *resolver.Context, msrc MultiSource, mcfg MultiConfig) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/driver/ztests/parallel-err.yaml
+++ b/driver/ztests/parallel-err.yaml
@@ -1,0 +1,13 @@
+script: |
+  zq -P -t '( put k=a+10 ; put k=b+20) | sort k' A.tzng
+
+inputs:
+  - name: A.tzng
+    data: |
+      #0:record[a:int32]
+      0:[1;]
+
+outputs:
+  - name: stderr
+    data: |
+      number of input sources must match number of parallel inputs in zql query

--- a/driver/ztests/parallel-stdin.yaml
+++ b/driver/ztests/parallel-stdin.yaml
@@ -1,0 +1,36 @@
+script: |
+  zq -P -t '( put k=a+10 ; put k=b+20) | sort k' - B.tzng
+
+inputs:
+  - name: stdin
+    data: |
+      #0:record[a:int32]
+      0:[1;]
+      0:[3;]
+      0:[5;]
+      0:[3;]
+      0:[1;]
+  - name: B.tzng
+    data: |
+      #0:record[b:int32]
+      0:[2;]
+      0:[4;]
+      0:[6;]
+      0:[4;]
+      0:[2;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[a:int32,k:int64]
+      0:[1;11;]
+      0:[1;11;]
+      0:[3;13;]
+      0:[3;13;]
+      0:[5;15;]
+      #1:record[b:int32,k:int64]
+      1:[2;22;]
+      1:[2;22;]
+      1:[4;24;]
+      1:[4;24;]
+      1:[6;26;]

--- a/driver/ztests/parallel.yaml
+++ b/driver/ztests/parallel.yaml
@@ -1,0 +1,36 @@
+script: |
+  zq -P -t '( put k=a+10 ; put k=b+20) | sort k' A.tzng B.tzng
+
+inputs:
+  - name: A.tzng
+    data: |
+      #0:record[a:int32]
+      0:[1;]
+      0:[3;]
+      0:[5;]
+      0:[3;]
+      0:[1;]
+  - name: B.tzng
+    data: |
+      #0:record[b:int32]
+      0:[2;]
+      0:[4;]
+      0:[6;]
+      0:[4;]
+      0:[2;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[a:int32,k:int64]
+      0:[1;11;]
+      0:[1;11;]
+      0:[3;13;]
+      0:[3;13;]
+      0:[5;15;]
+      #1:record[b:int32,k:int64]
+      1:[2;22;]
+      1:[2;22;]
+      1:[4;24;]
+      1:[4;24;]
+      1:[6;26;]


### PR DESCRIPTION
This commit adds a new flag (-P) to zq to interconnect two or
more inputs directly to a zql query that begins with a parallel
flow graph.  This is needed by the forthcoming join proc.

Closes #1616 