### PR TITLE
unify the three variants of AST

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -196,8 +196,8 @@ type (
 		// If non-zero, MergeOrderField contains the field name on
 		// which the branches of this parallel proc should be
 		// merged in the order indicated by MergeOrderReverse.
-		MergeOrderField   field.Static `json:"merge_order_field"`
-		MergeOrderReverse bool         `json:"merge_order_reverse"`
+		MergeOrderField   field.Static `json:"merge_order_field,omitempty"`
+		MergeOrderReverse bool         `json:"merge_order_reverse,omitempty"`
 		Procs             []Proc       `json:"procs"`
 	}
 	// A SortProc node represents a proc that sorts records.
@@ -268,11 +268,11 @@ type (
 	// if any reducer in Reducers is non-decomposable.
 	GroupByProc struct {
 		Node
-		Duration     Duration     `json:"duration,omitempty"`
+		Duration     Duration     `json:"duration"`
 		InputSortDir int          `json:"input_sort_dir,omitempty"`
-		Limit        int          `json:"limit,omitempty"`
-		Keys         []Assignment `json:"keys,omitempty"`
-		Reducers     []Assignment `json:"reducers,omitempty"`
+		Limit        int          `json:"limit"`
+		Keys         []Assignment `json:"keys"`
+		Reducers     []Assignment `json:"reducers"`
 		ConsumePart  bool         `json:"consume_part,omitempty"`
 		EmitPart     bool         `json:"emit_part,omitempty"`
 	}
@@ -283,8 +283,8 @@ type (
 	// - It has a hidden option (FlushEvery) to sort and emit on every batch.
 	TopProc struct {
 		Node
-		Limit  int          `json:"limit,omitempty"`
-		Fields []Expression `json:"fields,omitempty"`
+		Limit  int          `json:"limit"`
+		Fields []Expression `json:"fields"`
 		Flush  bool         `json:"flush"`
 	}
 
@@ -314,7 +314,8 @@ type (
 )
 
 type Assignment struct {
-	LHS Expression `json:"lhs,omitempty"`
+	Node
+	LHS Expression `json:"lhs"`
 	RHS Expression `json:"rhs"`
 }
 
@@ -326,6 +327,14 @@ type Duration struct {
 type DurationNode struct {
 	Type    string `json:"type"`
 	Seconds int    `json:"seconds"`
+}
+
+func (d *Duration) MarshalJSON() ([]byte, error) {
+	if d.Seconds == 0 {
+		return json.Marshal(nil)
+	}
+	v := DurationNode{"Duration", d.Seconds}
+	return json.Marshal(&v)
 }
 
 func (d *Duration) UnmarshalJSON(b []byte) error {
@@ -362,8 +371,8 @@ func (*JoinProc) ProcNode()       {}
 type Reducer struct {
 	Node
 	Operator string     `json:"operator"`
-	Expr     Expression `json:"expr,omitempty"`
-	Where    Expression `json:"where,omitempty"`
+	Expr     Expression `json:"expr"`
+	Where    Expression `json:"where"`
 }
 
 func DotExprToField(n Expression) (field.Static, bool) {

--- a/zql/valid.zql
+++ b/zql/valid.zql
@@ -22,3 +22,4 @@ foo\x11\bar
 *
 *abc*
 field=null
+every 3600s count() by _path

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -387,7 +387,7 @@ function peg$parse(input, options) {
       peg$c46 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
       peg$c47 = "null",
       peg$c48 = peg$literalExpectation("null", false),
-      peg$c49 = function() { return {"op": "Literal", "type": "null"} },
+      peg$c49 = function() { return {"op": "Literal", "type": "null", "value": ""} },
       peg$c50 = function(first, rest) {
            if (rest) {
               return [first, ... rest]
@@ -412,25 +412,12 @@ function peg$parse(input, options) {
       peg$c57 = peg$literalExpectation(";", false),
       peg$c58 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
       peg$c59 = function(every, keys, limit) {
-            let p = {"op": "GroupByProc", "keys": keys};
-            if (every) {
-              p["duration"] = every;
-            }
-            if (limit) {
-              p["limit"] = limit;
-            }
-            return p
+            return {"op": "GroupByProc", "keys": keys, "reducers": null, "duration": every, "limit": limit}
           },
       peg$c60 = function(every, reducers, keys, limit) {
-            let p = {"op": "GroupByProc", "reducers": reducers};
-            if (every) {
-              p["duration"] = every;
-            }
+            let p = {"op": "GroupByProc", "keys": null, "reducers": reducers, "duration": every, "limit": limit};
             if (keys) {
               p["keys"] = keys[1];
-            }
-            if (limit) {
-              p["limit"] = limit;
             }
             return p
           },
@@ -445,43 +432,45 @@ function peg$parse(input, options) {
       peg$c69 = "-limit",
       peg$c70 = peg$literalExpectation("-limit", false),
       peg$c71 = function(limit) { return limit },
-      peg$c72 = function(expr) { return {"op": "Assignment", "rhs": expr} },
-      peg$c73 = ",",
-      peg$c74 = peg$literalExpectation(",", false),
-      peg$c75 = function(first, expr) { return expr },
-      peg$c76 = function(first, rest) {
+      peg$c72 = "",
+      peg$c73 = function() { return 0 },
+      peg$c74 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c75 = ",",
+      peg$c76 = peg$literalExpectation(",", false),
+      peg$c77 = function(first, expr) { return expr },
+      peg$c78 = function(first, rest) {
             return [first, ... rest]
           },
-      peg$c77 = "=",
-      peg$c78 = peg$literalExpectation("=", false),
-      peg$c79 = function(lval, reducer) {
+      peg$c79 = "=",
+      peg$c80 = peg$literalExpectation("=", false),
+      peg$c81 = function(lval, reducer) {
             return {"op": "Assignment", "lhs": lval, "rhs": reducer}
           },
-      peg$c80 = function(reducer) {
-            return {"op": "Assignment", "rhs": reducer}
+      peg$c82 = function(reducer) {
+            return {"op": "Assignment", "lhs": null, "rhs": reducer}
           },
-      peg$c81 = "not",
-      peg$c82 = peg$literalExpectation("not", false),
-      peg$c83 = function(op, expr, where) {
-            let r = {"op": "Reducer", "operator": op, "where":where};
+      peg$c83 = "not",
+      peg$c84 = peg$literalExpectation("not", false),
+      peg$c85 = function(op, expr, where) {
+            let r = {"op": "Reducer", "operator": op, "expr": null, "where":where};
             if (expr) {
               r["expr"] = expr;
             }
             return r
           },
-      peg$c84 = "where",
-      peg$c85 = peg$literalExpectation("where", false),
-      peg$c86 = function(first, rest) {
+      peg$c86 = "where",
+      peg$c87 = peg$literalExpectation("where", false),
+      peg$c88 = function(first, rest) {
             let result = [first];
             for(let  r of rest) {
               result.push( r[3]);
             }
             return result
           },
-      peg$c87 = "sort",
-      peg$c88 = peg$literalExpectation("sort", true),
-      peg$c89 = function(args, l) { return l },
-      peg$c90 = function(args, list) {
+      peg$c89 = "sort",
+      peg$c90 = peg$literalExpectation("sort", true),
+      peg$c91 = function(args, l) { return l },
+      peg$c92 = function(args, list) {
             let argm = args;
             let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false};
             if ( "r" in argm) {
@@ -494,27 +483,27 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c91 = function(a) { return a },
-      peg$c92 = function(args) { return makeArgMap(args) },
-      peg$c93 = "-r",
-      peg$c94 = peg$literalExpectation("-r", false),
-      peg$c95 = function() { return {"name": "r", "value": null} },
-      peg$c96 = "-nulls",
-      peg$c97 = peg$literalExpectation("-nulls", false),
-      peg$c98 = "first",
-      peg$c99 = peg$literalExpectation("first", false),
-      peg$c100 = "last",
-      peg$c101 = peg$literalExpectation("last", false),
-      peg$c102 = function() { return text() },
-      peg$c103 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c104 = "top",
-      peg$c105 = peg$literalExpectation("top", true),
-      peg$c106 = function(n) { return n},
-      peg$c107 = "-flush",
-      peg$c108 = peg$literalExpectation("-flush", false),
-      peg$c109 = function(limit, flush, f) { return f },
-      peg$c110 = function(limit, flush, fields) {
-            let proc = {"op": "TopProc"};
+      peg$c93 = function(a) { return a },
+      peg$c94 = function(args) { return makeArgMap(args) },
+      peg$c95 = "-r",
+      peg$c96 = peg$literalExpectation("-r", false),
+      peg$c97 = function() { return {"name": "r", "value": null} },
+      peg$c98 = "-nulls",
+      peg$c99 = peg$literalExpectation("-nulls", false),
+      peg$c100 = "first",
+      peg$c101 = peg$literalExpectation("first", false),
+      peg$c102 = "last",
+      peg$c103 = peg$literalExpectation("last", false),
+      peg$c104 = function() { return text() },
+      peg$c105 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c106 = "top",
+      peg$c107 = peg$literalExpectation("top", true),
+      peg$c108 = function(n) { return n},
+      peg$c109 = "-flush",
+      peg$c110 = peg$literalExpectation("-flush", false),
+      peg$c111 = function(limit, flush, f) { return f },
+      peg$c112 = function(limit, flush, fields) {
+            let proc = {"op": "TopProc", "limit": 0, "fields": null, "flush": false};
             if (limit) {
               proc["limit"] = limit;
             }
@@ -526,9 +515,9 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c111 = "cut",
-      peg$c112 = peg$literalExpectation("cut", true),
-      peg$c113 = function(args, columns) {
+      peg$c113 = "cut",
+      peg$c114 = peg$literalExpectation("cut", true),
+      peg$c115 = function(args, columns) {
             let argm = args;
             let proc = {"op": "CutProc", "fields": columns, "complement": false};
             if ( "c" in argm) {
@@ -536,67 +525,67 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c114 = "-c",
-      peg$c115 = peg$literalExpectation("-c", false),
-      peg$c116 = function() { return {"name": "c", "value": null} },
-      peg$c117 = function(args) {
+      peg$c116 = "-c",
+      peg$c117 = peg$literalExpectation("-c", false),
+      peg$c118 = function() { return {"name": "c", "value": null} },
+      peg$c119 = function(args) {
             return makeArgMap(args)
           },
-      peg$c118 = "head",
-      peg$c119 = peg$literalExpectation("head", true),
-      peg$c120 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c121 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c122 = "tail",
-      peg$c123 = peg$literalExpectation("tail", true),
-      peg$c124 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c125 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c126 = "filter",
-      peg$c127 = peg$literalExpectation("filter", true),
-      peg$c128 = "uniq",
-      peg$c129 = peg$literalExpectation("uniq", true),
-      peg$c130 = function() {
+      peg$c120 = "head",
+      peg$c121 = peg$literalExpectation("head", true),
+      peg$c122 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c123 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c124 = "tail",
+      peg$c125 = peg$literalExpectation("tail", true),
+      peg$c126 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c127 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c128 = "filter",
+      peg$c129 = peg$literalExpectation("filter", true),
+      peg$c130 = "uniq",
+      peg$c131 = peg$literalExpectation("uniq", true),
+      peg$c132 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c131 = function() {
+      peg$c133 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c132 = "put",
-      peg$c133 = peg$literalExpectation("put", true),
-      peg$c134 = function(columns) {
+      peg$c134 = "put",
+      peg$c135 = peg$literalExpectation("put", true),
+      peg$c136 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c135 = "rename",
-      peg$c136 = peg$literalExpectation("rename", true),
-      peg$c137 = function(first, cl) { return cl },
-      peg$c138 = function(first, rest) {
+      peg$c137 = "rename",
+      peg$c138 = peg$literalExpectation("rename", true),
+      peg$c139 = function(first, cl) { return cl },
+      peg$c140 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c139 = "fuse",
-      peg$c140 = peg$literalExpectation("fuse", true),
-      peg$c141 = function() {
+      peg$c141 = "fuse",
+      peg$c142 = peg$literalExpectation("fuse", true),
+      peg$c143 = function() {
             return {"op": "FuseProc"}
           },
-      peg$c142 = "join",
-      peg$c143 = peg$literalExpectation("join", true),
-      peg$c144 = function(leftKey, rightKey, columns) {
-            let proc = {"op": "JoinProc", "left_key": leftKey, "right_key": rightKey};
+      peg$c144 = "join",
+      peg$c145 = peg$literalExpectation("join", true),
+      peg$c146 = function(leftKey, rightKey, columns) {
+            let proc = {"op": "JoinProc", "left_key": leftKey, "right_key": rightKey, "clauses": null};
             if (columns) {
               proc["clauses"] = columns[1];
             }
             return proc
           },
-      peg$c145 = function(key, columns) {
-            let proc = {"op": "JoinProc", "left_key": key, "right_key": key};
+      peg$c147 = function(key, columns) {
+            let proc = {"op": "JoinProc", "left_key": key, "right_key": key, "clauses": null};
             if (columns) {
               proc["clauses"] = columns[1];
             }
             return proc
           },
-      peg$c146 = ".",
-      peg$c147 = peg$literalExpectation(".", false),
-      peg$c148 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
-      peg$c149 = function() { return {"op": "RootRecord"} },
-      peg$c150 = function(first, rest) {
+      peg$c148 = ".",
+      peg$c149 = peg$literalExpectation(".", false),
+      peg$c150 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
+      peg$c151 = function() { return {"op": "RootRecord"} },
+      peg$c152 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -605,269 +594,269 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c151 = function(lhs, rhs) { return {"lhs": lhs, "rhs": rhs} },
-      peg$c152 = "?",
-      peg$c153 = peg$literalExpectation("?", false),
-      peg$c154 = ":",
-      peg$c155 = peg$literalExpectation(":", false),
-      peg$c156 = function(condition, thenClause, elseClause) {
+      peg$c153 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c154 = "?",
+      peg$c155 = peg$literalExpectation("?", false),
+      peg$c156 = ":",
+      peg$c157 = peg$literalExpectation(":", false),
+      peg$c158 = function(condition, thenClause, elseClause) {
             return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c157 = function(first, op, expr) { return [op, expr] },
-      peg$c158 = function(first, rest) {
+      peg$c159 = function(first, op, expr) { return [op, expr] },
+      peg$c160 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c159 = function(first, comp, expr) { return [comp, expr] },
-      peg$c160 = "=~",
-      peg$c161 = peg$literalExpectation("=~", false),
-      peg$c162 = "!~",
-      peg$c163 = peg$literalExpectation("!~", false),
-      peg$c164 = "!=",
-      peg$c165 = peg$literalExpectation("!=", false),
-      peg$c166 = "in",
-      peg$c167 = peg$literalExpectation("in", false),
-      peg$c168 = "<=",
-      peg$c169 = peg$literalExpectation("<=", false),
-      peg$c170 = "<",
-      peg$c171 = peg$literalExpectation("<", false),
-      peg$c172 = ">=",
-      peg$c173 = peg$literalExpectation(">=", false),
-      peg$c174 = ">",
-      peg$c175 = peg$literalExpectation(">", false),
-      peg$c176 = "+",
-      peg$c177 = peg$literalExpectation("+", false),
-      peg$c178 = "/",
-      peg$c179 = peg$literalExpectation("/", false),
-      peg$c180 = function(e) {
+      peg$c161 = function(first, comp, expr) { return [comp, expr] },
+      peg$c162 = "=~",
+      peg$c163 = peg$literalExpectation("=~", false),
+      peg$c164 = "!~",
+      peg$c165 = peg$literalExpectation("!~", false),
+      peg$c166 = "!=",
+      peg$c167 = peg$literalExpectation("!=", false),
+      peg$c168 = "in",
+      peg$c169 = peg$literalExpectation("in", false),
+      peg$c170 = "<=",
+      peg$c171 = peg$literalExpectation("<=", false),
+      peg$c172 = "<",
+      peg$c173 = peg$literalExpectation("<", false),
+      peg$c174 = ">=",
+      peg$c175 = peg$literalExpectation(">=", false),
+      peg$c176 = ">",
+      peg$c177 = peg$literalExpectation(">", false),
+      peg$c178 = "+",
+      peg$c179 = peg$literalExpectation("+", false),
+      peg$c180 = "/",
+      peg$c181 = peg$literalExpectation("/", false),
+      peg$c182 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c181 = function(e, typ) { return typ },
-      peg$c182 = function(e, typ) {
+      peg$c183 = function(e, typ) { return typ },
+      peg$c184 = function(e, typ) {
             return {"op": "CastExpr", "expr": e, "type": typ}
           },
-      peg$c183 = "bytes",
-      peg$c184 = peg$literalExpectation("bytes", false),
-      peg$c185 = "uint8",
-      peg$c186 = peg$literalExpectation("uint8", false),
-      peg$c187 = "uint16",
-      peg$c188 = peg$literalExpectation("uint16", false),
-      peg$c189 = "uint32",
-      peg$c190 = peg$literalExpectation("uint32", false),
-      peg$c191 = "uint64",
-      peg$c192 = peg$literalExpectation("uint64", false),
-      peg$c193 = "int8",
-      peg$c194 = peg$literalExpectation("int8", false),
-      peg$c195 = "int16",
-      peg$c196 = peg$literalExpectation("int16", false),
-      peg$c197 = "int32",
-      peg$c198 = peg$literalExpectation("int32", false),
-      peg$c199 = "int64",
-      peg$c200 = peg$literalExpectation("int64", false),
-      peg$c201 = "duration",
-      peg$c202 = peg$literalExpectation("duration", false),
-      peg$c203 = "time",
-      peg$c204 = peg$literalExpectation("time", false),
-      peg$c205 = "float64",
-      peg$c206 = peg$literalExpectation("float64", false),
-      peg$c207 = "bool",
-      peg$c208 = peg$literalExpectation("bool", false),
-      peg$c209 = "string",
-      peg$c210 = peg$literalExpectation("string", false),
-      peg$c211 = "bstring",
-      peg$c212 = peg$literalExpectation("bstring", false),
-      peg$c213 = "ip",
-      peg$c214 = peg$literalExpectation("ip", false),
-      peg$c215 = "net",
-      peg$c216 = peg$literalExpectation("net", false),
-      peg$c217 = "type",
-      peg$c218 = peg$literalExpectation("type", false),
-      peg$c219 = "error",
-      peg$c220 = peg$literalExpectation("error", false),
-      peg$c221 = function(first, rest) {
+      peg$c185 = "bytes",
+      peg$c186 = peg$literalExpectation("bytes", false),
+      peg$c187 = "uint8",
+      peg$c188 = peg$literalExpectation("uint8", false),
+      peg$c189 = "uint16",
+      peg$c190 = peg$literalExpectation("uint16", false),
+      peg$c191 = "uint32",
+      peg$c192 = peg$literalExpectation("uint32", false),
+      peg$c193 = "uint64",
+      peg$c194 = peg$literalExpectation("uint64", false),
+      peg$c195 = "int8",
+      peg$c196 = peg$literalExpectation("int8", false),
+      peg$c197 = "int16",
+      peg$c198 = peg$literalExpectation("int16", false),
+      peg$c199 = "int32",
+      peg$c200 = peg$literalExpectation("int32", false),
+      peg$c201 = "int64",
+      peg$c202 = peg$literalExpectation("int64", false),
+      peg$c203 = "duration",
+      peg$c204 = peg$literalExpectation("duration", false),
+      peg$c205 = "time",
+      peg$c206 = peg$literalExpectation("time", false),
+      peg$c207 = "float64",
+      peg$c208 = peg$literalExpectation("float64", false),
+      peg$c209 = "bool",
+      peg$c210 = peg$literalExpectation("bool", false),
+      peg$c211 = "string",
+      peg$c212 = peg$literalExpectation("string", false),
+      peg$c213 = "bstring",
+      peg$c214 = peg$literalExpectation("bstring", false),
+      peg$c215 = "ip",
+      peg$c216 = peg$literalExpectation("ip", false),
+      peg$c217 = "net",
+      peg$c218 = peg$literalExpectation("net", false),
+      peg$c219 = "type",
+      peg$c220 = peg$literalExpectation("type", false),
+      peg$c221 = "error",
+      peg$c222 = peg$literalExpectation("error", false),
+      peg$c223 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c222 = function(fn, args) {
+      peg$c224 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c223 = function(first, e) { return e },
-      peg$c224 = function() { return [] },
-      peg$c225 = "[",
-      peg$c226 = peg$literalExpectation("[", false),
-      peg$c227 = "]",
-      peg$c228 = peg$literalExpectation("]", false),
-      peg$c229 = function(expr) { return ["[", expr] },
-      peg$c230 = function(id) { return [".", id] },
-      peg$c231 = "and",
-      peg$c232 = peg$literalExpectation("and", true),
-      peg$c233 = "or",
-      peg$c234 = peg$literalExpectation("or", true),
-      peg$c235 = peg$literalExpectation("in", true),
-      peg$c236 = peg$literalExpectation("not", true),
-      peg$c237 = /^[A-Za-z_$]/,
-      peg$c238 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c239 = /^[0-9]/,
-      peg$c240 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c241 = function() { return {"op": "Identifier", "name": text()} },
-      peg$c242 = peg$literalExpectation("and", false),
-      peg$c243 = "seconds",
-      peg$c244 = peg$literalExpectation("seconds", false),
-      peg$c245 = "second",
-      peg$c246 = peg$literalExpectation("second", false),
-      peg$c247 = "secs",
-      peg$c248 = peg$literalExpectation("secs", false),
-      peg$c249 = "sec",
-      peg$c250 = peg$literalExpectation("sec", false),
-      peg$c251 = "s",
-      peg$c252 = peg$literalExpectation("s", false),
-      peg$c253 = "minutes",
-      peg$c254 = peg$literalExpectation("minutes", false),
-      peg$c255 = "minute",
-      peg$c256 = peg$literalExpectation("minute", false),
-      peg$c257 = "mins",
-      peg$c258 = peg$literalExpectation("mins", false),
-      peg$c259 = "min",
-      peg$c260 = peg$literalExpectation("min", false),
-      peg$c261 = "m",
-      peg$c262 = peg$literalExpectation("m", false),
-      peg$c263 = "hours",
-      peg$c264 = peg$literalExpectation("hours", false),
-      peg$c265 = "hrs",
-      peg$c266 = peg$literalExpectation("hrs", false),
-      peg$c267 = "hr",
-      peg$c268 = peg$literalExpectation("hr", false),
-      peg$c269 = "h",
-      peg$c270 = peg$literalExpectation("h", false),
-      peg$c271 = "hour",
-      peg$c272 = peg$literalExpectation("hour", false),
-      peg$c273 = "days",
-      peg$c274 = peg$literalExpectation("days", false),
-      peg$c275 = "day",
-      peg$c276 = peg$literalExpectation("day", false),
-      peg$c277 = "d",
-      peg$c278 = peg$literalExpectation("d", false),
-      peg$c279 = "weeks",
-      peg$c280 = peg$literalExpectation("weeks", false),
-      peg$c281 = "week",
-      peg$c282 = peg$literalExpectation("week", false),
-      peg$c283 = "wks",
-      peg$c284 = peg$literalExpectation("wks", false),
-      peg$c285 = "wk",
-      peg$c286 = peg$literalExpectation("wk", false),
-      peg$c287 = "w",
-      peg$c288 = peg$literalExpectation("w", false),
-      peg$c289 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c290 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c291 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c292 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c293 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c294 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c295 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c296 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c297 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c298 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c299 = function(a, b) {
+      peg$c225 = function(first, e) { return e },
+      peg$c226 = function() { return [] },
+      peg$c227 = "[",
+      peg$c228 = peg$literalExpectation("[", false),
+      peg$c229 = "]",
+      peg$c230 = peg$literalExpectation("]", false),
+      peg$c231 = function(expr) { return ["[", expr] },
+      peg$c232 = function(id) { return [".", id] },
+      peg$c233 = "and",
+      peg$c234 = peg$literalExpectation("and", true),
+      peg$c235 = "or",
+      peg$c236 = peg$literalExpectation("or", true),
+      peg$c237 = peg$literalExpectation("in", true),
+      peg$c238 = peg$literalExpectation("not", true),
+      peg$c239 = /^[A-Za-z_$]/,
+      peg$c240 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c241 = /^[0-9]/,
+      peg$c242 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c243 = function() { return {"op": "Identifier", "name": text()} },
+      peg$c244 = peg$literalExpectation("and", false),
+      peg$c245 = "seconds",
+      peg$c246 = peg$literalExpectation("seconds", false),
+      peg$c247 = "second",
+      peg$c248 = peg$literalExpectation("second", false),
+      peg$c249 = "secs",
+      peg$c250 = peg$literalExpectation("secs", false),
+      peg$c251 = "sec",
+      peg$c252 = peg$literalExpectation("sec", false),
+      peg$c253 = "s",
+      peg$c254 = peg$literalExpectation("s", false),
+      peg$c255 = "minutes",
+      peg$c256 = peg$literalExpectation("minutes", false),
+      peg$c257 = "minute",
+      peg$c258 = peg$literalExpectation("minute", false),
+      peg$c259 = "mins",
+      peg$c260 = peg$literalExpectation("mins", false),
+      peg$c261 = "min",
+      peg$c262 = peg$literalExpectation("min", false),
+      peg$c263 = "m",
+      peg$c264 = peg$literalExpectation("m", false),
+      peg$c265 = "hours",
+      peg$c266 = peg$literalExpectation("hours", false),
+      peg$c267 = "hrs",
+      peg$c268 = peg$literalExpectation("hrs", false),
+      peg$c269 = "hr",
+      peg$c270 = peg$literalExpectation("hr", false),
+      peg$c271 = "h",
+      peg$c272 = peg$literalExpectation("h", false),
+      peg$c273 = "hour",
+      peg$c274 = peg$literalExpectation("hour", false),
+      peg$c275 = "days",
+      peg$c276 = peg$literalExpectation("days", false),
+      peg$c277 = "day",
+      peg$c278 = peg$literalExpectation("day", false),
+      peg$c279 = "d",
+      peg$c280 = peg$literalExpectation("d", false),
+      peg$c281 = "weeks",
+      peg$c282 = peg$literalExpectation("weeks", false),
+      peg$c283 = "week",
+      peg$c284 = peg$literalExpectation("week", false),
+      peg$c285 = "wks",
+      peg$c286 = peg$literalExpectation("wks", false),
+      peg$c287 = "wk",
+      peg$c288 = peg$literalExpectation("wk", false),
+      peg$c289 = "w",
+      peg$c290 = peg$literalExpectation("w", false),
+      peg$c291 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c292 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c293 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c294 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c295 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c296 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c297 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c298 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c299 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c300 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c301 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c300 = "::",
-      peg$c301 = peg$literalExpectation("::", false),
-      peg$c302 = function(a, b, d, e) {
+      peg$c302 = "::",
+      peg$c303 = peg$literalExpectation("::", false),
+      peg$c304 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c303 = function(a, b) {
+      peg$c305 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c304 = function(a, b) {
+      peg$c306 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c305 = function() {
+      peg$c307 = function() {
             return "::"
           },
-      peg$c306 = function(v) { return ":" + v },
-      peg$c307 = function(v) { return v + ":" },
-      peg$c308 = function(a, m) {
+      peg$c308 = function(v) { return ":" + v },
+      peg$c309 = function(v) { return v + ":" },
+      peg$c310 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c309 = function(a, m) {
+      peg$c311 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c310 = function(s) { return parseInt(s) },
-      peg$c311 = function() {
+      peg$c312 = function(s) { return parseInt(s) },
+      peg$c313 = function() {
             return text()
           },
-      peg$c312 = "e",
-      peg$c313 = peg$literalExpectation("e", true),
-      peg$c314 = /^[+\-]/,
-      peg$c315 = peg$classExpectation(["+", "-"], false, false),
-      peg$c316 = /^[0-9a-fA-F]/,
-      peg$c317 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c318 = function(chars) { return joinChars(chars) },
-      peg$c319 = "\\",
-      peg$c320 = peg$literalExpectation("\\", false),
-      peg$c321 = /^[\0-\x1F\\(),!><="|';:]/,
-      peg$c322 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
-      peg$c323 = peg$anyExpectation(),
-      peg$c324 = "\"",
-      peg$c325 = peg$literalExpectation("\"", false),
-      peg$c326 = function(v) { return joinChars(v) },
-      peg$c327 = "'",
-      peg$c328 = peg$literalExpectation("'", false),
-      peg$c329 = "x",
-      peg$c330 = peg$literalExpectation("x", false),
-      peg$c331 = function() { return "\\" + text() },
-      peg$c332 = "b",
-      peg$c333 = peg$literalExpectation("b", false),
-      peg$c334 = function() { return "\b" },
-      peg$c335 = "f",
-      peg$c336 = peg$literalExpectation("f", false),
-      peg$c337 = function() { return "\f" },
-      peg$c338 = "n",
-      peg$c339 = peg$literalExpectation("n", false),
-      peg$c340 = function() { return "\n" },
-      peg$c341 = "r",
-      peg$c342 = peg$literalExpectation("r", false),
-      peg$c343 = function() { return "\r" },
-      peg$c344 = "t",
-      peg$c345 = peg$literalExpectation("t", false),
-      peg$c346 = function() { return "\t" },
-      peg$c347 = "v",
-      peg$c348 = peg$literalExpectation("v", false),
-      peg$c349 = function() { return "\v" },
-      peg$c350 = function() { return "=" },
-      peg$c351 = function() { return "\\*" },
-      peg$c352 = "u",
-      peg$c353 = peg$literalExpectation("u", false),
-      peg$c354 = function(chars) {
+      peg$c314 = "e",
+      peg$c315 = peg$literalExpectation("e", true),
+      peg$c316 = /^[+\-]/,
+      peg$c317 = peg$classExpectation(["+", "-"], false, false),
+      peg$c318 = /^[0-9a-fA-F]/,
+      peg$c319 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c320 = function(chars) { return joinChars(chars) },
+      peg$c321 = "\\",
+      peg$c322 = peg$literalExpectation("\\", false),
+      peg$c323 = /^[\0-\x1F\\(),!><="|';:]/,
+      peg$c324 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
+      peg$c325 = peg$anyExpectation(),
+      peg$c326 = "\"",
+      peg$c327 = peg$literalExpectation("\"", false),
+      peg$c328 = function(v) { return joinChars(v) },
+      peg$c329 = "'",
+      peg$c330 = peg$literalExpectation("'", false),
+      peg$c331 = "x",
+      peg$c332 = peg$literalExpectation("x", false),
+      peg$c333 = function() { return "\\" + text() },
+      peg$c334 = "b",
+      peg$c335 = peg$literalExpectation("b", false),
+      peg$c336 = function() { return "\b" },
+      peg$c337 = "f",
+      peg$c338 = peg$literalExpectation("f", false),
+      peg$c339 = function() { return "\f" },
+      peg$c340 = "n",
+      peg$c341 = peg$literalExpectation("n", false),
+      peg$c342 = function() { return "\n" },
+      peg$c343 = "r",
+      peg$c344 = peg$literalExpectation("r", false),
+      peg$c345 = function() { return "\r" },
+      peg$c346 = "t",
+      peg$c347 = peg$literalExpectation("t", false),
+      peg$c348 = function() { return "\t" },
+      peg$c349 = "v",
+      peg$c350 = peg$literalExpectation("v", false),
+      peg$c351 = function() { return "\v" },
+      peg$c352 = function() { return "=" },
+      peg$c353 = function() { return "\\*" },
+      peg$c354 = "u",
+      peg$c355 = peg$literalExpectation("u", false),
+      peg$c356 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c355 = "{",
-      peg$c356 = peg$literalExpectation("{", false),
-      peg$c357 = "}",
-      peg$c358 = peg$literalExpectation("}", false),
-      peg$c359 = function(body) { return body },
-      peg$c360 = /^[^\/\\]/,
-      peg$c361 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c362 = "\\/",
-      peg$c363 = peg$literalExpectation("\\/", false),
-      peg$c364 = /^[\0-\x1F\\]/,
-      peg$c365 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c366 = peg$otherExpectation("whitespace"),
-      peg$c367 = "\t",
-      peg$c368 = peg$literalExpectation("\t", false),
-      peg$c369 = "\x0B",
-      peg$c370 = peg$literalExpectation("\x0B", false),
-      peg$c371 = "\f",
-      peg$c372 = peg$literalExpectation("\f", false),
-      peg$c373 = " ",
-      peg$c374 = peg$literalExpectation(" ", false),
-      peg$c375 = "\xA0",
-      peg$c376 = peg$literalExpectation("\xA0", false),
-      peg$c377 = "\uFEFF",
-      peg$c378 = peg$literalExpectation("\uFEFF", false),
-      peg$c379 = /^[\n\r\u2028\u2029]/,
-      peg$c380 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c381 = peg$otherExpectation("comment"),
-      peg$c386 = "//",
-      peg$c387 = peg$literalExpectation("//", false),
+      peg$c357 = "{",
+      peg$c358 = peg$literalExpectation("{", false),
+      peg$c359 = "}",
+      peg$c360 = peg$literalExpectation("}", false),
+      peg$c361 = function(body) { return body },
+      peg$c362 = /^[^\/\\]/,
+      peg$c363 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c364 = "\\/",
+      peg$c365 = peg$literalExpectation("\\/", false),
+      peg$c366 = /^[\0-\x1F\\]/,
+      peg$c367 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c368 = peg$otherExpectation("whitespace"),
+      peg$c369 = "\t",
+      peg$c370 = peg$literalExpectation("\t", false),
+      peg$c371 = "\x0B",
+      peg$c372 = peg$literalExpectation("\x0B", false),
+      peg$c373 = "\f",
+      peg$c374 = peg$literalExpectation("\f", false),
+      peg$c375 = " ",
+      peg$c376 = peg$literalExpectation(" ", false),
+      peg$c377 = "\xA0",
+      peg$c378 = peg$literalExpectation("\xA0", false),
+      peg$c379 = "\uFEFF",
+      peg$c380 = peg$literalExpectation("\uFEFF", false),
+      peg$c381 = /^[\n\r\u2028\u2029]/,
+      peg$c382 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c383 = peg$otherExpectation("comment"),
+      peg$c388 = "//",
+      peg$c389 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -2255,9 +2244,6 @@ function peg$parse(input, options) {
       s2 = peg$parseGroupByKeys();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseLimitArg();
-        if (s3 === peg$FAILED) {
-          s3 = null;
-        }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$c59(s1, s2, s3);
@@ -2462,6 +2448,15 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$c72;
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c73();
+      }
+      s0 = s1;
+    }
 
     return s0;
   }
@@ -2475,7 +2470,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72(s1);
+        s1 = peg$c74(s1);
       }
       s0 = s1;
     }
@@ -2494,11 +2489,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c75;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2506,7 +2501,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c75(s1, s7);
+              s4 = peg$c77(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2530,11 +2525,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c75;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c76); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2542,7 +2537,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c75(s1, s7);
+                s4 = peg$c77(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2563,7 +2558,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c76(s1, s2);
+        s1 = peg$c78(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2586,11 +2581,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c77;
+          s3 = peg$c79;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -2598,7 +2593,7 @@ function peg$parse(input, options) {
             s5 = peg$parseReducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c79(s1, s5);
+              s1 = peg$c81(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2625,7 +2620,7 @@ function peg$parse(input, options) {
       s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1);
+        s1 = peg$c82(s1);
       }
       s0 = s1;
     }
@@ -2639,12 +2634,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
-    if (input.substr(peg$currPos, 3) === peg$c81) {
-      s2 = peg$c81;
+    if (input.substr(peg$currPos, 3) === peg$c83) {
+      s2 = peg$c83;
       peg$currPos += 3;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c82); }
+      if (peg$silentFails === 0) { peg$fail(peg$c84); }
     }
     if (s2 === peg$FAILED) {
       if (input.substr(peg$currPos, 3) === peg$c26) {
@@ -2698,7 +2693,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c83(s2, s6, s9);
+                      s1 = peg$c85(s2, s6, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -2746,12 +2741,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c84) {
-        s2 = peg$c84;
+      if (input.substr(peg$currPos, 5) === peg$c86) {
+        s2 = peg$c86;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        if (peg$silentFails === 0) { peg$fail(peg$c87); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -2792,11 +2787,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c75;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2827,11 +2822,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c75;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c76); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2859,7 +2854,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c86(s1, s2);
+        s1 = peg$c88(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2915,12 +2910,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c87) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c89) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c88); }
+      if (peg$silentFails === 0) { peg$fail(peg$c90); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -2931,7 +2926,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c89(s2, s5);
+            s4 = peg$c91(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2946,7 +2941,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c90(s2, s3);
+          s1 = peg$c92(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2975,7 +2970,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c91(s4);
+        s3 = peg$c93(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -2993,7 +2988,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c91(s4);
+          s3 = peg$c93(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3006,7 +3001,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c92(s1);
+      s1 = peg$c94(s1);
     }
     s0 = s1;
 
@@ -3017,55 +3012,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c93) {
-      s1 = peg$c93;
+    if (input.substr(peg$currPos, 2) === peg$c95) {
+      s1 = peg$c95;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      if (peg$silentFails === 0) { peg$fail(peg$c96); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c95();
+      s1 = peg$c97();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c96) {
-        s1 = peg$c96;
+      if (input.substr(peg$currPos, 6) === peg$c98) {
+        s1 = peg$c98;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+        if (peg$silentFails === 0) { peg$fail(peg$c99); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c98) {
-            s4 = peg$c98;
+          if (input.substr(peg$currPos, 5) === peg$c100) {
+            s4 = peg$c100;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c99); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c100) {
-              s4 = peg$c100;
+            if (input.substr(peg$currPos, 4) === peg$c102) {
+              s4 = peg$c102;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c101); }
+              if (peg$silentFails === 0) { peg$fail(peg$c103); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c102();
+            s4 = peg$c104();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c103(s3);
+            s1 = peg$c105(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3088,12 +3083,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c104) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c106) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c105); }
+      if (peg$silentFails === 0) { peg$fail(peg$c107); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -3102,7 +3097,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c106(s4);
+          s3 = peg$c108(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3119,12 +3114,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c107) {
-            s5 = peg$c107;
+          if (input.substr(peg$currPos, 6) === peg$c109) {
+            s5 = peg$c109;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c108); }
+            if (peg$silentFails === 0) { peg$fail(peg$c110); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3147,7 +3142,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c109(s2, s3, s6);
+              s5 = peg$c111(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3162,7 +3157,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c110(s2, s3, s4);
+            s1 = peg$c112(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3188,12 +3183,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c111) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c113) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c112); }
+      if (peg$silentFails === 0) { peg$fail(peg$c114); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseCutArgs();
@@ -3203,7 +3198,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFlexAssignments();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c113(s2, s4);
+            s1 = peg$c115(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3233,16 +3228,16 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     s3 = peg$parse_();
     if (s3 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c114) {
-        s4 = peg$c114;
+      if (input.substr(peg$currPos, 2) === peg$c116) {
+        s4 = peg$c116;
         peg$currPos += 2;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c116();
+        s3 = peg$c118();
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3257,16 +3252,16 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c114) {
-          s4 = peg$c114;
+        if (input.substr(peg$currPos, 2) === peg$c116) {
+          s4 = peg$c116;
           peg$currPos += 2;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+          if (peg$silentFails === 0) { peg$fail(peg$c117); }
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c116();
+          s3 = peg$c118();
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3279,7 +3274,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c117(s1);
+      s1 = peg$c119(s1);
     }
     s0 = s1;
 
@@ -3290,12 +3285,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c118) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c120) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c119); }
+      if (peg$silentFails === 0) { peg$fail(peg$c121); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3303,7 +3298,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c120(s3);
+          s1 = peg$c122(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3319,16 +3314,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c118) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c120) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c119); }
+        if (peg$silentFails === 0) { peg$fail(peg$c121); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c121();
+        s1 = peg$c123();
       }
       s0 = s1;
     }
@@ -3340,12 +3335,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c122) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c124) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c123); }
+      if (peg$silentFails === 0) { peg$fail(peg$c125); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3353,7 +3348,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c124(s3);
+          s1 = peg$c126(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3369,16 +3364,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c122) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c124) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c123); }
+        if (peg$silentFails === 0) { peg$fail(peg$c125); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c125();
+        s1 = peg$c127();
       }
       s0 = s1;
     }
@@ -3390,12 +3385,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c126) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c128) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c127); }
+      if (peg$silentFails === 0) { peg$fail(peg$c129); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3425,26 +3420,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c130) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c129); }
+      if (peg$silentFails === 0) { peg$fail(peg$c131); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c114) {
-          s3 = peg$c114;
+        if (input.substr(peg$currPos, 2) === peg$c116) {
+          s3 = peg$c116;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+          if (peg$silentFails === 0) { peg$fail(peg$c117); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c130();
+          s1 = peg$c132();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3460,16 +3455,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c130) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c129); }
+        if (peg$silentFails === 0) { peg$fail(peg$c131); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c131();
+        s1 = peg$c133();
       }
       s0 = s1;
     }
@@ -3481,12 +3476,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c132) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c134) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c133); }
+      if (peg$silentFails === 0) { peg$fail(peg$c135); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3494,7 +3489,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c134(s3);
+          s1 = peg$c136(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3516,12 +3511,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c135) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c137) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c136); }
+      if (peg$silentFails === 0) { peg$fail(peg$c138); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3533,11 +3528,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c73;
+              s7 = peg$c75;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c74); }
+              if (peg$silentFails === 0) { peg$fail(peg$c76); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -3545,7 +3540,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c137(s3, s9);
+                  s6 = peg$c139(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -3569,11 +3564,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c73;
+                s7 = peg$c75;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                if (peg$silentFails === 0) { peg$fail(peg$c76); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -3581,7 +3576,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c137(s3, s9);
+                    s6 = peg$c139(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -3602,7 +3597,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c138(s3, s4);
+            s1 = peg$c140(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3628,16 +3623,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c141) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c142); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c141();
+      s1 = peg$c143();
     }
     s0 = s1;
 
@@ -3648,12 +3643,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c142) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c144) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      if (peg$silentFails === 0) { peg$fail(peg$c145); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3663,11 +3658,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 61) {
-              s5 = peg$c77;
+              s5 = peg$c79;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c78); }
+              if (peg$silentFails === 0) { peg$fail(peg$c80); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
@@ -3694,7 +3689,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c144(s3, s7, s8);
+                    s1 = peg$c146(s3, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3730,12 +3725,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c142) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c144) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+        if (peg$silentFails === 0) { peg$fail(peg$c145); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -3762,7 +3757,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c145(s3, s4);
+              s1 = peg$c147(s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3834,11 +3829,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c146;
+      s1 = peg$c148;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c147); }
+      if (peg$silentFails === 0) { peg$fail(peg$c149); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -3861,7 +3856,7 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifier();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c148(s3);
+          s1 = peg$c150(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3878,11 +3873,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c146;
+        s1 = peg$c148;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c147); }
+        if (peg$silentFails === 0) { peg$fail(peg$c149); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
@@ -3897,7 +3892,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c149();
+          s1 = peg$c151();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3923,11 +3918,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c75;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3958,11 +3953,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c75;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c76); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3990,7 +3985,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c150(s1, s2);
+        s1 = peg$c152(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4015,11 +4010,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c75;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -4050,11 +4045,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c75;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c76); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -4082,7 +4077,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c150(s1, s2);
+        s1 = peg$c152(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4105,11 +4100,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c77;
+          s3 = peg$c79;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4117,7 +4112,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c151(s1, s5);
+              s1 = peg$c153(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4160,11 +4155,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c152;
+          s3 = peg$c154;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c153); }
+          if (peg$silentFails === 0) { peg$fail(peg$c155); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4174,11 +4169,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c154;
+                  s7 = peg$c156;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c155); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c157); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -4186,7 +4181,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c156(s1, s5, s9);
+                      s1 = peg$c158(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4248,7 +4243,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c157(s1, s5, s7);
+              s4 = peg$c159(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4278,7 +4273,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c157(s1, s5, s7);
+                s4 = peg$c159(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4299,7 +4294,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c160(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4330,7 +4325,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c157(s1, s5, s7);
+              s4 = peg$c159(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4360,7 +4355,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c157(s1, s5, s7);
+                s4 = peg$c159(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4381,7 +4376,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c160(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4412,7 +4407,7 @@ function peg$parse(input, options) {
             s7 = peg$parseRelativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c159(s1, s5, s7);
+              s4 = peg$c161(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4442,7 +4437,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c159(s1, s5, s7);
+                s4 = peg$c161(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4463,7 +4458,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c160(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4481,43 +4476,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c160) {
-      s1 = peg$c160;
+    if (input.substr(peg$currPos, 2) === peg$c162) {
+      s1 = peg$c162;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c161); }
+      if (peg$silentFails === 0) { peg$fail(peg$c163); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c162) {
-        s1 = peg$c162;
+      if (input.substr(peg$currPos, 2) === peg$c164) {
+        s1 = peg$c164;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c165); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c77;
+          s1 = peg$c79;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c164) {
-            s1 = peg$c164;
+          if (input.substr(peg$currPos, 2) === peg$c166) {
+            s1 = peg$c166;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c165); }
+            if (peg$silentFails === 0) { peg$fail(peg$c167); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -4530,16 +4525,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c166) {
-        s1 = peg$c166;
+      if (input.substr(peg$currPos, 2) === peg$c168) {
+        s1 = peg$c168;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c167); }
+        if (peg$silentFails === 0) { peg$fail(peg$c169); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -4564,7 +4559,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c157(s1, s5, s7);
+              s4 = peg$c159(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4594,7 +4589,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c157(s1, s5, s7);
+                s4 = peg$c159(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4615,7 +4610,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c160(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4633,43 +4628,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c168) {
-      s1 = peg$c168;
+    if (input.substr(peg$currPos, 2) === peg$c170) {
+      s1 = peg$c170;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c169); }
+      if (peg$silentFails === 0) { peg$fail(peg$c171); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c170;
+        s1 = peg$c172;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c171); }
+        if (peg$silentFails === 0) { peg$fail(peg$c173); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c172) {
-          s1 = peg$c172;
+        if (input.substr(peg$currPos, 2) === peg$c174) {
+          s1 = peg$c174;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c173); }
+          if (peg$silentFails === 0) { peg$fail(peg$c175); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c174;
+            s1 = peg$c176;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c175); }
+            if (peg$silentFails === 0) { peg$fail(peg$c177); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -4693,7 +4688,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c157(s1, s5, s7);
+              s4 = peg$c159(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4723,7 +4718,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c157(s1, s5, s7);
+                s4 = peg$c159(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4744,7 +4739,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c160(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4763,11 +4758,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c176;
+      s1 = peg$c178;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c177); }
+      if (peg$silentFails === 0) { peg$fail(peg$c179); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
@@ -4780,7 +4775,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -4804,7 +4799,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c157(s1, s5, s7);
+              s4 = peg$c159(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4834,7 +4829,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c157(s1, s5, s7);
+                s4 = peg$c159(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4855,7 +4850,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c160(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4882,16 +4877,16 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c178;
+        s1 = peg$c180;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c181); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -4915,7 +4910,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c180(s3);
+          s1 = peg$c182(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4944,17 +4939,17 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 58) {
-        s3 = peg$c154;
+        s3 = peg$c156;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c157); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parsePrimitiveType();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c181(s1, s4);
+          s3 = peg$c183(s1, s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4966,7 +4961,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c182(s1, s2);
+        s1 = peg$c184(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4987,164 +4982,164 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c183) {
-      s1 = peg$c183;
+    if (input.substr(peg$currPos, 5) === peg$c185) {
+      s1 = peg$c185;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c184); }
+      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c185) {
-        s1 = peg$c185;
+      if (input.substr(peg$currPos, 5) === peg$c187) {
+        s1 = peg$c187;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c186); }
+        if (peg$silentFails === 0) { peg$fail(peg$c188); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c187) {
-          s1 = peg$c187;
+        if (input.substr(peg$currPos, 6) === peg$c189) {
+          s1 = peg$c189;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c188); }
+          if (peg$silentFails === 0) { peg$fail(peg$c190); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c189) {
-            s1 = peg$c189;
+          if (input.substr(peg$currPos, 6) === peg$c191) {
+            s1 = peg$c191;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c190); }
+            if (peg$silentFails === 0) { peg$fail(peg$c192); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c191) {
-              s1 = peg$c191;
+            if (input.substr(peg$currPos, 6) === peg$c193) {
+              s1 = peg$c193;
               peg$currPos += 6;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c192); }
+              if (peg$silentFails === 0) { peg$fail(peg$c194); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4) === peg$c193) {
-                s1 = peg$c193;
+              if (input.substr(peg$currPos, 4) === peg$c195) {
+                s1 = peg$c195;
                 peg$currPos += 4;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c194); }
+                if (peg$silentFails === 0) { peg$fail(peg$c196); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c195) {
-                  s1 = peg$c195;
+                if (input.substr(peg$currPos, 5) === peg$c197) {
+                  s1 = peg$c197;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c196); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c198); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c197) {
-                    s1 = peg$c197;
+                  if (input.substr(peg$currPos, 5) === peg$c199) {
+                    s1 = peg$c199;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c198); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c200); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c199) {
-                      s1 = peg$c199;
+                    if (input.substr(peg$currPos, 5) === peg$c201) {
+                      s1 = peg$c201;
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c200); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c202); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 8) === peg$c201) {
-                        s1 = peg$c201;
+                      if (input.substr(peg$currPos, 8) === peg$c203) {
+                        s1 = peg$c203;
                         peg$currPos += 8;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c202); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c204); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c203) {
-                          s1 = peg$c203;
+                        if (input.substr(peg$currPos, 4) === peg$c205) {
+                          s1 = peg$c205;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c204); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c206); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 7) === peg$c205) {
-                            s1 = peg$c205;
+                          if (input.substr(peg$currPos, 7) === peg$c207) {
+                            s1 = peg$c207;
                             peg$currPos += 7;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c206); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c208); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 4) === peg$c207) {
-                              s1 = peg$c207;
+                            if (input.substr(peg$currPos, 4) === peg$c209) {
+                              s1 = peg$c209;
                               peg$currPos += 4;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c208); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c210); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 5) === peg$c183) {
-                                s1 = peg$c183;
+                              if (input.substr(peg$currPos, 5) === peg$c185) {
+                                s1 = peg$c185;
                                 peg$currPos += 5;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c184); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c186); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 6) === peg$c209) {
-                                  s1 = peg$c209;
+                                if (input.substr(peg$currPos, 6) === peg$c211) {
+                                  s1 = peg$c211;
                                   peg$currPos += 6;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c210); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c212); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 7) === peg$c211) {
-                                    s1 = peg$c211;
+                                  if (input.substr(peg$currPos, 7) === peg$c213) {
+                                    s1 = peg$c213;
                                     peg$currPos += 7;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c212); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c214); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c213) {
-                                      s1 = peg$c213;
+                                    if (input.substr(peg$currPos, 2) === peg$c215) {
+                                      s1 = peg$c215;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c214); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c216); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c215) {
-                                        s1 = peg$c215;
+                                      if (input.substr(peg$currPos, 3) === peg$c217) {
+                                        s1 = peg$c217;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c218); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c217) {
-                                          s1 = peg$c217;
+                                        if (input.substr(peg$currPos, 4) === peg$c219) {
+                                          s1 = peg$c219;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c218); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c220); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 5) === peg$c219) {
-                                            s1 = peg$c219;
+                                          if (input.substr(peg$currPos, 5) === peg$c221) {
+                                            s1 = peg$c221;
                                             peg$currPos += 5;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c220); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c222); }
                                           }
                                           if (s1 === peg$FAILED) {
                                             if (input.substr(peg$currPos, 4) === peg$c47) {
@@ -5176,7 +5171,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -5197,7 +5192,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c221(s1, s2);
+        s1 = peg$c223(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5244,7 +5239,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c222(s1, s4);
+              s1 = peg$c224(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5280,11 +5275,11 @@ function peg$parse(input, options) {
       s3 = peg$parseIdentifierRest();
       if (s3 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c146;
+          s3 = peg$c148;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c147); }
+          if (peg$silentFails === 0) { peg$fail(peg$c149); }
         }
       }
       while (s3 !== peg$FAILED) {
@@ -5292,17 +5287,17 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifierRest();
         if (s3 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s3 = peg$c146;
+            s3 = peg$c148;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c147); }
+            if (peg$silentFails === 0) { peg$fail(peg$c149); }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c104();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5327,11 +5322,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c75;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5339,7 +5334,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c223(s1, s7);
+              s4 = peg$c225(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5363,11 +5358,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c75;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c76); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5375,7 +5370,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c223(s1, s7);
+                s4 = peg$c225(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5396,7 +5391,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c76(s1, s2);
+        s1 = peg$c78(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5411,7 +5406,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c224();
+        s1 = peg$c226();
       }
       s0 = s1;
     }
@@ -5433,7 +5428,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c221(s1, s2);
+        s1 = peg$c223(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5452,25 +5447,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c225;
+      s1 = peg$c227;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+      if (peg$silentFails === 0) { peg$fail(peg$c228); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseConditionalExpr();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c227;
+          s3 = peg$c229;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c228); }
+          if (peg$silentFails === 0) { peg$fail(peg$c230); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c229(s2);
+          s1 = peg$c231(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5487,21 +5482,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c146;
+        s1 = peg$c148;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c147); }
+        if (peg$silentFails === 0) { peg$fail(peg$c149); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c146;
+          s3 = peg$c148;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c147); }
+          if (peg$silentFails === 0) { peg$fail(peg$c149); }
         }
         peg$silentFails--;
         if (s3 === peg$FAILED) {
@@ -5514,7 +5509,7 @@ function peg$parse(input, options) {
           s3 = peg$parseIdentifier();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c230(s3);
+            s1 = peg$c232(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5625,16 +5620,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c231) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c233) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c232); }
+      if (peg$silentFails === 0) { peg$fail(peg$c234); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -5645,16 +5640,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c233) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c235) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
+      if (peg$silentFails === 0) { peg$fail(peg$c236); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -5665,16 +5660,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c166) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c168) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c237); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -5685,16 +5680,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c81) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c83) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c236); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -5715,7 +5710,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c104();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5732,12 +5727,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c237.test(input.charAt(peg$currPos))) {
+    if (peg$c239.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
 
     return s0;
@@ -5748,12 +5743,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c239.test(input.charAt(peg$currPos))) {
+      if (peg$c241.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c240); }
+        if (peg$silentFails === 0) { peg$fail(peg$c242); }
       }
     }
 
@@ -5774,7 +5769,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c241();
+        s1 = peg$c243();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5802,12 +5797,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c231) {
-                s3 = peg$c231;
+              if (input.substr(peg$currPos, 3) === peg$c233) {
+                s3 = peg$c233;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c242); }
+                if (peg$silentFails === 0) { peg$fail(peg$c244); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -5852,44 +5847,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c243) {
-      s0 = peg$c243;
+    if (input.substr(peg$currPos, 7) === peg$c245) {
+      s0 = peg$c245;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c245) {
-        s0 = peg$c245;
+      if (input.substr(peg$currPos, 6) === peg$c247) {
+        s0 = peg$c247;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c246); }
+        if (peg$silentFails === 0) { peg$fail(peg$c248); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c247) {
-          s0 = peg$c247;
+        if (input.substr(peg$currPos, 4) === peg$c249) {
+          s0 = peg$c249;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c248); }
+          if (peg$silentFails === 0) { peg$fail(peg$c250); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c249) {
-            s0 = peg$c249;
+          if (input.substr(peg$currPos, 3) === peg$c251) {
+            s0 = peg$c251;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c250); }
+            if (peg$silentFails === 0) { peg$fail(peg$c252); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c251;
+              s0 = peg$c253;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c252); }
+              if (peg$silentFails === 0) { peg$fail(peg$c254); }
             }
           }
         }
@@ -5902,44 +5897,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c253) {
-      s0 = peg$c253;
+    if (input.substr(peg$currPos, 7) === peg$c255) {
+      s0 = peg$c255;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c254); }
+      if (peg$silentFails === 0) { peg$fail(peg$c256); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c255) {
-        s0 = peg$c255;
+      if (input.substr(peg$currPos, 6) === peg$c257) {
+        s0 = peg$c257;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c256); }
+        if (peg$silentFails === 0) { peg$fail(peg$c258); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c257) {
-          s0 = peg$c257;
+        if (input.substr(peg$currPos, 4) === peg$c259) {
+          s0 = peg$c259;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c258); }
+          if (peg$silentFails === 0) { peg$fail(peg$c260); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c259) {
-            s0 = peg$c259;
+          if (input.substr(peg$currPos, 3) === peg$c261) {
+            s0 = peg$c261;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c260); }
+            if (peg$silentFails === 0) { peg$fail(peg$c262); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c261;
+              s0 = peg$c263;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c262); }
+              if (peg$silentFails === 0) { peg$fail(peg$c264); }
             }
           }
         }
@@ -5952,44 +5947,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c263) {
-      s0 = peg$c263;
+    if (input.substr(peg$currPos, 5) === peg$c265) {
+      s0 = peg$c265;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c266); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c265) {
-        s0 = peg$c265;
+      if (input.substr(peg$currPos, 3) === peg$c267) {
+        s0 = peg$c267;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c267) {
-          s0 = peg$c267;
+        if (input.substr(peg$currPos, 2) === peg$c269) {
+          s0 = peg$c269;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c268); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c269;
+            s0 = peg$c271;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c270); }
+            if (peg$silentFails === 0) { peg$fail(peg$c272); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c271) {
-              s0 = peg$c271;
+            if (input.substr(peg$currPos, 4) === peg$c273) {
+              s0 = peg$c273;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c272); }
+              if (peg$silentFails === 0) { peg$fail(peg$c274); }
             }
           }
         }
