### PR TITLE
Move archive Chunk to its own package

### DIFF
--- a/ppl/archive/chunk/chunk.go
+++ b/ppl/archive/chunk/chunk.go
@@ -54,7 +54,7 @@ func FileMatch(s string) (kind FileKind, id ksuid.KSUID, ok bool) {
 // seekIndexPath returns the path of an associated microindex written at import
 // time, which can be used to lookup a nearby seek offset for a desired
 // timestamp.
-// metadataPath returns the path of an associated zng file that holds
+// MetadataPath returns the path of an associated zng file that holds
 // information about the records in the chunk, including the total number,
 // and the first and last record timestamps.
 type Chunk struct {

--- a/ppl/archive/chunk/chunk.go
+++ b/ppl/archive/chunk/chunk.go
@@ -1,0 +1,167 @@
+package chunk
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zqe"
+	"github.com/segmentio/ksuid"
+)
+
+// A FileKind is the first part of a file name, used to differentiate files
+// when they are listed from the archive's backing store.
+type FileKind string
+
+const (
+	FileKindUnknown  FileKind = ""
+	FileKindData              = "d"
+	FileKindMetadata          = "m"
+	FileKindSeek              = "ts"
+)
+
+var fileRegex = regexp.MustCompile(`(d|m)-([0-9A-Za-z]{27}).zng$`)
+
+func FileMatch(s string) (kind FileKind, id ksuid.KSUID, ok bool) {
+	match := fileRegex.FindStringSubmatch(s)
+	if match == nil {
+		return
+	}
+	k := FileKind(match[1])
+	switch k {
+	case FileKindData:
+	case FileKindMetadata:
+	default:
+		return
+	}
+	id, err := ksuid.Parse(match[2])
+	if err != nil {
+		return
+	}
+	return k, id, true
+}
+
+// A Chunk is a file that holds records ordered according to the archive's
+// data order.
+// To support reading chunks that contain records originally from one or
+// more other chunks, a chunk has a list of chunk IDs it "masks". During a read
+// of data for time span T, if chunks X and Y both have data within span T, and
+// X masks Y, then only data from X should be used.
+// seekIndexPath returns the path of an associated microindex written at import
+// time, which can be used to lookup a nearby seek offset for a desired
+// timestamp.
+// metadataPath returns the path of an associated zng file that holds
+// information about the records in the chunk, including the total number,
+// and the first and last record timestamps.
+type Chunk struct {
+	Dir         iosrc.URI
+	Id          ksuid.KSUID
+	First       nano.Ts
+	Last        nano.Ts
+	RecordCount uint64
+	Masks       []ksuid.KSUID
+	Size        int64
+}
+
+func Open(ctx context.Context, dir iosrc.URI, id ksuid.KSUID) (Chunk, error) {
+	meta, err := ReadMetadata(ctx, MetadataPath(dir, id))
+	if err != nil {
+		return Chunk{}, err
+	}
+	return meta.Chunk(dir, id), nil
+}
+
+func (c Chunk) Path() iosrc.URI {
+	return c.Dir.AppendPath(c.FileName())
+}
+
+func (c Chunk) SeekIndexPath() iosrc.URI {
+	return chunkSeekIndexPath(c.Dir, c.Id)
+}
+
+func (c Chunk) MetadataPath() iosrc.URI {
+	return MetadataPath(c.Dir, c.Id)
+}
+
+func (c Chunk) Span() nano.Span {
+	return nano.Span{Ts: c.First, Dur: 1}.Union(nano.Span{Ts: c.Last, Dur: 1})
+}
+
+func (c Chunk) FileName() string {
+	return ChunkFileName(c.Id)
+}
+
+func ChunkFileName(id ksuid.KSUID) string {
+	return fmt.Sprintf("%s-%s.zng", FileKindData, id)
+}
+
+// ZarDir returns a URI for a directory specific to this data file, expected
+// to hold microindexes or other files associated with this chunk's data.
+func (c Chunk) ZarDir() iosrc.URI {
+	return c.Dir.AppendPath(c.FileName() + ".zar")
+}
+
+// Localize returns a URI that joins the provided relative path name to the
+// zardir for this chunk. The special name "_" is mapped to the path of the
+// data file for this chunk.
+func (c Chunk) Localize(pathname string) iosrc.URI {
+	if pathname == "_" {
+		return c.Path()
+	}
+	return c.ZarDir().AppendPath(pathname)
+}
+
+func ChunkPath(dir iosrc.URI, id ksuid.KSUID) iosrc.URI {
+	return dir.AppendPath(ChunkFileName(id))
+}
+
+func chunkSeekIndexPath(tsd iosrc.URI, id ksuid.KSUID) iosrc.URI {
+	return tsd.AppendPath(fmt.Sprintf("%s-%s.zng", FileKindSeek, id))
+}
+
+func (c Chunk) Range() string {
+	return fmt.Sprintf("[%d-%d]", c.First, c.Last)
+}
+
+// Remove deletes the data, metadata, seek, and any other associated files
+// with the chunk, including the zar directory. Any 'not found' errors will
+// be ignored.
+func (c Chunk) Remove(ctx context.Context) error {
+	uris := []iosrc.URI{
+		c.Path(),
+		c.ZarDir(),
+		c.MetadataPath(),
+		c.SeekIndexPath(),
+	}
+	for _, u := range uris {
+		if err := iosrc.RemoveAll(ctx, u); err != nil && !zqe.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func Less(order zbuf.Order, a, b Chunk) bool {
+	if order == zbuf.OrderDesc {
+		a, b = b, a
+	}
+	switch {
+	case a.First != b.First:
+		return a.First < b.First
+	case a.Last != b.Last:
+		return a.Last < b.Last
+	case a.RecordCount != b.RecordCount:
+		return a.RecordCount < b.RecordCount
+	}
+	return ksuid.Compare(a.Id, b.Id) < 0
+}
+
+func Sort(order zbuf.Order, c []Chunk) {
+	sort.Slice(c, func(i, j int) bool {
+		return Less(order, c[i], c[j])
+	})
+}

--- a/ppl/archive/chunk/metadata.go
+++ b/ppl/archive/chunk/metadata.go
@@ -20,40 +20,6 @@ type Metadata struct {
 	Size        int64
 }
 
-func (md Metadata) Chunk(dir iosrc.URI, id ksuid.KSUID) Chunk {
-	return Chunk{
-		Dir:         dir,
-		Id:          id,
-		First:       md.First,
-		Last:        md.Last,
-		RecordCount: md.RecordCount,
-		Masks:       md.Masks,
-		Size:        md.Size,
-	}
-}
-
-func MetadataPath(dir iosrc.URI, id ksuid.KSUID) iosrc.URI {
-	return dir.AppendPath(fmt.Sprintf("%s-%s.zng", FileKindMetadata, id))
-}
-
-func WriteMetadata(ctx context.Context, uri iosrc.URI, md Metadata) error {
-	zctx := resolver.NewContext()
-	rec, err := resolver.MarshalRecord(zctx, md)
-	if err != nil {
-		return err
-	}
-	out, err := iosrc.NewWriter(ctx, uri)
-	if err != nil {
-		return err
-	}
-	zw := zngio.NewWriter(bufwriter.New(out), zngio.WriterOpts{})
-	if err := zw.Write(rec); err != nil {
-		zw.Close()
-		return err
-	}
-	return zw.Close()
-}
-
 func ReadMetadata(ctx context.Context, uri iosrc.URI) (Metadata, error) {
 	in, err := iosrc.NewReader(ctx, uri)
 	if err != nil {
@@ -71,4 +37,38 @@ func ReadMetadata(ctx context.Context, uri iosrc.URI) (Metadata, error) {
 		return Metadata{}, err
 	}
 	return md, nil
+}
+
+func (m Metadata) Chunk(dir iosrc.URI, id ksuid.KSUID) Chunk {
+	return Chunk{
+		Dir:         dir,
+		Id:          id,
+		First:       m.First,
+		Last:        m.Last,
+		RecordCount: m.RecordCount,
+		Masks:       m.Masks,
+		Size:        m.Size,
+	}
+}
+
+func (m Metadata) Write(ctx context.Context, uri iosrc.URI) error {
+	zctx := resolver.NewContext()
+	rec, err := resolver.MarshalRecord(zctx, m)
+	if err != nil {
+		return err
+	}
+	out, err := iosrc.NewWriter(ctx, uri)
+	if err != nil {
+		return err
+	}
+	zw := zngio.NewWriter(bufwriter.New(out), zngio.WriterOpts{})
+	if err := zw.Write(rec); err != nil {
+		zw.Close()
+		return err
+	}
+	return zw.Close()
+}
+
+func MetadataPath(dir iosrc.URI, id ksuid.KSUID) iosrc.URI {
+	return dir.AppendPath(fmt.Sprintf("%s-%s.zng", FileKindMetadata, id))
 }

--- a/ppl/archive/chunk/metadata.go
+++ b/ppl/archive/chunk/metadata.go
@@ -1,0 +1,74 @@
+package chunk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/brimsec/zq/pkg/bufwriter"
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/segmentio/ksuid"
+)
+
+type Metadata struct {
+	First       nano.Ts
+	Last        nano.Ts
+	RecordCount uint64
+	Masks       []ksuid.KSUID
+	Size        int64
+}
+
+func (md Metadata) Chunk(dir iosrc.URI, id ksuid.KSUID) Chunk {
+	return Chunk{
+		Dir:         dir,
+		Id:          id,
+		First:       md.First,
+		Last:        md.Last,
+		RecordCount: md.RecordCount,
+		Masks:       md.Masks,
+		Size:        md.Size,
+	}
+}
+
+func MetadataPath(dir iosrc.URI, id ksuid.KSUID) iosrc.URI {
+	return dir.AppendPath(fmt.Sprintf("%s-%s.zng", FileKindMetadata, id))
+}
+
+func WriteMetadata(ctx context.Context, uri iosrc.URI, md Metadata) error {
+	zctx := resolver.NewContext()
+	rec, err := resolver.MarshalRecord(zctx, md)
+	if err != nil {
+		return err
+	}
+	out, err := iosrc.NewWriter(ctx, uri)
+	if err != nil {
+		return err
+	}
+	zw := zngio.NewWriter(bufwriter.New(out), zngio.WriterOpts{})
+	if err := zw.Write(rec); err != nil {
+		zw.Close()
+		return err
+	}
+	return zw.Close()
+}
+
+func ReadMetadata(ctx context.Context, uri iosrc.URI) (Metadata, error) {
+	in, err := iosrc.NewReader(ctx, uri)
+	if err != nil {
+		return Metadata{}, err
+	}
+	defer in.Close()
+	zctx := resolver.NewContext()
+	zr := zngio.NewReader(in, zctx)
+	rec, err := zr.Read()
+	if err != nil {
+		return Metadata{}, err
+	}
+	var md Metadata
+	if err := resolver.UnmarshalRecord(zctx, rec, &md); err != nil {
+		return Metadata{}, err
+	}
+	return md, nil
+}

--- a/ppl/archive/chunk/reader.go
+++ b/ppl/archive/chunk/reader.go
@@ -18,9 +18,9 @@ type Reader struct {
 	ReadSize  int64
 }
 
-// newChunkReader returns an io.ReadCloser for this chunk. If the chunk has a seek
-// index and if the provided span skips part of the chunk, the seek index will
-// be used to limit the reading window of the chunk's reader.
+// NewReader returns a Reader for this chunk. If the chunk has a seek index and
+// if the provided span skips part of the chunk, the seek index will be used to
+// limit the reading window of the returned reader.
 func NewReader(ctx context.Context, chunk Chunk, span nano.Span) (*Reader, error) {
 	cspan := chunk.Span()
 	span = cspan.Intersect(span)

--- a/ppl/archive/chunk/reader.go
+++ b/ppl/archive/chunk/reader.go
@@ -1,0 +1,59 @@
+package chunk
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/ppl/archive/seekindex"
+	"github.com/brimsec/zq/zqe"
+)
+
+type Reader struct {
+	io.Reader
+	io.Closer
+	TotalSize int64
+	ReadSize  int64
+}
+
+// newChunkReader returns an io.ReadCloser for this chunk. If the chunk has a seek
+// index and if the provided span skips part of the chunk, the seek index will
+// be used to limit the reading window of the chunk's reader.
+func NewReader(ctx context.Context, chunk Chunk, span nano.Span) (*Reader, error) {
+	cspan := chunk.Span()
+	span = cspan.Intersect(span)
+	if span.Dur == 0 {
+		return nil, errors.New("chunk span does intersect provided span")
+	}
+	r, err := iosrc.NewReader(ctx, chunk.Path())
+	if err != nil {
+		return nil, err
+	}
+	cr := &Reader{
+		Reader:    r,
+		Closer:    r,
+		TotalSize: chunk.Size,
+		ReadSize:  chunk.Size,
+	}
+	if span == cspan {
+		return cr, nil
+	}
+	s, err := seekindex.Open(ctx, chunk.SeekIndexPath())
+	if err != nil {
+		if zqe.IsNotFound(err) {
+			return cr, nil
+		}
+		return nil, err
+	}
+	defer s.Close()
+	rg, err := s.Lookup(ctx, span)
+	if err != nil {
+		return nil, err
+	}
+	rg = rg.TrimEnd(cr.TotalSize)
+	cr.ReadSize = rg.Size()
+	cr.Reader, err = rg.LimitReader(r)
+	return cr, err
+}

--- a/ppl/archive/chunk/writer.go
+++ b/ppl/archive/chunk/writer.go
@@ -108,7 +108,7 @@ func (cw *Writer) CloseWithTs(ctx context.Context, firstTs, lastTs nano.Ts) (Chu
 		Masks:       cw.masks,
 		Size:        cw.dataFileWriter.Position(),
 	}
-	if err := WriteMetadata(ctx, MetadataPath(cw.dir, cw.id), metadata); err != nil {
+	if err := metadata.Write(ctx, MetadataPath(cw.dir, cw.id)); err != nil {
 		cw.seekIndex.Abort()
 		return Chunk{}, err
 	}

--- a/ppl/archive/chunk/writer.go
+++ b/ppl/archive/chunk/writer.go
@@ -1,0 +1,141 @@
+package chunk
+
+import (
+	"context"
+	"io"
+
+	"github.com/brimsec/zq/pkg/bufwriter"
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/ppl/archive/seekindex"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/segmentio/ksuid"
+)
+
+// Writer is a zbuf.Writer that writes a stream of sorted records into an
+// archive chunk file.
+type Writer struct {
+	byteCounter    *writeCounter
+	count          uint64
+	dataFileWriter *zngio.Writer
+	firstTs        nano.Ts
+	id             ksuid.KSUID
+	lastTs         nano.Ts
+	masks          []ksuid.KSUID
+	needIndexWrite bool
+	seekIndex      *seekindex.Builder
+	dir            iosrc.URI
+	wroteFirst     bool
+}
+
+func NewWriter(ctx context.Context, dir iosrc.URI, order zbuf.Order, masks []ksuid.KSUID, opts zngio.WriterOpts) (*Writer, error) {
+	id := ksuid.New()
+	out, err := iosrc.NewWriter(ctx, dir.AppendPath(ChunkFileName(id)))
+	if err != nil {
+		return nil, err
+	}
+	counter := &writeCounter{bufwriter.New(out), 0}
+	dataFileWriter := zngio.NewWriter(counter, opts)
+	seekIndexPath := chunkSeekIndexPath(dir, id)
+	seekIndex, err := seekindex.NewBuilder(ctx, seekIndexPath.String(), order)
+	if err != nil {
+		return nil, err
+	}
+	return &Writer{
+		byteCounter:    counter,
+		dataFileWriter: dataFileWriter,
+		id:             id,
+		seekIndex:      seekIndex,
+		masks:          masks,
+		dir:            dir,
+	}, nil
+}
+
+func (cw *Writer) Position() (int64, nano.Ts, nano.Ts) {
+	return cw.dataFileWriter.Position(), cw.firstTs, cw.lastTs
+}
+
+func (cw *Writer) Write(rec *zng.Record) error {
+	// We want to index the start of stream (SOS) position of the data file by
+	// record timestamps; we don't know when we've started a new stream until
+	// after we written the first record in the stream.
+	sos := cw.dataFileWriter.LastSOS()
+	if err := cw.dataFileWriter.Write(rec); err != nil {
+		return err
+	}
+	ts := rec.Ts()
+	if !cw.wroteFirst || (cw.needIndexWrite && ts != cw.lastTs) {
+		if err := cw.seekIndex.Enter(ts, sos); err != nil {
+			return err
+		}
+		cw.needIndexWrite = false
+	}
+	if cw.dataFileWriter.LastSOS() != sos {
+		cw.needIndexWrite = true
+	}
+	if !cw.wroteFirst {
+		cw.firstTs = ts
+		cw.wroteFirst = true
+	}
+	cw.lastTs = ts
+	cw.count++
+	return nil
+}
+
+// abort should be called when an error occurs during write. Errors are ignored
+// because the write error will be more informative and should be returned.
+func (cw *Writer) Abort() {
+	cw.dataFileWriter.Close()
+	cw.seekIndex.Abort()
+}
+
+func (cw *Writer) Close(ctx context.Context) (Chunk, error) {
+	return cw.CloseWithTs(ctx, cw.firstTs, cw.lastTs)
+}
+
+func (cw *Writer) CloseWithTs(ctx context.Context, firstTs, lastTs nano.Ts) (Chunk, error) {
+	err := cw.dataFileWriter.Close()
+	if err != nil {
+		cw.seekIndex.Abort()
+		return Chunk{}, err
+	}
+	metadata := Metadata{
+		First:       firstTs,
+		Last:        lastTs,
+		RecordCount: cw.count,
+		Masks:       cw.masks,
+		Size:        cw.dataFileWriter.Position(),
+	}
+	if err := WriteMetadata(ctx, MetadataPath(cw.dir, cw.id), metadata); err != nil {
+		cw.seekIndex.Abort()
+		return Chunk{}, err
+	}
+	if err := cw.seekIndex.Close(); err != nil {
+		return Chunk{}, err
+	}
+	// TODO: zq#1264
+	// Add an entry to the update log for S3 backed stores containing the
+	// location of the just added data & index file.
+	return metadata.Chunk(cw.dir, cw.id), nil
+}
+
+func (cw *Writer) BytesWritten() int64 {
+	return cw.byteCounter.size
+}
+
+func (cw *Writer) RecordsWritten() uint64 {
+	return cw.count
+}
+
+type writeCounter struct {
+	io.WriteCloser
+	size int64
+}
+
+func (w *writeCounter) Write(b []byte) (int, error) {
+	n, err := w.WriteCloser.Write(b)
+	w.size += int64(n)
+	return n, err
+}

--- a/ppl/archive/indexer.go
+++ b/ppl/archive/indexer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/microindex"
 	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/ppl/archive/chunk"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng"
@@ -28,9 +29,9 @@ func fieldMicroIndexName(fieldname string) string {
 }
 
 func IndexDirTree(ctx context.Context, ark *Archive, rules []Rule, path string, progress chan<- string) error {
-	return Walk(ctx, ark, func(chunk Chunk) error {
-		zardir := chunk.ZarDir(ark)
-		logPath := chunk.Localize(ark, path)
+	return Walk(ctx, ark, func(chunk chunk.Chunk) error {
+		zardir := chunk.ZarDir()
+		logPath := chunk.Localize(path)
 		return run(ctx, zardir, rules, logPath, progress)
 	})
 }

--- a/ppl/archive/multisource.go
+++ b/ppl/archive/multisource.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"path"
+	"path/filepath"
 	"sync/atomic"
 
 	"github.com/brimsec/zq/api"
@@ -117,7 +118,7 @@ func (m *spanMultiSource) SendSources(ctx context.Context, span nano.Span, srcCh
 func (m *spanMultiSource) SourceFromRequest(ctx context.Context, req *api.WorkerRequest) (driver.Source, error) {
 	si := SpanInfo{Span: req.Span}
 	for _, p := range req.ChunkPaths {
-		dir, file := path.Split(p)
+		dir, file := path.Split(filepath.ToSlash(p))
 		_, id, ok := chunk.FileMatch(file)
 		if !ok {
 			return nil, zqe.E(zqe.Invalid, "invalid chunk path: %v", p)

--- a/ppl/archive/multisource.go
+++ b/ppl/archive/multisource.go
@@ -122,7 +122,11 @@ func (m *spanMultiSource) SourceFromRequest(ctx context.Context, req *api.Worker
 		if !ok {
 			return nil, zqe.E(zqe.Invalid, "invalid chunk path: %v", p)
 		}
-		uri := m.ark.Root.AppendPath(dir)
+		tsdir, ok := parseTsDirName(path.Base(dir))
+		if !ok {
+			return nil, zqe.E(zqe.Invalid, "invalid chunk path: %v", p)
+		}
+		uri := tsdir.path(m.ark)
 		md, err := chunk.ReadMetadata(ctx, chunk.MetadataPath(uri, id))
 		if err != nil {
 			return nil, err

--- a/ppl/archive/overlap_test.go
+++ b/ppl/archive/overlap_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/ppl/archive/chunk"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
@@ -33,87 +34,87 @@ func importTzng(t *testing.T, ark *Archive, s string) {
 
 func TestAlignChunksToSpans(t *testing.T) {
 	cases := []struct {
-		chunks []Chunk
+		chunks []chunk.Chunk
 		filter nano.Span
 		order  zbuf.Order
 		exp    []SpanInfo
 	}{
 		{
-			chunks: []Chunk{
+			chunks: []chunk.Chunk{
 				{Id: kid("a"), First: 0, Last: 0},
 				{Id: kid("b"), First: 1, Last: 1},
 			},
 			filter: nano.MaxSpan,
 			order:  zbuf.OrderAsc,
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []Chunk{{Id: kid("a"), First: 0, Last: 0}}},
-				{Span: nano.Span{Ts: 1, Dur: 1}, Chunks: []Chunk{{Id: kid("b"), First: 1, Last: 1}}},
+				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []chunk.Chunk{{Id: kid("a"), First: 0, Last: 0}}},
+				{Span: nano.Span{Ts: 1, Dur: 1}, Chunks: []chunk.Chunk{{Id: kid("b"), First: 1, Last: 1}}},
 			},
 		},
 		{
-			chunks: []Chunk{
+			chunks: []chunk.Chunk{
 				{Id: kid("a"), First: 0, Last: 1},
 				{Id: kid("b"), First: 1, Last: 2},
 			},
 			filter: nano.MaxSpan,
 			order:  zbuf.OrderAsc,
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []Chunk{{Id: kid("a"), First: 0, Last: 1}}},
-				{Span: nano.Span{Ts: 1, Dur: 1}, Chunks: []Chunk{{Id: kid("a"), First: 0, Last: 1}, {Id: kid("b"), First: 1, Last: 2}}},
-				{Span: nano.Span{Ts: 2, Dur: 1}, Chunks: []Chunk{{Id: kid("b"), First: 1, Last: 2}}},
+				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []chunk.Chunk{{Id: kid("a"), First: 0, Last: 1}}},
+				{Span: nano.Span{Ts: 1, Dur: 1}, Chunks: []chunk.Chunk{{Id: kid("a"), First: 0, Last: 1}, {Id: kid("b"), First: 1, Last: 2}}},
+				{Span: nano.Span{Ts: 2, Dur: 1}, Chunks: []chunk.Chunk{{Id: kid("b"), First: 1, Last: 2}}},
 			},
 		},
 		{
-			chunks: []Chunk{
+			chunks: []chunk.Chunk{
 				{Id: kid("a"), First: 0, Last: 3},
 				{Id: kid("b"), First: 1, Last: 2},
 			},
 			filter: nano.MaxSpan,
 			order:  zbuf.OrderAsc,
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []Chunk{{Id: kid("a"), First: 0, Last: 3}}},
-				{Span: nano.Span{Ts: 1, Dur: 2}, Chunks: []Chunk{{Id: kid("a"), First: 0, Last: 3}, {Id: kid("b"), First: 1, Last: 2}}},
-				{Span: nano.Span{Ts: 3, Dur: 1}, Chunks: []Chunk{{Id: kid("a"), First: 0, Last: 3}}},
+				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []chunk.Chunk{{Id: kid("a"), First: 0, Last: 3}}},
+				{Span: nano.Span{Ts: 1, Dur: 2}, Chunks: []chunk.Chunk{{Id: kid("a"), First: 0, Last: 3}, {Id: kid("b"), First: 1, Last: 2}}},
+				{Span: nano.Span{Ts: 3, Dur: 1}, Chunks: []chunk.Chunk{{Id: kid("a"), First: 0, Last: 3}}},
 			},
 		},
 		{
-			chunks: []Chunk{
+			chunks: []chunk.Chunk{
 				{Id: kid("a"), First: 0, Last: 3},
 				{Id: kid("b"), First: 1, Last: 2},
 			},
 			filter: nano.Span{Ts: 1, Dur: 2},
 			order:  zbuf.OrderAsc,
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 1, Dur: 2}, Chunks: []Chunk{{Id: kid("a"), First: 0, Last: 3}, {Id: kid("b"), First: 1, Last: 2}}},
+				{Span: nano.Span{Ts: 1, Dur: 2}, Chunks: []chunk.Chunk{{Id: kid("a"), First: 0, Last: 3}, {Id: kid("b"), First: 1, Last: 2}}},
 			},
 		},
 		{
-			chunks: []Chunk{
+			chunks: []chunk.Chunk{
 				{Id: kid("a"), First: 9, Last: 7},
 				{Id: kid("b"), First: 5, Last: 3},
 			},
 			filter: nano.MaxSpan,
 			order:  zbuf.OrderDesc,
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 7, Dur: 3}, Chunks: []Chunk{{Id: kid("a"), First: 9, Last: 7}}},
-				{Span: nano.Span{Ts: 3, Dur: 3}, Chunks: []Chunk{{Id: kid("b"), First: 5, Last: 3}}},
+				{Span: nano.Span{Ts: 7, Dur: 3}, Chunks: []chunk.Chunk{{Id: kid("a"), First: 9, Last: 7}}},
+				{Span: nano.Span{Ts: 3, Dur: 3}, Chunks: []chunk.Chunk{{Id: kid("b"), First: 5, Last: 3}}},
 			},
 		},
 		{
-			chunks: []Chunk{
+			chunks: []chunk.Chunk{
 				{Id: kid("a"), First: 9, Last: 5},
 				{Id: kid("b"), First: 7, Last: 3},
 			},
 			filter: nano.MaxSpan,
 			order:  zbuf.OrderDesc,
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 8, Dur: 2}, Chunks: []Chunk{{Id: kid("a"), First: 9, Last: 5}}},
-				{Span: nano.Span{Ts: 5, Dur: 3}, Chunks: []Chunk{{Id: kid("a"), First: 9, Last: 5}, {Id: kid("b"), First: 7, Last: 3}}},
-				{Span: nano.Span{Ts: 3, Dur: 2}, Chunks: []Chunk{{Id: kid("b"), First: 7, Last: 3}}},
+				{Span: nano.Span{Ts: 8, Dur: 2}, Chunks: []chunk.Chunk{{Id: kid("a"), First: 9, Last: 5}}},
+				{Span: nano.Span{Ts: 5, Dur: 3}, Chunks: []chunk.Chunk{{Id: kid("a"), First: 9, Last: 5}, {Id: kid("b"), First: 7, Last: 3}}},
+				{Span: nano.Span{Ts: 3, Dur: 2}, Chunks: []chunk.Chunk{{Id: kid("b"), First: 7, Last: 3}}},
 			},
 		},
 		{
-			chunks: []Chunk{
+			chunks: []chunk.Chunk{
 				{Id: kid("b"), First: 0, Last: 0},
 				{Id: kid("a"), First: 0, Last: 0},
 				{Id: kid("d"), First: 0, Last: 0},
@@ -122,7 +123,7 @@ func TestAlignChunksToSpans(t *testing.T) {
 			filter: nano.MaxSpan,
 			order:  zbuf.OrderAsc,
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 0},
 					{Id: kid("b"), First: 0, Last: 0},
 					{Id: kid("c"), First: 0, Last: 0},
@@ -130,7 +131,7 @@ func TestAlignChunksToSpans(t *testing.T) {
 			},
 		},
 		{
-			chunks: []Chunk{
+			chunks: []chunk.Chunk{
 				{Id: kid("a"), First: 0, Last: 5},
 				{Id: kid("b"), First: 1, Last: 8},
 				{Id: kid("c"), First: 6, Last: 6},
@@ -139,23 +140,23 @@ func TestAlignChunksToSpans(t *testing.T) {
 			filter: nano.MaxSpan,
 			order:  zbuf.OrderAsc,
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 5}}},
-				{Span: nano.Span{Ts: 1, Dur: 5}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 1, Dur: 5}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 5},
 					{Id: kid("b"), First: 1, Last: 8}}},
-				{Span: nano.Span{Ts: 6, Dur: 1}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 6, Dur: 1}, Chunks: []chunk.Chunk{
 					{Id: kid("b"), First: 1, Last: 8},
 					{Id: kid("c"), First: 6, Last: 6}}},
-				{Span: nano.Span{Ts: 7, Dur: 2}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 7, Dur: 2}, Chunks: []chunk.Chunk{
 					{Id: kid("b"), First: 1, Last: 8},
 					{Id: kid("d"), First: 7, Last: 10}}},
-				{Span: nano.Span{Ts: 9, Dur: 2}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 9, Dur: 2}, Chunks: []chunk.Chunk{
 					{Id: kid("d"), First: 7, Last: 10}}},
 			},
 		},
 		{
-			chunks: []Chunk{
+			chunks: []chunk.Chunk{
 				{Id: kid("a"), First: 0, Last: 10},
 				{Id: kid("b"), First: 1, Last: 10},
 				{Id: kid("c"), First: 2, Last: 10},
@@ -163,12 +164,12 @@ func TestAlignChunksToSpans(t *testing.T) {
 			filter: nano.MaxSpan,
 			order:  zbuf.OrderAsc,
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 10}}},
-				{Span: nano.Span{Ts: 1, Dur: 1}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 1, Dur: 1}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 10},
 					{Id: kid("b"), First: 1, Last: 10}}},
