### PR TITLE
allow outer records to be aliased

### DIFF
--- a/expr/dot.go
+++ b/expr/dot.go
@@ -10,7 +10,7 @@ import (
 type RootRecord struct{}
 
 func (r *RootRecord) Eval(rec *zng.Record) (zng.Value, error) {
-	return zng.Value{rec.Type, rec.Raw}, nil
+	return zng.Value{rec.Alias, rec.Raw}, nil
 }
 
 type DotExpr struct {

--- a/proc/fuse/fuse.go
+++ b/proc/fuse/fuse.go
@@ -173,7 +173,7 @@ func (p *Proc) finish() error {
 	for _, typ := range p.types {
 		if typ != nil {
 			id := typ.ID()
-			p.slotByID[id] = uber.mixin(typ)
+			p.slotByID[id] = uber.mixin(zng.AliasedType(typ).(*zng.TypeRecord))
 		}
 	}
 	var err error

--- a/zbuf/mapper.go
+++ b/zbuf/mapper.go
@@ -28,11 +28,12 @@ func (m *Mapper) Read() (*zng.Record, error) {
 	id := rec.Type.ID()
 	sharedType := m.mapper.Map(id)
 	if sharedType == nil {
-		sharedType, err = m.mapper.Enter(id, rec.Type)
+		sharedType, err = m.mapper.Enter(id, rec.Alias)
 		if err != nil {
 			return nil, err
 		}
 	}
-	rec.Type = sharedType
+	rec.Alias = sharedType
+	rec.Type = zng.AliasedType(sharedType).(*zng.TypeRecord)
 	return rec, nil
 }

--- a/zio/tzngio/reader_test.go
+++ b/zio/tzngio/reader_test.go
@@ -28,11 +28,11 @@ func TestCtrl(t *testing.T) {
 
 	_, body, err := r.ReadPayload()
 	assert.NoError(t, err)
-	assert.Equal(t, body, []byte("message1"))
+	assert.Equal(t, "message1", string(body))
 
 	_, body, err = r.ReadPayload()
 	assert.NoError(t, err)
-	assert.Equal(t, body, []byte("message2"))
+	assert.Equal(t, "message2", string(body))
 
 	_, body, err = r.ReadPayload()
 	assert.NoError(t, err)
@@ -40,11 +40,11 @@ func TestCtrl(t *testing.T) {
 
 	_, body, err = r.ReadPayload()
 	assert.NoError(t, err)
-	assert.Equal(t, body, []byte("message3"))
+	assert.Equal(t, "message3", string(body))
 
 	_, body, err = r.ReadPayload()
 	assert.NoError(t, err)
-	assert.Equal(t, body, []byte("message4"))
+	assert.Equal(t, "message4", string(body))
 }
 
 func TestAlias(t *testing.T) {

--- a/zio/tzngio/writer.go
+++ b/zio/tzngio/writer.go
@@ -14,7 +14,7 @@ type Writer struct {
 	// new record encountered (i.e., which triggers a typedef) so that we
 	// generate the output in canonical form whereby the typedefs in the
 	// stream are numbered sequentially from 0.
-	tracker map[int]int
+	tracker map[int]string
 	// aliases keeps track of whether an alias has been written to the stream
 	// on not.
 	aliases map[int]struct{}
@@ -23,7 +23,7 @@ type Writer struct {
 func NewWriter(w io.WriteCloser) *Writer {
 	return &Writer{
 		writer:  w,
-		tracker: make(map[int]int),
+		tracker: make(map[int]string),
 		aliases: make(map[int]struct{}),
 	}
 }
@@ -39,19 +39,28 @@ func (w *Writer) WriteControl(b []byte) error {
 
 func (w *Writer) Write(r *zng.Record) error {
 	inId := r.Type.ID()
-	outId, ok := w.tracker[inId]
+	name, ok := w.tracker[inId]
 	if !ok {
-		if err := w.writeAliases(r); err != nil {
+		if err := w.writeAliases(r.Type); err != nil {
 			return err
 		}
-		outId = len(w.tracker)
-		w.tracker[inId] = outId
-		_, err := fmt.Fprintf(w.writer, "#%d:%s\n", outId, r.Type)
+		typ := r.Alias
+		var op string
+		if alias, ok := typ.(*zng.TypeAlias); ok {
+			name = alias.Name
+			op = "="
+		} else {
+			id := len(w.tracker)
+			name = strconv.Itoa(id)
+			op = ":"
+		}
+		w.tracker[inId] = name
+		_, err := fmt.Fprintf(w.writer, "#%s%s%s\n", name, op, r.Type)
 		if err != nil {
 			return err
 		}
 	}
-	_, err := fmt.Fprintf(w.writer, "%d:", outId)
+	_, err := fmt.Fprintf(w.writer, "%s:", name)
 	if err != nil {
 		return nil
 	}
@@ -65,8 +74,8 @@ func (w *Writer) Write(r *zng.Record) error {
 	return w.write("\n")
 }
 
-func (w *Writer) writeAliases(r *zng.Record) error {
-	aliases := zng.AliasTypes(r.Type)
+func (w *Writer) writeAliases(typ zng.Type) error {
+	aliases := zng.AliasTypes(typ)
 	for _, alias := range aliases {
 		id := alias.AliasID()
 		if _, ok := w.aliases[id]; !ok {

--- a/zio/zio_test.go
+++ b/zio/zio_test.go
@@ -13,7 +13,9 @@ import (
 
 func assertError(t *testing.T, err error, pattern, what string) {
 	assert.Error(t, err, "Received error for %s", what)
-	assert.Containsf(t, err.Error(), pattern, "error message for %s is as expected", what)
+	if err != nil {
+		assert.Containsf(t, err.Error(), pattern, "error message for %s is as expected", what)
+	}
 }
 
 // Test things related to parsing tzng
@@ -81,21 +83,11 @@ func TestTzngDescriptors(t *testing.T) {
 		_, err = r.Read()
 		assert.Error(t, err, "tzng parse error", "invalid tzng")
 	}
-	// Can't use a descriptor of non-record type
-	r = tzngio.NewReader(strings.NewReader("#3:string\n"), resolver.NewContext())
-	_, err = r.Read()
-	assertError(t, err, "not a record", "descriptor with non-record type")
 
 	// Descriptor with an invalid type is rejected
 	r = tzngio.NewReader(strings.NewReader("#4:notatype\n"), resolver.NewContext())
 	_, err = r.Read()
 	assertError(t, err, "unknown type", "descriptor with invalid type")
-
-	// Trying to redefine a descriptor is an error XXX this should be ok
-	d := "#1:record[n:int32]\n"
-	r = tzngio.NewReader(strings.NewReader(d+d), resolver.NewContext())
-	_, err = r.Read()
-	assertError(t, err, "descriptor already exists", "redefining //descriptor")
 }
 
 // XXX add test for mixing legacy and non-legacy

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -490,9 +490,9 @@ func (r *Reader) parseValue(rec *zng.Record, id int, b []byte) (*zng.Record, err
 		}
 	}
 	if rec == nil {
-		rec = zng.NewVolatileRecord(sharedType, b)
+		rec = zng.NewVolatileRecordFromType(sharedType, b)
 	} else {
-		*rec = *zng.NewVolatileRecord(sharedType, b)
+		*rec = *zng.NewVolatileRecordFromType(sharedType, b)
 	}
 	if r.validate {
 		if err := rec.TypeCheck(); err != nil {

--- a/zio/zngio/writer.go
+++ b/zio/zngio/writer.go
@@ -108,7 +108,7 @@ func (w *Writer) Write(r *zng.Record) error {
 	if typ == nil {
 		var b []byte
 		var err error
-		b, typ, err = w.encoder.Encode(w.buffer[:0], r.Type)
+		b, typ, err = w.encoder.Encode(w.buffer[:0], r.Alias)
 		if err != nil {
 			return err
 		}

--- a/zng/builder.go
+++ b/zng/builder.go
@@ -47,6 +47,7 @@ func (b *Builder) Build(zvs ...zcode.Bytes) *Record {
 	// will have to copy the record and we can re-use the record value
 	// between subsequent calls.
 	b.rec.Type = b.Type
+	b.rec.Alias = b.Type
 	b.rec.Raw = b.Bytes()
 	return &b.rec
 }

--- a/zng/flattener/flattener.go
+++ b/zng/flattener/flattener.go
@@ -69,7 +69,7 @@ func (f *Flattener) Flatten(r *zng.Record) (*zng.Record, error) {
 		if err != nil {
 			return nil, err
 		}
-		f.mapper.EnterTypeRecord(id, flatType)
+		f.mapper.EnterType(id, flatType)
 	}
 	// Since we are mapping the input context to itself we can do a
 	// pointer comparison to see if the types are the same and there
@@ -81,7 +81,7 @@ func (f *Flattener) Flatten(r *zng.Record) (*zng.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	return zng.NewRecord(flatType, zv), nil
+	return zng.NewRecord(flatType.(*zng.TypeRecord), zv), nil
 }
 
 // FlattenColumns turns nested records into a series of columns of

--- a/zng/resolver/mapper.go
+++ b/zng/resolver/mapper.go
@@ -17,13 +17,13 @@ func NewMapper(out *Context) *Mapper {
 // The outputs are stored in a Slice, which will create a new decriptor if
 // the type mapping is unknown to it.  The output side is assumed to be shared
 // while the input side owned by one thread of control.
-func (m *Mapper) Map(td int) *zng.TypeRecord {
+func (m *Mapper) Map(td int) zng.Type {
 	return m.Lookup(td)
 }
 
 //XXX Enter should allocate the td as it creates the new type in the output context
-func (m *Mapper) Enter(id int, ext *zng.TypeRecord) (*zng.TypeRecord, error) {
-	typ, err := m.outputCtx.TranslateTypeRecord(ext)
+func (m *Mapper) Enter(id int, ext zng.Type) (zng.Type, error) {
+	typ, err := m.outputCtx.TranslateType(ext)
 	if err != nil {
 		return nil, err
 	}
@@ -34,14 +34,13 @@ func (m *Mapper) Enter(id int, ext *zng.TypeRecord) (*zng.TypeRecord, error) {
 	return nil, nil
 }
 
-func (m *Mapper) Translate(foreign *zng.TypeRecord) (*zng.TypeRecord, error) {
+func (m *Mapper) Translate(foreign zng.Type) (zng.Type, error) {
 	id := foreign.ID()
 	if local := m.Map(id); local != nil {
 		return local, nil
 	}
 	return m.Enter(id, foreign)
 }
-
-func (m *Mapper) EnterTypeRecord(td int, typ *zng.TypeRecord) {
+func (m *Mapper) EnterType(td int, typ zng.Type) {
 	m.Slice.Enter(td, typ)
 }

--- a/zng/resolver/slice.go
+++ b/zng/resolver/slice.go
@@ -6,18 +6,18 @@ import (
 
 // Slice is a table of descriptors respresented as a slice and grown
 // on demand as small-in type descriptors are entered into the table.
-type Slice []*zng.TypeRecord
+type Slice []zng.Type
 
-func (s Slice) Lookup(td int) *zng.TypeRecord {
+func (s Slice) Lookup(td int) zng.Type {
 	if td >= 0 && td < len(s) {
 		return s[td]
 	}
 	return nil
 }
 
-func (s *Slice) Enter(td int, d *zng.TypeRecord) {
+func (s *Slice) Enter(td int, d zng.Type) {
 	if td >= len(*s) {
-		new := make([]*zng.TypeRecord, td+1)
+		new := make([]zng.Type, td+1)
 		copy(new, *s)
 		*s = new
 	}

--- a/zng/resolver/slice.go
+++ b/zng/resolver/slice.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Slice is a table of descriptors respresented as a slice and grown
-// on demand as small-in type descriptors are entered into the table.
+// on demand as small-int type descriptors are entered into the table.
 type Slice []zng.Type
 
 func (s Slice) Lookup(td int) zng.Type {

--- a/zng/resolver/translator.go
+++ b/zng/resolver/translator.go
@@ -21,7 +21,7 @@ func NewTranslator(in, out *Context) *Translator {
 }
 
 // Lookup implements zng.Resolver
-func (t *Translator) Lookup(id int) (*zng.TypeRecord, error) {
+func (t *Translator) Lookup(id int) (zng.Type, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	outputType := t.Slice.Lookup(id)

--- a/zson/reader.go
+++ b/zson/reader.go
@@ -45,13 +45,10 @@ func (r *Reader) Read() (*zng.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	//XXX Ideally, we'd like to set the type of the record to val.TypeOf(),
-	// e.g., in case the record type's is a typedef name (i.e., alias), but
-	// record types currently must be zng.TypeRecord. See issue #1801.
-	if recType, ok := zng.AliasedType(zv.Type).(*zng.TypeRecord); ok {
-		return zng.NewRecord(recType, zv.Bytes), nil
-	}
 	// ZSON can represent value streams that aren't records,
 	// but we handle only top-level records here.
-	return nil, fmt.Errorf("top-level ZSON value not a record: %s", zv.Type.ZSON())
+	if _, ok := zng.AliasedType(zv.Type).(*zng.TypeRecord); !ok {
+		return nil, fmt.Errorf("top-level ZSON value not a record: %s", zv.Type.ZSON())
+	}
+	return zng.NewRecordFromType(zv.Type, zv.Bytes), nil
 }

--- a/zson/ztests/outer-schema.yaml
+++ b/zson/ztests/outer-schema.yaml
@@ -1,0 +1,17 @@
+script: |
+  zq -t -i zson -pretty=0 in.zson
+
+inputs:
+  - name: in.zson
+    data: |
+      { city: "Berkeley", state: "CA", population: 121643 (uint32) } (=city_schema)
+      { city: "Broad Cove", state: "ME", population: 806 } (city_schema)
+      { city: "Baton Rouge", state: "LA", population: 221599 } (city_schema)
+
+outputs:
+  - name: stdout
+    data: |
+      #city_schema=record[city:string,state:string,population:uint32]
+      city_schema:[Berkeley;CA;121643;]
+      city_schema:[Broad Cove;ME;806;]
+      city_schema:[Baton Rouge;LA;221599;]

--- a/zson/ztests/spec-example.yaml
+++ b/zson/ztests/spec-example.yaml
@@ -1,0 +1,41 @@
+script: |
+  zq -t -i zson in.zson
+
+inputs:
+  - name: in.zson
+    data: |
+      {
+          info: "Connection Example",
+          src: { addr: 10.1.1.2, port: 80 (uint16) } (=socket),
+          dst: { addr: 10.0.1.2, port: 20130 } (socket)
+      } (=conn)
+      {
+          info: "Connection Example 2",
+          src: { addr: 10.1.1.8, port: 80 },
+          dst: { addr: 10.1.2.88, port: 19801 }
+      } (conn)
+      {
+          info: "Access List Example",
+          nets: [ 10.1.1.0/24, 10.1.2.0/24 ]
+      } (=access_list)
+      { metric: "A", ts: 2020-11-24T08:44:09.586441-08:00, value: 120 }
+      { metric: "B", ts: 2020-11-24T08:44:20.726057-08:00, value: 0.86 }
+      { metric: "A", ts: 2020-11-24T08:44:32.201458-08:00, value: 126 }
+      { metric: "C", ts: 2020-11-24T08:44:43.547506-08:00, value: { x:10, y:101 } }
+
+outputs:
+  - name: stdout
+    data: |
+      #socket=record[addr:ip,port:uint16]
+      #conn=record[info:string,src:socket,dst:socket]
+      conn:[Connection Example;[10.1.1.2;80;][10.0.1.2;20130;]]
+      conn:[Connection Example 2;[10.1.1.8;80;][10.1.2.88;19801;]]
+      #access_list=record[info:string,nets:array[net]]
+      access_list:[Access List Example;[10.1.1.0/24;10.1.2.0/24;]]
+      #2:record[metric:string,ts:time,value:int64]
+      2:[A;1606236249.586441;120;]
+      #3:record[metric:string,ts:time,value:float64]
+      3:[B;1606236260.726057;0.86;]
+      2:[A;1606236272.201458;126;]
+      #4:record[metric:string,ts:time,value:record[x:int64,y:int64]]
+      4:[C;1606236283.547506;[10;101;]]

--- a/zson/ztests/typeof.yaml
+++ b/zson/ztests/typeof.yaml
@@ -1,0 +1,34 @@
+script: |
+  zq -t -i zson "by typeof(.) | sort ." in.zson
+
+inputs:
+  - name: in.zson
+    data: |
+      {
+          info: "Connection Example",
+          src: { addr: 10.1.1.2, port: 80 (uint16) } (=socket),
+          dst: { addr: 10.0.1.2, port: 20130 } (socket)
+      } (=conn)
+      {
+          info: "Connection Example 2",
+          src: { addr: 10.1.1.8, port: 80 },
+          dst: { addr: 10.1.2.88, port: 19801 }
+      } (conn)
+      {
+          info: "Access List Example",
+          nets: [ 10.1.1.0/24, 10.1.2.0/24 ]
+      } (=access_list)
+      { metric: "A", ts: 2020-11-24T08:44:09.586441-08:00, value: 120 }
+      { metric: "B", ts: 2020-11-24T08:44:20.726057-08:00, value: 0.86 }
+      { metric: "A", ts: 2020-11-24T08:44:32.201458-08:00, value: 126 }
+      { metric: "C", ts: 2020-11-24T08:44:43.547506-08:00, value: { x:10, y:101 } }
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[typeof:type]
+      0:[{metric:string,ts:time,value:int64};]
+      0:[{metric:string,ts:time,value:float64};]
+      0:[access_list=({info:string,nets:[net]});]
+      0:[{metric:string,ts:time,value:{x:int64,y:int64}};]
+      0:[conn=({info:string,src:socket=({addr:ip,port:uint16}),dst:socket=({addr:ip,port:uint16})});]


### PR DESCRIPTION
This commit is a first step toward #1801, which is to embed
zng.Value into zng.Record so that a record can take on any
alias type.  This step toward this goal adds an extra zng.Type
to record called Alias, which is either a zng.TypeRecord
(behavior as before) or a zng.TypeAlias (new behavior).

This allows the example ZSONs in the ZSON spec, which have
top-level type defs, to actually work.  Tests were adding
to cover these examples and make sure the typeof(.) operator
worked on the aliased outer records.