@@ -6002,28 +5997,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c273) {
-      s0 = peg$c273;
+    if (input.substr(peg$currPos, 4) === peg$c275) {
+      s0 = peg$c275;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c274); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c275) {
-        s0 = peg$c275;
+      if (input.substr(peg$currPos, 3) === peg$c277) {
+        s0 = peg$c277;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c276); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c277;
+          s0 = peg$c279;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c278); }
+          if (peg$silentFails === 0) { peg$fail(peg$c280); }
         }
       }
     }
@@ -6034,44 +6029,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c279) {
-      s0 = peg$c279;
+    if (input.substr(peg$currPos, 5) === peg$c281) {
+      s0 = peg$c281;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c282); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c281) {
-        s0 = peg$c281;
+      if (input.substr(peg$currPos, 4) === peg$c283) {
+        s0 = peg$c283;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c284); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c283) {
-          s0 = peg$c283;
+        if (input.substr(peg$currPos, 3) === peg$c285) {
+          s0 = peg$c285;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c284); }
+          if (peg$silentFails === 0) { peg$fail(peg$c286); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c285) {
-            s0 = peg$c285;
+          if (input.substr(peg$currPos, 2) === peg$c287) {
+            s0 = peg$c287;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c286); }
+            if (peg$silentFails === 0) { peg$fail(peg$c288); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c287;
+              s0 = peg$c289;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c288); }
+              if (peg$silentFails === 0) { peg$fail(peg$c290); }
             }
           }
         }
@@ -6085,16 +6080,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c245) {
-      s1 = peg$c245;
+    if (input.substr(peg$currPos, 6) === peg$c247) {
+      s1 = peg$c247;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c248); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c289();
+      s1 = peg$c291();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6106,7 +6101,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c290(s1);
+            s1 = peg$c292(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6129,16 +6124,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c255) {
-      s1 = peg$c255;
+    if (input.substr(peg$currPos, 6) === peg$c257) {
+      s1 = peg$c257;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c256); }
+      if (peg$silentFails === 0) { peg$fail(peg$c258); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c291();
+      s1 = peg$c293();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6150,7 +6145,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c292(s1);
+            s1 = peg$c294(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6173,16 +6168,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c271) {
-      s1 = peg$c271;
+    if (input.substr(peg$currPos, 4) === peg$c273) {
+      s1 = peg$c273;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c272); }
+      if (peg$silentFails === 0) { peg$fail(peg$c274); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c293();
+      s1 = peg$c295();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6194,7 +6189,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c294(s1);
+            s1 = peg$c296(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6217,16 +6212,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c275) {
-      s1 = peg$c275;
+    if (input.substr(peg$currPos, 3) === peg$c277) {
+      s1 = peg$c277;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c276); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c295();
+      s1 = peg$c297();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6238,7 +6233,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c296(s1);
+            s1 = peg$c298(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6261,16 +6256,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c281) {
-      s1 = peg$c281;
+    if (input.substr(peg$currPos, 4) === peg$c283) {
+      s1 = peg$c283;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c284); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c297();
+      s1 = peg$c299();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6282,7 +6277,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c298(s1);
+            s1 = peg$c300(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6308,37 +6303,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c146;
+        s2 = peg$c148;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c147); }
+        if (peg$silentFails === 0) { peg$fail(peg$c149); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c146;
+            s4 = peg$c148;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c147); }
+            if (peg$silentFails === 0) { peg$fail(peg$c149); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c146;
+                s6 = peg$c148;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c147); }
+                if (peg$silentFails === 0) { peg$fail(peg$c149); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c102();
+                  s1 = peg$c104();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6390,7 +6385,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c301(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6411,12 +6406,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c300) {
-            s3 = peg$c300;
+          if (input.substr(peg$currPos, 2) === peg$c302) {
+            s3 = peg$c302;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c301); }
+            if (peg$silentFails === 0) { peg$fail(peg$c303); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6429,7 +6424,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c302(s1, s2, s4, s5);
+                s1 = peg$c304(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6453,12 +6448,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c300) {
-          s1 = peg$c300;
+        if (input.substr(peg$currPos, 2) === peg$c302) {
+          s1 = peg$c302;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c301); }
+          if (peg$silentFails === 0) { peg$fail(peg$c303); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6471,7 +6466,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c303(s2, s3);
+              s1 = peg$c305(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6496,16 +6491,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c300) {
-                s3 = peg$c300;
+              if (input.substr(peg$currPos, 2) === peg$c302) {
+                s3 = peg$c302;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c301); }
+                if (peg$silentFails === 0) { peg$fail(peg$c303); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c304(s1, s2);
+                s1 = peg$c306(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6521,16 +6516,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c300) {
-              s1 = peg$c300;
+            if (input.substr(peg$currPos, 2) === peg$c302) {
+              s1 = peg$c302;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c301); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c305();
+              s1 = peg$c307();
             }
             s0 = s1;
           }
@@ -6557,17 +6552,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c154;
+      s1 = peg$c156;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+      if (peg$silentFails === 0) { peg$fail(peg$c157); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c306(s2);
+        s1 = peg$c308(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6588,15 +6583,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c154;
+        s2 = peg$c156;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c157); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c307(s1);
+        s1 = peg$c309(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6617,17 +6612,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c178;
+        s2 = peg$c180;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c181); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c308(s1, s3);
+          s1 = peg$c310(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6652,17 +6647,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c178;
+        s2 = peg$c180;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c181); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c309(s1, s3);
+          s1 = peg$c311(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6687,7 +6682,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c310(s1);
+      s1 = peg$c312(s1);
     }
     s0 = s1;
 
@@ -6710,22 +6705,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c239.test(input.charAt(peg$currPos))) {
+    if (peg$c241.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      if (peg$silentFails === 0) { peg$fail(peg$c242); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c239.test(input.charAt(peg$currPos))) {
+        if (peg$c241.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          if (peg$silentFails === 0) { peg$fail(peg$c242); }
         }
       }
     } else {
@@ -6733,7 +6728,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -6755,7 +6750,7 @@ function peg$parse(input, options) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c104();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6785,22 +6780,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c239.test(input.charAt(peg$currPos))) {
+      if (peg$c241.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c240); }
+        if (peg$silentFails === 0) { peg$fail(peg$c242); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c239.test(input.charAt(peg$currPos))) {
+          if (peg$c241.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c242); }
           }
         }
       } else {
@@ -6808,30 +6803,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c146;
+          s3 = peg$c148;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c147); }
+          if (peg$silentFails === 0) { peg$fail(peg$c149); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c239.test(input.charAt(peg$currPos))) {
+          if (peg$c241.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c242); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c239.test(input.charAt(peg$currPos))) {
+              if (peg$c241.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c240); }
+                if (peg$silentFails === 0) { peg$fail(peg$c242); }
               }
             }
           } else {
@@ -6844,7 +6839,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311();
+              s1 = peg$c313();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6880,30 +6875,30 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c146;
+          s2 = peg$c148;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c147); }
+          if (peg$silentFails === 0) { peg$fail(peg$c149); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c239.test(input.charAt(peg$currPos))) {
+          if (peg$c241.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c242); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c239.test(input.charAt(peg$currPos))) {
+              if (peg$c241.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c240); }
+                if (peg$silentFails === 0) { peg$fail(peg$c242); }
               }
             }
           } else {
@@ -6916,7 +6911,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311();
+              s1 = peg$c313();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6943,20 +6938,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c312) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c314) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c313); }
+      if (peg$silentFails === 0) { peg$fail(peg$c315); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c314.test(input.charAt(peg$currPos))) {
+      if (peg$c316.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c315); }
+        if (peg$silentFails === 0) { peg$fail(peg$c317); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -6998,7 +6993,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -7008,12 +7003,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c316.test(input.charAt(peg$currPos))) {
+    if (peg$c318.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c317); }
+      if (peg$silentFails === 0) { peg$fail(peg$c319); }
     }
 
     return s0;
@@ -7035,7 +7030,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c318(s1);
+      s1 = peg$c320(s1);
     }
     s0 = s1;
 
@@ -7047,11 +7042,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c319;
+      s1 = peg$c321;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c320); }
+      if (peg$silentFails === 0) { peg$fail(peg$c322); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
@@ -7074,12 +7069,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c321.test(input.charAt(peg$currPos))) {
+      if (peg$c323.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        if (peg$silentFails === 0) { peg$fail(peg$c324); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseWhiteSpace();
@@ -7097,11 +7092,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c323); }
+          if (peg$silentFails === 0) { peg$fail(peg$c325); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c102();
+          s1 = peg$c104();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7121,11 +7116,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c324;
+      s1 = peg$c326;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c327); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -7136,15 +7131,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c324;
+          s3 = peg$c326;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c325); }
+          if (peg$silentFails === 0) { peg$fail(peg$c327); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c326(s2);
+          s1 = peg$c328(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7161,11 +7156,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c327;
+        s1 = peg$c329;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c328); }
+        if (peg$silentFails === 0) { peg$fail(peg$c330); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7176,15 +7171,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c327;
+            s3 = peg$c329;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c328); }
+            if (peg$silentFails === 0) { peg$fail(peg$c330); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c326(s2);
+            s1 = peg$c328(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7210,11 +7205,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c324;
+      s2 = peg$c326;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c327); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -7232,11 +7227,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c323); }
+        if (peg$silentFails === 0) { peg$fail(peg$c325); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c104();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7249,11 +7244,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c319;
+        s1 = peg$c321;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c320); }
+        if (peg$silentFails === 0) { peg$fail(peg$c322); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -7281,11 +7276,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c327;
+      s2 = peg$c329;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -7303,11 +7298,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c323); }
+        if (peg$silentFails === 0) { peg$fail(peg$c325); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c104();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7320,11 +7315,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c319;
+        s1 = peg$c321;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c320); }
+        if (peg$silentFails === 0) { peg$fail(peg$c322); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -7350,11 +7345,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c329;
+      s1 = peg$c331;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c332); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -7362,7 +7357,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c331();
+          s1 = peg$c333();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7390,110 +7385,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c327;
+      s0 = peg$c329;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c324;
+        s0 = peg$c326;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c325); }
+        if (peg$silentFails === 0) { peg$fail(peg$c327); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c319;
+          s0 = peg$c321;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c320); }
+          if (peg$silentFails === 0) { peg$fail(peg$c322); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c332;
+            s1 = peg$c334;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c333); }
+            if (peg$silentFails === 0) { peg$fail(peg$c335); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c334();
+            s1 = peg$c336();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c335;
+              s1 = peg$c337;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c336); }
+              if (peg$silentFails === 0) { peg$fail(peg$c338); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c337();
+              s1 = peg$c339();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c338;
+                s1 = peg$c340;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c339); }
+                if (peg$silentFails === 0) { peg$fail(peg$c341); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c340();
+                s1 = peg$c342();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c341;
+                  s1 = peg$c343;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c342); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c344); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c343();
+                  s1 = peg$c345();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c344;
+                    s1 = peg$c346;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c345); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c347); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c346();
+                    s1 = peg$c348();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c347;
+                      s1 = peg$c349;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c350); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c349();
+                      s1 = peg$c351();
                     }
                     s0 = s1;
                   }
@@ -7513,15 +7508,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c77;
+      s1 = peg$c79;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c78); }
+      if (peg$silentFails === 0) { peg$fail(peg$c80); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c350();
+      s1 = peg$c352();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7535,7 +7530,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c351();
+        s1 = peg$c353();
       }
       s0 = s1;
     }
@@ -7548,11 +7543,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c352;
+      s1 = peg$c354;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+      if (peg$silentFails === 0) { peg$fail(peg$c355); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7584,7 +7579,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c354(s2);
+        s1 = peg$c356(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7597,19 +7592,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c352;
+        s1 = peg$c354;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c353); }
+        if (peg$silentFails === 0) { peg$fail(peg$c355); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c355;
+          s2 = peg$c357;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c356); }
+          if (peg$silentFails === 0) { peg$fail(peg$c358); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7668,15 +7663,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c357;
+              s4 = peg$c359;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c358); }
+              if (peg$silentFails === 0) { peg$fail(peg$c360); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c354(s3);
+              s1 = peg$c356(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7704,25 +7699,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c178;
+      s1 = peg$c180;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c179); }
+      if (peg$silentFails === 0) { peg$fail(peg$c181); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c178;
+          s3 = peg$c180;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c179); }
+          if (peg$silentFails === 0) { peg$fail(peg$c181); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c359(s2);
+          s1 = peg$c361(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7745,39 +7740,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c360.test(input.charAt(peg$currPos))) {
+    if (peg$c362.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c362) {
-        s2 = peg$c362;
+      if (input.substr(peg$currPos, 2) === peg$c364) {
+        s2 = peg$c364;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c363); }
+        if (peg$silentFails === 0) { peg$fail(peg$c365); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c360.test(input.charAt(peg$currPos))) {
+        if (peg$c362.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c361); }
+          if (peg$silentFails === 0) { peg$fail(peg$c363); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c362) {
-            s2 = peg$c362;
+          if (input.substr(peg$currPos, 2) === peg$c364) {
+            s2 = peg$c364;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c363); }
+            if (peg$silentFails === 0) { peg$fail(peg$c365); }
           }
         }
       }
@@ -7786,7 +7781,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -7796,12 +7791,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c364.test(input.charAt(peg$currPos))) {
+    if (peg$c366.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
 
     return s0;
@@ -7859,7 +7854,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c323); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
 
     return s0;
@@ -7870,51 +7865,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c367;
+      s0 = peg$c369;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c370); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c369;
+        s0 = peg$c371;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c370); }
+        if (peg$silentFails === 0) { peg$fail(peg$c372); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c371;
+          s0 = peg$c373;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c372); }
+          if (peg$silentFails === 0) { peg$fail(peg$c374); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c373;
+            s0 = peg$c375;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c374); }
+            if (peg$silentFails === 0) { peg$fail(peg$c376); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c375;
+              s0 = peg$c377;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c376); }
+              if (peg$silentFails === 0) { peg$fail(peg$c378); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c377;
+                s0 = peg$c379;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c378); }
+                if (peg$silentFails === 0) { peg$fail(peg$c380); }
               }
             }
           }
@@ -7923,7 +7918,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
 
     return s0;
@@ -7932,12 +7927,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c379.test(input.charAt(peg$currPos))) {
+    if (peg$c381.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c380); }
+      if (peg$silentFails === 0) { peg$fail(peg$c382); }
     }
 
     return s0;
@@ -7950,7 +7945,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c381); }
+      if (peg$silentFails === 0) { peg$fail(peg$c383); }
     }
 
     return s0;
@@ -7960,12 +7955,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c386) {
-      s1 = peg$c386;
+    if (input.substr(peg$currPos, 2) === peg$c388) {
+      s1 = peg$c388;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c387); }
+      if (peg$silentFails === 0) { peg$fail(peg$c389); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -8045,7 +8040,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c323); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -1052,28 +1052,28 @@ var g = &grammar{
 		},
 		{
 			name: "SequentialProcs",
-			pos:  position{line: 158, col: 1, offset: 5052},
+			pos:  position{line: 158, col: 1, offset: 5065},
 			expr: &actionExpr{
-				pos: position{line: 159, col: 5, offset: 5072},
+				pos: position{line: 159, col: 5, offset: 5085},
 				run: (*parser).callonSequentialProcs1,
 				expr: &seqExpr{
-					pos: position{line: 159, col: 5, offset: 5072},
+					pos: position{line: 159, col: 5, offset: 5085},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 159, col: 5, offset: 5072},
+							pos:   position{line: 159, col: 5, offset: 5085},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 159, col: 11, offset: 5078},
+								pos:  position{line: 159, col: 11, offset: 5091},
 								name: "Proc",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 159, col: 16, offset: 5083},
+							pos:   position{line: 159, col: 16, offset: 5096},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 159, col: 21, offset: 5088},
+								pos: position{line: 159, col: 21, offset: 5101},
 								expr: &ruleRefExpr{
-									pos:  position{line: 159, col: 21, offset: 5088},
+									pos:  position{line: 159, col: 21, offset: 5101},
 									name: "SequentialTail",
 								},
 							},
@@ -1084,31 +1084,31 @@ var g = &grammar{
 		},
 		{
 			name: "SequentialTail",
-			pos:  position{line: 166, col: 1, offset: 5259},
+			pos:  position{line: 166, col: 1, offset: 5272},
 			expr: &actionExpr{
-				pos: position{line: 166, col: 18, offset: 5276},
+				pos: position{line: 166, col: 18, offset: 5289},
 				run: (*parser).callonSequentialTail1,
 				expr: &seqExpr{
-					pos: position{line: 166, col: 18, offset: 5276},
+					pos: position{line: 166, col: 18, offset: 5289},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 166, col: 18, offset: 5276},
+							pos:  position{line: 166, col: 18, offset: 5289},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 166, col: 21, offset: 5279},
+							pos:        position{line: 166, col: 21, offset: 5292},
 							val:        "|",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 166, col: 25, offset: 5283},
+							pos:  position{line: 166, col: 25, offset: 5296},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 166, col: 28, offset: 5286},
+							pos:   position{line: 166, col: 28, offset: 5299},
 							label: "p",
 							expr: &ruleRefExpr{
-								pos:  position{line: 166, col: 30, offset: 5288},
+								pos:  position{line: 166, col: 30, offset: 5301},
 								name: "Proc",
 							},
 						},
@@ -1118,47 +1118,47 @@ var g = &grammar{
 		},
 		{
 			name: "Proc",
-			pos:  position{line: 168, col: 1, offset: 5312},
+			pos:  position{line: 168, col: 1, offset: 5325},
 			expr: &choiceExpr{
-				pos: position{line: 169, col: 5, offset: 5321},
+				pos: position{line: 169, col: 5, offset: 5334},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 169, col: 5, offset: 5321},
+						pos:  position{line: 169, col: 5, offset: 5334},
 						name: "NamedProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 170, col: 5, offset: 5335},
+						pos:  position{line: 170, col: 5, offset: 5348},
 						name: "GroupByProc",
 					},
 					&actionExpr{
-						pos: position{line: 171, col: 5, offset: 5351},
+						pos: position{line: 171, col: 5, offset: 5364},
 						run: (*parser).callonProc4,
 						expr: &seqExpr{
-							pos: position{line: 171, col: 5, offset: 5351},
+							pos: position{line: 171, col: 5, offset: 5364},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 171, col: 5, offset: 5351},
+									pos:        position{line: 171, col: 5, offset: 5364},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 171, col: 9, offset: 5355},
+									pos:  position{line: 171, col: 9, offset: 5368},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 171, col: 12, offset: 5358},
+									pos:   position{line: 171, col: 12, offset: 5371},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 171, col: 17, offset: 5363},
+										pos:  position{line: 171, col: 17, offset: 5376},
 										name: "Procs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 171, col: 23, offset: 5369},
