### PR TITLE
fix bug in translating aliased types between type contexts

### DIFF
--- a/zng/resolver/context.go
+++ b/zng/resolver/context.go
@@ -760,7 +760,11 @@ func (c *Context) TranslateType(ext zng.Type) (zng.Type, error) {
 	case *zng.TypeMap:
 		return c.TranslateTypeMap(ext)
 	case *zng.TypeAlias:
-		return c.LookupTypeAlias(ext.Name, ext.Type)
+		local, err := c.TranslateType(ext.Type)
+		if err != nil {
+			return nil, err
+		}
+		return c.LookupTypeAlias(ext.Name, local)
 	default:
 		//XXX
 		panic(fmt.Sprintf("zng cannot translate type: %s", ext))

--- a/zng/resolver/context_test.go
+++ b/zng/resolver/context_test.go
@@ -45,3 +45,19 @@ func TestDuplicates(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, setType.ID(), typ3.ID())
 }
+
+func TestTranslateAlias(t *testing.T) {
+	c1 := resolver.NewContext()
+	c2 := resolver.NewContext()
+	set1, err := c1.LookupByName("set[int64]")
+	require.NoError(t, err)
+	set2, err := c2.LookupByName("set[int64]")
+	require.NoError(t, err)
+	alias1, err := c1.LookupTypeAlias("foo", set1)
+	require.NoError(t, err)
+	alias2, err := c2.LookupTypeAlias("foo", set2)
+	require.NoError(t, err)
+	alias3, err := c2.TranslateType(alias1)
+	require.NoError(t, err)
+	assert.Equal(t, alias2, alias3)
+}


### PR DESCRIPTION
When translating an alias from one type context to another,
you need to translate the aliased type to the target context
before looking up the alias name in the local context to establish
the binding.
