### PR TITLE
Don't pass in flowgraph warnings channel from outside

### DIFF
--- a/ppl/zqd/ingest/log.go
+++ b/ppl/zqd/ingest/log.go
@@ -67,7 +67,7 @@ func NewLogOp(ctx context.Context, store storage.Storage, req api.LogPostRequest
 			p.openWarning(path, err)
 			continue
 		}
-		zr := zbuf.NewWarningReader(sf, p.warningCh)
+		zr := zbuf.NewWarningReader(sf, p)
 		p.bytesTotal += size
 		p.readCounters = append(p.readCounters, rc)
 		p.readers = append(p.readers, zr)
@@ -76,8 +76,13 @@ func NewLogOp(ctx context.Context, store storage.Storage, req api.LogPostRequest
 	return p, nil
 }
 
+func (p *LogOp) Warn(msg string) error {
+	p.warnings = append(p.warnings, msg)
+	return nil
+}
+
 func (p *LogOp) openWarning(path string, err error) {
-	p.warnings = append(p.warnings, fmt.Sprintf("%s: %s", path, err))
+	p.Warn(fmt.Sprintf("%s: %s", path, err))
 }
 
 type readCounter struct {


### PR DESCRIPTION
This seems like an improvement, prompted by getting confused by the client-supplied warnings channel while working on #1833 (I initially thought that the point of passing it in was that I could then read from it... but of course the driver reads from it). From the commit:

Previously, the driver package allowed clients to pass in a flowgraph
warnings channel. This was used by clients that created a channel for
use by a zbuf.WarningReader, and then passed that channel to a
flowgraph.

This commit changes zbuf.WarningReader to take a callback instead. It is
a slightly simpler API and when used in conjunction with the driver package,
the pattern is cleaner: the driver creates its warning channel
internally, and the neither WarningReader nor the client plumbing
things together needs to know about either one.