### PR TITLE
fix bug with rows larger than max read buffer

### DIFF
--- a/cli/auto/bytes.go
+++ b/cli/auto/bytes.go
@@ -1,0 +1,38 @@
+package auto
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/units"
+)
+
+type Bytes struct {
+	defStr string
+	Bytes  units.Base2Bytes
+}
+
+func (b Bytes) String() string {
+	if b.defStr != "" {
+		return b.defStr
+	}
+	return b.Bytes.String()
+}
+
+func (b *Bytes) Set(s string) error {
+	b.defStr = ""
+	b.Bytes = 0
+	bytes, err := units.ParseStrictBytes(s)
+	if err != nil {
+		return err
+	}
+	b.Bytes = units.Base2Bytes(bytes)
+	return nil
+}
+
+func NewBytes(def uint64) Bytes {
+	bytes := units.Base2Bytes(def)
+	return Bytes{
+		defStr: fmt.Sprintf("auto(%s)", bytes),
+		Bytes:  bytes,
+	}
+}

--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -21,10 +21,10 @@ import (
 
 type Flags struct {
 	zio.ReaderOpts
+	ReadMax  auto.Bytes
+	ReadSize auto.Bytes
 	// The JSON type config is loaded from the types filie when Init is called.
 	jsonTypesFile string
-	ReadSize      auto.Bytes
-	ReadMax       auto.Bytes
 }
 
 func (f *Flags) Options() zio.ReaderOpts {
@@ -62,7 +62,7 @@ func (f *Flags) Init() error {
 	}
 	f.Zng.Size = int(f.ReadSize.Bytes)
 	if f.Zng.Size < 0 {
-		return errors.New("max read buffer size must be greater than zero")
+		return errors.New("target read buffer size must be greater than zero")
 	}
 	return nil
 }

--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -2,17 +2,20 @@ package inputflags
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"regexp"
 
+	"github.com/brimsec/zq/cli/auto"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/azngio"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zio/ndjsonio"
+	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng/resolver"
 )
 
@@ -20,6 +23,8 @@ type Flags struct {
 	zio.ReaderOpts
 	// The JSON type config is loaded from the types filie when Init is called.
 	jsonTypesFile string
+	ReadSize      auto.Bytes
+	ReadMax       auto.Bytes
 }
 
 func (f *Flags) Options() zio.ReaderOpts {
@@ -32,6 +37,10 @@ func (f *Flags) SetFlags(fs *flag.FlagSet) {
 	fs.StringVar(&f.jsonTypesFile, "j", "", "path to json types file")
 	fs.StringVar(&f.JSON.PathRegexp, "pathregexp", ndjsonio.DefaultPathRegexp,
 		"regexp for extracting _path from json log name (when -inferpath=true)")
+	f.ReadMax = auto.NewBytes(zngio.MaxSize)
+	fs.Var(&f.ReadMax, "readmax", "maximum memory used read buffers in MiB, MB, etc")
+	f.ReadSize = auto.NewBytes(zngio.ReadSize)
+	fs.Var(&f.ReadSize, "readsize", "target memory used read buffers in MiB, MB, etc")
 }
 
 // Init is called after flags have been parsed.
@@ -46,6 +55,14 @@ func (f *Flags) Init() error {
 			return err
 		}
 		f.JSON.TypeConfig = c
+	}
+	f.Zng.Max = int(f.ReadMax.Bytes)
+	if f.Zng.Max < 0 {
+		return errors.New("max read buffer size must be greater than zero")
+	}
+	f.Zng.Size = int(f.ReadSize.Bytes)
+	if f.Zng.Size < 0 {
+		return errors.New("max read buffer size must be greater than zero")
 	}
 	return nil
 }

--- a/cli/procflags/procflags.go
+++ b/cli/procflags/procflags.go
@@ -3,9 +3,8 @@ package procflags
 import (
 	"errors"
 	"flag"
-	"fmt"
 
-	"github.com/alecthomas/units"
+	"github.com/brimsec/zq/cli/auto"
 	"github.com/brimsec/zq/proc/fuse"
 	"github.com/brimsec/zq/proc/sort"
 	"github.com/pbnjay/memory"
@@ -28,59 +27,28 @@ func defaultMemMaxBytes() uint64 {
 	}
 }
 
