### PR TITLE
Baby step towards storing type associated with type value

### DIFF
--- a/zio/zsonio/typemap.go
+++ b/zio/zsonio/typemap.go
@@ -15,7 +15,7 @@ func (t typemap) known(typ zng.Type) bool {
 	if _, ok := t[typ]; ok {
 		return true
 	}
-	if _, ok := typ.(*zng.TypeOfType); ok {
+	if _, ok := typ.(*zng.TypeType); ok {
 		return true
 	}
 	if _, ok := typ.(*zng.TypeAlias); ok {

--- a/zio/zsonio/writer.go
+++ b/zio/zsonio/writer.go
@@ -101,7 +101,7 @@ func (w *Writer) writeValue(indent int, typ zng.Type, bytes zcode.Bytes, parentK
 		null, err = w.writeMap(indent, t, bytes, known)
 	case *zng.TypeEnum:
 		err = w.write(t.ZSONOf(bytes))
-	case *zng.TypeOfType:
+	case *zng.TypeType:
 		err = w.writef("(%s)", string(bytes))
 	}
 	if err == nil && decorate {
@@ -344,7 +344,7 @@ func (w *Writer) formatType(typ zng.Type) string {
 		return w.formatUnion(typ)
 	case *zng.TypeEnum:
 		return w.formatEnum(typ)
-	case *zng.TypeOfType:
+	case *zng.TypeType:
 		return typ.ZSON()
 	}
 	panic("unknown case in formatType(): " + typ.String())

--- a/zng/type.go
+++ b/zng/type.go
@@ -90,7 +90,6 @@ var (
 	TypeBstring = &TypeOfBstring{}
 	TypeIP      = &TypeOfIP{}
 	TypeNet     = &TypeOfNet{}
-	TypeType    = &TypeOfType{}
 	TypeError   = &TypeOfError{}
 	TypeNull    = &TypeOfNull{}
 )
@@ -237,7 +236,7 @@ func LookupPrimitive(name string) Type {
 	case "net":
 		return TypeNet
 	case "type":
-		return TypeType
+		return &TypeType{}
 	case "error":
 		return TypeError
 	case "null":
@@ -281,7 +280,7 @@ func LookupPrimitiveById(id int) Type {
 	case IdDuration:
 		return TypeDuration
 	case IdType:
-		return TypeType
+		return &TypeType{}
 	case IdError:
 		return TypeError
 	case IdNull:

--- a/zng/typetype.go
+++ b/zng/typetype.go
@@ -6,38 +6,36 @@ import (
 	"github.com/brimsec/zq/zcode"
 )
 
-type TypeOfType struct{}
-
-func NewTypeType(t Type) Value {
-	return Value{TypeType, zcode.Bytes(t.ZSON())}
+type TypeType struct {
+	targetType Type
 }
 
-func (t *TypeOfType) ID() int {
+func (t *TypeType) ID() int {
 	return IdType
 }
 
-func (t *TypeOfType) Parse(in []byte) (zcode.Bytes, error) {
+func (t *TypeType) Parse(in []byte) (zcode.Bytes, error) {
 	// There's nothing to parse.  The zcode value is the ZSON value.
 	// The caller should validate the canonical form.
 	return zcode.Bytes(in), nil
 }
 
-func (t *TypeOfType) String() string {
+func (t *TypeType) String() string {
 	return "type"
 }
 
-func (t *TypeOfType) StringOf(zv zcode.Bytes, fmt OutFmt, inContainer bool) string {
+func (t *TypeType) StringOf(zv zcode.Bytes, fmt OutFmt, inContainer bool) string {
 	return string(zv)
 }
 
-func (t *TypeOfType) Marshal(zv zcode.Bytes) (interface{}, error) {
+func (t *TypeType) Marshal(zv zcode.Bytes) (interface{}, error) {
 	return t.StringOf(zv, OutFormatUnescaped, false), nil
 }
 
-func (t *TypeOfType) ZSON() string {
+func (t *TypeType) ZSON() string {
 	return "type"
 }
 
-func (t *TypeOfType) ZSONOf(zv zcode.Bytes) string {
+func (t *TypeType) ZSONOf(zv zcode.Bytes) string {
 	return fmt.Sprintf("(%s)", string(zv))
 }

--- a/zng/typevector/type.go
+++ b/zng/typevector/type.go
@@ -6,6 +6,11 @@ import (
 
 type Type []zng.Type
 
+// This is a draft, and this func should go somewhere else.
+func eq(s, t zng.Type) bool {
+	return s == t || s.ID() == zng.IdType && t.ID() == zng.IdType
+}
+
 func New(in []zng.Type) Type {
 	out := make(Type, 0, len(in))
 	for _, t := range in {
@@ -27,7 +32,7 @@ func (t Type) Equal(to []zng.Type) bool {
 		return false
 	}
 	for k, typ := range t {
-		if typ != to[k] {
+		if !eq(typ, to[k]) {
 			return false
 		}
 	}
@@ -39,7 +44,7 @@ func (t Type) EqualToValues(vals []zng.Value) bool {
 		return false
 	}
 	for k, typ := range t {
-		if typ != vals[k].Type {
+		if !eq(typ, vals[k].Type) {
 			return false
 		}
 	}

--- a/zson/analyzer.go
+++ b/zson/analyzer.go
@@ -537,7 +537,7 @@ func (a Analyzer) convertMap(zctx *resolver.Context, m *ast.Map, cast zng.Type) 
 
 func (a Analyzer) convertTypeValue(zctx *resolver.Context, tv *ast.TypeValue, cast zng.Type) (Value, error) {
 	if cast != nil {
-		if _, ok := zng.AliasedType(cast).(*zng.TypeOfType); !ok {
+		if _, ok := zng.AliasedType(cast).(*zng.TypeType); !ok {
 			return nil, fmt.Errorf("cannot apply decorator (%q) to a type value", cast.ZSON())
 		}
 	}
@@ -549,7 +549,7 @@ func (a Analyzer) convertTypeValue(zctx *resolver.Context, tv *ast.TypeValue, ca
 		cast = typ
 	}
 	return &TypeValue{
-		Type:  zng.TypeType,
+		Type:  &zng.TypeType{},
 		Value: cast,
 	}, nil
 }

--- a/zson/table.go
+++ b/zson/table.go
@@ -33,7 +33,7 @@ func (t *TypeTable) LookupValue(typ zng.Type) zng.Value {
 		bytes = zcode.Bytes(typ.ZSON())
 		t.enter(typ, bytes)
 	}
-	return zng.Value{zng.TypeType, bytes}
+	return zng.Value{&zng.TypeType{}, bytes}
 }
 
 func (t *TypeTable) LookupType(zson string) (zng.Type, error) {

--- a/zson/zson.go
+++ b/zson/zson.go
@@ -14,7 +14,7 @@ import (
 // syntactically from its value and thus never needs a decorator.
 func Implied(typ zng.Type) bool {
 	switch typ.(type) {
-	case *zng.TypeOfInt64, *zng.TypeOfTime, *zng.TypeOfFloat64, *zng.TypeOfBool, *zng.TypeOfBytes, *zng.TypeOfString, *zng.TypeOfIP, *zng.TypeOfNet, *zng.TypeOfType:
+	case *zng.TypeOfInt64, *zng.TypeOfTime, *zng.TypeOfFloat64, *zng.TypeOfBool, *zng.TypeOfBytes, *zng.TypeOfString, *zng.TypeOfIP, *zng.TypeOfNet, *zng.TypeType:
 		return true
 	}
 	return false


### PR DESCRIPTION
@mccanne this is a first step toward what you outlined in #1619 and which I also need for #1785 : 

> Also, to be efficient on this front, zng.TypeType should have a zng.Type value inside of it in addition to the string.

The `eq` func in typevector/type.go should probably be lifted to `zng/type.go`. If we go this route, I would also look for any other occurences of type comparisons that may need to use this. But I wanted to see first if this route makes sense?

(And, the next step would be to fill in the Type pointer lazily for values that originated from zson, and where the zng.Type is not available at value creation time... )


