### PR TITLE
fix pcap space time range regression

### DIFF
--- a/ppl/zqd/apiserver/manager.go
+++ b/ppl/zqd/apiserver/manager.go
@@ -349,6 +349,7 @@ func (m *Manager) rowToSpaceInfo(ctx context.Context, sr SpaceRow) (api.SpaceInf
 				union := span.Union(pcapinfo.Span)
 				span = &union
 			}
+			spaceInfo.Span = span
 		}
 	}
 

--- a/ppl/zqd/handlers_pcap_test.go
+++ b/ppl/zqd/handlers_pcap_test.go
@@ -201,6 +201,19 @@ func TestPcapPostZeekFailAfterWrite(t *testing.T) {
 	})
 }
 
+// TestPcapTimeRange verifies that the time range for a space with an imported
+// pcap includes the pcap's time range, regardless of whether any records are
+// present or not. See zq#1797.
+func TestPcapTimeRange(t *testing.T) {
+	noopWrite := func(p *testPcapProcess) error { return nil }
+	p := pcapPostTest(t, "testdata/valid.pcap", testLauncher(nil, noopWrite))
+	info, err := p.client.SpaceInfo(context.Background(), p.space.ID)
+	require.NoError(t, err)
+	require.NotNil(t, info.Span)
+	exp := nano.NewSpanTs(nano.Unix(1501770877, 471635000), nano.Unix(1501770880, 988247000))
+	require.Equal(t, exp, *info.Span)
+}
+
 func launcherFromEnv(t *testing.T, key string) pcapanalyzer.Launcher {
 	ln, err := pcapanalyzer.LauncherFromPath(os.Getenv(key), false)
 	require.NoError(t, err)


### PR DESCRIPTION
This fixes a bug that I introduced in https://github.com/brimsec/zq/pull/1693 , when moving code to a new location. 

I didn't notice this until it became apparent in the UI when importing a pcap. I'll add a test, but I verified this fixes https://github.com/brimsec/zq/issues/1797 .

