### PR TITLE
Add pick docs and cross-ref with cut

### DIFF
--- a/expr/cut_test.go
+++ b/expr/cut_test.go
@@ -48,7 +48,7 @@ func TestCut(t *testing.T) {
 	proctest.TestOneProc(t, fooAndBar, fooOnly, "cut foo")
 
 	// test "cut foo" on records that don't have field foo
-	warning := "cut: nothing found for foo"
+	warning := "cut: no record found with columns foo"
 	proctest.TestOneProcWithWarnings(t, barOnly, "", []string{warning}, "cut foo")
 
 	// test "cut foo" on some fields with foo, some without

--- a/expr/cutter.go
+++ b/expr/cutter.go
@@ -137,7 +137,7 @@ func (c *Cutter) Warning() string {
 	if c.FoundCut() {
 		return ""
 	}
-	return fmt.Sprintf("nothing found for %s", fieldList(c.fieldExprs))
+	return fmt.Sprintf("no record found with columns %s", fieldList(c.fieldExprs))
 }
 
 func (c *Cutter) Eval(rec *zng.Record) (zng.Value, error) {

--- a/zql/docs/processors/README.md
+++ b/zql/docs/processors/README.md
@@ -79,7 +79,7 @@ zq -f table 'cut nothere,alsoabsent' weird.log.gz
 
 #### Output:
 ```zq-output
-cut: nothing found for nothere,alsoabsent
+cut: no record found with columns nothere,alsoabsent
 ```
 
 #### Example #4:
@@ -331,7 +331,7 @@ zq -f table 'pick nothere,alsoabsent' weird.log.gz
 
 #### Output:
 ```zq-output
-pick: nothing found for nothere,alsoabsent
+pick: no record found with columns nothere,alsoabsent
 ```
 
 #### Example #4:

--- a/zql/docs/processors/README.md
+++ b/zql/docs/processors/README.md
@@ -52,18 +52,18 @@ TS                          UID
 
 #### Example #2:
 
-As long as some of the named fields are present, these will be returned. No warning is generated regarding absent fields.
+As long as some of the named fields are present, these will be returned. No warning is generated regarding absent fields. For instance, even though only the Zeek `smb_mapping` logs in our sample data contain the field named `share_type`, the following query returns records for many other log types that contain the `_path` and/or `ts` that we included in our field list.
 
 ```zq-command
-zq -f table 'cut nothere,name' weird.log.gz
+zq -f table 'cut _path,ts,share_type' *
 ```
 
 #### Output:
 ```zq-output head:4
-NAME
-TCP_ack_underflow_or_misorder
-truncated_header
-above_hole_data_without_any_acks
+_PATH  TS
+stats  2018-03-24T17:15:20.600725Z
+weird  2018-03-24T17:15:20.600843Z
+weird  2018-03-24T17:15:20.608108Z
 ...
 ```
 
@@ -81,7 +81,6 @@ zq -f table 'cut nothere,alsoabsent' weird.log.gz
 ```zq-output
 cut: nothing found for nothere,alsoabsent
 ```
-
 
 #### Example #4:
 
@@ -305,20 +304,37 @@ TS                          UID
 
 #### Example #2:
 
-All of the named fields must be present in a record for `pick` to return a result for it. If we extend the field list from our previous example to include a field that's not present anywhere in our data, now a warning is shown and no data is returned for `ts` and `uid` fields.
+All of the named fields must be present in a record for `pick` to return a result for it. For instance, since only the Zeek `smb_mapping` in our sample data contains the field named `share_type`, the following query returns columns for only that log type. Records from the many other Zeek log types that also include `_path` and/or `ts` fields are not returned.
 
 ```zq-command
-zq -f table 'pick ts,uid,nothere' conn.log.gz
+zq -f table 'pick _path,ts,share_type' *
 ```
 
 #### Output:
-```zq-output
-pick: nothing found for ts,uid,nothere
+```zq-output head:4
+_PATH       TS                          SHARE_TYPE
+smb_mapping 2018-03-24T17:15:21.382822Z DISK
+smb_mapping 2018-03-24T17:15:21.625534Z PIPE
+smb_mapping 2018-03-24T17:15:22.021668Z PIPE
+...
 ```
 
 Contrast this with a [similar example](#example-2) that shows how [`cut`](#cut)'s relaxed behavior would produce a partial result here.
 
 #### Example #3:
+
+If no records are found that contain any of the named fields, `pick` returns a warning.
+
+```zq-command
+zq -f table 'pick nothere,alsoabsent' weird.log.gz
+```
+
+#### Output:
+```zq-output
+pick: nothing found for nothere,alsoabsent
+```
+
+#### Example #4:
 
 To return only the `ts` and `uid` columns of `conn` events, with `ts` renamed to `time`:
 


### PR DESCRIPTION
This PR adds ZQL docs for the recently added `pick` processor. I've made sure to include an example that illustrates their fundamental difference and included links between the two so users who start at one but are seeking the stricter/looser behavior of the other can easily find it. I also swapped the order of two of the `cut` examples so the the numeric order matches to its comparable `pick` example.

I'm aware this introduces some redundant examples between `cut` and `pick`, but, so be it. I happen to prefer this approach to making a new user look in two places to get the full story. With what I'm doing here, I'm hoping if a user likes what they see in the first one they find, they're off to the races.