### PR TITLE
archive index package

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -204,8 +204,12 @@ func (mr *muxReader) Close() error {
 }
 
 func NewReader(ctx context.Context, program ast.Proc, zctx *resolver.Context, reader zbuf.Reader) (zbuf.ReadCloser, error) {
+	return NewReaderWithConfig(ctx, Config{}, program, zctx, reader)
+}
+
+func NewReaderWithConfig(ctx context.Context, conf Config, program ast.Proc, zctx *resolver.Context, reader zbuf.Reader) (zbuf.ReadCloser, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	mux, err := compile(ctx, program, zctx, []zbuf.Reader{reader}, Config{})
+	mux, err := compile(ctx, program, zctx, []zbuf.Reader{reader}, conf)
 	if err != nil {
 		cancel()
 		return nil, err

--- a/go.sum
+++ b/go.sum
@@ -198,7 +198,6 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/ppl/archive/index/definition.go
+++ b/ppl/archive/index/definition.go
@@ -1,0 +1,97 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"regexp"
+
+	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/segmentio/ksuid"
+)
+
+type Definition struct {
+	Rule
+	ID   ksuid.KSUID
+	Proc ast.Proc
+}
+
+func ReadDefinition(ctx context.Context, u iosrc.URI) (*Definition, error) {
+	id, err := parseDefFile(path.Base(u.Path))
+	if err != nil {
+		return nil, err
+	}
+	b, err := iosrc.ReadFile(ctx, u)
+	if err != nil {
+		return nil, err
+	}
+	def := &Definition{ID: id}
+	def.Rule, err = UnmarshalRule(b)
+	if err != nil {
+		return nil, err
+	}
+	def.Proc, err = def.Rule.Proc()
+	return def, err
+}
+
+func NewDefinition(r Rule) (*Definition, error) {
+	proc, err := r.Proc()
+	if err != nil {
+		return nil, err
+	}
+	return &Definition{ID: ksuid.New(), Rule: r, Proc: proc}, nil
+}
+
+func MustNewDefinition(r Rule) *Definition {
+	d, err := NewDefinition(r)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+var defFileRegex = regexp.MustCompile(`idxdef-([0-9A-Za-z]{27}).zng$`)
+
+func parseDefFile(name string) (ksuid.KSUID, error) {
+	match := defFileRegex.FindStringSubmatch(name)
+	if match == nil {
+		return ksuid.Nil, fmt.Errorf("invalid definition file: %s", name)
+	}
+	return ksuid.Parse(match[1])
+}
+
+func (d *Definition) Filename() string {
+	return fmt.Sprintf("idxdef-%s.zng", d.ID)
+}
+
+func (d *Definition) Write(ctx context.Context, dir iosrc.URI) error {
+	b, err := d.Rule.Marshal()
+	if err != nil {
+		return err
+	}
+	return iosrc.WriteFile(ctx, dir.AppendPath(d.Filename()), b)
+}
+
+type DefinitionMap map[ksuid.KSUID]*Definition
+
+type Definitions []*Definition
+
+func (l Definitions) MapByInputPath() map[string][]*Definition {
+	m := make(map[string][]*Definition)
+	for _, d := range l {
+		m[d.Input] = append(m[d.Input], d)
+	}
+	return m
+}
+
+// StandardInputs returns the Defs from the list that have an empty InputPath.
+func (l Definitions) StandardInputs() []*Definition {
+	var defs []*Definition
+	for _, d := range l {
+		if d.Input == "" {
+			defs = append(defs, d)
+		}
+	}
+	return defs
+}

--- a/ppl/archive/index/index.go
+++ b/ppl/archive/index/index.go
@@ -1,0 +1,139 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/brimsec/zq/microindex"
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zqe"
+	"github.com/segmentio/ksuid"
+)
+
+type Index struct {
+	Definition *Definition
+	Dir        iosrc.URI
+}
+
+func (i Index) Path() iosrc.URI {
+	return IndexPath(iosrc.URI(i.Dir), i.Definition.ID)
+}
+
+func IndexPath(dir iosrc.URI, id ksuid.KSUID) iosrc.URI {
+	return dir.AppendPath(indexFilename(id))
+}
+
+func (i Index) Filename() string {
+	return indexFilename(i.Definition.ID)
+}
+
+func ListDefinitionIDs(ctx context.Context, d iosrc.URI) ([]ksuid.KSUID, error) {
+	infos, err := infos(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+	var indices []ksuid.KSUID
+	for _, info := range infos {
+		if uuid, err := parseIndexFile(info.Name()); err == nil {
+			indices = append(indices, uuid)
+		}
+	}
+	return indices, nil
+}
+
+func ListFilenames(ctx context.Context, d iosrc.URI) ([]string, error) {
+	infos, err := infos(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, info := range infos {
+		if _, err := parseIndexFile(info.Name()); err != nil {
+			files = append(files, info.Name())
+		}
+	}
+	return files, nil
+}
+
+func Indices(ctx context.Context, d iosrc.URI, m DefinitionMap) ([]Index, error) {
+	ids, err := ListDefinitionIDs(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+	var indices []Index
+	for _, id := range ids {
+		if def, ok := m[id]; ok {
+			indices = append(indices, Index{def, d})
+		}
+	}
+	return indices, nil
+}
+
+func ApplyDefinitions(ctx context.Context, d iosrc.URI, r zbuf.Reader, defs ...*Definition) ([]Index, error) {
+	writers, err := NewMultiWriter(ctx, d, defs)
+	if err != nil {
+		return nil, err
+	}
+	if len(writers) == 0 {
+		return nil, nil
+	}
+	if err := zbuf.CopyWithContext(ctx, writers, r); err != nil {
+		writers.Abort()
+		return nil, err
+	}
+	if err := writers.Close(); err != nil {
+		return nil, err
+	}
+	return writers.Indices(), nil
+}
+
+func Find(ctx context.Context, d iosrc.URI, id ksuid.KSUID, patterns ...string) (*zng.Record, error) {
+	return FindFromPath(ctx, IndexPath(d, id), patterns...)
+}
+
+func FindFromPath(ctx context.Context, idxfile iosrc.URI, patterns ...string) (*zng.Record, error) {
+	finder, err := microindex.NewFinder(ctx, resolver.NewContext(), idxfile)
+	if err != nil {
+		return nil, fmt.Errorf("index find %s: %w", idxfile, err)
+	}
+	defer finder.Close()
+	keys, err := finder.ParseKeys(patterns...)
+	if err != nil {
+		return nil, fmt.Errorf("index find %s: %w", finder.Path(), err)
+	}
+	rec, err := finder.Lookup(keys)
+	if err != nil {
+		return nil, fmt.Errorf("index find %s: %w", finder.Path(), err)
+	}
+	return rec, nil
+}
+
+func indexFilename(id ksuid.KSUID) string {
+	return fmt.Sprintf("idx-%s.zng", id)
+}
+
+var indexFileRegex = regexp.MustCompile(`idx-([0-9A-Za-z]{27}).zng$`)
+
+func parseIndexFile(name string) (ksuid.KSUID, error) {
+	match := indexFileRegex.FindStringSubmatch(name)
+	if match == nil {
+		return ksuid.Nil, fmt.Errorf("invalid index file: %s", name)
+	}
+	return ksuid.Parse(match[1])
+}
+
+func mkdir(d iosrc.URI) error {
+	return iosrc.MkdirAll(d, 0700)
+}
+
+func infos(ctx context.Context, d iosrc.URI) ([]iosrc.Info, error) {
+	infos, err := iosrc.ReadDir(ctx, d)
+	if zqe.IsNotFound(err) {
+		return nil, mkdir(d)
+	}
+	return infos, err
+}

--- a/ppl/archive/index/index_test.go
+++ b/ppl/archive/index/index_test.go
@@ -1,0 +1,118 @@
+package index
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/tzngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyDefinitions(t *testing.T) {
+	const data = `
+#0:record[ts:time,orig_h:ip,proto:string]
+0:[1;127.0.0.1;conn;]
+0:[2;127.0.0.2;conn;]
+`
+	dir := iosrc.MustParseURI(t.TempDir())
+
+	ctx := context.Background()
+	r := tzngio.NewReader(strings.NewReader(data), resolver.NewContext())
+
+	ip := MustNewDefinition(NewTypeRule(zng.TypeIP))
+	proto := MustNewDefinition(NewFieldRule("proto"))
+
+	indices, err := ApplyDefinitions(ctx, dir, r, ip, proto)
+	require.NoError(t, err)
+	assert.Len(t, indices, 2)
+
+	tests := []struct {
+		def     *Definition
+		pattern string
+		has     bool
+	}{
+		{
+			def:     ip,
+			pattern: "127.0.0.1",
+			has:     true,
+		},
+		{
+			def:     ip,
+			pattern: "127.0.0.9",
+			has:     false,
+		},
+		{
+			def:     proto,
+			pattern: "conn",
+			has:     true,
+		},
+		{
+			def:     proto,
+			pattern: "http",
+			has:     false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Find-%s-%t", test.def.Kind, test.has), func(t *testing.T) {
+			rec, err := Find(ctx, dir, test.def.ID, test.pattern)
+			require.NoError(t, err)
+
+			if test.has {
+				assert.NotNilf(t, rec, "expected query %s=%s to return a result", test.def, test.pattern)
+			} else {
+				assert.Nilf(t, rec, "expected query %s=%s to return a result", test.def, test.pattern)
+			}
+		})
+	}
+}
+
+func TestFindTypeRule(t *testing.T) {
+	r := NewTypeRule(zng.TypeInt64)
+	w := testWriter(t, r)
+	err := zbuf.Copy(w, babbleReader(t))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	rec, err := FindFromPath(context.Background(), w.URI, "456")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	count, err := rec.AccessInt("count")
+	require.NoError(t, err)
+	key, err := rec.AccessInt("key")
+	require.NoError(t, err)
+	assert.EqualValues(t, 456, key)
+	assert.EqualValues(t, 3, count)
+}
+
+func TestZQLRule(t *testing.T) {
+	r, err := NewZqlRule("sum(v) by s | put key=s | sort key", "custom", nil)
+	require.NoError(t, err)
+	w := testWriter(t, r)
+	err = zbuf.Copy(w, babbleReader(t))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	rec, err := FindFromPath(context.Background(), w.URI, "kartometer-trifocal")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	count, err := rec.AccessInt("sum")
+	require.NoError(t, err)
+	key, err := rec.AccessString("key")
+	require.NoError(t, err)
+	assert.EqualValues(t, "kartometer-trifocal", key)
+	assert.EqualValues(t, 397, count)
+}
+
+func babbleReader(t *testing.T) zbuf.Reader {
+	t.Helper()
+	r, err := os.Open("../../../ztests/suite/data/babble-sorted.tzng")
+	require.NoError(t, err)
+	return tzngio.NewReader(r, resolver.NewContext())
+}

--- a/ppl/archive/index/multiwriter.go
+++ b/ppl/archive/index/multiwriter.go
@@ -1,0 +1,76 @@
+package index
+
+import (
+	"context"
+	"path"
+
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zqe"
+	"go.uber.org/multierr"
+)
+
+type MultiWriter []*Writer
+
+func NewMultiWriter(ctx context.Context, d iosrc.URI, defs []*Definition) (MultiWriter, error) {
+	mkdirOnce := true
+	writers := make(MultiWriter, 0, len(defs))
+	for _, def := range defs {
+	again:
+		w, err := NewWriter(ctx, IndexPath(d, def.ID), def)
+		if err != nil {
+			if zqe.IsExists(err) {
+				// skip indices that already exist
+				continue
+			}
+
+			// Only mkdir once, if for some reason the fails again return error.
+			if zqe.IsNotFound(err) && mkdirOnce {
+				if err = mkdir(d); err == nil {
+					mkdirOnce = false
+					goto again
+				}
+			}
+
+			writers.Abort()
+			return nil, err
+		}
+
+		writers = append(writers, w)
+	}
+	return writers, nil
+}
+
+func (ws MultiWriter) Write(rec *zng.Record) error {
+	for _, w := range ws {
+		if err := w.Write(rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ws MultiWriter) Close() (merr error) {
+	for _, w := range ws {
+		if err := w.Close(); err != nil {
+			merr = multierr.Append(merr, err)
+		}
+	}
+	return
+}
+
+func (ws MultiWriter) Indices() []Index {
+	indices := make([]Index, len(ws))
+	for i, w := range ws {
+		u := w.URI
+		u.Path = path.Dir(u.Path)
+		indices[i] = Index{w.Definition, u}
+	}
+	return indices
+}
+
+func (ws MultiWriter) Abort() {
+	for _, w := range ws {
+		w.Abort()
+	}
+}

--- a/ppl/archive/index/proc.go
+++ b/ppl/archive/index/proc.go
@@ -1,0 +1,167 @@
+package index
+
+import (
+	"fmt"
+
+	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/proc"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+)
+
+// A FieldCutter is a custom proc that, given an input record and a
+// field name, outputs one record per input record containing the
+// field, with the field as only column.  It is used for field-based
+// indexing. Unlike the zql cut proc, which has support for different
+// types in a same-named field, this proc doesn't support different
+// types, and errors if more than one type is seen.
+type FieldCutter struct {
+	pctx     *proc.Context
+	parent   proc.Interface
+	builder  *zng.Builder
+	accessor expr.Evaluator
+	field    field.Static
+	out      field.Static
+	typ      zng.Type
+}
+
+// NewFieldCutter creates a FieldCutter for field fieldName, where the
+// output records' single column is named out.
+func NewFieldCutter(pctx *proc.Context, parent proc.Interface, fieldName, out field.Static) (proc.Interface, error) {
+	accessor := expr.NewDotExpr(fieldName)
+	if accessor == nil {
+		return nil, fmt.Errorf("bad field syntax: %s", fieldName)
+	}
+
+	return &FieldCutter{
+		pctx:     pctx,
+		parent:   parent,
+		field:    fieldName,
+		out:      out,
+		accessor: accessor,
+	}, nil
+}
+
+func (f *FieldCutter) checkType(typ zng.Type) error {
+	if f.typ == nil {
+		f.typ = typ
+	}
+	if f.typ == typ {
+		return nil
+	}
+	return fmt.Errorf("type of %s field changed from %s to %s", f.field, f.typ, typ)
+}
+
+func (f *FieldCutter) Pull() (zbuf.Batch, error) {
+	for {
+		batch, err := f.parent.Pull()
+		if proc.EOS(batch, err) {
+			return nil, err
+		}
+		recs := make([]*zng.Record, 0, batch.Length())
+		for _, rec := range batch.Records() {
+			val, err := f.accessor.Eval(rec)
+			if err != nil || val.Bytes == nil {
+				continue
+			}
+			if err := f.checkType(val.Type); err != nil {
+				return nil, err
+			}
+			if f.builder == nil {
+				cols := []zng.Column{{f.out.Leaf(), val.Type}}
+				rectyp := f.pctx.TypeContext.MustLookupTypeRecord(cols)
+				f.builder = zng.NewBuilder(rectyp)
+			}
+			recs = append(recs, f.builder.Build(val.Bytes).Keep())
+		}
+		batch.Unref()
+		if len(recs) > 0 {
+			return zbuf.Array(recs), nil
+		}
+	}
+}
+
+func (f *FieldCutter) Done() {
+	f.parent.Done()
+}
+
+type fieldCutterNode struct {
+	field field.Static
+	out   field.Static
+}
+
+func (t *fieldCutterNode) ProcNode() {}
+
+// A TypeSplitter is a custom proc that, given an input record and a
+// zng type T, outputs one record for each field of the input record of
+// type T. It is used for type-based indexing.
+type TypeSplitter struct {
+	parent  proc.Interface
+	builder zng.Builder
+	typ     zng.Type
+}
+
+// NewTypeSplitter creates a TypeSplitter for type typ, where the
+// output records' single column is named colName.
+func NewTypeSplitter(pctx *proc.Context, parent proc.Interface, typ zng.Type, colName string) (proc.Interface, error) {
+	cols := []zng.Column{{colName, typ}}
+	rectyp := pctx.TypeContext.MustLookupTypeRecord(cols)
+	builder := zng.NewBuilder(rectyp)
+
+	return &TypeSplitter{
+		parent:  parent,
+		builder: *builder,
+		typ:     typ,
+	}, nil
+}
+
+func (t *TypeSplitter) Pull() (zbuf.Batch, error) {
+	for {
+		batch, err := t.parent.Pull()
+		if proc.EOS(batch, err) {
+			return nil, err
+		}
+		recs := make([]*zng.Record, 0, batch.Length())
+		for _, rec := range batch.Records() {
+			rec.Walk(func(typ zng.Type, body zcode.Bytes) error {
+				if typ == t.typ && body != nil {
+					recs = append(recs, t.builder.Build(body).Keep())
+					return zng.SkipContainer
+				}
+				return nil
+			})
+		}
+		batch.Unref()
+		if len(recs) > 0 {
+			return zbuf.Array(recs), nil
+		}
+	}
+}
+
+func (t *TypeSplitter) Done() {
+	t.parent.Done()
+}
+
+type typeSplitterNode struct {
+	key      field.Static
+	typeName string
+}
+
+func (t *typeSplitterNode) ProcNode() {}
+
+func compile(node ast.Proc, pctx *proc.Context, parent proc.Interface) (proc.Interface, error) {
+	switch v := node.(type) {
+	case *fieldCutterNode:
+		return NewFieldCutter(pctx, parent, v.field, v.out)
+	case *typeSplitterNode:
+		typ, err := pctx.TypeContext.LookupByName(v.typeName)
+		if err != nil {
+			return nil, err
+		}
+		return NewTypeSplitter(pctx, parent, typ, v.key.String())
+	}
+	return nil, nil
+}

--- a/ppl/archive/index/rule.go
+++ b/ppl/archive/index/rule.go
@@ -1,0 +1,190 @@
+package index
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/zio"
+	"github.com/brimsec/zq/zio/zngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zql"
+)
+
+type RuleKind string
+
+const (
+	RuleType  RuleKind = "type"
+	RuleField RuleKind = "field"
+	RuleZQL   RuleKind = "zql"
+)
+
+// Rule contains the runtime configuration for an indexing rule.
+type Rule struct {
+	Kind      RuleKind       `zng:"kind"`
+	Type      string         `zng:"type"`
+	Name      string         `zng:"name"`
+	Field     string         `zng:"field"`
+	Framesize int            `zng:"framesize"`
+	Input     string         `zng:"input_path"`
+	Keys      []field.Static `zng:"keys"`
+	ZQL       string         `zng:"zql"`
+}
+
+func NewRule(pattern string) (Rule, error) {
+	if pattern[0] == ':' {
+		typ, err := resolver.NewContext().LookupByName(pattern[1:])
+		if err != nil {
+			return Rule{}, err
+		}
+		return NewTypeRule(typ), nil
+	}
+	return NewFieldRule(pattern), nil
+}
+
+func NewTypeRule(typ zng.Type) Rule {
+	return Rule{
+		Kind: RuleType,
+		Type: typ.String(),
+	}
+}
+
+// NewFieldRule creates an indexing rule that will index the field passed in as argument.
+// It is currently an error to try to index a field name that appears as different types.
+func NewFieldRule(fieldName string) Rule {
+	return Rule{
+		Kind:  RuleField,
+		Field: fieldName,
+	}
+}
+
+func UnmarshalRule(b []byte) (Rule, error) {
+	zctx := resolver.NewContext()
+	zr := zngio.NewReader(bytes.NewReader(b), zctx)
+	rec, err := zr.Read()
+	if err != nil {
+		return Rule{}, err
+	}
+	r := Rule{}
+	return r, resolver.UnmarshalRecord(zctx, rec, &r)
+}
+
+func NewZqlRule(prog, name string, keys []field.Static) (Rule, error) {
+	// make sure it compiles
+	if _, err := zql.ParseProc(prog); err != nil {
+		return Rule{}, err
+	}
+	return Rule{
+		Kind: RuleZQL,
+		ZQL:  prog,
+		Name: name,
+		Keys: keys,
+	}, nil
+}
+
+// Equivalent determine if the provided Rule is equivalent to the receiver. It
+// should used to check if a Definition already contains and equivalent rule.
+func (r Rule) Equivalent(r2 Rule) bool {
+	if r.Kind != r2.Kind || r.Input != r2.Input {
+		return false
+	}
+	switch r.Kind {
+	case RuleType:
+		return r.Type == r2.Type
+	case RuleField:
+		return r.Field == r2.Field
+	case RuleZQL:
+		return r.Name == r2.Name && r.ZQL == r2.ZQL
+	default:
+		return false
+	}
+}
+
+func (r Rule) Proc() (ast.Proc, error) {
+	switch r.Kind {
+	case RuleType:
+		return r.typeProc()
+	case RuleField:
+		return r.fieldProc()
+	case RuleZQL:
+		return r.zqlProc()
+	default:
+		return nil, fmt.Errorf("unknown rule kind: %s", r.Kind)
+	}
+}
+
+var keyName = field.New("key")
+
+var keyAst = ast.Assignment{
+	LHS: ast.NewDotExpr(keyName),
+	RHS: ast.NewDotExpr(keyName),
+}
+var countAst = ast.NewReducerAssignment("count", nil, nil)
+
+// NewFieldRule creates an indexing rule that will index all fields of
+// the type passed in as argument.
+func (r Rule) typeProc() (ast.Proc, error) {
+	return &ast.SequentialProc{
+		Procs: []ast.Proc{
+			&typeSplitterNode{
+				key:      keyName,
+				typeName: r.Type,
+			},
+			&ast.GroupByProc{
+				Keys:     []ast.Assignment{keyAst},
+				Reducers: []ast.Assignment{countAst},
+			},
+			&ast.SortProc{Fields: []ast.Expression{ast.NewDotExpr(keyName)}},
+		},
+	}, nil
+}
+
+func (r Rule) fieldProc() (ast.Proc, error) {
+	return &ast.SequentialProc{
+		Procs: []ast.Proc{
+			&fieldCutterNode{
+				field: field.Dotted(r.Field),
+				out:   keyName,
+			},
+			&ast.GroupByProc{
+				Keys:     []ast.Assignment{keyAst},
+				Reducers: []ast.Assignment{countAst},
+			},
+			&ast.SortProc{Fields: []ast.Expression{ast.NewDotExpr(keyName)}},
+		},
+	}, nil
+}
+
+func (r Rule) zqlProc() (ast.Proc, error) {
+	return zql.ParseProc(r.ZQL)
+}
+
+func (r Rule) String() string {
+	var name string
+	switch r.Kind {
+	case RuleType:
+		name = r.Type
+	case RuleField:
+		name = r.Field
+	case RuleZQL:
+		name = r.Name
+	default:
+		return fmt.Sprintf("unknown type: %s", r.Kind)
+	}
+	return fmt.Sprintf("%s-%s", r.Kind, name)
+}
+
+func (r Rule) Marshal() ([]byte, error) {
+	rec, err := resolver.MarshalRecord(resolver.NewContext(), r)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	zw := zngio.NewWriter(zio.NopCloser(&buf), zngio.WriterOpts{})
+	if err := zw.Write(rec); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/ppl/archive/index/rule_test.go
+++ b/ppl/archive/index/rule_test.go
@@ -1,0 +1,33 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/zng"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func boomerang(t *testing.T, r1 Rule) Rule {
+	t.Helper()
+	b, err := r1.Marshal()
+	require.NoError(t, err)
+	r2, err := UnmarshalRule(b)
+	require.NoError(t, err)
+	return r2
+}
+
+func TestRuleTypeMarshal(t *testing.T) {
+	r1 := NewTypeRule(zng.TypeIP)
+	r2 := boomerang(t, r1)
+	assert.Equal(t, r1, r2)
+}
+
+func TestRuleZqlMarshal(t *testing.T) {
+	keys := []field.Static{field.Dotted("id.orig_h")}
+	r1, err := NewZqlRule("count() by id.orig_h", "id.orig_h.count", keys)
+	require.NoError(t, err)
+	r2 := boomerang(t, r1)
+	assert.Equal(t, r1, r2)
+}

--- a/ppl/archive/index/writer.go
+++ b/ppl/archive/index/writer.go
@@ -1,0 +1,173 @@
+package index
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/brimsec/zq/compiler"
+	"github.com/brimsec/zq/driver"
+	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/microindex"
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+func NewWriter(ctx context.Context, u iosrc.URI, def *Definition) (*Writer, error) {
+	rwCh := make(rwChan)
+	indexer, err := newIndexer(ctx, u, def, rwCh)
+	if err != nil {
+		return nil, err
+	}
+	w := &Writer{
+		URI:        u,
+		Definition: def,
+
+		done:    make(chan struct{}),
+		indexer: indexer,
+		rwCh:    rwCh,
+	}
+	return w, nil
+}
+
+type Writer struct {
+	Definition *Definition
+	URI        iosrc.URI
+
+	done    chan struct{}
+	indexer *indexer
+	once    sync.Once
+	rwCh    rwChan
+}
+
+type rwChan chan *zng.Record
+
+func (c rwChan) Read() (*zng.Record, error) {
+	return <-c, nil
+}
+
+func (w *Writer) Write(rec *zng.Record) error {
+	select {
+	case <-w.done:
+		if err := w.indexer.err.Load(); err != nil {
+			return err
+		}
+		return errors.New("index writer closed")
+	default:
+		w.once.Do(w.indexer.start)
+		w.rwCh <- rec
+		return nil
+	}
+}
+
+func (w *Writer) Close() error {
+	// If once has not be called, this means a write has never been called.
+	// Abort microindex so no file is written.
+	w.once.Do(func() {
+		w.indexer.microindex.Abort()
+	})
+	close(w.done)
+	close(w.rwCh)
+	return w.indexer.Wait()
+}
+
+func (w *Writer) Abort() {
+	w.Close()
+	w.indexer.microindex.Abort()
+}
+
+// onceError is an object that will only store an error once.
+type onceError struct {
+	sync.Mutex // guards following
+	err        error
+}
+
+func (a *onceError) Store(err error) {
+	a.Lock()
+	defer a.Unlock()
+	if a.err != nil {
+		return
+	}
+	a.err = err
+}
+func (a *onceError) Load() error {
+	a.Lock()
+	defer a.Unlock()
+	return a.err
+}
+
+type indexer struct {
+	err        onceError
+	cutter     *expr.Cutter
+	fgr        zbuf.ReadCloser
+	keyType    zng.Type
+	microindex *microindex.Writer
+	wg         sync.WaitGroup
+}
+
+func newIndexer(ctx context.Context, u iosrc.URI, def *Definition, r zbuf.Reader) (*indexer, error) {
+	zctx := resolver.NewContext()
+	conf := driver.Config{Custom: compile}
+	fgr, err := driver.NewReaderWithConfig(ctx, conf, def.Proc, zctx, r)
+	if err != nil {
+		return nil, err
+	}
+	keys := def.Keys
+	if len(keys) == 0 {
+		keys = []field.Static{keyName}
+	}
+	opts := []microindex.Option{microindex.KeyFields(keys...)}
+	if def.Framesize > 0 {
+		opts = append(opts, microindex.FrameThresh(def.Framesize))
+	}
+	writer, err := microindex.NewWriterWithContext(ctx, zctx, u.String(), opts...)
+	if err != nil {
+		return nil, err
+	}
+	fields, resolvers := compiler.CompileAssignments(keys, keys)
+	cutter, err := expr.NewCutter(zctx, fields, resolvers)
+	if err != nil {
+		return nil, err
+	}
+	d := &indexer{
+		fgr:        fgr,
+		cutter:     cutter,
+		microindex: writer,
+	}
+	return d, nil
+}
+
+func (d *indexer) start() {
+	d.wg.Add(1)
+	go func() {
+		if err := zbuf.Copy(d, d.fgr); err != nil {
+			d.microindex.Abort()
+			d.err.Store(err)
+		}
+		d.err.Store(d.microindex.Close())
+		d.wg.Done()
+	}()
+}
+
+func (d *indexer) Wait() error {
+	d.wg.Wait()
+	return d.err.Load()
+}
+
+func (d *indexer) Write(rec *zng.Record) error {
+	key, err := d.cutter.Apply(rec)
+	if err != nil {
+		return fmt.Errorf("checking index record: %w", err)
+	}
+	if d.keyType == nil {
+		d.keyType = key.Type
+	}
+	if key.Type.ID() != d.keyType.ID() {
+		return fmt.Errorf("key type changed from %s to %s", d.keyType, key.Type)
+	}
+	return d.microindex.Write(rec)
+}

--- a/ppl/archive/index/writer_test.go
+++ b/ppl/archive/index/writer_test.go
@@ -1,0 +1,65 @@
+package index
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/tzngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriter(t *testing.T) {
+	r := NewTypeRule(zng.TypeInt64)
+	w := testWriter(t, r)
+	err := zbuf.Copy(w, babbleReader(t))
+	require.NoError(t, err, "copy error")
+	require.NoError(t, w.Close())
+}
+
+func TestWriterWriteAfterClose(t *testing.T) {
+	r := NewTypeRule(zng.TypeInt64)
+	w := testWriter(t, r)
+	require.NoError(t, w.Close())
+	err := w.Write(nil)
+	assert.EqualError(t, err, "index writer closed")
+	err = w.Write(nil)
+	assert.EqualError(t, err, "index writer closed")
+}
+
+func TestWriterError(t *testing.T) {
+	const r1 = `
+#0:record[ts:time,id:string]
+0:[1;id1;]`
+	const r2 = `
+#0:record[ts:time,id:int64]
+0:[2;2;]`
+	w := testWriter(t, NewFieldRule("id"))
+	zctx := resolver.NewContext()
+	arr1, err := zbuf.ReadAll(tzngio.NewReader(strings.NewReader(r1), zctx))
+	require.NoError(t, err)
+	arr2, err := zbuf.ReadAll(tzngio.NewReader(strings.NewReader(r2), zctx))
+	require.NoError(t, err)
+	require.NoError(t, zbuf.Copy(w, arr1.NewReader()))
+	require.NoError(t, zbuf.Copy(w, arr2.NewReader()))
+
+	err = w.Close()
+	assert.EqualError(t, err, "type of id field changed from string to int64")
+
+	// if an on close, the writer should have removed the microindex
+	assert.NoFileExists(t, w.URI.Filepath())
+}
+
+func testWriter(t *testing.T, rule Rule) *Writer {
+	def, err := NewDefinition(rule)
+	require.NoError(t, err)
+	u := iosrc.MustParseURI(t.TempDir()).AppendPath("zng.idx")
+	w, err := NewWriter(context.Background(), u, def)
+	require.NoError(t, err)
+	return w
+}

--- a/zbuf/array.go
+++ b/zbuf/array.go
@@ -36,6 +36,11 @@ func (a *Array) Append(r *zng.Record) {
 	*a = append(*a, r)
 }
 
+func (a *Array) Write(r *zng.Record) error {
+	a.Append(r)
+	return nil
+}
+
 // Read returns removes the first element of the Array and returns it,
 // or it returns nil if the Array is empty.
 func (a *Array) Read() (*zng.Record, error) {

--- a/zbuf/zbuf.go
+++ b/zbuf/zbuf.go
@@ -101,3 +101,10 @@ func CloseReaders(readers []Reader) error {
 	}
 	return err
 }
+
+func ReadAll(r Reader) (arr Array, err error) {
+	if err := Copy(&arr, r); err != nil {
+		return nil, err
+	}
+	return
+}


### PR DESCRIPTION
The index package provides the foundation for building indexdef functionality
into archives. index.Defs are rules for creating indexes within a chunk's zar
dir. The pr includes functionality for creating an indexing Rule and Defintion,
then transforming these into microindices by applying the defs to a stream of zng
records.

Future prs will incorporate this package into the wider archive eco-system as
well as remove redundant existing funtionality from the archive package.

Part of #1656