### PR TITLE
Remove links to Developer Docs for now

### DIFF
--- a/zql/docs/aggregate-functions/README.md
+++ b/zql/docs/aggregate-functions/README.md
@@ -109,7 +109,6 @@ TS                   SHORT_RTT            SHORT_COUNT LONG_RTT             LONG_
 | **Syntax**                | `and(<expression>)`                                            |
 | **Required<br>arguments** | `<expression>`<br>A valid ZQL [expression](../expressions/README.md). |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Logical       |
 
 #### Example:
 
@@ -152,7 +151,6 @@ COUNT
 | **Syntax**                | `avg(<field-name>)`                                            |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Avg           |
 
 #### Example:
 
@@ -179,7 +177,6 @@ AVG
 | **Syntax**                | `collect(<field-name>)`                                        |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Collect       |
 
 #### Example #1:
 
@@ -210,7 +207,6 @@ CI0SCN14gWpY087KA3 GET,POST,GET,GET,GET,GET,GET,GET,GET,GET,GET,GET,GET
 | **Syntax**                | `count([field-name])`                                          |
 | **Required<br>arguments** | None                                                           |
 | **Optional<br>arguments** | `[field-name]`<br>The name a field. If specified, only events that contain this field will be counted. |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Count         |
 
 #### Example #1:
 
