### PR TITLE
add skip flag to ztest

### DIFF
--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -174,6 +174,9 @@ func Run(t *testing.T, dirname string) {
 			if err != nil {
 				t.Fatalf("%s: %s", filename, err)
 			}
+			if zt.Skip {
+				t.Skip("test is disabled")
+			}
 			zt.Run(t, testname, path, dirname, filename)
 		})
 	}
@@ -244,6 +247,7 @@ func (f *File) load(dir string) ([]byte, *regexp.Regexp, error) {
 // ZTest defines a ztest.
 type ZTest struct {
 	ZQL         string `yaml:"zql,omitempty"`
+	Skip        bool   `yaml:"skip,omitempty"`
 	Input       Inputs `yaml:"input,omitempty"`
 	Output      string `yaml:"output,omitempty"`
 	OutputHex   string `yaml:"outputHex,omitempty"`


### PR DESCRIPTION
This commit adds a yaml flag to ztest (skip: true) to tell ztest
to skip a particular test.  This is useful for test-driven dev or
when changes break tests and you want to disable certain tests
while you get them working again one at a time.