### PR TITLE
more flexibe zson type names and aliased rec bug fix

### DIFF
--- a/expr/dot.go
+++ b/expr/dot.go
@@ -31,7 +31,7 @@ func NewDotExpr(f field.Static) Evaluator {
 }
 
 func accessField(record zng.Value, field string) (zng.Value, error) {
-	recType, ok := record.Type.(*zng.TypeRecord)
+	recType, ok := zng.AliasedType(record.Type).(*zng.TypeRecord)
 	if !ok {
 		return zng.Value{}, ErrNoSuchField
 	}

--- a/expr/ztests/dot-alias-rec.yaml
+++ b/expr/ztests/dot-alias-rec.yaml
@@ -1,0 +1,10 @@
+zql: cut v=a.f
+
+input: |
+  #foo=record[f:int8]
+  #0:record[a:foo]
+  0:[[1;]]
+
+output: |
+  #0:record[v:int8]
+  0:[1;]

--- a/zng/docs/zson.md
+++ b/zng/docs/zson.md
@@ -287,9 +287,9 @@ It is an error for the decorator to be type incompatible with its referenced val
 New type names are created by binding a name to a type with an assignment decorator
 of the form
 ```
-<value> (= <identifier> )
+<value> (= <type-name> )
 ```
-This creates a new type whose name is given by the identifier and whose
+This creates a new type whose name is given by the type name and whose
 type is equivalent to the type of `<value>`.  This new
 type may then be used anywhere a type may appear.  The name
 of the type definition
@@ -297,13 +297,13 @@ must not be equal to any of the primitive type names.
 
 A type definition may also appear inside a decorator as in
 ```
-<identifier> = ( <type> )
+<type-name> = ( <type> )
 ```
 where the result of this expression is the newly named type.
 With this syntax, you can create a new type and decorate a value
 as follows
 ```
-<value> ( <identifier> = ( )<type> ) )
+<value> ( <type-name> = ( <type> ) )
 ```
 e.g.,
 ```
@@ -311,13 +311,13 @@ e.g.,
 ````
 is the value 80 of type "port", where "port" is a type name bound to `uint16`.
 
-The abbreviated form `(=<identifier>)` may be used whenever a type value is
+The abbreviated form `(=<type-name>)` may be used whenever a type value is
 _self describing_ in the sense that its type name can be entirely derived
 from its value, e.g., a record type can be derived from a record value
 because all of the field names and type names are present in the value, but
 an enum type cannot be derived from an enum value because not all the enumerated
 names are present in the value.  In the the latter case, the long form
-`(<identifier>=(<type>))` must be used.
+`(<type-name>=(<type>))` must be used.
 
 It is an error for an external type to be defined to a different type
 than its previous definition though multiple definitions of the same
@@ -675,12 +675,15 @@ types in the value using the embedded type definition syntax:
 ```
 <name> = ( <type> )
 ```
-where `<name>` is a string or integer, e.g.,
+where `<name>` is a type name or integer, e.g.,
 ```
 conn=({ info:string, src:(socket=({ addr:ip, port:uint16 }), dst:socket })
 ```
 Types in canonical form can be decoded and interpreted independently
 of a type context.
+
+A type name has the same form as an identifier except the characters
+`/` and `.` are also permitted.
 
 ### 3.6 Null Value
 
@@ -864,5 +867,5 @@ the defines their type.
 
 <type-def> = <identifier> = <type-type>
 
-<type-name> = <identifier> | <integer>
+<type-name> = as defined above
 ```

--- a/zng/name.go
+++ b/zng/name.go
@@ -1,12 +1,17 @@
 package zng
 
 import (
+	"strconv"
 	"strings"
 	"unicode"
 )
 
 func IdChar(c rune) bool {
 	return unicode.IsLetter(c) || c == '_' || c == '$'
+}
+
+func TypeChar(c rune) bool {
+	return IdChar(c) || unicode.IsDigit(c) || c == '/' || c == '.'
 }
 
 func IsIdentifier(s string) bool {
@@ -18,6 +23,18 @@ func IsIdentifier(s string) bool {
 		first = false
 	}
 	return true
+}
+
+// IsTypeName returns true iff s is a valid zson typedef name (exclusive
+// of integer names for locally-scoped typedefs).
+func IsTypeName(s string) bool {
+	for _, c := range s {
+		if !TypeChar(c) {
+			return false
+		}
+	}
+	_, err := strconv.ParseInt(s, 10, 64)
+	return err != nil
 }
 
 func FormatName(name string) string {

--- a/zson/lexer.go
+++ b/zson/lexer.go
@@ -275,7 +275,7 @@ func (l *Lexer) scanTypeName() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if !zng.IdChar(r) && !unicode.IsDigit(r) {
+		if !zng.TypeChar(r) {
 			return s.String(), nil
 		}
 		s.WriteRune(r)

--- a/zson/ztests/type-name.yaml
+++ b/zson/ztests/type-name.yaml
@@ -1,0 +1,14 @@
+script: |
+  zq -f zson -i zson -pretty=0 in.zson
+
+inputs:
+  - name: in.zson
+    data: |
+      {s: "hello, world"} (=github.com/acme/foo.Bar)
+      {s: "goodnight, gracie"} (github.com/acme/foo.Bar)
+
+outputs:
+  - name: stdout
+    data: |
+      {s: "hello, world"} (=github.com/acme/foo.Bar)
+      {s: "goodnight, gracie"} (github.com/acme/foo.Bar)

--- a/zson/ztests/union-cast.yaml
+++ b/zson/ztests/union-cast.yaml
@@ -1,0 +1,23 @@
+script: |
+  zq -t -i zson "by typeof(.) | sort ." in.zson
+
+inputs:
+  - name: in.zson
+    data: |
+      {
+          r: {
+              u: "\"hello\"" (sint=(0=((int32,string))))
+          } (=1)
+      } (=2)
+      {
+          r: {
+              v: 123 (int32) (sint)
+          } (=3)
+      } (=4)
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[typeof:type]
+      0:[{r:{u:sint=((int32,string))}};]
+      0:[{r:{v:sint=((int32,string))}};]


### PR DESCRIPTION
This commit changes the definition of zson type names to include
the characters "." and "/".  This will permit go-style etc type
names of the form "github.com/acme/foo.Bar".  It will also be
useful to embed schema versions in type names for a new style of
decentralized and hierarchical schema management that zson
enables (e.g., shopping_cart_v1.0 or employee_record.2).

It also fixes a bug that happened when casting a union type
in alias form, which caused the alias to be lost and replaced
with the underlying union type.

Finally, we found and fixed a bug where r.field failed if r
was type alias of a record type.