### PR TITLE
add MarshalCustomRecord

### DIFF
--- a/zng/resolver/marshal.go
+++ b/zng/resolver/marshal.go
@@ -43,6 +43,26 @@ func MarshalRecord(zctx *Context, v interface{}) (*zng.Record, error) {
 	return zng.NewRecord(recType, body), nil
 }
 
+func MarshalCustomRecord(zctx *Context, names []string, fields []interface{}) (*zng.Record, error) {
+	if len(names) != len(fields) {
+		return nil, errors.New("fields and columns don't match")
+	}
+	var cols []zng.Column
+	var b zcode.Builder
+	for k, field := range fields {
+		typ, err := Marshal(zctx, &b, field)
+		if err != nil {
+			return nil, err
+		}
+		cols = append(cols, zng.Column{names[k], typ})
+	}
+	recType, err := zctx.LookupTypeRecord(cols)
+	if err != nil {
+		return nil, err
+	}
+	return zng.NewRecord(recType, b.Bytes()), nil
+}
+
 const (
 	tagName = "zng"
 	tagSep  = ","

--- a/zng/resolver/marshal_test.go
+++ b/zng/resolver/marshal_test.go
@@ -363,3 +363,17 @@ func TestIntsAndUints(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, r1, r2)
 }
+
+func TestCustomRecord(t *testing.T) {
+	vals := []interface{}{
+		Thing{"hello", 123},
+		99,
+	}
+	zctx := resolver.NewContext()
+	rec, err := resolver.MarshalCustomRecord(zctx, []string{"foo", "bar"}, vals)
+	require.NoError(t, err)
+	exp := `
+#0:record[foo:record[a:string,B:int64],bar:int64]
+0:[[hello;123;]99;]`
+	assert.Equal(t, trim(exp), rectzng(t, rec))
+}


### PR DESCRIPTION
This commit adds a function to the zng marshaler to create a record
from a slice of strings containing the field names and a corresponding
slice of values as []interface{}.  This lets a client of the marshaler
create a record with a reliable column order and specify the field names
dynamically instead of with fixed struct tags.