### PR TITLE
archive import: Flush stale tsdirs

### DIFF
--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -112,7 +112,7 @@ func (w *Writer) Write(rec *zng.Record) error {
 }
 
 // flusher is a background goroutine for an active Writer that periodically
-// checks for tsdir writers that have not recieved data in a while. If such a
+// checks for tsdir writers that have not received data in a while. If such a
 // writer is found, it is flushed to disk and closed.
 func (w *Writer) flusher() error {
 	ticker := time.NewTicker(time.Second)

--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -2,11 +2,14 @@ package archive
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/ppl/archive/chunk"
 	"github.com/brimsec/zq/proc/sort"
 	"github.com/brimsec/zq/proc/spill"
@@ -15,6 +18,7 @@ import (
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"go.uber.org/multierr"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -50,38 +54,94 @@ func Import(ctx context.Context, ark *Archive, zctx *resolver.Context, r zbuf.Re
 // provided read stream is closed. Add some kind of timeout functionality that
 // periodically flushes stale tsDirWriters.
 type Writer struct {
-	ark     *Archive
-	ctx     context.Context
-	writers map[tsDir]*tsDirWriter
+	ark      *Archive
+	cancel   context.CancelFunc
+	ctx      context.Context
+	errgroup *errgroup.Group
+	mu       sync.RWMutex
+	once     sync.Once
+	writers  map[tsDir]*tsDirWriter
 
 	memBuffered int64
 	stats       ImportStats
 }
 
 func NewWriter(ctx context.Context, ark *Archive) *Writer {
+	g, ctx := errgroup.WithContext(ctx)
+	ctx, cancel := context.WithCancel(ctx)
 	return &Writer{
-		ark:     ark,
-		ctx:     ctx,
-		writers: make(map[tsDir]*tsDirWriter),
+		ark:      ark,
+		cancel:   cancel,
+		ctx:      ctx,
+		errgroup: g,
+		writers:  make(map[tsDir]*tsDirWriter),
 	}
 }
 
 func (w *Writer) Write(rec *zng.Record) error {
+	w.once.Do(func() {
+		w.errgroup.Go(w.flusher)
+	})
+	if w.ctx.Err() != nil {
+		return w.errgroup.Wait()
+	}
+
 	tsDir := newTsDir(rec.Ts())
+	w.mu.RLock()
 	dw, ok := w.writers[tsDir]
+	w.mu.RUnlock()
 	if !ok {
 		var err error
 		dw, err = newTsDirWriter(w, tsDir)
 		if err != nil {
 			return err
 		}
+		w.mu.Lock()
 		w.writers[tsDir] = dw
+		w.mu.Unlock()
 	}
-	if err := dw.writeOne(rec); err != nil {
+	if err := dw.Write(rec); err != nil {
 		return err
 	}
 	for w.memBuffered > ImportBufSize {
 		if err := w.spillLargestBuffer(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// flusher is a background go-routine for an active Writer that periodically
+// checks for tsdir writers that have not recieved data in a while. If such a
+// writer is found, it is flushed to disk and closed.
+func (w *Writer) flusher() error {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := w.flushStaleWriters(); err != nil {
+				return err
+			}
+		case <-w.ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (w *Writer) flushStaleWriters() error {
+	w.mu.Lock()
+	var stale []*tsDirWriter
+	now := time.Now()
+	for tsd, writer := range w.writers {
+		if now.Sub(writer.modified()) > w.ark.ImportFlushTimeout {
+			stale = append(stale, writer)
+			delete(w.writers, tsd)
+		}
+	}
+	w.mu.Unlock()
+	for _, writer := range stale {
+		if err := writer.flush(); err != nil {
 			return err
 		}
 	}
@@ -93,6 +153,8 @@ func (w *Writer) Write(rec *zng.Record) error {
 // spilling to disk the records of the tsDirWriter with the largest memory
 // footprint.
 func (w *Writer) spillLargestBuffer() error {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
 	var largest *tsDirWriter
 	for _, dw := range w.writers {
 		if largest == nil || dw.bufSize > largest.bufSize {
@@ -103,12 +165,18 @@ func (w *Writer) spillLargestBuffer() error {
 }
 
 func (w *Writer) Close() error {
+	w.mu.Lock()
 	var merr error
 	for ts, dw := range w.writers {
 		if err := dw.flush(); err != nil {
 			merr = multierr.Append(merr, err)
 		}
 		delete(w.writers, ts)
+	}
+	w.mu.Unlock()
+	w.cancel()
+	if err := w.errgroup.Wait(); merr == nil {
+		merr = err
 	}
 	return merr
 }
@@ -145,6 +213,7 @@ type tsDirWriter struct {
 	ark     *Archive
 	bufSize int64
 	ctx     context.Context
+	modts   int64
 	records []*zng.Record
 	spiller *spill.MergeSort
 	tsDir   tsDir
@@ -181,7 +250,7 @@ func (dw *tsDirWriter) chunkSizeEstimate() int64 {
 	return b / 2
 }
 
-func (dw *tsDirWriter) writeOne(rec *zng.Record) error {
+func (dw *tsDirWriter) Write(rec *zng.Record) error {
 	// XXX This call leads to a ton of one-off allocations that burden the GC
 	// and slow down import. We should instead copy the raw record bytes into a
 	// recycled buffer and keep around an array of ts + byte-slice structs for
@@ -189,12 +258,21 @@ func (dw *tsDirWriter) writeOne(rec *zng.Record) error {
 	rec.CopyBody()
 	dw.records = append(dw.records, rec)
 	dw.addBufSize(int64(len(rec.Raw)))
+	dw.touch()
 	if dw.chunkSizeEstimate() > dw.ark.LogSizeThreshold {
 		if err := dw.flush(); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (dw *tsDirWriter) touch() {
+	atomic.StoreInt64(&dw.modts, int64(nano.Now()))
+}
+
+func (dw *tsDirWriter) modified() time.Time {
+	return nano.Ts(atomic.LoadInt64(&dw.modts)).Time()
 }
 
 func (dw *tsDirWriter) spill() error {

--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -111,7 +111,7 @@ func (w *Writer) Write(rec *zng.Record) error {
 	return nil
 }
 
-// flusher is a background go-routine for an active Writer that periodically
+// flusher is a background goroutine for an active Writer that periodically
 // checks for tsdir writers that have not recieved data in a while. If such a
 // writer is found, it is flushed to disk and closed.
 func (w *Writer) flusher() error {

--- a/ppl/archive/import_test.go
+++ b/ppl/archive/import_test.go
@@ -1,0 +1,50 @@
+package archive
+
+import (
+	"context"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/tzngio"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportFlushTimeout(t *testing.T) {
+	t.Run("Stale", func(t *testing.T) {
+		testImportFlushTimeout(t, 1, 1)
+	})
+	t.Run("NotStale", func(t *testing.T) {
+		testImportFlushTimeout(t, math.MaxInt64, 0)
+	})
+}
+
+func testImportFlushTimeout(t *testing.T, timeout time.Duration, expected uint64) {
+	const data = `
+#0:record[ts:time,offset:int64]
+0:[1587508850.06466032;202;]`
+
+	// create archive with a 1 ns ImportFlushTimeout
+	ark, err := CreateOrOpenArchive(t.TempDir(), &CreateOptions{
+		ImportFlushTimeout: timeout,
+	}, nil)
+	require.NoError(t, err)
+
+	// write one record to an open archive.Writer and do NOT close it.
+	w := NewWriter(context.Background(), ark)
+	defer w.Close()
+	r := tzngio.NewReader(strings.NewReader(data), resolver.NewContext())
+	require.NoError(t, zbuf.Copy(w, r))
+
+	// flush stale writers and ensure data has been written to archive
+	time.Sleep(10)
+	err = w.flushStaleWriters()
+	require.NoError(t, err)
+	count, err := RecordCount(context.Background(), ark)
+	require.NoError(t, err)
+	assert.EqualValues(t, expected, count)
+}

--- a/ppl/archive/import_test.go
+++ b/ppl/archive/import_test.go
@@ -29,14 +29,13 @@ func testImportFlushTimeout(t *testing.T, timeout time.Duration, expected uint64
 0:[1587508850.06466032;202;]`
 
 	// create archive with a 1 ns ImportFlushTimeout
-	ark, err := CreateOrOpenArchive(t.TempDir(), &CreateOptions{
-		ImportFlushTimeout: timeout,
-	}, nil)
+	ark, err := CreateOrOpenArchive(t.TempDir(), nil, nil)
 	require.NoError(t, err)
 
 	// write one record to an open archive.Writer and do NOT close it.
 	w := NewWriter(context.Background(), ark)
 	defer w.Close()
+	w.SetFlushTimeout(timeout)
 	r := tzngio.NewReader(strings.NewReader(data), resolver.NewContext())
 	require.NoError(t, zbuf.Copy(w, r))
 

--- a/ppl/archive/schema.go
+++ b/ppl/archive/schema.go
@@ -19,10 +19,9 @@ const metadataFilename = "zar.json"
 type Metadata struct {
 	Version int `json:"version"`
 
-	DataPath           string        `json:"data_path"`
-	DataOrder          zbuf.Order    `json:"data_order"`
-	ImportFlushTimeout time.Duration `json:"import_flush_time"`
-	LogSizeThreshold   int64         `json:"log_size_threshold"`
+	DataPath         string     `json:"data_path"`
+	DataOrder        zbuf.Order `json:"data_order"`
+	LogSizeThreshold int64      `json:"log_size_threshold"`
 }
 
 func (c *Metadata) Write(uri iosrc.URI) error {
@@ -57,31 +56,22 @@ func MetadataRead(ctx context.Context, uri iosrc.URI) (*Metadata, error) {
 }
 
 const (
-	DefaultDataOrder = zbuf.OrderDesc
-	// DefaultImportFlushTimeout is the default time that an archive will wait
-	// before flushing to disk and closing a tsdir has not received any new
-	// data.
-	DefaultImportFlushTimeout = time.Second * 5
-	DefaultLogSizeThreshold   = 500 * 1024 * 1024
+	DefaultDataOrder        = zbuf.OrderDesc
+	DefaultLogSizeThreshold = 500 * 1024 * 1024
 )
 
 type CreateOptions struct {
-	DataPath           string
-	ImportFlushTimeout time.Duration
-	LogSizeThreshold   *int64
-	SortAscending      bool
+	DataPath         string
+	LogSizeThreshold *int64
+	SortAscending    bool
 }
 
 func (c *CreateOptions) toMetadata() *Metadata {
 	m := &Metadata{
-		Version:            0,
-		ImportFlushTimeout: DefaultImportFlushTimeout,
-		LogSizeThreshold:   DefaultLogSizeThreshold,
-		DataOrder:          DefaultDataOrder,
-		DataPath:           ".",
-	}
-	if c.ImportFlushTimeout != 0 {
-		m.ImportFlushTimeout = c.ImportFlushTimeout
+		Version:          0,
+		LogSizeThreshold: DefaultLogSizeThreshold,
+		DataOrder:        DefaultDataOrder,
+		DataPath:         ".",
 	}
 	if c.LogSizeThreshold != nil {
 		m.LogSizeThreshold = *c.LogSizeThreshold
@@ -96,22 +86,20 @@ func (c *CreateOptions) toMetadata() *Metadata {
 }
 
 type Archive struct {
-	Root               iosrc.URI
-	DataPath           iosrc.URI
-	DataOrder          zbuf.Order
-	ImportFlushTimeout time.Duration
-	LogSizeThreshold   int64
-	LogFilter          []ksuid.KSUID
-	dataSrc            iosrc.Source
+	Root             iosrc.URI
+	DataPath         iosrc.URI
+	DataOrder        zbuf.Order
+	LogSizeThreshold int64
+	LogFilter        []ksuid.KSUID
+	dataSrc          iosrc.Source
 }
 
 func (ark *Archive) metaWrite() error {
 	m := &Metadata{
-		Version:            0,
-		ImportFlushTimeout: ark.ImportFlushTimeout,
-		LogSizeThreshold:   ark.LogSizeThreshold,
-		DataOrder:          ark.DataOrder,
-		DataPath:           ark.DataPath.String(),
+		Version:          0,
+		LogSizeThreshold: ark.LogSizeThreshold,
+		DataOrder:        ark.DataOrder,
+		DataPath:         ark.DataPath.String(),
 	}
 	return m.Write(ark.mdURI())
 }
@@ -163,11 +151,10 @@ func openArchive(ctx context.Context, root iosrc.URI, oo *OpenOptions) (*Archive
 	}
 
 	ark := &Archive{
-		Root:               root,
-		DataOrder:          m.DataOrder,
-		ImportFlushTimeout: m.ImportFlushTimeout,
-		LogSizeThreshold:   m.LogSizeThreshold,
-		DataPath:           dpuri,
+		Root:             root,
+		DataOrder:        m.DataOrder,
+		LogSizeThreshold: m.LogSizeThreshold,
+		DataPath:         dpuri,
 	}
 
 	if oo != nil && oo.DataSource != nil {
@@ -214,6 +201,9 @@ func CreateOrOpenArchiveWithContext(ctx context.Context, rpath string, co *Creat
 			if err := dm.MkdirAll(root.AppendPath(dataDirname), 0700); err != nil {
 				return nil, err
 			}
+		}
+		if co == nil {
+			co = &CreateOptions{}
 		}
 		if err := co.toMetadata().Write(mdPath); err != nil {
 			return nil, err

--- a/ppl/archive/stat.go
+++ b/ppl/archive/stat.go
@@ -159,6 +159,15 @@ func (s *statReadCloser) run() {
 	})
 }
 
+func RecordCount(ctx context.Context, ark *Archive) (uint64, error) {
+	var count uint64
+	err := Walk(ctx, ark, func(chunk chunk.Chunk) error {
+		count += chunk.RecordCount
+		return nil
+	})
+	return count, err
+}
+
 func Stat(ctx context.Context, zctx *resolver.Context, ark *Archive) (zbuf.ReadCloser, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	s := &statReadCloser{


### PR DESCRIPTION
Add a background co-routine to periodically (configured at 1 second intervals)
checks for active tsDirWriters whose time of last modified time is less than
ark.ImportFlushThreshold, and commits its data to disk.

Closes #1433