### PR TITLE
improve space list performance

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -105,27 +105,21 @@ func (s *SpaceID) Set(str string) error {
 	return nil
 }
 
-type SpaceInfo struct {
+type Space struct {
 	ID          SpaceID     `json:"id"`
+	ParentID    SpaceID     `json:"parent_id,omitempty"`
 	Name        string      `json:"name"`
 	DataPath    iosrc.URI   `json:"data_path"`
 	StorageKind StorageKind `json:"storage_kind"`
-	Span        *nano.Span  `json:"span,omitempty"`
-	Size        int64       `json:"size" unit:"bytes"`
-	PcapSupport bool        `json:"pcap_support"`
-	PcapSize    int64       `json:"pcap_size" unit:"bytes"`
-	PcapPath    iosrc.URI   `json:"pcap_path"`
-	ParentID    SpaceID     `json:"parent_id,omitempty"`
 }
 
-type SpaceInfos []SpaceInfo
-
-func (s SpaceInfos) Names() []string {
-	names := make([]string, len(s))
-	for i, info := range s {
-		names[i] = info.Name
-	}
-	return names
+type SpaceInfo struct {
+	Space
+	Span        *nano.Span `json:"span,omitempty"`
+	Size        int64      `json:"size" unit:"bytes"`
+	PcapSupport bool       `json:"pcap_support"`
+	PcapSize    int64      `json:"pcap_size" unit:"bytes"`
+	PcapPath    iosrc.URI  `json:"pcap_path"`
 }
 
 type VersionResponse struct {

--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -164,10 +164,10 @@ func (c *Connection) SpaceInfo(ctx context.Context, id api.SpaceID) (*api.SpaceI
 	return resp.Result().(*api.SpaceInfo), nil
 }
 
-func (c *Connection) SpacePost(ctx context.Context, req api.SpacePostRequest) (*api.SpaceInfo, error) {
+func (c *Connection) SpacePost(ctx context.Context, req api.SpacePostRequest) (*api.Space, error) {
 	resp, err := c.Request(ctx).
 		SetBody(req).
-		SetResult(&api.SpaceInfo{}).
+		SetResult(&api.Space{}).
 		Post("/space")
 	if err != nil {
 		if r, ok := err.(*ErrorResponse); ok && r.StatusCode() == http.StatusConflict {
@@ -175,13 +175,13 @@ func (c *Connection) SpacePost(ctx context.Context, req api.SpacePostRequest) (*
 		}
 		return nil, err
 	}
-	return resp.Result().(*api.SpaceInfo), nil
+	return resp.Result().(*api.Space), nil
 }
 
-func (c *Connection) SubspacePost(ctx context.Context, id api.SpaceID, req api.SubspacePostRequest) (*api.SpaceInfo, error) {
+func (c *Connection) SubspacePost(ctx context.Context, id api.SpaceID, req api.SubspacePostRequest) (*api.Space, error) {
 	resp, err := c.Request(ctx).
 		SetBody(req).
-		SetResult(&api.SpaceInfo{}).
+		SetResult(&api.Space{}).
 		Post(path.Join("/space", string(id), "subspace"))
 	if err != nil {
 		if r, ok := err.(*ErrorResponse); ok && r.StatusCode() == http.StatusConflict {
@@ -189,7 +189,7 @@ func (c *Connection) SubspacePost(ctx context.Context, id api.SpaceID, req api.S
 		}
 		return nil, err
 	}
-	return resp.Result().(*api.SpaceInfo), nil
+	return resp.Result().(*api.Space), nil
 }
 
 func (c *Connection) SpacePut(ctx context.Context, id api.SpaceID, req api.SpacePutRequest) error {
@@ -199,8 +199,8 @@ func (c *Connection) SpacePut(ctx context.Context, id api.SpaceID, req api.Space
 	return err
 }
 
-func (c *Connection) SpaceList(ctx context.Context) ([]api.SpaceInfo, error) {
-	var res []api.SpaceInfo
+func (c *Connection) SpaceList(ctx context.Context) ([]api.Space, error) {
+	var res []api.Space
 	_, err := c.Request(ctx).
 		SetResult(&res).
 		Get("/space")

--- a/cmd/zapi/cmd/info/ls.go
+++ b/cmd/zapi/cmd/info/ls.go
@@ -52,9 +52,9 @@ func (c *LsCommand) Run(args []string) error {
 	}
 	if c.lflag {
 		// print details about each space
-		return printInfoList(matches)
+		return printSpaceSummaries(matches)
 	}
-	names := api.SpaceInfos(matches).Names()
+	names := cmd.SpaceNames(matches)
 	width := termwidth.Width()
 	// print listing laid out in columns like ls
 	err = colw.Write(os.Stdout, names, width, 3)
@@ -62,4 +62,13 @@ func (c *LsCommand) Run(args []string) error {
 		fmt.Println(strings.Join(names, "\n"))
 	}
 	return err
+}
+
+func printSpaceSummaries(sl []api.Space) error {
+	for _, space := range sl {
+		if err := printSpace(space.Name, space); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/ppl/zqd/handlers_pcap_test.go
+++ b/ppl/zqd/handlers_pcap_test.go
@@ -149,10 +149,12 @@ func TestPcapPostInvalidPcap(t *testing.T) {
 		info, err := p.client.SpaceInfo(context.Background(), p.space.ID)
 		assert.NoError(t, err)
 		expected := api.SpaceInfo{
-			ID:          p.space.ID,
-			Name:        p.space.Name,
-			DataPath:    p.space.DataPath,
-			StorageKind: api.FileStore,
+			Space: api.Space{
+				ID:          p.space.ID,
+				Name:        p.space.Name,
+				DataPath:    p.space.DataPath,
+				StorageKind: api.FileStore,
+			},
 		}
 		require.Equal(t, &expected, info)
 	})
@@ -208,7 +210,7 @@ func launcherFromEnv(t *testing.T, key string) pcapanalyzer.Launcher {
 type pcapPostTestResult struct {
 	client   *client.Connection
 	core     *zqd.Core
-	space    api.SpaceInfo
+	space    api.Space
 	err      error
 	payloads client.Payloads
 }

--- a/ppl/zqd/handlers_test.go
+++ b/ppl/zqd/handlers_test.go
@@ -207,14 +207,14 @@ func TestSearchError(t *testing.T) {
 
 func TestSpaceList(t *testing.T) {
 	names := []string{"sp1", "sp2", "sp3", "sp4"}
-	var expected []api.SpaceInfo
+	var expected []api.Space
 
 	ctx := context.Background()
 	c, conn := newCore(t)
 	for _, n := range names {
 		sp, err := conn.SpacePost(ctx, api.SpacePostRequest{Name: n})
 		require.NoError(t, err)
-		expected = append(expected, api.SpaceInfo{
+		expected = append(expected, api.Space{
 			ID:          sp.ID,
 			Name:        n,
 			DataPath:    c.Root().AppendPath(string(sp.ID)),
@@ -242,10 +242,12 @@ func TestSpaceInfo(t *testing.T) {
 
 	span := nano.Span{Ts: 1e9, Dur: 1e9 + 1}
 	expected := &api.SpaceInfo{
-		ID:          sp.ID,
-		Name:        sp.Name,
-		DataPath:    sp.DataPath,
-		StorageKind: api.FileStore,
+		Space: api.Space{
+			ID:          sp.ID,
+			Name:        sp.Name,
+			DataPath:    sp.DataPath,
+			StorageKind: api.FileStore,
+		},
 		Span:        &span,
 		Size:        81,
 		PcapSupport: false,
@@ -263,10 +265,12 @@ func TestSpaceInfoNoData(t *testing.T) {
 	info, err := conn.SpaceInfo(ctx, sp.ID)
 	require.NoError(t, err)
 	expected := &api.SpaceInfo{
-		ID:          sp.ID,
-		Name:        sp.Name,
-		DataPath:    sp.DataPath,
-		StorageKind: api.FileStore,
+		Space: api.Space{
+			ID:          sp.ID,
+			Name:        sp.Name,
+			DataPath:    sp.DataPath,
+			StorageKind: api.FileStore,
+		},
 		Size:        0,
 		PcapSupport: false,
 	}
@@ -434,10 +438,12 @@ func TestPostZngLogs(t *testing.T) {
 	info, err := conn.SpaceInfo(context.Background(), sp.ID)
 	require.NoError(t, err)
 	assert.Equal(t, &api.SpaceInfo{
-		ID:          sp.ID,
-		Name:        sp.Name,
-		DataPath:    sp.DataPath,
-		StorageKind: api.FileStore,
+		Space: api.Space{
+			ID:          sp.ID,
+			Name:        sp.Name,
+			DataPath:    sp.DataPath,
+			StorageKind: api.FileStore,
+		},
 		Span:        &nano.Span{Ts: nano.Ts(time.Second), Dur: int64(time.Second) + 1},
 		Size:        79,
 		PcapSupport: false,
@@ -508,10 +514,12 @@ func TestPostNDJSONLogs(t *testing.T) {
 		info, err := conn.SpaceInfo(context.Background(), sp.ID)
 		require.NoError(t, err)
 		require.Equal(t, &api.SpaceInfo{
-			ID:          sp.ID,
-			Name:        sp.Name,
-			DataPath:    sp.DataPath,
-			StorageKind: api.FileStore,
+			Space: api.Space{
+				ID:          sp.ID,
+				Name:        sp.Name,
+				DataPath:    sp.DataPath,
+				StorageKind: api.FileStore,
+			},
 			Span:        &span,
 			Size:        79,
 			PcapSupport: false,
@@ -634,12 +642,14 @@ func TestCreateArchiveSpace(t *testing.T) {
 
 	span := nano.Span{Ts: 1587508830068523240, Dur: 9789993714061}
 	expsi := &api.SpaceInfo{
-		ID:          sp.ID,
-		Name:        sp.Name,
-		DataPath:    sp.DataPath,
-		StorageKind: api.ArchiveStore,
-		Span:        &span,
-		Size:        35118,
+		Space: api.Space{
+			ID:          sp.ID,
+			Name:        sp.Name,
+			DataPath:    sp.DataPath,
+			StorageKind: api.ArchiveStore,
+		},
+		Span: &span,
+		Size: 35118,
 	}
 	si, err := conn.SpaceInfo(context.Background(), sp.ID)
 	require.NoError(t, err)


### PR DESCRIPTION
This change removes the storage details, like total size of the space's data, from the space list api response. Fetching those details was significantly slowing down `zapi` operations, since zapi uses the space list api to translate space names to space id's.

Brim tests pass against this change, and I didn't notice any difference using Brim manually with it. I'm checking with the frontend folks to be sure, but it seems like Brim uses the 'get space' operation for a space's storage details, and doesn't rely on the space list response for them.

Closes https://github.com/brimsec/zq/issues/1778 