+									pos:  position{line: 171, col: 23, offset: 5382},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 171, col: 26, offset: 5372},
+									pos:        position{line: 171, col: 26, offset: 5385},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -1170,28 +1170,28 @@ var g = &grammar{
 		},
 		{
 			name: "Procs",
-			pos:  position{line: 175, col: 1, offset: 5408},
+			pos:  position{line: 175, col: 1, offset: 5421},
 			expr: &actionExpr{
-				pos: position{line: 176, col: 5, offset: 5418},
+				pos: position{line: 176, col: 5, offset: 5431},
 				run: (*parser).callonProcs1,
 				expr: &seqExpr{
-					pos: position{line: 176, col: 5, offset: 5418},
+					pos: position{line: 176, col: 5, offset: 5431},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 176, col: 5, offset: 5418},
+							pos:   position{line: 176, col: 5, offset: 5431},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 176, col: 11, offset: 5424},
+								pos:  position{line: 176, col: 11, offset: 5437},
 								name: "SequentialProcs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 176, col: 27, offset: 5440},
+							pos:   position{line: 176, col: 27, offset: 5453},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 176, col: 32, offset: 5445},
+								pos: position{line: 176, col: 32, offset: 5458},
 								expr: &ruleRefExpr{
-									pos:  position{line: 176, col: 32, offset: 5445},
+									pos:  position{line: 176, col: 32, offset: 5458},
 									name: "ParallelTail",
 								},
 							},
@@ -1202,31 +1202,31 @@ var g = &grammar{
 		},
 		{
 			name: "ParallelTail",
-			pos:  position{line: 185, col: 1, offset: 5744},
+			pos:  position{line: 185, col: 1, offset: 5757},
 			expr: &actionExpr{
-				pos: position{line: 186, col: 5, offset: 5761},
+				pos: position{line: 186, col: 5, offset: 5774},
 				run: (*parser).callonParallelTail1,
 				expr: &seqExpr{
-					pos: position{line: 186, col: 5, offset: 5761},
+					pos: position{line: 186, col: 5, offset: 5774},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 5, offset: 5761},
+							pos:  position{line: 186, col: 5, offset: 5774},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 186, col: 8, offset: 5764},
+							pos:        position{line: 186, col: 8, offset: 5777},
 							val:        ";",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 12, offset: 5768},
+							pos:  position{line: 186, col: 12, offset: 5781},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 186, col: 15, offset: 5771},
+							pos:   position{line: 186, col: 15, offset: 5784},
 							label: "ch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 186, col: 18, offset: 5774},
+								pos:  position{line: 186, col: 18, offset: 5787},
 								name: "SequentialProcs",
 							},
 						},
@@ -1236,88 +1236,85 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByProc",
-			pos:  position{line: 188, col: 1, offset: 5867},
+			pos:  position{line: 188, col: 1, offset: 5880},
 			expr: &choiceExpr{
-				pos: position{line: 189, col: 5, offset: 5883},
+				pos: position{line: 189, col: 5, offset: 5896},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 189, col: 5, offset: 5883},
+						pos: position{line: 189, col: 5, offset: 5896},
 						run: (*parser).callonGroupByProc2,
 						expr: &seqExpr{
-							pos: position{line: 189, col: 5, offset: 5883},
+							pos: position{line: 189, col: 5, offset: 5896},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 189, col: 5, offset: 5883},
+									pos:   position{line: 189, col: 5, offset: 5896},
 									label: "every",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 189, col: 11, offset: 5889},
+										pos: position{line: 189, col: 11, offset: 5902},
 										expr: &ruleRefExpr{
-											pos:  position{line: 189, col: 11, offset: 5889},
+											pos:  position{line: 189, col: 11, offset: 5902},
 											name: "EveryDur",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 189, col: 21, offset: 5899},
+									pos:   position{line: 189, col: 21, offset: 5912},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 189, col: 26, offset: 5904},
+										pos:  position{line: 189, col: 26, offset: 5917},
 										name: "GroupByKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 189, col: 38, offset: 5916},
+									pos:   position{line: 189, col: 38, offset: 5929},
 									label: "limit",
-									expr: &zeroOrOneExpr{
-										pos: position{line: 189, col: 44, offset: 5922},
-										expr: &ruleRefExpr{
-											pos:  position{line: 189, col: 44, offset: 5922},
-											name: "LimitArg",
-										},
+									expr: &ruleRefExpr{
+										pos:  position{line: 189, col: 44, offset: 5935},
+										name: "LimitArg",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 199, col: 5, offset: 6157},
-						run: (*parser).callonGroupByProc12,
+						pos: position{line: 192, col: 5, offset: 6084},
+						run: (*parser).callonGroupByProc11,
 						expr: &seqExpr{
-							pos: position{line: 199, col: 5, offset: 6157},
+							pos: position{line: 192, col: 5, offset: 6084},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 199, col: 5, offset: 6157},
+									pos:   position{line: 192, col: 5, offset: 6084},
 									label: "every",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 199, col: 11, offset: 6163},
+										pos: position{line: 192, col: 11, offset: 6090},
 										expr: &ruleRefExpr{
-											pos:  position{line: 199, col: 11, offset: 6163},
+											pos:  position{line: 192, col: 11, offset: 6090},
 											name: "EveryDur",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 199, col: 21, offset: 6173},
+									pos:   position{line: 192, col: 21, offset: 6100},
 									label: "reducers",
 									expr: &ruleRefExpr{
-										pos:  position{line: 199, col: 30, offset: 6182},
+										pos:  position{line: 192, col: 30, offset: 6109},
 										name: "Reducers",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 199, col: 39, offset: 6191},
+									pos:   position{line: 192, col: 39, offset: 6118},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 199, col: 44, offset: 6196},
+										pos: position{line: 192, col: 44, offset: 6123},
 										expr: &seqExpr{
-											pos: position{line: 199, col: 45, offset: 6197},
+											pos: position{line: 192, col: 45, offset: 6124},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 199, col: 45, offset: 6197},
+													pos:  position{line: 192, col: 45, offset: 6124},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 199, col: 47, offset: 6199},
+													pos:  position{line: 192, col: 47, offset: 6126},
 													name: "GroupByKeys",
 												},
 											},
@@ -1325,12 +1322,12 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 199, col: 61, offset: 6213},
+									pos:   position{line: 192, col: 61, offset: 6140},
 									label: "limit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 199, col: 67, offset: 6219},
+										pos: position{line: 192, col: 67, offset: 6146},
 										expr: &ruleRefExpr{
-											pos:  position{line: 199, col: 67, offset: 6219},
+											pos:  position{line: 192, col: 67, offset: 6146},
 											name: "LimitArg",
 										},
 									},
@@ -1343,32 +1340,32 @@ var g = &grammar{
 		},
 		{
 			name: "EveryDur",
-			pos:  position{line: 213, col: 1, offset: 6534},
+			pos:  position{line: 200, col: 1, offset: 6388},
 			expr: &actionExpr{
-				pos: position{line: 214, col: 5, offset: 6547},
+				pos: position{line: 201, col: 5, offset: 6401},
 				run: (*parser).callonEveryDur1,
 				expr: &seqExpr{
-					pos: position{line: 214, col: 5, offset: 6547},
+					pos: position{line: 201, col: 5, offset: 6401},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 214, col: 5, offset: 6547},
+							pos:        position{line: 201, col: 5, offset: 6401},
 							val:        "every",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 214, col: 14, offset: 6556},
+							pos:  position{line: 201, col: 14, offset: 6410},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 214, col: 16, offset: 6558},
+							pos:   position{line: 201, col: 16, offset: 6412},
 							label: "dur",
 							expr: &ruleRefExpr{
-								pos:  position{line: 214, col: 20, offset: 6562},
+								pos:  position{line: 201, col: 20, offset: 6416},
 								name: "Duration",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 214, col: 29, offset: 6571},
+							pos:  position{line: 201, col: 29, offset: 6425},
 							name: "_",
 						},
 					},
@@ -1377,27 +1374,27 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 216, col: 1, offset: 6594},
+			pos:  position{line: 203, col: 1, offset: 6448},
 			expr: &actionExpr{
-				pos: position{line: 217, col: 5, offset: 6610},
+				pos: position{line: 204, col: 5, offset: 6464},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 217, col: 5, offset: 6610},
+					pos: position{line: 204, col: 5, offset: 6464},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 217, col: 5, offset: 6610},
+							pos:        position{line: 204, col: 5, offset: 6464},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 217, col: 11, offset: 6616},
+							pos:  position{line: 204, col: 11, offset: 6470},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 217, col: 13, offset: 6618},
+							pos:   position{line: 204, col: 13, offset: 6472},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 217, col: 21, offset: 6626},
+								pos:  position{line: 204, col: 21, offset: 6480},
 								name: "FlexAssignments",
 							},
 						},
@@ -1407,42 +1404,56 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 219, col: 1, offset: 6667},
-			expr: &actionExpr{
-				pos: position{line: 220, col: 5, offset: 6680},
-				run: (*parser).callonLimitArg1,
-				expr: &seqExpr{
-					pos: position{line: 220, col: 5, offset: 6680},
-					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 220, col: 5, offset: 6680},
-							name: "_",
-						},
-						&litMatcher{
-							pos:        position{line: 220, col: 7, offset: 6682},
-							val:        "with",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 220, col: 14, offset: 6689},
-							name: "_",
-						},
-						&litMatcher{
-							pos:        position{line: 220, col: 16, offset: 6691},
-							val:        "-limit",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 220, col: 25, offset: 6700},
-							name: "_",
-						},
-						&labeledExpr{
-							pos:   position{line: 220, col: 27, offset: 6702},
-							label: "limit",
-							expr: &ruleRefExpr{
-								pos:  position{line: 220, col: 33, offset: 6708},
-								name: "UInt",
+			pos:  position{line: 206, col: 1, offset: 6521},
+			expr: &choiceExpr{
+				pos: position{line: 207, col: 5, offset: 6534},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 207, col: 5, offset: 6534},
+						run: (*parser).callonLimitArg2,
+						expr: &seqExpr{
+							pos: position{line: 207, col: 5, offset: 6534},
+							exprs: []interface{}{
+								&ruleRefExpr{
+									pos:  position{line: 207, col: 5, offset: 6534},
+									name: "_",
+								},
+								&litMatcher{
+									pos:        position{line: 207, col: 7, offset: 6536},
+									val:        "with",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 207, col: 14, offset: 6543},
+									name: "_",
+								},
+								&litMatcher{
+									pos:        position{line: 207, col: 16, offset: 6545},
+									val:        "-limit",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 207, col: 25, offset: 6554},
+									name: "_",
+								},
+								&labeledExpr{
+									pos:   position{line: 207, col: 27, offset: 6556},
+									label: "limit",
+									expr: &ruleRefExpr{
+										pos:  position{line: 207, col: 33, offset: 6562},
+										name: "UInt",
+									},
+								},
 							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 208, col: 5, offset: 6593},
+						run: (*parser).callonLimitArg11,
+						expr: &litMatcher{
+							pos:        position{line: 208, col: 5, offset: 6593},
+							val:        "",
+							ignoreCase: false,
 						},
 					},
 				},
@@ -1450,22 +1461,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 225, col: 1, offset: 6974},
+			pos:  position{line: 213, col: 1, offset: 6853},
 			expr: &choiceExpr{
-				pos: position{line: 226, col: 5, offset: 6993},
+				pos: position{line: 214, col: 5, offset: 6872},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 226, col: 5, offset: 6993},
+						pos:  position{line: 214, col: 5, offset: 6872},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 227, col: 5, offset: 7008},
+						pos: position{line: 215, col: 5, offset: 6887},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 227, col: 5, offset: 7008},
+							pos:   position{line: 215, col: 5, offset: 6887},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 227, col: 10, offset: 7013},
+								pos:  position{line: 215, col: 10, offset: 6892},
 								name: "Expr",
 							},
 						},
@@ -1475,50 +1486,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 229, col: 1, offset: 7091},
+			pos:  position{line: 217, col: 1, offset: 6982},
 			expr: &actionExpr{
-				pos: position{line: 230, col: 5, offset: 7111},
+				pos: position{line: 218, col: 5, offset: 7002},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 230, col: 5, offset: 7111},
+					pos: position{line: 218, col: 5, offset: 7002},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 230, col: 5, offset: 7111},
+							pos:   position{line: 218, col: 5, offset: 7002},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 230, col: 11, offset: 7117},
+								pos:  position{line: 218, col: 11, offset: 7008},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 230, col: 26, offset: 7132},
+							pos:   position{line: 218, col: 26, offset: 7023},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 230, col: 31, offset: 7137},
+								pos: position{line: 218, col: 31, offset: 7028},
 								expr: &actionExpr{
-									pos: position{line: 230, col: 32, offset: 7138},
+									pos: position{line: 218, col: 32, offset: 7029},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 230, col: 32, offset: 7138},
+										pos: position{line: 218, col: 32, offset: 7029},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 230, col: 32, offset: 7138},
+												pos:  position{line: 218, col: 32, offset: 7029},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 230, col: 35, offset: 7141},
+												pos:        position{line: 218, col: 35, offset: 7032},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 230, col: 39, offset: 7145},
+												pos:  position{line: 218, col: 39, offset: 7036},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 230, col: 42, offset: 7148},
+												pos:   position{line: 218, col: 42, offset: 7039},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 230, col: 47, offset: 7153},
+													pos:  position{line: 218, col: 47, offset: 7044},
 													name: "FlexAssignment",
 												},
 											},
@@ -1533,42 +1544,42 @@ var g = &grammar{
 		},
 		{
 			name: "ReducerAssignment",
-			pos:  position{line: 234, col: 1, offset: 7275},
+			pos:  position{line: 222, col: 1, offset: 7166},
 			expr: &choiceExpr{
-				pos: position{line: 235, col: 5, offset: 7297},
+				pos: position{line: 223, col: 5, offset: 7188},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 235, col: 5, offset: 7297},
+						pos: position{line: 223, col: 5, offset: 7188},
 						run: (*parser).callonReducerAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 235, col: 5, offset: 7297},
+							pos: position{line: 223, col: 5, offset: 7188},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 235, col: 5, offset: 7297},
+									pos:   position{line: 223, col: 5, offset: 7188},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 235, col: 10, offset: 7302},
+										pos:  position{line: 223, col: 10, offset: 7193},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 235, col: 15, offset: 7307},
+									pos:  position{line: 223, col: 15, offset: 7198},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 235, col: 18, offset: 7310},
+									pos:        position{line: 223, col: 18, offset: 7201},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 235, col: 22, offset: 7314},
+									pos:  position{line: 223, col: 22, offset: 7205},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 235, col: 25, offset: 7317},
+									pos:   position{line: 223, col: 25, offset: 7208},
 									label: "reducer",
 									expr: &ruleRefExpr{
-										pos:  position{line: 235, col: 33, offset: 7325},
+										pos:  position{line: 223, col: 33, offset: 7216},
 										name: "Reducer",
 									},
 								},
@@ -1576,13 +1587,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 238, col: 5, offset: 7435},
+						pos: position{line: 226, col: 5, offset: 7326},
 						run: (*parser).callonReducerAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 238, col: 5, offset: 7435},
+							pos:   position{line: 226, col: 5, offset: 7326},
 							label: "reducer",
 							expr: &ruleRefExpr{
-								pos:  position{line: 238, col: 13, offset: 7443},
+								pos:  position{line: 226, col: 13, offset: 7334},
 								name: "Reducer",
 							},
 						},
@@ -1592,25 +1603,25 @@ var g = &grammar{
 		},
 		{
 			name: "Reducer",
-			pos:  position{line: 242, col: 1, offset: 7537},
+			pos:  position{line: 230, col: 1, offset: 7440},
 			expr: &actionExpr{
-				pos: position{line: 243, col: 5, offset: 7549},
+				pos: position{line: 231, col: 5, offset: 7452},
 				run: (*parser).callonReducer1,
 				expr: &seqExpr{
-					pos: position{line: 243, col: 5, offset: 7549},
+					pos: position{line: 231, col: 5, offset: 7452},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 243, col: 5, offset: 7549},
+							pos: position{line: 231, col: 5, offset: 7452},
 							expr: &choiceExpr{
-								pos: position{line: 243, col: 7, offset: 7551},
+								pos: position{line: 231, col: 7, offset: 7454},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 243, col: 7, offset: 7551},
+										pos:        position{line: 231, col: 7, offset: 7454},
 										val:        "not",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 243, col: 13, offset: 7557},
+										pos:        position{line: 231, col: 13, offset: 7460},
 										val:        "len",
 										ignoreCase: false,
 									},
@@ -1618,53 +1629,53 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 243, col: 20, offset: 7564},
+							pos:   position{line: 231, col: 20, offset: 7467},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 243, col: 23, offset: 7567},
+								pos:  position{line: 231, col: 23, offset: 7470},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 243, col: 38, offset: 7582},
+							pos:  position{line: 231, col: 38, offset: 7485},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 243, col: 41, offset: 7585},
+							pos:        position{line: 231, col: 41, offset: 7488},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 243, col: 45, offset: 7589},
+							pos:  position{line: 231, col: 45, offset: 7492},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 243, col: 48, offset: 7592},
+							pos:   position{line: 231, col: 48, offset: 7495},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 243, col: 53, offset: 7597},
+								pos: position{line: 231, col: 53, offset: 7500},
 								expr: &ruleRefExpr{
-									pos:  position{line: 243, col: 53, offset: 7597},
+									pos:  position{line: 231, col: 53, offset: 7500},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 243, col: 60, offset: 7604},
+							pos:  position{line: 231, col: 60, offset: 7507},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 243, col: 63, offset: 7607},
+							pos:        position{line: 231, col: 63, offset: 7510},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 243, col: 67, offset: 7611},
+							pos:   position{line: 231, col: 67, offset: 7514},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 243, col: 73, offset: 7617},
+								pos: position{line: 231, col: 73, offset: 7520},
 								expr: &ruleRefExpr{
-									pos:  position{line: 243, col: 73, offset: 7617},
+									pos:  position{line: 231, col: 73, offset: 7520},
 									name: "WhereClause",
 								},
 							},
@@ -1675,31 +1686,31 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 251, col: 1, offset: 7800},
+			pos:  position{line: 239, col: 1, offset: 7716},
 			expr: &actionExpr{
-				pos: position{line: 251, col: 15, offset: 7814},
+				pos: position{line: 239, col: 15, offset: 7730},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 251, col: 15, offset: 7814},
+					pos: position{line: 239, col: 15, offset: 7730},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 251, col: 15, offset: 7814},
+							pos:  position{line: 239, col: 15, offset: 7730},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 251, col: 17, offset: 7816},
+							pos:        position{line: 239, col: 17, offset: 7732},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 251, col: 25, offset: 7824},
+							pos:  position{line: 239, col: 25, offset: 7740},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 251, col: 27, offset: 7826},
+							pos:   position{line: 239, col: 27, offset: 7742},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 251, col: 32, offset: 7831},
+								pos:  position{line: 239, col: 32, offset: 7747},
 								name: "Expr",
 							},
 						},
@@ -1709,44 +1720,44 @@ var g = &grammar{
 		},
 		{
 			name: "Reducers",
-			pos:  position{line: 253, col: 1, offset: 7858},
+			pos:  position{line: 241, col: 1, offset: 7774},
 			expr: &actionExpr{
-				pos: position{line: 254, col: 5, offset: 7871},
+				pos: position{line: 242, col: 5, offset: 7787},
 				run: (*parser).callonReducers1,
 				expr: &seqExpr{
-					pos: position{line: 254, col: 5, offset: 7871},
+					pos: position{line: 242, col: 5, offset: 7787},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 254, col: 5, offset: 7871},
+							pos:   position{line: 242, col: 5, offset: 7787},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 254, col: 11, offset: 7877},
+								pos:  position{line: 242, col: 11, offset: 7793},
 								name: "ReducerAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 254, col: 29, offset: 7895},
+							pos:   position{line: 242, col: 29, offset: 7811},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 254, col: 34, offset: 7900},
+								pos: position{line: 242, col: 34, offset: 7816},
 								expr: &seqExpr{
-									pos: position{line: 254, col: 35, offset: 7901},
+									pos: position{line: 242, col: 35, offset: 7817},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 254, col: 35, offset: 7901},
+											pos:  position{line: 242, col: 35, offset: 7817},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 254, col: 38, offset: 7904},
+											pos:        position{line: 242, col: 38, offset: 7820},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 254, col: 42, offset: 7908},
+											pos:  position{line: 242, col: 42, offset: 7824},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 254, col: 45, offset: 7911},
+											pos:  position{line: 242, col: 45, offset: 7827},
 											name: "ReducerAssignment",
 										},
 									},
@@ -1759,52 +1770,52 @@ var g = &grammar{
 		},
 		{
 			name: "NamedProc",
-			pos:  position{line: 262, col: 1, offset: 8116},
+			pos:  position{line: 250, col: 1, offset: 8032},
 			expr: &choiceExpr{
-				pos: position{line: 263, col: 5, offset: 8130},
+				pos: position{line: 251, col: 5, offset: 8046},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 263, col: 5, offset: 8130},
+						pos:  position{line: 251, col: 5, offset: 8046},
 						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 264, col: 5, offset: 8143},
+						pos:  position{line: 252, col: 5, offset: 8059},
 						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 265, col: 5, offset: 8155},
+						pos:  position{line: 253, col: 5, offset: 8071},
 						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 266, col: 5, offset: 8167},
+						pos:  position{line: 254, col: 5, offset: 8083},
 						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 267, col: 5, offset: 8180},
+						pos:  position{line: 255, col: 5, offset: 8096},
 						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 268, col: 5, offset: 8193},
+						pos:  position{line: 256, col: 5, offset: 8109},
 						name: "FilterProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 269, col: 5, offset: 8208},
+						pos:  position{line: 257, col: 5, offset: 8124},
 						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 270, col: 5, offset: 8221},
+						pos:  position{line: 258, col: 5, offset: 8137},
 						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 271, col: 5, offset: 8233},
+						pos:  position{line: 259, col: 5, offset: 8149},
 						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 272, col: 5, offset: 8248},
+						pos:  position{line: 260, col: 5, offset: 8164},
 						name: "FuseProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 273, col: 5, offset: 8261},
+						pos:  position{line: 261, col: 5, offset: 8177},
 						name: "JoinProc",
 					},
 				},
@@ -1812,46 +1823,46 @@ var g = &grammar{
 		},
 		{
 			name: "SortProc",
-			pos:  position{line: 275, col: 1, offset: 8271},
+			pos:  position{line: 263, col: 1, offset: 8187},
 			expr: &actionExpr{
-				pos: position{line: 276, col: 5, offset: 8284},
+				pos: position{line: 264, col: 5, offset: 8200},
 				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 276, col: 5, offset: 8284},
+					pos: position{line: 264, col: 5, offset: 8200},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 276, col: 5, offset: 8284},
+							pos:        position{line: 264, col: 5, offset: 8200},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 276, col: 13, offset: 8292},
+							pos:   position{line: 264, col: 13, offset: 8208},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 18, offset: 8297},
+								pos:  position{line: 264, col: 18, offset: 8213},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 276, col: 27, offset: 8306},
+							pos:   position{line: 264, col: 27, offset: 8222},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 276, col: 32, offset: 8311},
+								pos: position{line: 264, col: 32, offset: 8227},
 								expr: &actionExpr{
-									pos: position{line: 276, col: 33, offset: 8312},
+									pos: position{line: 264, col: 33, offset: 8228},
 									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 276, col: 33, offset: 8312},
+										pos: position{line: 264, col: 33, offset: 8228},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 276, col: 33, offset: 8312},
+												pos:  position{line: 264, col: 33, offset: 8228},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 276, col: 35, offset: 8314},
+												pos:   position{line: 264, col: 35, offset: 8230},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 276, col: 37, offset: 8316},
+													pos:  position{line: 264, col: 37, offset: 8232},
 													name: "Exprs",
 												},
 											},
@@ -1866,30 +1877,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 290, col: 1, offset: 8735},
+			pos:  position{line: 278, col: 1, offset: 8651},
 			expr: &actionExpr{
-				pos: position{line: 290, col: 12, offset: 8746},
+				pos: position{line: 278, col: 12, offset: 8662},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 290, col: 12, offset: 8746},
+					pos:   position{line: 278, col: 12, offset: 8662},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 290, col: 17, offset: 8751},
+						pos: position{line: 278, col: 17, offset: 8667},
 						expr: &actionExpr{
-							pos: position{line: 290, col: 18, offset: 8752},
+							pos: position{line: 278, col: 18, offset: 8668},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 290, col: 18, offset: 8752},
+								pos: position{line: 278, col: 18, offset: 8668},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 290, col: 18, offset: 8752},
+										pos:  position{line: 278, col: 18, offset: 8668},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 290, col: 20, offset: 8754},
+										pos:   position{line: 278, col: 20, offset: 8670},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 290, col: 22, offset: 8756},
+											pos:  position{line: 278, col: 22, offset: 8672},
 											name: "SortArg",
 										},
 									},
@@ -1902,50 +1913,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 292, col: 1, offset: 8812},
+			pos:  position{line: 280, col: 1, offset: 8728},
 			expr: &choiceExpr{
-				pos: position{line: 293, col: 5, offset: 8824},
+				pos: position{line: 281, col: 5, offset: 8740},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 293, col: 5, offset: 8824},
+						pos: position{line: 281, col: 5, offset: 8740},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 293, col: 5, offset: 8824},
+							pos:        position{line: 281, col: 5, offset: 8740},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 294, col: 5, offset: 8899},
+						pos: position{line: 282, col: 5, offset: 8815},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 294, col: 5, offset: 8899},
+							pos: position{line: 282, col: 5, offset: 8815},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 294, col: 5, offset: 8899},
+									pos:        position{line: 282, col: 5, offset: 8815},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 294, col: 14, offset: 8908},
+									pos:  position{line: 282, col: 14, offset: 8824},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 294, col: 16, offset: 8910},
+									pos:   position{line: 282, col: 16, offset: 8826},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 294, col: 23, offset: 8917},
+										pos: position{line: 282, col: 23, offset: 8833},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 294, col: 24, offset: 8918},
+											pos: position{line: 282, col: 24, offset: 8834},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 294, col: 24, offset: 8918},
+													pos:        position{line: 282, col: 24, offset: 8834},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 294, col: 34, offset: 8928},
+													pos:        position{line: 282, col: 34, offset: 8844},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -1961,38 +1972,38 @@ var g = &grammar{
 		},
 		{
 			name: "TopProc",
-			pos:  position{line: 296, col: 1, offset: 9042},
+			pos:  position{line: 284, col: 1, offset: 8958},
 			expr: &actionExpr{
-				pos: position{line: 297, col: 5, offset: 9054},
+				pos: position{line: 285, col: 5, offset: 8970},
 				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 297, col: 5, offset: 9054},
+					pos: position{line: 285, col: 5, offset: 8970},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 297, col: 5, offset: 9054},
+							pos:        position{line: 285, col: 5, offset: 8970},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 297, col: 12, offset: 9061},
+							pos:   position{line: 285, col: 12, offset: 8977},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 297, col: 18, offset: 9067},
+								pos: position{line: 285, col: 18, offset: 8983},
 								expr: &actionExpr{
-									pos: position{line: 297, col: 19, offset: 9068},
+									pos: position{line: 285, col: 19, offset: 8984},
 									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 297, col: 19, offset: 9068},
+										pos: position{line: 285, col: 19, offset: 8984},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 297, col: 19, offset: 9068},
+												pos:  position{line: 285, col: 19, offset: 8984},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 297, col: 21, offset: 9070},
+												pos:   position{line: 285, col: 21, offset: 8986},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 297, col: 23, offset: 9072},
+													pos:  position{line: 285, col: 23, offset: 8988},
 													name: "UInt",
 												},
 											},
@@ -2002,19 +2013,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 297, col: 47, offset: 9096},
+							pos:   position{line: 285, col: 47, offset: 9012},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 297, col: 53, offset: 9102},
+								pos: position{line: 285, col: 53, offset: 9018},
 								expr: &seqExpr{
-									pos: position{line: 297, col: 54, offset: 9103},
+									pos: position{line: 285, col: 54, offset: 9019},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 297, col: 54, offset: 9103},
+											pos:  position{line: 285, col: 54, offset: 9019},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 297, col: 56, offset: 9105},
+											pos:        position{line: 285, col: 56, offset: 9021},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2023,25 +2034,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 297, col: 67, offset: 9116},
+							pos:   position{line: 285, col: 67, offset: 9032},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 297, col: 74, offset: 9123},
+								pos: position{line: 285, col: 74, offset: 9039},
 								expr: &actionExpr{
-									pos: position{line: 297, col: 75, offset: 9124},
+									pos: position{line: 285, col: 75, offset: 9040},
 									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 297, col: 75, offset: 9124},
+										pos: position{line: 285, col: 75, offset: 9040},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 297, col: 75, offset: 9124},
+												pos:  position{line: 285, col: 75, offset: 9040},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 297, col: 77, offset: 9126},
+												pos:   position{line: 285, col: 77, offset: 9042},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 297, col: 79, offset: 9128},
+													pos:  position{line: 285, col: 79, offset: 9044},
 													name: "FieldExprs",
 												},
 											},
@@ -2056,35 +2067,35 @@ var g = &grammar{
 		},
 		{
 			name: "CutProc",
-			pos:  position{line: 311, col: 1, offset: 9436},
+			pos:  position{line: 299, col: 1, offset: 9395},
 			expr: &actionExpr{
-				pos: position{line: 312, col: 5, offset: 9448},
+				pos: position{line: 300, col: 5, offset: 9407},
 				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 312, col: 5, offset: 9448},
+					pos: position{line: 300, col: 5, offset: 9407},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 312, col: 5, offset: 9448},
+							pos:        position{line: 300, col: 5, offset: 9407},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 312, col: 12, offset: 9455},
+							pos:   position{line: 300, col: 12, offset: 9414},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 312, col: 17, offset: 9460},
+								pos:  position{line: 300, col: 17, offset: 9419},
 								name: "CutArgs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 312, col: 25, offset: 9468},
+							pos:  position{line: 300, col: 25, offset: 9427},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 312, col: 27, offset: 9470},
+							pos:   position{line: 300, col: 27, offset: 9429},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 312, col: 35, offset: 9478},
+								pos:  position{line: 300, col: 35, offset: 9437},
 								name: "FlexAssignments",
 							},
 						},
@@ -2094,27 +2105,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutArgs",
-			pos:  position{line: 321, col: 1, offset: 9747},
+			pos:  position{line: 309, col: 1, offset: 9706},
 			expr: &actionExpr{
-				pos: position{line: 322, col: 5, offset: 9759},
+				pos: position{line: 310, col: 5, offset: 9718},
 				run: (*parser).callonCutArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 322, col: 5, offset: 9759},
+					pos:   position{line: 310, col: 5, offset: 9718},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 322, col: 10, offset: 9764},
+						pos: position{line: 310, col: 10, offset: 9723},
 						expr: &actionExpr{
-							pos: position{line: 322, col: 11, offset: 9765},
+							pos: position{line: 310, col: 11, offset: 9724},
 							run: (*parser).callonCutArgs4,
 							expr: &seqExpr{
-								pos: position{line: 322, col: 11, offset: 9765},
+								pos: position{line: 310, col: 11, offset: 9724},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 322, col: 11, offset: 9765},
+										pos:  position{line: 310, col: 11, offset: 9724},
 										name: "_",
 									},
 									&litMatcher{
-										pos:        position{line: 322, col: 13, offset: 9767},
+										pos:        position{line: 310, col: 13, offset: 9726},
 										val:        "-c",
 										ignoreCase: false,
 									},
@@ -2127,30 +2138,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadProc",
-			pos:  position{line: 326, col: 1, offset: 9879},
+			pos:  position{line: 314, col: 1, offset: 9838},
 			expr: &choiceExpr{
-				pos: position{line: 327, col: 5, offset: 9892},
+				pos: position{line: 315, col: 5, offset: 9851},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 327, col: 5, offset: 9892},
+						pos: position{line: 315, col: 5, offset: 9851},
 						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 327, col: 5, offset: 9892},
+							pos: position{line: 315, col: 5, offset: 9851},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 327, col: 5, offset: 9892},
+									pos:        position{line: 315, col: 5, offset: 9851},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 327, col: 13, offset: 9900},
+									pos:  position{line: 315, col: 13, offset: 9859},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 327, col: 15, offset: 9902},
+									pos:   position{line: 315, col: 15, offset: 9861},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 327, col: 21, offset: 9908},
+										pos:  position{line: 315, col: 21, offset: 9867},
 										name: "UInt",
 									},
 								},
@@ -2158,10 +2169,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 328, col: 5, offset: 9990},
+						pos: position{line: 316, col: 5, offset: 9949},
 						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 328, col: 5, offset: 9990},
+							pos:        position{line: 316, col: 5, offset: 9949},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2171,30 +2182,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailProc",
-			pos:  position{line: 330, col: 1, offset: 10068},
+			pos:  position{line: 318, col: 1, offset: 10027},
 			expr: &choiceExpr{
-				pos: position{line: 331, col: 5, offset: 10081},
+				pos: position{line: 319, col: 5, offset: 10040},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 331, col: 5, offset: 10081},
+						pos: position{line: 319, col: 5, offset: 10040},
 						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 331, col: 5, offset: 10081},
+							pos: position{line: 319, col: 5, offset: 10040},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 331, col: 5, offset: 10081},
+									pos:        position{line: 319, col: 5, offset: 10040},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 331, col: 13, offset: 10089},
+									pos:  position{line: 319, col: 13, offset: 10048},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 331, col: 15, offset: 10091},
+									pos:   position{line: 319, col: 15, offset: 10050},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 331, col: 21, offset: 10097},
+										pos:  position{line: 319, col: 21, offset: 10056},
 										name: "UInt",
 									},
 								},
@@ -2202,10 +2213,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 332, col: 5, offset: 10179},
+						pos: position{line: 320, col: 5, offset: 10138},
 						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 332, col: 5, offset: 10179},
+							pos:        position{line: 320, col: 5, offset: 10138},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2215,27 +2226,27 @@ var g = &grammar{
 		},
 		{
 			name: "FilterProc",
-			pos:  position{line: 334, col: 1, offset: 10257},
+			pos:  position{line: 322, col: 1, offset: 10216},
 			expr: &actionExpr{
-				pos: position{line: 335, col: 5, offset: 10272},
+				pos: position{line: 323, col: 5, offset: 10231},
 				run: (*parser).callonFilterProc1,
 				expr: &seqExpr{
-					pos: position{line: 335, col: 5, offset: 10272},
+					pos: position{line: 323, col: 5, offset: 10231},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 335, col: 5, offset: 10272},
+							pos:        position{line: 323, col: 5, offset: 10231},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 335, col: 15, offset: 10282},
+							pos:  position{line: 323, col: 15, offset: 10241},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 335, col: 17, offset: 10284},
+							pos:   position{line: 323, col: 17, offset: 10243},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 335, col: 22, offset: 10289},
+								pos:  position{line: 323, col: 22, offset: 10248},
 								name: "SearchExpr",
 							},
 						},
@@ -2245,27 +2256,27 @@ var g = &grammar{
 		},
 		{
 			name: "UniqProc",
-			pos:  position{line: 339, col: 1, offset: 10386},
+			pos:  position{line: 327, col: 1, offset: 10345},
 			expr: &choiceExpr{
-				pos: position{line: 340, col: 5, offset: 10399},
+				pos: position{line: 328, col: 5, offset: 10358},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 340, col: 5, offset: 10399},
+						pos: position{line: 328, col: 5, offset: 10358},
 						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 340, col: 5, offset: 10399},
+							pos: position{line: 328, col: 5, offset: 10358},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 340, col: 5, offset: 10399},
+									pos:        position{line: 328, col: 5, offset: 10358},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 340, col: 13, offset: 10407},
+									pos:  position{line: 328, col: 13, offset: 10366},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 340, col: 15, offset: 10409},
+									pos:        position{line: 328, col: 15, offset: 10368},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2273,10 +2284,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 343, col: 5, offset: 10500},
+						pos: position{line: 331, col: 5, offset: 10459},
 						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 343, col: 5, offset: 10500},
+							pos:        position{line: 331, col: 5, offset: 10459},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2286,27 +2297,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutProc",
-			pos:  position{line: 347, col: 1, offset: 10592},
+			pos:  position{line: 335, col: 1, offset: 10551},
 			expr: &actionExpr{
-				pos: position{line: 348, col: 5, offset: 10604},
+				pos: position{line: 336, col: 5, offset: 10563},
 				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 348, col: 5, offset: 10604},
+					pos: position{line: 336, col: 5, offset: 10563},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 348, col: 5, offset: 10604},
+							pos:        position{line: 336, col: 5, offset: 10563},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 348, col: 12, offset: 10611},
+							pos:  position{line: 336, col: 12, offset: 10570},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 348, col: 14, offset: 10613},
+							pos:   position{line: 336, col: 14, offset: 10572},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 348, col: 22, offset: 10621},
+								pos:  position{line: 336, col: 22, offset: 10580},
 								name: "FlexAssignments",
 							},
 						},
@@ -2316,59 +2327,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameProc",
-			pos:  position{line: 352, col: 1, offset: 10724},
+			pos:  position{line: 340, col: 1, offset: 10683},
 			expr: &actionExpr{
-				pos: position{line: 353, col: 5, offset: 10739},
+				pos: position{line: 341, col: 5, offset: 10698},
 				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 353, col: 5, offset: 10739},
+					pos: position{line: 341, col: 5, offset: 10698},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 353, col: 5, offset: 10739},
+							pos:        position{line: 341, col: 5, offset: 10698},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 353, col: 15, offset: 10749},
+							pos:  position{line: 341, col: 15, offset: 10708},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 353, col: 17, offset: 10751},
+							pos:   position{line: 341, col: 17, offset: 10710},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 353, col: 23, offset: 10757},
+								pos:  position{line: 341, col: 23, offset: 10716},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 353, col: 34, offset: 10768},
+							pos:   position{line: 341, col: 34, offset: 10727},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 353, col: 39, offset: 10773},
+								pos: position{line: 341, col: 39, offset: 10732},
 								expr: &actionExpr{
-									pos: position{line: 353, col: 40, offset: 10774},
+									pos: position{line: 341, col: 40, offset: 10733},
 									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 353, col: 40, offset: 10774},
