### PR TITLE
skip alpha migration check for new spaces

### DIFF
--- a/ppl/zqd/storage/filestore/filestore.go
+++ b/ppl/zqd/storage/filestore/filestore.go
@@ -198,10 +198,10 @@ type info struct {
 func (s *Storage) readInfoFile() error {
 	var inf info
 	if err := fs.UnmarshalJSONFile(s.join(infoFile), &inf); err != nil {
-		if os.IsNotExist(err) {
-			return nil
+		if !os.IsNotExist(err) {
+			return err
 		}
-		return err
+		inf.AlphaMigrated = true
 	}
 	s.span = nano.NewSpanTs(inf.MinTime, inf.MaxTime)
 	s.alphaMigrated = inf.AlphaMigrated


### PR DESCRIPTION
When a new space is created, immediately mark that it does not need an alpha migration check.

Fixes #1664 .
