### PR TITLE
eliminate zng.ErrUnset

### DIFF
--- a/expr/function/bytes.go
+++ b/expr/function/bytes.go
@@ -13,6 +13,9 @@ func (*fromBase64) Call(args []zng.Value) (zng.Value, error) {
 	if !zv.IsStringy() {
 		return badarg("from_base64")
 	}
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeBytes, nil}, nil
+	}
 	s, _ := zng.DecodeString(zv.Bytes)
 	b, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
@@ -27,6 +30,9 @@ func (*toBase64) Call(args []zng.Value) (zng.Value, error) {
 	zv := args[0]
 	if !zv.IsStringy() {
 		return badarg("from_base64")
+	}
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeString, nil}, nil
 	}
 	s := base64.StdEncoding.EncodeToString(zv.Bytes)
 	return zng.Value{zng.TypeString, zng.EncodeString(s)}, nil

--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -156,16 +156,19 @@ type lenFn struct {
 }
 
 func (l *lenFn) Call(args []zng.Value) (zng.Value, error) {
+	zv := args[0]
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeInt64, nil}, nil
+	}
 	switch zng.AliasedType(args[0].Type).(type) {
 	case *zng.TypeArray, *zng.TypeSet:
-		v := args[0]
-		len, err := v.ContainerLength()
+		len, err := zv.ContainerLength()
 		if err != nil {
 			return zng.Value{}, err
 		}
 		return zng.Value{zng.TypeInt64, l.Int(int64(len))}, nil
 	case *zng.TypeOfString, *zng.TypeOfBstring, *zng.TypeOfIP, *zng.TypeOfNet:
-		v := len(args[0].Bytes)
+		v := len(zv.Bytes)
 		return zng.Value{zng.TypeInt64, l.Int(int64(v))}, nil
 	default:
 		return badarg("len")
@@ -175,6 +178,7 @@ func (l *lenFn) Call(args []zng.Value) (zng.Value, error) {
 type typeOf struct{}
 
 func (t *typeOf) Call(args []zng.Value) (zng.Value, error) {
+	// XXX This needs to change to a ZSON type value format. See issue #1675.
 	return zng.Value{zng.TypeType, zng.EncodeType(args[0].Type.String())}, nil
 }
 

--- a/expr/function/string.go
+++ b/expr/function/string.go
@@ -19,6 +19,9 @@ func (s *stringFormatFloat) Call(args []zng.Value) (zng.Value, error) {
 	if zv.Type.ID() != zng.IdFloat64 {
 		return badarg("string.floatToString")
 	}
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeString, nil}, nil
+	}
 	f, _ := zng.DecodeFloat64(zv.Bytes)
 	// XXX GC
 	v := strconv.FormatFloat(f, 'g', -1, 64)
@@ -33,6 +36,9 @@ func (s *stringFormatInt) Call(args []zng.Value) (zng.Value, error) {
 	var out string
 	if !zng.IsInteger(id) {
 		return badarg("string.intToString")
+	}
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeString, nil}, nil
 	}
 	if zng.IsSigned(id) {
 		v, _ := zng.DecodeInt(zv.Bytes)
@@ -53,6 +59,9 @@ func (s *stringFormatIp) Call(args []zng.Value) (zng.Value, error) {
 	if zv.Type.ID() != zng.IdIP {
 		return badarg("string.ipToString")
 	}
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeString, nil}, nil
+	}
 	// XXX GC
 	ip, _ := zng.DecodeIP(zv.Bytes)
 	return zng.Value{zng.TypeString, zng.EncodeString(ip.String())}, nil
