### PR TITLE
allow len() function to work on IPs

### DIFF
--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -164,7 +164,7 @@ func (l *lenFn) Call(args []zng.Value) (zng.Value, error) {
 			return zng.Value{}, err
 		}
 		return zng.Value{zng.TypeInt64, l.Int(int64(len))}, nil
-	case *zng.TypeOfString, *zng.TypeOfBstring:
+	case *zng.TypeOfString, *zng.TypeOfBstring, *zng.TypeOfIP, *zng.TypeOfNet:
 		v := len(args[0].Bytes)
 		return zng.Value{zng.TypeInt64, l.Int(int64(v))}, nil
 	default:

--- a/expr/ztests/ip-len.yaml
+++ b/expr/ztests/ip-len.yaml
@@ -1,0 +1,11 @@
+zql: cut len(addr)
+
+input: |
+  #0:record[addr:ip]
+  0:[10.0.0.1;]
+  0:[fe80::215:17ff:fe84:c13f;]
+
+output: |
+  #0:record[len:int64]
+  0:[4;]
+  0:[16;]

--- a/expr/ztests/ip-len.yaml
+++ b/expr/ztests/ip-len.yaml
@@ -1,11 +1,11 @@
-zql: cut len(addr)
+zql: cut n1=len(addr),n2=len(n)
 
 input: |
-  #0:record[addr:ip]
-  0:[10.0.0.1;]
-  0:[fe80::215:17ff:fe84:c13f;]
+  #0:record[addr:ip,n:net]
+  0:[10.0.0.1;10.0.0.0/8;]
+  0:[fe80::215:17ff:fe84:c13f;2001:db8::/32;]
 
 output: |
-  #0:record[len:int64]
-  0:[4;]
-  0:[16;]
+  #0:record[n1:int64,n2:int64]
+  0:[4;8;]
+  0:[16;32;]

--- a/zng/net.go
+++ b/zng/net.go
@@ -25,7 +25,7 @@ func EncodeNet(subnet *net.IPNet) zcode.Bytes {
 		}
 		return b[:8]
 	}
-	copy(b[:], ip)
+	copy(b[:], subnet.IP)
 	copy(b[16:], subnet.Mask)
 	return b[:]
 }


### PR DESCRIPTION
This commit extends the len function to return the length of IP
addresses and networks.  This is handy for differentiating between
IPv4 (len=4) and IPv6 (len=16).  Likewise, networks are len 8 and
len 32.