### PR TITLE
finish refactoring compiler

### DIFF
--- a/compiler/bufferfilter.go
+++ b/compiler/bufferfilter.go
@@ -8,12 +8,12 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
-// NewBufferFilter tries to return a BufferFilter for e such that the
+// compileBufferFilter tries to return a BufferFilter for e such that the
 // BufferFilter's Eval method returns true for any byte slice containing the ZNG
 // encoding of a record matching e. (It may also return true for some byte
 // slices that do not match.) NewBufferFilter returns a nil pointer and nil
 // error if it cannot construct a useful filter.
-func CompileBufferFilter(e ast.BooleanExpr) (*filter.BufferFilter, error) {
+func compileBufferFilter(e ast.BooleanExpr) (*filter.BufferFilter, error) {
 	switch e := e.(type) {
 	case *ast.CompareAny:
 		if e.Comparator != "=" && e.Comparator != "in" {
@@ -28,11 +28,11 @@ func CompileBufferFilter(e ast.BooleanExpr) (*filter.BufferFilter, error) {
 	case *ast.BinaryExpression:
 		return nil, nil
 	case *ast.LogicalAnd:
-		left, err := CompileBufferFilter(e.Left)
+		left, err := compileBufferFilter(e.Left)
 		if err != nil {
 			return nil, err
 		}
-		right, err := CompileBufferFilter(e.Right)
+		right, err := compileBufferFilter(e.Right)
 		if err != nil {
 			return nil, err
 		}
@@ -44,11 +44,11 @@ func CompileBufferFilter(e ast.BooleanExpr) (*filter.BufferFilter, error) {
 		}
 		return filter.NewAndBufferFilter(left, right), nil
 	case *ast.LogicalOr:
-		left, err := CompileBufferFilter(e.Left)
+		left, err := compileBufferFilter(e.Left)
 		if err != nil {
 			return nil, err
 		}
-		right, err := CompileBufferFilter(e.Right)
+		right, err := compileBufferFilter(e.Right)
 		if left == nil || right == nil || err != nil {
 			return nil, err
 		}

--- a/compiler/bufferfilter.go
+++ b/compiler/bufferfilter.go
@@ -11,7 +11,7 @@ import (
 // compileBufferFilter tries to return a BufferFilter for e such that the
 // BufferFilter's Eval method returns true for any byte slice containing the ZNG
 // encoding of a record matching e. (It may also return true for some byte
-// slices that do not match.) NewBufferFilter returns a nil pointer and nil
+// slices that do not match.) compileBufferFilter returns a nil pointer and nil
 // error if it cannot construct a useful filter.
 func compileBufferFilter(e ast.BooleanExpr) (*filter.BufferFilter, error) {
 	switch e := e.(type) {

--- a/compiler/bufferfilter.go
+++ b/compiler/bufferfilter.go
@@ -1,0 +1,108 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/filter"
+	"github.com/brimsec/zq/zng"
+)
+
+// NewBufferFilter tries to return a BufferFilter for e such that the
+// BufferFilter's Eval method returns true for any byte slice containing the ZNG
+// encoding of a record matching e. (It may also return true for some byte
+// slices that do not match.) NewBufferFilter returns a nil pointer and nil
+// error if it cannot construct a useful filter.
+func CompileBufferFilter(e ast.BooleanExpr) (*filter.BufferFilter, error) {
+	switch e := e.(type) {
+	case *ast.CompareAny:
+		if e.Comparator != "=" && e.Comparator != "in" {
+			return nil, nil
+		}
+		return newBufferFilterForLiteral(e.Value)
+	case *ast.CompareField:
+		if e.Comparator != "=" && e.Comparator != "in" {
+			return nil, nil
+		}
+		return newBufferFilterForLiteral(e.Value)
+	case *ast.BinaryExpression:
+		return nil, nil
+	case *ast.LogicalAnd:
+		left, err := CompileBufferFilter(e.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := CompileBufferFilter(e.Right)
+		if err != nil {
+			return nil, err
+		}
+		if left == nil {
+			return right, nil
+		}
+		if right == nil {
+			return left, nil
+		}
+		return filter.NewAndBufferFilter(left, right), nil
+	case *ast.LogicalOr:
+		left, err := CompileBufferFilter(e.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := CompileBufferFilter(e.Right)
+		if left == nil || right == nil || err != nil {
+			return nil, err
+		}
+		return filter.NewOrBufferFilter(left, right), nil
+	case *ast.LogicalNot, *ast.MatchAll:
+		return nil, nil
+	case *ast.Search:
+		if e.Value.Type == "net" || e.Value.Type == "regexp" {
+			return nil, nil
+		}
+		if e.Value.Type == "string" {
+			pattern, err := zng.TypeBstring.Parse([]byte(e.Value.Value))
+			if err != nil {
+				return nil, err
+			}
+			left := filter.NewBufferFilterForStringCase(string(pattern))
+			if left == nil {
+				return nil, nil
+			}
+			right := filter.NewFieldNameFinder(string(pattern))
+			return filter.NewOrBufferFilter(left, right), nil
+		}
+		left := filter.NewBufferFilterForStringCase(e.Text)
+		right, err := newBufferFilterForLiteral(e.Value)
+		if left == nil || right == nil || err != nil {
+			return nil, err
+		}
+		return filter.NewOrBufferFilter(left, right), nil
+	default:
+		return nil, fmt.Errorf("filter AST unknown type: %T", e)
+	}
+}
+
+func newBufferFilterForLiteral(l ast.Literal) (*filter.BufferFilter, error) {
+	switch l.Type {
+	case "bool", "byte", "int16", "uint16", "int32", "uint32", "int64", "uint64", "float64", "time", "duration":
+		// These are all comparable, so they can require up to three
+		// patterns: float, varint, and uvarint.
+		return nil, nil
+	case "null":
+		return nil, nil
+	case "regexp":
+		// Could try to extract a pattern (e.g., "efg" from "(ab|cd)(efg)+[hi]").
+		return nil, nil
+	case "string":
+		// Match the behavior of zng.ParseLiteral.
+		l.Type = "bstring"
+	}
+	v, err := zng.Parse(l)
+	if err != nil {
+		return nil, err
+	}
+	// We're looking for a complete ZNG value, so we can lengthen the
+	// pattern by calling Encode to add a tag.
+	pattern := string(v.Encode(nil))
+	return filter.NewBufferFilterForString(pattern), nil
+}

--- a/compiler/expr.go
+++ b/compiler/expr.go
@@ -1,0 +1,298 @@
+package compiler
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/expr/function"
+	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zql"
+)
+
+// CompileExpr compiles the given Expression into an object
+// that evaluates the expression against a provided Record.  It returns an
+// error if compilation fails for any reason.
+//
+// This is the "intepreted slow path" of the analytics engine.  Because it
+// handles dynamic typinig at runtime, overheads are incurrend due to
+// various type checks and coercions that determine different computational
+// outcomes based on type.  There is nothing here that optimizes analytics
+// for native machine types; these optimizations (will) happen in the pushdown
+// predicate processing engine in the zst columnar scanner.
+//
+// Eventually, we will optimize this zst "fast path" by dynamically
+// generating byte codes (which an in turn be JIT assembled into machine code)
+// for each zng TypeRecord encountered.  Once you know the type record,
+// you can generate code using strong typing just as an OLAP system does
+// due to its schemas defined up-front in its relational tables.  Here,
+// each record type is like a schema and as we encounter them, we can compile
+// optimized code for the now-static types within that record type.
+//
+// The Evaluator return by CompilExpr produces zng.Values that are stored
+// in temporary buffers and may be modified on subsequent calls to Eval.
+// This is intended to minimize the garbage collection needs of the inner loop
+// by not allocating memory on a per-Eval basis.  For uses like filtering and
+// aggregations, where the results are immediately use, this is desirable and
+// efficient but for use cases like storing the results as groupby keys, the
+// resulting zng.Value should be copied (e.g., via zng.Value.Copy()).
+//
+// TBD: string values and net.IP address do not need to be copied because they
+// are allocated by go libraries and temporary buffers are not used.  This will
+// change down the road when we implement no-allocation string and IP conversion.
+func CompileExpr(zctx *resolver.Context, node ast.Expression) (expr.Evaluator, error) {
+	switch n := node.(type) {
+	case *ast.Literal:
+		return expr.NewLiteral(*n)
+	case *ast.Identifier:
+		return nil, fmt.Errorf("stray identifier in AST: %s", n.Name)
+	case *ast.RootRecord:
+		return &expr.RootRecord{}, nil
+	case *ast.UnaryExpression:
+		return compileUnary(zctx, *n)
+
+	case *ast.BinaryExpression:
+		if n.Operator == "." {
+			return compileDotExpr(zctx, n.LHS, n.RHS)
+		}
+		lhs, err := CompileExpr(zctx, n.LHS)
+		if err != nil {
+			return nil, err
+		}
+		rhs, err := CompileExpr(zctx, n.RHS)
+		if err != nil {
+			return nil, err
+		}
+		switch n.Operator {
+		case "AND", "OR":
+			return compileLogical(lhs, rhs, n.Operator)
+		case "in":
+			return expr.NewIn(lhs, rhs), nil
+		case "=", "!=":
+			return expr.NewCompareEquality(lhs, rhs, n.Operator)
+		case "=~", "!~":
+			return expr.NewPatternMatch(lhs, rhs, n.Operator)
+		case "<", "<=", ">", ">=":
+			return expr.NewCompareRelative(lhs, rhs, n.Operator)
+		case "+", "-", "*", "/":
+			return expr.NewArithmetic(lhs, rhs, n.Operator)
+		case "[":
+			return expr.NewIndexExpr(zctx, lhs, rhs)
+		default:
+			return nil, fmt.Errorf("invalid binary operator %s", n.Operator)
+		}
+
+	case *ast.ConditionalExpression:
+		return compileConditional(zctx, *n)
+
+	case *ast.FunctionCall:
+		return compileCall(zctx, *n)
+
+	case *ast.CastExpression:
+		return compileCast(zctx, *n)
+
+	default:
+		return nil, fmt.Errorf("invalid expression type %T", node)
+	}
+}
+
+func CompileExprs(zctx *resolver.Context, nodes []ast.Expression) ([]expr.Evaluator, error) {
+	var exprs []expr.Evaluator
+	for k := range nodes {
+		e, err := CompileExpr(zctx, nodes[k])
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, e)
+	}
+	return exprs, nil
+}
+
+func compileExpr(s string) (expr.Evaluator, error) {
+	parsed, err := zql.ParseExpression(s)
+	if err != nil {
+		return nil, err
+	}
+
+	node, ok := parsed.(ast.Expression)
+	if !ok {
+		return nil, errors.New("expected Expression")
+	}
+
+	return CompileExpr(resolver.NewContext(), node)
+}
+
+func compileUnary(zctx *resolver.Context, node ast.UnaryExpression) (expr.Evaluator, error) {
+	if node.Operator != "!" {
+		return nil, fmt.Errorf("unknown unary operator %s\n", node.Operator)
+	}
+	e, err := CompileExpr(zctx, node.Operand)
+	if err != nil {
+		return nil, err
+	}
+	return expr.NewLogicalNot(e), nil
+}
+
+func compileLogical(lhs, rhs expr.Evaluator, operator string) (expr.Evaluator, error) {
+	switch operator {
+	case "AND":
+		return expr.NewLogicalAnd(lhs, rhs), nil
+	case "OR":
+		return expr.NewLogicalOr(lhs, rhs), nil
+	default:
+		return nil, fmt.Errorf("unknown logical operator: %s", operator)
+	}
+}
+
+func compileConditional(zctx *resolver.Context, node ast.ConditionalExpression) (expr.Evaluator, error) {
+	var err error
+	predicate, err := CompileExpr(zctx, node.Condition)
+	if err != nil {
+		return nil, err
+	}
+	thenExpr, err := CompileExpr(zctx, node.Then)
+	if err != nil {
+		return nil, err
+	}
+	elseExpr, err := CompileExpr(zctx, node.Else)
+	if err != nil {
+		return nil, err
+	}
+	return expr.NewConditional(predicate, thenExpr, elseExpr), nil
+}
+
+func compileDotExpr(zctx *resolver.Context, lhs, rhs ast.Expression) (expr.Evaluator, error) {
+	id, ok := rhs.(*ast.Identifier)
+	if !ok {
+		return nil, errors.New("rhs of dot expression is not an identifier")
+	}
+	record, err := CompileExpr(zctx, lhs)
+	if err != nil {
+		return nil, err
+	}
+	return expr.NewDotAccess(record, id.Name), nil
+}
+
+func compileCast(zctx *resolver.Context, node ast.CastExpression) (expr.Evaluator, error) {
+	e, err := CompileExpr(zctx, node.Expr)
+	if err != nil {
+		return nil, err
+	}
+	return expr.NewCast(e, node.Type)
+}
+
+func CompileLval(node ast.Expression) (field.Static, error) {
+	switch node := node.(type) {
+	case *ast.RootRecord:
+		return field.NewRoot(), nil
+	// XXX We need to allow index operators at some point, but for now
+	// we have been assuming only dotted field lvalues.  See Issue #1462.
+	case *ast.BinaryExpression:
+		if node.Operator != "." {
+			break
+		}
+		id, ok := node.RHS.(*ast.Identifier)
+		if !ok {
+			return nil, errors.New("rhs of dot operator is not an identifier")
+		}
+		lhs, err := CompileLval(node.LHS)
+		if err != nil {
+			return nil, err
+		}
+		return append(lhs, id.Name), nil
+	}
+	return nil, errors.New("invalid expression on lhs of assignment")
+}
+
+func CompileAssignment(zctx *resolver.Context, node *ast.Assignment) (expr.Assignment, error) {
+	rhs, err := CompileExpr(zctx, node.RHS)
+	if err != nil {
+		return expr.Assignment{}, fmt.Errorf("rhs of assigment expression: %w", err)
+	}
+	var lhs field.Static
+	if node.LHS != nil {
+		lhs, err = CompileLval(node.LHS)
+		if err != nil {
+			return expr.Assignment{}, fmt.Errorf("lhs of assigment expression: %w", err)
+		}
+	} else {
+		switch rhs := node.RHS.(type) {
+		case *ast.RootRecord:
+			lhs = field.New(".")
+		case *ast.FunctionCall:
+			lhs = field.New(rhs.Function)
+		case *ast.BinaryExpression:
+			// This can be a dotted record or some other expression.
+			// In the latter case, it might be nice to infer a name,
+			// e.g., forr "count() by a+b" we could infer "sum" for
+			// the name, i,e., "count() by sum=a+b".  But for now,
+			// we'll just catch this as an error.
+			lhs, err = CompileLval(rhs)
+			if err != nil {
+				err = expr.ErrInference
+			}
+		default:
+			err = expr.ErrInference
+		}
+	}
+	return expr.Assignment{lhs, rhs}, err
+}
+
+func CompileAssignments(dsts []field.Static, srcs []field.Static) ([]field.Static, []expr.Evaluator) {
+	if len(srcs) != len(dsts) {
+		panic("CompileAssignmentFromStrings argument mismatch")
+	}
+	var resolvers []expr.Evaluator
+	var fields []field.Static
+	for k, dst := range dsts {
+		fields = append(fields, dst)
+		resolvers = append(resolvers, expr.NewDotExpr(srcs[k]))
+	}
+	return fields, resolvers
+}
+
+func compileCut(zctx *resolver.Context, node ast.FunctionCall) (expr.Evaluator, error) {
+	var lhs []field.Static
+	var rhs []expr.Evaluator
+	for _, expr := range node.Args {
+		// This is a bit of a hack and could be cleaed up by re-factoring
+		// CompileAssigment, but for now, we create an assigment expression
+		// where the LHS and RHS are the same, so that cut(id.orig_h,_path)
+		// gives a value of type record[id:record[orig_h:ip],_path:string]
+		// with field names that are the same as the cut names.
+		assignment := &ast.Assignment{LHS: expr, RHS: expr}
+		compiled, err := CompileAssignment(zctx, assignment)
+		if err != nil {
+			return nil, err
+		}
+		lhs = append(lhs, compiled.LHS)
+		rhs = append(rhs, compiled.RHS)
+	}
+	return expr.NewCutFunc(expr.NewCutter(zctx, false, lhs, rhs)), nil
+}
+
+func compileCall(zctx *resolver.Context, node ast.FunctionCall) (expr.Evaluator, error) {
+	// For now, we special case cut here.  As we add more stateful functions
+	// this will make more sense.  We could also compile any reducer as a
+	// stateful function here, e.g., count(), would produce a new count() for
+	// each record encountered analogous to juttle stream functions.
+	if node.Function == "cut" {
+		return compileCut(zctx, node)
+	}
+	nargs := len(node.Args)
+	fn, err := function.New(node.Function, nargs)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", node.Function, err)
+	}
+	exprs := make([]expr.Evaluator, 0, nargs)
+	for _, expr := range node.Args {
+		e, err := CompileExpr(zctx, expr)
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, e)
+	}
+	return expr.NewCall(zctx, node.Function, fn, exprs), nil
+}

--- a/compiler/filter.go
+++ b/compiler/filter.go
@@ -1,0 +1,178 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/filter"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+// Filter wraps an ast.BooleanExpr and implements the filter.Program interface
+// so that scanners can generate filters and buffer filters from an AST without
+// importing compiler (and causing an import loop).
+type Filter struct {
+	zctx *resolver.Context
+	ast  ast.BooleanExpr
+}
+
+func NewFilter(zctx *resolver.Context, ast ast.BooleanExpr) *Filter {
+	return &Filter{zctx, ast}
+}
+
+// AsFilter implements filter.Program
+func (f *Filter) AsFilter() (filter.Filter, error) {
+	if f == nil {
+		return nil, nil
+	}
+	return CompileFilter(f.zctx, f.ast)
+}
+
+// AsBufferFilter implements filter.Program
+func (f *Filter) AsBufferFilter() (*filter.BufferFilter, error) {
+	if f == nil {
+		return nil, nil
+	}
+	return CompileBufferFilter(f.ast)
+}
+
+func (f *Filter) AST() ast.BooleanExpr {
+	return f.ast
+}
+
+func (f *Filter) AsProc() ast.Proc {
+	return ast.FilterToProc(f.ast)
+}
+
+func CompileFieldCompare(zctx *resolver.Context, node *ast.CompareField) (filter.Filter, error) {
+	literal := node.Value
+	// Treat len(field) specially since we're looking at a computed
+	// value rather than a field from a record.
+
+	// XXX we need to implement proper expressions
+	// XXX we took out field call and need to put expressions back into
+	// the search sytnax, which is tricky syntactically to mix this stuff
+	// with keyword search
+
+	comparison, err := filter.Comparison(node.Comparator, literal)
+	if err != nil {
+		return nil, err
+	}
+	resolver, err := CompileExpr(zctx, node.Field)
+	if err != nil {
+		return nil, err
+	}
+	return filter.Combine(resolver, comparison), nil
+}
+
+func compileSearch(node *ast.Search) (filter.Filter, error) {
+	if node.Value.Type == "regexp" || node.Value.Type == "net" {
+		match, err := filter.Comparison("=~", node.Value)
+		if err != nil {
+			return nil, err
+		}
+		contains := filter.Contains(match)
+		pred := func(zv zng.Value) bool {
+			return match(zv) || contains(zv)
+		}
+
+		return filter.EvalAny(pred, true), nil
+	}
+
+	if node.Value.Type == "string" {
+		term, err := zng.TypeBstring.Parse([]byte(node.Value.Value))
+		if err != nil {
+			return nil, err
+		}
+		return filter.SearchRecordString(string(term)), nil
+	}
+
+	return filter.SearchRecordOther(node.Text, node.Value)
+}
+
+func CompileFilter(zctx *resolver.Context, node ast.BooleanExpr) (filter.Filter, error) {
+	switch v := node.(type) {
+	case *ast.LogicalNot:
+		expr, err := CompileFilter(zctx, v.Expr)
+		if err != nil {
+			return nil, err
+		}
+		return filter.LogicalNot(expr), nil
+
+	case *ast.LogicalAnd:
+		left, err := CompileFilter(zctx, v.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := CompileFilter(zctx, v.Right)
+		if err != nil {
+			return nil, err
+		}
+		return filter.LogicalAnd(left, right), nil
+
+	case *ast.LogicalOr:
+		left, err := CompileFilter(zctx, v.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := CompileFilter(zctx, v.Right)
+		if err != nil {
+			return nil, err
+		}
+		return filter.LogicalOr(left, right), nil
+
+	case *ast.MatchAll:
+		return func(*zng.Record) bool { return true }, nil
+
+	case *ast.Search:
+		return compileSearch(v)
+
+	case *ast.CompareField:
+		if v.Comparator == "in" {
+			resolver, err := CompileExpr(zctx, v.Field)
+			if err != nil {
+				return nil, err
+			}
+			eql, _ := filter.Comparison("=", v.Value)
+			comparison := filter.Contains(eql)
+			return filter.Combine(resolver, comparison), nil
+		}
+
+		return CompileFieldCompare(zctx, v)
+
+	case *ast.BinaryExpression:
+		predicate, err := CompileExpr(zctx, v)
+		if err != nil {
+			return nil, err
+		}
+		return func(rec *zng.Record) bool {
+			zv, err := predicate.Eval(rec)
+			if err != nil {
+				return false
+			}
+			if zv.Type == zng.TypeBool && zng.IsTrue(zv.Bytes) {
+				return true
+			}
+			return false
+		}, nil
+
+	case *ast.CompareAny:
+		if v.Comparator == "in" {
+			compare, err := filter.Comparison("=", v.Value)
+			if err != nil {
+				return nil, err
+			}
+			contains := filter.Contains(compare)
+			return filter.EvalAny(contains, v.Recursive), nil
+		}
+		comparison, err := filter.Comparison(v.Comparator, v.Value)
+		if err != nil {
+			return nil, err
+		}
+		return filter.EvalAny(comparison, v.Recursive), nil
+
+	default:
+		return nil, fmt.Errorf("Filter AST unknown type: %v", v)
+	}
+}

--- a/compiler/groupby.go
+++ b/compiler/groupby.go
@@ -48,7 +48,7 @@ func compileReducer(zctx *resolver.Context, assignment ast.Assignment) (field.St
 	var err error
 	var arg expr.Evaluator
 	if reducerAST.Expr != nil {
-		arg, err = expr.CompileExpr(zctx, reducerAST.Expr)
+		arg, err = CompileExpr(zctx, reducerAST.Expr)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -60,14 +60,14 @@ func compileReducer(zctx *resolver.Context, assignment ast.Assignment) (field.St
 	if assignment.LHS == nil {
 		lhs = field.New(reducerOp)
 	} else {
-		lhs, err = expr.CompileLval(assignment.LHS)
+		lhs, err = CompileLval(assignment.LHS)
 		if err != nil {
 			return nil, nil, fmt.Errorf("lhs of reducer expression: %w", err)
 		}
 	}
 	var where expr.Evaluator
 	if reducerAST.Where != nil {
-		where, err = expr.CompileExpr(zctx, reducerAST.Where)
+		where, err = CompileExpr(zctx, reducerAST.Where)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/compiler/parallelize.go
+++ b/compiler/parallelize.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/zng/resolver"
 )
 
 var passProc = &ast.PassProc{Node: ast.Node{"PassProc"}}
@@ -18,7 +19,7 @@ func zbufDirInt(reversed bool) int {
 	return 1
 }
 
-func Optimize(program ast.Proc, sortKey field.Static, sortReversed bool) (ast.BooleanExpr, ast.Proc) {
+func Optimize(zctx *resolver.Context, program ast.Proc, sortKey field.Static, sortReversed bool) (*Filter, ast.Proc) {
 	if program == nil {
 		return nil, passProc
 	}
@@ -26,7 +27,11 @@ func Optimize(program ast.Proc, sortKey field.Static, sortReversed bool) (ast.Bo
 	if sortKey != nil {
 		setGroupByProcInputSortDir(program, sortKey, zbufDirInt(sortReversed))
 	}
-	return liftFilter(program)
+	fe, p := liftFilter(program)
+	if fe == nil {
+		return nil, p
+	}
+	return NewFilter(zctx, fe), p
 }
 
 func ensureSequentialProc(p ast.Proc) *ast.SequentialProc {

--- a/compiler/proc.go
+++ b/compiler/proc.go
@@ -7,7 +7,6 @@ import (
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/field"
-	"github.com/brimsec/zq/filter"
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/proc/combine"
 	"github.com/brimsec/zq/proc/cut"
@@ -69,7 +68,7 @@ func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, parent proc.Int
 		return cut, nil
 
 	case *ast.SortProc:
-		fields, err := expr.CompileExprs(pctx.TypeContext, v.Fields)
+		fields, err := CompileExprs(pctx.TypeContext, v.Fields)
 		if err != nil {
 			return nil, err
 		}
@@ -100,14 +99,14 @@ func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, parent proc.Int
 		return pass.New(parent), nil
 
 	case *ast.FilterProc:
-		f, err := filter.Compile(pctx.TypeContext, v.Filter)
+		f, err := CompileFilter(pctx.TypeContext, v.Filter)
 		if err != nil {
 			return nil, fmt.Errorf("compiling filter: %w", err)
 		}
 		return filterproc.New(parent, f), nil
 
 	case *ast.TopProc:
-		fields, err := expr.CompileExprs(pctx.TypeContext, v.Fields)
+		fields, err := CompileExprs(pctx.TypeContext, v.Fields)
 		if err != nil {
 			return nil, fmt.Errorf("compiling top: %w", err)
 		}
@@ -132,7 +131,32 @@ func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, parent proc.Int
 		return put, nil
 
 	case *ast.RenameProc:
-		rename, err := rename.New(pctx, parent, v)
+		var srcs, dsts []field.Static
+		for _, fa := range v.Fields {
+			dst, err := CompileLval(fa.LHS)
+			if err != nil {
+				return nil, err
+			}
+			// We call CompileLval on the RHS because renames are
+			// restricted to dotted field name expressions.
+			src, err := CompileLval(fa.RHS)
+			if err != nil {
+				return nil, err
+			}
+			if len(dst) != len(src) {
+				return nil, fmt.Errorf("cannot rename %s to %s", src, dst)
+			}
+			// Check that the prefixes match and, if not, report first place
+			// that they don't.
+			for i := 0; i <= len(src)-2; i++ {
+				if src[i] != dst[i] {
+					return nil, fmt.Errorf("cannot rename %s to %s (differ in %s vs %s)", src, dst, src[i], dst[i])
+				}
+			}
+			dsts = append(dsts, dst)
+			srcs = append(srcs, src)
+		}
+		rename, err := rename.New(pctx, parent, srcs, dsts)
 		if err != nil {
 			return nil, err
 		}
@@ -153,7 +177,7 @@ func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, parent proc.Int
 func compileAssignments(assignments []ast.Assignment, zctx *resolver.Context) ([]expr.Assignment, error) {
 	keys := make([]expr.Assignment, 0, len(assignments))
 	for _, assignment := range assignments {
-		a, err := expr.CompileAssignment(zctx, &assignment)
+		a, err := CompileAssignment(zctx, &assignment)
 		if err != nil {
 			return nil, err
 		}
@@ -253,7 +277,20 @@ func Compile(custom Hook, node ast.Proc, pctx *proc.Context, parents []proc.Inte
 		if len(parents) != 2 {
 			return nil, ErrJoinParents
 		}
-		join, err := join.New(pctx, parents[0], parents[1], node)
+		assignments, err := compileAssignments(node.Clauses, pctx.TypeContext)
+		if err != nil {
+			return nil, err
+		}
+		lhs, rhs := splitAssignments(assignments)
+		leftKey, err := CompileExpr(pctx.TypeContext, node.LeftKey)
+		if err != nil {
+			return nil, err
+		}
+		rightKey, err := CompileExpr(pctx.TypeContext, node.RightKey)
+		if err != nil {
+			return nil, err
+		}
+		join, err := join.New(pctx, parents[0], parents[1], leftKey, rightKey, lhs, rhs)
 		if err != nil {
 			return nil, err
 		}

--- a/compiler/proc.go
+++ b/compiler/proc.go
@@ -99,7 +99,7 @@ func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, parent proc.Int
 		return pass.New(parent), nil
 
 	case *ast.FilterProc:
-		f, err := CompileFilter(pctx.TypeContext, v.Filter)
+		f, err := compileFilter(pctx.TypeContext, v.Filter)
 		if err != nil {
 			return nil, fmt.Errorf("compiling filter: %w", err)
 		}

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -62,7 +62,7 @@ func compile(ctx context.Context, program ast.Proc, zctx *resolver.Context, read
 		cfg.Warnings = make(chan string, 5)
 	}
 
-	filterExpr, program := compiler.Optimize(program, field.Dotted(cfg.ReaderSortKey), cfg.ReaderSortReverse)
+	filterExpr, program := compiler.Optimize(zctx, program, field.Dotted(cfg.ReaderSortKey), cfg.ReaderSortReverse)
 	procs := make([]proc.Interface, 0, len(readers))
 	scanners := make([]zbuf.Scanner, 0, len(readers))
 	for _, r := range readers {
@@ -128,7 +128,7 @@ func compileMulti(ctx context.Context, program ast.Proc, zctx *resolver.Context,
 	}
 
 	sortKey, sortReversed := msrc.OrderInfo()
-	filterExpr, program := compiler.Optimize(program, sortKey, sortReversed)
+	filterExpr, program := compiler.Optimize(zctx, program, sortKey, sortReversed)
 
 	var isParallel bool
 	if mcfg.Parallelism > 1 {

--- a/driver/multisource.go
+++ b/driver/multisource.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/brimsec/zq/api"
-	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
@@ -44,6 +44,6 @@ type ScannerCloser interface {
 }
 
 type SourceFilter struct {
-	FilterExpr ast.BooleanExpr
-	Span       nano.Span
+	Filter *compiler.Filter
+	Span   nano.Span
 }

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/api/client"
-	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/zbuf"
 )
@@ -181,8 +181,8 @@ func (pg *parallelGroup) sourceToRequest(src Source) (*api.WorkerRequest, error)
 	if err := src.ToRequest(&req); err != nil {
 		return nil, err
 	}
-	if filterExpr := pg.filter.FilterExpr; filterExpr != nil {
-		b, err := json.Marshal(ast.FilterToProc(filterExpr))
+	if filterExpr := pg.filter.Filter; filterExpr != nil {
+		b, err := json.Marshal(filterExpr.AsProc())
 		if err != nil {
 			return nil, err
 		}
@@ -207,12 +207,12 @@ func (pg *parallelGroup) run() {
 	close(pg.sourceChan)
 }
 
-func createParallelGroup(pctx *proc.Context, filterExpr ast.BooleanExpr, msrc MultiSource, mcfg MultiConfig, workerURLs []string) ([]proc.Interface, *parallelGroup, error) {
+func createParallelGroup(pctx *proc.Context, filter *compiler.Filter, msrc MultiSource, mcfg MultiConfig, workerURLs []string) ([]proc.Interface, *parallelGroup, error) {
 	pg := &parallelGroup{
 		pctx: pctx,
 		filter: SourceFilter{
-			FilterExpr: filterExpr,
-			Span:       mcfg.Span,
+			Filter: filter,
+			Span:   mcfg.Span,
 		},
 		msrc:       msrc,
 		mcfg:       mcfg,

--- a/driver/parallel_test.go
+++ b/driver/parallel_test.go
@@ -84,7 +84,7 @@ func (m *orderedmsrc) SendSources(ctx context.Context, span nano.Span, srcChan c
 		i := i
 		opener := func(zctx *resolver.Context, sf SourceFilter) (ScannerCloser, error) {
 			rdr := tzngio.NewReader(strings.NewReader(parallelTestInputs[i]), zctx)
-			sn, err := zbuf.NewScanner(ctx, rdr, sf.FilterExpr, sf.Span)
+			sn, err := zbuf.NewScanner(ctx, rdr, sf.Filter, sf.Span)
 			if err != nil {
 				return nil, err
 			}

--- a/expr/cut.go
+++ b/expr/cut.go
@@ -1,34 +1,15 @@
 package expr
 
 import (
-	"github.com/brimsec/zq/ast"
-	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zng/resolver"
 )
 
 type cutFunc struct {
 	*Cutter
 }
 
-func compileCut(zctx *resolver.Context, node ast.FunctionCall) (Evaluator, error) {
-	var lhs []field.Static
-	var rhs []Evaluator
-	for _, expr := range node.Args {
-		// This is a bit of a hack and could be cleaed up by re-factoring
-		// CompileAssigment, but for now, we create an assigment expression
-		// where the LHS and RHS are the same, so that cut(id.orig_h,_path)
-		// gives a value of type record[id:record[orig_h:ip],_path:string]
-		// with field names that are the same as the cut names.
-		assignment := &ast.Assignment{LHS: expr, RHS: expr}
-		compiled, err := CompileAssignment(zctx, assignment)
-		if err != nil {
-			return nil, err
-		}
-		lhs = append(lhs, compiled.LHS)
-		rhs = append(rhs, compiled.RHS)
-	}
-	return &cutFunc{NewCutter(zctx, false, lhs, rhs)}, nil
+func NewCutFunc(c *Cutter) *cutFunc {
+	return &cutFunc{c}
 }
 
 func (c *cutFunc) Eval(rec *zng.Record) (zng.Value, error) {

--- a/expr/dot.go
+++ b/expr/dot.go
@@ -18,6 +18,10 @@ type DotExpr struct {
 	field  string
 }
 
+func NewDotAccess(record Evaluator, field string) *DotExpr {
+	return &DotExpr{record, field}
+}
+
 func NewDotExpr(f field.Static) Evaluator {
 	ret := Evaluator(&RootRecord{})
 	for _, name := range f {

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zio/tzngio"
@@ -53,7 +54,7 @@ func compileExpr(s string) (expr.Evaluator, error) {
 		return nil, errors.New("expected Expression")
 	}
 
-	return expr.CompileExpr(resolver.NewContext(), node)
+	return compiler.CompileExpr(resolver.NewContext(), node)
 }
 
 // Compile and evaluate a zql expression against a provided Record.

--- a/filter/bufferfilter.go
+++ b/filter/bufferfilter.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"unicode/utf8"
 
-	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/pkg/byteconv"
-	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 )
 
@@ -28,109 +26,22 @@ type BufferFilter struct {
 	sf    *stringFinder
 }
 
-// NewBufferFilter tries to return a BufferFilter for e such that the
-// BufferFilter's Eval method returns true for any byte slice containing the ZNG
-// encoding of a record matching e. (It may also return true for some byte
-// slices that do not match.) NewBufferFilter returns a nil pointer and nil
-// error if it cannot construct a useful filter.
-func NewBufferFilter(e ast.BooleanExpr) (*BufferFilter, error) {
-	switch e := e.(type) {
-	case *ast.CompareAny:
-		if e.Comparator != "=" && e.Comparator != "in" {
-			return nil, nil
-		}
-		return newBufferFilterForLiteral(e.Value)
-	case *ast.CompareField:
-		if e.Comparator != "=" && e.Comparator != "in" {
-			return nil, nil
-		}
-		return newBufferFilterForLiteral(e.Value)
-	case *ast.BinaryExpression:
-		return nil, nil
-	case *ast.LogicalAnd:
-		left, err := NewBufferFilter(e.Left)
-		if err != nil {
-			return nil, err
-		}
-		right, err := NewBufferFilter(e.Right)
-		if err != nil {
-			return nil, err
-		}
-		if left == nil {
-			return right, nil
-		}
-		if right == nil {
-			return left, nil
-		}
-		return &BufferFilter{op: opAnd, left: left, right: right}, nil
-	case *ast.LogicalOr:
-		left, err := NewBufferFilter(e.Left)
-		if err != nil {
-			return nil, err
-		}
-		right, err := NewBufferFilter(e.Right)
-		if left == nil || right == nil || err != nil {
-			return nil, err
-		}
-		return &BufferFilter{op: opOr, left: left, right: right}, nil
-	case *ast.LogicalNot, *ast.MatchAll:
-		return nil, nil
-	case *ast.Search:
-		if e.Value.Type == "net" || e.Value.Type == "regexp" {
-			return nil, nil
-		}
-		if e.Value.Type == "string" {
-			pattern, err := zng.TypeBstring.Parse([]byte(e.Value.Value))
-			if err != nil {
-				return nil, err
-			}
-			left := newBufferFilterForStringCase(string(pattern))
-			if left == nil {
-				return nil, nil
-			}
-			right := &BufferFilter{
-				op:  opFieldNameFinder,
-				fnf: newFieldNameFinder(string(pattern)),
-			}
-			return &BufferFilter{op: opOr, left: left, right: right}, nil
-		}
-		left := newBufferFilterForStringCase(e.Text)
-		right, err := newBufferFilterForLiteral(e.Value)
-		if left == nil || right == nil || err != nil {
-			return nil, err
-		}
-		return &BufferFilter{op: opOr, left: left, right: right}, nil
-	default:
-		return nil, fmt.Errorf("filter AST unknown type: %T", e)
+func NewAndBufferFilter(left, right *BufferFilter) *BufferFilter {
+	return &BufferFilter{op: opAnd, left: left, right: right}
+}
+
+func NewOrBufferFilter(left, right *BufferFilter) *BufferFilter {
+	return &BufferFilter{op: opOr, left: left, right: right}
+}
+
+func NewFieldNameFinder(pattern string) *BufferFilter {
+	return &BufferFilter{
+		op:  opFieldNameFinder,
+		fnf: newFieldNameFinder(pattern),
 	}
 }
 
-func newBufferFilterForLiteral(l ast.Literal) (*BufferFilter, error) {
-	switch l.Type {
-	case "bool", "byte", "int16", "uint16", "int32", "uint32", "int64", "uint64", "float64", "time", "duration":
-		// These are all comparable, so they can require up to three
-		// patterns: float, varint, and uvarint.
-		return nil, nil
-	case "null":
-		return nil, nil
-	case "regexp":
-		// Could try to extract a pattern (e.g., "efg" from "(ab|cd)(efg)+[hi]").
-		return nil, nil
-	case "string":
-		// Match the behavior of zng.ParseLiteral.
-		l.Type = "bstring"
-	}
-	v, err := zng.Parse(l)
-	if err != nil {
-		return nil, err
-	}
-	// We're looking for a complete ZNG value, so we can lengthen the
-	// pattern by calling Encode to add a tag.
-	pattern := string(v.Encode(nil))
-	return newBufferFilterForString(pattern), nil
-}
-
-func newBufferFilterForString(pattern string) *BufferFilter {
+func NewBufferFilterForString(pattern string) *BufferFilter {
 	if len(pattern) < 2 {
 		// Very short patterns are unprofitable.
 		return nil
@@ -138,7 +49,7 @@ func newBufferFilterForString(pattern string) *BufferFilter {
 	return &BufferFilter{op: opStringFinder, sf: makeStringFinder(pattern)}
 }
 
-func newBufferFilterForStringCase(pattern string) *BufferFilter {
+func NewBufferFilterForStringCase(pattern string) *BufferFilter {
 	if len(pattern) < 2 {
 		// Very short patterns are unprofitable.
 		return nil

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -13,11 +13,6 @@ import (
 
 type Filter func(*zng.Record) bool
 
-type Program interface {
-	AsFilter() (Filter, error)
-	AsBufferFilter() (*BufferFilter, error)
-}
-
 func LogicalAnd(left, right Filter) Filter {
 	return func(p *zng.Record) bool { return left(p) && right(p) }
 }

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -2,7 +2,6 @@ package filter
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/brimsec/zq/ast"
@@ -10,10 +9,14 @@ import (
 	"github.com/brimsec/zq/pkg/byteconv"
 	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zng/resolver"
 )
 
 type Filter func(*zng.Record) bool
+
+type Program interface {
+	AsFilter() (Filter, error)
+	AsBufferFilter() (*BufferFilter, error)
+}
 
 func LogicalAnd(left, right Filter) Filter {
 	return func(p *zng.Record) bool { return left(p) && right(p) }
@@ -27,7 +30,7 @@ func LogicalNot(expr Filter) Filter {
 	return func(p *zng.Record) bool { return !expr(p) }
 }
 
-func combine(res expr.Evaluator, pred Predicate) Filter {
+func Combine(res expr.Evaluator, pred Predicate) Filter {
 	return func(r *zng.Record) bool {
 		v, err := res.Eval(r)
 		if err != nil || v.Type == nil {
@@ -36,27 +39,6 @@ func combine(res expr.Evaluator, pred Predicate) Filter {
 		}
 		return pred(v)
 	}
-}
-
-func CompileFieldCompare(zctx *resolver.Context, node *ast.CompareField) (Filter, error) {
-	literal := node.Value
-	// Treat len(field) specially since we're looking at a computed
-	// value rather than a field from a record.
-
-	// XXX we need to implement proper expressions
-	// XXX we took out field call and need to put expressions back into
-	// the search sytnax, which is tricky syntactically to mix this stuff
-	// with keyword search
-
-	comparison, err := Comparison(node.Comparator, literal)
-	if err != nil {
-		return nil, err
-	}
-	resolver, err := expr.CompileExpr(zctx, node.Field)
-	if err != nil {
-		return nil, err
-	}
-	return combine(resolver, comparison), nil
 }
 
 func EvalAny(eval Predicate, recursive bool) Filter {
@@ -98,31 +80,6 @@ func EvalAny(eval Predicate, recursive bool) Filter {
 	}
 }
 
-func compileSearch(node *ast.Search) (Filter, error) {
-	if node.Value.Type == "regexp" || node.Value.Type == "net" {
-		match, err := Comparison("=~", node.Value)
-		if err != nil {
-			return nil, err
-		}
-		contains := Contains(match)
-		pred := func(zv zng.Value) bool {
-			return match(zv) || contains(zv)
-		}
-
-		return EvalAny(pred, true), nil
-	}
-
-	if node.Value.Type == "string" {
-		term, err := zng.TypeBstring.Parse([]byte(node.Value.Value))
-		if err != nil {
-			return nil, err
-		}
-		return searchRecordString(string(term)), nil
-	}
-
-	return searchRecordOther(node.Text, node.Value)
-}
-
 // stringSearch is like strings.Contains() but with case-insensitive
 // comparison.
 func stringSearch(a, b string) bool {
@@ -146,13 +103,13 @@ func stringSearch(a, b string) bool {
 
 var errMatch = errors.New("match")
 
-// searchRecordOther creates a filter that searches zng records for the
+// SearchRecordOther creates a filter that searches zng records for the
 // given value, which must be of a type other than (b)string.  The filter
 // matches a record that contains this value either as the value of any
 // field or inside any set or array.  It also matches a record if the string
 // representaton of the search value appears inside inside any string-valued
 // field (or inside any element of a set or array of strings).
-func searchRecordOther(searchtext string, searchval ast.Literal) (Filter, error) {
+func SearchRecordOther(searchtext string, searchval ast.Literal) (Filter, error) {
 	typedCompare, err := Comparison("=", searchval)
 	if err != nil {
 		return nil, err
@@ -172,9 +129,9 @@ func searchRecordOther(searchtext string, searchval ast.Literal) (Filter, error)
 
 }
 
-// searchRecordString handles the special case of string searching -- it
+// SearchRecordString handles the special case of string searching -- it
 // matches both field names and values.
-func searchRecordString(term string) Filter {
+func SearchRecordString(term string) Filter {
 	fieldNameCheck := make(map[zng.Type]bool)
 	var nameIter fieldNameIter
 	return func(r *zng.Record) bool {
@@ -201,91 +158,5 @@ func searchRecordString(term string) Filter {
 			}
 			return nil
 		})
-	}
-}
-
-func Compile(zctx *resolver.Context, node ast.BooleanExpr) (Filter, error) {
-	switch v := node.(type) {
-	case *ast.LogicalNot:
-		expr, err := Compile(zctx, v.Expr)
-		if err != nil {
-			return nil, err
-		}
-		return LogicalNot(expr), nil
-
-	case *ast.LogicalAnd:
-		left, err := Compile(zctx, v.Left)
-		if err != nil {
-			return nil, err
-		}
-		right, err := Compile(zctx, v.Right)
-		if err != nil {
-			return nil, err
-		}
-		return LogicalAnd(left, right), nil
-
-	case *ast.LogicalOr:
-		left, err := Compile(zctx, v.Left)
-		if err != nil {
-			return nil, err
-		}
-		right, err := Compile(zctx, v.Right)
-		if err != nil {
-			return nil, err
-		}
-		return LogicalOr(left, right), nil
-
-	case *ast.MatchAll:
-		return func(*zng.Record) bool { return true }, nil
-
-	case *ast.Search:
-		return compileSearch(v)
-
-	case *ast.CompareField:
-		if v.Comparator == "in" {
-			resolver, err := expr.CompileExpr(zctx, v.Field)
-			if err != nil {
-				return nil, err
-			}
-			eql, _ := Comparison("=", v.Value)
-			comparison := Contains(eql)
-			return combine(resolver, comparison), nil
-		}
-
-		return CompileFieldCompare(zctx, v)
-
-	case *ast.BinaryExpression:
-		predicate, err := expr.CompileExpr(zctx, v)
-		if err != nil {
-			return nil, err
-		}
-		return func(rec *zng.Record) bool {
-			zv, err := predicate.Eval(rec)
-			if err != nil {
-				return false
-			}
-			if zv.Type == zng.TypeBool && zng.IsTrue(zv.Bytes) {
-				return true
-			}
-			return false
-		}, nil
-
-	case *ast.CompareAny:
-		if v.Comparator == "in" {
-			compare, err := Comparison("=", v.Value)
-			if err != nil {
-				return nil, err
-			}
-			contains := Contains(compare)
-			return EvalAny(contains, v.Recursive), nil
-		}
-		comparison, err := Comparison(v.Comparator, v.Value)
-		if err != nil {
-			return nil, err
-		}
-		return EvalAny(comparison, v.Recursive), nil
-
-	default:
-		return nil, fmt.Errorf("Filter AST unknown type: %v", v)
 	}
 }

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -505,7 +505,8 @@ func TestBadFilter(t *testing.T) {
 	t.Parallel()
 	proc, err := zql.ParseProc(`s =~ \xa8*`)
 	require.NoError(t, err)
-	_, err = compiler.CompileFilter(resolver.NewContext(), proc.(*ast.FilterProc).Filter)
+	f := compiler.NewFilter(resolver.NewContext(), proc.(*ast.FilterProc).Filter)
+	_, err = f.AsFilter()
 	assert.Error(t, err, "Received error for bad glob")
 	assert.Contains(t, err.Error(), "invalid UTF-8", "Received good error message for invalid UTF-8 in a regexp")
 }

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/ast"
-	"github.com/brimsec/zq/filter"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zio/tzngio"
@@ -48,14 +48,15 @@ func runCasesHelper(t *testing.T, tzng string, cases []testcase, expectBufferFil
 			require.NoError(t, err, "filter: %q", c.filter)
 			filterExpr := proc.(*ast.FilterProc).Filter
 
-			f, err := filter.Compile(zctx, filterExpr)
+			filterAST := compiler.NewFilter(zctx, filterExpr)
+			f, err := filterAST.AsFilter()
 			assert.NoError(t, err, "filter: %q", c.filter)
 			if f != nil {
 				assert.Equal(t, c.expected, f(rec),
 					"filter: %q\nrecord:\n%s", c.filter, hex.Dump(rec.Raw))
 			}
 
-			bf, err := filter.NewBufferFilter(filterExpr)
+			bf, err := filterAST.AsBufferFilter()
 			assert.NoError(t, err, "filter: %q", c.filter)
 			if bf != nil {
 				expected := c.expected
@@ -504,7 +505,7 @@ func TestBadFilter(t *testing.T) {
 	t.Parallel()
 	proc, err := zql.ParseProc(`s =~ \xa8*`)
 	require.NoError(t, err)
-	_, err = filter.Compile(resolver.NewContext(), proc.(*ast.FilterProc).Filter)
+	_, err = compiler.CompileFilter(resolver.NewContext(), proc.(*ast.FilterProc).Filter)
 	assert.Error(t, err, "Received error for bad glob")
 	assert.Contains(t, err.Error(), "invalid UTF-8", "Received good error message for invalid UTF-8 in a regexp")
 }

--- a/microindex/writer.go
+++ b/microindex/writer.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/pkg/bufwriter"
@@ -108,7 +109,7 @@ func NewWriterWithContext(ctx context.Context, zctx *resolver.Context, path stri
 	if err != nil {
 		return nil, err
 	}
-	fields, resolvers := expr.CompileAssignments(w.keyFields, w.keyFields)
+	fields, resolvers := compiler.CompileAssignments(w.keyFields, w.keyFields)
 	w.cutter = expr.NewStrictCutter(zctx, false, fields, resolvers)
 	return w, nil
 }

--- a/ppl/archive/indexer.go
+++ b/ppl/archive/indexer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/brimsec/zq/api"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/field"
@@ -85,7 +86,7 @@ func NewFlowgraphIndexer(ctx context.Context, zctx *resolver.Context, uri iosrc.
 	if err != nil {
 		return nil, err
 	}
-	fields, resolvers := expr.CompileAssignments(keys, keys)
+	fields, resolvers := compiler.CompileAssignments(keys, keys)
 	return &FlowgraphIndexer{
 		zctx:   zctx,
 		w:      writer,

--- a/ppl/archive/multisource.go
+++ b/ppl/archive/multisource.go
@@ -59,7 +59,7 @@ func newSpanScanner(ctx context.Context, ark *Archive, zctx *resolver.Context, s
 		stats.ChunksReadBytes += rc.ReadSize
 		closers = append(closers, rc)
 		reader := zngio.NewReader(rc, zctx)
-		scanner, err := reader.NewScanner(ctx, sf.FilterExpr, si.Span)
+		scanner, err := reader.NewScanner(ctx, sf.Filter, si.Span)
 		if err != nil {
 			closers.Close()
 			return nil, stats, err
@@ -224,7 +224,7 @@ func (s *chunkSource) Open(ctx context.Context, zctx *resolver.Context, sf drive
 		paths[i] = u.String()
 	}
 	rc := detector.MultiFileReader(zctx, paths, zio.ReaderOpts{Format: "zng"})
-	sn, err := zbuf.NewScanner(ctx, rc, sf.FilterExpr, sf.Span)
+	sn, err := zbuf.NewScanner(ctx, rc, sf.Filter, sf.Span)
 	if err != nil {
 		rc.Close()
 		return nil, err

--- a/proc/rename/rename.go
+++ b/proc/rename/rename.go
@@ -3,8 +3,6 @@ package rename
 import (
 	"fmt"
 
-	"github.com/brimsec/zq/ast"
-	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/zbuf"
@@ -26,32 +24,7 @@ type Proc struct {
 	typeMap map[int]*zng.TypeRecord
 }
 
-func New(pctx *proc.Context, parent proc.Interface, node *ast.RenameProc) (*Proc, error) {
-	var srcs, dsts []field.Static
-	for _, fa := range node.Fields {
-		dst, err := expr.CompileLval(fa.LHS)
-		if err != nil {
-			return nil, err
-		}
-		// We call CompileLval on the RHS because renames are
-		// restricted to dotted field name expressions.
-		src, err := expr.CompileLval(fa.RHS)
-		if err != nil {
-			return nil, err
-		}
-		if len(dst) != len(src) {
-			return nil, fmt.Errorf("cannot rename %s to %s", src, dst)
-		}
-		// Check that the prefixes match and, if not, report first place
-		// that they don't.
-		for i := 0; i <= len(src)-2; i++ {
-			if src[i] != dst[i] {
-				return nil, fmt.Errorf("cannot rename %s to %s (differ in %s vs %s)", src, dst, src[i], dst[i])
-			}
-		}
-		dsts = append(dsts, dst)
-		srcs = append(srcs, src)
-	}
+func New(pctx *proc.Context, parent proc.Interface, srcs, dsts []field.Static) (*Proc, error) {
 	return &Proc{
 		pctx:    pctx,
 		parent:  parent,

--- a/zbuf/scanner.go
+++ b/zbuf/scanner.go
@@ -9,10 +9,15 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
+type Filter interface {
+	AsFilter() (filter.Filter, error)
+	AsBufferFilter() (*filter.BufferFilter, error)
+}
+
 // ScannerAble is implemented by Readers that provide an optimized
 // implementation of the Scanner interface.
 type ScannerAble interface {
-	NewScanner(ctx context.Context, filterExpr filter.Program, s nano.Span) (Scanner, error)
+	NewScanner(ctx context.Context, filterExpr Filter, s nano.Span) (Scanner, error)
 }
 
 // A Statser produces scanner statistics.
@@ -73,7 +78,7 @@ func ReadersToPullers(ctx context.Context, readers []Reader) ([]Puller, error) {
 }
 
 // NewScanner returns a Scanner for r that filters records by filterExpr and s.
-func NewScanner(ctx context.Context, r Reader, filterExpr filter.Program, s nano.Span) (Scanner, error) {
+func NewScanner(ctx context.Context, r Reader, filterExpr Filter, s nano.Span) (Scanner, error) {
 	var sa ScannerAble
 	if zf, ok := r.(*File); ok {
 		sa, _ = zf.Reader.(ScannerAble)

--- a/zbuf/scanner.go
+++ b/zbuf/scanner.go
@@ -4,17 +4,15 @@ import (
 	"context"
 	"sync/atomic"
 
-	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/filter"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zng"
-	"github.com/brimsec/zq/zng/resolver"
 )
 
 // ScannerAble is implemented by Readers that provide an optimized
 // implementation of the Scanner interface.
 type ScannerAble interface {
-	NewScanner(ctx context.Context, filterExpr ast.BooleanExpr, s nano.Span) (Scanner, error)
+	NewScanner(ctx context.Context, filterExpr filter.Program, s nano.Span) (Scanner, error)
 }
 
 // A Statser produces scanner statistics.
@@ -75,7 +73,7 @@ func ReadersToPullers(ctx context.Context, readers []Reader) ([]Puller, error) {
 }
 
 // NewScanner returns a Scanner for r that filters records by filterExpr and s.
-func NewScanner(ctx context.Context, r Reader, filterExpr ast.BooleanExpr, s nano.Span) (Scanner, error) {
+func NewScanner(ctx context.Context, r Reader, filterExpr filter.Program, s nano.Span) (Scanner, error) {
 	var sa ScannerAble
 	if zf, ok := r.(*File); ok {
 		sa, _ = zf.Reader.(ScannerAble)
@@ -88,7 +86,7 @@ func NewScanner(ctx context.Context, r Reader, filterExpr ast.BooleanExpr, s nan
 	var f filter.Filter
 	if filterExpr != nil {
 		var err error
-		if f, err = filter.Compile(resolver.NewContext(), filterExpr); err != nil {
+		if f, err = filterExpr.AsFilter(); err != nil {
 			return nil, err
 		}
 	}

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"sync"
 
-	"github.com/brimsec/zq/filter"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
@@ -166,7 +165,7 @@ func (r *multiFileReader) Close() (err error) {
 	return
 }
 
-func (r *multiFileReader) NewScanner(ctx context.Context, filter filter.Program, s nano.Span) (zbuf.Scanner, error) {
+func (r *multiFileReader) NewScanner(ctx context.Context, filter zbuf.Filter, s nano.Span) (zbuf.Scanner, error) {
 	return &multiFileScanner{
 		multiFileReader: r,
 		ctx:             ctx,
@@ -178,7 +177,7 @@ func (r *multiFileReader) NewScanner(ctx context.Context, filter filter.Program,
 type multiFileScanner struct {
 	*multiFileReader
 	ctx    context.Context
-	filter filter.Program
+	filter zbuf.Filter
 	span   nano.Span
 
 	mu      sync.Mutex // protects below

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/filter"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
@@ -166,20 +166,20 @@ func (r *multiFileReader) Close() (err error) {
 	return
 }
 
-func (r *multiFileReader) NewScanner(ctx context.Context, filterExpr ast.BooleanExpr, s nano.Span) (zbuf.Scanner, error) {
+func (r *multiFileReader) NewScanner(ctx context.Context, filter filter.Program, s nano.Span) (zbuf.Scanner, error) {
 	return &multiFileScanner{
 		multiFileReader: r,
 		ctx:             ctx,
-		filterExpr:      filterExpr,
+		filter:          filter,
 		span:            s,
 	}, nil
 }
 
 type multiFileScanner struct {
 	*multiFileReader
-	ctx        context.Context
-	filterExpr ast.BooleanExpr
-	span       nano.Span
+	ctx    context.Context
+	filter filter.Program
+	span   nano.Span
 
 	mu      sync.Mutex // protects below
 	scanner zbuf.Scanner
@@ -194,7 +194,7 @@ func (s *multiFileScanner) Pull() (zbuf.Batch, error) {
 			return nil, err
 		}
 		if s.scanner == nil {
-			sn, err := zbuf.NewScanner(s.ctx, s.reader, s.filterExpr, s.span)
+			sn, err := zbuf.NewScanner(s.ctx, s.reader, s.filter, s.span)
 			if err != nil {
 				return nil, err
 			}

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/filter"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/pkg/peeker"
@@ -495,16 +494,16 @@ func (r *Reader) parseValue(rec *zng.Record, id int, b []byte) (*zng.Record, err
 
 var _ zbuf.ScannerAble = (*Reader)(nil)
 
-func (r *Reader) NewScanner(ctx context.Context, filterExpr ast.BooleanExpr, s nano.Span) (zbuf.Scanner, error) {
+func (r *Reader) NewScanner(ctx context.Context, pruner filter.Program, s nano.Span) (zbuf.Scanner, error) {
 	var bf *filter.BufferFilter
 	var f filter.Filter
-	if filterExpr != nil {
+	if pruner != nil {
 		var err error
-		bf, err = filter.NewBufferFilter(filterExpr)
+		bf, err = pruner.AsBufferFilter()
 		if err != nil {
 			return nil, err
 		}
-		f, err = filter.Compile(resolver.NewContext(), filterExpr)
+		f, err = pruner.AsFilter()
 		if err != nil {
 			return nil, err
 		}

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -494,7 +494,7 @@ func (r *Reader) parseValue(rec *zng.Record, id int, b []byte) (*zng.Record, err
 
 var _ zbuf.ScannerAble = (*Reader)(nil)
 
-func (r *Reader) NewScanner(ctx context.Context, pruner filter.Program, s nano.Span) (zbuf.Scanner, error) {
+func (r *Reader) NewScanner(ctx context.Context, pruner zbuf.Filter, s nano.Span) (zbuf.Scanner, error) {
 	var bf *filter.BufferFilter
 	var f filter.Filter
 	if pruner != nil {


### PR DESCRIPTION
This is the final, heavy lift on the compiler refactor issue #1162.
Except for the creation of the filter.Program interface and its
implementation as compiler.Filter, everything here is just code
movement.  All the compiler related logic from packages filter and
expr have been moved into package compiler.  Also, we missed
the rename and join procs in the previous commit so they are taken
care of here.

The filter.Program interface needed to be created to break an import
cycle since the scanner was previously calling filter.Compile and
moving that into compiler created the cycle.

The functions in expr/eval.go should br broken out in a subsequent PR 
See issue #1756.

Closes #1162.