### PR TITLE
Fix type null handling in zng.Parse

### DIFF
--- a/proc/put/ztests/null.yaml
+++ b/proc/put/ztests/null.yaml
@@ -1,0 +1,9 @@
+zql: put b=null
+
+input: |
+  #0:record[a:int32]
+  0:[1;]
+
+output: |
+  #0:record[a:int32,b:null]
+  0:[1;-;]

--- a/zng/null.go
+++ b/zng/null.go
@@ -1,17 +1,18 @@
 package zng
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/brimsec/zq/zcode"
 )
 
-var ErrInstantiateNull = errors.New("cannot instantiate type null")
-
 type TypeOfNull struct{}
 
 func (t *TypeOfNull) Parse(in []byte) (zcode.Bytes, error) {
-	return nil, ErrInstantiateNull
+	if len(in) > 0 {
+		return nil, fmt.Errorf("cannot instantiate type null with nonempty value %q", in)
+	}
+	return nil, nil
 }
 
 func (t *TypeOfNull) ID() int {

--- a/zng/value.go
+++ b/zng/value.go
@@ -19,12 +19,9 @@ type Value struct {
 	Bytes zcode.Bytes
 }
 
-// Parse translates an Literal into a Value.
+// Parse translates an ast.Literal into a Value.
 // This currently supports only primitive literals.
 func Parse(v ast.Literal) (Value, error) {
-	if v.Type == "null" {
-		return Value{}, nil
-	}
 	t := LookupPrimitive(v.Type)
 	if t == nil {
 		return Value{}, fmt.Errorf("unsupported type %s in ast.Literal", v.Type)

--- a/ztests/suite/errors/null.yaml
+++ b/ztests/suite/errors/null.yaml
@@ -10,4 +10,4 @@ inputs:
 outputs:
   - name: stderr
     regexp: |
-      cannot instantiate type null
+      cannot instantiate type null with nonempty value "bleah"


### PR DESCRIPTION
zng.Parse translates an ast.Literal with type null to a zng.Value with a
Type field of nil instead of zng.TypeNull.  Fix that by allowing
zng.TypeNull.Parse to succeed if its parameter is empty.

Closes #1387.