+										pos: position{line: 341, col: 40, offset: 10733},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 353, col: 40, offset: 10774},
+												pos:  position{line: 341, col: 40, offset: 10733},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 353, col: 43, offset: 10777},
+												pos:        position{line: 341, col: 43, offset: 10736},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 353, col: 47, offset: 10781},
+												pos:  position{line: 341, col: 47, offset: 10740},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 353, col: 50, offset: 10784},
+												pos:   position{line: 341, col: 50, offset: 10743},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 353, col: 53, offset: 10787},
+													pos:  position{line: 341, col: 53, offset: 10746},
 													name: "Assignment",
 												},
 											},
@@ -2383,12 +2394,12 @@ var g = &grammar{
 		},
 		{
 			name: "FuseProc",
-			pos:  position{line: 357, col: 1, offset: 10957},
+			pos:  position{line: 345, col: 1, offset: 10916},
 			expr: &actionExpr{
-				pos: position{line: 358, col: 5, offset: 10970},
+				pos: position{line: 346, col: 5, offset: 10929},
 				run: (*parser).callonFuseProc1,
 				expr: &litMatcher{
-					pos:        position{line: 358, col: 5, offset: 10970},
+					pos:        position{line: 346, col: 5, offset: 10929},
 					val:        "fuse",
 					ignoreCase: true,
 				},
@@ -2396,68 +2407,68 @@ var g = &grammar{
 		},
 		{
 			name: "JoinProc",
-			pos:  position{line: 362, col: 1, offset: 11046},
+			pos:  position{line: 350, col: 1, offset: 11005},
 			expr: &choiceExpr{
-				pos: position{line: 363, col: 5, offset: 11059},
+				pos: position{line: 351, col: 5, offset: 11018},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 363, col: 5, offset: 11059},
+						pos: position{line: 351, col: 5, offset: 11018},
 						run: (*parser).callonJoinProc2,
 						expr: &seqExpr{
-							pos: position{line: 363, col: 5, offset: 11059},
+							pos: position{line: 351, col: 5, offset: 11018},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 363, col: 5, offset: 11059},
+									pos:        position{line: 351, col: 5, offset: 11018},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 363, col: 13, offset: 11067},
+									pos:  position{line: 351, col: 13, offset: 11026},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 363, col: 15, offset: 11069},
+									pos:   position{line: 351, col: 15, offset: 11028},
 									label: "leftKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 363, col: 23, offset: 11077},
+										pos:  position{line: 351, col: 23, offset: 11036},
 										name: "JoinKey",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 363, col: 31, offset: 11085},
+									pos:  position{line: 351, col: 31, offset: 11044},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 363, col: 34, offset: 11088},
+									pos:        position{line: 351, col: 34, offset: 11047},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 363, col: 38, offset: 11092},
+									pos:  position{line: 351, col: 38, offset: 11051},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 363, col: 41, offset: 11095},
+									pos:   position{line: 351, col: 41, offset: 11054},
 									label: "rightKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 363, col: 50, offset: 11104},
+										pos:  position{line: 351, col: 50, offset: 11063},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 363, col: 58, offset: 11112},
+									pos:   position{line: 351, col: 58, offset: 11071},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 363, col: 66, offset: 11120},
+										pos: position{line: 351, col: 66, offset: 11079},
 										expr: &seqExpr{
-											pos: position{line: 363, col: 67, offset: 11121},
+											pos: position{line: 351, col: 67, offset: 11080},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 363, col: 67, offset: 11121},
+													pos:  position{line: 351, col: 67, offset: 11080},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 363, col: 69, offset: 11123},
+													pos:  position{line: 351, col: 69, offset: 11082},
 													name: "FlexAssignments",
 												},
 											},
@@ -2468,42 +2479,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 370, col: 5, offset: 11365},
+						pos: position{line: 358, col: 5, offset: 11340},
 						run: (*parser).callonJoinProc18,
 						expr: &seqExpr{
-							pos: position{line: 370, col: 5, offset: 11365},
+							pos: position{line: 358, col: 5, offset: 11340},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 370, col: 5, offset: 11365},
+									pos:        position{line: 358, col: 5, offset: 11340},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 370, col: 13, offset: 11373},
+									pos:  position{line: 358, col: 13, offset: 11348},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 370, col: 15, offset: 11375},
+									pos:   position{line: 358, col: 15, offset: 11350},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 370, col: 19, offset: 11379},
+										pos:  position{line: 358, col: 19, offset: 11354},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 370, col: 27, offset: 11387},
+									pos:   position{line: 358, col: 27, offset: 11362},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 370, col: 35, offset: 11395},
+										pos: position{line: 358, col: 35, offset: 11370},
 										expr: &seqExpr{
-											pos: position{line: 370, col: 36, offset: 11396},
+											pos: position{line: 358, col: 36, offset: 11371},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 370, col: 36, offset: 11396},
+													pos:  position{line: 358, col: 36, offset: 11371},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 370, col: 38, offset: 11398},
+													pos:  position{line: 358, col: 38, offset: 11373},
 													name: "FlexAssignments",
 												},
 											},
@@ -2518,35 +2529,35 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 378, col: 1, offset: 11628},
+			pos:  position{line: 366, col: 1, offset: 11619},
 			expr: &choiceExpr{
-				pos: position{line: 379, col: 5, offset: 11640},
+				pos: position{line: 367, col: 5, offset: 11631},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 379, col: 5, offset: 11640},
+						pos:  position{line: 367, col: 5, offset: 11631},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 380, col: 5, offset: 11649},
+						pos: position{line: 368, col: 5, offset: 11640},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 380, col: 5, offset: 11649},
+							pos: position{line: 368, col: 5, offset: 11640},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 380, col: 5, offset: 11649},
+									pos:        position{line: 368, col: 5, offset: 11640},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 380, col: 9, offset: 11653},
+									pos:   position{line: 368, col: 9, offset: 11644},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 380, col: 14, offset: 11658},
+										pos:  position{line: 368, col: 14, offset: 11649},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 380, col: 19, offset: 11663},
+									pos:        position{line: 368, col: 19, offset: 11654},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -2558,45 +2569,45 @@ var g = &grammar{
 		},
 		{
 			name: "RootField",
-			pos:  position{line: 382, col: 1, offset: 11689},
+			pos:  position{line: 370, col: 1, offset: 11680},
 			expr: &choiceExpr{
-				pos: position{line: 383, col: 5, offset: 11703},
+				pos: position{line: 371, col: 5, offset: 11694},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 383, col: 5, offset: 11703},
+						pos: position{line: 371, col: 5, offset: 11694},
 						run: (*parser).callonRootField2,
 						expr: &seqExpr{
-							pos: position{line: 383, col: 5, offset: 11703},
+							pos: position{line: 371, col: 5, offset: 11694},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 383, col: 5, offset: 11703},
+									pos: position{line: 371, col: 5, offset: 11694},
 									expr: &litMatcher{
-										pos:        position{line: 383, col: 5, offset: 11703},
+										pos:        position{line: 371, col: 5, offset: 11694},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&notExpr{
-									pos: position{line: 383, col: 10, offset: 11708},
+									pos: position{line: 371, col: 10, offset: 11699},
 									expr: &choiceExpr{
-										pos: position{line: 383, col: 12, offset: 11710},
+										pos: position{line: 371, col: 12, offset: 11701},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 383, col: 12, offset: 11710},
+												pos:  position{line: 371, col: 12, offset: 11701},
 												name: "BooleanLiteral",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 383, col: 29, offset: 11727},
+												pos:  position{line: 371, col: 29, offset: 11718},
 												name: "NullLiteral",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 383, col: 42, offset: 11740},
+									pos:   position{line: 371, col: 42, offset: 11731},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 383, col: 48, offset: 11746},
+										pos:  position{line: 371, col: 48, offset: 11737},
 										name: "Identifier",
 									},
 								},
@@ -2604,20 +2615,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 384, col: 5, offset: 11899},
+						pos: position{line: 372, col: 5, offset: 11890},
 						run: (*parser).callonRootField12,
 						expr: &seqExpr{
-							pos: position{line: 384, col: 5, offset: 11899},
+							pos: position{line: 372, col: 5, offset: 11890},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 384, col: 5, offset: 11899},
+									pos:        position{line: 372, col: 5, offset: 11890},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 384, col: 9, offset: 11903},
+									pos: position{line: 372, col: 9, offset: 11894},
 									expr: &ruleRefExpr{
-										pos:  position{line: 384, col: 11, offset: 11905},
+										pos:  position{line: 372, col: 11, offset: 11896},
 										name: "Identifier",
 									},
 								},
@@ -2629,60 +2640,60 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 386, col: 1, offset: 11978},
+			pos:  position{line: 374, col: 1, offset: 11969},
 			expr: &ruleRefExpr{
-				pos:  position{line: 386, col: 8, offset: 11985},
+				pos:  position{line: 374, col: 8, offset: 11976},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 388, col: 1, offset: 11996},
+			pos:  position{line: 376, col: 1, offset: 11987},
 			expr: &ruleRefExpr{
-				pos:  position{line: 388, col: 13, offset: 12008},
+				pos:  position{line: 376, col: 13, offset: 11999},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 390, col: 1, offset: 12014},
+			pos:  position{line: 378, col: 1, offset: 12005},
 			expr: &actionExpr{
-				pos: position{line: 391, col: 5, offset: 12029},
+				pos: position{line: 379, col: 5, offset: 12020},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 391, col: 5, offset: 12029},
+					pos: position{line: 379, col: 5, offset: 12020},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 391, col: 5, offset: 12029},
+							pos:   position{line: 379, col: 5, offset: 12020},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 391, col: 11, offset: 12035},
+								pos:  position{line: 379, col: 11, offset: 12026},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 391, col: 21, offset: 12045},
+							pos:   position{line: 379, col: 21, offset: 12036},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 391, col: 26, offset: 12050},
+								pos: position{line: 379, col: 26, offset: 12041},
 								expr: &seqExpr{
-									pos: position{line: 391, col: 27, offset: 12051},
+									pos: position{line: 379, col: 27, offset: 12042},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 391, col: 27, offset: 12051},
+											pos:  position{line: 379, col: 27, offset: 12042},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 391, col: 30, offset: 12054},
+											pos:        position{line: 379, col: 30, offset: 12045},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 391, col: 34, offset: 12058},
+											pos:  position{line: 379, col: 34, offset: 12049},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 391, col: 37, offset: 12061},
+											pos:  position{line: 379, col: 37, offset: 12052},
 											name: "FieldExpr",
 										},
 									},
@@ -2695,44 +2706,44 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 401, col: 1, offset: 12260},
+			pos:  position{line: 389, col: 1, offset: 12251},
 			expr: &actionExpr{
-				pos: position{line: 402, col: 5, offset: 12270},
+				pos: position{line: 390, col: 5, offset: 12261},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 402, col: 5, offset: 12270},
+					pos: position{line: 390, col: 5, offset: 12261},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 402, col: 5, offset: 12270},
+							pos:   position{line: 390, col: 5, offset: 12261},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 402, col: 11, offset: 12276},
+								pos:  position{line: 390, col: 11, offset: 12267},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 402, col: 16, offset: 12281},
+							pos:   position{line: 390, col: 16, offset: 12272},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 402, col: 21, offset: 12286},
+								pos: position{line: 390, col: 21, offset: 12277},
 								expr: &seqExpr{
-									pos: position{line: 402, col: 22, offset: 12287},
+									pos: position{line: 390, col: 22, offset: 12278},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 402, col: 22, offset: 12287},
+											pos:  position{line: 390, col: 22, offset: 12278},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 402, col: 25, offset: 12290},
+											pos:        position{line: 390, col: 25, offset: 12281},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 402, col: 29, offset: 12294},
+											pos:  position{line: 390, col: 29, offset: 12285},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 402, col: 32, offset: 12297},
+											pos:  position{line: 390, col: 32, offset: 12288},
 											name: "Expr",
 										},
 									},
@@ -2745,39 +2756,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 412, col: 1, offset: 12491},
+			pos:  position{line: 400, col: 1, offset: 12482},
 			expr: &actionExpr{
-				pos: position{line: 413, col: 5, offset: 12506},
+				pos: position{line: 401, col: 5, offset: 12497},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 413, col: 5, offset: 12506},
+					pos: position{line: 401, col: 5, offset: 12497},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 413, col: 5, offset: 12506},
+							pos:   position{line: 401, col: 5, offset: 12497},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 413, col: 9, offset: 12510},
+								pos:  position{line: 401, col: 9, offset: 12501},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 413, col: 14, offset: 12515},
+							pos:  position{line: 401, col: 14, offset: 12506},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 413, col: 17, offset: 12518},
+							pos:        position{line: 401, col: 17, offset: 12509},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 413, col: 21, offset: 12522},
+							pos:  position{line: 401, col: 21, offset: 12513},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 413, col: 24, offset: 12525},
+							pos:   position{line: 401, col: 24, offset: 12516},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 413, col: 28, offset: 12529},
+								pos:  position{line: 401, col: 28, offset: 12520},
 								name: "Expr",
 							},
 						},
@@ -2787,71 +2798,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 415, col: 1, offset: 12598},
+			pos:  position{line: 403, col: 1, offset: 12609},
 			expr: &ruleRefExpr{
-				pos:  position{line: 415, col: 8, offset: 12605},
+				pos:  position{line: 403, col: 8, offset: 12616},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 417, col: 1, offset: 12622},
+			pos:  position{line: 405, col: 1, offset: 12633},
 			expr: &choiceExpr{
-				pos: position{line: 418, col: 5, offset: 12642},
+				pos: position{line: 406, col: 5, offset: 12653},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 418, col: 5, offset: 12642},
+						pos: position{line: 406, col: 5, offset: 12653},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 418, col: 5, offset: 12642},
+							pos: position{line: 406, col: 5, offset: 12653},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 418, col: 5, offset: 12642},
+									pos:   position{line: 406, col: 5, offset: 12653},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 418, col: 15, offset: 12652},
+										pos:  position{line: 406, col: 15, offset: 12663},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 418, col: 29, offset: 12666},
+									pos:  position{line: 406, col: 29, offset: 12677},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 418, col: 32, offset: 12669},
+									pos:        position{line: 406, col: 32, offset: 12680},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 418, col: 36, offset: 12673},
+									pos:  position{line: 406, col: 36, offset: 12684},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 418, col: 39, offset: 12676},
+									pos:   position{line: 406, col: 39, offset: 12687},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 418, col: 50, offset: 12687},
+										pos:  position{line: 406, col: 50, offset: 12698},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 418, col: 55, offset: 12692},
+									pos:  position{line: 406, col: 55, offset: 12703},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 418, col: 58, offset: 12695},
+									pos:        position{line: 406, col: 58, offset: 12706},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 418, col: 62, offset: 12699},
+									pos:  position{line: 406, col: 62, offset: 12710},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 418, col: 65, offset: 12702},
+									pos:   position{line: 406, col: 65, offset: 12713},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 418, col: 76, offset: 12713},
+										pos:  position{line: 406, col: 76, offset: 12724},
 										name: "Expr",
 									},
 								},
@@ -2859,7 +2870,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 421, col: 5, offset: 12860},
+						pos:  position{line: 409, col: 5, offset: 12871},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -2867,53 +2878,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 423, col: 1, offset: 12875},
+			pos:  position{line: 411, col: 1, offset: 12886},
 			expr: &actionExpr{
-				pos: position{line: 424, col: 5, offset: 12893},
+				pos: position{line: 412, col: 5, offset: 12904},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 424, col: 5, offset: 12893},
+					pos: position{line: 412, col: 5, offset: 12904},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 424, col: 5, offset: 12893},
+							pos:   position{line: 412, col: 5, offset: 12904},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 424, col: 11, offset: 12899},
+								pos:  position{line: 412, col: 11, offset: 12910},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 425, col: 5, offset: 12918},
+							pos:   position{line: 413, col: 5, offset: 12929},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 425, col: 10, offset: 12923},
+								pos: position{line: 413, col: 10, offset: 12934},
 								expr: &actionExpr{
-									pos: position{line: 425, col: 11, offset: 12924},
+									pos: position{line: 413, col: 11, offset: 12935},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 425, col: 11, offset: 12924},
+										pos: position{line: 413, col: 11, offset: 12935},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 425, col: 11, offset: 12924},
+												pos:  position{line: 413, col: 11, offset: 12935},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 425, col: 14, offset: 12927},
+												pos:   position{line: 413, col: 14, offset: 12938},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 425, col: 17, offset: 12930},
+													pos:  position{line: 413, col: 17, offset: 12941},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 425, col: 25, offset: 12938},
+												pos:  position{line: 413, col: 25, offset: 12949},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 425, col: 28, offset: 12941},
+												pos:   position{line: 413, col: 28, offset: 12952},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 425, col: 33, offset: 12946},
+													pos:  position{line: 413, col: 33, offset: 12957},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -2928,53 +2939,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 429, col: 1, offset: 13064},
+			pos:  position{line: 417, col: 1, offset: 13075},
 			expr: &actionExpr{
-				pos: position{line: 430, col: 5, offset: 13083},
+				pos: position{line: 418, col: 5, offset: 13094},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 430, col: 5, offset: 13083},
+					pos: position{line: 418, col: 5, offset: 13094},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 430, col: 5, offset: 13083},
+							pos:   position{line: 418, col: 5, offset: 13094},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 430, col: 11, offset: 13089},
+								pos:  position{line: 418, col: 11, offset: 13100},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 431, col: 5, offset: 13113},
+							pos:   position{line: 419, col: 5, offset: 13124},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 431, col: 10, offset: 13118},
+								pos: position{line: 419, col: 10, offset: 13129},
 								expr: &actionExpr{
-									pos: position{line: 431, col: 11, offset: 13119},
+									pos: position{line: 419, col: 11, offset: 13130},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 431, col: 11, offset: 13119},
+										pos: position{line: 419, col: 11, offset: 13130},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 431, col: 11, offset: 13119},
+												pos:  position{line: 419, col: 11, offset: 13130},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 431, col: 14, offset: 13122},
+												pos:   position{line: 419, col: 14, offset: 13133},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 431, col: 17, offset: 13125},
+													pos:  position{line: 419, col: 17, offset: 13136},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 431, col: 26, offset: 13134},
+												pos:  position{line: 419, col: 26, offset: 13145},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 431, col: 29, offset: 13137},
+												pos:   position{line: 419, col: 29, offset: 13148},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 431, col: 34, offset: 13142},
+													pos:  position{line: 419, col: 34, offset: 13153},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -2989,53 +3000,53 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 435, col: 1, offset: 13265},
+			pos:  position{line: 423, col: 1, offset: 13276},
 			expr: &actionExpr{
-				pos: position{line: 436, col: 5, offset: 13289},
+				pos: position{line: 424, col: 5, offset: 13300},
 				run: (*parser).callonEqualityCompareExpr1,
 				expr: &seqExpr{
-					pos: position{line: 436, col: 5, offset: 13289},
+					pos: position{line: 424, col: 5, offset: 13300},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 436, col: 5, offset: 13289},
+							pos:   position{line: 424, col: 5, offset: 13300},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 436, col: 11, offset: 13295},
+								pos:  position{line: 424, col: 11, offset: 13306},
 								name: "RelativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 437, col: 5, offset: 13312},
+							pos:   position{line: 425, col: 5, offset: 13323},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 437, col: 10, offset: 13317},
+								pos: position{line: 425, col: 10, offset: 13328},
 								expr: &actionExpr{
-									pos: position{line: 437, col: 11, offset: 13318},
+									pos: position{line: 425, col: 11, offset: 13329},
 									run: (*parser).callonEqualityCompareExpr7,
 									expr: &seqExpr{
-										pos: position{line: 437, col: 11, offset: 13318},
+										pos: position{line: 425, col: 11, offset: 13329},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 437, col: 11, offset: 13318},
+												pos:  position{line: 425, col: 11, offset: 13329},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 437, col: 14, offset: 13321},
+												pos:   position{line: 425, col: 14, offset: 13332},
 												label: "comp",
 												expr: &ruleRefExpr{
-													pos:  position{line: 437, col: 19, offset: 13326},
+													pos:  position{line: 425, col: 19, offset: 13337},
 													name: "EqualityComparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 437, col: 38, offset: 13345},
+												pos:  position{line: 425, col: 38, offset: 13356},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 437, col: 41, offset: 13348},
+												pos:   position{line: 425, col: 41, offset: 13359},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 437, col: 46, offset: 13353},
+													pos:  position{line: 425, col: 46, offset: 13364},
 													name: "RelativeExpr",
 												},
 											},
@@ -3050,30 +3061,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 441, col: 1, offset: 13471},
+			pos:  position{line: 429, col: 1, offset: 13482},
 			expr: &actionExpr{
-				pos: position{line: 441, col: 20, offset: 13490},
+				pos: position{line: 429, col: 20, offset: 13501},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 441, col: 21, offset: 13491},
+					pos: position{line: 429, col: 21, offset: 13502},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 441, col: 21, offset: 13491},
+							pos:        position{line: 429, col: 21, offset: 13502},
 							val:        "=~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 441, col: 28, offset: 13498},
+							pos:        position{line: 429, col: 28, offset: 13509},
 							val:        "!~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 441, col: 35, offset: 13505},
+							pos:        position{line: 429, col: 35, offset: 13516},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 441, col: 41, offset: 13511},
+							pos:        position{line: 429, col: 41, offset: 13522},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3083,19 +3094,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 443, col: 1, offset: 13549},
+			pos:  position{line: 431, col: 1, offset: 13560},
 			expr: &choiceExpr{
-				pos: position{line: 444, col: 5, offset: 13572},
+				pos: position{line: 432, col: 5, offset: 13583},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 444, col: 5, offset: 13572},
+						pos:  position{line: 432, col: 5, offset: 13583},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 445, col: 5, offset: 13593},
+						pos: position{line: 433, col: 5, offset: 13604},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 445, col: 5, offset: 13593},
+							pos:        position{line: 433, col: 5, offset: 13604},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3105,53 +3116,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 447, col: 1, offset: 13630},
+			pos:  position{line: 435, col: 1, offset: 13641},
 			expr: &actionExpr{
-				pos: position{line: 448, col: 5, offset: 13647},
+				pos: position{line: 436, col: 5, offset: 13658},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 448, col: 5, offset: 13647},
+					pos: position{line: 436, col: 5, offset: 13658},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 448, col: 5, offset: 13647},
+							pos:   position{line: 436, col: 5, offset: 13658},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 448, col: 11, offset: 13653},
+								pos:  position{line: 436, col: 11, offset: 13664},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 449, col: 5, offset: 13670},
+							pos:   position{line: 437, col: 5, offset: 13681},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 449, col: 10, offset: 13675},
+								pos: position{line: 437, col: 10, offset: 13686},
 								expr: &actionExpr{
-									pos: position{line: 449, col: 11, offset: 13676},
+									pos: position{line: 437, col: 11, offset: 13687},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 449, col: 11, offset: 13676},
+										pos: position{line: 437, col: 11, offset: 13687},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 449, col: 11, offset: 13676},
+												pos:  position{line: 437, col: 11, offset: 13687},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 449, col: 14, offset: 13679},
+												pos:   position{line: 437, col: 14, offset: 13690},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 449, col: 17, offset: 13682},
+													pos:  position{line: 437, col: 17, offset: 13693},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 449, col: 34, offset: 13699},
+												pos:  position{line: 437, col: 34, offset: 13710},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 449, col: 37, offset: 13702},
+												pos:   position{line: 437, col: 37, offset: 13713},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 449, col: 42, offset: 13707},
+													pos:  position{line: 437, col: 42, offset: 13718},
 													name: "AdditiveExpr",
 												},
 											},
@@ -3166,30 +3177,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 453, col: 1, offset: 13823},
+			pos:  position{line: 441, col: 1, offset: 13834},
 			expr: &actionExpr{
-				pos: position{line: 453, col: 20, offset: 13842},
+				pos: position{line: 441, col: 20, offset: 13853},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 453, col: 21, offset: 13843},
+					pos: position{line: 441, col: 21, offset: 13854},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 453, col: 21, offset: 13843},
+							pos:        position{line: 441, col: 21, offset: 13854},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 453, col: 28, offset: 13850},
+							pos:        position{line: 441, col: 28, offset: 13861},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 453, col: 34, offset: 13856},
+							pos:        position{line: 441, col: 34, offset: 13867},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 453, col: 41, offset: 13863},
+							pos:        position{line: 441, col: 41, offset: 13874},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -3199,53 +3210,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 455, col: 1, offset: 13900},
+			pos:  position{line: 443, col: 1, offset: 13911},
 			expr: &actionExpr{
-				pos: position{line: 456, col: 5, offset: 13917},
+				pos: position{line: 444, col: 5, offset: 13928},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 456, col: 5, offset: 13917},
+					pos: position{line: 444, col: 5, offset: 13928},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 456, col: 5, offset: 13917},
+							pos:   position{line: 444, col: 5, offset: 13928},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 456, col: 11, offset: 13923},
+								pos:  position{line: 444, col: 11, offset: 13934},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 457, col: 5, offset: 13946},
+							pos:   position{line: 445, col: 5, offset: 13957},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 457, col: 10, offset: 13951},
+								pos: position{line: 445, col: 10, offset: 13962},
 								expr: &actionExpr{
-									pos: position{line: 457, col: 11, offset: 13952},
+									pos: position{line: 445, col: 11, offset: 13963},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 457, col: 11, offset: 13952},
+										pos: position{line: 445, col: 11, offset: 13963},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 457, col: 11, offset: 13952},
+												pos:  position{line: 445, col: 11, offset: 13963},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 457, col: 14, offset: 13955},
+												pos:   position{line: 445, col: 14, offset: 13966},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 457, col: 17, offset: 13958},
+													pos:  position{line: 445, col: 17, offset: 13969},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 457, col: 34, offset: 13975},
+												pos:  position{line: 445, col: 34, offset: 13986},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 457, col: 37, offset: 13978},
+												pos:   position{line: 445, col: 37, offset: 13989},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 457, col: 42, offset: 13983},
+													pos:  position{line: 445, col: 42, offset: 13994},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -3260,20 +3271,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 461, col: 1, offset: 14105},
+			pos:  position{line: 449, col: 1, offset: 14116},
 			expr: &actionExpr{
-				pos: position{line: 461, col: 20, offset: 14124},
+				pos: position{line: 449, col: 20, offset: 14135},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 461, col: 21, offset: 14125},
+					pos: position{line: 449, col: 21, offset: 14136},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 461, col: 21, offset: 14125},
+							pos:        position{line: 449, col: 21, offset: 14136},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 461, col: 27, offset: 14131},
+							pos:        position{line: 449, col: 27, offset: 14142},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3283,53 +3294,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 463, col: 1, offset: 14168},
+			pos:  position{line: 451, col: 1, offset: 14179},
 			expr: &actionExpr{
-				pos: position{line: 464, col: 5, offset: 14191},
+				pos: position{line: 452, col: 5, offset: 14202},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 464, col: 5, offset: 14191},
+					pos: position{line: 452, col: 5, offset: 14202},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 464, col: 5, offset: 14191},
+							pos:   position{line: 452, col: 5, offset: 14202},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 464, col: 11, offset: 14197},
+								pos:  position{line: 452, col: 11, offset: 14208},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 465, col: 5, offset: 14209},
+							pos:   position{line: 453, col: 5, offset: 14220},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 465, col: 10, offset: 14214},
+								pos: position{line: 453, col: 10, offset: 14225},
 								expr: &actionExpr{
-									pos: position{line: 465, col: 11, offset: 14215},
+									pos: position{line: 453, col: 11, offset: 14226},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 465, col: 11, offset: 14215},
+										pos: position{line: 453, col: 11, offset: 14226},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 465, col: 11, offset: 14215},
+												pos:  position{line: 453, col: 11, offset: 14226},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 465, col: 14, offset: 14218},
+												pos:   position{line: 453, col: 14, offset: 14229},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 465, col: 17, offset: 14221},
+													pos:  position{line: 453, col: 17, offset: 14232},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 465, col: 40, offset: 14244},
+												pos:  position{line: 453, col: 40, offset: 14255},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 465, col: 43, offset: 14247},
+												pos:   position{line: 453, col: 43, offset: 14258},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 465, col: 48, offset: 14252},
+													pos:  position{line: 453, col: 48, offset: 14263},
 													name: "NotExpr",
 												},
 											},
@@ -3344,20 +3355,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 469, col: 1, offset: 14363},
+			pos:  position{line: 457, col: 1, offset: 14374},
 			expr: &actionExpr{
-				pos: position{line: 469, col: 26, offset: 14388},
+				pos: position{line: 457, col: 26, offset: 14399},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 469, col: 27, offset: 14389},
+					pos: position{line: 457, col: 27, offset: 14400},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 469, col: 27, offset: 14389},
+							pos:        position{line: 457, col: 27, offset: 14400},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 469, col: 33, offset: 14395},
+							pos:        position{line: 457, col: 33, offset: 14406},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -3367,30 +3378,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 471, col: 1, offset: 14432},
+			pos:  position{line: 459, col: 1, offset: 14443},
 			expr: &choiceExpr{
-				pos: position{line: 472, col: 5, offset: 14444},
+				pos: position{line: 460, col: 5, offset: 14455},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 472, col: 5, offset: 14444},
+						pos: position{line: 460, col: 5, offset: 14455},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 472, col: 5, offset: 14444},
+							pos: position{line: 460, col: 5, offset: 14455},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 472, col: 5, offset: 14444},
+									pos:        position{line: 460, col: 5, offset: 14455},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 472, col: 9, offset: 14448},
+									pos:  position{line: 460, col: 9, offset: 14459},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 472, col: 12, offset: 14451},
+									pos:   position{line: 460, col: 12, offset: 14462},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 472, col: 14, offset: 14453},
+										pos:  position{line: 460, col: 14, offset: 14464},
 										name: "NotExpr",
 									},
 								},
@@ -3398,7 +3409,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 475, col: 5, offset: 14566},
+						pos:  position{line: 463, col: 5, offset: 14577},
 						name: "CastExpr",
 					},
 				},
@@ -3406,43 +3417,43 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpr",
-			pos:  position{line: 477, col: 1, offset: 14576},
+			pos:  position{line: 465, col: 1, offset: 14587},
 			expr: &choiceExpr{
-				pos: position{line: 478, col: 5, offset: 14589},
+				pos: position{line: 466, col: 5, offset: 14600},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 478, col: 5, offset: 14589},
+						pos: position{line: 466, col: 5, offset: 14600},
 						run: (*parser).callonCastExpr2,
 						expr: &seqExpr{
-							pos: position{line: 478, col: 5, offset: 14589},
+							pos: position{line: 466, col: 5, offset: 14600},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 478, col: 5, offset: 14589},
+									pos:   position{line: 466, col: 5, offset: 14600},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 478, col: 7, offset: 14591},
+										pos:  position{line: 466, col: 7, offset: 14602},
 										name: "FuncExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 478, col: 16, offset: 14600},
+									pos:   position{line: 466, col: 16, offset: 14611},
 									label: "typ",
 									expr: &actionExpr{
-										pos: position{line: 478, col: 22, offset: 14606},
+										pos: position{line: 466, col: 22, offset: 14617},
 										run: (*parser).callonCastExpr7,
 										expr: &seqExpr{
-											pos: position{line: 478, col: 22, offset: 14606},
+											pos: position{line: 466, col: 22, offset: 14617},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 478, col: 22, offset: 14606},
+													pos:        position{line: 466, col: 22, offset: 14617},
 													val:        ":",
 													ignoreCase: false,
 												},
 												&labeledExpr{
-													pos:   position{line: 478, col: 26, offset: 14610},
+													pos:   position{line: 466, col: 26, offset: 14621},
 													label: "typ",
 													expr: &ruleRefExpr{
-														pos:  position{line: 478, col: 30, offset: 14614},
+														pos:  position{line: 466, col: 30, offset: 14625},
 														name: "PrimitiveType",
 													},
 												},
@@ -3454,7 +3465,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 481, col: 5, offset: 14744},
+						pos:  position{line: 469, col: 5, offset: 14755},
 						name: "FuncExpr",
 					},
 				},
@@ -3462,115 +3473,115 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 484, col: 1, offset: 14755},
+			pos:  position{line: 472, col: 1, offset: 14766},
 			expr: &actionExpr{
-				pos: position{line: 485, col: 5, offset: 14773},
+				pos: position{line: 473, col: 5, offset: 14784},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 485, col: 9, offset: 14777},
+					pos: position{line: 473, col: 9, offset: 14788},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 485, col: 9, offset: 14777},
+							pos:        position{line: 473, col: 9, offset: 14788},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 19, offset: 14787},
+							pos:        position{line: 473, col: 19, offset: 14798},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 29, offset: 14797},
+							pos:        position{line: 473, col: 29, offset: 14808},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 40, offset: 14808},
+							pos:        position{line: 473, col: 40, offset: 14819},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 51, offset: 14819},
+							pos:        position{line: 473, col: 51, offset: 14830},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 486, col: 9, offset: 14836},
+							pos:        position{line: 474, col: 9, offset: 14847},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 486, col: 18, offset: 14845},
+							pos:        position{line: 474, col: 18, offset: 14856},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 486, col: 28, offset: 14855},
+							pos:        position{line: 474, col: 28, offset: 14866},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 486, col: 38, offset: 14865},
+							pos:        position{line: 474, col: 38, offset: 14876},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 487, col: 9, offset: 14881},
+							pos:        position{line: 475, col: 9, offset: 14892},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 487, col: 22, offset: 14894},
+							pos:        position{line: 475, col: 22, offset: 14905},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 488, col: 9, offset: 14909},
+							pos:        position{line: 476, col: 9, offset: 14920},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 9, offset: 14927},
+							pos:        position{line: 477, col: 9, offset: 14938},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 18, offset: 14936},
+							pos:        position{line: 477, col: 18, offset: 14947},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 28, offset: 14946},
+							pos:        position{line: 477, col: 28, offset: 14957},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 39, offset: 14957},
+							pos:        position{line: 477, col: 39, offset: 14968},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 490, col: 9, offset: 14975},
+							pos:        position{line: 478, col: 9, offset: 14986},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 490, col: 16, offset: 14982},
+							pos:        position{line: 478, col: 16, offset: 14993},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 491, col: 9, offset: 14996},
+							pos:        position{line: 479, col: 9, offset: 15007},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 491, col: 18, offset: 15005},
+							pos:        position{line: 479, col: 18, offset: 15016},
 							val:        "error",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 491, col: 28, offset: 15015},
+							pos:        position{line: 479, col: 28, offset: 15026},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -3580,31 +3591,31 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 493, col: 1, offset: 15056},
+			pos:  position{line: 481, col: 1, offset: 15067},
 			expr: &choiceExpr{
-				pos: position{line: 494, col: 5, offset: 15069},
+				pos: position{line: 482, col: 5, offset: 15080},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 494, col: 5, offset: 15069},
+						pos: position{line: 482, col: 5, offset: 15080},
 						run: (*parser).callonFuncExpr2,
 						expr: &seqExpr{
-							pos: position{line: 494, col: 5, offset: 15069},
+							pos: position{line: 482, col: 5, offset: 15080},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 494, col: 5, offset: 15069},
+									pos:   position{line: 482, col: 5, offset: 15080},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 494, col: 11, offset: 15075},
+										pos:  position{line: 482, col: 11, offset: 15086},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 494, col: 20, offset: 15084},
+									pos:   position{line: 482, col: 20, offset: 15095},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 494, col: 25, offset: 15089},
+										pos: position{line: 482, col: 25, offset: 15100},
 										expr: &ruleRefExpr{
-											pos:  position{line: 494, col: 26, offset: 15090},
+											pos:  position{line: 482, col: 26, offset: 15101},
 											name: "Deref",
 										},
 									},
@@ -3613,11 +3624,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 497, col: 5, offset: 15161},
+						pos:  position{line: 485, col: 5, offset: 15172},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 498, col: 5, offset: 15175},
+						pos:  position{line: 486, col: 5, offset: 15186},
 						name: "Primary",
 					},
 				},
@@ -3625,40 +3636,40 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 500, col: 1, offset: 15184},
+			pos:  position{line: 488, col: 1, offset: 15195},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 15197},
+				pos: position{line: 489, col: 5, offset: 15208},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 5, offset: 15197},
+					pos: position{line: 489, col: 5, offset: 15208},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 501, col: 5, offset: 15197},
+							pos:   position{line: 489, col: 5, offset: 15208},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 8, offset: 15200},
+								pos:  position{line: 489, col: 8, offset: 15211},
 								name: "DeprecatedName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 23, offset: 15215},
+							pos:  position{line: 489, col: 23, offset: 15226},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 501, col: 26, offset: 15218},
+							pos:        position{line: 489, col: 26, offset: 15229},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 30, offset: 15222},
+							pos:   position{line: 489, col: 30, offset: 15233},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 35, offset: 15227},
+								pos:  position{line: 489, col: 35, offset: 15238},
 								name: "ArgumentList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 501, col: 48, offset: 15240},