@@ -66,6 +75,9 @@ func (s *stringParseInt) Call(args []zng.Value) (zng.Value, error) {
 	zv := args[0]
 	if !zv.IsStringy() {
 		return badarg("String.parseInt")
+	}
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeInt64, nil}, nil
 	}
 	v, e := zng.DecodeString(zv.Bytes)
 	if e != nil {
@@ -90,6 +102,9 @@ func (s *stringParseFloat) Call(args []zng.Value) (zng.Value, error) {
 	if !zv.IsStringy() {
 		return badarg("String.parseFloat")
 	}
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeFloat64, nil}, nil
+	}
 	v, perr := zng.DecodeString(zv.Bytes)
 	if perr != nil {
 		return zng.Value{}, perr
@@ -111,6 +126,9 @@ func (s *stringParseIp) Call(args []zng.Value) (zng.Value, error) {
 	if !zv.IsStringy() {
 		return badarg("String.parseIp")
 	}
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeIP, nil}, nil
+	}
 	v, err := zng.DecodeString(zv.Bytes)
 	if err != nil {
 		return zng.Value{}, err
@@ -131,6 +149,12 @@ func (*replace) Call(args []zng.Value) (zng.Value, error) {
 	zvold := args[1]
 	zvnew := args[2]
 	if !zvs.IsStringy() || !zvold.IsStringy() || !zvnew.IsStringy() {
+		return badarg("replace")
+	}
+	if zvs.Bytes == nil {
+		return zvs, nil
+	}
+	if zvold.Bytes == nil || zvnew.Bytes == nil {
 		return badarg("replace")
 	}
 	s, err := zng.DecodeString(zvs.Bytes)
@@ -158,6 +182,9 @@ func (s *runeLen) Call(args []zng.Value) (zng.Value, error) {
 	if !zv.IsStringy() {
 		return badarg("rune_len")
 	}
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeInt64, s.Int(0)}, nil
+	}
 	in, err := zng.DecodeString(zv.Bytes)
 	if err != nil {
 		return zng.Value{}, err
@@ -172,6 +199,9 @@ func (*toLower) Call(args []zng.Value) (zng.Value, error) {
 	zv := args[0]
 	if !zv.IsStringy() {
 		return badarg("to_lower")
+	}
+	if zv.Bytes == nil {
+		return zv, nil
 	}
 	s, err := zng.DecodeString(zv.Bytes)
 	if err != nil {
@@ -189,6 +219,9 @@ func (*toUpper) Call(args []zng.Value) (zng.Value, error) {
 	if !zv.IsStringy() {
 		return badarg("to_upper")
 	}
+	if zv.Bytes == nil {
+		return zv, nil
+	}
 	s, err := zng.DecodeString(zv.Bytes)
 	if err != nil {
 		return zng.Value{}, err
@@ -204,6 +237,9 @@ func (*trim) Call(args []zng.Value) (zng.Value, error) {
 	zv := args[0]
 	if !zv.IsStringy() {
 		return badarg("trim")
+	}
+	if zv.Bytes == nil {
+		return zv, nil
 	}
 	// XXX GC
 	s := strings.TrimSpace(string(zv.Bytes))

--- a/expr/function/time.go
+++ b/expr/function/time.go
@@ -18,6 +18,9 @@ func (i *iso) Call(args []zng.Value) (zng.Value, error) {
 	if !zv.IsStringy() {
 		return badarg("iso")
 	}
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeTime, nil}, nil
+	}
 	ts, e := time.Parse(time.RFC3339Nano, string(zv.Bytes))
 	if e != nil {
 		return badarg("iso")
@@ -31,6 +34,9 @@ type sec struct {
 
 func (s *sec) Call(args []zng.Value) (zng.Value, error) {
 	zv := args[0]
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeInt64, nil}, nil
+	}
 	ns, ok := coerce.ToInt(zv)
 	if !ok {
 		sec, ok := coerce.ToFloat(zv)
@@ -50,6 +56,9 @@ type msec struct {
 
 func (m *msec) Call(args []zng.Value) (zng.Value, error) {
 	zv := args[0]
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeInt64, nil}, nil
+	}
 	ns, ok := coerce.ToInt(zv)
 	if !ok {
 		ms, ok := coerce.ToFloat(zv)
@@ -69,6 +78,9 @@ type usec struct {
 
 func (u *usec) Call(args []zng.Value) (zng.Value, error) {
 	zv := args[0]
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeInt64, nil}, nil
+	}
 	ns, ok := coerce.ToInt(zv)
 	if !ok {
 		us, ok := coerce.ToFloat(zv)
@@ -88,6 +100,9 @@ type trunc struct {
 
 func (t *trunc) Call(args []zng.Value) (zng.Value, error) {
 	zv := args[0]
+	if zv.Bytes == nil {
+		return zng.Value{zng.TypeTime, nil}, nil
+	}
 	ts, ok := coerce.ToTime(zv)
 	if !ok {
 		return badarg("trunc")

--- a/proc/groupby/groupby.go
+++ b/proc/groupby/groupby.go
@@ -349,7 +349,7 @@ func (a *Aggregator) Consume(r *zng.Record) error {
 	var prim *zng.Value
 	for i, key := range a.keyExprs {
 		zv, err := key.RHS.Eval(r)
-		if err != nil && !errors.Is(err, zng.ErrUnset) {
+		if err != nil {
 			return err
 		}
 		if i == 0 && a.inputSortDir != 0 {
@@ -400,7 +400,7 @@ func (a *Aggregator) spillTable(eof bool) error {
 	}
 	if !eof && a.inputSortDir != 0 {
 		v, err := a.keyExprs[0].RHS.Eval(recs[len(recs)-1])
-		if err != nil && !errors.Is(err, zng.ErrUnset) {
+		if err != nil {
 			return err
 		}
 		// pass volatile zng.Value since updateMaxSpillKey will make
@@ -459,7 +459,7 @@ func (a *Aggregator) readSpills(eof bool) (zbuf.Batch, error) {
 				break
 			}
 			keyVal, err := a.keyExprs[0].RHS.Eval(rec)
-			if err != nil && !errors.Is(err, zng.ErrUnset) {
+			if err != nil {
 				return nil, err
 			}
 			if a.valueCompare(keyVal, *a.maxSpillKey) >= 0 {

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -194,7 +194,7 @@ func (s suite) runSystem(t *testing.T) {
 		t.Run(d.Name, func(t *testing.T) {
 			results, err := d.Run()
 			require.NoError(t, err)
-			assert.Exactly(t, d.Expected, results, "Wrong query results")
+			assert.Exactly(t, d.Expected, results, "Wrong query results...\nQuery: %s\nInput: %s\n", d.Query, d.Input)
 		})
 	}
 }

--- a/zng/array.go
+++ b/zng/array.go
@@ -31,7 +31,7 @@ func (t *TypeArray) String() string {
 
 func (t *TypeArray) Decode(zv zcode.Bytes) ([]Value, error) {
 	if zv == nil {
-		return nil, ErrUnset
+		return nil, nil
 	}
 	return parseContainer(t, t.Type, zv)
 }

--- a/zng/bool.go
+++ b/zng/bool.go
@@ -28,7 +28,7 @@ func EncodeBool(b bool) zcode.Bytes {
 
 func DecodeBool(zv zcode.Bytes) (bool, error) {
 	if zv == nil {
-		return false, ErrUnset
+		return false, nil
 	}
 	if zv[0] != 0 {
 		return true, nil

--- a/zng/bytes.go
+++ b/zng/bytes.go
@@ -18,7 +18,7 @@ func EncodeBytes(b []byte) zcode.Bytes {
 
 func DecodeBytes(zv zcode.Bytes) ([]byte, error) {
 	if zv == nil {
-		return nil, ErrUnset
+		return nil, nil
 	}
 	return []byte(zv), nil
 }

--- a/zng/bytes.go
+++ b/zng/bytes.go
@@ -17,9 +17,6 @@ func EncodeBytes(b []byte) zcode.Bytes {
 }
 
 func DecodeBytes(zv zcode.Bytes) ([]byte, error) {
-	if zv == nil {
-		return nil, nil
-	}
 	return []byte(zv), nil
 }
 

--- a/zng/error.go
+++ b/zng/error.go
@@ -24,7 +24,7 @@ func EncodeError(err error) zcode.Bytes {
 
 func DecodeError(zv zcode.Bytes) (error, error) {
 	if zv == nil {
-		return nil, ErrUnset
+		return nil, nil
 	}
 	return errors.New(string(zv)), nil
 }

--- a/zng/int.go
+++ b/zng/int.go
@@ -41,14 +41,14 @@ func AppendUint(bytes zcode.Bytes, i uint64) zcode.Bytes {
 
 func DecodeInt(zv zcode.Bytes) (int64, error) {
 	if zv == nil {
-		return 0, ErrUnset
+		return 0, nil
 	}
 	return zcode.DecodeCountedVarint(zv), nil
 }
 
 func DecodeUint(zv zcode.Bytes) (uint64, error) {
 	if zv == nil {
-		return 0, ErrUnset
+		return 0, nil
 	}
 	return zcode.DecodeCountedUvarint(zv), nil
 }

--- a/zng/ip.go
+++ b/zng/ip.go
@@ -24,7 +24,7 @@ func EncodeIP(a net.IP) zcode.Bytes {
 
 func DecodeIP(zv zcode.Bytes) (net.IP, error) {
 	if zv == nil {
-		return nil, ErrUnset
+		return nil, nil
 	}
 	switch len(zv) {
 	case 4, 16:

--- a/zng/map.go
+++ b/zng/map.go
@@ -33,7 +33,7 @@ func (t *TypeMap) String() string {
 
 func (t *TypeMap) Decode(zv zcode.Bytes) (Value, Value, error) {
 	if zv == nil {
-		return Value{}, Value{}, ErrUnset
+		return Value{}, Value{}, nil
 	}
 	it := zv.Iter()
 	key, container, err := it.Next()

--- a/zng/net.go
+++ b/zng/net.go
@@ -32,7 +32,7 @@ func EncodeNet(subnet *net.IPNet) zcode.Bytes {
 
 func DecodeNet(zv zcode.Bytes) (*net.IPNet, error) {
 	if zv == nil {
-		return nil, ErrUnset
+		return nil, nil
 	}
 	switch len(zv) {
 	case 8:

--- a/zng/record.go
+++ b/zng/record.go
@@ -44,7 +44,7 @@ func (t *TypeRecord) String() string {
 //XXX we shouldn't need this... tests are using it
 func (t *TypeRecord) Decode(zv zcode.Bytes) ([]Value, error) {
 	if zv == nil {
-		return nil, ErrUnset
+		return nil, nil
 	}
 	var vals []Value
 	for i, it := 0, zv.Iter(); !it.Done(); i++ {

--- a/zng/set.go
+++ b/zng/set.go
@@ -33,7 +33,7 @@ func (t *TypeSet) String() string {
 
 func (t *TypeSet) Decode(zv zcode.Bytes) ([]Value, error) {
 	if zv == nil {
-		return nil, ErrUnset
+		return nil, nil
 	}
 	return parseContainer(t, t.Type, zv)
 }

--- a/zng/string.go
+++ b/zng/string.go
@@ -22,9 +22,6 @@ func EncodeString(s string) zcode.Bytes {
 }
 
 func DecodeString(zv zcode.Bytes) (string, error) {
-	if zv == nil {
-		return "", nil
-	}
 	return string(zv), nil
 }
 

--- a/zng/string.go
+++ b/zng/string.go
@@ -23,7 +23,7 @@ func EncodeString(s string) zcode.Bytes {
 
 func DecodeString(zv zcode.Bytes) (string, error) {
 	if zv == nil {
-		return "", ErrUnset
+		return "", nil
 	}
 	return string(zv), nil
 }

--- a/zng/time.go
+++ b/zng/time.go
@@ -25,7 +25,7 @@ func AppendTime(bytes zcode.Bytes, t nano.Ts) zcode.Bytes {
 
 func DecodeTime(zv zcode.Bytes) (nano.Ts, error) {
 	if zv == nil {
-		return 0, ErrUnset
+		return 0, nil
 	}
 	return nano.Ts(zcode.DecodeCountedVarint(zv)), nil
 }

--- a/zng/type.go
+++ b/zng/type.go
@@ -17,7 +17,6 @@ import (
 )
 
 var (
-	ErrUnset      = errors.New("value is unset")
 	ErrLenUnset   = errors.New("len(unset) is undefined")
 	ErrNotArray   = errors.New("cannot index a non-array")
 	ErrIndex      = errors.New("array index out of bounds")

--- a/zng/typetype.go
+++ b/zng/typetype.go
@@ -16,7 +16,7 @@ func EncodeType(s string) zcode.Bytes {
 
 func DecodeType(zv zcode.Bytes) (string, error) {
 	if zv == nil {
-		return "", ErrUnset
+		return "", nil
 	}
 	return string(zv), nil
 }

--- a/zng/typetype.go
+++ b/zng/typetype.go
@@ -16,7 +16,7 @@ func EncodeType(s string) zcode.Bytes {
 
 func DecodeType(zv zcode.Bytes) (string, error) {
 	if zv == nil {
-		return "", nil
+		return "null", nil
 	}
 	return string(zv), nil
 }


### PR DESCRIPTION
Now that the zson spec more clearly defines the null concept,
zng.ErrUnset is no longer needed and is otherwise causing problems
with  the new groupby model to handle dynamic types.

This commit removes zng.ErrUnset and has each zng.Decode*()
function return the zero value of the type it decodes to.
If a callee of zng.Decode*() wants to treat null differently
from the zero value, then it should check for zv.Bytes==nil
before calling zng.Decode*().  This means that ErrUnset is no
longer bubbled up as an error condition, e.g., to groupby,
and further, that we should decide what each functions should
do with null (the reducers already handle nulls).  For example,
len(null) returns int64(0) but replace("foo", null, null) is
an error.  I made a first pass over the expr/function in this
regard, but we should decide and document it all. See #1737.