### PR TITLE
verify subspace storage configuration on creation

### DIFF
--- a/ztests/suite/zqd/archivestore/subspace.yaml
+++ b/ztests/suite/zqd/archivestore/subspace.yaml
@@ -1,0 +1,19 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new -k archivestore s1
+  export SPACE_ID=$(zapi -h $ZQD_HOST ls -l s1 | grep "id:" | head -n 1 | awk  '{print $2}')
+  echo ===
+  zapi -h $ZQD_HOST newsubspace -p ${SPACE_ID} -n sub1 badlogid
+
+inputs:
+  - name: services.sh
+    source: ../services.sh
+
+outputs:
+  - name: stdout
+    data: |
+      s1: space created
+      ===
+  - name: stderr
+    regexp: |
+      .*badlogid not a chunk file name.*


### PR DESCRIPTION
Bad on me: I thought I ran all of the Brim integration tests locally when I tested #1779 , but I missed running the zealot tests. This fixes an issue that they hit, and adds a zq side test: when we create a subspace, we should validate the storage options.

Brim side CI tests in: https://github.com/brimsec/brim/pull/1270
