### PR TITLE
Replace stopErr with stopOnErr everywhere

### DIFF
--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -78,7 +78,7 @@ type Command struct {
 	verbose     bool
 	stats       bool
 	quiet       bool
-	stopErr     bool
+	stopOnErr   bool
 	parallel    bool
 	zqlPath     string
 	inputFlags  inputflags.Flags
@@ -103,7 +103,7 @@ func New(f *flag.FlagSet) (charm.Command, error) {
 	f.BoolVar(&c.verbose, "v", false, "show verbose details")
 	f.BoolVar(&c.stats, "S", false, "display search stats on stderr")
 	f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
-	f.BoolVar(&c.stopErr, "e", true, "stop upon input errors")
+	f.BoolVar(&c.stopOnErr, "e", true, "stop upon input errors")
 	f.BoolVar(&c.parallel, "P", false, "read two or more files into parallel-input zql query")
 	f.StringVar(&c.zqlPath, "z", "", "source file containing zql query text")
 	return c, nil
@@ -143,13 +143,13 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	zctx := resolver.NewContext()
-	readers, err := c.inputFlags.Open(zctx, paths, c.stopErr)
+	readers, err := c.inputFlags.Open(zctx, paths, c.stopOnErr)
 	if err != nil {
 		return err
 	}
 
 	wch := make(chan string, 5)
-	if !c.stopErr {
+	if !c.stopOnErr {
 		for i, r := range readers {
 			readers[i] = zbuf.NewWarningReader(r, wch)
 		}

--- a/ppl/cmd/zar/map/command.go
+++ b/ppl/cmd/zar/map/command.go
@@ -46,7 +46,7 @@ type Command struct {
 	*root.Command
 	quiet       bool
 	root        string
-	stopErr     bool
+	stopOnErr   bool
 	outputFlags outputflags.Flags
 	procFlags   procflags.Flags
 }
@@ -55,7 +55,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c := &Command{Command: parent.(*root.Command)}
 	f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
 	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
-	f.BoolVar(&c.stopErr, "e", true, "stop upon input errors")
+	f.BoolVar(&c.stopOnErr, "e", true, "stop upon input errors")
 	c.outputFlags.SetFlags(f)
 	c.procFlags.SetFlags(f)
 	return c, nil
@@ -111,7 +111,7 @@ func (c *Command) Run(args []string) error {
 		defer rc.Close()
 		reader := zbuf.Reader(rc)
 		wch := make(chan string, 5)
-		if !c.stopErr {
+		if !c.stopOnErr {
 			reader = zbuf.NewWarningReader(reader, wch)
 		}
 		writer, err := c.openOutput(zardir)

--- a/ppl/cmd/zar/zq/command.go
+++ b/ppl/cmd/zar/zq/command.go
@@ -42,7 +42,7 @@ type Command struct {
 	quiet       bool
 	root        string
 	stats       bool
-	stopErr     bool
+	stopOnErr   bool
 	outputFlags outputflags.Flags
 	procFlags   procflags.Flags
 	searchFlags searchflags.Flags
@@ -53,7 +53,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	f.BoolVar(&c.quiet, "q", false, "don't display zql warnings")
 	f.StringVar(&c.root, "R", os.Getenv("ZAR_ROOT"), "root directory of zar archive to walk")
 	f.BoolVar(&c.stats, "s", false, "print search stats to stderr on successful completion")
-	f.BoolVar(&c.stopErr, "e", true, "stop upon input errors")
+	f.BoolVar(&c.stopOnErr, "e", true, "stop upon input errors")
 	c.outputFlags.SetFlags(f)
 	c.procFlags.SetFlags(f)
 	c.searchFlags.SetFlags(f)

--- a/ppl/zqd/ingest/multipartlogreader.go
+++ b/ppl/zqd/ingest/multipartlogreader.go
@@ -18,13 +18,13 @@ import (
 )
 
 type MultipartLogReader struct {
-	mr       *multipart.Reader
-	opts     zio.ReaderOpts
-	stopErr  bool
-	warnings []string
-	zreader  *zbuf.File
-	zctx     *resolver.Context
-	nread    int64
+	mr        *multipart.Reader
+	opts      zio.ReaderOpts
+	stopOnErr bool
+	warnings  []string
+	zreader   *zbuf.File
+	zctx      *resolver.Context
+	nread     int64
 }
 
 func NewMultipartLogReader(mr *multipart.Reader, zctx *resolver.Context) *MultipartLogReader {
@@ -36,7 +36,7 @@ func NewMultipartLogReader(mr *multipart.Reader, zctx *resolver.Context) *Multip
 }
 
 func (m *MultipartLogReader) SetStopOnError() {
-	m.stopErr = true
+	m.stopOnErr = true
 }
 
 func (m *MultipartLogReader) Read() (*zng.Record, error) {
@@ -54,7 +54,7 @@ read:
 		m.zreader.Close()
 		m.zreader = nil
 		if err != nil {
-			if m.stopErr {
+			if m.stopOnErr {
 				return nil, err
 			}
 			m.appendWarning(zr, err)
@@ -89,7 +89,7 @@ next:
 	zr, err := detector.OpenFromNamedReadCloser(m.zctx, counter, name, m.opts)
 	if err != nil {
 		part.Close()
-		if m.stopErr {
+		if m.stopOnErr {
 			return nil, err
 		}
 		m.appendWarning(zr, err)


### PR DESCRIPTION
Various fields named stopErr are bools, but that name reads like an
error.  Replace it with stopOnErr, which reads like a bool.