### PR TITLE
zson lexer: fix cursor length check

### DIFF
--- a/zson/lexer.go
+++ b/zson/lexer.go
@@ -62,14 +62,14 @@ func (l *Lexer) match(b byte) (bool, error) {
 }
 
 func (l *Lexer) matchTight(b byte) (bool, error) {
-	if len(l.cursor) > 1 {
-		ok := b == l.cursor[0]
-		if ok {
-			l.skip(1)
-		}
-		return ok, nil
+	if len(l.cursor) == 0 {
+		return false, io.EOF
 	}
-	return false, io.EOF
+	ok := b == l.cursor[0]
+	if ok {
+		l.skip(1)
+	}
+	return ok, nil
 }
 
 func (l *Lexer) matchBytes(b []byte) (bool, error) {

--- a/zson/lexer.go
+++ b/zson/lexer.go
@@ -65,11 +65,11 @@ func (l *Lexer) matchTight(b byte) (bool, error) {
 	if len(l.cursor) == 0 {
 		return false, io.EOF
 	}
-	ok := b == l.cursor[0]
-	if ok {
+	if b == l.cursor[0] {
 		l.skip(1)
+		return true, nil
 	}
-	return ok, nil
+	return false, nil
 }
 
 func (l *Lexer) matchBytes(b []byte) (bool, error) {

--- a/zson/ztests/no-trailing-newline.yaml
+++ b/zson/ztests/no-trailing-newline.yaml
@@ -1,0 +1,18 @@
+script: |
+  zq -t -i zson "count()" in.zson
+
+inputs:
+  - name: in.zson
+    data: |- # |- means no newline at end
+      {
+          c: 23 (int32)
+      } (=0)
+      {
+          c: 42
+      } (0)
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[count:uint64]
+      0:[2;]


### PR DESCRIPTION
I noticed this while parsing a hand-written type value, which was was returning `nil, io.EOF` until i added a trailing newline.