### PR TITLE
archive: fix seekindex for consecutive timestamps

### DIFF
--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -315,7 +315,8 @@ func (cw *chunkWriter) Write(rec *zng.Record) error {
 	if err := cw.dataFileWriter.Write(rec); err != nil {
 		return err
 	}
-	if cw.needIndexWrite {
+	ts := rec.Ts()
+	if !cw.wroteFirst || (cw.needIndexWrite && ts != cw.lastTs) {
 		if err := cw.seekIndex.Enter(rec.Ts(), sos); err != nil {
 			return err
 		}
@@ -324,7 +325,6 @@ func (cw *chunkWriter) Write(rec *zng.Record) error {
 	if cw.dataFileWriter.LastSOS() != sos {
 		cw.needIndexWrite = true
 	}
-	ts := rec.Ts()
 	if !cw.wroteFirst {
 		cw.firstTs = ts
 		cw.wroteFirst = true

--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -298,7 +298,6 @@ func newChunkWriter(ctx context.Context, ark *Archive, tsd tsDir, masks []ksuid.
 		id:             id,
 		seekIndex:      seekIndex,
 		masks:          masks,
-		needIndexWrite: true,
 		tsd:            tsd,
 	}, nil
 }
@@ -317,7 +316,7 @@ func (cw *chunkWriter) Write(rec *zng.Record) error {
 	}
 	ts := rec.Ts()
 	if !cw.wroteFirst || (cw.needIndexWrite && ts != cw.lastTs) {
-		if err := cw.seekIndex.Enter(rec.Ts(), sos); err != nil {
+		if err := cw.seekIndex.Enter(ts, sos); err != nil {
 			return err
 		}
 		cw.needIndexWrite = false

--- a/ztests/suite/zar/consecutive-ts.yaml
+++ b/ztests/suite/zar/consecutive-ts.yaml
@@ -1,0 +1,26 @@
+script: |
+  zar import -R logs -streammax 2 -
+  microindex section -s 0 -t logs/zd/19700101/ts-*.zng
+
+inputs:
+  - name: stdin
+    data: |
+      #0:record[ts:time]
+      0:[0;]
+      0:[2;]
+      0:[2;]
+      0:[3;]
+      0:[3;]
+      0:[3;]
+      0:[6;]
+      0:[7;]
+      0:[8;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[ts:time,offset:int64]
+      0:[8;0;]
+      0:[6;23;]
+      0:[2;69;]
+      0:[0;90;]


### PR DESCRIPTION
During archive import do not generate seek indexes if the current record's
timestamp equals the previous records timestamp.

The previous functionality had a bug where searches would drop records if an
entry record for the seekindex had records with equal timetamps before it.

zq#1594