+							pos:        position{line: 489, col: 48, offset: 15251},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -3668,28 +3679,28 @@ var g = &grammar{
 		},
 		{
 			name: "DeprecatedName",
-			pos:  position{line: 507, col: 1, offset: 15472},
+			pos:  position{line: 495, col: 1, offset: 15483},
 			expr: &actionExpr{
-				pos: position{line: 507, col: 18, offset: 15489},
+				pos: position{line: 495, col: 18, offset: 15500},
 				run: (*parser).callonDeprecatedName1,
 				expr: &seqExpr{
-					pos: position{line: 507, col: 18, offset: 15489},
+					pos: position{line: 495, col: 18, offset: 15500},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 507, col: 18, offset: 15489},
+							pos:  position{line: 495, col: 18, offset: 15500},
 							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 507, col: 34, offset: 15505},
+							pos: position{line: 495, col: 34, offset: 15516},
 							expr: &choiceExpr{
-								pos: position{line: 507, col: 35, offset: 15506},
+								pos: position{line: 495, col: 35, offset: 15517},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 507, col: 35, offset: 15506},
+										pos:  position{line: 495, col: 35, offset: 15517},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 507, col: 52, offset: 15523},
+										pos:        position{line: 495, col: 52, offset: 15534},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -3702,53 +3713,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 509, col: 1, offset: 15561},
+			pos:  position{line: 497, col: 1, offset: 15572},
 			expr: &choiceExpr{
-				pos: position{line: 510, col: 5, offset: 15578},
+				pos: position{line: 498, col: 5, offset: 15589},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 510, col: 5, offset: 15578},
+						pos: position{line: 498, col: 5, offset: 15589},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 510, col: 5, offset: 15578},
+							pos: position{line: 498, col: 5, offset: 15589},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 510, col: 5, offset: 15578},
+									pos:   position{line: 498, col: 5, offset: 15589},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 510, col: 11, offset: 15584},
+										pos:  position{line: 498, col: 11, offset: 15595},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 510, col: 16, offset: 15589},
+									pos:   position{line: 498, col: 16, offset: 15600},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 510, col: 21, offset: 15594},
+										pos: position{line: 498, col: 21, offset: 15605},
 										expr: &actionExpr{
-											pos: position{line: 510, col: 22, offset: 15595},
+											pos: position{line: 498, col: 22, offset: 15606},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 510, col: 22, offset: 15595},
+												pos: position{line: 498, col: 22, offset: 15606},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 510, col: 22, offset: 15595},
+														pos:  position{line: 498, col: 22, offset: 15606},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 510, col: 25, offset: 15598},
+														pos:        position{line: 498, col: 25, offset: 15609},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 510, col: 29, offset: 15602},
+														pos:  position{line: 498, col: 29, offset: 15613},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 510, col: 32, offset: 15605},
+														pos:   position{line: 498, col: 32, offset: 15616},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 510, col: 34, offset: 15607},
+															pos:  position{line: 498, col: 34, offset: 15618},
 															name: "Expr",
 														},
 													},
@@ -3761,10 +3772,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 513, col: 5, offset: 15719},
+						pos: position{line: 501, col: 5, offset: 15730},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 513, col: 5, offset: 15719},
+							pos:  position{line: 501, col: 5, offset: 15730},
 							name: "__",
 						},
 					},
@@ -3773,28 +3784,28 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 515, col: 1, offset: 15755},
+			pos:  position{line: 503, col: 1, offset: 15766},
 			expr: &actionExpr{
-				pos: position{line: 516, col: 5, offset: 15769},
+				pos: position{line: 504, col: 5, offset: 15780},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 516, col: 5, offset: 15769},
+					pos: position{line: 504, col: 5, offset: 15780},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 516, col: 5, offset: 15769},
+							pos:   position{line: 504, col: 5, offset: 15780},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 516, col: 11, offset: 15775},
+								pos:  position{line: 504, col: 11, offset: 15786},
 								name: "RootField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 516, col: 21, offset: 15785},
+							pos:   position{line: 504, col: 21, offset: 15796},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 516, col: 26, offset: 15790},
+								pos: position{line: 504, col: 26, offset: 15801},
 								expr: &ruleRefExpr{
-									pos:  position{line: 516, col: 27, offset: 15791},
+									pos:  position{line: 504, col: 27, offset: 15802},
 									name: "Deref",
 								},
 							},
@@ -3805,31 +3816,31 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 520, col: 1, offset: 15859},
+			pos:  position{line: 508, col: 1, offset: 15870},
 			expr: &choiceExpr{
-				pos: position{line: 521, col: 5, offset: 15869},
+				pos: position{line: 509, col: 5, offset: 15880},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 521, col: 5, offset: 15869},
+						pos: position{line: 509, col: 5, offset: 15880},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 521, col: 5, offset: 15869},
+							pos: position{line: 509, col: 5, offset: 15880},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 521, col: 5, offset: 15869},
+									pos:        position{line: 509, col: 5, offset: 15880},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 521, col: 9, offset: 15873},
+									pos:   position{line: 509, col: 9, offset: 15884},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 521, col: 14, offset: 15878},
+										pos:  position{line: 509, col: 14, offset: 15889},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 521, col: 19, offset: 15883},
+									pos:        position{line: 509, col: 19, offset: 15894},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -3837,29 +3848,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 522, col: 5, offset: 15932},
+						pos: position{line: 510, col: 5, offset: 15943},
 						run: (*parser).callonDeref8,
 						expr: &seqExpr{
-							pos: position{line: 522, col: 5, offset: 15932},
+							pos: position{line: 510, col: 5, offset: 15943},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 522, col: 5, offset: 15932},
+									pos:        position{line: 510, col: 5, offset: 15943},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 522, col: 9, offset: 15936},
+									pos: position{line: 510, col: 9, offset: 15947},
 									expr: &litMatcher{
-										pos:        position{line: 522, col: 11, offset: 15938},
+										pos:        position{line: 510, col: 11, offset: 15949},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 522, col: 16, offset: 15943},
+									pos:   position{line: 510, col: 16, offset: 15954},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 522, col: 19, offset: 15946},
+										pos:  position{line: 510, col: 19, offset: 15957},
 										name: "Identifier",
 									},
 								},
@@ -3871,71 +3882,71 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 524, col: 1, offset: 15997},
+			pos:  position{line: 512, col: 1, offset: 16008},
 			expr: &choiceExpr{
-				pos: position{line: 525, col: 5, offset: 16009},
+				pos: position{line: 513, col: 5, offset: 16020},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 525, col: 5, offset: 16009},
+						pos:  position{line: 513, col: 5, offset: 16020},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 526, col: 5, offset: 16027},
+						pos:  position{line: 514, col: 5, offset: 16038},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 527, col: 5, offset: 16045},
+						pos:  position{line: 515, col: 5, offset: 16056},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 528, col: 5, offset: 16063},
+						pos:  position{line: 516, col: 5, offset: 16074},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 529, col: 5, offset: 16082},
+						pos:  position{line: 517, col: 5, offset: 16093},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 530, col: 5, offset: 16099},
+						pos:  position{line: 518, col: 5, offset: 16110},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 531, col: 5, offset: 16118},
+						pos:  position{line: 519, col: 5, offset: 16129},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 532, col: 5, offset: 16137},
+						pos:  position{line: 520, col: 5, offset: 16148},
 						name: "NullLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 533, col: 5, offset: 16153},
+						pos: position{line: 521, col: 5, offset: 16164},
 						run: (*parser).callonPrimary10,
 						expr: &seqExpr{
-							pos: position{line: 533, col: 5, offset: 16153},
+							pos: position{line: 521, col: 5, offset: 16164},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 533, col: 5, offset: 16153},
+									pos:        position{line: 521, col: 5, offset: 16164},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 533, col: 9, offset: 16157},
+									pos:  position{line: 521, col: 9, offset: 16168},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 533, col: 12, offset: 16160},
+									pos:   position{line: 521, col: 12, offset: 16171},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 533, col: 17, offset: 16165},
+										pos:  position{line: 521, col: 17, offset: 16176},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 533, col: 22, offset: 16170},
+									pos:  position{line: 521, col: 22, offset: 16181},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 533, col: 25, offset: 16173},
+									pos:        position{line: 521, col: 25, offset: 16184},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3947,16 +3958,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 535, col: 1, offset: 16199},
+			pos:  position{line: 523, col: 1, offset: 16210},
 			expr: &choiceExpr{
-				pos: position{line: 536, col: 5, offset: 16217},
+				pos: position{line: 524, col: 5, offset: 16228},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 536, col: 5, offset: 16217},
+						pos:  position{line: 524, col: 5, offset: 16228},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 536, col: 24, offset: 16236},
+						pos:  position{line: 524, col: 24, offset: 16247},
 						name: "RelativeOperator",
 					},
 				},
@@ -3964,12 +3975,12 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 538, col: 1, offset: 16254},
+			pos:  position{line: 526, col: 1, offset: 16265},
 			expr: &actionExpr{
-				pos: position{line: 538, col: 12, offset: 16265},
+				pos: position{line: 526, col: 12, offset: 16276},
 				run: (*parser).callonAndToken1,
 				expr: &litMatcher{
-					pos:        position{line: 538, col: 12, offset: 16265},
+					pos:        position{line: 526, col: 12, offset: 16276},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -3977,12 +3988,12 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 539, col: 1, offset: 16303},
+			pos:  position{line: 527, col: 1, offset: 16314},
 			expr: &actionExpr{
-				pos: position{line: 539, col: 11, offset: 16313},
+				pos: position{line: 527, col: 11, offset: 16324},
 				run: (*parser).callonOrToken1,
 				expr: &litMatcher{
-					pos:        position{line: 539, col: 11, offset: 16313},
+					pos:        position{line: 527, col: 11, offset: 16324},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -3990,12 +4001,12 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 540, col: 1, offset: 16350},
+			pos:  position{line: 528, col: 1, offset: 16361},
 			expr: &actionExpr{
-				pos: position{line: 540, col: 11, offset: 16360},
+				pos: position{line: 528, col: 11, offset: 16371},
 				run: (*parser).callonInToken1,
 				expr: &litMatcher{
-					pos:        position{line: 540, col: 11, offset: 16360},
+					pos:        position{line: 528, col: 11, offset: 16371},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -4003,12 +4014,12 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 541, col: 1, offset: 16397},
+			pos:  position{line: 529, col: 1, offset: 16408},
 			expr: &actionExpr{
-				pos: position{line: 541, col: 12, offset: 16408},
+				pos: position{line: 529, col: 12, offset: 16419},
 				run: (*parser).callonNotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 541, col: 12, offset: 16408},
+					pos:        position{line: 529, col: 12, offset: 16419},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -4016,21 +4027,21 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 543, col: 1, offset: 16447},
+			pos:  position{line: 531, col: 1, offset: 16458},
 			expr: &actionExpr{
-				pos: position{line: 543, col: 18, offset: 16464},
+				pos: position{line: 531, col: 18, offset: 16475},
 				run: (*parser).callonIdentifierName1,
 				expr: &seqExpr{
-					pos: position{line: 543, col: 18, offset: 16464},
+					pos: position{line: 531, col: 18, offset: 16475},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 543, col: 18, offset: 16464},
+							pos:  position{line: 531, col: 18, offset: 16475},
 							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 543, col: 34, offset: 16480},
+							pos: position{line: 531, col: 34, offset: 16491},
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 34, offset: 16480},
+								pos:  position{line: 531, col: 34, offset: 16491},
 								name: "IdentifierRest",
 							},
 						},
@@ -4040,9 +4051,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 545, col: 1, offset: 16528},
+			pos:  position{line: 533, col: 1, offset: 16539},
 			expr: &charClassMatcher{
-				pos:        position{line: 545, col: 19, offset: 16546},
+				pos:        position{line: 533, col: 19, offset: 16557},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -4052,16 +4063,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 546, col: 1, offset: 16557},
+			pos:  position{line: 534, col: 1, offset: 16568},
 			expr: &choiceExpr{
-				pos: position{line: 546, col: 18, offset: 16574},
+				pos: position{line: 534, col: 18, offset: 16585},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 546, col: 18, offset: 16574},
+						pos:  position{line: 534, col: 18, offset: 16585},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 546, col: 36, offset: 16592},
+						pos:        position{line: 534, col: 36, offset: 16603},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4072,21 +4083,21 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 548, col: 1, offset: 16599},
+			pos:  position{line: 536, col: 1, offset: 16610},
 			expr: &actionExpr{
-				pos: position{line: 549, col: 5, offset: 16614},
+				pos: position{line: 537, col: 5, offset: 16625},
 				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 549, col: 5, offset: 16614},
+					pos: position{line: 537, col: 5, offset: 16625},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 549, col: 5, offset: 16614},
+							pos:  position{line: 537, col: 5, offset: 16625},
 							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 549, col: 21, offset: 16630},
+							pos: position{line: 537, col: 21, offset: 16641},
 							expr: &ruleRefExpr{
-								pos:  position{line: 549, col: 21, offset: 16630},
+								pos:  position{line: 537, col: 21, offset: 16641},
 								name: "IdentifierRest",
 							},
 						},
@@ -4096,54 +4107,54 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 551, col: 1, offset: 16730},
+			pos:  position{line: 539, col: 1, offset: 16741},
 			expr: &choiceExpr{
-				pos: position{line: 552, col: 5, offset: 16743},
+				pos: position{line: 540, col: 5, offset: 16754},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 552, col: 5, offset: 16743},
+						pos:  position{line: 540, col: 5, offset: 16754},
 						name: "Seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 553, col: 5, offset: 16755},
+						pos:  position{line: 541, col: 5, offset: 16766},
 						name: "Minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 554, col: 5, offset: 16767},
+						pos:  position{line: 542, col: 5, offset: 16778},
 						name: "Hours",
 					},
 					&seqExpr{
-						pos: position{line: 555, col: 5, offset: 16777},
+						pos: position{line: 543, col: 5, offset: 16788},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 555, col: 5, offset: 16777},
+								pos:  position{line: 543, col: 5, offset: 16788},
 								name: "Hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 555, col: 11, offset: 16783},
+								pos:  position{line: 543, col: 11, offset: 16794},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 555, col: 13, offset: 16785},
+								pos:        position{line: 543, col: 13, offset: 16796},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 555, col: 19, offset: 16791},
+								pos:  position{line: 543, col: 19, offset: 16802},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 555, col: 21, offset: 16793},
+								pos:  position{line: 543, col: 21, offset: 16804},
 								name: "Minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 556, col: 5, offset: 16805},
+						pos:  position{line: 544, col: 5, offset: 16816},
 						name: "Days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 557, col: 5, offset: 16814},
+						pos:  position{line: 545, col: 5, offset: 16825},
 						name: "Weeks",
 					},
 				},
@@ -4151,32 +4162,32 @@ var g = &grammar{
 		},
 		{
 			name: "SecondsToken",
-			pos:  position{line: 559, col: 1, offset: 16821},
+			pos:  position{line: 547, col: 1, offset: 16832},
 			expr: &choiceExpr{
-				pos: position{line: 560, col: 5, offset: 16838},
+				pos: position{line: 548, col: 5, offset: 16849},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 560, col: 5, offset: 16838},
+						pos:        position{line: 548, col: 5, offset: 16849},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 561, col: 5, offset: 16852},
+						pos:        position{line: 549, col: 5, offset: 16863},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 562, col: 5, offset: 16865},
+						pos:        position{line: 550, col: 5, offset: 16876},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 563, col: 5, offset: 16876},
+						pos:        position{line: 551, col: 5, offset: 16887},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 564, col: 5, offset: 16886},
+						pos:        position{line: 552, col: 5, offset: 16897},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -4185,32 +4196,32 @@ var g = &grammar{
 		},
 		{
 			name: "MinutesToken",
-			pos:  position{line: 566, col: 1, offset: 16891},
+			pos:  position{line: 554, col: 1, offset: 16902},
 			expr: &choiceExpr{
-				pos: position{line: 567, col: 5, offset: 16908},
+				pos: position{line: 555, col: 5, offset: 16919},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 567, col: 5, offset: 16908},
+						pos:        position{line: 555, col: 5, offset: 16919},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 568, col: 5, offset: 16922},
+						pos:        position{line: 556, col: 5, offset: 16933},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 569, col: 5, offset: 16935},
+						pos:        position{line: 557, col: 5, offset: 16946},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 570, col: 5, offset: 16946},
+						pos:        position{line: 558, col: 5, offset: 16957},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 571, col: 5, offset: 16956},
+						pos:        position{line: 559, col: 5, offset: 16967},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -4219,32 +4230,32 @@ var g = &grammar{
 		},
 		{
 			name: "HoursToken",
-			pos:  position{line: 573, col: 1, offset: 16961},
+			pos:  position{line: 561, col: 1, offset: 16972},
 			expr: &choiceExpr{
-				pos: position{line: 574, col: 5, offset: 16976},
+				pos: position{line: 562, col: 5, offset: 16987},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 574, col: 5, offset: 16976},
+						pos:        position{line: 562, col: 5, offset: 16987},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 575, col: 5, offset: 16988},
+						pos:        position{line: 563, col: 5, offset: 16999},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 576, col: 5, offset: 16998},
+						pos:        position{line: 564, col: 5, offset: 17009},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 577, col: 5, offset: 17007},
+						pos:        position{line: 565, col: 5, offset: 17018},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 578, col: 5, offset: 17015},
+						pos:        position{line: 566, col: 5, offset: 17026},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -4253,22 +4264,22 @@ var g = &grammar{
 		},
 		{
 			name: "DaysToken",
-			pos:  position{line: 580, col: 1, offset: 17023},
+			pos:  position{line: 568, col: 1, offset: 17034},
 			expr: &choiceExpr{
-				pos: position{line: 580, col: 13, offset: 17035},
+				pos: position{line: 568, col: 13, offset: 17046},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 580, col: 13, offset: 17035},
+						pos:        position{line: 568, col: 13, offset: 17046},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 580, col: 20, offset: 17042},
+						pos:        position{line: 568, col: 20, offset: 17053},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 580, col: 26, offset: 17048},
+						pos:        position{line: 568, col: 26, offset: 17059},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -4277,32 +4288,32 @@ var g = &grammar{
 		},
 		{
 			name: "WeeksToken",
-			pos:  position{line: 581, col: 1, offset: 17052},
+			pos:  position{line: 569, col: 1, offset: 17063},
 			expr: &choiceExpr{
-				pos: position{line: 581, col: 14, offset: 17065},
+				pos: position{line: 569, col: 14, offset: 17076},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 581, col: 14, offset: 17065},
+						pos:        position{line: 569, col: 14, offset: 17076},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 581, col: 22, offset: 17073},
+						pos:        position{line: 569, col: 22, offset: 17084},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 581, col: 29, offset: 17080},
+						pos:        position{line: 569, col: 29, offset: 17091},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 581, col: 35, offset: 17086},
+						pos:        position{line: 569, col: 35, offset: 17097},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 581, col: 40, offset: 17091},
+						pos:        position{line: 569, col: 40, offset: 17102},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -4311,39 +4322,39 @@ var g = &grammar{
 		},
 		{
 			name: "Seconds",
-			pos:  position{line: 583, col: 1, offset: 17096},
+			pos:  position{line: 571, col: 1, offset: 17107},
 			expr: &choiceExpr{
-				pos: position{line: 584, col: 5, offset: 17108},
+				pos: position{line: 572, col: 5, offset: 17119},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 584, col: 5, offset: 17108},
+						pos: position{line: 572, col: 5, offset: 17119},
 						run: (*parser).callonSeconds2,
 						expr: &litMatcher{
-							pos:        position{line: 584, col: 5, offset: 17108},
+							pos:        position{line: 572, col: 5, offset: 17119},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 585, col: 5, offset: 17194},
+						pos: position{line: 573, col: 5, offset: 17205},
 						run: (*parser).callonSeconds4,
 						expr: &seqExpr{
-							pos: position{line: 585, col: 5, offset: 17194},
+							pos: position{line: 573, col: 5, offset: 17205},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 585, col: 5, offset: 17194},
+									pos:   position{line: 573, col: 5, offset: 17205},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 585, col: 9, offset: 17198},
+										pos:  position{line: 573, col: 9, offset: 17209},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 585, col: 14, offset: 17203},
+									pos:  position{line: 573, col: 14, offset: 17214},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 585, col: 17, offset: 17206},
+									pos:  position{line: 573, col: 17, offset: 17217},
 									name: "SecondsToken",
 								},
 							},
@@ -4354,39 +4365,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minutes",
-			pos:  position{line: 587, col: 1, offset: 17295},
+			pos:  position{line: 575, col: 1, offset: 17306},
 			expr: &choiceExpr{
-				pos: position{line: 588, col: 5, offset: 17307},
+				pos: position{line: 576, col: 5, offset: 17318},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 588, col: 5, offset: 17307},
+						pos: position{line: 576, col: 5, offset: 17318},
 						run: (*parser).callonMinutes2,
 						expr: &litMatcher{
-							pos:        position{line: 588, col: 5, offset: 17307},
+							pos:        position{line: 576, col: 5, offset: 17318},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 589, col: 5, offset: 17394},
+						pos: position{line: 577, col: 5, offset: 17405},
 						run: (*parser).callonMinutes4,
 						expr: &seqExpr{
-							pos: position{line: 589, col: 5, offset: 17394},
+							pos: position{line: 577, col: 5, offset: 17405},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 589, col: 5, offset: 17394},
+									pos:   position{line: 577, col: 5, offset: 17405},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 589, col: 9, offset: 17398},
+										pos:  position{line: 577, col: 9, offset: 17409},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 589, col: 14, offset: 17403},
+									pos:  position{line: 577, col: 14, offset: 17414},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 589, col: 17, offset: 17406},
+									pos:  position{line: 577, col: 17, offset: 17417},
 									name: "MinutesToken",
 								},
 							},
@@ -4397,39 +4408,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hours",
-			pos:  position{line: 591, col: 1, offset: 17504},
+			pos:  position{line: 579, col: 1, offset: 17515},
 			expr: &choiceExpr{
-				pos: position{line: 592, col: 5, offset: 17514},
+				pos: position{line: 580, col: 5, offset: 17525},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 592, col: 5, offset: 17514},
+						pos: position{line: 580, col: 5, offset: 17525},
 						run: (*parser).callonHours2,
 						expr: &litMatcher{
-							pos:        position{line: 592, col: 5, offset: 17514},
+							pos:        position{line: 580, col: 5, offset: 17525},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 593, col: 5, offset: 17601},
+						pos: position{line: 581, col: 5, offset: 17612},
 						run: (*parser).callonHours4,
 						expr: &seqExpr{
-							pos: position{line: 593, col: 5, offset: 17601},
+							pos: position{line: 581, col: 5, offset: 17612},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 593, col: 5, offset: 17601},
+									pos:   position{line: 581, col: 5, offset: 17612},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 593, col: 9, offset: 17605},
+										pos:  position{line: 581, col: 9, offset: 17616},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 14, offset: 17610},
+									pos:  position{line: 581, col: 14, offset: 17621},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 17, offset: 17613},
+									pos:  position{line: 581, col: 17, offset: 17624},
 									name: "HoursToken",
 								},
 							},
@@ -4440,39 +4451,39 @@ var g = &grammar{
 		},
 		{
 			name: "Days",
-			pos:  position{line: 595, col: 1, offset: 17711},
+			pos:  position{line: 583, col: 1, offset: 17722},
 			expr: &choiceExpr{
-				pos: position{line: 596, col: 5, offset: 17720},
+				pos: position{line: 584, col: 5, offset: 17731},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 596, col: 5, offset: 17720},
+						pos: position{line: 584, col: 5, offset: 17731},
 						run: (*parser).callonDays2,
 						expr: &litMatcher{
-							pos:        position{line: 596, col: 5, offset: 17720},
+							pos:        position{line: 584, col: 5, offset: 17731},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 597, col: 5, offset: 17809},
+						pos: position{line: 585, col: 5, offset: 17820},
 						run: (*parser).callonDays4,
 						expr: &seqExpr{
-							pos: position{line: 597, col: 5, offset: 17809},
+							pos: position{line: 585, col: 5, offset: 17820},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 597, col: 5, offset: 17809},
+									pos:   position{line: 585, col: 5, offset: 17820},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 597, col: 9, offset: 17813},
+										pos:  position{line: 585, col: 9, offset: 17824},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 597, col: 14, offset: 17818},
+									pos:  position{line: 585, col: 14, offset: 17829},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 597, col: 17, offset: 17821},
+									pos:  position{line: 585, col: 17, offset: 17832},
 									name: "DaysToken",
 								},
 							},
@@ -4483,39 +4494,39 @@ var g = &grammar{
 		},
 		{
 			name: "Weeks",
-			pos:  position{line: 599, col: 1, offset: 17923},
+			pos:  position{line: 587, col: 1, offset: 17934},
 			expr: &choiceExpr{
-				pos: position{line: 600, col: 5, offset: 17933},
+				pos: position{line: 588, col: 5, offset: 17944},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 600, col: 5, offset: 17933},
+						pos: position{line: 588, col: 5, offset: 17944},
 						run: (*parser).callonWeeks2,
 						expr: &litMatcher{
-							pos:        position{line: 600, col: 5, offset: 17933},
+							pos:        position{line: 588, col: 5, offset: 17944},
 							val:        "week",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 601, col: 5, offset: 18025},
+						pos: position{line: 589, col: 5, offset: 18036},
 						run: (*parser).callonWeeks4,
 						expr: &seqExpr{
-							pos: position{line: 601, col: 5, offset: 18025},
+							pos: position{line: 589, col: 5, offset: 18036},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 601, col: 5, offset: 18025},
+									pos:   position{line: 589, col: 5, offset: 18036},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 601, col: 9, offset: 18029},
+										pos:  position{line: 589, col: 9, offset: 18040},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 601, col: 14, offset: 18034},
+									pos:  position{line: 589, col: 14, offset: 18045},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 601, col: 17, offset: 18037},
+									pos:  position{line: 589, col: 17, offset: 18048},
 									name: "WeeksToken",
 								},
 							},
@@ -4526,42 +4537,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 604, col: 1, offset: 18168},
+			pos:  position{line: 592, col: 1, offset: 18179},
 			expr: &actionExpr{
-				pos: position{line: 605, col: 5, offset: 18175},
+				pos: position{line: 593, col: 5, offset: 18186},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 605, col: 5, offset: 18175},
+					pos: position{line: 593, col: 5, offset: 18186},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 5, offset: 18175},
+							pos:  position{line: 593, col: 5, offset: 18186},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 605, col: 10, offset: 18180},
+							pos:        position{line: 593, col: 10, offset: 18191},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 14, offset: 18184},
+							pos:  position{line: 593, col: 14, offset: 18195},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 605, col: 19, offset: 18189},
+							pos:        position{line: 593, col: 19, offset: 18200},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 23, offset: 18193},
+							pos:  position{line: 593, col: 23, offset: 18204},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 605, col: 28, offset: 18198},
+							pos:        position{line: 593, col: 28, offset: 18209},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 32, offset: 18202},
+							pos:  position{line: 593, col: 32, offset: 18213},
 							name: "UInt",
 						},
 					},
@@ -4570,32 +4581,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 609, col: 1, offset: 18370},
+			pos:  position{line: 597, col: 1, offset: 18381},
 			expr: &choiceExpr{
-				pos: position{line: 610, col: 5, offset: 18378},
+				pos: position{line: 598, col: 5, offset: 18389},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 610, col: 5, offset: 18378},
+						pos: position{line: 598, col: 5, offset: 18389},
 						run: (*parser).callonIP62,
 						expr: &seqExpr{
-							pos: position{line: 610, col: 5, offset: 18378},
+							pos: position{line: 598, col: 5, offset: 18389},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 610, col: 5, offset: 18378},
+									pos:   position{line: 598, col: 5, offset: 18389},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 610, col: 7, offset: 18380},
+										pos: position{line: 598, col: 7, offset: 18391},
 										expr: &ruleRefExpr{
-											pos:  position{line: 610, col: 7, offset: 18380},
+											pos:  position{line: 598, col: 7, offset: 18391},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 610, col: 17, offset: 18390},
+									pos:   position{line: 598, col: 17, offset: 18401},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 610, col: 19, offset: 18392},
+										pos:  position{line: 598, col: 19, offset: 18403},
 										name: "IP6Tail",
 									},
 								},
@@ -4603,51 +4614,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 613, col: 5, offset: 18456},
+						pos: position{line: 601, col: 5, offset: 18467},
 						run: (*parser).callonIP69,
 						expr: &seqExpr{
-							pos: position{line: 613, col: 5, offset: 18456},
+							pos: position{line: 601, col: 5, offset: 18467},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 613, col: 5, offset: 18456},
+									pos:   position{line: 601, col: 5, offset: 18467},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 613, col: 7, offset: 18458},
+										pos:  position{line: 601, col: 7, offset: 18469},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 613, col: 11, offset: 18462},
+									pos:   position{line: 601, col: 11, offset: 18473},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 613, col: 13, offset: 18464},
+										pos: position{line: 601, col: 13, offset: 18475},
 										expr: &ruleRefExpr{
-											pos:  position{line: 613, col: 13, offset: 18464},
+											pos:  position{line: 601, col: 13, offset: 18475},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 613, col: 23, offset: 18474},
+									pos:        position{line: 601, col: 23, offset: 18485},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 613, col: 28, offset: 18479},
+									pos:   position{line: 601, col: 28, offset: 18490},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 613, col: 30, offset: 18481},
+										pos: position{line: 601, col: 30, offset: 18492},
 										expr: &ruleRefExpr{
-											pos:  position{line: 613, col: 30, offset: 18481},
+											pos:  position{line: 601, col: 30, offset: 18492},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 613, col: 40, offset: 18491},
+									pos:   position{line: 601, col: 40, offset: 18502},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 613, col: 42, offset: 18493},
+										pos:  position{line: 601, col: 42, offset: 18504},
 										name: "IP6Tail",
 									},
 								},
@@ -4655,32 +4666,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 616, col: 5, offset: 18592},
+						pos: position{line: 604, col: 5, offset: 18603},
 						run: (*parser).callonIP622,
 						expr: &seqExpr{
-							pos: position{line: 616, col: 5, offset: 18592},
+							pos: position{line: 604, col: 5, offset: 18603},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 616, col: 5, offset: 18592},
+									pos:        position{line: 604, col: 5, offset: 18603},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 616, col: 10, offset: 18597},
+									pos:   position{line: 604, col: 10, offset: 18608},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 616, col: 12, offset: 18599},
+										pos: position{line: 604, col: 12, offset: 18610},
 										expr: &ruleRefExpr{
-											pos:  position{line: 616, col: 12, offset: 18599},
+											pos:  position{line: 604, col: 12, offset: 18610},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 616, col: 22, offset: 18609},
+									pos:   position{line: 604, col: 22, offset: 18620},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 616, col: 24, offset: 18611},
+										pos:  position{line: 604, col: 24, offset: 18622},
 										name: "IP6Tail",
 									},
 								},
@@ -4688,32 +4699,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 619, col: 5, offset: 18682},
+						pos: position{line: 607, col: 5, offset: 18693},
 						run: (*parser).callonIP630,
 						expr: &seqExpr{
-							pos: position{line: 619, col: 5, offset: 18682},
+							pos: position{line: 607, col: 5, offset: 18693},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 619, col: 5, offset: 18682},
+									pos:   position{line: 607, col: 5, offset: 18693},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 619, col: 7, offset: 18684},
+										pos:  position{line: 607, col: 7, offset: 18695},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 619, col: 11, offset: 18688},
+									pos:   position{line: 607, col: 11, offset: 18699},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 619, col: 13, offset: 18690},
+										pos: position{line: 607, col: 13, offset: 18701},
 										expr: &ruleRefExpr{
-											pos:  position{line: 619, col: 13, offset: 18690},
+											pos:  position{line: 607, col: 13, offset: 18701},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 619, col: 23, offset: 18700},
+									pos:        position{line: 607, col: 23, offset: 18711},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -4721,10 +4732,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 622, col: 5, offset: 18768},
+						pos: position{line: 610, col: 5, offset: 18779},
 						run: (*parser).callonIP638,
 						expr: &litMatcher{
-							pos:        position{line: 622, col: 5, offset: 18768},
+							pos:        position{line: 610, col: 5, offset: 18779},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -4734,16 +4745,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 626, col: 1, offset: 18805},
+			pos:  position{line: 614, col: 1, offset: 18816},
 			expr: &choiceExpr{
-				pos: position{line: 627, col: 5, offset: 18817},
+				pos: position{line: 615, col: 5, offset: 18828},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 627, col: 5, offset: 18817},
+						pos:  position{line: 615, col: 5, offset: 18828},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 628, col: 5, offset: 18824},
+						pos:  position{line: 616, col: 5, offset: 18835},
 						name: "Hex",
 					},
 				},
@@ -4751,23 +4762,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 630, col: 1, offset: 18829},
+			pos:  position{line: 618, col: 1, offset: 18840},
 			expr: &actionExpr{
-				pos: position{line: 630, col: 12, offset: 18840},
+				pos: position{line: 618, col: 12, offset: 18851},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 630, col: 12, offset: 18840},
+					pos: position{line: 618, col: 12, offset: 18851},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 630, col: 12, offset: 18840},
+							pos:        position{line: 618, col: 12, offset: 18851},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 630, col: 16, offset: 18844},
+							pos:   position{line: 618, col: 16, offset: 18855},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 630, col: 18, offset: 18846},
+								pos:  position{line: 618, col: 18, offset: 18857},
 								name: "Hex",
 							},
 						},
@@ -4777,23 +4788,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 631, col: 1, offset: 18883},
+			pos:  position{line: 619, col: 1, offset: 18894},
 			expr: &actionExpr{
-				pos: position{line: 631, col: 12, offset: 18894},
+				pos: position{line: 619, col: 12, offset: 18905},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 631, col: 12, offset: 18894},
+					pos: position{line: 619, col: 12, offset: 18905},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 631, col: 12, offset: 18894},
+							pos:   position{line: 619, col: 12, offset: 18905},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 631, col: 14, offset: 18896},
+								pos:  position{line: 619, col: 14, offset: 18907},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 631, col: 18, offset: 18900},
+							pos:        position{line: 619, col: 18, offset: 18911},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -4803,31 +4814,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 633, col: 1, offset: 18938},
+			pos:  position{line: 621, col: 1, offset: 18949},
 			expr: &actionExpr{
-				pos: position{line: 634, col: 5, offset: 18949},
+				pos: position{line: 622, col: 5, offset: 18960},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 634, col: 5, offset: 18949},
+					pos: position{line: 622, col: 5, offset: 18960},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 634, col: 5, offset: 18949},
+							pos:   position{line: 622, col: 5, offset: 18960},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 634, col: 7, offset: 18951},
+								pos:  position{line: 622, col: 7, offset: 18962},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 634, col: 10, offset: 18954},
+							pos:        position{line: 622, col: 10, offset: 18965},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 634, col: 14, offset: 18958},
+							pos:   position{line: 622, col: 14, offset: 18969},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 634, col: 16, offset: 18960},
+								pos:  position{line: 622, col: 16, offset: 18971},
 								name: "UInt",
 							},
 						},
@@ -4837,31 +4848,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 638, col: 1, offset: 19033},
+			pos:  position{line: 626, col: 1, offset: 19044},
 			expr: &actionExpr{
-				pos: position{line: 639, col: 5, offset: 19044},
+				pos: position{line: 627, col: 5, offset: 19055},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 639, col: 5, offset: 19044},
+					pos: position{line: 627, col: 5, offset: 19055},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 639, col: 5, offset: 19044},
+							pos:   position{line: 627, col: 5, offset: 19055},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 639, col: 7, offset: 19046},
+								pos:  position{line: 627, col: 7, offset: 19057},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 639, col: 11, offset: 19050},
+							pos:        position{line: 627, col: 11, offset: 19061},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 639, col: 15, offset: 19054},
+							pos:   position{line: 627, col: 15, offset: 19065},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 639, col: 17, offset: 19056},
+								pos:  position{line: 627, col: 17, offset: 19067},
 								name: "UInt",
 							},
 						},
@@ -4871,15 +4882,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 643, col: 1, offset: 19119},
+			pos:  position{line: 631, col: 1, offset: 19130},
 			expr: &actionExpr{
-				pos: position{line: 644, col: 4, offset: 19127},
+				pos: position{line: 632, col: 4, offset: 19138},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 644, col: 4, offset: 19127},
+					pos:   position{line: 632, col: 4, offset: 19138},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 644, col: 6, offset: 19129},
+						pos:  position{line: 632, col: 6, offset: 19140},
 						name: "UIntString",
 					},
 				},
@@ -4887,16 +4898,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 646, col: 1, offset: 19169},
+			pos:  position{line: 634, col: 1, offset: 19180},
 			expr: &choiceExpr{
-				pos: position{line: 647, col: 5, offset: 19183},
+				pos: position{line: 635, col: 5, offset: 19194},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 647, col: 5, offset: 19183},
+						pos:  position{line: 635, col: 5, offset: 19194},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 648, col: 5, offset: 19198},
+						pos:  position{line: 636, col: 5, offset: 19209},
 						name: "MinusIntString",
 					},
 				},
@@ -4904,14 +4915,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 650, col: 1, offset: 19214},
+			pos:  position{line: 638, col: 1, offset: 19225},
 			expr: &actionExpr{
-				pos: position{line: 650, col: 14, offset: 19227},
+				pos: position{line: 638, col: 14, offset: 19238},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 650, col: 14, offset: 19227},
+					pos: position{line: 638, col: 14, offset: 19238},
 					expr: &charClassMatcher{
-						pos:        position{line: 650, col: 14, offset: 19227},
+						pos:        position{line: 638, col: 14, offset: 19238},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4922,20 +4933,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 652, col: 1, offset: 19266},
+			pos:  position{line: 640, col: 1, offset: 19277},
 			expr: &actionExpr{
-				pos: position{line: 653, col: 5, offset: 19285},
+				pos: position{line: 641, col: 5, offset: 19296},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 653, col: 5, offset: 19285},
+					pos: position{line: 641, col: 5, offset: 19296},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 653, col: 5, offset: 19285},
+							pos:        position{line: 641, col: 5, offset: 19296},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 653, col: 9, offset: 19289},
+							pos:  position{line: 641, col: 9, offset: 19300},
 							name: "UIntString",
 						},
 					},
