### PR TITLE
add zson marshaler and clean up zng marshaler

### DIFF
--- a/zng/resolver/marshal_test.go
+++ b/zng/resolver/marshal_test.go
@@ -413,18 +413,18 @@ type Rolls []int
 func TestInterfaceMarshal(t *testing.T) {
 	t1 := Make(2)
 	m := resolver.NewMarshaler()
-	m.Decorate(resolver.TypeStylePackage)
+	m.Decorate(resolver.StylePackage)
 	zv, err := m.Marshal(t1)
 	require.NoError(t, err)
 	assert.Equal(t, "resolver_test.ThingTwo=({c:string})", zv.Type.ZSON())
 
-	m.Decorate(resolver.TypeStyleSimple)
+	m.Decorate(resolver.StyleSimple)
 	rolls := Rolls{1, 2, 3}
 	zv, err = m.Marshal(rolls)
 	require.NoError(t, err)
 	assert.Equal(t, "Rolls=([int64])", zv.Type.ZSON())
 
-	m.Decorate(resolver.TypeStyleFull)
+	m.Decorate(resolver.StyleFull)
 	zv, err = m.Marshal(rolls)
 	require.NoError(t, err)
 	assert.Equal(t, "github.com/brimsec/zq/zng/resolver_test.Rolls=([int64])", zv.Type.ZSON())
@@ -438,7 +438,7 @@ func TestInterfaceMarshal(t *testing.T) {
 func TestInterfaceUnmarshal(t *testing.T) {
 	t1 := Make(1)
 	m := resolver.NewMarshaler()
-	m.Decorate(resolver.TypeStylePackage)
+	m.Decorate(resolver.StylePackage)
 	zv, err := m.Marshal(t1)
 	require.NoError(t, err)
 	assert.Equal(t, "resolver_test.Thing=({a:string,B:int64})", zv.Type.ZSON())
@@ -511,7 +511,7 @@ type CustomInt8 int8
 func TestNamedNormal(t *testing.T) {
 	t1 := CustomInt8(88)
 	m := resolver.NewMarshaler()
-	m.Decorate(resolver.TypeStyleSimple)
+	m.Decorate(resolver.StyleSimple)
 
 	zv, err := m.Marshal(t1)
 	require.NoError(t, err)
@@ -545,7 +545,7 @@ func TestEmbeddedInterface(t *testing.T) {
 		A: Make(1),
 	}
 	m := resolver.NewMarshaler()
-	m.Decorate(resolver.TypeStyleSimple)
+	m.Decorate(resolver.StyleSimple)
 	zv, err := m.Marshal(t1)
 	require.NoError(t, err)
 	assert.Equal(t, "EmbeddedA=({A:Thing=({a:string,B:int64})})", zv.Type.ZSON())

--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -55,6 +55,14 @@ func (f *Formatter) FormatRecord(rec *zng.Record) (string, error) {
 	return f.builder.String(), nil
 }
 
+func (f *Formatter) Format(zv zng.Value) (string, error) {
+	f.builder.Reset()
+	if err := f.formatValueAndDecorate(zv.Type, zv.Bytes); err != nil {
+		return "", err
+	}
+	return f.builder.String(), nil
+}
+
 func (f *Formatter) formatValueAndDecorate(typ zng.Type, bytes zcode.Bytes) error {
 	known := f.typedefs.exists(typ)
 	if err := f.formatValue(0, typ, bytes, known, false); err != nil {

--- a/zson/marshal.go
+++ b/zson/marshal.go
@@ -1,0 +1,96 @@
+package zson
+
+import (
+	"strings"
+
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+const (
+	StyleNone    = resolver.StyleNone
+	StyleSimple  = resolver.StyleSimple
+	StylePackage = resolver.StylePackage
+	StyleFull    = resolver.StyleFull
+)
+
+func Marshal(v interface{}) (string, error) {
+	return NewMarshaler().Marshal(v)
+}
+
+type MarshalContext struct {
+	*resolver.MarshalContext
+	formatter *Formatter
+}
+
+func NewMarshaler() *MarshalContext {
+	return NewMarshalerIndent(0)
+}
+
+func NewMarshalerIndent(indent int) *MarshalContext {
+	return &MarshalContext{
+		MarshalContext: resolver.NewMarshaler(),
+		formatter:      NewFormatter(indent),
+	}
+}
+
+func NewMarshalerWithContext(zctx *resolver.Context) *MarshalContext {
+	return &MarshalContext{
+		MarshalContext: resolver.NewMarshalerWithContext(zctx),
+	}
+}
+
+func (m *MarshalContext) Marshal(v interface{}) (string, error) {
+	zv, err := m.MarshalContext.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return m.formatter.Format(zv)
+}
+
+func (m *MarshalContext) MarshalCustom(names []string, fields []interface{}) (string, error) {
+	rec, err := m.MarshalContext.MarshalCustom(names, fields)
+	if err != nil {
+		return "", err
+	}
+	return m.formatter.FormatRecord(rec)
+}
+
+type UnmarshalContext struct {
+	*resolver.UnmarshalContext
+	zctx     *resolver.Context
+	analyzer Analyzer
+	builder  *Builder
+}
+
+func NewUnmarshaler() *UnmarshalContext {
+	return &UnmarshalContext{
+		UnmarshalContext: resolver.NewUnmarshaler(),
+		zctx:             resolver.NewContext(),
+		analyzer:         NewAnalyzer(),
+		builder:          NewBuilder(),
+	}
+}
+
+func Unmarshal(zson string, v interface{}) error {
+	return NewUnmarshaler().Unmarshal(zson, v)
+}
+
+func (u *UnmarshalContext) Unmarshal(zson string, v interface{}) error {
+	parser, err := NewParser(strings.NewReader(zson))
+	if err != nil {
+		return err
+	}
+	ast, err := parser.ParseValue()
+	if err != nil {
+		return err
+	}
+	val, err := u.analyzer.ConvertValue(u.zctx, ast)
+	if err != nil {
+		return err
+	}
+	zv, err := u.builder.Build(val)
+	if err != nil {
+		return nil
+	}
+	return u.UnmarshalContext.Unmarshal(zv, v)
+}

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -1,0 +1,98 @@
+package zson_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/brimsec/zq/zson"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func trim(s string) string {
+	return strings.TrimSpace(s) + "\n"
+}
+
+type Thing interface {
+	Color() string
+}
+
+type Plant struct {
+	MyColor string
+}
+
+func (p *Plant) Color() string { return p.MyColor }
+
+type Animal struct {
+	MyColor string
+}
+
+func (a *Animal) Color() string { return a.MyColor }
+
+func Make(which, color string) Thing {
+	switch which {
+	case "plant":
+		return &Plant{color}
+	case "animal":
+		return &Animal{color}
+	default:
+		return nil
+	}
+}
+
+func TestInterfaceMarshal(t *testing.T) {
+	rose := Make("plant", "red")
+	expectedRose := `{MyColor: "red"} (=Plant)`
+	flamingo := Make("animal", "pink")
+	expectedFlamingo := `{MyColor: "pink"} (=Animal)`
+
+	m := zson.NewMarshaler()
+	m.Decorate(zson.StyleSimple)
+
+	zsonRose, err := m.Marshal(rose)
+	require.NoError(t, err)
+	assert.Equal(t, trim(expectedRose), trim(zsonRose))
+
+	zsonFlamingo, err := m.Marshal(flamingo)
+	require.NoError(t, err)
+	assert.Equal(t, trim(expectedFlamingo), trim(zsonFlamingo))
+
+	u := zson.NewUnmarshaler()
+	u.Bind(Plant{}, Animal{})
+	var thing Thing
+	require.NoError(t, err)
+
+	err = u.Unmarshal(zsonRose, &thing)
+	require.NoError(t, err)
+	assert.Equal(t, "red", thing.Color())
+
+	err = u.Unmarshal(zsonFlamingo, &thing)
+	require.NoError(t, err)
+	assert.Equal(t, "pink", thing.Color())
+}
+
+type Roll bool
+
+func TestMarshal(t *testing.T) {
+	z, err := zson.Marshal("hello, world")
+	require.NoError(t, err)
+	assert.Equal(t, `"hello, world"`, z)
+
+	aIn := []int8{1, 2, 3}
+	z, err = zson.Marshal(aIn)
+	require.NoError(t, err)
+	assert.Equal(t, `[1 (int8),2 (int8),3 (int8)] (=0)`, z)
+
+	var v interface{}
+	err = zson.Unmarshal(z, &v)
+	require.NoError(t, err)
+	aOut, ok := v.([]int8)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, aIn, aOut)
+
+	m := zson.NewMarshaler()
+	m.Decorate(zson.StyleSimple)
+	z, err = m.Marshal(Roll(true))
+	require.NoError(t, err)
+	assert.Equal(t, `true (=Roll)`, z)
+}

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -29,21 +29,10 @@ type Animal struct {
 
 func (a *Animal) Color() string { return a.MyColor }
 
-func Make(which, color string) Thing {
-	switch which {
-	case "plant":
-		return &Plant{color}
-	case "animal":
-		return &Animal{color}
-	default:
-		return nil
-	}
-}
-
 func TestInterfaceMarshal(t *testing.T) {
-	rose := Make("plant", "red")
+	rose := Thing(&Plant{"red"})
 	expectedRose := `{MyColor: "red"} (=Plant)`
-	flamingo := Make("animal", "pink")
+	flamingo := Thing(&Animal{"pink"})
 	expectedFlamingo := `{MyColor: "pink"} (=Animal)`
 
 	m := zson.NewMarshaler()


### PR DESCRIPTION
This commit adds a zson marshaler, which is basically a wrapper
around zng marshal that allows one to do marshaling strictly
with ZSON text format and not worry about zng or package zng/resolver.

This work also exposed some problems with the zng marshaler regarding
interfaces so several bug fixes there included here as well as
an extension of the zng marshaler to handle empty interface for
non-struct types.  We also made things work when records have
recursively invested interface types (which are resolvable with
marshaler bindings).