### PR TITLE
Fix microindex trailer read bug

### DIFF
--- a/microindex/trailer.go
+++ b/microindex/trailer.go
@@ -87,14 +87,8 @@ func readTrailer(r io.ReadSeeker, n int64) (*Trailer, int, error) {
 		return nil, 0, err
 	}
 	buf := make([]byte, n)
-	cc, err := io.ReadFull(r, buf)
-	if err != nil {
+	if _, err := io.ReadFull(r, buf); err != nil {
 		return nil, 0, err
-	}
-	if int64(cc) != n {
-		// this shouldn't happen but maybe could occur under a corner case
-		// or I/O problems XXX
-		return nil, 0, fmt.Errorf("couldn't read trailer: expected %d bytes but read %d", n, cc)
 	}
 	for off := int(n) - 3; off >= 0; off-- {
 		// look for end of stream followed by an array[int64] typedef then

--- a/microindex/trailer.go
+++ b/microindex/trailer.go
@@ -87,7 +87,7 @@ func readTrailer(r io.ReadSeeker, n int64) (*Trailer, int, error) {
 		return nil, 0, err
 	}
 	buf := make([]byte, n)
-	cc, err := r.Read(buf)
+	cc, err := io.ReadFull(r, buf)
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
The read trailer part of microindex was relying on the call to the
io.Reader.Read to fill the entire buffer. For the aws sdk this often do not
happen.

According to the golang io.Reader.Read documentation:

If some data is available but not len(p) bytes, Read conventionally returns
what is available instead of waiting for more.

Use io.ReadFull to ensure the entire trailer is read.

Closes #1730