### PR TITLE
copy columns when looking up TypeRecord

### DIFF
--- a/zng/resolver/context.go
+++ b/zng/resolver/context.go
@@ -232,7 +232,8 @@ func (c *Context) LookupTypeRecord(columns []zng.Column) (*zng.TypeRecord, error
 	if ok {
 		return c.table[id].(*zng.TypeRecord), nil
 	}
-	typ := zng.NewTypeRecord(-1, columns)
+	dup := make([]zng.Column, 0, len(columns))
+	typ := zng.NewTypeRecord(-1, append(dup, columns...))
 	c.addTypeWithLock(key, typ)
 	return typ, nil
 }

--- a/zng/resolver/context_test.go
+++ b/zng/resolver/context_test.go
@@ -61,3 +61,12 @@ func TestTranslateAlias(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, alias2, alias3)
 }
+
+func TestCopyMutateColumns(t *testing.T) {
+	c := resolver.NewContext()
+	cols := []zng.Column{{"foo", zng.TypeString}, {"bar", zng.TypeInt64}}
+	typ, err := c.LookupTypeRecord(cols)
+	require.NoError(t, err)
+	cols[0].Type = nil
+	require.NotNil(t, typ.Columns[0].Type)
+}


### PR DESCRIPTION
This commit makes a copy of the zng.Columns when looking up
a TypeRecord so that the caller mutate its underlying zng.Column
slice without harming the type context.