### PR TITLE
wrap zng marshalers with state

### DIFF
--- a/ppl/archive/chunk/metadata.go
+++ b/ppl/archive/chunk/metadata.go
@@ -34,7 +34,7 @@ func ReadMetadata(ctx context.Context, uri iosrc.URI, order zbuf.Order) (Metadat
 		return Metadata{}, err
 	}
 	var md Metadata
-	if err := resolver.UnmarshalRecord(zctx, rec, &md); err != nil {
+	if err := resolver.UnmarshalRecord(rec, &md); err != nil {
 		return Metadata{}, err
 	}
 	if err := mdTsOrderCheck(uri, "read", order, md.First, md.Last); err != nil {
@@ -59,8 +59,7 @@ func (m Metadata) Write(ctx context.Context, uri iosrc.URI, order zbuf.Order) er
 	if err := mdTsOrderCheck(uri, "write", order, m.First, m.Last); err != nil {
 		return err
 	}
-	zctx := resolver.NewContext()
-	rec, err := resolver.MarshalRecord(zctx, m)
+	rec, err := resolver.NewMarshaler().MarshalRecord(m)
 	if err != nil {
 		return err
 	}

--- a/ppl/archive/index/rule.go
+++ b/ppl/archive/index/rule.go
@@ -68,7 +68,7 @@ func UnmarshalRule(b []byte) (Rule, error) {
 		return Rule{}, err
 	}
 	r := Rule{}
-	return r, resolver.UnmarshalRecord(zctx, rec, &r)
+	return r, resolver.UnmarshalRecord(rec, &r)
 }
 
 func NewZqlRule(prog, name string, keys []field.Static) (Rule, error) {
@@ -177,7 +177,7 @@ func (r Rule) String() string {
 }
 
 func (r Rule) Marshal() ([]byte, error) {
-	rec, err := resolver.MarshalRecord(resolver.NewContext(), r)
+	rec, err := resolver.NewMarshaler().MarshalRecord(r)
 	if err != nil {
 		return nil, err
 	}

--- a/zng/resolver/marshal.go
+++ b/zng/resolver/marshal.go
@@ -292,7 +292,7 @@ func Unmarshal(zv zng.Value, v interface{}) error {
 	return NewUnmarshaler().decodeAny(zv, reflect.ValueOf(v))
 }
 
-func UnmarshalRecord(zctx *Context, rec *zng.Record, v interface{}) error {
+func UnmarshalRecord(rec *zng.Record, v interface{}) error {
 	return NewUnmarshaler().decodeAny(zng.Value{rec.Alias, rec.Raw}, reflect.ValueOf(v))
 }
 

--- a/zng/resolver/marshal_test.go
+++ b/zng/resolver/marshal_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/pkg/nano"
-	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zio/zngio"
@@ -39,7 +38,7 @@ func tzngToRec(t *testing.T, zctx *resolver.Context, tzng string) *zng.Record {
 }
 
 func boomerang(t *testing.T, in interface{}, out interface{}) {
-	rec, err := resolver.MarshalRecord(resolver.NewContext(), in)
+	rec, err := resolver.NewMarshaler().MarshalRecord(in)
 	require.NoError(t, err)
 	var buf bytes.Buffer
 	zw := zngio.NewWriter(zio.NopCloser(&buf), zngio.WriterOpts{})
@@ -63,8 +62,7 @@ func TestMarshal(t *testing.T) {
 		Sub1    S2
 		PField1 *bool
 	}
-	zctx := resolver.NewContext()
-	rec, err := resolver.MarshalRecord(zctx, S1{
+	rec, err := resolver.NewMarshaler().MarshalRecord(S1{
 		Field1: "value1",
 		Sub1: S2{
 			Field2: "value2",
@@ -93,8 +91,8 @@ type Things struct {
 func TestMarshalSlice(t *testing.T) {
 	s := []Thing{{"hello", 123}, {"world", 0}}
 	r := Things{s}
-	zctx := resolver.NewContext()
-	rec, err := resolver.MarshalRecord(zctx, r)
+	m := resolver.NewMarshaler()
+	rec, err := m.MarshalRecord(r)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 
@@ -106,7 +104,7 @@ func TestMarshalSlice(t *testing.T) {
 
 	empty := []Thing{}
 	r2 := Things{empty}
-	rec2, err := resolver.MarshalRecord(zctx, r2)
+	rec2, err := m.MarshalRecord(r2)
 	require.NoError(t, err)
 	require.NotNil(t, rec2)
 
@@ -158,7 +156,8 @@ func TestIPType(t *testing.T) {
 	require.NotNil(t, addr)
 	s := TestIP{Addr: addr}
 	zctx := resolver.NewContext()
-	rec, err := resolver.MarshalRecord(zctx, s)
+	m := resolver.NewMarshalerWithContext(zctx)
+	rec, err := m.MarshalRecord(s)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 
@@ -189,8 +188,7 @@ func TestUnmarshalRecord(t *testing.T) {
 	v1 := T1{
 		T1f1: &T2{T2f1: T3{T3f1: 1, T3f2: 1.0}, T2f2: "t2f2-string1"},
 	}
-	zctx := resolver.NewContext()
-	rec, err := resolver.MarshalRecord(zctx, v1)
+	rec, err := resolver.NewMarshaler().MarshalRecord(v1)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 
@@ -200,7 +198,7 @@ func TestUnmarshalRecord(t *testing.T) {
 `
 	require.Equal(t, trim(exp), rectzng(t, rec))
 
-	zctx = resolver.NewContext()
+	zctx := resolver.NewContext()
 	rec = tzngToRec(t, zctx, exp)
 
 	var v2 T1
@@ -227,7 +225,7 @@ func TestUnmarshalSlice(t *testing.T) {
 		T1f1: []bool{true, false, true},
 	}
 	zctx := resolver.NewContext()
-	rec, err := resolver.MarshalRecord(zctx, v1)
+	rec, err := resolver.NewMarshalerWithContext(zctx).MarshalRecord(v1)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 
@@ -244,7 +242,7 @@ func TestUnmarshalSlice(t *testing.T) {
 		Field1: []*int{intp(1), intp(2)},
 	}
 	zctx = resolver.NewContext()
-	rec, err = resolver.MarshalRecord(zctx, v3)
+	rec, err = resolver.NewMarshalerWithContext(zctx).MarshalRecord(v3)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 
@@ -256,13 +254,13 @@ func TestUnmarshalSlice(t *testing.T) {
 
 type testMarshaler string
 
-func (m testMarshaler) MarshalZNG(zctx *resolver.Context, b *zcode.Builder) (zng.Type, error) {
-	return resolver.Marshal(zctx, b, "marshal-"+string(m))
+func (m testMarshaler) MarshalZNG(mc *resolver.MarshalContext) (zng.Type, error) {
+	return mc.Marshal("marshal-" + string(m))
 }
 
-func (m *testMarshaler) UnmarshalZNG(zctx *resolver.Context, zt zng.Type, zb zcode.Bytes) error {
+func (m *testMarshaler) UnmarshalZNG(zv zng.Value) error {
 	var s string
-	if err := resolver.Unmarshal(zctx, zt, zb, &s); err != nil {
+	if err := resolver.NewUnmarshaler().Unmarshal(zv, &s); err != nil {
 		return err
 	}
 	ss := strings.Split(s, "-")
@@ -280,7 +278,7 @@ func TestMarshalInterface(t *testing.T) {
 	}
 	m1 := testMarshaler("m1")
 	r1 := rectype{M1: &m1, M2: testMarshaler("m2")}
-	rec, err := resolver.MarshalRecord(resolver.NewContext(), r1)
+	rec, err := resolver.NewMarshaler().MarshalRecord(r1)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 
@@ -305,7 +303,7 @@ func TestMarshalArray(t *testing.T) {
 	}
 	a2 := &[2]string{"foo", "bar"}
 	r1 := rectype{A1: [2]int8{1, 2}, A2: a2} // A3 left as nil
-	rec, err := resolver.MarshalRecord(resolver.NewContext(), r1)
+	rec, err := resolver.NewMarshaler().MarshalRecord(r1)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 
@@ -348,7 +346,7 @@ func TestIntsAndUints(t *testing.T) {
 		UI32: math.MaxUint32,
 		UI64: math.MaxUint64,
 	}
-	rec, err := resolver.MarshalRecord(resolver.NewContext(), r1)
+	rec, err := resolver.NewMarshaler().MarshalRecord(r1)
 	require.NoError(t, err)
 	require.NotNil(t, rec)
 
@@ -369,8 +367,8 @@ func TestCustomRecord(t *testing.T) {
 		Thing{"hello", 123},
 		99,
 	}
-	zctx := resolver.NewContext()
-	rec, err := resolver.MarshalCustomRecord(zctx, []string{"foo", "bar"}, vals)
+	m := resolver.NewMarshaler()
+	rec, err := m.MarshalCustom([]string{"foo", "bar"}, vals)
 	require.NoError(t, err)
 	exp := `
 #0:record[foo:record[a:string,B:int64],bar:int64]
@@ -384,7 +382,7 @@ func TestCustomRecord(t *testing.T) {
 	exp = `
 #0:record[foo:record[a:string,B:int64],bar:null]
 0:[[hello;123;]-;]`
-	rec, err = resolver.MarshalCustomRecord(zctx, []string{"foo", "bar"}, vals)
+	rec, err = m.MarshalCustom([]string{"foo", "bar"}, vals)
 	require.NoError(t, err)
 	assert.Equal(t, trim(exp), rectzng(t, rec))
 }

--- a/zng/resolver/marshal_test.go
+++ b/zng/resolver/marshal_test.go
@@ -48,7 +48,7 @@ func boomerang(t *testing.T, in interface{}, out interface{}) {
 	zr := zngio.NewReader(&buf, zctx)
 	rec, err = zr.Read()
 	require.NoError(t, err)
-	err = resolver.UnmarshalRecord(zctx, rec, out)
+	err = resolver.UnmarshalRecord(rec, out)
 	require.NoError(t, err)
 }
 
@@ -168,7 +168,7 @@ func TestIPType(t *testing.T) {
 	assert.Equal(t, trim(exp), rectzng(t, rec))
 
 	var tip TestIP
-	err = resolver.UnmarshalRecord(zctx, rec, &tip)
+	err = resolver.UnmarshalRecord(rec, &tip)
 	require.NoError(t, err)
 	require.Equal(t, s, tip)
 }
@@ -202,7 +202,7 @@ func TestUnmarshalRecord(t *testing.T) {
 	rec = tzngToRec(t, zctx, exp)
 
 	var v2 T1
-	err = resolver.UnmarshalRecord(zctx, rec, &v2)
+	err = resolver.UnmarshalRecord(rec, &v2)
 	require.NoError(t, err)
 	require.Equal(t, v1, v2)
 
@@ -210,7 +210,7 @@ func TestUnmarshalRecord(t *testing.T) {
 		T4f1 *T2 `zng:"top"`
 	}
 	var v3 *T4
-	err = resolver.UnmarshalRecord(zctx, rec, &v3)
+	err = resolver.UnmarshalRecord(rec, &v3)
 	require.NoError(t, err)
 	require.NotNil(t, v3)
 	require.NotNil(t, v3.T4f1)
@@ -230,7 +230,7 @@ func TestUnmarshalSlice(t *testing.T) {
 	require.NotNil(t, rec)
 
 	var v2 T1
-	err = resolver.UnmarshalRecord(zctx, rec, &v2)
+	err = resolver.UnmarshalRecord(rec, &v2)
 	require.NoError(t, err)
 	require.Equal(t, v1, v2)
 
@@ -247,7 +247,7 @@ func TestUnmarshalSlice(t *testing.T) {
 	require.NotNil(t, rec)
 
 	var v4 T2
-	err = resolver.UnmarshalRecord(zctx, rec, &v4)
+	err = resolver.UnmarshalRecord(rec, &v4)
 	require.NoError(t, err)
 	require.Equal(t, v1, v2)
 }
@@ -289,7 +289,7 @@ func TestMarshalInterface(t *testing.T) {
 	assert.Equal(t, trim(exp), rectzng(t, rec))
 
 	var r2 rectype
-	err = resolver.UnmarshalRecord(resolver.NewContext(), rec, &r2)
+	err = resolver.UnmarshalRecord(rec, &r2)
 	require.NoError(t, err)
 	assert.Equal(t, "m1", string(*r1.M1))
 	assert.Equal(t, "m2", string(r1.M2))
@@ -314,7 +314,7 @@ func TestMarshalArray(t *testing.T) {
 	assert.Equal(t, trim(exp), rectzng(t, rec))
 
 	var r2 rectype
-	err = resolver.UnmarshalRecord(resolver.NewContext(), rec, &r2)
+	err = resolver.UnmarshalRecord(rec, &r2)
 	require.NoError(t, err)
 	assert.Equal(t, r1.A1, r2.A1)
 	assert.Equal(t, *r2.A2, *r2.A2)
@@ -357,7 +357,7 @@ func TestIntsAndUints(t *testing.T) {
 	assert.Equal(t, trim(exp), rectzng(t, rec))
 
 	var r2 rectype
-	err = resolver.UnmarshalRecord(resolver.NewContext(), rec, &r2)
+	err = resolver.UnmarshalRecord(rec, &r2)
 	require.NoError(t, err)
 	assert.Equal(t, r1, r2)
 }


### PR DESCRIPTION
This commit refactors the zng marshaling code to use state data structure
instead of passing it in.  This represents the fundamental notion that
a marshaler must have a type context as outside data is marshaled into
a zng stream (unlike JSON where there is no type state).

The MarshalContext struct embeds and exports zcode.Buidler and
resolver.Context so that custom marshalers may operate directly
on both sets of methods when build marshaled results and return
the proper (and newly constructed) zng.Types.

This also sets up the code for a subsequent PR that will add the
ability to unmarshal into an interface type (unlike json.Unmarshal),
where we will use the ZSON type name to determine what concrete
implementation should be unmarshaled into for a given interface value.