-				{Span: nano.Span{Ts: 2, Dur: 9}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 2, Dur: 9}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 10},
 					{Id: kid("b"), First: 1, Last: 10},
 					{Id: kid("c"), First: 2, Last: 10}}},
@@ -217,14 +218,14 @@ func TestOverlapWalking(t *testing.T) {
 	importTzng(t, ark, data3)
 
 	{
-		var chunks []Chunk
-		err = tsDirVisit(context.Background(), ark, nano.MaxSpan, func(tsd tsDir, c []Chunk) error {
+		var chunks []chunk.Chunk
+		err = tsDirVisit(context.Background(), ark, nano.MaxSpan, func(tsd tsDir, c []chunk.Chunk) error {
 			chunks = append(chunks, c...)
 			return nil
 		})
 		require.NoError(t, err)
 		require.Len(t, chunks, 3)
-		chunksSort(ark.DataOrder, chunks)
+		chunk.Sort(ark.DataOrder, chunks)
 		var spans []nano.Span
 		for _, c := range chunks {
 			spans = append(spans, c.Span())
@@ -232,8 +233,8 @@ func TestOverlapWalking(t *testing.T) {
 		require.Equal(t, dataChunkSpans, spans)
 	}
 	{
-		var chunks []Chunk
-		err = Walk(context.Background(), ark, func(c Chunk) error {
+		var chunks []chunk.Chunk
+		err = Walk(context.Background(), ark, func(c chunk.Chunk) error {
 			chunks = append(chunks, c)
 			return nil
 		})
@@ -246,14 +247,14 @@ func TestOverlapWalking(t *testing.T) {
 		require.Equal(t, dataChunkSpans, spans)
 	}
 	{
-		var chunks []Chunk
-		err = tsDirVisit(context.Background(), ark, nano.Span{Ts: 12, Dur: 20}, func(tsd tsDir, c []Chunk) error {
+		var chunks []chunk.Chunk
+		err = tsDirVisit(context.Background(), ark, nano.Span{Ts: 12, Dur: 20}, func(tsd tsDir, c []chunk.Chunk) error {
 			chunks = append(chunks, c...)
 			return nil
 		})
 		require.NoError(t, err)
 		assert.Len(t, chunks, 2)
-		chunksSort(ark.DataOrder, chunks)
+		chunk.Sort(ark.DataOrder, chunks)
 		var spans []nano.Span
 		for _, c := range chunks {
 			spans = append(spans, c.Span())
@@ -291,15 +292,15 @@ func TestMergeLargestChunkSpanInfos(t *testing.T) {
 	}{
 		{
 			in: []SpanInfo{
-				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 1, RecordCount: 10}}},
-				{Span: nano.Span{Ts: 1, Dur: 1}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 1, Dur: 1}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 1, RecordCount: 10},
 					{Id: kid("b"), First: 1, Last: 1, RecordCount: 5},
 				}},
 			},
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 0, Dur: 2}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 0, Dur: 2}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 1, RecordCount: 10},
 					{Id: kid("b"), First: 1, Last: 1, RecordCount: 5},
 				}},
@@ -315,50 +316,50 @@ func TestMergeLargestChunkSpanInfos(t *testing.T) {
 
 func TestMergeChunksToSpans(t *testing.T) {
 	cases := []struct {
-		in     []Chunk
+		in     []chunk.Chunk
 		filter nano.Span
 		order  zbuf.Order
 		exp    []SpanInfo
 	}{
 		{
-			in: []Chunk{
+			in: []chunk.Chunk{
 				{Id: kid("a"), First: 0, Last: 3, RecordCount: 10},
 				{Id: kid("b"), First: 1, Last: 3, RecordCount: 20},
 			},
 			filter: nano.MaxSpan,
 			order:  zbuf.OrderAsc,
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 3, RecordCount: 10}}},
-				{Span: nano.Span{Ts: 1, Dur: 3}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 1, Dur: 3}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 3, RecordCount: 10},
 					{Id: kid("b"), First: 1, Last: 3, RecordCount: 20}}},
 			},
 		},
 		{
-			in: []Chunk{
+			in: []chunk.Chunk{
 				{Id: kid("a"), First: 0, Last: 3, RecordCount: 20},
 				{Id: kid("b"), First: 2, Last: 5, RecordCount: 10},
 			},
 			filter: nano.MaxSpan,
 			order:  zbuf.OrderAsc,
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 0, Dur: 4}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 0, Dur: 4}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 3, RecordCount: 20},
 					{Id: kid("b"), First: 2, Last: 5, RecordCount: 10}}},
