### PR TITLE
Adjust bin/minio Makefile rule for Go 1.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ bin/$(SURICATAPATH):
 bin/minio:
 	@mkdir -p bin
 	@echo 'module deps' > bin/go.mod
-	@echo 'require github.com/minio/minio latest' >> bin/go.mod
 	@echo 'replace github.com/minio/minio => github.com/brimsec/minio v0.0.0-20201019191454-3c6f24527f6d' >> bin/go.mod
+	@cd bin && go get -d github.com/minio/minio
 	@cd bin && GOBIN="$(CURDIR)/bin" go install github.com/minio/minio
 
 generate:


### PR DESCRIPTION
@mattnibs noticed that the current rule for bin/minio doesn't work with the Go master branch. Fix it now in the hope that it will continue to work for Go 1.16.