### PR TITLE
Add default import stale duration

### DIFF
--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -26,13 +26,12 @@ var (
 	// before they are flushed to disk.
 	ImportBufSize          = int64(sort.MemMaxBytes)
 	ImportStreamRecordsMax = zngio.DefaultStreamRecordsMax
+
+	// For unit testing.
+	importLZ4BlockSize = zngio.DefaultLZ4BlockSize
 )
 
-// For unit testing.
-var (
-	importLZ4BlockSize         = zngio.DefaultLZ4BlockSize
-	importDefaultStaleDuration = time.Second * 5
-)
+const importDefaultStaleDuration = time.Second * 5
 
 func Import(ctx context.Context, ark *Archive, zctx *resolver.Context, r zbuf.Reader) error {
 	w := NewWriter(ctx, ark)

--- a/ppl/archive/import.go
+++ b/ppl/archive/import.go
@@ -29,7 +29,10 @@ var (
 )
 
 // For unit testing.
-var importLZ4BlockSize = zngio.DefaultLZ4BlockSize
+var (
+	importLZ4BlockSize         = zngio.DefaultLZ4BlockSize
+	importDefaultStaleDuration = time.Second * 5
+)
 
 func Import(ctx context.Context, ark *Archive, zctx *resolver.Context, r zbuf.Reader) error {
 	w := NewWriter(ctx, ark)
@@ -68,11 +71,12 @@ func NewWriter(ctx context.Context, ark *Archive) *Writer {
 	ctx, cancel := context.WithCancel(ctx)
 	g, ctx := errgroup.WithContext(ctx)
 	return &Writer{
-		ark:      ark,
-		cancel:   cancel,
-		ctx:      ctx,
-		errgroup: g,
-		writers:  make(map[tsDir]*tsDirWriter),
+		ark:           ark,
+		cancel:        cancel,
+		ctx:           ctx,
+		errgroup:      g,
+		staleDuration: importDefaultStaleDuration,
+		writers:       make(map[tsDir]*tsDirWriter),
 	}
 }
 


### PR DESCRIPTION
Currently if StaleDuration for an archive import was not getting set (as is the
case for the zar command and zqd post to archive store), the StaleDuration
would stay at 0. A StaleDuration of 0 means that pretty much all the data in
the archive would get flushed every 1 second (the interval at which the flusher
checks for new data to flush).

Set a default staleDuration to a more appropriate 5 seconds for an archive
Writer.