### PR TITLE
Makefile: force GOARCH to amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ export GO111MODULE=on
 
 # If VERSION or LDFLAGS change, please also change
 # npm/build.
+GOARCH = "amd64"
 VERSION = $(shell git describe --tags --dirty --always)
 ECR_VERSION = $(VERSION)-$(ZQD_K8S_USER)
 LDFLAGS = -s -X github.com/brimsec/zq/cli.Version=$(VERSION)
@@ -44,14 +45,14 @@ sampledata: $(SAMPLEDATA)
 bin/$(ZEEKPATH):
 	@mkdir -p bin
 	@curl -L -o bin/$(ZEEKPATH).zip \
-		https://github.com/brimsec/zeek/releases/download/$(ZEEKTAG)/zeek-$(ZEEKTAG).$$(go env GOOS)-$$(go env GOARCH).zip
+		https://github.com/brimsec/zeek/releases/download/$(ZEEKTAG)/zeek-$(ZEEKTAG).$$(go env GOOS)-$(GOARCH).zip
 	@unzip -q bin/$(ZEEKPATH).zip -d bin \
 		&& mv bin/zeek bin/$(ZEEKPATH)
 
 bin/$(SURICATAPATH):
 	@mkdir -p bin
 	curl -L -o bin/$(SURICATAPATH).zip \
-		https://github.com/brimsec/build-suricata/releases/download/$(SURICATATAG)/suricata-$(SURICATATAG).$$(go env GOOS)-$$(go env GOARCH).zip
+		https://github.com/brimsec/build-suricata/releases/download/$(SURICATATAG)/suricata-$(SURICATATAG).$$(go env GOOS)-$(GOARCH).zip
 	unzip -q bin/$(SURICATAPATH).zip -d bin \
 		&& mv bin/suricata bin/$(SURICATAPATH)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export GO111MODULE=on
 
 # If VERSION or LDFLAGS change, please also change
 # npm/build.
-GOARCH = "amd64"
+ARCH = "amd64"
 VERSION = $(shell git describe --tags --dirty --always)
 ECR_VERSION = $(VERSION)-$(ZQD_K8S_USER)
 LDFLAGS = -s -X github.com/brimsec/zq/cli.Version=$(VERSION)
@@ -45,14 +45,14 @@ sampledata: $(SAMPLEDATA)
 bin/$(ZEEKPATH):
 	@mkdir -p bin
 	@curl -L -o bin/$(ZEEKPATH).zip \
-		https://github.com/brimsec/zeek/releases/download/$(ZEEKTAG)/zeek-$(ZEEKTAG).$$(go env GOOS)-$(GOARCH).zip
+		https://github.com/brimsec/zeek/releases/download/$(ZEEKTAG)/zeek-$(ZEEKTAG).$$(go env GOOS)-$(ARCH).zip
 	@unzip -q bin/$(ZEEKPATH).zip -d bin \
 		&& mv bin/zeek bin/$(ZEEKPATH)
 
 bin/$(SURICATAPATH):
 	@mkdir -p bin
 	curl -L -o bin/$(SURICATAPATH).zip \
-		https://github.com/brimsec/build-suricata/releases/download/$(SURICATATAG)/suricata-$(SURICATATAG).$$(go env GOOS)-$(GOARCH).zip
+		https://github.com/brimsec/build-suricata/releases/download/$(SURICATATAG)/suricata-$(SURICATATAG).$$(go env GOOS)-$(ARCH).zip
 	unzip -q bin/$(SURICATAPATH).zip -d bin \
 		&& mv bin/suricata bin/$(SURICATAPATH)
 
@@ -139,7 +139,7 @@ create-release-assets:
 		rm -rf dist/$${zqdir} ; \
 		mkdir -p dist/$${zqdir} ; \
 		cp LICENSE.txt acknowledgments.txt dist/$${zqdir} ; \
-		GOOS=$${os} GOARCH=amd64 go build -ldflags='$(LDFLAGS)' -o dist/$${zqdir} ./cmd/... ./ppl/cmd/... ; \
+		GOOS=$${os} GOARCH=$(ARCH) go build -ldflags='$(LDFLAGS)' -o dist/$${zqdir} ./cmd/... ./ppl/cmd/... ; \
 	done
 	rm -rf dist/release && mkdir -p dist/release
 	cd dist && for d in zq-$(VERSION)* ; do \


### PR DESCRIPTION
Currently we only support builds for zeek and suricata for amd64. Until we have
builds for other architectures (e.g. arm64) just download the amd64 binary.

This will work for Mac silicon users who have Rosetta 2 enabled (current master
does not).