@@ -4944,28 +4955,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 655, col: 1, offset: 19332},
+			pos:  position{line: 643, col: 1, offset: 19343},
 			expr: &choiceExpr{
-				pos: position{line: 656, col: 5, offset: 19348},
+				pos: position{line: 644, col: 5, offset: 19359},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 656, col: 5, offset: 19348},
+						pos: position{line: 644, col: 5, offset: 19359},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 656, col: 5, offset: 19348},
+							pos: position{line: 644, col: 5, offset: 19359},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 656, col: 5, offset: 19348},
+									pos: position{line: 644, col: 5, offset: 19359},
 									expr: &litMatcher{
-										pos:        position{line: 656, col: 5, offset: 19348},
+										pos:        position{line: 644, col: 5, offset: 19359},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 656, col: 10, offset: 19353},
+									pos: position{line: 644, col: 10, offset: 19364},
 									expr: &charClassMatcher{
-										pos:        position{line: 656, col: 10, offset: 19353},
+										pos:        position{line: 644, col: 10, offset: 19364},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -4973,14 +4984,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 656, col: 17, offset: 19360},
+									pos:        position{line: 644, col: 17, offset: 19371},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 656, col: 21, offset: 19364},
+									pos: position{line: 644, col: 21, offset: 19375},
 									expr: &charClassMatcher{
-										pos:        position{line: 656, col: 21, offset: 19364},
+										pos:        position{line: 644, col: 21, offset: 19375},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -4988,9 +4999,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 656, col: 28, offset: 19371},
+									pos: position{line: 644, col: 28, offset: 19382},
 									expr: &ruleRefExpr{
-										pos:  position{line: 656, col: 28, offset: 19371},
+										pos:  position{line: 644, col: 28, offset: 19382},
 										name: "ExponentPart",
 									},
 								},
@@ -4998,28 +5009,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 19430},
+						pos: position{line: 647, col: 5, offset: 19441},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 19430},
+							pos: position{line: 647, col: 5, offset: 19441},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 659, col: 5, offset: 19430},
+									pos: position{line: 647, col: 5, offset: 19441},
 									expr: &litMatcher{
-										pos:        position{line: 659, col: 5, offset: 19430},
+										pos:        position{line: 647, col: 5, offset: 19441},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 659, col: 10, offset: 19435},
+									pos:        position{line: 647, col: 10, offset: 19446},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 659, col: 14, offset: 19439},
+									pos: position{line: 647, col: 14, offset: 19450},
 									expr: &charClassMatcher{
-										pos:        position{line: 659, col: 14, offset: 19439},
+										pos:        position{line: 647, col: 14, offset: 19450},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -5027,9 +5038,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 659, col: 21, offset: 19446},
+									pos: position{line: 647, col: 21, offset: 19457},
 									expr: &ruleRefExpr{
-										pos:  position{line: 659, col: 21, offset: 19446},
+										pos:  position{line: 647, col: 21, offset: 19457},
 										name: "ExponentPart",
 									},
 								},
@@ -5041,19 +5052,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 663, col: 1, offset: 19502},
+			pos:  position{line: 651, col: 1, offset: 19513},
 			expr: &seqExpr{
-				pos: position{line: 663, col: 16, offset: 19517},
+				pos: position{line: 651, col: 16, offset: 19528},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 663, col: 16, offset: 19517},
+						pos:        position{line: 651, col: 16, offset: 19528},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 663, col: 21, offset: 19522},
+						pos: position{line: 651, col: 21, offset: 19533},
 						expr: &charClassMatcher{
-							pos:        position{line: 663, col: 21, offset: 19522},
+							pos:        position{line: 651, col: 21, offset: 19533},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -5061,7 +5072,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 663, col: 27, offset: 19528},
+						pos:  position{line: 651, col: 27, offset: 19539},
 						name: "UIntString",
 					},
 				},
@@ -5069,14 +5080,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 665, col: 1, offset: 19540},
+			pos:  position{line: 653, col: 1, offset: 19551},
 			expr: &actionExpr{
-				pos: position{line: 665, col: 7, offset: 19546},
+				pos: position{line: 653, col: 7, offset: 19557},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 665, col: 7, offset: 19546},
+					pos: position{line: 653, col: 7, offset: 19557},
 					expr: &ruleRefExpr{
-						pos:  position{line: 665, col: 7, offset: 19546},
+						pos:  position{line: 653, col: 7, offset: 19557},
 						name: "HexDigit",
 					},
 				},
@@ -5084,9 +5095,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 667, col: 1, offset: 19588},
+			pos:  position{line: 655, col: 1, offset: 19599},
 			expr: &charClassMatcher{
-				pos:        position{line: 667, col: 12, offset: 19599},
+				pos:        position{line: 655, col: 12, offset: 19610},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -5095,17 +5106,17 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 669, col: 1, offset: 19612},
+			pos:  position{line: 657, col: 1, offset: 19623},
 			expr: &actionExpr{
-				pos: position{line: 670, col: 5, offset: 19624},
+				pos: position{line: 658, col: 5, offset: 19635},
 				run: (*parser).callonKeyWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 670, col: 5, offset: 19624},
+					pos:   position{line: 658, col: 5, offset: 19635},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 670, col: 11, offset: 19630},
+						pos: position{line: 658, col: 11, offset: 19641},
 						expr: &ruleRefExpr{
-							pos:  position{line: 670, col: 11, offset: 19630},
+							pos:  position{line: 658, col: 11, offset: 19641},
 							name: "KeyWordPart",
 						},
 					},
@@ -5114,33 +5125,33 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordPart",
-			pos:  position{line: 672, col: 1, offset: 19677},
+			pos:  position{line: 660, col: 1, offset: 19688},
 			expr: &choiceExpr{
-				pos: position{line: 673, col: 5, offset: 19693},
+				pos: position{line: 661, col: 5, offset: 19704},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 673, col: 5, offset: 19693},
+						pos: position{line: 661, col: 5, offset: 19704},
 						run: (*parser).callonKeyWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 673, col: 5, offset: 19693},
+							pos: position{line: 661, col: 5, offset: 19704},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 673, col: 5, offset: 19693},
+									pos:        position{line: 661, col: 5, offset: 19704},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 673, col: 10, offset: 19698},
+									pos:   position{line: 661, col: 10, offset: 19709},
 									label: "s",
 									expr: &choiceExpr{
-										pos: position{line: 673, col: 13, offset: 19701},
+										pos: position{line: 661, col: 13, offset: 19712},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 673, col: 13, offset: 19701},
+												pos:  position{line: 661, col: 13, offset: 19712},
 												name: "EscapeSequence",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 673, col: 30, offset: 19718},
+												pos:  position{line: 661, col: 30, offset: 19729},
 												name: "SearchEscape",
 											},
 										},
@@ -5150,18 +5161,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 674, col: 5, offset: 19755},
+						pos: position{line: 662, col: 5, offset: 19766},
 						run: (*parser).callonKeyWordPart9,
 						expr: &seqExpr{
-							pos: position{line: 674, col: 5, offset: 19755},
+							pos: position{line: 662, col: 5, offset: 19766},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 674, col: 5, offset: 19755},
+									pos: position{line: 662, col: 5, offset: 19766},
 									expr: &choiceExpr{
-										pos: position{line: 674, col: 7, offset: 19757},
+										pos: position{line: 662, col: 7, offset: 19768},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 674, col: 7, offset: 19757},
+												pos:        position{line: 662, col: 7, offset: 19768},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;:]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';', ':'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -5169,14 +5180,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 674, col: 43, offset: 19793},
+												pos:  position{line: 662, col: 43, offset: 19804},
 												name: "WhiteSpace",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 674, col: 55, offset: 19805,
+									line: 662, col: 55, offset: 19816,
 								},
 							},
 						},
@@ -5186,34 +5197,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 676, col: 1, offset: 19839},
+			pos:  position{line: 664, col: 1, offset: 19850},
 			expr: &choiceExpr{
-				pos: position{line: 677, col: 5, offset: 19856},
+				pos: position{line: 665, col: 5, offset: 19867},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 677, col: 5, offset: 19856},
+						pos: position{line: 665, col: 5, offset: 19867},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 677, col: 5, offset: 19856},
+							pos: position{line: 665, col: 5, offset: 19867},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 677, col: 5, offset: 19856},
+									pos:        position{line: 665, col: 5, offset: 19867},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 677, col: 9, offset: 19860},
+									pos:   position{line: 665, col: 9, offset: 19871},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 677, col: 11, offset: 19862},
+										pos: position{line: 665, col: 11, offset: 19873},
 										expr: &ruleRefExpr{
-											pos:  position{line: 677, col: 11, offset: 19862},
+											pos:  position{line: 665, col: 11, offset: 19873},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 677, col: 29, offset: 19880},
+									pos:        position{line: 665, col: 29, offset: 19891},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5221,29 +5232,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 678, col: 5, offset: 19917},
+						pos: position{line: 666, col: 5, offset: 19928},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 678, col: 5, offset: 19917},
+							pos: position{line: 666, col: 5, offset: 19928},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 678, col: 5, offset: 19917},
+									pos:        position{line: 666, col: 5, offset: 19928},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 678, col: 9, offset: 19921},
+									pos:   position{line: 666, col: 9, offset: 19932},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 678, col: 11, offset: 19923},
+										pos: position{line: 666, col: 11, offset: 19934},
 										expr: &ruleRefExpr{
-											pos:  position{line: 678, col: 11, offset: 19923},
+											pos:  position{line: 666, col: 11, offset: 19934},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 678, col: 29, offset: 19941},
+									pos:        position{line: 666, col: 29, offset: 19952},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5255,55 +5266,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 680, col: 1, offset: 19975},
+			pos:  position{line: 668, col: 1, offset: 19986},
 			expr: &choiceExpr{
-				pos: position{line: 681, col: 5, offset: 19996},
+				pos: position{line: 669, col: 5, offset: 20007},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 681, col: 5, offset: 19996},
+						pos: position{line: 669, col: 5, offset: 20007},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 681, col: 5, offset: 19996},
+							pos: position{line: 669, col: 5, offset: 20007},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 681, col: 5, offset: 19996},
+									pos: position{line: 669, col: 5, offset: 20007},
 									expr: &choiceExpr{
-										pos: position{line: 681, col: 7, offset: 19998},
+										pos: position{line: 669, col: 7, offset: 20009},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 681, col: 7, offset: 19998},
+												pos:        position{line: 669, col: 7, offset: 20009},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 681, col: 13, offset: 20004},
+												pos:  position{line: 669, col: 13, offset: 20015},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 681, col: 26, offset: 20017,
+									line: 669, col: 26, offset: 20028,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 682, col: 5, offset: 20054},
+						pos: position{line: 670, col: 5, offset: 20065},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 682, col: 5, offset: 20054},
+							pos: position{line: 670, col: 5, offset: 20065},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 682, col: 5, offset: 20054},
+									pos:        position{line: 670, col: 5, offset: 20065},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 682, col: 10, offset: 20059},
+									pos:   position{line: 670, col: 10, offset: 20070},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 682, col: 12, offset: 20061},
+										pos:  position{line: 670, col: 12, offset: 20072},
 										name: "EscapeSequence",
 									},
 								},
@@ -5315,55 +5326,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 684, col: 1, offset: 20095},
+			pos:  position{line: 672, col: 1, offset: 20106},
 			expr: &choiceExpr{
-				pos: position{line: 685, col: 5, offset: 20116},
+				pos: position{line: 673, col: 5, offset: 20127},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 685, col: 5, offset: 20116},
+						pos: position{line: 673, col: 5, offset: 20127},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 685, col: 5, offset: 20116},
+							pos: position{line: 673, col: 5, offset: 20127},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 685, col: 5, offset: 20116},
+									pos: position{line: 673, col: 5, offset: 20127},
 									expr: &choiceExpr{
-										pos: position{line: 685, col: 7, offset: 20118},
+										pos: position{line: 673, col: 7, offset: 20129},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 685, col: 7, offset: 20118},
+												pos:        position{line: 673, col: 7, offset: 20129},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 685, col: 13, offset: 20124},
+												pos:  position{line: 673, col: 13, offset: 20135},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 685, col: 26, offset: 20137,
+									line: 673, col: 26, offset: 20148,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 686, col: 5, offset: 20174},
+						pos: position{line: 674, col: 5, offset: 20185},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 686, col: 5, offset: 20174},
+							pos: position{line: 674, col: 5, offset: 20185},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 686, col: 5, offset: 20174},
+									pos:        position{line: 674, col: 5, offset: 20185},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 686, col: 10, offset: 20179},
+									pos:   position{line: 674, col: 10, offset: 20190},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 686, col: 12, offset: 20181},
+										pos:  position{line: 674, col: 12, offset: 20192},
 										name: "EscapeSequence",
 									},
 								},
@@ -5375,38 +5386,38 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 688, col: 1, offset: 20215},
+			pos:  position{line: 676, col: 1, offset: 20226},
 			expr: &choiceExpr{
-				pos: position{line: 689, col: 5, offset: 20234},
+				pos: position{line: 677, col: 5, offset: 20245},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 689, col: 5, offset: 20234},
+						pos: position{line: 677, col: 5, offset: 20245},
 						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 689, col: 5, offset: 20234},
+							pos: position{line: 677, col: 5, offset: 20245},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 689, col: 5, offset: 20234},
+									pos:        position{line: 677, col: 5, offset: 20245},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 9, offset: 20238},
+									pos:  position{line: 677, col: 9, offset: 20249},
 									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 18, offset: 20247},
+									pos:  position{line: 677, col: 18, offset: 20258},
 									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 690, col: 5, offset: 20298},
+						pos:  position{line: 678, col: 5, offset: 20309},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 691, col: 5, offset: 20319},
+						pos:  position{line: 679, col: 5, offset: 20330},
 						name: "UnicodeEscape",
 					},
 				},
@@ -5414,75 +5425,75 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 693, col: 1, offset: 20334},
+			pos:  position{line: 681, col: 1, offset: 20345},
 			expr: &choiceExpr{
-				pos: position{line: 694, col: 5, offset: 20355},
+				pos: position{line: 682, col: 5, offset: 20366},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 694, col: 5, offset: 20355},
+						pos:        position{line: 682, col: 5, offset: 20366},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 695, col: 5, offset: 20363},
+						pos:        position{line: 683, col: 5, offset: 20374},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 696, col: 5, offset: 20371},
+						pos:        position{line: 684, col: 5, offset: 20382},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 697, col: 5, offset: 20380},
+						pos: position{line: 685, col: 5, offset: 20391},
 						run: (*parser).callonSingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 697, col: 5, offset: 20380},
+							pos:        position{line: 685, col: 5, offset: 20391},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 698, col: 5, offset: 20409},
+						pos: position{line: 686, col: 5, offset: 20420},
 						run: (*parser).callonSingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 698, col: 5, offset: 20409},
+							pos:        position{line: 686, col: 5, offset: 20420},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 699, col: 5, offset: 20438},
+						pos: position{line: 687, col: 5, offset: 20449},
 						run: (*parser).callonSingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 699, col: 5, offset: 20438},
+							pos:        position{line: 687, col: 5, offset: 20449},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 700, col: 5, offset: 20467},
+						pos: position{line: 688, col: 5, offset: 20478},
 						run: (*parser).callonSingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 700, col: 5, offset: 20467},
+							pos:        position{line: 688, col: 5, offset: 20478},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 701, col: 5, offset: 20496},
+						pos: position{line: 689, col: 5, offset: 20507},
 						run: (*parser).callonSingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 701, col: 5, offset: 20496},
+							pos:        position{line: 689, col: 5, offset: 20507},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 702, col: 5, offset: 20525},
+						pos: position{line: 690, col: 5, offset: 20536},
 						run: (*parser).callonSingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 702, col: 5, offset: 20525},
+							pos:        position{line: 690, col: 5, offset: 20536},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5492,24 +5503,24 @@ var g = &grammar{
 		},
 		{
 			name: "SearchEscape",
-			pos:  position{line: 704, col: 1, offset: 20551},
+			pos:  position{line: 692, col: 1, offset: 20562},
 			expr: &choiceExpr{
-				pos: position{line: 705, col: 5, offset: 20568},
+				pos: position{line: 693, col: 5, offset: 20579},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 705, col: 5, offset: 20568},
+						pos: position{line: 693, col: 5, offset: 20579},
 						run: (*parser).callonSearchEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 705, col: 5, offset: 20568},
+							pos:        position{line: 693, col: 5, offset: 20579},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 706, col: 5, offset: 20596},
+						pos: position{line: 694, col: 5, offset: 20607},
 						run: (*parser).callonSearchEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 706, col: 5, offset: 20596},
+							pos:        position{line: 694, col: 5, offset: 20607},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -5519,41 +5530,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 708, col: 1, offset: 20623},
+			pos:  position{line: 696, col: 1, offset: 20634},
 			expr: &choiceExpr{
-				pos: position{line: 709, col: 5, offset: 20641},
+				pos: position{line: 697, col: 5, offset: 20652},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 709, col: 5, offset: 20641},
+						pos: position{line: 697, col: 5, offset: 20652},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 709, col: 5, offset: 20641},
+							pos: position{line: 697, col: 5, offset: 20652},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 709, col: 5, offset: 20641},
+									pos:        position{line: 697, col: 5, offset: 20652},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 709, col: 9, offset: 20645},
+									pos:   position{line: 697, col: 9, offset: 20656},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 709, col: 16, offset: 20652},
+										pos: position{line: 697, col: 16, offset: 20663},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 709, col: 16, offset: 20652},
+												pos:  position{line: 697, col: 16, offset: 20663},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 709, col: 25, offset: 20661},
+												pos:  position{line: 697, col: 25, offset: 20672},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 709, col: 34, offset: 20670},
+												pos:  position{line: 697, col: 34, offset: 20681},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 709, col: 43, offset: 20679},
+												pos:  position{line: 697, col: 43, offset: 20690},
 												name: "HexDigit",
 											},
 										},
@@ -5563,63 +5574,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 712, col: 5, offset: 20742},
+						pos: position{line: 700, col: 5, offset: 20753},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 712, col: 5, offset: 20742},
+							pos: position{line: 700, col: 5, offset: 20753},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 712, col: 5, offset: 20742},
+									pos:        position{line: 700, col: 5, offset: 20753},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 712, col: 9, offset: 20746},
+									pos:        position{line: 700, col: 9, offset: 20757},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 712, col: 13, offset: 20750},
+									pos:   position{line: 700, col: 13, offset: 20761},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 712, col: 20, offset: 20757},
+										pos: position{line: 700, col: 20, offset: 20768},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 712, col: 20, offset: 20757},
+												pos:  position{line: 700, col: 20, offset: 20768},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 29, offset: 20766},
+												pos: position{line: 700, col: 29, offset: 20777},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 29, offset: 20766},
+													pos:  position{line: 700, col: 29, offset: 20777},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 39, offset: 20776},
+												pos: position{line: 700, col: 39, offset: 20787},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 39, offset: 20776},
+													pos:  position{line: 700, col: 39, offset: 20787},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 49, offset: 20786},
+												pos: position{line: 700, col: 49, offset: 20797},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 49, offset: 20786},
+													pos:  position{line: 700, col: 49, offset: 20797},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 59, offset: 20796},
+												pos: position{line: 700, col: 59, offset: 20807},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 59, offset: 20796},
+													pos:  position{line: 700, col: 59, offset: 20807},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 69, offset: 20806},
+												pos: position{line: 700, col: 69, offset: 20817},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 69, offset: 20806},
+													pos:  position{line: 700, col: 69, offset: 20817},
 													name: "HexDigit",
 												},
 											},
@@ -5627,7 +5638,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 712, col: 80, offset: 20817},
+									pos:        position{line: 700, col: 80, offset: 20828},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5639,28 +5650,28 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 716, col: 1, offset: 20871},
+			pos:  position{line: 704, col: 1, offset: 20882},
 			expr: &actionExpr{
-				pos: position{line: 717, col: 5, offset: 20882},
+				pos: position{line: 705, col: 5, offset: 20893},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 717, col: 5, offset: 20882},
+					pos: position{line: 705, col: 5, offset: 20893},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 717, col: 5, offset: 20882},
+							pos:        position{line: 705, col: 5, offset: 20893},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 717, col: 9, offset: 20886},
+							pos:   position{line: 705, col: 9, offset: 20897},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 717, col: 14, offset: 20891},
+								pos:  position{line: 705, col: 14, offset: 20902},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 717, col: 25, offset: 20902},
+							pos:        position{line: 705, col: 25, offset: 20913},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5670,24 +5681,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 719, col: 1, offset: 20928},
+			pos:  position{line: 707, col: 1, offset: 20939},
 			expr: &actionExpr{
-				pos: position{line: 720, col: 5, offset: 20943},
+				pos: position{line: 708, col: 5, offset: 20954},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 720, col: 5, offset: 20943},
+					pos: position{line: 708, col: 5, offset: 20954},
 					expr: &choiceExpr{
-						pos: position{line: 720, col: 6, offset: 20944},
+						pos: position{line: 708, col: 6, offset: 20955},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 720, col: 6, offset: 20944},
+								pos:        position{line: 708, col: 6, offset: 20955},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 720, col: 13, offset: 20951},
+								pos:        position{line: 708, col: 13, offset: 20962},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -5698,9 +5709,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 722, col: 1, offset: 20991},
+			pos:  position{line: 710, col: 1, offset: 21002},
 			expr: &charClassMatcher{
-				pos:        position{line: 723, col: 5, offset: 21007},
+				pos:        position{line: 711, col: 5, offset: 21018},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5710,42 +5721,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 725, col: 1, offset: 21022},
+			pos:  position{line: 713, col: 1, offset: 21033},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 725, col: 6, offset: 21027},
+				pos: position{line: 713, col: 6, offset: 21038},
 				expr: &ruleRefExpr{
-					pos:  position{line: 725, col: 6, offset: 21027},
+					pos:  position{line: 713, col: 6, offset: 21038},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 726, col: 1, offset: 21037},
+			pos:  position{line: 714, col: 1, offset: 21048},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 726, col: 6, offset: 21042},
+				pos: position{line: 714, col: 6, offset: 21053},
 				expr: &ruleRefExpr{
-					pos:  position{line: 726, col: 6, offset: 21042},
+					pos:  position{line: 714, col: 6, offset: 21053},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 728, col: 1, offset: 21053},
+			pos:  position{line: 716, col: 1, offset: 21064},
 			expr: &choiceExpr{
-				pos: position{line: 729, col: 5, offset: 21066},
+				pos: position{line: 717, col: 5, offset: 21077},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 729, col: 5, offset: 21066},
+						pos:  position{line: 717, col: 5, offset: 21077},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 730, col: 5, offset: 21081},
+						pos:  position{line: 718, col: 5, offset: 21092},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 731, col: 5, offset: 21100},
+						pos:  position{line: 719, col: 5, offset: 21111},
 						name: "Comment",
 					},
 				},
@@ -5753,45 +5764,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 733, col: 1, offset: 21109},
+			pos:  position{line: 721, col: 1, offset: 21120},
 			expr: &anyMatcher{
-				line: 734, col: 5, offset: 21129,
+				line: 722, col: 5, offset: 21140,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 736, col: 1, offset: 21132},
+			pos:         position{line: 724, col: 1, offset: 21143},
 			expr: &choiceExpr{
-				pos: position{line: 737, col: 5, offset: 21160},
+				pos: position{line: 725, col: 5, offset: 21171},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 737, col: 5, offset: 21160},
+						pos:        position{line: 725, col: 5, offset: 21171},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 738, col: 5, offset: 21169},
+						pos:        position{line: 726, col: 5, offset: 21180},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 739, col: 5, offset: 21178},
+						pos:        position{line: 727, col: 5, offset: 21189},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 740, col: 5, offset: 21187},
+						pos:        position{line: 728, col: 5, offset: 21198},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 741, col: 5, offset: 21195},
+						pos:        position{line: 729, col: 5, offset: 21206},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 742, col: 5, offset: 21208},
+						pos:        position{line: 730, col: 5, offset: 21219},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5800,9 +5811,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 744, col: 1, offset: 21218},
+			pos:  position{line: 732, col: 1, offset: 21229},
 			expr: &charClassMatcher{
-				pos:        position{line: 745, col: 5, offset: 21237},
+				pos:        position{line: 733, col: 5, offset: 21248},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -5812,45 +5823,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 751, col: 1, offset: 21567},
+			pos:         position{line: 739, col: 1, offset: 21578},
 			expr: &ruleRefExpr{
-				pos:  position{line: 754, col: 5, offset: 21638},
+				pos:  position{line: 742, col: 5, offset: 21649},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 756, col: 1, offset: 21657},
+			pos:  position{line: 744, col: 1, offset: 21668},
 			expr: &seqExpr{
-				pos: position{line: 757, col: 5, offset: 21678},
+				pos: position{line: 745, col: 5, offset: 21689},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 757, col: 5, offset: 21678},
+						pos:        position{line: 745, col: 5, offset: 21689},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 757, col: 10, offset: 21683},
+						pos: position{line: 745, col: 10, offset: 21694},
 						expr: &seqExpr{
-							pos: position{line: 757, col: 11, offset: 21684},
+							pos: position{line: 745, col: 11, offset: 21695},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 757, col: 11, offset: 21684},
+									pos: position{line: 745, col: 11, offset: 21695},
 									expr: &litMatcher{
-										pos:        position{line: 757, col: 12, offset: 21685},
+										pos:        position{line: 745, col: 12, offset: 21696},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 757, col: 17, offset: 21690},
+									pos:  position{line: 745, col: 17, offset: 21701},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 757, col: 35, offset: 21708},
+						pos:        position{line: 745, col: 35, offset: 21719},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -5859,29 +5870,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 759, col: 1, offset: 21714},
+			pos:  position{line: 747, col: 1, offset: 21725},
 			expr: &seqExpr{
-				pos: position{line: 760, col: 5, offset: 21736},
+				pos: position{line: 748, col: 5, offset: 21747},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 760, col: 5, offset: 21736},
+						pos:        position{line: 748, col: 5, offset: 21747},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 760, col: 10, offset: 21741},
+						pos: position{line: 748, col: 10, offset: 21752},
 						expr: &seqExpr{
-							pos: position{line: 760, col: 11, offset: 21742},
+							pos: position{line: 748, col: 11, offset: 21753},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 760, col: 11, offset: 21742},
+									pos: position{line: 748, col: 11, offset: 21753},
 									expr: &ruleRefExpr{
-										pos:  position{line: 760, col: 12, offset: 21743},
+										pos:  position{line: 748, col: 12, offset: 21754},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 760, col: 27, offset: 21758},
+									pos:  position{line: 748, col: 27, offset: 21769},
 									name: "SourceCharacter",
 								},
 							},
@@ -5892,11 +5903,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 762, col: 1, offset: 21777},
+			pos:  position{line: 750, col: 1, offset: 21788},
 			expr: &notExpr{
-				pos: position{line: 762, col: 7, offset: 21783},
+				pos: position{line: 750, col: 7, offset: 21794},
 				expr: &anyMatcher{
-					line: 762, col: 8, offset: 21784,
+					line: 750, col: 8, offset: 21795,
 				},
 			},
 		},
@@ -6270,7 +6281,7 @@ func (p *parser) callonBooleanLiteral4() (interface{}, error) {
 }
 
 func (c *current) onNullLiteral1() (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "null"}, nil
