### PR TITLE
Archive: create indices on write/compact

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -26,15 +26,7 @@ func (f *Flags) Options() zio.WriterOpts {
 	return f.WriterOpts
 }
 
-func (f *Flags) formatFlags(fs *flag.FlagSet) {
-	fs.StringVar(&f.Format, "f", "zng", "format for output data [zng,zst,ndjson,table,text,csv,zeek,zjson,zson,tzng]")
-	fs.BoolVar(&f.textShortcut, "t", false, "use format tzng independent of -f option")
-	fs.BoolVar(&f.forceBinary, "B", false, "allow binary zng be sent to a terminal output")
-}
-
 func (f *Flags) setFlags(fs *flag.FlagSet) {
-	f.formatFlags(fs)
-
 	// zio stuff
 	fs.BoolVar(&f.UTF8, "U", false, "display zeek strings as UTF-8")
 	fs.BoolVar(&f.Text.ShowTypes, "T", false, "display field types in text output")
@@ -57,6 +49,7 @@ func (f *Flags) setFlags(fs *flag.FlagSet) {
 }
 
 func (f *Flags) SetFlags(fs *flag.FlagSet) {
+	f.SetFormatFlags(fs)
 	f.setFlags(fs)
 }
 
@@ -66,7 +59,9 @@ func (f *Flags) SetFlagsWithFormat(fs *flag.FlagSet, format string) {
 }
 
 func (f *Flags) SetFormatFlags(fs *flag.FlagSet) {
-	f.formatFlags(fs)
+	fs.StringVar(&f.Format, "f", "zng", "format for output data [zng,zst,ndjson,table,text,csv,zeek,zjson,zson,tzng]")
+	fs.BoolVar(&f.textShortcut, "t", false, "use format tzng independent of -f option")
+	fs.BoolVar(&f.forceBinary, "B", false, "allow binary zng be sent to a terminal output")
 }
 
 func (f *Flags) Init() error {

--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -26,7 +26,15 @@ func (f *Flags) Options() zio.WriterOpts {
 	return f.WriterOpts
 }
 
+func (f *Flags) formatFlags(fs *flag.FlagSet) {
+	fs.StringVar(&f.Format, "f", "zng", "format for output data [zng,zst,ndjson,table,text,csv,zeek,zjson,zson,tzng]")
+	fs.BoolVar(&f.textShortcut, "t", false, "use format tzng independent of -f option")
+	fs.BoolVar(&f.forceBinary, "B", false, "allow binary zng be sent to a terminal output")
+}
+
 func (f *Flags) setFlags(fs *flag.FlagSet) {
+	f.formatFlags(fs)
+
 	// zio stuff
 	fs.BoolVar(&f.UTF8, "U", false, "display zeek strings as UTF-8")
 	fs.BoolVar(&f.Text.ShowTypes, "T", false, "display field types in text output")
@@ -45,19 +53,20 @@ func (f *Flags) setFlags(fs *flag.FlagSet) {
 	// emitter stuff
 	fs.StringVar(&f.dir, "d", "", "directory for output data files")
 	fs.StringVar(&f.outputFile, "o", "", "write data to output file")
-	fs.BoolVar(&f.forceBinary, "B", false, "allow binary zng be sent to a terminal output")
 
 }
 
 func (f *Flags) SetFlags(fs *flag.FlagSet) {
 	f.setFlags(fs)
-	fs.StringVar(&f.Format, "f", "zng", "format for output data [zng,zst,ndjson,table,text,csv,zeek,zjson,zson,tzng]")
-	fs.BoolVar(&f.textShortcut, "t", false, "use format tzng independent of -f option")
 }
 
 func (f *Flags) SetFlagsWithFormat(fs *flag.FlagSet, format string) {
 	f.setFlags(fs)
 	f.Format = format
+}
+
+func (f *Flags) SetFormatFlags(fs *flag.FlagSet) {
+	f.formatFlags(fs)
 }
 
 func (f *Flags) Init() error {

--- a/ppl/archive/chunk/writer.go
+++ b/ppl/archive/chunk/writer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/brimsec/zq/pkg/bufwriter"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/ppl/archive/index"
 	"github.com/brimsec/zq/ppl/archive/seekindex"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/zngio"
@@ -19,41 +20,72 @@ import (
 type Writer struct {
 	byteCounter    *writeCounter
 	count          uint64
+	chunk          Chunk
 	dataFileWriter *zngio.Writer
 	firstTs        nano.Ts
 	id             ksuid.KSUID
+	indexWriter    indexWriter
 	lastTs         nano.Ts
 	masks          []ksuid.KSUID
-	needIndexWrite bool
+	needSeekWrite  bool
 	order          zbuf.Order
 	seekIndex      *seekindex.Builder
 	dir            iosrc.URI
 	wroteFirst     bool
 }
 
-func NewWriter(ctx context.Context, dir iosrc.URI, order zbuf.Order, masks []ksuid.KSUID, opts zngio.WriterOpts) (*Writer, error) {
+type WriterOpts struct {
+	Definitions index.Definitions
+	Masks       []ksuid.KSUID
+	Order       zbuf.Order
+	Zng         zngio.WriterOpts
+}
+
+func NewWriter(ctx context.Context, dir iosrc.URI, opts WriterOpts) (*Writer, error) {
 	id := ksuid.New()
 	out, err := iosrc.NewWriter(ctx, dir.AppendPath(ChunkFileName(id)))
 	if err != nil {
 		return nil, err
 	}
 	counter := &writeCounter{bufwriter.New(out), 0}
-	dataFileWriter := zngio.NewWriter(counter, opts)
+	dataFileWriter := zngio.NewWriter(counter, opts.Zng)
 	seekIndexPath := chunkSeekIndexPath(dir, id)
-	seekIndex, err := seekindex.NewBuilder(ctx, seekIndexPath.String(), order)
+	seekIndex, err := seekindex.NewBuilder(ctx, seekIndexPath.String(), opts.Order)
 	if err != nil {
 		return nil, err
+	}
+	idxWriter := indexWriter(nopIndexWriter{})
+	// For a Chunk writer we only care about writing index defs whose input
+	// path is empty (i.e. references the chunk data itself).
+	if defs := opts.Definitions.StandardInputs(); len(defs) > 0 {
+		dir := chunkZarDir(dir, id)
+		idxWriter, err = index.NewMultiWriter(ctx, dir, defs)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &Writer{
 		byteCounter:    counter,
 		dataFileWriter: dataFileWriter,
 		id:             id,
+		indexWriter:    idxWriter,
 		seekIndex:      seekIndex,
-		masks:          masks,
-		order:          order,
+		masks:          opts.Masks,
+		order:          opts.Order,
 		dir:            dir,
 	}, nil
 }
+
+type indexWriter interface {
+	zbuf.WriteCloser
+	Abort()
+}
+
+type nopIndexWriter struct{}
+
+func (n nopIndexWriter) Write(*zng.Record) error { return nil }
+func (n nopIndexWriter) Close() error            { return nil }
+func (n nopIndexWriter) Abort()                  {}
 
 func (cw *Writer) Position() (int64, nano.Ts, nano.Ts) {
 	return cw.dataFileWriter.Position(), cw.firstTs, cw.lastTs
@@ -68,18 +100,21 @@ func (cw *Writer) Write(rec *zng.Record) error {
 		return err
 	}
 	ts := rec.Ts()
-	if !cw.wroteFirst || (cw.needIndexWrite && ts != cw.lastTs) {
+	if !cw.wroteFirst || (cw.needSeekWrite && ts != cw.lastTs) {
 		if err := cw.seekIndex.Enter(ts, sos); err != nil {
 			return err
 		}
-		cw.needIndexWrite = false
+		cw.needSeekWrite = false
 	}
 	if cw.dataFileWriter.LastSOS() != sos {
-		cw.needIndexWrite = true
+		cw.needSeekWrite = true
 	}
 	if !cw.wroteFirst {
 		cw.firstTs = ts
 		cw.wroteFirst = true
+	}
+	if err := cw.indexWriter.Write(rec); err != nil {
+		return err
 	}
 	cw.lastTs = ts
 	cw.count++
@@ -91,17 +126,18 @@ func (cw *Writer) Write(rec *zng.Record) error {
 func (cw *Writer) Abort() {
 	cw.dataFileWriter.Close()
 	cw.seekIndex.Abort()
+	cw.indexWriter.Abort()
 }
 
-func (cw *Writer) Close(ctx context.Context) (Chunk, error) {
+func (cw *Writer) Close(ctx context.Context) error {
 	return cw.CloseWithTs(ctx, cw.firstTs, cw.lastTs)
 }
 
-func (cw *Writer) CloseWithTs(ctx context.Context, firstTs, lastTs nano.Ts) (Chunk, error) {
+func (cw *Writer) CloseWithTs(ctx context.Context, firstTs, lastTs nano.Ts) error {
 	err := cw.dataFileWriter.Close()
 	if err != nil {
-		cw.seekIndex.Abort()
-		return Chunk{}, err
+		cw.Abort()
+		return err
 	}
 	metadata := Metadata{
 		First:       firstTs,
@@ -111,16 +147,21 @@ func (cw *Writer) CloseWithTs(ctx context.Context, firstTs, lastTs nano.Ts) (Chu
 		Size:        cw.dataFileWriter.Position(),
 	}
 	if err := metadata.Write(ctx, MetadataPath(cw.dir, cw.id), cw.order); err != nil {
-		cw.seekIndex.Abort()
-		return Chunk{}, err
+		cw.Abort()
+		return err
 	}
 	if err := cw.seekIndex.Close(); err != nil {
-		return Chunk{}, err
+		cw.Abort()
+		return err
+	}
+	if err := cw.indexWriter.Close(); err != nil {
+		return err
 	}
 	// TODO: zq#1264
 	// Add an entry to the update log for S3 backed stores containing the
 	// location of the just added data & index file.
-	return metadata.Chunk(cw.dir, cw.id), nil
+	cw.chunk = metadata.Chunk(cw.dir, cw.id)
+	return nil
 }
 
 func (cw *Writer) BytesWritten() int64 {
@@ -129,6 +170,12 @@ func (cw *Writer) BytesWritten() int64 {
 
 func (cw *Writer) RecordsWritten() uint64 {
 	return cw.count
+}
+
+// Chunk returns the Chunk written by the writer. This is only valid after
+// Close() has returned a nil error.
+func (cw *Writer) Chunk() Chunk {
+	return cw.chunk
 }
 
 type writeCounter struct {

--- a/ppl/archive/chunk/writer_test.go
+++ b/ppl/archive/chunk/writer_test.go
@@ -1,0 +1,57 @@
+package chunk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/ppl/archive/index"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zio/tzngio"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/brimsec/zq/zqe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriterIndex(t *testing.T) {
+	const data = `
+#0:record[ts:time,v:int64]
+0:[5;100;]
+0:[4;101;]
+0:[3;104;]
+0:[2;109;]
+0:[1;100;]`
+	def := index.MustNewDefinition(index.NewTypeRule(zng.TypeInt64))
+	chunk := testWriteWithDef(t, data, def)
+	rec, err := index.Find(context.Background(), resolver.NewContext(), chunk.ZarDir(), def.ID, "100")
+	require.NoError(t, err)
+	v, err := rec.AccessInt("count")
+	require.NoError(t, err)
+	require.EqualValues(t, 2, v)
+}
+
+func TestWriterSkipsInputPath(t *testing.T) {
+	const data = `
+#0:record[ts:time,v:int64,s:string]
+0:[5;100;test;]`
+	sdef := index.MustNewDefinition(index.NewFieldRule("s"))
+	inputdef := index.MustNewDefinition(index.NewTypeRule(zng.TypeInt64))
+	inputdef.Input = "input_path"
+	zctx := resolver.NewContext()
+	chunk := testWriteWithDef(t, data, sdef, inputdef)
+	_, err := index.Find(context.Background(), zctx, chunk.ZarDir(), sdef.ID, "100")
+	assert.NoError(t, err)
+	_, err = index.Find(context.Background(), zctx, chunk.ZarDir(), inputdef.ID, "100")
+	assert.Truef(t, zqe.IsNotFound(err), "expected err to be zqe.IsNotFound, got: %v", err)
+}
+
+func testWriteWithDef(t *testing.T, tzng string, defs ...*index.Definition) Chunk {
+	dir := iosrc.MustParseURI(t.TempDir())
+	w, err := NewWriter(context.Background(), dir, WriterOpts{Order: zbuf.OrderDesc, Definitions: defs})
+	require.NoError(t, err)
+	require.NoError(t, tzngio.WriteString(w, tzng))
+	require.NoError(t, w.Close(context.Background()))
+	return w.Chunk()
+}

--- a/ppl/archive/import_test.go
+++ b/ppl/archive/import_test.go
@@ -33,7 +33,8 @@ func testImportStaleDuration(t *testing.T, stale time.Duration, expected uint64)
 	require.NoError(t, err)
 
 	// write one record to an open archive.Writer and do NOT close it.
-	w := NewWriter(context.Background(), ark)
+	w, err := NewWriter(context.Background(), ark)
+	require.NoError(t, err)
 	defer w.Close()
 	w.SetStaleDuration(stale)
 	r := tzngio.NewReader(strings.NewReader(data), resolver.NewContext())

--- a/ppl/archive/index/definition.go
+++ b/ppl/archive/index/definition.go
@@ -55,6 +55,10 @@ func ReadDefinition(ctx context.Context, u iosrc.URI) (*Definition, error) {
 	return def, err
 }
 
+func RemoveDefinition(ctx context.Context, dir iosrc.URI, id ksuid.KSUID) error {
+	return iosrc.Remove(ctx, dir.AppendPath(defFilename(id)))
+}
+
 func WriteRules(ctx context.Context, dir iosrc.URI, rules []Rule) ([]*Definition, error) {
 	existing, err := ReadDefinitions(ctx, dir)
 	if err != nil {
@@ -100,6 +104,10 @@ func MustNewDefinition(r Rule) *Definition {
 	return d
 }
 
+func defFilename(id ksuid.KSUID) string {
+	return fmt.Sprintf("idxdef-%s.zng", id)
+}
+
 var defFileRegex = regexp.MustCompile(`idxdef-([0-9A-Za-z]{27}).zng$`)
 
 func parseDefFile(name string) (ksuid.KSUID, error) {
@@ -111,7 +119,7 @@ func parseDefFile(name string) (ksuid.KSUID, error) {
 }
 
 func (d *Definition) Filename() string {
-	return fmt.Sprintf("idxdef-%s.zng", d.ID)
+	return defFilename(d.ID)
 }
 
 func (d *Definition) Write(ctx context.Context, dir iosrc.URI) error {

--- a/ppl/archive/index/index.go
+++ b/ppl/archive/index/index.go
@@ -73,7 +73,22 @@ func Indices(ctx context.Context, d iosrc.URI, m DefinitionMap) ([]Index, error)
 	return indices, nil
 }
 
-func ApplyDefinitions(ctx context.Context, d iosrc.URI, r zbuf.Reader, defs ...*Definition) ([]Index, error) {
+func RemoveIndices(ctx context.Context, dir iosrc.URI, defs []*Definition) ([]Index, error) {
+	removed := make([]Index, 0, len(defs))
+	for _, def := range defs {
+		path := IndexPath(dir, def.ID)
+		if err := iosrc.Remove(ctx, path); err != nil {
+			if zqe.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+		removed = append(removed, Index{def, dir})
+	}
+	return removed, nil
+}
+
+func WriteIndices(ctx context.Context, d iosrc.URI, r zbuf.Reader, defs ...*Definition) ([]Index, error) {
 	writers, err := NewMultiWriter(ctx, d, defs)
 	if err != nil {
 		return nil, err

--- a/ppl/archive/index/index_test.go
+++ b/ppl/archive/index/index_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestApplyDefinitions(t *testing.T) {
+func TestWriteIndices(t *testing.T) {
 	const data = `
 #0:record[ts:time,orig_h:ip,proto:string]
 0:[1;127.0.0.1;conn;]
@@ -30,7 +30,7 @@ func TestApplyDefinitions(t *testing.T) {
 	ip := MustNewDefinition(NewTypeRule(zng.TypeIP))
 	proto := MustNewDefinition(NewFieldRule("proto"))
 
-	indices, err := ApplyDefinitions(ctx, dir, r, ip, proto)
+	indices, err := WriteIndices(ctx, dir, r, ip, proto)
 	require.NoError(t, err)
 	assert.Len(t, indices, 2)
 

--- a/ppl/archive/ztests/basic.yaml
+++ b/ppl/archive/ztests/basic.yaml
@@ -2,7 +2,7 @@ script: |
   mkdir logs
   zar import -R logs babble.tzng
   echo ===
-  zar index -R logs -q v
+  zar index create -R logs -q v
   zar find -R logs -z v=2 | zq -t "drop _log" -
   echo ===
   zar find -R logs -z v=10 | zq -t "drop _log" -

--- a/ppl/archive/ztests/custom-index-multitype-error.yaml
+++ b/ppl/archive/ztests/custom-index-multitype-error.yaml
@@ -1,7 +1,7 @@
 script: |
   mkdir logs
   zar import -R logs multitype.tzng
-  zar index -R logs -q -o custom -k id.orig_h -z "cut id.orig_h | sort" _
+  zar index create -R logs -q -o custom -k id.orig_h -z "cut id.orig_h | sort" _
 
 inputs:
   - name: multitype.tzng

--- a/ppl/archive/ztests/custom-index.yaml
+++ b/ppl/archive/ztests/custom-index.yaml
@@ -1,7 +1,7 @@
 script: |
   mkdir logs
   zar import -R logs babble.tzng
-  zar index -R logs -q -f 500 -o customindex -z "sum(v) by s | put key=s | sort key"
+  zar index create -R logs -q -f 500 -o customindex -z "sum(v) by s | put key=s | sort key"
   echo ===
   zar find -R logs -x customindex -z -f tzng "inelegancy-Atoxyl" | zq -f tzng "cut s, sum" -
 

--- a/ppl/archive/ztests/find-index-field.yaml
+++ b/ppl/archive/ztests/find-index-field.yaml
@@ -2,7 +2,7 @@
 script: |
   mkdir logs
   zar import -R logs log.tzng
-  zar index -R logs -q referenced_file.id.orig_h
+  zar index create -R logs -q referenced_file.id.orig_h
   echo ===
   zar find -R logs referenced_file.id.orig_h=1.1.1.1
   zar find -R logs -z referenced_file.id.orig_h=192.168.1.102 | zq -t "drop _log" -

--- a/ppl/archive/ztests/find-index-type.yaml
+++ b/ppl/archive/ztests/find-index-type.yaml
@@ -2,7 +2,7 @@
 script: |
   mkdir logs
   zar import -R logs log.tzng
-  zar index -R logs -q :ip
+  zar index create -R logs -q :ip
   echo ===
   zar find -R logs :ip=1.1.1.1
   echo ===

--- a/ppl/archive/ztests/findzng.yaml
+++ b/ppl/archive/ztests/findzng.yaml
@@ -3,7 +3,7 @@ script: |
   mkdir logs
   zar import -R logs babble.tzng
   # make an index by hand for each log containing a sum
-  zar index -R logs -q -o index -k s -z "sum(v) by s | sort s"
+  zar index create -R logs -q -o index -k s -z "sum(v) by s | sort s"
   zar find -R logs -o - -x index -z amphitheatral-televox | zq -t "drop _log" -
 
 inputs:

--- a/ppl/archive/ztests/index-custom-input.yaml
+++ b/ppl/archive/ztests/index-custom-input.yaml
@@ -3,7 +3,7 @@ script: |
   mkdir logs
   zar import -R logs babble.tzng
   zar map -R logs  -q -o sums.zng "sum(v) by s"
-  zar index -R logs -f 10000 -i sums.zng -q -o testindex -z "put key=s | sort key"
+  zar index create -R logs -f 10000 -i sums.zng -q -o testindex -z "put key=s | sort key"
   echo ===
   id=$(zar stat -f zng -R logs | zq -f text 'type = index | cut definition.id | head 1' -)
   microindex section -t -s 1 $(find logs/zd/20200422/ -name "idx-$id.zng" | head -n 1)

--- a/ppl/archive/ztests/index-drop.yaml
+++ b/ppl/archive/ztests/index-drop.yaml
@@ -1,0 +1,28 @@
+script: |
+  zar import -R logs -empty
+  zar import -R logs data.tzng
+  zar index create -R logs -q _path :ip
+  zar index ls -R logs -stats -f zng > stats.zng
+  zq -f table "drop id" stats.zng
+  echo ===
+  zar index drop -R logs $(zq -f text "desc=field-_path | cut id" stats.zng) >/dev/null
+  zar index ls -R logs -stats -f zng | zq -f table "drop id" -
+
+inputs:
+  - name: data.tzng
+    data: |
+      #0:record[_path:string,ts:time,orig_h:ip]
+      0:[conn;1;127.0.0.1;]
+      0:[http;1;127.0.0.1;]
+      0:[conn;2;127.0.0.2;]
+      0:[http;2;127.0.0.2;]
+
+outputs:
+  - name: stdout
+    data: |
+      DESC        ZQL INPUT INDEX_COUNT CHUNK_COUNT
+      field-_path _   _     1           1
+      type-ip     _   _     1           1
+      ===
+      DESC    ZQL INPUT INDEX_COUNT CHUNK_COUNT
+      type-ip _   _     1           1

--- a/ppl/archive/ztests/index-new-data.yaml
+++ b/ppl/archive/ztests/index-new-data.yaml
@@ -1,0 +1,30 @@
+script: |
+  zar import -R logs -empty
+  zar index create -R logs -o countbypath -k _path -z "count() by _path" _path:string :ip
+  zar index ls -R logs -stats -f zng | zq -f table "drop id" -
+  zar import -R logs data.tzng
+  zar import -R logs data.tzng
+  echo ===
+  zar index ls -R logs -stats -f zng | zq -f table "drop id" -
+
+inputs:
+  - name: data.tzng
+    data: |
+      #0:record[_path:string,ts:time,orig_h:ip]
+      0:[conn;1;127.0.0.1;]
+      0:[http;1;127.0.0.1;]
+      0:[conn;2;127.0.0.2;]
+      0:[http;2;127.0.0.2;]
+
+outputs:
+  - name: stdout
+    data: |
+      DESC               ZQL              INPUT INDEX_COUNT CHUNK_COUNT
+      field-_path:string _                _     0           0
+      type-ip            _                _     0           0
+      zql-countbypath    count() by _path _     0           0
+      ===
+      DESC               ZQL              INPUT INDEX_COUNT CHUNK_COUNT
+      field-_path:string _                _     2           2
+      type-ip            _                _     2           2
+      zql-countbypath    count() by _path _     2           2

--- a/ppl/archive/ztests/index-on-compact.yaml
+++ b/ppl/archive/ztests/index-on-compact.yaml
@@ -1,0 +1,31 @@
+script: |
+  zar import -R logs data.tzng
+  zar import -R logs data.tzng
+  zar import -R logs data.tzng
+  zar import -R logs data.tzng
+  zar index create -R logs -noapply _path:string :ip
+  zar index ls -R logs -stats -f zng | zq -f table "drop id" -
+  echo ===
+  zar compact -R logs -purge > /dev/null
+  zar index ls -R logs -stats -f zng | zq -f table "drop id" -
+
+
+inputs:
+  - name: data.tzng
+    data: |
+      #0:record[_path:string,ts:time,orig_h:ip]
+      0:[conn;1;127.0.0.1;]
+      0:[http;1;127.0.0.1;]
+      0:[conn;2;127.0.0.2;]
+      0:[http;2;127.0.0.2;]
+
+outputs:
+  - name: stdout
+    data: |
+      DESC               ZQL INPUT INDEX_COUNT CHUNK_COUNT
+      field-_path:string _   _     0           4
+      type-ip            _   _     0           4
+      ===
+      DESC               ZQL INPUT INDEX_COUNT CHUNK_COUNT
+      field-_path:string _   _     1           1
+      type-ip            _   _     1           1

--- a/ppl/archive/ztests/multikey-index.yaml
+++ b/ppl/archive/ztests/multikey-index.yaml
@@ -1,7 +1,7 @@
 script: |
   mkdir logs
   zar import -R logs babble.tzng
-  zar index -R logs -q -o index -k sum,s -z "sum(v) by s | sort sum,s"
+  zar index create -R logs -q -o index -k sum,s -z "sum(v) by s | sort sum,s"
   zar find -R logs -z -x index 149 wailer-strick | zq -t "drop _log" -
 
 inputs:

--- a/ppl/archive/ztests/notcustom-index-multitype-error.yaml
+++ b/ppl/archive/ztests/notcustom-index-multitype-error.yaml
@@ -2,7 +2,7 @@ script: |
   mkdir logs
   zar import -R logs multitype.tzng
   # ignore stdout here
-  zar index -R logs id.orig_h > trash
+  zar index create -R logs id.orig_h > trash
   # since index operation failed, no files should be left behind so this
   # ls command should have an empty output
   echo ===

--- a/ppl/archive/ztests/s3/find-index-type.yaml
+++ b/ppl/archive/ztests/s3/find-index-type.yaml
@@ -1,7 +1,7 @@
 script: |
   source minio.sh
   zar import -R logs -data s3://bucket/zartest log.tzng
-  zar index -R logs -q :ip
+  zar index create -R logs -q :ip
   zar find -R logs -z :ip=1.1.1.1 | zq -t "drop _log" -
   echo ===
   zar find -R logs -z :ip=192.168.1.102 | zq -t "drop _log" -

--- a/ppl/archive/ztests/s3/s3root.yaml
+++ b/ppl/archive/ztests/s3/s3root.yaml
@@ -2,7 +2,7 @@ script: |
   source minio.sh
   zar import -R s3://bucket/zartest babble.tzng
   zar ls -R s3://bucket/zartest -ranges
-  zar index -R s3://bucket/zartest -q v
+  zar index create -R s3://bucket/zartest -q v
   echo ===
   zar zq -R s3://bucket/zartest -t "count()"
   zar find -R s3://bucket/zartest -z v=2 | zq -t "drop _log" -

--- a/ppl/archive/ztests/sortmem.yaml
+++ b/ppl/archive/ztests/sortmem.yaml
@@ -4,7 +4,7 @@ script: |
   echo ===
   zar  import -R logs -sortmem 1MiB babble.tzng
   echo ===
-  zar index -R logs -q v
+  zar index create -R logs -q v
   zar find -R logs -z v=106 | zq -t "drop _log" -
   echo ===
 

--- a/ppl/archive/ztests/stat.yaml
+++ b/ppl/archive/ztests/stat.yaml
@@ -1,7 +1,7 @@
 script: |
   mkdir logs
   zar import -R logs babble.tzng
-  zar index -R logs -q :string v
+  zar index create -R logs -q :string v
   echo ===
   # Verify the log_id's in the default table format.
   zq -t "count()" $(zar stat -R logs | grep -v ^TYPE | awk '{print "logs/"$2}' | sort | uniq)

--- a/ppl/cmd/zar/index/command.go
+++ b/ppl/cmd/zar/index/command.go
@@ -1,144 +1,37 @@
 package index
 
 import (
-	"errors"
 	"flag"
-	"fmt"
-	"os"
 
-	"github.com/brimsec/zq/cli/procflags"
-	"github.com/brimsec/zq/field"
-	"github.com/brimsec/zq/pkg/rlimit"
-	"github.com/brimsec/zq/pkg/signalctx"
-	"github.com/brimsec/zq/ppl/archive"
-	"github.com/brimsec/zq/ppl/archive/index"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/mccanne/charm"
 )
 
 var Index = &charm.Spec{
 	Name:  "index",
-	Usage: "index [-R root] [options] [-z zql] [ pattern [ pattern ...]]",
-	Short: "create index files for zng files",
-	Long: `
-"zar index" creates index files in a zar archive using one or more indexing
-rules.
-
-A pattern is either a field name or a ":" followed by a zng type name.
-For example, to index the all fields of type port and the field id.orig_h,
-you would run:
-
-	zar index -R /path/to/logs id.orig_h :port
-
-Each pattern results in a separate microindex file for each log file found.
-
-For custom indexes, zql can be used instead of a pattern. This
-requires specifying the key and output file name. For example:
-
-       zar index -k id.orig_h -o custom -z "count() by _path, id.orig_h | sort id.orig_h"
-`,
-	New: New,
+	Usage: "index [subcommand]",
+	Short: "perform index related tasks on an archive",
+	New:   New,
 }
 
 func init() {
+	Index.Add(Create)
+	Index.Add(Drop)
+	Index.Add(Ls)
 	root.Zar.Add(Index)
 }
 
 type Command struct {
 	*root.Command
-	framesize  int
-	inputFile  string
-	keys       string
-	outputFile string
-	procFlags  procflags.Flags
-	progress   chan string
-	quiet      bool
-	root       string
-	zql        string
 }
 
 func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
-	c := &Command{Command: parent.(*root.Command)}
-	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
-	f.StringVar(&c.keys, "k", "key", "one or more comma-separated key fields")
-	f.IntVar(&c.framesize, "f", 32*1024, "minimum frame size used in microindex file")
-	f.StringVar(&c.inputFile, "i", "_", "input file relative to each zar directory ('_' means archive log file in the parent of the zar directory)")
-	f.StringVar(&c.outputFile, "o", "index.zng", "name of microindex output file (for custom indexes)")
-	f.BoolVar(&c.quiet, "q", false, "don't print progress on stdout")
-	f.StringVar(&c.zql, "z", "", "zql for custom indexes")
-	c.procFlags.SetFlags(f)
-	return c, nil
+	return &Command{parent.(*root.Command)}, nil
 }
 
 func (c *Command) Run(args []string) error {
-	defer c.Cleanup()
-	if err := c.Init(&c.procFlags); err != nil {
-		return err
+	if len(args) == 0 {
+		return root.Zar.Exec(c.Command, []string{"help", "index"})
 	}
-	if len(args) == 0 && c.zql == "" {
-		return errors.New("zar index: one or more indexing patterns must be specified")
-	}
-	if c.root == "" {
-		return errors.New("zar index: a directory must be specified with -R or ZAR_ROOT")
-	}
-	if _, err := rlimit.RaiseOpenFilesLimit(); err != nil {
-		return err
-	}
-
-	ark, err := archive.OpenArchive(c.root, nil)
-	if err != nil {
-		return err
-	}
-
-	rules, err := c.rules(args)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := signalctx.New(os.Interrupt)
-	defer cancel()
-
-	defs, err := archive.AddRules(ctx, ark, rules)
-	if err != nil {
-		return err
-	}
-	if !c.quiet {
-		c.progress = make(chan string)
-		go c.displayProgress()
-	}
-
-	return archive.ApplyDefinitions(ctx, ark, c.progress, defs...)
-}
-
-func (c *Command) displayProgress() {
-	for line := range c.progress {
-		fmt.Println(line)
-	}
-}
-
-func (c *Command) rules(args []string) ([]index.Rule, error) {
-	var input string
-	if c.inputFile != "_" {
-		input = c.inputFile
-	}
-
-	var rules []index.Rule
-	if c.zql != "" {
-		rule, err := index.NewZqlRule(c.zql, c.outputFile, field.DottedList(c.keys))
-		if err != nil {
-			return nil, fmt.Errorf("zar index add: %w", err)
-		}
-		rule.Framesize = c.framesize
-		rule.Input = input
-		rules = append(rules, rule)
-	}
-	for _, pattern := range args {
-		rule, err := index.NewRule(pattern)
-		if err != nil {
-			return nil, fmt.Errorf("zar index add: %w", err)
-		}
-		rule.Input = input
-		rules = append(rules, rule)
-	}
-	return rules, nil
+	return charm.ErrNoRun
 }

--- a/ppl/cmd/zar/index/create.go
+++ b/ppl/cmd/zar/index/create.go
@@ -1,0 +1,160 @@
+package index
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/brimsec/zq/cli/procflags"
+	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/pkg/rlimit"
+	"github.com/brimsec/zq/pkg/signalctx"
+	"github.com/brimsec/zq/ppl/archive"
+	"github.com/brimsec/zq/ppl/archive/index"
+	"github.com/brimsec/zq/ppl/cmd/zar/root"
+	"github.com/mccanne/charm"
+)
+
+var Create = &charm.Spec{
+	Name:  "create",
+	Usage: "create [-R root] [options] [-z zql] [ pattern [ pattern ...]]",
+	Short: "create index rule for archive chunk files",
+	Long: `
+"zar index create" creates index files in a zar archive using one or more indexing
+rules.
+
+A pattern is either a field name or a ":" followed by a zng type name.
+For example, to create two indexes, one on the field id.orig_h, and one on all
+fields of type uint16, you would run:
+
+	zar index create -R /path/to/logs id.orig_h :uint16
+
+Each pattern results in a separate microindex file for each log file found.
+
+For custom indexes, zql can be used instead of a pattern. This
+requires specifying the key and output file name. For example:
+
+       zar index create -k id.orig_h -o custom -z "count() by _path, id.orig_h | sort id.orig_h"
+`,
+	New: NewCreate,
+}
+
+type CreateCommand struct {
+	*root.Command
+	framesize  int
+	inputFile  string
+	keys       string
+	outputFile string
+	ensure     bool
+	noapply    bool
+	procFlags  procflags.Flags
+	progress   chan string
+	quiet      bool
+	root       string
+	zql        string
+}
+
+func NewCreate(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &CreateCommand{Command: parent.(*Command).Command}
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.BoolVar(&c.ensure, "ensure", false, "ensures that index rules are applied to all chunks")
+	f.StringVar(&c.keys, "k", "key", "one or more comma-separated key fields")
+	f.IntVar(&c.framesize, "f", 32*1024, "minimum frame size used in microindex file")
+	f.StringVar(&c.inputFile, "i", "_", "input file relative to each zar directory ('_' means archive log file in the parent of the zar directory)")
+	f.BoolVar(&c.noapply, "noapply", false, "create index rules but do not apply them to the archive")
+	f.StringVar(&c.outputFile, "o", "index.zng", "name of microindex output file (for custom indexes)")
+	f.BoolVar(&c.quiet, "q", false, "don't print progress on stdout")
+	f.StringVar(&c.zql, "z", "", "zql for custom indexes")
+	c.procFlags.SetFlags(f)
+	return c, nil
+}
+
+func (c *CreateCommand) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(&c.procFlags); err != nil {
+		return err
+	}
+	if len(args) == 0 && c.zql == "" && !c.ensure {
+		return errors.New("unless -ensure is specified, one or more indexing patterns must be specified")
+	}
+	if c.root == "" {
+		return errors.New("a directory must be specified with -R or ZAR_ROOT")
+	}
+	if _, err := rlimit.RaiseOpenFilesLimit(); err != nil {
+		return err
+	}
+
+	ark, err := archive.OpenArchive(c.root, nil)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := signalctx.New(os.Interrupt)
+	defer cancel()
+
+	defs, err := c.addRules(ctx, ark, args)
+	if err != nil {
+		return err
+	}
+
+	if c.noapply {
+		return nil
+	}
+
+	if c.ensure {
+		defs, err = ark.ReadDefinitions(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !c.quiet {
+		c.progress = make(chan string)
+		go c.displayProgress()
+	}
+
+	if err := archive.WriteIndices(ctx, ark, c.progress, defs...); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateCommand) addRules(ctx context.Context, ark *archive.Archive, args []string) ([]*index.Definition, error) {
+	if len(args) == 0 && c.zql == "" {
+		return nil, nil
+	}
+	var input string
+	if c.inputFile != "_" {
+		input = c.inputFile
+	}
+
+	var rules []index.Rule
+	if c.zql != "" {
+		rule, err := index.NewZqlRule(c.zql, c.outputFile, field.DottedList(c.keys))
+		if err != nil {
+			return nil, err
+		}
+		rule.Framesize = c.framesize
+		rule.Input = input
+		rules = append(rules, rule)
+	}
+
+	for _, pattern := range args {
+		rule, err := index.NewRule(pattern)
+		if err != nil {
+			return nil, err
+		}
+		rule.Input = input
+		rules = append(rules, rule)
+	}
+
+	return archive.AddRules(ctx, ark, rules)
+}
+
+func (c *CreateCommand) displayProgress() {
+	for line := range c.progress {
+		fmt.Println(line)
+	}
+}

--- a/ppl/cmd/zar/index/drop.go
+++ b/ppl/cmd/zar/index/drop.go
@@ -1,0 +1,107 @@
+package index
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/brimsec/zq/ppl/archive"
+	"github.com/brimsec/zq/ppl/archive/index"
+	"github.com/brimsec/zq/ppl/cmd/zar/root"
+	"github.com/mccanne/charm"
+	"github.com/segmentio/ksuid"
+)
+
+var Drop = &charm.Spec{
+	Name:  "drop",
+	Usage: "drop [-R root] [options] id... ",
+	Short: "drop index defintion(s) from archive",
+	Long: `
+"zar index drop" removes an index definition from the archive then walks through
+the tree removing referenced index files.
+
+If the -noapply option is enabled the command will only removed the index
+definition. The individual index files will still exist but they will no longer
+be queryable.
+`,
+	New: NewDrop,
+}
+
+type DropCommand struct {
+	*root.Command
+	root     string
+	noapply  bool
+	progress chan string
+	quiet    bool
+}
+
+func NewDrop(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &DropCommand{Command: parent.(*Command).Command}
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.BoolVar(&c.noapply, "noapply", false, "remove index definition only")
+	f.BoolVar(&c.quiet, "q", false, "do not display progress updates will deleting indices")
+
+	return c, nil
+}
+
+func (c *DropCommand) Run(args []string) error {
+	return c.run(args)
+}
+
+func (c *DropCommand) run(args []string) error {
+	if len(args) == 0 {
+		return errors.New("no index definition specified")
+	}
+
+	ark, err := archive.OpenArchive(c.root, nil)
+	if err != nil {
+		return err
+	}
+
+	alldefs, err := ark.ReadDefinitions(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	defs := make([]*index.Definition, 0, len(args))
+	for _, arg := range args {
+		id, err := ksuid.Parse(arg)
+		if err != nil {
+			return err
+		}
+		def := alldefs.Lookup(id)
+		if def == nil {
+			fmt.Fprintf(os.Stderr, "defintion for id '%s' not found\n", arg)
+			continue
+		}
+		defs = append(defs, def)
+	}
+
+	if len(defs) == 0 {
+		return errors.New("no definitions deleted")
+	}
+
+	if err := archive.RemoveDefinitions(context.TODO(), ark, defs...); err != nil {
+		return err
+	}
+
+	if !c.noapply {
+		if !c.quiet {
+			c.progress = make(chan string)
+			go c.displayProgress()
+		}
+		if err := archive.RemoveIndices(context.TODO(), ark, c.progress, defs...); err != nil {
+			return err
+		}
+	}
+	fmt.Printf("%d index definitions removed\n", len(defs))
+	return nil
+}
+
+func (c *DropCommand) displayProgress() {
+	for line := range c.progress {
+		fmt.Println(line)
+	}
+}

--- a/ppl/cmd/zar/index/ls.go
+++ b/ppl/cmd/zar/index/ls.go
@@ -1,0 +1,148 @@
+package index
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/brimsec/zq/cli/outputflags"
+	"github.com/brimsec/zq/ppl/archive"
+	"github.com/brimsec/zq/ppl/archive/index"
+	"github.com/brimsec/zq/ppl/cmd/zar/root"
+	"github.com/brimsec/zq/zng/resolver"
+	"github.com/mccanne/charm"
+	"github.com/segmentio/ksuid"
+)
+
+var Ls = &charm.Spec{
+	Name:  "ls",
+	Usage: "ls [-R root] [options]",
+	Short: "list and display stats for indices defined in archive",
+	New:   NewLs,
+}
+
+type LsCommand struct {
+	*root.Command
+
+	output outputflags.Flags
+	root   string
+	stats  bool
+}
+
+func NewLs(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &LsCommand{Command: parent.(*Command).Command}
+	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root location of zar archive to walk")
+	f.BoolVar(&c.stats, "stats", false, "print stats for each index definition")
+	c.output.SetFormatFlags(f)
+	c.output.Format = "table"
+	return c, nil
+}
+
+type DefLine struct {
+	ID    string `zng:"id"`
+	Desc  string `zng:"desc"`
+	ZQL   string `zng:"zql"`
+	Input string `zng:"input"`
+}
+
+type DefStatLine struct {
+	ID         string `zng:"id"`
+	Desc       string `zng:"desc"`
+	ZQL        string `zng:"zql"`
+	Input      string `zng:"input"`
+	IndexCount uint64 `zng:"index_count"`
+	ChunkCount uint64 `zng:"chunk_count"`
+}
+
+func (c *LsCommand) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(&c.output); err != nil {
+		return err
+	}
+	if c.root == "" {
+		return errors.New("a directory must be specified with -R or ZAR_ROOT")
+	}
+
+	ark, err := archive.OpenArchive(c.root, nil)
+	if err != nil {
+		return err
+	}
+
+	defs, err := ark.ReadDefinitions(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	w, err := c.output.Open(context.TODO())
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	var stats map[ksuid.KSUID]archive.IndexInfo
+	if c.stats {
+		if stats, err = c.getStats(ark, defs); err != nil {
+			return err
+		}
+	}
+
+	sort.Slice(defs, func(i, j int) bool {
+		return strings.Compare(defs[i].String(), defs[j].String()) < 0
+	})
+	m := resolver.NewMarshaler()
+	for _, def := range defs {
+		input, zql := "_", "_"
+		if def.Input != "" {
+			input = def.Input
+		}
+		if def.ZQL != "" {
+			zql = def.ZQL
+		}
+
+		var line interface{}
+		if c.stats {
+			stat := stats[def.ID]
+			// XXX Would be better to embed DefLine however resolver.Marshal
+			// does not support untagged embedded structs the way
+			// encoding/json does.
+			line = DefStatLine{
+				ID:         def.ID.String(),
+				Desc:       def.String(),
+				ZQL:        zql,
+				Input:      input,
+				IndexCount: stat.IndexCount,
+				ChunkCount: stat.ChunkCount,
+			}
+		} else {
+			line = DefLine{
+				ID:    def.ID.String(),
+				Desc:  def.String(),
+				ZQL:   zql,
+				Input: input,
+			}
+		}
+		rec, err := m.MarshalRecord(line)
+		if err != nil {
+			return err
+		}
+		if w.Write(rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *LsCommand) getStats(ark *archive.Archive, defs []*index.Definition) (map[ksuid.KSUID]archive.IndexInfo, error) {
+	stats, err := archive.IndexStat(context.TODO(), ark, defs)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[ksuid.KSUID]archive.IndexInfo)
+	for _, stat := range stats {
+		m[stat.DefinitionID] = stat
+	}
+	return m, nil
+}

--- a/ppl/zqd/ingest/archivepcap.go
+++ b/ppl/zqd/ingest/archivepcap.go
@@ -61,6 +61,12 @@ func newArchivePcapOp(ctx context.Context, logstore *archivestore.Storage, pcaps
 	if err != nil {
 		return nil, err
 	}
+
+	writer, err := logstore.NewWriter(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	p := &archivePcapOp{
 		done:      make(chan struct{}),
 		pcapstore: pcapstore,
@@ -68,7 +74,7 @@ func newArchivePcapOp(ctx context.Context, logstore *archivestore.Storage, pcaps
 		pcapuri:   pcapuri,
 		snap:      make(chan struct{}),
 		suricata:  suricata,
-		writer:    logstore.NewWriter(ctx),
+		writer:    writer,
 		zeek:      zeek,
 		zctx:      resolver.NewContext(),
 

--- a/ppl/zqd/storage/archivestore/archivestore.go
+++ b/ppl/zqd/storage/archivestore/archivestore.go
@@ -102,8 +102,12 @@ func (w *Writer) Close() error {
 }
 
 // NewWriter returns a writer that will start a compaction when it is closed.
-func (s *Storage) NewWriter(ctx context.Context) *Writer {
-	return &Writer{archive.NewWriter(ctx, s.ark), s.notifier}
+func (s *Storage) NewWriter(ctx context.Context) (*Writer, error) {
+	w, err := archive.NewWriter(ctx, s.ark)
+	if err != nil {
+		return nil, err
+	}
+	return &Writer{w, s.notifier}, nil
 }
 
 func (s *Storage) IndexCreate(ctx context.Context, req api.IndexPostRequest) error {

--- a/ztests/suite/zqd/index-new-data.yaml
+++ b/ztests/suite/zqd/index-new-data.yaml
@@ -1,0 +1,28 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new -k archivestore testsp >/dev/null
+  zapi -h $ZQD_HOST -s testsp index create :ip _path
+  zapi -h $ZQD_HOST -s testsp post data.tzng >/dev/null
+  zapi -h $ZQD_HOST -s testsp index find -z _path=http | zq -t "drop _log" -
+  echo ===
+  zapi -h $ZQD_HOST -s testsp index find -z :ip=127.0.0.3 | zq -t "drop _log" -
+
+inputs:
+  - name: services.sh
+    source: services.sh
+  - name: data.tzng
+    data: |
+      #0:record[_path:string,ts:time,orig_h:ip]
+      0:[conn;1;127.0.0.1;]
+      0:[http;1;127.0.0.1;]
+      0:[conn;2;127.0.0.2;]
+      0:[http;2;127.0.0.3;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[key:string,count:uint64,first:time,last:time]
+      0:[http;2;2;1;]
+      ===
+      #0:record[key:ip,count:uint64,first:time,last:time]
+      0:[127.0.0.3;1;2;1;]


### PR DESCRIPTION
When an archive has index definitions  and either new data is imported 
or chunks are compacted, apply index rules to newly created chunks.

Also:

- Break zar index into base command with three subcommands:
    - add: same as what zar index was before.
    - ls: prints information and stats on index rules.
    - drop: removes index definitions.

Closes #1656