-				{Span: nano.Span{Ts: 4, Dur: 2}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 4, Dur: 2}, Chunks: []chunk.Chunk{
 					{Id: kid("b"), First: 2, Last: 5, RecordCount: 10}}},
 			},
 		},
 		{
-			in: []Chunk{
+			in: []chunk.Chunk{
 				{Id: kid("b"), First: 0, Last: 0, RecordCount: 10},
 				{Id: kid("a"), First: 0, Last: 0, RecordCount: 10},
 			},
 			filter: nano.MaxSpan,
 			order:  zbuf.OrderAsc,
 			exp: []SpanInfo{
-				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []Chunk{
+				{Span: nano.Span{Ts: 0, Dur: 1}, Chunks: []chunk.Chunk{
 					{Id: kid("a"), First: 0, Last: 0, RecordCount: 10},
 					{Id: kid("b"), First: 0, Last: 0, RecordCount: 10}}},
 			},

--- a/ppl/archive/schema.go
+++ b/ppl/archive/schema.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/ppl/archive/chunk"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zqe"
 	"github.com/segmentio/ksuid"
@@ -165,7 +166,7 @@ func openArchive(ctx context.Context, root iosrc.URI, oo *OpenOptions) (*Archive
 	}
 	if oo != nil {
 		for _, l := range oo.LogFilter {
-			_, id, ok := chunkFileMatch(l)
+			_, id, ok := chunk.FileMatch(l)
 			if !ok {
 				return nil, zqe.E(zqe.Invalid, "log filter %s not a chunk file name", l)
 			}

--- a/ppl/archive/stat.go
+++ b/ppl/archive/stat.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/brimsec/zq/microindex"
 	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/ppl/archive/chunk"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zng"
@@ -43,8 +44,8 @@ func (s *statReadCloser) Close() error {
 	return nil
 }
 
-func (s *statReadCloser) chunkRecord(chunk Chunk) error {
-	fi, err := iosrc.Stat(s.ctx, chunk.Path(s.ark))
+func (s *statReadCloser) chunkRecord(chunk chunk.Chunk) error {
+	fi, err := iosrc.Stat(s.ctx, chunk.Path())
 	if err != nil {
 		return err
 	}
@@ -62,7 +63,7 @@ func (s *statReadCloser) chunkRecord(chunk Chunk) error {
 
 	rec := s.chunkBuilder.Build(
 		zng.EncodeString("chunk"),
-		zng.EncodeString(string(chunk.RelativePath())),
+		zng.EncodeString(s.ark.Root.RelPath(chunk.Path())),
 		zng.EncodeTime(chunk.First),
 		zng.EncodeTime(chunk.Last),
 		zng.EncodeUint(uint64(fi.Size())),
@@ -76,8 +77,8 @@ func (s *statReadCloser) chunkRecord(chunk Chunk) error {
 	}
 }
 
-func (s *statReadCloser) indexRecord(chunk Chunk, indexPath string) error {
-	zardir := chunk.ZarDir(s.ark)
+func (s *statReadCloser) indexRecord(chunk chunk.Chunk, indexPath string) error {
+	zardir := chunk.ZarDir()
 	info, err := microindex.Stat(s.ctx, zardir.AppendPath(indexPath))
 	if err != nil {
 		if errors.Is(err, zqe.E(zqe.NotFound)) {
@@ -121,7 +122,7 @@ func (s *statReadCloser) indexRecord(chunk Chunk, indexPath string) error {
 
 	rec := s.indexBuilders[indexPath].Build(
 		zng.EncodeString("index"),
-		zng.EncodeString(string(chunk.RelativePath())),
+		zng.EncodeString(s.ark.Root.RelPath(chunk.Path())),
 		zng.EncodeTime(chunk.First),
 		zng.EncodeTime(chunk.Last),
 		zng.EncodeString(indexPath),
@@ -140,11 +141,11 @@ func (s *statReadCloser) indexRecord(chunk Chunk, indexPath string) error {
 func (s *statReadCloser) run() {
 	defer close(s.recs)
 
-	s.err = Walk(s.ctx, s.ark, func(chunk Chunk) error {
+	s.err = Walk(s.ctx, s.ark, func(chunk chunk.Chunk) error {
 		if err := s.chunkRecord(chunk); err != nil {
 			return err
 		}
-		if dirents, err := s.ark.dataSrc.ReadDir(s.ctx, chunk.ZarDir(s.ark)); err == nil {
+		if dirents, err := s.ark.dataSrc.ReadDir(s.ctx, chunk.ZarDir()); err == nil {
 			for _, e := range dirents {
 				if e.IsDir() {
 					continue

--- a/ppl/archive/walk.go
+++ b/ppl/archive/walk.go
@@ -2,22 +2,14 @@ package archive
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
-	"path"
-	"regexp"
 	"sort"
-	"strings"
 	"time"
 
-	"github.com/brimsec/zq/pkg/bufwriter"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/brimsec/zq/ppl/archive/seekindex"
+	"github.com/brimsec/zq/ppl/archive/chunk"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zio/zngio"
-	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
 	"github.com/segmentio/ksuid"
 )
@@ -25,17 +17,6 @@ import (
 const (
 	dataDirname = "zd"
 	zarExt      = ".zar"
-)
-
-// A FileKind is the first part of a file name, used to differentiate files
-// when they are listed from the archive's backing store.
-type FileKind string
-
-const (
-	FileKindUnknown  FileKind = ""
-	FileKindData              = "d"
-	FileKindMetadata          = "m"
-	FileKindSeek              = "ts"
 )
 
 // A tsDir is a directory found in the "<DataPath>/zd" directory of the archive,
@@ -65,7 +46,7 @@ func (t tsDir) name() string {
 	return t.Ts.Time().Format("20060102")
 }
 
-type tsDirVisitor func(tsd tsDir, unsortedChunks []Chunk) error
+type tsDirVisitor func(tsd tsDir, unsortedChunks []chunk.Chunk) error
 
 // tsDirVisit calls visitor for each tsDir whose span overlaps with the
 // given span. tsDirs are visited in the archive's order, but the
@@ -109,40 +90,41 @@ func tsDirVisit(ctx context.Context, ark *Archive, filterSpan nano.Span, visitor
 	return nil
 }
 
-func tsDirEntriesToChunks(ctx context.Context, ark *Archive, filterSpan nano.Span, tsDir tsDir, entries []iosrc.Info) ([]Chunk, error) {
+func tsDirEntriesToChunks(ctx context.Context, ark *Archive, filterSpan nano.Span, tsDir tsDir, entries []iosrc.Info) ([]chunk.Chunk, error) {
 	type seen struct {
 		data bool
 		meta bool
 	}
 	m := make(map[ksuid.KSUID]seen)
 	for _, e := range entries {
-		if kind, id, ok := chunkFileMatch(e.Name()); ok {
+		if kind, id, ok := chunk.FileMatch(e.Name()); ok {
 			if !ark.filterAllowed(id) {
 				continue
 			}
 			s := m[id]
 			switch kind {
-			case FileKindData:
+			case chunk.FileKindData:
 				s.data = true
-			case FileKindMetadata:
+			case chunk.FileKindMetadata:
 				s.meta = true
 			}
 			m[id] = s
 		}
 	}
-	var chunks []Chunk
+	var chunks []chunk.Chunk
 	for id, seen := range m {
 		if !seen.meta || !seen.data {
 			continue
 		}
-		md, err := readChunkMetadata(ctx, chunkMetadataPath(ark, tsDir, id))
+		dir := tsDir.path(ark)
+		md, err := chunk.ReadMetadata(ctx, chunk.MetadataPath(dir, id))
 		if err != nil {
 			if zqe.IsNotFound(err) {
 				continue
 			}
 			return nil, err
 		}
-		chunk := md.Chunk(id)
+		chunk := md.Chunk(dir, id)
 		if !filterSpan.Overlaps(chunk.Span()) {
 			continue
 		}
@@ -151,276 +133,16 @@ func tsDirEntriesToChunks(ctx context.Context, ark *Archive, filterSpan nano.Spa
 	return chunks, nil
 }
 
-var chunkFileRegex = regexp.MustCompile(`(d|m)-([0-9A-Za-z]{27}).zng$`)
-
-func chunkFileMatch(s string) (kind FileKind, id ksuid.KSUID, ok bool) {
-	match := chunkFileRegex.FindStringSubmatch(s)
-	if match == nil {
-		return
-	}
-	k := FileKind(match[1])
-	switch k {
-	case FileKindData:
-	case FileKindMetadata:
-	default:
-		return
-	}
-	id, err := ksuid.Parse(match[2])
-	if err != nil {
-		return
-	}
-	return k, id, true
-}
-
-// A Chunk is a file that holds records ordered according to the archive's
-// data order.
-// To support reading chunks that contain records originally from one or
-// more other chunks, a chunk has a list of chunk IDs it "masks". During a read
-// of data for time span T, if chunks X and Y both have data within span T, and
-// X masks Y, then only data from X should be used.
-// seekIndexPath returns the path of an associated microindex written at import
-// time, which can be used to lookup a nearby seek offset for a desired
-// timestamp.
-// metadataPath returns the path of an associated zng file that holds
-// information about the records in the chunk, including the total number,
-// and the first and last record timestamps.
-type Chunk struct {
-	Id          ksuid.KSUID
-	First       nano.Ts
-	Last        nano.Ts
-	RecordCount uint64
-	Masks       []ksuid.KSUID
-	Size        int64
-}
-
-func (c Chunk) tsDir() tsDir {
-	return newTsDir(c.First)
-}
-
-func (c Chunk) seekIndexPath(ark *Archive) iosrc.URI {
-	return chunkSeekIndexPath(ark, c.tsDir(), c.Id)
-}
-
-func (c Chunk) metadataPath(ark *Archive) iosrc.URI {
-	return chunkMetadataPath(ark, c.tsDir(), c.Id)
-}
-
-func (c Chunk) Span() nano.Span {
-	return firstLastToSpan(c.First, c.Last)
-}
-
-func (c Chunk) RelativePath() string {
-	return chunkRelativePath(c.tsDir(), c.Id)
-}
-
-func chunkRelativePath(tsd tsDir, id ksuid.KSUID) string {
-	return path.Join(dataDirname, tsd.name(), fmt.Sprintf("%s-%s.zng", FileKindData, id))
-}
-
-func parseChunkRelativePath(s string) (tsDir, FileKind, ksuid.KSUID, bool) {
-	ss := strings.Split(s, "/")
-	if len(ss) < 2 {
-		return tsDir{}, FileKindUnknown, ksuid.Nil, false
-	}
-	kind, id, ok := chunkFileMatch(ss[len(ss)-1])
-	if !ok {
-		return tsDir{}, FileKindUnknown, ksuid.Nil, false
-	}
-	tsd, ok := parseTsDirName(ss[len(ss)-2])
-	if !ok {
-		return tsDir{}, FileKindUnknown, ksuid.Nil, false
-	}
-	return tsd, kind, id, true
-}
-
-// ZarDir returns a URI for a directory specific to this data file, expected
-// to hold microindexes or other files associated with this chunk's data.
-func (c Chunk) ZarDir(ark *Archive) iosrc.URI {
-	return ark.DataPath.AppendPath(string(c.RelativePath() + zarExt))
-}
-
-// Localize returns a URI that joins the provided relative path name to the
-// zardir for this chunk. The special name "_" is mapped to the path of the
-// data file for this chunk.
-func (c Chunk) Localize(ark *Archive, pathname string) iosrc.URI {
-	if pathname == "_" {
-		return c.Path(ark)
-	}
-	return c.ZarDir(ark).AppendPath(pathname)
-}
-
-func (c Chunk) Path(ark *Archive) iosrc.URI {
-	return chunkPath(ark, c.tsDir(), c.Id)
-}
-
-func chunkPath(ark *Archive, tsd tsDir, id ksuid.KSUID) iosrc.URI {
-	return ark.DataPath.AppendPath(chunkRelativePath(tsd, id))
-}
-
-func chunkSeekIndexPath(ark *Archive, tsd tsDir, id ksuid.KSUID) iosrc.URI {
-	return tsd.path(ark).AppendPath(fmt.Sprintf("%s-%s.zng", FileKindSeek, id))
-}
-
-func (c Chunk) Range() string {
-	return fmt.Sprintf("[%d-%d]", c.First, c.Last)
-}
-
-// Remove deletes the data, metadata, seek, and any other associated files
-// with the chunk, including the zar directory. Any 'not found' errors will
-// be ignored.
-func (c Chunk) Remove(ctx context.Context, ark *Archive) error {
-	uris := []iosrc.URI{
-		c.Path(ark),
-		c.ZarDir(ark),
-		c.metadataPath(ark),
-		c.seekIndexPath(ark),
-	}
-	for _, u := range uris {
-		if err := ark.dataSrc.RemoveAll(ctx, u); err != nil && !zqe.IsNotFound(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-type chunkReader struct {
-	io.Reader
-	io.Closer
-	totalSize int64
-	readSize  int64
-}
-
-// newChunkReader returns an io.ReadCloser for this chunk. If the chunk has a seek
-// index and if the provided span skips part of the chunk, the seek index will
-// be used to limit the reading window of the chunk's reader.
-func newChunkReader(ctx context.Context, chunk Chunk, ark *Archive, span nano.Span) (*chunkReader, error) {
-	cspan := chunk.Span()
-	span = cspan.Intersect(span)
-	if span.Dur == 0 {
-		return nil, errors.New("chunk span does intersect provided span")
-	}
-	r, err := iosrc.NewReader(ctx, chunk.Path(ark))
-	if err != nil {
-		return nil, err
-	}
-	cr := &chunkReader{
-		Reader:    r,
-		Closer:    r,
-		totalSize: chunk.Size,
-		readSize:  chunk.Size,
-	}
-	if span == cspan {
-		return cr, nil
-	}
-	s, err := seekindex.Open(ctx, chunk.seekIndexPath(ark))
-	if err != nil {
-		if zqe.IsNotFound(err) {
-			return cr, nil
-		}
-		return nil, err
-	}
-	defer s.Close()
-	rg, err := s.Lookup(ctx, span)
-	if err != nil {
-		return nil, err
-	}
-	rg = rg.TrimEnd(cr.totalSize)
-	cr.readSize = rg.Size()
-	cr.Reader, err = rg.LimitReader(r)
-	return cr, err
-}
-
-func chunkLess(order zbuf.Order, a, b Chunk) bool {
-	if order == zbuf.OrderDesc {
-		a, b = b, a
-	}
-	switch {
-	case a.First != b.First:
-		return a.First < b.First
-	case a.Last != b.Last:
-		return a.Last < b.Last
-	case a.RecordCount != b.RecordCount:
-		return a.RecordCount < b.RecordCount
-	}
-	return ksuid.Compare(a.Id, b.Id) < 0
-}
-
-func chunksSort(order zbuf.Order, c []Chunk) {
-	sort.Slice(c, func(i, j int) bool {
-		return chunkLess(order, c[i], c[j])
-	})
-}
-
-type chunkMetadata struct {
-	First       nano.Ts
-	Last        nano.Ts
-	RecordCount uint64
-	Masks       []ksuid.KSUID
-	Size        int64
-}
-
-func (md chunkMetadata) Chunk(id ksuid.KSUID) Chunk {
-	return Chunk{
-		Id:          id,
-		First:       md.First,
-		Last:        md.Last,
-		RecordCount: md.RecordCount,
-		Masks:       md.Masks,
-		Size:        md.Size,
-	}
-}
-
-func chunkMetadataPath(ark *Archive, tsDir tsDir, id ksuid.KSUID) iosrc.URI {
-	return tsDir.path(ark).AppendPath(fmt.Sprintf("%s-%s.zng", FileKindMetadata, id))
-}
-
-func writeChunkMetadata(ctx context.Context, uri iosrc.URI, md chunkMetadata) error {
-	zctx := resolver.NewContext()
-	rec, err := resolver.MarshalRecord(zctx, md)
-	if err != nil {
-		return err
-	}
-	out, err := iosrc.NewWriter(ctx, uri)
-	if err != nil {
-		return err
-	}
-	zw := zngio.NewWriter(bufwriter.New(out), zngio.WriterOpts{})
-	if err := zw.Write(rec); err != nil {
-		zw.Close()
-		return err
-	}
-	return zw.Close()
-}
-
-func readChunkMetadata(ctx context.Context, uri iosrc.URI) (chunkMetadata, error) {
-	in, err := iosrc.NewReader(ctx, uri)
-	if err != nil {
-		return chunkMetadata{}, err
-	}
-	defer in.Close()
-	zctx := resolver.NewContext()
-	zr := zngio.NewReader(in, zctx)
-	rec, err := zr.Read()
-	if err != nil {
-		return chunkMetadata{}, err
-	}
-	var md chunkMetadata
-	if err := resolver.UnmarshalRecord(zctx, rec, &md); err != nil {
-		return chunkMetadata{}, err
-	}
-	return md, nil
-}
-
-type Visitor func(chunk Chunk) error
+type Visitor func(chunk chunk.Chunk) error
 
 // Walk calls visitor for every data chunk in the archive.
 func Walk(ctx context.Context, ark *Archive, v Visitor) error {
 	dirmkr, _ := ark.dataSrc.(iosrc.DirMaker)
-	return tsDirVisit(ctx, ark, nano.MaxSpan, func(_ tsDir, chunks []Chunk) error {
-		chunksSort(ark.DataOrder, chunks)
+	return tsDirVisit(ctx, ark, nano.MaxSpan, func(_ tsDir, chunks []chunk.Chunk) error {
+		chunk.Sort(ark.DataOrder, chunks)
 		for _, c := range chunks {
 			if dirmkr != nil {
-				zardir := c.ZarDir(ark)
+				zardir := c.ZarDir()
 				if err := dirmkr.MkdirAll(zardir, 0700); err != nil {
 					return err
 				}
@@ -436,8 +158,8 @@ func Walk(ctx context.Context, ark *Archive, v Visitor) error {
 // RmDirs descends a directory hierarchy looking for zar dirs and remove
 // each such directory and all of its contents.
 func RmDirs(ctx context.Context, ark *Archive) error {
-	return Walk(ctx, ark, func(chunk Chunk) error {
-		return ark.dataSrc.RemoveAll(ctx, chunk.ZarDir(ark))
+	return Walk(ctx, ark, func(chunk chunk.Chunk) error {
+		return ark.dataSrc.RemoveAll(ctx, chunk.ZarDir())
 	})
 }
 
@@ -450,7 +172,7 @@ type SpanInfo struct {
 	// The Chunks may have spans that extend beyond this SpanInfo, so any
 	// records from these Chunks should be limited to those that fall within
 	// this SpanInfo's Span.
-	Chunks []Chunk
+	Chunks []chunk.Chunk
 }
 
 func (s SpanInfo) ChunkRange(order zbuf.Order, chunkIdx int) string {
@@ -459,7 +181,7 @@ func (s SpanInfo) ChunkRange(order zbuf.Order, chunkIdx int) string {
 	return fmt.Sprintf("[%d-%d,%d-%d]", first, last, c.First, c.Last)
 }
 
-func (si *SpanInfo) RemoveMasked() []Chunk {
+func (si *SpanInfo) RemoveMasked() []chunk.Chunk {
 	if len(si.Chunks) == 1 {
 		return nil
 	}
@@ -472,7 +194,7 @@ func (si *SpanInfo) RemoveMasked() []Chunk {
 	if len(maskIds) == 0 {
 		return nil
 	}
-	var chunks, removed []Chunk
+	var chunks, removed []chunk.Chunk
 	for _, c := range si.Chunks {
 		var masked bool
 		for _, mid := range maskIds {
@@ -494,12 +216,12 @@ func (si *SpanInfo) RemoveMasked() []Chunk {
 // SpanWalk calls visitor with each SpanInfo within the filter span.
 func SpanWalk(ctx context.Context, ark *Archive, filter nano.Span, visitor func(si SpanInfo) error) error {
 	dirmkr, _ := ark.dataSrc.(iosrc.DirMaker)
-	return tsDirVisit(ctx, ark, filter, func(_ tsDir, chunks []Chunk) error {
+	return tsDirVisit(ctx, ark, filter, func(_ tsDir, chunks []chunk.Chunk) error {
 		sinfos := mergeChunksToSpans(chunks, ark.DataOrder, filter)
 		for _, s := range sinfos {
 			if dirmkr != nil {
 				for _, c := range s.Chunks {
-					zardir := c.ZarDir(ark)
+					zardir := c.ZarDir()
 					if err := dirmkr.MkdirAll(zardir, 0700); err != nil {
 						return err
 					}

--- a/ppl/cmd/zar/ls/command.go
+++ b/ppl/cmd/zar/ls/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/ppl/archive"
+	"github.com/brimsec/zq/ppl/archive/chunk"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/mccanne/charm"
 )
@@ -66,13 +67,13 @@ func (c *Command) Run(args []string) error {
 		return archive.SpanWalk(context.TODO(), ark, nano.MaxSpan, func(si archive.SpanInfo) error {
 			for i, chunk := range si.Chunks {
 				rangeStr := si.ChunkRange(ark.DataOrder, i)
-				c.printDir(ark, rangeStr, chunk.ZarDir(ark), pattern)
+				c.printDir(ark, rangeStr, chunk.ZarDir(), pattern)
 			}
 			return nil
 		})
 	}
-	return archive.Walk(context.TODO(), ark, func(chunk archive.Chunk) error {
-		c.printDir(ark, "", chunk.ZarDir(ark), pattern)
+	return archive.Walk(context.TODO(), ark, func(chunk chunk.Chunk) error {
+		c.printDir(ark, "", chunk.ZarDir(), pattern)
 		return nil
 	})
 }

--- a/ppl/cmd/zar/map/command.go
+++ b/ppl/cmd/zar/map/command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/brimsec/zq/pkg/rlimit"
 	"github.com/brimsec/zq/pkg/signalctx"
 	"github.com/brimsec/zq/ppl/archive"
+	"github.com/brimsec/zq/ppl/archive/chunk"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
@@ -98,11 +99,11 @@ func (c *Command) Run(args []string) error {
 
 	// XXX this is parallelizable except for writing to stdout when
 	// concatenating results
-	return archive.Walk(ctx, ark, func(chunk archive.Chunk) error {
-		zardir := chunk.ZarDir(ark)
+	return archive.Walk(ctx, ark, func(chunk chunk.Chunk) error {
+		zardir := chunk.ZarDir()
 		var paths []string
 		for _, input := range inputs {
-			paths = append(paths, chunk.Localize(ark, input).String())
+			paths = append(paths, chunk.Localize(input).String())
 		}
 		zctx := resolver.NewContext()
 		opts := zio.ReaderOpts{Format: "zng"}

--- a/ppl/cmd/zar/rm/command.go
+++ b/ppl/cmd/zar/rm/command.go
@@ -12,6 +12,7 @@ import (
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/ppl/archive"
+	"github.com/brimsec/zq/ppl/archive/chunk"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/zqe"
 	"github.com/mccanne/charm"
@@ -64,13 +65,13 @@ func (c *Command) Run(args []string) error {
 		return archive.SpanWalk(context.TODO(), ark, nano.MaxSpan, func(si archive.SpanInfo) error {
 			for i, chunk := range si.Chunks {
 				rangeStr := si.ChunkRange(ark.DataOrder, i)
-				c.remove(ark, rangeStr, chunk.ZarDir(ark), args)
+				c.remove(ark, rangeStr, chunk.ZarDir(), args)
 			}
 			return nil
 		})
 	}
-	return archive.Walk(context.TODO(), ark, func(chunk archive.Chunk) error {
-		c.remove(ark, "", chunk.ZarDir(ark), args)
+	return archive.Walk(context.TODO(), ark, func(chunk chunk.Chunk) error {
+		c.remove(ark, "", chunk.ZarDir(), args)
 		return nil
 	})
 }

--- a/ppl/zqd/storage/archivestore/archivestore.go
+++ b/ppl/zqd/storage/archivestore/archivestore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/ppl/archive"
+	"github.com/brimsec/zq/ppl/archive/chunk"
 	"github.com/brimsec/zq/ppl/zqd/storage"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
@@ -62,9 +63,8 @@ func (s *Storage) StaticSource(src driver.Source) driver.MultiSource {
 func (s *Storage) Summary(ctx context.Context) (storage.Summary, error) {
 	var sum storage.Summary
 	sum.Kind = api.ArchiveStore
-	err := archive.Walk(ctx, s.ark, func(chunk archive.Chunk) error {
-		zngpath := chunk.Path(s.ark)
-		info, err := iosrc.Stat(ctx, zngpath)
+	err := archive.Walk(ctx, s.ark, func(chunk chunk.Chunk) error {
+		info, err := iosrc.Stat(ctx, chunk.Path())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Overtime package archive is becoming more complex with more moving parts.
Moving Chunk into its own package is an attempt at simplifying things. A chunk
is only aware of the directory it is supposed to write itself in. The wide
archive that is made up of chunks is responsible for writing them to the
correct tsdir.

Having a simplified chunk will allow for more isolated testing on specific
chunk features.