### PR TITLE
archive.Writer: fix staleDuration

### DIFF
--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -76,9 +76,8 @@ func NewWriter(ctx context.Context, ark *Archive) *Writer {
 	}
 }
 
-// SetStaleDuration sets the StaleThreshold for the writer which is the
-// duration since a tsdir has last since received new data will  flushed to
-// disk. Must be set before the first Write call occurs.
+// SetStaleDuration sets the stale threshold for the writer which is the delay
+// after the last write to a tsdir until it is flushed and removed.
 func (w *Writer) SetStaleDuration(dur time.Duration) {
 	w.staleDuration = dur
 }

--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -146,7 +146,7 @@ func (w *Writer) flushStaleWriters() error {
 	w.writersMu.Lock()
 	var stale []*tsDirWriter
 	for tsd, writer := range w.writers {
-		if now.Sub(writer.modified()) > w.staleDuration {
+		if now.Sub(writer.modified()) >= w.staleDuration {
 			stale = append(stale, writer)
 			delete(w.writers, tsd)
 		}

--- a/ppl/archive/import_test.go
+++ b/ppl/archive/import_test.go
@@ -14,16 +14,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestImportFlushTimeout(t *testing.T) {
+func TestImportStaleDuration(t *testing.T) {
 	t.Run("Stale", func(t *testing.T) {
-		testImportFlushTimeout(t, 1, 1)
+		testImportStaleDuration(t, 1, 1)
 	})
 	t.Run("NotStale", func(t *testing.T) {
-		testImportFlushTimeout(t, math.MaxInt64, 0)
+		testImportStaleDuration(t, math.MaxInt64, 0)
 	})
 }
 
-func testImportFlushTimeout(t *testing.T, stale time.Duration, expected uint64) {
+func testImportStaleDuration(t *testing.T, stale time.Duration, expected uint64) {
 	const data = `
 #0:record[ts:time,offset:int64]
 0:[1587508850.06466032;202;]`

--- a/ppl/archive/import_test.go
+++ b/ppl/archive/import_test.go
@@ -23,7 +23,7 @@ func TestImportFlushTimeout(t *testing.T) {
 	})
 }
 
-func testImportFlushTimeout(t *testing.T, timeout time.Duration, expected uint64) {
+func testImportFlushTimeout(t *testing.T, stale time.Duration, expected uint64) {
 	const data = `
 #0:record[ts:time,offset:int64]
 0:[1587508850.06466032;202;]`
@@ -35,12 +35,11 @@ func testImportFlushTimeout(t *testing.T, timeout time.Duration, expected uint64
 	// write one record to an open archive.Writer and do NOT close it.
 	w := NewWriter(context.Background(), ark)
 	defer w.Close()
-	w.SetFlushTimeout(timeout)
+	w.SetStaleDuration(stale)
 	r := tzngio.NewReader(strings.NewReader(data), resolver.NewContext())
 	require.NoError(t, zbuf.Copy(w, r))
 
 	// flush stale writers and ensure data has been written to archive
-	time.Sleep(10)
 	err = w.flushStaleWriters()
 	require.NoError(t, err)
 	count, err := RecordCount(context.Background(), ark)

--- a/ppl/archive/import_test.go
+++ b/ppl/archive/import_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestImportStaleDuration(t *testing.T) {
 	t.Run("Stale", func(t *testing.T) {
-		testImportStaleDuration(t, 1, 1)
+		testImportStaleDuration(t, 0, 1)
 	})
 	t.Run("NotStale", func(t *testing.T) {
 		testImportStaleDuration(t, math.MaxInt64, 0)


### PR DESCRIPTION
Previously archive.Writer was setting the flusher interval to whatever the
flush timeout was. This didn't make sense and was also causing import test
flakiness. Set the flush interval to an arbitrary one second and make
staleDuration configurable.