### PR TITLE
move all ast references out of the procs and into the compiler package

### DIFF
--- a/compiler/groupby.go
+++ b/compiler/groupby.go
@@ -14,7 +14,7 @@ import (
 )
 
 func compileGroupBy(pctx *proc.Context, parent proc.Interface, node *ast.GroupByProc) (*groupby.Proc, error) {
-	keys, err := compileKeys(node.Keys, pctx.TypeContext)
+	keys, err := compileAssignments(node.Keys, pctx.TypeContext)
 	if err != nil {
 		return nil, err
 	}
@@ -23,18 +23,6 @@ func compileGroupBy(pctx *proc.Context, parent proc.Interface, node *ast.GroupBy
 		return nil, err
 	}
 	return groupby.New(pctx, parent, keys, names, reducers, node.Limit, node.InputSortDir, node.ConsumePart, node.EmitPart)
-}
-
-func compileKeys(assignments []ast.Assignment, zctx *resolver.Context) ([]expr.Assignment, error) {
-	keys := make([]expr.Assignment, 0, len(assignments))
-	for _, assignment := range assignments {
-		a, err := expr.CompileAssignment(zctx, &assignment)
-		if err != nil {
-			return nil, err
-		}
-		keys = append(keys, a)
-	}
-	return keys, nil
 }
 
 func compileReducers(assignments []ast.Assignment, zctx *resolver.Context) ([]field.Static, []reducer.Maker, error) {

--- a/proc/cut/cut.go
+++ b/proc/cut/cut.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/proc"
@@ -21,19 +20,9 @@ type Proc struct {
 	cutter     *expr.Cutter
 }
 
-func New(pctx *proc.Context, parent proc.Interface, node *ast.CutProc) (*Proc, error) {
-	lhs := make([]field.Static, 0, len(node.Fields))
-	rhs := make([]expr.Evaluator, 0, len(node.Fields))
-	for _, f := range node.Fields {
-		c, err := expr.CompileAssignment(pctx.TypeContext, &f)
-		if err != nil {
-			return nil, err
-		}
-		lhs = append(lhs, c.LHS)
-		rhs = append(rhs, c.RHS)
-	}
+func New(pctx *proc.Context, parent proc.Interface, lhs []field.Static, rhs []expr.Evaluator, complement bool) (*Proc, error) {
 	// build this once at compile time for error checking.
-	if !node.Complement {
+	if !complement {
 		_, err := builder.NewColumnBuilder(pctx.TypeContext, lhs)
 		if err != nil {
 			return nil, fmt.Errorf("compiling cut: %w", err)
@@ -43,9 +32,9 @@ func New(pctx *proc.Context, parent proc.Interface, node *ast.CutProc) (*Proc, e
 	return &Proc{
 		pctx:       pctx,
 		parent:     parent,
-		complement: node.Complement,
+		complement: complement,
 		resolvers:  rhs,
-		cutter:     expr.NewCutter(pctx.TypeContext, node.Complement, lhs, rhs),
+		cutter:     expr.NewCutter(pctx.TypeContext, complement, lhs, rhs),
 	}, nil
 }
 

--- a/proc/put/put.go
+++ b/proc/put/put.go
@@ -1,9 +1,6 @@
 package put
 
 import (
-	"fmt"
-
-	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/zbuf"
@@ -52,24 +49,12 @@ type clauseType struct {
 	container bool
 }
 
-func New(pctx *proc.Context, parent proc.Interface, node *ast.PutProc) (proc.Interface, error) {
-	clauses := make([]expr.Assignment, 0, len(node.Clauses))
-	for _, cl := range node.Clauses {
-		c, err := expr.CompileAssignment(pctx.TypeContext, &cl)
-		if err != nil {
-			return nil, err
-		}
-		if len(c.LHS) > 1 {
-			name := c.LHS.String()
-			return nil, fmt.Errorf("%s: put currently supports only top-level field assignemnts", name)
-		}
-		clauses = append(clauses, c)
-	}
+func New(pctx *proc.Context, parent proc.Interface, clauses []expr.Assignment) (proc.Interface, error) {
 	return &Proc{
 		pctx:    pctx,
 		parent:  parent,
 		clauses: clauses,
-		vals:    make([]zng.Value, len(node.Clauses)),
+		vals:    make([]zng.Value, len(clauses)),
 		rules:   make(map[int]*putRule),
 		warned:  make(map[string]struct{}),
 	}, nil

--- a/proc/sort/sort.go
+++ b/proc/sort/sort.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/proc"
@@ -22,7 +21,6 @@ type Proc struct {
 	parent     proc.Interface
 	dir        int
 	nullsFirst bool
-	fields     []ast.Expression
 
 	fieldResolvers     []expr.Evaluator
 	once               sync.Once
@@ -31,17 +29,12 @@ type Proc struct {
 	unseenFieldTracker *unseenFieldTracker
 }
 
-func New(pctx *proc.Context, parent proc.Interface, node *ast.SortProc) (*Proc, error) {
-	fields, err := expr.CompileExprs(pctx.TypeContext, node.Fields)
-	if err != nil {
-		return nil, err
-	}
+func New(pctx *proc.Context, parent proc.Interface, fields []expr.Evaluator, sortDir int, nullsFirst bool) (*Proc, error) {
 	return &Proc{
 		pctx:               pctx,
 		parent:             parent,
-		dir:                node.SortDir,
-		nullsFirst:         node.NullsFirst,
-		fields:             node.Fields,
+		dir:                sortDir,
+		nullsFirst:         nullsFirst,
 		fieldResolvers:     fields,
 		resultCh:           make(chan proc.Result),
 		unseenFieldTracker: newUnseenFieldTracker(fields),


### PR DESCRIPTION
This commit removes all remaining vestiges of "compilation" patterns
that operate on AST data structures out of the various proc packages
and into the compiler package.  This is step two of the compiler
refactoring issue #1162.