### PR TITLE
add metadata time order check

### DIFF
--- a/ppl/archive/archive_test.go
+++ b/ppl/archive/archive_test.go
@@ -111,7 +111,7 @@ func TestOpenOptions(t *testing.T) {
 				return err
 			}
 			uri.Path = path.Dir(uri.Path)
-			chunk, err := chunk.Open(context.Background(), uri, id)
+			chunk, err := chunk.Open(context.Background(), uri, id, zbuf.OrderDesc)
 			if err != nil {
 				return err
 			}
@@ -178,7 +178,7 @@ func TestSeekIndex(t *testing.T) {
 				return err
 			}
 			uri.Path = path.Dir(uri.Path)
-			chunk, err := chunk.Open(context.Background(), uri, id)
+			chunk, err := chunk.Open(context.Background(), uri, id, zbuf.OrderAsc)
 			if err != nil {
 				return err
 			}

--- a/ppl/archive/chunk/chunk.go
+++ b/ppl/archive/chunk/chunk.go
@@ -67,8 +67,8 @@ type Chunk struct {
 	Size        int64
 }
 
-func Open(ctx context.Context, dir iosrc.URI, id ksuid.KSUID) (Chunk, error) {
-	meta, err := ReadMetadata(ctx, MetadataPath(dir, id))
+func Open(ctx context.Context, dir iosrc.URI, id ksuid.KSUID, order zbuf.Order) (Chunk, error) {
+	meta, err := ReadMetadata(ctx, MetadataPath(dir, id), order)
 	if err != nil {
 		return Chunk{}, err
 	}

--- a/ppl/archive/chunk/metadata.go
+++ b/ppl/archive/chunk/metadata.go
@@ -88,5 +88,5 @@ func mdTsOrderCheck(u iosrc.URI, op string, order zbuf.Order, first, last nano.T
 	if x <= y {
 		return nil
 	}
-	return fmt.Errorf("metadata failed order check %s op %s order %s first %v last %v", u, op, order, int64(first), int64(last))
+	return fmt.Errorf("metadata failed order check %s op %s order %s first %d last %d", u, op, order, first, last)
 }

--- a/ppl/archive/chunk/reader.go
+++ b/ppl/archive/chunk/reader.go
@@ -2,7 +2,7 @@ package chunk
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 
 	"github.com/brimsec/zq/pkg/iosrc"
@@ -21,11 +21,11 @@ type Reader struct {
 // NewReader returns a Reader for this chunk. If the chunk has a seek index and
 // if the provided span skips part of the chunk, the seek index will be used to
 // limit the reading window of the returned reader.
-func NewReader(ctx context.Context, chunk Chunk, span nano.Span) (*Reader, error) {
+func NewReader(ctx context.Context, chunk Chunk, readspan nano.Span) (*Reader, error) {
 	cspan := chunk.Span()
-	span = cspan.Intersect(span)
+	span := cspan.Intersect(readspan)
 	if span.Dur == 0 {
-		return nil, errors.New("chunk span does intersect provided span")
+		return nil, fmt.Errorf("chunk reader: chunk does not intersect provided span: %s chunkspan %v readspan %v", chunk.Path(), cspan, readspan)
 	}
 	r, err := iosrc.NewReader(ctx, chunk.Path())
 	if err != nil {

--- a/ppl/archive/chunk/writer.go
+++ b/ppl/archive/chunk/writer.go
@@ -25,6 +25,7 @@ type Writer struct {
 	lastTs         nano.Ts
 	masks          []ksuid.KSUID
 	needIndexWrite bool
+	order          zbuf.Order
 	seekIndex      *seekindex.Builder
 	dir            iosrc.URI
 	wroteFirst     bool
@@ -49,6 +50,7 @@ func NewWriter(ctx context.Context, dir iosrc.URI, order zbuf.Order, masks []ksu
 		id:             id,
 		seekIndex:      seekIndex,
 		masks:          masks,
+		order:          order,
 		dir:            dir,
 	}, nil
 }
@@ -108,7 +110,7 @@ func (cw *Writer) CloseWithTs(ctx context.Context, firstTs, lastTs nano.Ts) (Chu
 		Masks:       cw.masks,
 		Size:        cw.dataFileWriter.Position(),
 	}
-	if err := metadata.Write(ctx, MetadataPath(cw.dir, cw.id)); err != nil {
+	if err := metadata.Write(ctx, MetadataPath(cw.dir, cw.id), cw.order); err != nil {
 		cw.seekIndex.Abort()
 		return Chunk{}, err
 	}

--- a/ppl/archive/multisource.go
+++ b/ppl/archive/multisource.go
@@ -128,7 +128,7 @@ func (m *spanMultiSource) SourceFromRequest(ctx context.Context, req *api.Worker
 			return nil, zqe.E(zqe.Invalid, "invalid chunk path: %v", p)
 		}
 		uri := tsdir.path(m.ark)
-		md, err := chunk.ReadMetadata(ctx, chunk.MetadataPath(uri, id))
+		md, err := chunk.ReadMetadata(ctx, chunk.MetadataPath(uri, id), m.ark.DataOrder)
 		if err != nil {
 			return nil, err
 		}

--- a/ppl/archive/walk.go
+++ b/ppl/archive/walk.go
@@ -117,7 +117,7 @@ func tsDirEntriesToChunks(ctx context.Context, ark *Archive, filterSpan nano.Spa
 			continue
 		}
 		dir := tsDir.path(ark)
-		md, err := chunk.ReadMetadata(ctx, chunk.MetadataPath(dir, id))
+		md, err := chunk.ReadMetadata(ctx, chunk.MetadataPath(dir, id), ark.DataOrder)
 		if err != nil {
 			if zqe.IsNotFound(err) {
 				continue


### PR DESCRIPTION
Adds checks at metadata read and write time that will help investigate #1758  , and enhance error message when #1758 is hit.

Example with archive from that issue:
```
[ec2-user@ip-172-31-28-207 zq]$ zar zq -R  s3://zqd-demo-1/mark/zeek-logs/conn-try3 -t "count()"
metadata failed order check s3://zqd-demo-1/mark/zeek-logs/conn-try3/zd/20180324/m-1lCqLeLXGOPbdXNyM9vVml7jCxQ.zng op read order descending first 1521908907351058000 last 1521910044521300000
```
