### PR TITLE
Say "REST" in place of "REST-like"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ and store structured log data, including:
 
 * The [zq](cmd/zq/README.md) command line tool, for searching and analyzing log
  files
-* The [zqd](ppl/cmd/zqd/README.md) daemon, which serves a REST-like API to manage
+* The [zqd](ppl/cmd/zqd/README.md) daemon, which serves a REST API to manage
  and query log archives, and is the backend for the [Brim](https://github.com/brimsec/brim)
  application
 * The [zar](ppl/cmd/zar/README.md) command line tool, for working with log data

--- a/ppl/cmd/zqd/README.md
+++ b/ppl/cmd/zqd/README.md
@@ -1,6 +1,6 @@
 # `zqd`
 
-`zqd` serves a REST-like API used to manage and query "spaces" than contain log
+`zqd` serves a REST API used to manage and query "spaces" than contain log
  data. It is used as the backend service for the [Brim](https://github.com/brimsec/brim)
 application.
 


### PR DESCRIPTION
In reviewing a draft blog post from @orochford I pointed out that describing our API as "REST-like" seemed strange, to which he responded that he was just mimicking what we said ourselves in these README files. @alfred-landrum chimed in to imply that we could go to just saying flat out "REST", so I'm proposing that change here.