### PR TITLE
fix bug in groupby output for dynamic types

### DIFF
--- a/proc/groupby/groupby.go
+++ b/proc/groupby/groupby.go
@@ -46,14 +46,11 @@ type Proc struct {
 // deterministic but undefined total order.
 type Aggregator struct {
 	zctx *resolver.Context
-	// typeTable maps a set of key types resulting from evaluating
-	// the key expressions to a small int such that the same vector
-	// of types maps to the same small int.  Then int can then be
-	// used as a unique id for the vector of key types.
-	// XXX likewise it is used to map the entire output vector of types
-	// to a small int in the same space.  XXX We could separate the
-	// key table and the output table and exploit locality to presume
-	// that the types are usually uniform.
+	// The keyTypes and outTypes tables maps a vector of types resulting
+	// from evaluating the key and reducer expressions to a small int,
+	// such that the same vector of types maps to the same small int.
+	// The int is used in each row to track the type of the keys and used
+	// at the output to track the combined type of the keys and aggregations.
 	keyTypes     *typevector.Table
 	outTypes     *typevector.Table
 	block        map[int]struct{}

--- a/proc/groupby/ztests/mixed-output-types.yaml
+++ b/proc/groupby/ztests/mixed-output-types.yaml
@@ -1,0 +1,12 @@
+zql: 'by x=network_of(addr) | sort .'
+
+input: |
+  #0:record[addr:ip]
+  0:[10.0.0.1;]
+  0:[fe80::215:17ff:fe84:c13f;]
+
+output: |
+  #0:record[x:error]
+  0:[not an IPv4;]
+  #1:record[x:net]
+  1:[10.0.0.0/8;]

--- a/proc/groupby/ztests/nested-agg-name.yaml
+++ b/proc/groupby/ztests/nested-agg-name.yaml
@@ -1,0 +1,15 @@
+zql: "result.count=count() by result.animal=animal | sort ."
+
+input: |
+  #0:record[animal:string,s:string,x:int32]
+  0:[cat;a;1;]
+  0:[dog;b;1;]
+  0:[cat;a;1;]
+  0:[elephant;a;1;]
+  0:[cat;b;1;]
+
+output: |
+  #0:record[result:record[animal:string,count:uint64]]
+  0:[[cat;3;]]
+  0:[[dog;1;]]
+  0:[[elephant;1;]]

--- a/zng/typevector/type.go
+++ b/zng/typevector/type.go
@@ -1,0 +1,81 @@
+package typevector
+
+import (
+	"github.com/brimsec/zq/zng"
+)
+
+type Type []zng.Type
+
+func New(in []zng.Type) Type {
+	out := make(Type, 0, len(in))
+	for _, t := range in {
+		out = append(out, t)
+	}
+	return out
+}
+
+func NewFromValues(vals []zng.Value) Type {
+	out := make(Type, 0, len(vals))
+	for _, zv := range vals {
+		out = append(out, zv.Type)
+	}
+	return out
+}
+
+func (t Type) Equal(to []zng.Type) bool {
+	if len(t) != len(to) {
+		return false
+	}
+	for k, typ := range t {
+		if typ != to[k] {
+			return false
+		}
+	}
+	return true
+}
+
+func (t Type) EqualToValues(vals []zng.Value) bool {
+	if len(t) != len(vals) {
+		return false
+	}
+	for k, typ := range t {
+		if typ != vals[k].Type {
+			return false
+		}
+	}
+	return true
+}
+
+type Table struct {
+	types []Type
+}
+
+func NewTable() *Table {
+	return &Table{}
+}
+
+func (t *Table) Lookup(types []zng.Type) int {
+	for k, typ := range t.types {
+		if typ.Equal(types) {
+			return k
+		}
+	}
+	k := len(t.types)
+	t.types = append(t.types, New(types))
+	return k
+}
+
+func (t *Table) LookupByValues(vals []zng.Value) int {
+	for k, typ := range t.types {
+		if typ.EqualToValues(vals) {
+			return k
+		}
+	}
+	k := len(t.types)
+	t.types = append(t.types, NewFromValues(vals))
+	return k
+}
+
+func (t *Table) Types(id int) []zng.Type {
+	return t.types[id]
+}

--- a/ztests/suite/reducer/duplicate.yaml
+++ b/ztests/suite/reducer/duplicate.yaml
@@ -5,4 +5,4 @@ input: |
   0:[1;]
   0:[2;]
 
-errorRE: duplicate field count
+errorRE: field count is repeated


### PR DESCRIPTION
This commit fixes a bug where output types can change based on
input values so the assumption that input type ID determines the
output type record was invalid.  The fix is to map the vector
of types that comprise the output type to a unique small integer
and use the integer to index a map that provides the zng.TypeRecord
from the given type vector.  Since output types are typically one
maybe two distinct type values, the overhead of the linear-scan
lookup should be small.  Since key types can also change (this
was previously handled), we use the same type vector method
in the key values to simplify the code.

Fixes #1701.