-type AutoBytes struct {
-	defStr string
-	bytes  units.Base2Bytes
-}
-
-func (b AutoBytes) String() string {
-	if b.defStr != "" {
-		return b.defStr
-	}
-	return b.bytes.String()
-}
-
-func (b *AutoBytes) Set(s string) error {
-	b.defStr = ""
-	b.bytes = 0
-	bytes, err := units.ParseStrictBytes(s)
-	if err != nil {
-		return err
-	}
-	b.bytes = units.Base2Bytes(bytes)
-	return nil
-}
-
-func newAutoBytes(def uint64) AutoBytes {
-	bytes := units.Base2Bytes(def)
-	return AutoBytes{
-		defStr: fmt.Sprintf("auto(%s)", bytes),
-		bytes:  bytes,
-	}
-}
-
 type Flags struct {
 	// these memory limits should be based on a shared resource model
-	sortMemMax AutoBytes
-	fuseMemMax AutoBytes
+	sortMemMax auto.Bytes
+	fuseMemMax auto.Bytes
 }
 
 func (f *Flags) SetFlags(fs *flag.FlagSet) {
 	def := defaultMemMaxBytes()
-	f.sortMemMax = newAutoBytes(def)
+	f.sortMemMax = auto.NewBytes(def)
 	fs.Var(&f.sortMemMax, "sortmem", "maximum memory used by sort in MiB, MB, etc")
-	f.fuseMemMax = newAutoBytes(def)
+	f.fuseMemMax = auto.NewBytes(def)
 	fs.Var(&f.fuseMemMax, "fusemem", "maximum memory used by fuse in MiB, MB, etc")
 }
 
 func (f *Flags) Init() error {
-	if f.sortMemMax.bytes <= 0 {
+	if f.sortMemMax.Bytes <= 0 {
 		return errors.New("sortmem value must be greater than zero")
 	}
-	sort.MemMaxBytes = int(f.sortMemMax.bytes)
-	if f.fuseMemMax.bytes <= 0 {
+	sort.MemMaxBytes = int(f.sortMemMax.Bytes)
+	if f.fuseMemMax.Bytes <= 0 {
 		return errors.New("fusemem value must be greater than zero")
 	}
-	fuse.MemMaxBytes = int(f.fuseMemMax.bytes)
+	fuse.MemMaxBytes = int(f.fuseMemMax.Bytes)
 	return nil
 }

--- a/pkg/peeker/reader.go
+++ b/pkg/peeker/reader.go
@@ -33,6 +33,10 @@ func (r *Reader) Reset() {
 	r.eof = false
 }
 
+func (r *Reader) Limit() int {
+	return r.limit
+}
+
 func (r *Reader) fill(min int) error {
 	if min > r.limit {
 		return ErrBufferOverflow

--- a/zio/detector/reader.go
+++ b/zio/detector/reader.go
@@ -55,7 +55,9 @@ func NewReaderWithOpts(r io.Reader, zctx *resolver.Context, path string, opts zi
 	}
 	track.Reset()
 
-	zngErr := match(zngio.NewReaderWithOpts(track, resolver.NewContext(), zngio.ReaderOpts{Validate: true}), "zng")
+	zngOpts := opts.Zng
+	zngOpts.Validate = true
+	zngErr := match(zngio.NewReaderWithOpts(track, resolver.NewContext(), zngOpts), "zng")
 	if zngErr == nil {
 		return zngio.NewReaderWithOpts(recorder, zctx, opts.Zng), nil
 	}

--- a/zio/zngio/ztests/big-value.yaml
+++ b/zio/zngio/ztests/big-value.yaml
@@ -1,0 +1,30 @@
+script: |
+  zq -znglz4blocksize=0 -o out.zng in.tzng
+  cat out.zng out.zng out.zng out.zng > out2.zng
+  mv out2.zng out.zng
+  cat out.zng out.zng out.zng out.zng > out2.zng
+  mv out2.zng out.zng
+  cat out.zng out.zng out.zng out.zng > out2.zng
+  mv out2.zng out.zng
+  cat out.zng out.zng out.zng out.zng > out2.zng
+  mv out2.zng out.zng
+  cat out.zng out.zng out.zng out.zng > out2.zng
+  mv out2.zng out.zng
+  cat out.zng out.zng out.zng out.zng > out2.zng
+  mv out2.zng out.zng
+  cat out.zng out.zng out.zng out.zng > out2.zng
+  mv out2.zng out.zng
+  zq -znglz4blocksize=0 -o bigrow.zng "collect(s)" out.zng
+  zq  -i zng -o /dev/null -readmax 10KB "count()" bigrow.zng
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[s:string]
+      0:[big data;]
+      0:[too big;]
+
+outputs:
+  - name: stderr
+    data: |
+      bigrow.zng: large value of 278531 bytes exceeds maximum read buffer (10000 bytes)

--- a/zio/zngio/ztests/big-value.yaml
+++ b/zio/zngio/ztests/big-value.yaml
@@ -1,19 +1,9 @@
 script: |
   zq -znglz4blocksize=0 -o out.zng in.tzng
-  cat out.zng out.zng out.zng out.zng > out2.zng
-  mv out2.zng out.zng
-  cat out.zng out.zng out.zng out.zng > out2.zng
-  mv out2.zng out.zng
-  cat out.zng out.zng out.zng out.zng > out2.zng
-  mv out2.zng out.zng
-  cat out.zng out.zng out.zng out.zng > out2.zng
-  mv out2.zng out.zng
-  cat out.zng out.zng out.zng out.zng > out2.zng
-  mv out2.zng out.zng
-  cat out.zng out.zng out.zng out.zng > out2.zng
-  mv out2.zng out.zng
-  cat out.zng out.zng out.zng out.zng > out2.zng
-  mv out2.zng out.zng
+  for i in {1..7}; do
+    cat out.zng out.zng out.zng out.zng > out2.zng
+    mv out2.zng out.zng
+  done
   zq -znglz4blocksize=0 -o bigrow.zng "collect(s)" out.zng
   zq  -i zng -o /dev/null -readmax 10KB "count()" bigrow.zng
 


### PR DESCRIPTION
This commit adds a better error message to the zng reader with the
length of a value exceeds the max read size.   We also added flags
to set the max read buffer (and target read buffer) sizes.

Closes #1803