### PR TITLE
Make TypeTable.LookupType() error message conformant

### DIFF
--- a/zson/table.go
+++ b/zson/table.go
@@ -61,7 +61,7 @@ func (t *TypeTable) LookupType(zson string) (zng.Type, error) {
 		}
 		tv, ok := val.(*TypeValue)
 		if !ok {
-			return nil, fmt.Errorf("(*TypeTable).LookupType() internal error: value of type %T", val)
+			return nil, fmt.Errorf("internal error: value of type %T in TypeTable.LookupType()", val)
 		}
 		typ = tv.Value
 	}


### PR DESCRIPTION
As suggested in https://github.com/brimsec/zq/pull/1832#discussion_r545250338