+	return map[string]interface{}{"op": "Literal", "type": "null", "value": ""}, nil
 }
 
 func (p *parser) callonNullLiteral1() (interface{}, error) {
@@ -6341,14 +6352,7 @@ func (p *parser) callonParallelTail1() (interface{}, error) {
 }
 
 func (c *current) onGroupByProc2(every, keys, limit interface{}) (interface{}, error) {
-	var p = map[string]interface{}{"op": "GroupByProc", "keys": keys}
-	if every != nil {
-		p["duration"] = every
-	}
-	if limit != nil {
-		p["limit"] = limit
-	}
-	return p, nil
+	return map[string]interface{}{"op": "GroupByProc", "keys": keys, "reducers": nil, "duration": every, "limit": limit}, nil
 
 }
 
@@ -6358,25 +6362,19 @@ func (p *parser) callonGroupByProc2() (interface{}, error) {
 	return p.cur.onGroupByProc2(stack["every"], stack["keys"], stack["limit"])
 }
 
-func (c *current) onGroupByProc12(every, reducers, keys, limit interface{}) (interface{}, error) {
-	var p = map[string]interface{}{"op": "GroupByProc", "reducers": reducers}
-	if every != nil {
-		p["duration"] = every
-	}
+func (c *current) onGroupByProc11(every, reducers, keys, limit interface{}) (interface{}, error) {
+	var p = map[string]interface{}{"op": "GroupByProc", "keys": nil, "reducers": reducers, "duration": every, "limit": limit}
 	if keys != nil {
 		p["keys"] = keys.([]interface{})[1]
-	}
-	if limit != nil {
-		p["limit"] = limit
 	}
 	return p, nil
 
 }
 
-func (p *parser) callonGroupByProc12() (interface{}, error) {
+func (p *parser) callonGroupByProc11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onGroupByProc12(stack["every"], stack["reducers"], stack["keys"], stack["limit"])
+	return p.cur.onGroupByProc11(stack["every"], stack["reducers"], stack["keys"], stack["limit"])
 }
 
 func (c *current) onEveryDur1(dur interface{}) (interface{}, error) {
@@ -6399,18 +6397,28 @@ func (p *parser) callonGroupByKeys1() (interface{}, error) {
 	return p.cur.onGroupByKeys1(stack["columns"])
 }
 
-func (c *current) onLimitArg1(limit interface{}) (interface{}, error) {
+func (c *current) onLimitArg2(limit interface{}) (interface{}, error) {
 	return limit, nil
 }
 
-func (p *parser) callonLimitArg1() (interface{}, error) {
+func (p *parser) callonLimitArg2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onLimitArg1(stack["limit"])
+	return p.cur.onLimitArg2(stack["limit"])
+}
+
+func (c *current) onLimitArg11() (interface{}, error) {
+	return 0, nil
+}
+
+func (p *parser) callonLimitArg11() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onLimitArg11()
 }
 
 func (c *current) onFlexAssignment3(expr interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Assignment", "rhs": expr}, nil
+	return map[string]interface{}{"op": "Assignment", "lhs": nil, "rhs": expr}, nil
 }
 
 func (p *parser) callonFlexAssignment3() (interface{}, error) {
@@ -6452,7 +6460,7 @@ func (p *parser) callonReducerAssignment2() (interface{}, error) {
 }
 
 func (c *current) onReducerAssignment11(reducer interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Assignment", "rhs": reducer}, nil
+	return map[string]interface{}{"op": "Assignment", "lhs": nil, "rhs": reducer}, nil
 
 }
 
@@ -6463,7 +6471,7 @@ func (p *parser) callonReducerAssignment11() (interface{}, error) {
 }
 
 func (c *current) onReducer1(op, expr, where interface{}) (interface{}, error) {
-	var r = map[string]interface{}{"op": "Reducer", "operator": op, "where": where}
+	var r = map[string]interface{}{"op": "Reducer", "operator": op, "expr": nil, "where": where}
 	if expr != nil {
 		r["expr"] = expr
 	}
@@ -6604,7 +6612,7 @@ func (p *parser) callonTopProc18() (interface{}, error) {
 }
 
 func (c *current) onTopProc1(limit, flush, fields interface{}) (interface{}, error) {
-	var proc = map[string]interface{}{"op": "TopProc"}
+	var proc = map[string]interface{}{"op": "TopProc", "limit": 0, "fields": nil, "flush": false}
 	if limit != nil {
 		proc["limit"] = limit
 	}
@@ -6778,7 +6786,7 @@ func (p *parser) callonFuseProc1() (interface{}, error) {
 }
 
 func (c *current) onJoinProc2(leftKey, rightKey, columns interface{}) (interface{}, error) {
-	var proc = map[string]interface{}{"op": "JoinProc", "left_key": leftKey, "right_key": rightKey}
+	var proc = map[string]interface{}{"op": "JoinProc", "left_key": leftKey, "right_key": rightKey, "clauses": nil}
 	if columns != nil {
 		proc["clauses"] = columns.([]interface{})[1]
 	}
@@ -6793,7 +6801,7 @@ func (p *parser) callonJoinProc2() (interface{}, error) {
 }
 
 func (c *current) onJoinProc18(key, columns interface{}) (interface{}, error) {
-	var proc = map[string]interface{}{"op": "JoinProc", "left_key": key, "right_key": key}
+	var proc = map[string]interface{}{"op": "JoinProc", "left_key": key, "right_key": key, "clauses": nil}
 	if columns != nil {
 		proc["clauses"] = columns.([]interface{})[1]
 	}
@@ -6872,7 +6880,7 @@ func (p *parser) callonExprs1() (interface{}, error) {
 }
 
 func (c *current) onAssignment1(lhs, rhs interface{}) (interface{}, error) {
-	return map[string]interface{}{"lhs": lhs, "rhs": rhs}, nil
+	return map[string]interface{}{"op": "Assignment", "lhs": lhs, "rhs": rhs}, nil
 }
 
 func (p *parser) callonAssignment1() (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -243,7 +243,7 @@ function peg$parse(input, options) {
       peg$c46 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
       peg$c47 = "null",
       peg$c48 = peg$literalExpectation("null", false),
-      peg$c49 = function() { return {"op": "Literal", "type": "null"} },
+      peg$c49 = function() { return {"op": "Literal", "type": "null", "value": ""} },
       peg$c50 = function(first, rest) {
            if (rest) {
               return [first, ... rest]
@@ -268,25 +268,12 @@ function peg$parse(input, options) {
       peg$c57 = peg$literalExpectation(";", false),
       peg$c58 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
       peg$c59 = function(every, keys, limit) {
-            let p = {"op": "GroupByProc", "keys": keys}
-            if (every) {
-              p["duration"] = every
-            }
-            if (limit) {
-              p["limit"] = limit
-            }
-            return p
+            return {"op": "GroupByProc", "keys": keys, "reducers": null, "duration": every, "limit": limit}
           },
       peg$c60 = function(every, reducers, keys, limit) {
-            let p = {"op": "GroupByProc", "reducers": reducers}
-            if (every) {
-              p["duration"] = every
-            }
+            let p = {"op": "GroupByProc", "keys": null, "reducers": reducers, "duration": every, "limit": limit}
             if (keys) {
               p["keys"] = keys[1]
-            }
-            if (limit) {
-              p["limit"] = limit
             }
             return p
           },
@@ -301,43 +288,45 @@ function peg$parse(input, options) {
       peg$c69 = "-limit",
       peg$c70 = peg$literalExpectation("-limit", false),
       peg$c71 = function(limit) { return limit },
-      peg$c72 = function(expr) { return {"op": "Assignment", "rhs": expr} },
-      peg$c73 = ",",
-      peg$c74 = peg$literalExpectation(",", false),
-      peg$c75 = function(first, expr) { return expr },
-      peg$c76 = function(first, rest) {
+      peg$c72 = "",
+      peg$c73 = function() { return 0 },
+      peg$c74 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c75 = ",",
+      peg$c76 = peg$literalExpectation(",", false),
+      peg$c77 = function(first, expr) { return expr },
+      peg$c78 = function(first, rest) {
             return [first, ... rest]
           },
-      peg$c77 = "=",
-      peg$c78 = peg$literalExpectation("=", false),
-      peg$c79 = function(lval, reducer) {
+      peg$c79 = "=",
+      peg$c80 = peg$literalExpectation("=", false),
+      peg$c81 = function(lval, reducer) {
             return {"op": "Assignment", "lhs": lval, "rhs": reducer}
           },
-      peg$c80 = function(reducer) {
-            return {"op": "Assignment", "rhs": reducer}
+      peg$c82 = function(reducer) {
+            return {"op": "Assignment", "lhs": null, "rhs": reducer}
           },
-      peg$c81 = "not",
-      peg$c82 = peg$literalExpectation("not", false),
-      peg$c83 = function(op, expr, where) {
-            let r = {"op": "Reducer", "operator": op, "where":where}
+      peg$c83 = "not",
+      peg$c84 = peg$literalExpectation("not", false),
+      peg$c85 = function(op, expr, where) {
+            let r = {"op": "Reducer", "operator": op, "expr": null, "where":where}
             if (expr) {
               r["expr"] = expr
             }
             return r
           },
-      peg$c84 = "where",
-      peg$c85 = peg$literalExpectation("where", false),
-      peg$c86 = function(first, rest) {
+      peg$c86 = "where",
+      peg$c87 = peg$literalExpectation("where", false),
+      peg$c88 = function(first, rest) {
             let result = [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c87 = "sort",
-      peg$c88 = peg$literalExpectation("sort", true),
-      peg$c89 = function(args, l) { return l },
-      peg$c90 = function(args, list) {
+      peg$c89 = "sort",
+      peg$c90 = peg$literalExpectation("sort", true),
+      peg$c91 = function(args, l) { return l },
+      peg$c92 = function(args, list) {
             let argm = args
             let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false}
             if ( "r" in argm) {
@@ -350,27 +339,27 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c91 = function(a) { return a },
-      peg$c92 = function(args) { return makeArgMap(args) },
-      peg$c93 = "-r",
-      peg$c94 = peg$literalExpectation("-r", false),
-      peg$c95 = function() { return {"name": "r", "value": null} },
-      peg$c96 = "-nulls",
-      peg$c97 = peg$literalExpectation("-nulls", false),
-      peg$c98 = "first",
-      peg$c99 = peg$literalExpectation("first", false),
-      peg$c100 = "last",
-      peg$c101 = peg$literalExpectation("last", false),
-      peg$c102 = function() { return text() },
-      peg$c103 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c104 = "top",
-      peg$c105 = peg$literalExpectation("top", true),
-      peg$c106 = function(n) { return n},
-      peg$c107 = "-flush",
-      peg$c108 = peg$literalExpectation("-flush", false),
-      peg$c109 = function(limit, flush, f) { return f },
-      peg$c110 = function(limit, flush, fields) {
-            let proc = {"op": "TopProc"}
+      peg$c93 = function(a) { return a },
+      peg$c94 = function(args) { return makeArgMap(args) },
+      peg$c95 = "-r",
+      peg$c96 = peg$literalExpectation("-r", false),
+      peg$c97 = function() { return {"name": "r", "value": null} },
+      peg$c98 = "-nulls",
+      peg$c99 = peg$literalExpectation("-nulls", false),
+      peg$c100 = "first",
+      peg$c101 = peg$literalExpectation("first", false),
+      peg$c102 = "last",
+      peg$c103 = peg$literalExpectation("last", false),
+      peg$c104 = function() { return text() },
+      peg$c105 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c106 = "top",
+      peg$c107 = peg$literalExpectation("top", true),
+      peg$c108 = function(n) { return n},
+      peg$c109 = "-flush",
+      peg$c110 = peg$literalExpectation("-flush", false),
+      peg$c111 = function(limit, flush, f) { return f },
+      peg$c112 = function(limit, flush, fields) {
+            let proc = {"op": "TopProc", "limit": 0, "fields": null, "flush": false}
             if (limit) {
               proc["limit"] = limit
             }
@@ -382,9 +371,9 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c111 = "cut",
-      peg$c112 = peg$literalExpectation("cut", true),
-      peg$c113 = function(args, columns) {
+      peg$c113 = "cut",
+      peg$c114 = peg$literalExpectation("cut", true),
+      peg$c115 = function(args, columns) {
             let argm = args
             let proc = {"op": "CutProc", "fields": columns, "complement": false}
             if ( "c" in argm) {
@@ -392,67 +381,67 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c114 = "-c",
-      peg$c115 = peg$literalExpectation("-c", false),
-      peg$c116 = function() { return {"name": "c", "value": null} },
-      peg$c117 = function(args) {
+      peg$c116 = "-c",
+      peg$c117 = peg$literalExpectation("-c", false),
+      peg$c118 = function() { return {"name": "c", "value": null} },
+      peg$c119 = function(args) {
             return makeArgMap(args)
           },
-      peg$c118 = "head",
-      peg$c119 = peg$literalExpectation("head", true),
-      peg$c120 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c121 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c122 = "tail",
-      peg$c123 = peg$literalExpectation("tail", true),
-      peg$c124 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c125 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c126 = "filter",
-      peg$c127 = peg$literalExpectation("filter", true),
-      peg$c128 = "uniq",
-      peg$c129 = peg$literalExpectation("uniq", true),
-      peg$c130 = function() {
+      peg$c120 = "head",
+      peg$c121 = peg$literalExpectation("head", true),
+      peg$c122 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c123 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c124 = "tail",
+      peg$c125 = peg$literalExpectation("tail", true),
+      peg$c126 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c127 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c128 = "filter",
+      peg$c129 = peg$literalExpectation("filter", true),
+      peg$c130 = "uniq",
+      peg$c131 = peg$literalExpectation("uniq", true),
+      peg$c132 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c131 = function() {
+      peg$c133 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c132 = "put",
-      peg$c133 = peg$literalExpectation("put", true),
-      peg$c134 = function(columns) {
+      peg$c134 = "put",
+      peg$c135 = peg$literalExpectation("put", true),
+      peg$c136 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c135 = "rename",
-      peg$c136 = peg$literalExpectation("rename", true),
-      peg$c137 = function(first, cl) { return cl },
-      peg$c138 = function(first, rest) {
+      peg$c137 = "rename",
+      peg$c138 = peg$literalExpectation("rename", true),
+      peg$c139 = function(first, cl) { return cl },
+      peg$c140 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c139 = "fuse",
-      peg$c140 = peg$literalExpectation("fuse", true),
-      peg$c141 = function() {
+      peg$c141 = "fuse",
+      peg$c142 = peg$literalExpectation("fuse", true),
+      peg$c143 = function() {
             return {"op": "FuseProc"}
           },
-      peg$c142 = "join",
-      peg$c143 = peg$literalExpectation("join", true),
-      peg$c144 = function(leftKey, rightKey, columns) {
-            let proc = {"op": "JoinProc", "left_key": leftKey, "right_key": rightKey}
+      peg$c144 = "join",
+      peg$c145 = peg$literalExpectation("join", true),
+      peg$c146 = function(leftKey, rightKey, columns) {
+            let proc = {"op": "JoinProc", "left_key": leftKey, "right_key": rightKey, "clauses": null}
             if (columns) {
               proc["clauses"] = columns[1]
             }
             return proc
           },
-      peg$c145 = function(key, columns) {
-            let proc = {"op": "JoinProc", "left_key": key, "right_key": key}
+      peg$c147 = function(key, columns) {
+            let proc = {"op": "JoinProc", "left_key": key, "right_key": key, "clauses": null}
             if (columns) {
               proc["clauses"] = columns[1]
             }
             return proc
           },
-      peg$c146 = ".",
-      peg$c147 = peg$literalExpectation(".", false),
-      peg$c148 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
-      peg$c149 = function() { return {"op": "RootRecord"} },
-      peg$c150 = function(first, rest) {
+      peg$c148 = ".",
+      peg$c149 = peg$literalExpectation(".", false),
+      peg$c150 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
+      peg$c151 = function() { return {"op": "RootRecord"} },
+      peg$c152 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -461,273 +450,273 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c151 = function(lhs, rhs) { return {"lhs": lhs, "rhs": rhs} },
-      peg$c152 = "?",
-      peg$c153 = peg$literalExpectation("?", false),
-      peg$c154 = ":",
-      peg$c155 = peg$literalExpectation(":", false),
-      peg$c156 = function(condition, thenClause, elseClause) {
+      peg$c153 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c154 = "?",
+      peg$c155 = peg$literalExpectation("?", false),
+      peg$c156 = ":",
+      peg$c157 = peg$literalExpectation(":", false),
+      peg$c158 = function(condition, thenClause, elseClause) {
             return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c157 = function(first, op, expr) { return [op, expr] },
-      peg$c158 = function(first, rest) {
+      peg$c159 = function(first, op, expr) { return [op, expr] },
+      peg$c160 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c159 = function(first, comp, expr) { return [comp, expr] },
-      peg$c160 = "=~",
-      peg$c161 = peg$literalExpectation("=~", false),
-      peg$c162 = "!~",
-      peg$c163 = peg$literalExpectation("!~", false),
-      peg$c164 = "!=",
-      peg$c165 = peg$literalExpectation("!=", false),
-      peg$c166 = "in",
-      peg$c167 = peg$literalExpectation("in", false),
-      peg$c168 = "<=",
-      peg$c169 = peg$literalExpectation("<=", false),
-      peg$c170 = "<",
-      peg$c171 = peg$literalExpectation("<", false),
-      peg$c172 = ">=",
-      peg$c173 = peg$literalExpectation(">=", false),
-      peg$c174 = ">",
-      peg$c175 = peg$literalExpectation(">", false),
-      peg$c176 = "+",
-      peg$c177 = peg$literalExpectation("+", false),
-      peg$c178 = "/",
-      peg$c179 = peg$literalExpectation("/", false),
-      peg$c180 = function(e) {
+      peg$c161 = function(first, comp, expr) { return [comp, expr] },
+      peg$c162 = "=~",
+      peg$c163 = peg$literalExpectation("=~", false),
+      peg$c164 = "!~",
+      peg$c165 = peg$literalExpectation("!~", false),
+      peg$c166 = "!=",
+      peg$c167 = peg$literalExpectation("!=", false),
+      peg$c168 = "in",
+      peg$c169 = peg$literalExpectation("in", false),
+      peg$c170 = "<=",
+      peg$c171 = peg$literalExpectation("<=", false),
+      peg$c172 = "<",
+      peg$c173 = peg$literalExpectation("<", false),
+      peg$c174 = ">=",
+      peg$c175 = peg$literalExpectation(">=", false),
+      peg$c176 = ">",
+      peg$c177 = peg$literalExpectation(">", false),
+      peg$c178 = "+",
+      peg$c179 = peg$literalExpectation("+", false),
+      peg$c180 = "/",
+      peg$c181 = peg$literalExpectation("/", false),
+      peg$c182 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c181 = function(e, typ) { return typ },
-      peg$c182 = function(e, typ) {
+      peg$c183 = function(e, typ) { return typ },
+      peg$c184 = function(e, typ) {
             return {"op": "CastExpr", "expr": e, "type": typ}
           },
-      peg$c183 = "bytes",
-      peg$c184 = peg$literalExpectation("bytes", false),
-      peg$c185 = "uint8",
-      peg$c186 = peg$literalExpectation("uint8", false),
-      peg$c187 = "uint16",
-      peg$c188 = peg$literalExpectation("uint16", false),
-      peg$c189 = "uint32",
-      peg$c190 = peg$literalExpectation("uint32", false),
-      peg$c191 = "uint64",
-      peg$c192 = peg$literalExpectation("uint64", false),
-      peg$c193 = "int8",
-      peg$c194 = peg$literalExpectation("int8", false),
-      peg$c195 = "int16",
-      peg$c196 = peg$literalExpectation("int16", false),
-      peg$c197 = "int32",
-      peg$c198 = peg$literalExpectation("int32", false),
-      peg$c199 = "int64",
-      peg$c200 = peg$literalExpectation("int64", false),
-      peg$c201 = "duration",
-      peg$c202 = peg$literalExpectation("duration", false),
-      peg$c203 = "time",
-      peg$c204 = peg$literalExpectation("time", false),
-      peg$c205 = "float64",
-      peg$c206 = peg$literalExpectation("float64", false),
-      peg$c207 = "bool",
-      peg$c208 = peg$literalExpectation("bool", false),
-      peg$c209 = "string",
-      peg$c210 = peg$literalExpectation("string", false),
-      peg$c211 = "bstring",
-      peg$c212 = peg$literalExpectation("bstring", false),
-      peg$c213 = "ip",
-      peg$c214 = peg$literalExpectation("ip", false),
-      peg$c215 = "net",
-      peg$c216 = peg$literalExpectation("net", false),
-      peg$c217 = "type",
-      peg$c218 = peg$literalExpectation("type", false),
-      peg$c219 = "error",
-      peg$c220 = peg$literalExpectation("error", false),
-      peg$c221 = function(first, rest) {
+      peg$c185 = "bytes",
+      peg$c186 = peg$literalExpectation("bytes", false),
+      peg$c187 = "uint8",
+      peg$c188 = peg$literalExpectation("uint8", false),
+      peg$c189 = "uint16",
+      peg$c190 = peg$literalExpectation("uint16", false),
+      peg$c191 = "uint32",
+      peg$c192 = peg$literalExpectation("uint32", false),
+      peg$c193 = "uint64",
+      peg$c194 = peg$literalExpectation("uint64", false),
+      peg$c195 = "int8",
+      peg$c196 = peg$literalExpectation("int8", false),
+      peg$c197 = "int16",
+      peg$c198 = peg$literalExpectation("int16", false),
+      peg$c199 = "int32",
+      peg$c200 = peg$literalExpectation("int32", false),
+      peg$c201 = "int64",
+      peg$c202 = peg$literalExpectation("int64", false),
+      peg$c203 = "duration",
+      peg$c204 = peg$literalExpectation("duration", false),
+      peg$c205 = "time",
+      peg$c206 = peg$literalExpectation("time", false),
+      peg$c207 = "float64",
+      peg$c208 = peg$literalExpectation("float64", false),
+      peg$c209 = "bool",
+      peg$c210 = peg$literalExpectation("bool", false),
+      peg$c211 = "string",
+      peg$c212 = peg$literalExpectation("string", false),
+      peg$c213 = "bstring",
+      peg$c214 = peg$literalExpectation("bstring", false),
+      peg$c215 = "ip",
+      peg$c216 = peg$literalExpectation("ip", false),
+      peg$c217 = "net",
+      peg$c218 = peg$literalExpectation("net", false),
+      peg$c219 = "type",
+      peg$c220 = peg$literalExpectation("type", false),
+      peg$c221 = "error",
+      peg$c222 = peg$literalExpectation("error", false),
+      peg$c223 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c222 = function(fn, args) {
+      peg$c224 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c223 = function(first, e) { return e },
-      peg$c224 = function() { return [] },
-      peg$c225 = "[",
-      peg$c226 = peg$literalExpectation("[", false),
-      peg$c227 = "]",
-      peg$c228 = peg$literalExpectation("]", false),
-      peg$c229 = function(expr) { return ["[", expr] },
-      peg$c230 = function(id) { return [".", id] },
-      peg$c231 = "and",
-      peg$c232 = peg$literalExpectation("and", true),
-      peg$c233 = "or",
-      peg$c234 = peg$literalExpectation("or", true),
-      peg$c235 = peg$literalExpectation("in", true),
-      peg$c236 = peg$literalExpectation("not", true),
-      peg$c237 = /^[A-Za-z_$]/,
-      peg$c238 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c239 = /^[0-9]/,
-      peg$c240 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c241 = function() { return {"op": "Identifier", "name": text()} },
-      peg$c242 = peg$literalExpectation("and", false),
-      peg$c243 = "seconds",
-      peg$c244 = peg$literalExpectation("seconds", false),
-      peg$c245 = "second",
-      peg$c246 = peg$literalExpectation("second", false),
-      peg$c247 = "secs",
-      peg$c248 = peg$literalExpectation("secs", false),
-      peg$c249 = "sec",
-      peg$c250 = peg$literalExpectation("sec", false),
-      peg$c251 = "s",
-      peg$c252 = peg$literalExpectation("s", false),
-      peg$c253 = "minutes",
-      peg$c254 = peg$literalExpectation("minutes", false),
-      peg$c255 = "minute",
-      peg$c256 = peg$literalExpectation("minute", false),
-      peg$c257 = "mins",
-      peg$c258 = peg$literalExpectation("mins", false),
-      peg$c259 = "min",
-      peg$c260 = peg$literalExpectation("min", false),
-      peg$c261 = "m",
-      peg$c262 = peg$literalExpectation("m", false),
-      peg$c263 = "hours",
-      peg$c264 = peg$literalExpectation("hours", false),
-      peg$c265 = "hrs",
-      peg$c266 = peg$literalExpectation("hrs", false),
-      peg$c267 = "hr",
-      peg$c268 = peg$literalExpectation("hr", false),
-      peg$c269 = "h",
-      peg$c270 = peg$literalExpectation("h", false),
-      peg$c271 = "hour",
-      peg$c272 = peg$literalExpectation("hour", false),
-      peg$c273 = "days",
-      peg$c274 = peg$literalExpectation("days", false),
-      peg$c275 = "day",
-      peg$c276 = peg$literalExpectation("day", false),
-      peg$c277 = "d",
-      peg$c278 = peg$literalExpectation("d", false),
-      peg$c279 = "weeks",
-      peg$c280 = peg$literalExpectation("weeks", false),
-      peg$c281 = "week",
-      peg$c282 = peg$literalExpectation("week", false),
-      peg$c283 = "wks",
-      peg$c284 = peg$literalExpectation("wks", false),
-      peg$c285 = "wk",
-      peg$c286 = peg$literalExpectation("wk", false),
-      peg$c287 = "w",
-      peg$c288 = peg$literalExpectation("w", false),
-      peg$c289 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c290 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c291 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c292 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c293 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c294 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c295 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c296 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c297 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c298 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c299 = function(a, b) {
+      peg$c225 = function(first, e) { return e },
+      peg$c226 = function() { return [] },
+      peg$c227 = "[",
+      peg$c228 = peg$literalExpectation("[", false),
+      peg$c229 = "]",
+      peg$c230 = peg$literalExpectation("]", false),
+      peg$c231 = function(expr) { return ["[", expr] },
+      peg$c232 = function(id) { return [".", id] },
+      peg$c233 = "and",
+      peg$c234 = peg$literalExpectation("and", true),
+      peg$c235 = "or",
+      peg$c236 = peg$literalExpectation("or", true),
+      peg$c237 = peg$literalExpectation("in", true),
+      peg$c238 = peg$literalExpectation("not", true),
+      peg$c239 = /^[A-Za-z_$]/,
+      peg$c240 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c241 = /^[0-9]/,
+      peg$c242 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c243 = function() { return {"op": "Identifier", "name": text()} },
+      peg$c244 = peg$literalExpectation("and", false),
+      peg$c245 = "seconds",
+      peg$c246 = peg$literalExpectation("seconds", false),
+      peg$c247 = "second",
+      peg$c248 = peg$literalExpectation("second", false),
+      peg$c249 = "secs",
+      peg$c250 = peg$literalExpectation("secs", false),
+      peg$c251 = "sec",
+      peg$c252 = peg$literalExpectation("sec", false),
+      peg$c253 = "s",
+      peg$c254 = peg$literalExpectation("s", false),
+      peg$c255 = "minutes",
+      peg$c256 = peg$literalExpectation("minutes", false),
+      peg$c257 = "minute",
+      peg$c258 = peg$literalExpectation("minute", false),
+      peg$c259 = "mins",
+      peg$c260 = peg$literalExpectation("mins", false),
+      peg$c261 = "min",
+      peg$c262 = peg$literalExpectation("min", false),
+      peg$c263 = "m",
+      peg$c264 = peg$literalExpectation("m", false),
+      peg$c265 = "hours",
+      peg$c266 = peg$literalExpectation("hours", false),
+      peg$c267 = "hrs",
+      peg$c268 = peg$literalExpectation("hrs", false),
+      peg$c269 = "hr",
+      peg$c270 = peg$literalExpectation("hr", false),
+      peg$c271 = "h",
+      peg$c272 = peg$literalExpectation("h", false),
+      peg$c273 = "hour",
+      peg$c274 = peg$literalExpectation("hour", false),
+      peg$c275 = "days",
+      peg$c276 = peg$literalExpectation("days", false),
+      peg$c277 = "day",
+      peg$c278 = peg$literalExpectation("day", false),
+      peg$c279 = "d",
+      peg$c280 = peg$literalExpectation("d", false),
+      peg$c281 = "weeks",
+      peg$c282 = peg$literalExpectation("weeks", false),
+      peg$c283 = "week",
+      peg$c284 = peg$literalExpectation("week", false),
+      peg$c285 = "wks",
+      peg$c286 = peg$literalExpectation("wks", false),
+      peg$c287 = "wk",
+      peg$c288 = peg$literalExpectation("wk", false),
+      peg$c289 = "w",
+      peg$c290 = peg$literalExpectation("w", false),
+      peg$c291 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c292 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c293 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c294 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c295 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c296 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c297 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c298 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c299 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c300 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c301 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c300 = "::",
-      peg$c301 = peg$literalExpectation("::", false),
-      peg$c302 = function(a, b, d, e) {
+      peg$c302 = "::",
+      peg$c303 = peg$literalExpectation("::", false),
+      peg$c304 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c303 = function(a, b) {
+      peg$c305 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c304 = function(a, b) {
+      peg$c306 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c305 = function() {
+      peg$c307 = function() {
             return "::"
           },
-      peg$c306 = function(v) { return ":" + v },
-      peg$c307 = function(v) { return v + ":" },
-      peg$c308 = function(a, m) {
+      peg$c308 = function(v) { return ":" + v },
+      peg$c309 = function(v) { return v + ":" },
+      peg$c310 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c309 = function(a, m) {
+      peg$c311 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c310 = function(s) { return parseInt(s) },
-      peg$c311 = function() {
+      peg$c312 = function(s) { return parseInt(s) },
+      peg$c313 = function() {
             return text()
           },
-      peg$c312 = "e",
-      peg$c313 = peg$literalExpectation("e", true),
-      peg$c314 = /^[+\-]/,
-      peg$c315 = peg$classExpectation(["+", "-"], false, false),
-      peg$c316 = /^[0-9a-fA-F]/,
-      peg$c317 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c318 = function(chars) { return joinChars(chars) },
-      peg$c319 = "\\",
-      peg$c320 = peg$literalExpectation("\\", false),
-      peg$c321 = /^[\0-\x1F\\(),!><="|';:]/,
-      peg$c322 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
-      peg$c323 = peg$anyExpectation(),
-      peg$c324 = "\"",
-      peg$c325 = peg$literalExpectation("\"", false),
-      peg$c326 = function(v) { return joinChars(v) },
-      peg$c327 = "'",
-      peg$c328 = peg$literalExpectation("'", false),
-      peg$c329 = "x",
-      peg$c330 = peg$literalExpectation("x", false),
-      peg$c331 = function() { return "\\" + text() },
-      peg$c332 = "b",
-      peg$c333 = peg$literalExpectation("b", false),
-      peg$c334 = function() { return "\b" },
-      peg$c335 = "f",
-      peg$c336 = peg$literalExpectation("f", false),
-      peg$c337 = function() { return "\f" },
-      peg$c338 = "n",
-      peg$c339 = peg$literalExpectation("n", false),
-      peg$c340 = function() { return "\n" },
-      peg$c341 = "r",
-      peg$c342 = peg$literalExpectation("r", false),
-      peg$c343 = function() { return "\r" },
-      peg$c344 = "t",
-      peg$c345 = peg$literalExpectation("t", false),
-      peg$c346 = function() { return "\t" },
-      peg$c347 = "v",
-      peg$c348 = peg$literalExpectation("v", false),
-      peg$c349 = function() { return "\v" },
-      peg$c350 = function() { return "=" },
-      peg$c351 = function() { return "\\*" },
-      peg$c352 = "u",
-      peg$c353 = peg$literalExpectation("u", false),
-      peg$c354 = function(chars) {
+      peg$c314 = "e",
+      peg$c315 = peg$literalExpectation("e", true),
+      peg$c316 = /^[+\-]/,
+      peg$c317 = peg$classExpectation(["+", "-"], false, false),
+      peg$c318 = /^[0-9a-fA-F]/,
+      peg$c319 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c320 = function(chars) { return joinChars(chars) },
+      peg$c321 = "\\",
+      peg$c322 = peg$literalExpectation("\\", false),
+      peg$c323 = /^[\0-\x1F\\(),!><="|';:]/,
+      peg$c324 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
+      peg$c325 = peg$anyExpectation(),
+      peg$c326 = "\"",
+      peg$c327 = peg$literalExpectation("\"", false),
+      peg$c328 = function(v) { return joinChars(v) },
+      peg$c329 = "'",
+      peg$c330 = peg$literalExpectation("'", false),
+      peg$c331 = "x",
+      peg$c332 = peg$literalExpectation("x", false),
+      peg$c333 = function() { return "\\" + text() },
+      peg$c334 = "b",
+      peg$c335 = peg$literalExpectation("b", false),
+      peg$c336 = function() { return "\b" },
+      peg$c337 = "f",
+      peg$c338 = peg$literalExpectation("f", false),
+      peg$c339 = function() { return "\f" },
+      peg$c340 = "n",
+      peg$c341 = peg$literalExpectation("n", false),
+      peg$c342 = function() { return "\n" },
+      peg$c343 = "r",
+      peg$c344 = peg$literalExpectation("r", false),
+      peg$c345 = function() { return "\r" },
+      peg$c346 = "t",
+      peg$c347 = peg$literalExpectation("t", false),
+      peg$c348 = function() { return "\t" },
+      peg$c349 = "v",
+      peg$c350 = peg$literalExpectation("v", false),
+      peg$c351 = function() { return "\v" },
+      peg$c352 = function() { return "=" },
+      peg$c353 = function() { return "\\*" },
+      peg$c354 = "u",
+      peg$c355 = peg$literalExpectation("u", false),
+      peg$c356 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c355 = "{",
-      peg$c356 = peg$literalExpectation("{", false),
-      peg$c357 = "}",
-      peg$c358 = peg$literalExpectation("}", false),
-      peg$c359 = function(body) { return body },
-      peg$c360 = /^[^\/\\]/,
-      peg$c361 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c362 = "\\/",
-      peg$c363 = peg$literalExpectation("\\/", false),
-      peg$c364 = /^[\0-\x1F\\]/,
-      peg$c365 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c366 = peg$otherExpectation("whitespace"),
-      peg$c367 = "\t",
-      peg$c368 = peg$literalExpectation("\t", false),
-      peg$c369 = "\x0B",
-      peg$c370 = peg$literalExpectation("\x0B", false),
-      peg$c371 = "\f",
-      peg$c372 = peg$literalExpectation("\f", false),
-      peg$c373 = " ",
-      peg$c374 = peg$literalExpectation(" ", false),
-      peg$c375 = "\xA0",
-      peg$c376 = peg$literalExpectation("\xA0", false),
-      peg$c377 = "\uFEFF",
-      peg$c378 = peg$literalExpectation("\uFEFF", false),
-      peg$c379 = /^[\n\r\u2028\u2029]/,
-      peg$c380 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c381 = peg$otherExpectation("comment"),
-      peg$c382 = "/*",
-      peg$c383 = peg$literalExpectation("/*", false),
-      peg$c384 = "*/",
-      peg$c385 = peg$literalExpectation("*/", false),
-      peg$c386 = "//",
-      peg$c387 = peg$literalExpectation("//", false),
+      peg$c357 = "{",
+      peg$c358 = peg$literalExpectation("{", false),
+      peg$c359 = "}",
+      peg$c360 = peg$literalExpectation("}", false),
+      peg$c361 = function(body) { return body },
+      peg$c362 = /^[^\/\\]/,
+      peg$c363 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c364 = "\\/",
+      peg$c365 = peg$literalExpectation("\\/", false),
+      peg$c366 = /^[\0-\x1F\\]/,
+      peg$c367 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c368 = peg$otherExpectation("whitespace"),
+      peg$c369 = "\t",
+      peg$c370 = peg$literalExpectation("\t", false),
+      peg$c371 = "\x0B",
+      peg$c372 = peg$literalExpectation("\x0B", false),
+      peg$c373 = "\f",
+      peg$c374 = peg$literalExpectation("\f", false),
+      peg$c375 = " ",
+      peg$c376 = peg$literalExpectation(" ", false),
+      peg$c377 = "\xA0",
+      peg$c378 = peg$literalExpectation("\xA0", false),
+      peg$c379 = "\uFEFF",
+      peg$c380 = peg$literalExpectation("\uFEFF", false),
+      peg$c381 = /^[\n\r\u2028\u2029]/,
+      peg$c382 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c383 = peg$otherExpectation("comment"),
+      peg$c384 = "/*",
+      peg$c385 = peg$literalExpectation("/*", false),
+      peg$c386 = "*/",
+      peg$c387 = peg$literalExpectation("*/", false),
+      peg$c388 = "//",
+      peg$c389 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -2139,9 +2128,6 @@ function peg$parse(input, options) {
       s2 = peg$parseGroupByKeys();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseLimitArg();
-        if (s3 === peg$FAILED) {
-          s3 = null;
-        }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$c59(s1, s2, s3);
@@ -2346,6 +2332,15 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$c72;
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c73();
+      }
+      s0 = s1;
+    }
 
     return s0;
   }
@@ -2359,7 +2354,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72(s1);
+        s1 = peg$c74(s1);
       }
       s0 = s1;
     }
@@ -2378,11 +2373,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c75;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2390,7 +2385,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c75(s1, s7);
+              s4 = peg$c77(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2414,11 +2409,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c75;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c76); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2426,7 +2421,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c75(s1, s7);
+                s4 = peg$c77(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2447,7 +2442,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c76(s1, s2);
+        s1 = peg$c78(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2470,11 +2465,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c77;
+          s3 = peg$c79;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -2482,7 +2477,7 @@ function peg$parse(input, options) {
             s5 = peg$parseReducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c79(s1, s5);
+              s1 = peg$c81(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2509,7 +2504,7 @@ function peg$parse(input, options) {
       s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c80(s1);
+        s1 = peg$c82(s1);
       }
       s0 = s1;
     }
@@ -2523,12 +2518,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
-    if (input.substr(peg$currPos, 3) === peg$c81) {
-      s2 = peg$c81;
+    if (input.substr(peg$currPos, 3) === peg$c83) {
+      s2 = peg$c83;
       peg$currPos += 3;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c82); }
+      if (peg$silentFails === 0) { peg$fail(peg$c84); }
     }
     if (s2 === peg$FAILED) {
       if (input.substr(peg$currPos, 3) === peg$c26) {
@@ -2582,7 +2577,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c83(s2, s6, s9);
+                      s1 = peg$c85(s2, s6, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -2630,12 +2625,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c84) {
-        s2 = peg$c84;
+      if (input.substr(peg$currPos, 5) === peg$c86) {
+        s2 = peg$c86;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        if (peg$silentFails === 0) { peg$fail(peg$c87); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -2676,11 +2671,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c75;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2711,11 +2706,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c75;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c76); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2743,7 +2738,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c86(s1, s2);
+        s1 = peg$c88(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2799,12 +2794,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c87) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c89) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c88); }
+      if (peg$silentFails === 0) { peg$fail(peg$c90); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -2815,7 +2810,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c89(s2, s5);
+            s4 = peg$c91(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2830,7 +2825,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c90(s2, s3);
+          s1 = peg$c92(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2859,7 +2854,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c91(s4);
+        s3 = peg$c93(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -2877,7 +2872,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c91(s4);
+          s3 = peg$c93(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -2890,7 +2885,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c92(s1);
+      s1 = peg$c94(s1);
     }
     s0 = s1;
 
@@ -2901,55 +2896,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c93) {
-      s1 = peg$c93;
+    if (input.substr(peg$currPos, 2) === peg$c95) {
+      s1 = peg$c95;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      if (peg$silentFails === 0) { peg$fail(peg$c96); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c95();
+      s1 = peg$c97();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c96) {
-        s1 = peg$c96;
+      if (input.substr(peg$currPos, 6) === peg$c98) {
+        s1 = peg$c98;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+        if (peg$silentFails === 0) { peg$fail(peg$c99); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c98) {
-            s4 = peg$c98;
+          if (input.substr(peg$currPos, 5) === peg$c100) {
+            s4 = peg$c100;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c99); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c100) {
-              s4 = peg$c100;
+            if (input.substr(peg$currPos, 4) === peg$c102) {
+              s4 = peg$c102;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c101); }
+              if (peg$silentFails === 0) { peg$fail(peg$c103); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c102();
+            s4 = peg$c104();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c103(s3);
+            s1 = peg$c105(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2972,12 +2967,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c104) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c106) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c105); }
+      if (peg$silentFails === 0) { peg$fail(peg$c107); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -2986,7 +2981,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c106(s4);
+          s3 = peg$c108(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3003,12 +2998,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c107) {
-            s5 = peg$c107;
+          if (input.substr(peg$currPos, 6) === peg$c109) {
+            s5 = peg$c109;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c108); }
+            if (peg$silentFails === 0) { peg$fail(peg$c110); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3031,7 +3026,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c109(s2, s3, s6);
+              s5 = peg$c111(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3046,7 +3041,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c110(s2, s3, s4);
+            s1 = peg$c112(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3072,12 +3067,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c111) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c113) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c112); }
+      if (peg$silentFails === 0) { peg$fail(peg$c114); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseCutArgs();
@@ -3087,7 +3082,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFlexAssignments();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c113(s2, s4);
+            s1 = peg$c115(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3117,16 +3112,16 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     s3 = peg$parse_();
     if (s3 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c114) {
-        s4 = peg$c114;
+      if (input.substr(peg$currPos, 2) === peg$c116) {
+        s4 = peg$c116;
         peg$currPos += 2;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c116();
+        s3 = peg$c118();
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3141,16 +3136,16 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c114) {
-          s4 = peg$c114;
+        if (input.substr(peg$currPos, 2) === peg$c116) {
+          s4 = peg$c116;
           peg$currPos += 2;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+          if (peg$silentFails === 0) { peg$fail(peg$c117); }
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c116();
+          s3 = peg$c118();
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3163,7 +3158,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c117(s1);
+      s1 = peg$c119(s1);
     }
     s0 = s1;
 
@@ -3174,12 +3169,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c118) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c120) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c119); }
+      if (peg$silentFails === 0) { peg$fail(peg$c121); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3187,7 +3182,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c120(s3);
+          s1 = peg$c122(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3203,16 +3198,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c118) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c120) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c119); }
+        if (peg$silentFails === 0) { peg$fail(peg$c121); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c121();
+        s1 = peg$c123();
       }
       s0 = s1;
     }
@@ -3224,12 +3219,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c122) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c124) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c123); }
+      if (peg$silentFails === 0) { peg$fail(peg$c125); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3237,7 +3232,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c124(s3);
+          s1 = peg$c126(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3253,16 +3248,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c122) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c124) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c123); }
+        if (peg$silentFails === 0) { peg$fail(peg$c125); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c125();
+        s1 = peg$c127();
       }
       s0 = s1;
     }
@@ -3274,12 +3269,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c126) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c128) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c127); }
+      if (peg$silentFails === 0) { peg$fail(peg$c129); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3309,26 +3304,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c130) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c129); }
+      if (peg$silentFails === 0) { peg$fail(peg$c131); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c114) {
-          s3 = peg$c114;
+        if (input.substr(peg$currPos, 2) === peg$c116) {
+          s3 = peg$c116;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+          if (peg$silentFails === 0) { peg$fail(peg$c117); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c130();
+          s1 = peg$c132();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3344,16 +3339,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c128) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c130) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c129); }
+        if (peg$silentFails === 0) { peg$fail(peg$c131); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c131();
+        s1 = peg$c133();
       }
       s0 = s1;
     }
@@ -3365,12 +3360,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c132) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c134) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c133); }
+      if (peg$silentFails === 0) { peg$fail(peg$c135); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3378,7 +3373,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c134(s3);
+          s1 = peg$c136(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3400,12 +3395,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c135) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c137) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c136); }
+      if (peg$silentFails === 0) { peg$fail(peg$c138); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3417,11 +3412,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c73;
+              s7 = peg$c75;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c74); }
+              if (peg$silentFails === 0) { peg$fail(peg$c76); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -3429,7 +3424,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c137(s3, s9);
+                  s6 = peg$c139(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -3453,11 +3448,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c73;
+                s7 = peg$c75;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                if (peg$silentFails === 0) { peg$fail(peg$c76); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -3465,7 +3460,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c137(s3, s9);
+                    s6 = peg$c139(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -3486,7 +3481,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c138(s3, s4);
+            s1 = peg$c140(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3512,16 +3507,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c141) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c142); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c141();
+      s1 = peg$c143();
     }
     s0 = s1;
 
@@ -3532,12 +3527,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c142) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c144) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      if (peg$silentFails === 0) { peg$fail(peg$c145); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3547,11 +3542,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 61) {
-              s5 = peg$c77;
+              s5 = peg$c79;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c78); }
+              if (peg$silentFails === 0) { peg$fail(peg$c80); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
@@ -3578,7 +3573,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c144(s3, s7, s8);
+                    s1 = peg$c146(s3, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3614,12 +3609,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c142) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c144) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c143); }
+        if (peg$silentFails === 0) { peg$fail(peg$c145); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -3646,7 +3641,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c145(s3, s4);
+              s1 = peg$c147(s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3718,11 +3713,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c146;
+      s1 = peg$c148;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c147); }
+      if (peg$silentFails === 0) { peg$fail(peg$c149); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -3745,7 +3740,7 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifier();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c148(s3);
+          s1 = peg$c150(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3762,11 +3757,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c146;
+        s1 = peg$c148;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c147); }
+        if (peg$silentFails === 0) { peg$fail(peg$c149); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
@@ -3781,7 +3776,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c149();
+          s1 = peg$c151();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3807,11 +3802,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c75;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3842,11 +3837,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c75;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c76); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3874,7 +3869,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c150(s1, s2);
+        s1 = peg$c152(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3899,11 +3894,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c75;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3934,11 +3929,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c75;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c76); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3966,7 +3961,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c150(s1, s2);
+        s1 = peg$c152(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3989,11 +3984,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c77;
+          s3 = peg$c79;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4001,7 +3996,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c151(s1, s5);
+              s1 = peg$c153(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4044,11 +4039,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c152;
+          s3 = peg$c154;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c153); }
+          if (peg$silentFails === 0) { peg$fail(peg$c155); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4058,11 +4053,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c154;
+                  s7 = peg$c156;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c155); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c157); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -4070,7 +4065,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c156(s1, s5, s9);
+                      s1 = peg$c158(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4132,7 +4127,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c157(s1, s5, s7);
+              s4 = peg$c159(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4162,7 +4157,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c157(s1, s5, s7);
+                s4 = peg$c159(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4183,7 +4178,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c160(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4214,7 +4209,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c157(s1, s5, s7);
+              s4 = peg$c159(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4244,7 +4239,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c157(s1, s5, s7);
+                s4 = peg$c159(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4265,7 +4260,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c160(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4296,7 +4291,7 @@ function peg$parse(input, options) {
             s7 = peg$parseRelativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c159(s1, s5, s7);
+              s4 = peg$c161(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4326,7 +4321,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c159(s1, s5, s7);
+                s4 = peg$c161(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4347,7 +4342,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c160(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4365,43 +4360,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c160) {
-      s1 = peg$c160;
+    if (input.substr(peg$currPos, 2) === peg$c162) {
+      s1 = peg$c162;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c161); }
+      if (peg$silentFails === 0) { peg$fail(peg$c163); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c162) {
-        s1 = peg$c162;
+      if (input.substr(peg$currPos, 2) === peg$c164) {
+        s1 = peg$c164;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c165); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c77;
+          s1 = peg$c79;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c164) {
-            s1 = peg$c164;
+          if (input.substr(peg$currPos, 2) === peg$c166) {
+            s1 = peg$c166;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c165); }
+            if (peg$silentFails === 0) { peg$fail(peg$c167); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -4414,16 +4409,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c166) {
-        s1 = peg$c166;
+      if (input.substr(peg$currPos, 2) === peg$c168) {
+        s1 = peg$c168;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c167); }
+        if (peg$silentFails === 0) { peg$fail(peg$c169); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c104();
       }
       s0 = s1;
     }
@@ -4448,7 +4443,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c157(s1, s5, s7);
+              s4 = peg$c159(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4478,7 +4473,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c157(s1, s5, s7);
+                s4 = peg$c159(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4499,7 +4494,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c160(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4517,43 +4512,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c168) {
-      s1 = peg$c168;
+    if (input.substr(peg$currPos, 2) === peg$c170) {
+      s1 = peg$c170;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c169); }
+      if (peg$silentFails === 0) { peg$fail(peg$c171); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c170;
+        s1 = peg$c172;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c171); }
+        if (peg$silentFails === 0) { peg$fail(peg$c173); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c172) {
-          s1 = peg$c172;
+        if (input.substr(peg$currPos, 2) === peg$c174) {
+          s1 = peg$c174;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c173); }
+          if (peg$silentFails === 0) { peg$fail(peg$c175); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c174;
+            s1 = peg$c176;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c175); }
+            if (peg$silentFails === 0) { peg$fail(peg$c177); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -4577,7 +4572,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c157(s1, s5, s7);
+              s4 = peg$c159(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4607,7 +4602,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c157(s1, s5, s7);
+                s4 = peg$c159(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4628,7 +4623,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c160(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4647,11 +4642,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c176;
+      s1 = peg$c178;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c177); }
+      if (peg$silentFails === 0) { peg$fail(peg$c179); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
@@ -4664,7 +4659,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -4688,7 +4683,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c157(s1, s5, s7);
+              s4 = peg$c159(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4718,7 +4713,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c157(s1, s5, s7);
+                s4 = peg$c159(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4739,7 +4734,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c160(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4766,16 +4761,16 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c178;
+        s1 = peg$c180;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c181); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -4799,7 +4794,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c180(s3);
+          s1 = peg$c182(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4828,17 +4823,17 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 58) {
-        s3 = peg$c154;
+        s3 = peg$c156;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c157); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parsePrimitiveType();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c181(s1, s4);
+          s3 = peg$c183(s1, s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4850,7 +4845,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c182(s1, s2);
+        s1 = peg$c184(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4871,164 +4866,164 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c183) {
-      s1 = peg$c183;
+    if (input.substr(peg$currPos, 5) === peg$c185) {
+      s1 = peg$c185;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c184); }
+      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c185) {
-        s1 = peg$c185;
+      if (input.substr(peg$currPos, 5) === peg$c187) {
+        s1 = peg$c187;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c186); }
+        if (peg$silentFails === 0) { peg$fail(peg$c188); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c187) {
-          s1 = peg$c187;
+        if (input.substr(peg$currPos, 6) === peg$c189) {
+          s1 = peg$c189;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c188); }
+          if (peg$silentFails === 0) { peg$fail(peg$c190); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c189) {
-            s1 = peg$c189;
+          if (input.substr(peg$currPos, 6) === peg$c191) {
+            s1 = peg$c191;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c190); }
+            if (peg$silentFails === 0) { peg$fail(peg$c192); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c191) {
-              s1 = peg$c191;
+            if (input.substr(peg$currPos, 6) === peg$c193) {
+              s1 = peg$c193;
               peg$currPos += 6;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c192); }
+              if (peg$silentFails === 0) { peg$fail(peg$c194); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4) === peg$c193) {
-                s1 = peg$c193;
+              if (input.substr(peg$currPos, 4) === peg$c195) {
+                s1 = peg$c195;
                 peg$currPos += 4;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c194); }
+                if (peg$silentFails === 0) { peg$fail(peg$c196); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c195) {
-                  s1 = peg$c195;
+                if (input.substr(peg$currPos, 5) === peg$c197) {
+                  s1 = peg$c197;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c196); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c198); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c197) {
-                    s1 = peg$c197;
+                  if (input.substr(peg$currPos, 5) === peg$c199) {
+                    s1 = peg$c199;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c198); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c200); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c199) {
-                      s1 = peg$c199;
+                    if (input.substr(peg$currPos, 5) === peg$c201) {
+                      s1 = peg$c201;
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c200); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c202); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 8) === peg$c201) {
-                        s1 = peg$c201;
+                      if (input.substr(peg$currPos, 8) === peg$c203) {
+                        s1 = peg$c203;
                         peg$currPos += 8;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c202); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c204); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c203) {
-                          s1 = peg$c203;
+                        if (input.substr(peg$currPos, 4) === peg$c205) {
+                          s1 = peg$c205;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c204); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c206); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 7) === peg$c205) {
-                            s1 = peg$c205;
+                          if (input.substr(peg$currPos, 7) === peg$c207) {
+                            s1 = peg$c207;
                             peg$currPos += 7;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c206); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c208); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 4) === peg$c207) {
-                              s1 = peg$c207;
+                            if (input.substr(peg$currPos, 4) === peg$c209) {
+                              s1 = peg$c209;
                               peg$currPos += 4;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c208); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c210); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 5) === peg$c183) {
-                                s1 = peg$c183;
+                              if (input.substr(peg$currPos, 5) === peg$c185) {
+                                s1 = peg$c185;
                                 peg$currPos += 5;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c184); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c186); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 6) === peg$c209) {
-                                  s1 = peg$c209;
+                                if (input.substr(peg$currPos, 6) === peg$c211) {
+                                  s1 = peg$c211;
                                   peg$currPos += 6;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c210); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c212); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 7) === peg$c211) {
-                                    s1 = peg$c211;
+                                  if (input.substr(peg$currPos, 7) === peg$c213) {
+                                    s1 = peg$c213;
                                     peg$currPos += 7;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c212); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c214); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c213) {
-                                      s1 = peg$c213;
+                                    if (input.substr(peg$currPos, 2) === peg$c215) {
+                                      s1 = peg$c215;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c214); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c216); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c215) {
-                                        s1 = peg$c215;
+                                      if (input.substr(peg$currPos, 3) === peg$c217) {
+                                        s1 = peg$c217;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c218); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c217) {
-                                          s1 = peg$c217;
+                                        if (input.substr(peg$currPos, 4) === peg$c219) {
+                                          s1 = peg$c219;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c218); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c220); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 5) === peg$c219) {
-                                            s1 = peg$c219;
+                                          if (input.substr(peg$currPos, 5) === peg$c221) {
+                                            s1 = peg$c221;
                                             peg$currPos += 5;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c220); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c222); }
                                           }
                                           if (s1 === peg$FAILED) {
                                             if (input.substr(peg$currPos, 4) === peg$c47) {
@@ -5060,7 +5055,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -5081,7 +5076,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c221(s1, s2);
+        s1 = peg$c223(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5128,7 +5123,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c222(s1, s4);
+              s1 = peg$c224(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5164,11 +5159,11 @@ function peg$parse(input, options) {
       s3 = peg$parseIdentifierRest();
       if (s3 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c146;
+          s3 = peg$c148;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c147); }
+          if (peg$silentFails === 0) { peg$fail(peg$c149); }
         }
       }
       while (s3 !== peg$FAILED) {
@@ -5176,17 +5171,17 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifierRest();
         if (s3 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s3 = peg$c146;
+            s3 = peg$c148;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c147); }
+            if (peg$silentFails === 0) { peg$fail(peg$c149); }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c104();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5211,11 +5206,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c73;
+          s5 = peg$c75;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c76); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5223,7 +5218,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c223(s1, s7);
+              s4 = peg$c225(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5247,11 +5242,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c73;
+            s5 = peg$c75;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c76); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5259,7 +5254,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c223(s1, s7);
+                s4 = peg$c225(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5280,7 +5275,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c76(s1, s2);
+        s1 = peg$c78(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5295,7 +5290,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c224();
+        s1 = peg$c226();
       }
       s0 = s1;
     }
@@ -5317,7 +5312,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c221(s1, s2);
+        s1 = peg$c223(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5336,25 +5331,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c225;
+      s1 = peg$c227;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+      if (peg$silentFails === 0) { peg$fail(peg$c228); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseConditionalExpr();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c227;
+          s3 = peg$c229;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c228); }
+          if (peg$silentFails === 0) { peg$fail(peg$c230); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c229(s2);
+          s1 = peg$c231(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5371,21 +5366,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c146;
+        s1 = peg$c148;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c147); }
+        if (peg$silentFails === 0) { peg$fail(peg$c149); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c146;
+          s3 = peg$c148;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c147); }
+          if (peg$silentFails === 0) { peg$fail(peg$c149); }
         }
         peg$silentFails--;
         if (s3 === peg$FAILED) {
@@ -5398,7 +5393,7 @@ function peg$parse(input, options) {
           s3 = peg$parseIdentifier();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c230(s3);
+            s1 = peg$c232(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5509,16 +5504,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c231) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c233) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c232); }
+      if (peg$silentFails === 0) { peg$fail(peg$c234); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -5529,16 +5524,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c233) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c235) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
+      if (peg$silentFails === 0) { peg$fail(peg$c236); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -5549,16 +5544,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c166) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c168) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c237); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -5569,16 +5564,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c81) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c83) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c236); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -5599,7 +5594,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c104();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5616,12 +5611,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c237.test(input.charAt(peg$currPos))) {
+    if (peg$c239.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
 
     return s0;
@@ -5632,12 +5627,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c239.test(input.charAt(peg$currPos))) {
+      if (peg$c241.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c240); }
+        if (peg$silentFails === 0) { peg$fail(peg$c242); }
       }
     }
 
@@ -5658,7 +5653,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c241();
+        s1 = peg$c243();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5686,12 +5681,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c231) {
-                s3 = peg$c231;
+              if (input.substr(peg$currPos, 3) === peg$c233) {
+                s3 = peg$c233;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c242); }
+                if (peg$silentFails === 0) { peg$fail(peg$c244); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -5736,44 +5731,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c243) {
-      s0 = peg$c243;
+    if (input.substr(peg$currPos, 7) === peg$c245) {
+      s0 = peg$c245;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c245) {
-        s0 = peg$c245;
+      if (input.substr(peg$currPos, 6) === peg$c247) {
+        s0 = peg$c247;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c246); }
+        if (peg$silentFails === 0) { peg$fail(peg$c248); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c247) {
-          s0 = peg$c247;
+        if (input.substr(peg$currPos, 4) === peg$c249) {
+          s0 = peg$c249;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c248); }
+          if (peg$silentFails === 0) { peg$fail(peg$c250); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c249) {
-            s0 = peg$c249;
+          if (input.substr(peg$currPos, 3) === peg$c251) {
+            s0 = peg$c251;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c250); }
+            if (peg$silentFails === 0) { peg$fail(peg$c252); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c251;
+              s0 = peg$c253;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c252); }
+              if (peg$silentFails === 0) { peg$fail(peg$c254); }
             }
           }
         }
@@ -5786,44 +5781,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c253) {
-      s0 = peg$c253;
+    if (input.substr(peg$currPos, 7) === peg$c255) {
+      s0 = peg$c255;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c254); }
+      if (peg$silentFails === 0) { peg$fail(peg$c256); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c255) {
-        s0 = peg$c255;
+      if (input.substr(peg$currPos, 6) === peg$c257) {
+        s0 = peg$c257;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c256); }
+        if (peg$silentFails === 0) { peg$fail(peg$c258); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c257) {
-          s0 = peg$c257;
+        if (input.substr(peg$currPos, 4) === peg$c259) {
+          s0 = peg$c259;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c258); }
+          if (peg$silentFails === 0) { peg$fail(peg$c260); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c259) {
-            s0 = peg$c259;
+          if (input.substr(peg$currPos, 3) === peg$c261) {
+            s0 = peg$c261;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c260); }
+            if (peg$silentFails === 0) { peg$fail(peg$c262); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c261;
+              s0 = peg$c263;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c262); }
+              if (peg$silentFails === 0) { peg$fail(peg$c264); }
             }
           }
         }
@@ -5836,44 +5831,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c263) {
-      s0 = peg$c263;
+    if (input.substr(peg$currPos, 5) === peg$c265) {
+      s0 = peg$c265;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c266); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c265) {
-        s0 = peg$c265;
+      if (input.substr(peg$currPos, 3) === peg$c267) {
+        s0 = peg$c267;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c267) {
-          s0 = peg$c267;
+        if (input.substr(peg$currPos, 2) === peg$c269) {
+          s0 = peg$c269;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c268); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c269;
+            s0 = peg$c271;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c270); }
+            if (peg$silentFails === 0) { peg$fail(peg$c272); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c271) {
-              s0 = peg$c271;
+            if (input.substr(peg$currPos, 4) === peg$c273) {
+              s0 = peg$c273;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c272); }
+              if (peg$silentFails === 0) { peg$fail(peg$c274); }
             }
           }
         }
