### PR TITLE
Fix NDJSON encoding of single-character string "-"

### DIFF
--- a/zng/string.go
+++ b/zng/string.go
@@ -53,7 +53,7 @@ func uescape(r rune) []byte {
 }
 
 func (t *TypeOfString) StringOf(zv zcode.Bytes, fmt OutFmt, inContainer bool) string {
-	if bytes.Equal(zv, []byte{'-'}) {
+	if fmt != OutFormatUnescaped && bytes.Equal(zv, []byte{'-'}) {
 		return "\\u002d"
 	}
 

--- a/ztests/suite/ndjson/hyphen.yaml
+++ b/ztests/suite/ndjson/hyphen.yaml
@@ -1,0 +1,8 @@
+zql: '*'
+
+input: &input |
+  {"Hyphen":"-"}
+
+output-flags: -f ndjson
+
+output: *input


### PR DESCRIPTION
zio/ndjsonio.Writer encodes "-" as "\\u002d".  Encode it as "-" instead.

Fixes #1325.