@@ -253,7 +249,6 @@ ftp   93
 | **Required<br>arguments** | `<field-name>`<br>The name of a field containing values to be counted. |
 | **Optional<br>arguments** | None                                                           |
 | **Limitations**           | The potential inaccuracy of the calculated result is described in detail in the code and research linked from the [HyperLogLog repository](https://github.com/axiomhq/hyperloglog). |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#CountDistinct |
 
 #### Example:
 
@@ -294,7 +289,6 @@ to perform this test, the ZQL using `countdistinct()` executed almost 3x faster.
 | **Syntax**                | `first(<field-name>)`                                          |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#First         |
 
 #### Example:
 
@@ -320,7 +314,6 @@ TCP_ack_underflow_or_misorder
 | **Syntax**                | `last(<field-name>)`                                           |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Last          |
 
 #### Example:
 
@@ -346,7 +339,6 @@ talk.google.com
 | **Syntax**                | `max(<field-name>)`                                            |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer/field#FieldReducer |
 
 #### Example:
 
@@ -373,7 +365,6 @@ MAX
 | **Syntax**                | `min(<field-name>)`                                            |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer/field#FieldReducer |
 
 #### Example:
 
@@ -400,7 +391,6 @@ MIN
 | **Syntax**                | `or(<expression>)`                                             |
 | **Required<br>arguments** | `<expression>`<br>A valid ZQL [expression](../expressions/README.md). |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Logical       |
 
 #### Example:
 
@@ -444,7 +434,6 @@ T              F
 | **Syntax**                | `sum(<field-name>)`                                            |
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer/field#FieldReducer |
 
 #### Example:
 
@@ -472,7 +461,6 @@ SUM
 | **Required<br>arguments** | `<field-name>`<br>The name of a field.                         |
 | **Optional<br>arguments** | None                                                           |
 | **Limitations**           | The data type of the input values must be uniform.             |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/reducer#Union         |
 
 #### Example #1:
 

--- a/zql/docs/processors/README.md
+++ b/zql/docs/processors/README.md
@@ -31,7 +31,6 @@ The following available processors are documented in detail below:
 | **Description**           | Return the data only from the specified named fields, where available. Contrast with [`pick`](#pick), which is stricter. |
 | **Syntax**                | `cut <field-list>`                                |
 | **Required<br>arguments** | `<field-list>`<br>One or more comma-separated field names or assignments.  |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/cut |
 
 #### Example #1:
 
@@ -108,7 +107,6 @@ TIME                        UID
 | **Description**           | Return the data from all but the specified named fields.    |
 | **Syntax**                | `drop <field-list>`                   |
 | **Required<br>arguments** | `<field-list>`<br>One or more comma-separated field names or assignments.  |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc            |
 
 #### Example #1:
 
@@ -137,7 +135,6 @@ TS                          UID                NAME                             
 | **Syntax**                | `filter <search-expression>`                                          |
 | **Required<br>arguments** | `<search-expression>`<br>Any valid expression in ZQL [search syntax](../search-syntax/README.md) |
 | **Optional<br>arguments** | None                                                                  |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/filter                   |
 
 #### Example #1:
 
@@ -179,7 +176,6 @@ ssl   2018-03-24T17:24:00.189735Z CSbGJs3jOeB6glWLJj 10.47.7.154 27137     52.85
 | **Required<br>arguments** | None                                              |
 | **Optional<br>arguments** | None                                              |
 | **Limitations**           | Because `fuse` must make a first pass through the data to assemble the unified schema, results from queries that use `fuse` will not begin streaming back immediately. |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/fuse |
 
 #### Example:
 
@@ -240,7 +236,6 @@ Other output formats invoked via `zq -f` that benefit greatly from the use of `f
 | **Syntax**                | `head [N]`                                                            |
 | **Required<br>arguments** | None. If no arguments are specified, only the first event is returned.|
 | **Optional<br>arguments** | `[N]`<br>An integer specifying the number of results to return. If not specified, defaults to `1`. |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/head                     |
 
 #### Example #1:
 
@@ -283,7 +278,6 @@ conn  2018-03-24T17:15:20.607695Z CpjMvj2Cvj048u6bF1 10.164.94.120 39169     10.
 | **Description**           | Return the data from the named fields in records that contain _all_ of the specified fields. Contrast with [`cut`](#cut), which is more relaxed. |
 | **Syntax**                | `pick <field-list>`                           |
 | **Required<br>arguments** | `<field-list>`<br>One or more comma-separated field names or assignments.  |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc |
 
 #### Example #1:
 
@@ -362,7 +356,6 @@ TIME                        UID
 | **Required arguments**    | `<field>`<br>Field into which the computed value will be stored.<br><br>`<expression>`<br>A valid ZQL [expression](../expressions/README.md). If evaluation of any expression fails, a warning is emitted and the original record is passed through unchanged. |
 | **Optional arguments**    | None |
 | **Limitations**           | If multiple fields are written in a single `put`, all the new field values are computed first and then they are all written simultaneously.  As a result, a computed value cannot be referenced in another expression.  If you need to re-use a computed result, this can be done by chaining multiple `put` processors.  For example, this will not work:<br>`put N=len(somelist), isbig=N>10`<br>But it could be written instead as:<br>`put N=len(somelist) \| put isbig=N>10` |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/put |
 
 #### Example #1:
 
@@ -393,7 +386,6 @@ ID.ORIG_H     ID.ORIG_P ID.RESP_H       ID.RESP_P ORIG_BYTES RESP_BYTES TOTAL_BY
 | **Required arguments**    | One or more field assignment expressions. Renames are applied left to right; each rename observes the effect of all renames that preceded it. |
 | **Optional arguments**    | None |
 | **Limitations**           | A field can only be renamed within its own record. For example `id.orig_h` can be renamed to `id.src`, but it cannot be renamed to `src`. |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/rename |
 
 
 #### Example:
@@ -424,7 +416,6 @@ conn  2018-03-24T17:15:22.690601Z CuKFds250kxFgkhh8f 10.47.25.80    50813       
 | **Syntax**                | `sort [-r] [-nulls first\|last] [field-list]`                 |
 | **Required<br>arguments** | None                                                                      |
 | **Optional<br>arguments** | `[-r]`<br>If specified, results will be sorted in reverse order.<br><br>`[-nulls first\|last]`<br>Specifies where null values (i.e., values that are unset or that are not present at all in an incoming record) should be placed in the output.<br><br>`[field-list]`<br>One or more comma-separated field names by which to sort. Results will be sorted based on the values of the first field named in the list, then based on values in the second field named in the list, and so on.<br><br>If no field list is provided, sort will automatically pick a field by which to sort. The pick is done by examining the first result returned and finding the first field in left-to-right that is of one of the integer ZNG [data types](../data-types/README.md) (`int16`, `uint16`, `int32`, `uint32`, `int64`, `uint64`) and if no integer fields are found, the first `float64` field is used. If no fields of these numeric types are found, sorting will be performed on the first field found in left-to-right order that is _not_ of the `time` data type. |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/sort                         |
 
 #### Example #1:
 
@@ -520,7 +511,6 @@ wwonka       1
 | **Syntax**                | `tail [N]`                                                            |
 | **Required<br>arguments** | None. If no arguments are specified, only the last event is returned. |
 | **Optional<br>arguments** | `[N]`<br>An integer specifying the number of results to return. If not specified, defaults to `1`. |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/tail                     |
 
 #### Example #1:
 
@@ -564,7 +554,6 @@ conn  2018-03-24T17:36:28.752765Z COICgc1FXHKteyFy67 10.0.0.227     61314     10
 | **Syntax**                | `uniq [-c]`                                                           |
 | **Required<br>arguments** | None                                                                  |
 | **Optional<br>arguments** | `[-c]`<br>For each unique value shown, include a numeric count of how many times it appeared. |
-| **Developer Docs**        | https://pkg.go.dev/github.com/brimsec/zq/proc/uniq                     |
 
 #### Example:
 


### PR DESCRIPTION
In the time since we first put up the ZQL docs, we've included "Developer Docs" links with each processor and aggregate function to a pkg.go.dev destination that provided a reasonable jumping-in point in case someone wanted to start looking at its implementation. However, with the release of zq v0.25.0, the code is now structured so `cut` & `pick` (though not `drop` yet) can be used as both a function as well as an processor. This doesn't lend itself currently to being revealed through simple hyperlinks, so after speaking to @mccanne and @nwt a bit about it, it seems like we'd be ok just living without these links for now. Perhaps at some point in the future we can invest some cycles specifically toward making the project more approachable to new contributors, such as by investing in the sorts of things we did for Brim like the "code base walkthrough" we made available in both [doc](https://github.com/brimsec/brim/wiki/Code-Base-Walkthrough) and [video](https://www.youtube.com/watch?v=CPel0iu1pig) form.