@@ -5886,28 +5881,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c273) {
-      s0 = peg$c273;
+    if (input.substr(peg$currPos, 4) === peg$c275) {
+      s0 = peg$c275;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c274); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c275) {
-        s0 = peg$c275;
+      if (input.substr(peg$currPos, 3) === peg$c277) {
+        s0 = peg$c277;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c276); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c277;
+          s0 = peg$c279;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c278); }
+          if (peg$silentFails === 0) { peg$fail(peg$c280); }
         }
       }
     }
@@ -5918,44 +5913,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c279) {
-      s0 = peg$c279;
+    if (input.substr(peg$currPos, 5) === peg$c281) {
+      s0 = peg$c281;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c282); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c281) {
-        s0 = peg$c281;
+      if (input.substr(peg$currPos, 4) === peg$c283) {
+        s0 = peg$c283;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c282); }
+        if (peg$silentFails === 0) { peg$fail(peg$c284); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c283) {
-          s0 = peg$c283;
+        if (input.substr(peg$currPos, 3) === peg$c285) {
+          s0 = peg$c285;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c284); }
+          if (peg$silentFails === 0) { peg$fail(peg$c286); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c285) {
-            s0 = peg$c285;
+          if (input.substr(peg$currPos, 2) === peg$c287) {
+            s0 = peg$c287;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c286); }
+            if (peg$silentFails === 0) { peg$fail(peg$c288); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c287;
+              s0 = peg$c289;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c288); }
+              if (peg$silentFails === 0) { peg$fail(peg$c290); }
             }
           }
         }
@@ -5969,16 +5964,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c245) {
-      s1 = peg$c245;
+    if (input.substr(peg$currPos, 6) === peg$c247) {
+      s1 = peg$c247;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c248); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c289();
+      s1 = peg$c291();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5990,7 +5985,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c290(s1);
+            s1 = peg$c292(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6013,16 +6008,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c255) {
-      s1 = peg$c255;
+    if (input.substr(peg$currPos, 6) === peg$c257) {
+      s1 = peg$c257;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c256); }
+      if (peg$silentFails === 0) { peg$fail(peg$c258); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c291();
+      s1 = peg$c293();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6034,7 +6029,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c292(s1);
+            s1 = peg$c294(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6057,16 +6052,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c271) {
-      s1 = peg$c271;
+    if (input.substr(peg$currPos, 4) === peg$c273) {
+      s1 = peg$c273;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c272); }
+      if (peg$silentFails === 0) { peg$fail(peg$c274); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c293();
+      s1 = peg$c295();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6078,7 +6073,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c294(s1);
+            s1 = peg$c296(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6101,16 +6096,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c275) {
-      s1 = peg$c275;
+    if (input.substr(peg$currPos, 3) === peg$c277) {
+      s1 = peg$c277;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c276); }
+      if (peg$silentFails === 0) { peg$fail(peg$c278); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c295();
+      s1 = peg$c297();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6122,7 +6117,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c296(s1);
+            s1 = peg$c298(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6145,16 +6140,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c281) {
-      s1 = peg$c281;
+    if (input.substr(peg$currPos, 4) === peg$c283) {
+      s1 = peg$c283;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c284); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c297();
+      s1 = peg$c299();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6166,7 +6161,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c298(s1);
+            s1 = peg$c300(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6192,37 +6187,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c146;
+        s2 = peg$c148;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c147); }
+        if (peg$silentFails === 0) { peg$fail(peg$c149); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c146;
+            s4 = peg$c148;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c147); }
+            if (peg$silentFails === 0) { peg$fail(peg$c149); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c146;
+                s6 = peg$c148;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c147); }
+                if (peg$silentFails === 0) { peg$fail(peg$c149); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c102();
+                  s1 = peg$c104();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6274,7 +6269,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299(s1, s2);
+        s1 = peg$c301(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6295,12 +6290,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c300) {
-            s3 = peg$c300;
+          if (input.substr(peg$currPos, 2) === peg$c302) {
+            s3 = peg$c302;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c301); }
+            if (peg$silentFails === 0) { peg$fail(peg$c303); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6313,7 +6308,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c302(s1, s2, s4, s5);
+                s1 = peg$c304(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6337,12 +6332,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c300) {
-          s1 = peg$c300;
+        if (input.substr(peg$currPos, 2) === peg$c302) {
+          s1 = peg$c302;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c301); }
+          if (peg$silentFails === 0) { peg$fail(peg$c303); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6355,7 +6350,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c303(s2, s3);
+              s1 = peg$c305(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6380,16 +6375,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c300) {
-                s3 = peg$c300;
+              if (input.substr(peg$currPos, 2) === peg$c302) {
+                s3 = peg$c302;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c301); }
+                if (peg$silentFails === 0) { peg$fail(peg$c303); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c304(s1, s2);
+                s1 = peg$c306(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6405,16 +6400,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c300) {
-              s1 = peg$c300;
+            if (input.substr(peg$currPos, 2) === peg$c302) {
+              s1 = peg$c302;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c301); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c305();
+              s1 = peg$c307();
             }
             s0 = s1;
           }
@@ -6441,17 +6436,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c154;
+      s1 = peg$c156;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+      if (peg$silentFails === 0) { peg$fail(peg$c157); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c306(s2);
+        s1 = peg$c308(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6472,15 +6467,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c154;
+        s2 = peg$c156;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c157); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c307(s1);
+        s1 = peg$c309(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6501,17 +6496,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c178;
+        s2 = peg$c180;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c181); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c308(s1, s3);
+          s1 = peg$c310(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6536,17 +6531,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c178;
+        s2 = peg$c180;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c181); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c309(s1, s3);
+          s1 = peg$c311(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6571,7 +6566,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c310(s1);
+      s1 = peg$c312(s1);
     }
     s0 = s1;
 
@@ -6594,22 +6589,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c239.test(input.charAt(peg$currPos))) {
+    if (peg$c241.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      if (peg$silentFails === 0) { peg$fail(peg$c242); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c239.test(input.charAt(peg$currPos))) {
+        if (peg$c241.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          if (peg$silentFails === 0) { peg$fail(peg$c242); }
         }
       }
     } else {
@@ -6617,7 +6612,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -6639,7 +6634,7 @@ function peg$parse(input, options) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c104();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6669,22 +6664,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c239.test(input.charAt(peg$currPos))) {
+      if (peg$c241.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c240); }
+        if (peg$silentFails === 0) { peg$fail(peg$c242); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c239.test(input.charAt(peg$currPos))) {
+          if (peg$c241.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c242); }
           }
         }
       } else {
@@ -6692,30 +6687,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c146;
+          s3 = peg$c148;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c147); }
+          if (peg$silentFails === 0) { peg$fail(peg$c149); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c239.test(input.charAt(peg$currPos))) {
+          if (peg$c241.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c242); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c239.test(input.charAt(peg$currPos))) {
+              if (peg$c241.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c240); }
+                if (peg$silentFails === 0) { peg$fail(peg$c242); }
               }
             }
           } else {
@@ -6728,7 +6723,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311();
+              s1 = peg$c313();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6764,30 +6759,30 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c146;
+          s2 = peg$c148;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c147); }
+          if (peg$silentFails === 0) { peg$fail(peg$c149); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c239.test(input.charAt(peg$currPos))) {
+          if (peg$c241.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c240); }
+            if (peg$silentFails === 0) { peg$fail(peg$c242); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c239.test(input.charAt(peg$currPos))) {
+              if (peg$c241.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c240); }
+                if (peg$silentFails === 0) { peg$fail(peg$c242); }
               }
             }
           } else {
@@ -6800,7 +6795,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311();
+              s1 = peg$c313();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6827,20 +6822,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c312) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c314) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c313); }
+      if (peg$silentFails === 0) { peg$fail(peg$c315); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c314.test(input.charAt(peg$currPos))) {
+      if (peg$c316.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c315); }
+        if (peg$silentFails === 0) { peg$fail(peg$c317); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -6882,7 +6877,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -6892,12 +6887,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c316.test(input.charAt(peg$currPos))) {
+    if (peg$c318.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c317); }
+      if (peg$silentFails === 0) { peg$fail(peg$c319); }
     }
 
     return s0;
@@ -6919,7 +6914,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c318(s1);
+      s1 = peg$c320(s1);
     }
     s0 = s1;
 
@@ -6931,11 +6926,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c319;
+      s1 = peg$c321;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c320); }
+      if (peg$silentFails === 0) { peg$fail(peg$c322); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
@@ -6958,12 +6953,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c321.test(input.charAt(peg$currPos))) {
+      if (peg$c323.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c322); }
+        if (peg$silentFails === 0) { peg$fail(peg$c324); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseWhiteSpace();
@@ -6981,11 +6976,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c323); }
+          if (peg$silentFails === 0) { peg$fail(peg$c325); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c102();
+          s1 = peg$c104();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7005,11 +7000,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c324;
+      s1 = peg$c326;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c327); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -7020,15 +7015,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c324;
+          s3 = peg$c326;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c325); }
+          if (peg$silentFails === 0) { peg$fail(peg$c327); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c326(s2);
+          s1 = peg$c328(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7045,11 +7040,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c327;
+        s1 = peg$c329;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c328); }
+        if (peg$silentFails === 0) { peg$fail(peg$c330); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7060,15 +7055,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c327;
+            s3 = peg$c329;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c328); }
+            if (peg$silentFails === 0) { peg$fail(peg$c330); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c326(s2);
+            s1 = peg$c328(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7094,11 +7089,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c324;
+      s2 = peg$c326;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c327); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -7116,11 +7111,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c323); }
+        if (peg$silentFails === 0) { peg$fail(peg$c325); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c104();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7133,11 +7128,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c319;
+        s1 = peg$c321;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c320); }
+        if (peg$silentFails === 0) { peg$fail(peg$c322); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -7165,11 +7160,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c327;
+      s2 = peg$c329;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -7187,11 +7182,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c323); }
+        if (peg$silentFails === 0) { peg$fail(peg$c325); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102();
+        s1 = peg$c104();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7204,11 +7199,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c319;
+        s1 = peg$c321;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c320); }
+        if (peg$silentFails === 0) { peg$fail(peg$c322); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -7234,11 +7229,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c329;
+      s1 = peg$c331;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c332); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -7246,7 +7241,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c331();
+          s1 = peg$c333();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7274,110 +7269,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c327;
+      s0 = peg$c329;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c330); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c324;
+        s0 = peg$c326;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c325); }
+        if (peg$silentFails === 0) { peg$fail(peg$c327); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c319;
+          s0 = peg$c321;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c320); }
+          if (peg$silentFails === 0) { peg$fail(peg$c322); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c332;
+            s1 = peg$c334;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c333); }
+            if (peg$silentFails === 0) { peg$fail(peg$c335); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c334();
+            s1 = peg$c336();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c335;
+              s1 = peg$c337;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c336); }
+              if (peg$silentFails === 0) { peg$fail(peg$c338); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c337();
+              s1 = peg$c339();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c338;
+                s1 = peg$c340;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c339); }
+                if (peg$silentFails === 0) { peg$fail(peg$c341); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c340();
+                s1 = peg$c342();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c341;
+                  s1 = peg$c343;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c342); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c344); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c343();
+                  s1 = peg$c345();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c344;
+                    s1 = peg$c346;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c345); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c347); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c346();
+                    s1 = peg$c348();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c347;
+                      s1 = peg$c349;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c348); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c350); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c349();
+                      s1 = peg$c351();
                     }
                     s0 = s1;
                   }
@@ -7397,15 +7392,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c77;
+      s1 = peg$c79;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c78); }
+      if (peg$silentFails === 0) { peg$fail(peg$c80); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c350();
+      s1 = peg$c352();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7419,7 +7414,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c351();
+        s1 = peg$c353();
       }
       s0 = s1;
     }
@@ -7432,11 +7427,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c352;
+      s1 = peg$c354;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c353); }
+      if (peg$silentFails === 0) { peg$fail(peg$c355); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7468,7 +7463,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c354(s2);
+        s1 = peg$c356(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7481,19 +7476,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c352;
+        s1 = peg$c354;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c353); }
+        if (peg$silentFails === 0) { peg$fail(peg$c355); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c355;
+          s2 = peg$c357;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c356); }
+          if (peg$silentFails === 0) { peg$fail(peg$c358); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7552,15 +7547,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c357;
+              s4 = peg$c359;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c358); }
+              if (peg$silentFails === 0) { peg$fail(peg$c360); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c354(s3);
+              s1 = peg$c356(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7588,25 +7583,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c178;
+      s1 = peg$c180;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c179); }
+      if (peg$silentFails === 0) { peg$fail(peg$c181); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c178;
+          s3 = peg$c180;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c179); }
+          if (peg$silentFails === 0) { peg$fail(peg$c181); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c359(s2);
+          s1 = peg$c361(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7629,39 +7624,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c360.test(input.charAt(peg$currPos))) {
+    if (peg$c362.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c363); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c362) {
-        s2 = peg$c362;
+      if (input.substr(peg$currPos, 2) === peg$c364) {
+        s2 = peg$c364;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c363); }
+        if (peg$silentFails === 0) { peg$fail(peg$c365); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c360.test(input.charAt(peg$currPos))) {
+        if (peg$c362.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c361); }
+          if (peg$silentFails === 0) { peg$fail(peg$c363); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c362) {
-            s2 = peg$c362;
+          if (input.substr(peg$currPos, 2) === peg$c364) {
+            s2 = peg$c364;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c363); }
+            if (peg$silentFails === 0) { peg$fail(peg$c365); }
           }
         }
       }
@@ -7670,7 +7665,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c104();
     }
     s0 = s1;
 
@@ -7680,12 +7675,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c364.test(input.charAt(peg$currPos))) {
+    if (peg$c366.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c367); }
     }
 
     return s0;
@@ -7743,7 +7738,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c323); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
 
     return s0;
@@ -7754,51 +7749,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c367;
+      s0 = peg$c369;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c368); }
+      if (peg$silentFails === 0) { peg$fail(peg$c370); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c369;
+        s0 = peg$c371;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c370); }
+        if (peg$silentFails === 0) { peg$fail(peg$c372); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c371;
+          s0 = peg$c373;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c372); }
+          if (peg$silentFails === 0) { peg$fail(peg$c374); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c373;
+            s0 = peg$c375;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c374); }
+            if (peg$silentFails === 0) { peg$fail(peg$c376); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c375;
+              s0 = peg$c377;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c376); }
+              if (peg$silentFails === 0) { peg$fail(peg$c378); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c377;
+                s0 = peg$c379;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c378); }
+                if (peg$silentFails === 0) { peg$fail(peg$c380); }
               }
             }
           }
@@ -7808,7 +7803,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c366); }
+      if (peg$silentFails === 0) { peg$fail(peg$c368); }
     }
 
     return s0;
@@ -7817,12 +7812,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c379.test(input.charAt(peg$currPos))) {
+    if (peg$c381.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c380); }
+      if (peg$silentFails === 0) { peg$fail(peg$c382); }
     }
 
     return s0;
@@ -7836,7 +7831,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c381); }
+      if (peg$silentFails === 0) { peg$fail(peg$c383); }
     }
 
     return s0;
@@ -7846,24 +7841,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c382) {
-      s1 = peg$c382;
+    if (input.substr(peg$currPos, 2) === peg$c384) {
+      s1 = peg$c384;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c383); }
+      if (peg$silentFails === 0) { peg$fail(peg$c385); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c384) {
-        s5 = peg$c384;
+      if (input.substr(peg$currPos, 2) === peg$c386) {
+        s5 = peg$c386;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c385); }
+        if (peg$silentFails === 0) { peg$fail(peg$c387); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -7890,12 +7885,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c384) {
-          s5 = peg$c384;
+        if (input.substr(peg$currPos, 2) === peg$c386) {
+          s5 = peg$c386;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c385); }
+          if (peg$silentFails === 0) { peg$fail(peg$c387); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -7919,12 +7914,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c384) {
-          s3 = peg$c384;
+        if (input.substr(peg$currPos, 2) === peg$c386) {
+          s3 = peg$c386;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c385); }
+          if (peg$silentFails === 0) { peg$fail(peg$c387); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -7949,12 +7944,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c386) {
-      s1 = peg$c386;
+    if (input.substr(peg$currPos, 2) === peg$c388) {
+      s1 = peg$c388;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c387); }
+      if (peg$silentFails === 0) { peg$fail(peg$c389); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -8034,7 +8029,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c323); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -193,7 +193,7 @@ BooleanLiteral
   / "false"          { RETURN(MAP("op": "Literal", "type": "bool", "value": "false")) }
 
 NullLiteral
-  = "null"           { RETURN(MAP("op": "Literal", "type": "null")) }
+  = "null"           { RETURN(MAP("op": "Literal", "type": "null", "value": "")) }
 
 SequentialProcs
   = first:Proc rest:SequentialTail* {
@@ -226,26 +226,13 @@ ParallelTail
   = __ ";" __ ch:SequentialProcs { RETURN(MAP("op": "SequentialProc", "procs": ch)) }
 
 GroupByProc
-  = every:EveryDur? keys:GroupByKeys limit:LimitArg? {
-      VAR(p) = MAP("op": "GroupByProc", "keys": keys)
-      if ISNOTNULL(every) {
-        p["duration"] = every
-      }
-      if ISNOTNULL(limit) {
-        p["limit"] = limit
-      }
-      RETURN(p)
+  = every:EveryDur? keys:GroupByKeys limit:LimitArg {
+      RETURN(MAP("op": "GroupByProc", "keys": keys, "reducers": NULL, "duration": every, "limit": limit))
     }
   / every:EveryDur? reducers:Reducers keys:(_ GroupByKeys)? limit:LimitArg? {
-      VAR(p) = MAP("op": "GroupByProc", "reducers": reducers)
-      if ISNOTNULL(every) {
-        p["duration"] = every
-      }
+      VAR(p) = MAP("op": "GroupByProc", "keys": NULL, "reducers": reducers, "duration": every, "limit": limit)
       if ISNOTNULL(keys) {
         p["keys"] = ASSERT_ARRAY(keys)[1]
-      }
-      if ISNOTNULL(limit) {
-        p["limit"] = limit
       }
       RETURN(p)
     }
@@ -258,13 +245,14 @@ GroupByKeys
 
 LimitArg
   = _ "with" _ "-limit" _ limit:UInt { RETURN(limit) }
+  / "" { RETURN(0) }
 
 // A FlexAssignment is like an Assignment but it can optionally omit the lhs,
 // in which case the semantic pass will infer a name from the rhs, e.g., for
 // an expression like "count() by foo", the rhs is Field "foo" and the lhs is nil.
 FlexAssignment
   = Assignment
-  / expr:Expr { RETURN(MAP("op": "Assignment", "rhs": expr)) }
+  / expr:Expr { RETURN(MAP("op": "Assignment", "lhs": NULL, "rhs": expr)) }
 
 FlexAssignments
   = first:FlexAssignment rest:(__ "," __ expr:FlexAssignment { RETURN(expr) })* {
@@ -276,12 +264,12 @@ ReducerAssignment
       RETURN(MAP("op": "Assignment", "lhs": lval, "rhs": reducer))
     }
   / reducer:Reducer {
-      RETURN(MAP("op": "Assignment", "rhs": reducer))
+      RETURN(MAP("op": "Assignment", "lhs": NULL, "rhs": reducer))
     }
 
 Reducer
   = !("not"/"len") op:IdentifierName __ "(" __ expr:Expr?  __ ")" where:WhereClause? {
-      VAR(r) = MAP("op": "Reducer", "operator": op, "where":where)
+      VAR(r) = MAP("op": "Reducer", "operator": op, "expr": NULL, "where":where)
       if ISNOTNULL(expr) {
         r["expr"] = expr
       }
@@ -335,7 +323,7 @@ SortArg
 
 TopProc
   = "top"i limit:(_ n:UInt { RETURN(n)})? flush:(_ "-flush")? fields:(_ f:FieldExprs { RETURN(f) })? {
-      VAR(proc) = MAP("op": "TopProc")
+      VAR(proc) = MAP("op": "TopProc", "limit": 0, "fields": NULL, "flush": false)
       if ISNOTNULL(limit) {
         proc["limit"] = limit
       }
@@ -401,14 +389,14 @@ FuseProc
 
 JoinProc
   = "join"i _ leftKey:JoinKey __ "=" __ rightKey:JoinKey columns:(_ FlexAssignments)? {
-      VAR(proc) = MAP("op": "JoinProc", "left_key": leftKey, "right_key": rightKey)
+      VAR(proc) = MAP("op": "JoinProc", "left_key": leftKey, "right_key": rightKey, "clauses": NULL)
       if ISNOTNULL(columns) {
         proc["clauses"] = ASSERT_ARRAY(columns)[1]
       }
       RETURN(proc)
     }
   / "join"i _ key:JoinKey columns:(_ FlexAssignments)? {
-      VAR(proc) = MAP("op": "JoinProc", "left_key": key, "right_key": key)
+      VAR(proc) = MAP("op": "JoinProc", "left_key": key, "right_key": key, "clauses": NULL)
       if ISNOTNULL(columns) {
         proc["clauses"] = ASSERT_ARRAY(columns)[1]
       }
@@ -450,7 +438,7 @@ Exprs
     }
 
 Assignment
-  = lhs:Lval __ "=" __ rhs:Expr { RETURN(MAP("lhs": lhs, "rhs": rhs)) }
+  = lhs:Lval __ "=" __ rhs:Expr { RETURN(MAP("op": "Assignment", "lhs": lhs, "rhs": rhs)) }
 
 Expr = ConditionalExpr
 

--- a/zql/zql_test.go
+++ b/zql/zql_test.go
@@ -1,15 +1,85 @@
-package zql
+package zql_test
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/pkg/fs"
+	"github.com/brimsec/zq/zql"
+	"github.com/brimsec/zq/ztest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func searchForZqls() ([]string, error) {
+	var zqls []string
+	pattern := fmt.Sprintf(`.*ztests\%c.*\.yaml$`, filepath.Separator)
+	re := regexp.MustCompile(pattern)
+	err := filepath.Walk("..", func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() && strings.HasSuffix(path, ".yaml") && re.MatchString(path) {
+			zt, err := ztest.FromYAMLFile(path)
+			if err != nil {
+				return err
+			}
+			z := zt.ZQL
+			if z == "" || z == "*" {
+				return nil
+			}
+			zqls = append(zqls, z)
+		}
+		return err
+	})
+	return zqls, err
+}
+
+func parsePEGjs(z string) ([]byte, error) {
+	cmd := exec.Command("node", "run.js", "-e", "start")
+	cmd.Stdin = strings.NewReader(z)
+	return cmd.Output()
+}
+
+func parseProc(z string) ([]byte, error) {
+	proc, err := zql.ParseProc(z)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(proc)
+}
+
+func parsePigeon(z string) ([]byte, error) {
+	ast, err := zql.Parse("", []byte(z))
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(ast)
+}
+
+// testZQL parses the zql query in line by both the Go and Javascript
+// parsers.  It checks both that the parse is successful and that the
+// two resulting ASTs are equivalent.  On the go side, we take a round
+// trip through json marshal and unmarshal to turn the parse-tree types
+// into generic JSON types.
+func testZQL(t *testing.T, line string) {
+	pegJSON, err := parsePEGjs(line)
+	assert.NoError(t, err, "parsePEGjs: %q", line)
+
+	pigeonJSON, err := parsePigeon(line)
+	assert.NoError(t, err, "parsePigeon: %q", line)
+
+	astJSON, err := parseProc(line)
+	assert.NoError(t, err, "parseProc: %q", line)
+
+	assert.JSONEq(t, string(pigeonJSON), string(pegJSON), "pigeon and PEGjs mismatch: %q", line)
+	assert.JSONEq(t, string(pigeonJSON), string(astJSON), "pigeon and ast.Proc mismatch: %q", line)
+}
 
 func TestValid(t *testing.T) {
 	file, err := fs.Open("valid.zql")
@@ -17,8 +87,15 @@ func TestValid(t *testing.T) {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Bytes()
-		_, err := Parse("", line)
-		assert.NoError(t, err, "zql: %q", line)
+		testZQL(t, string(line))
+	}
+}
+
+func TestZtestZqls(t *testing.T) {
+	zqls, err := searchForZqls()
+	require.NoError(t, err)
+	for _, z := range zqls {
+		testZQL(t, z)
 	}
 }
 
@@ -28,7 +105,7 @@ func TestInvalid(t *testing.T) {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Bytes()
-		_, err := Parse("", line)
+		_, err := zql.Parse("", line)
 		assert.Error(t, err, "zql: %q", line)
 	}
 }
@@ -38,7 +115,7 @@ func TestInvalid(t *testing.T) {
 // string from inside the AST.
 func parseString(in string) (string, error) {
 	code := fmt.Sprintf("s = \"%s\"", in)
-	tree, err := ParseProc(code)
+	tree, err := zql.ParseProc(code)
 	if err != nil {
 		return "", err
 	}

--- a/zql/zql_test.go
+++ b/zql/zql_test.go
@@ -78,7 +78,6 @@ func testZQL(t *testing.T, line string) {
 	assert.JSONEq(t, string(pigeonJSON), string(astJSON), "pigeon and ast.Proc mismatch: %q", line)
 
 	if runtime.GOOS != "windows" {
-		var err error
 		pegJSON, err := parsePEGjs(line)
 		assert.NoError(t, err, "parsePEGjs: %q", line)
 		assert.JSONEq(t, string(pigeonJSON), string(pegJSON), "pigeon and PEGjs mismatch: %q", line)

--- a/zql/zql_test.go
+++ b/zql/zql_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -68,17 +69,20 @@ func parsePigeon(z string) ([]byte, error) {
 // trip through json marshal and unmarshal to turn the parse-tree types
 // into generic JSON types.
 func testZQL(t *testing.T, line string) {
-	pegJSON, err := parsePEGjs(line)
-	assert.NoError(t, err, "parsePEGjs: %q", line)
-
 	pigeonJSON, err := parsePigeon(line)
 	assert.NoError(t, err, "parsePigeon: %q", line)
 
 	astJSON, err := parseProc(line)
 	assert.NoError(t, err, "parseProc: %q", line)
 
-	assert.JSONEq(t, string(pigeonJSON), string(pegJSON), "pigeon and PEGjs mismatch: %q", line)
 	assert.JSONEq(t, string(pigeonJSON), string(astJSON), "pigeon and ast.Proc mismatch: %q", line)
+
+	if runtime.GOOS != "windows" {
+		var err error
+		pegJSON, err := parsePEGjs(line)
+		assert.NoError(t, err, "parsePEGjs: %q", line)
+		assert.JSONEq(t, string(pigeonJSON), string(pegJSON), "pigeon and PEGjs mismatch: %q", line)
+	}
 }
 
 func TestValid(t *testing.T) {


### PR DESCRIPTION
This commit unifies the parsed ASTs so that whether an AST is
generated by pigeon, pegjs, or by marshaling an ast.Proc, the
resulting JSON is deep equal for the same zql query text.
Previously, different versions treated the zero and empty values
differently.

This update involves changes to the peg grammar actions
as well as the go ast package.  We also updated the ast command
so that it can display these three variations, as previously,
there was no way to display the pigeon version of the ast.

We updated the unit tests in zq/zql to compare the three variants
and added a test that looks through all the ztest yaml files to find
zqls to run and run the three-way comparison.

Fixes #1638