### PR TITLE
Remove zqd listen's -pprof flag

### DIFF
--- a/ppl/zqd/core.go
+++ b/ppl/zqd/core.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"sync/atomic"
 
 	"github.com/brimsec/zq/api"
@@ -100,6 +101,11 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, indexPage)
 	})
+	router.HandleFunc("/debug/pprof/", pprof.Index)
+	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	router.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 	router.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, "ok")


### PR DESCRIPTION
Always serve profiling data.

I think we always want this, and we'll never have zqd listening directly on a public IP address, so I don't think there's any risk.