### PR TITLE
Remove useless ubuntu-latest CI step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,9 +17,6 @@ jobs:
       - run: go mod download
       - run: make fmt
       - run: make tidy
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y zip libnet1 libjansson4
       - run: make vet
       - run: make test-generate
       - run: make test-unit


### PR DESCRIPTION
Removing this saves 10 to 15 seconds.