### PR TITLE
fix bug with parents slice corruption in compiler

### DIFF
--- a/proc/compiler/compiler.go
+++ b/proc/compiler/compiler.go
@@ -144,8 +144,7 @@ func compileSequential(custom Hook, nodes []ast.Proc, pctx *proc.Context, parent
 		} else {
 			parent = combine.New(pctx, parents)
 		}
-		parents = parents[0:1]
-		parents[0] = parent
+		parents = []proc.Interface{parent}
 	}
 	return compileSequential(custom, nodes[1:], pctx, parents)
 }

--- a/proc/compiler/compiler_test.go
+++ b/proc/compiler/compiler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/pkg/test"
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/proc/compiler"
@@ -65,5 +66,41 @@ func TestCompileParents(t *testing.T) {
 		require.NoError(t, err)
 		_, err = compiler.Compile(nil, query, pctx, sources)
 		require.Error(t, err)
+	})
+}
+
+// TestCompileMergeDone exercises the bug reported in issue #1635.
+// When we refactor the AST to make merge/combine explicit, this test will
+// need to be updated and can be moved to ztest using the "merge" zql operator
+// that will be available then.
+func TestCompileMergeDone(t *testing.T) {
+	input := `
+#0:record[k:int32]
+0:[1;]
+0:[2;]
+0:[3;]
+0:[4;]
+`
+	zctx := resolver.NewContext()
+	pctx := &proc.Context{Context: context.Background(), TypeContext: zctx}
+	r := tzngio.NewReader(bytes.NewReader([]byte(input)), zctx)
+	src := &proctest.RecordPuller{R: r}
+	t.Run("merge done before scanners out of data", func(t *testing.T) {
+		query, err := zql.ParseProc("(filter * ; head 1) | head 3")
+		require.NoError(t, err)
+
+		seq, ok := query.(*ast.SequentialProc)
+		require.Equal(t, ok, true)
+		p, ok := seq.Procs[0].(*ast.ParallelProc)
+		require.Equal(t, ok, true)
+
+		// Force the parallel proc to create a merge proc instead of combine.
+		p.MergeOrderField = field.New("k")
+		leaves, err := compiler.Compile(nil, query, pctx, []proc.Interface{src})
+		require.NoError(t, err)
+
+		var sb strings.Builder
+		err = zbuf.CopyPuller(tzngio.NewWriter(zio.NopCloser(&sb)), leaves[0])
+		require.NoError(t, err)
 	})
 }

--- a/proc/compiler/compiler_test.go
+++ b/proc/compiler/compiler_test.go
@@ -85,22 +85,20 @@ func TestCompileMergeDone(t *testing.T) {
 	pctx := &proc.Context{Context: context.Background(), TypeContext: zctx}
 	r := tzngio.NewReader(bytes.NewReader([]byte(input)), zctx)
 	src := &proctest.RecordPuller{R: r}
-	t.Run("merge done before scanners out of data", func(t *testing.T) {
-		query, err := zql.ParseProc("(filter * ; head 1) | head 3")
-		require.NoError(t, err)
+	query, err := zql.ParseProc("(filter * ; head 1) | head 3")
+	require.NoError(t, err)
 
-		seq, ok := query.(*ast.SequentialProc)
-		require.Equal(t, ok, true)
-		p, ok := seq.Procs[0].(*ast.ParallelProc)
-		require.Equal(t, ok, true)
+	seq, ok := query.(*ast.SequentialProc)
+	require.Equal(t, ok, true)
+	p, ok := seq.Procs[0].(*ast.ParallelProc)
+	require.Equal(t, ok, true)
 
-		// Force the parallel proc to create a merge proc instead of combine.
-		p.MergeOrderField = field.New("k")
-		leaves, err := compiler.Compile(nil, query, pctx, []proc.Interface{src})
-		require.NoError(t, err)
+	// Force the parallel proc to create a merge proc instead of combine.
+	p.MergeOrderField = field.New("k")
+	leaves, err := compiler.Compile(nil, query, pctx, []proc.Interface{src})
+	require.NoError(t, err)
 
-		var sb strings.Builder
-		err = zbuf.CopyPuller(tzngio.NewWriter(zio.NopCloser(&sb)), leaves[0])
-		require.NoError(t, err)
-	})
+	var sb strings.Builder
+	err = zbuf.CopyPuller(tzngio.NewWriter(zio.NopCloser(&sb)), leaves[0])
+	require.NoError(t, err)
 }


### PR DESCRIPTION
This commit fixes a bug where the parents slice was overwritten
and reused so the parent linkage in the compiled flowgraph
becomes corrupt.  The fix is to make a new parents slice instead
of trying to reuse the buffer.

Fixes #1635