### PR TITLE
Fix link to unknown-mime-type-discovery Zeek package

### DIFF
--- a/zeek/README.md
+++ b/zeek/README.md
@@ -236,7 +236,7 @@ installed:
 
 * https://github.com/soelkongen/json-streaming-logs
 * https://github.com/salesforce/hassh
-* https://github.com/philrz/unknown-mime-type-discovery
+* https://github.com/sethhall/unknown-mime-type-discovery
 
 In addition to installing these via [Zeek Package Manager](https://docs.zeek.org/projects/package-manager/en/stable/),
 the necessary configuration is present in our `local.zeek` to invoke them:


### PR DESCRIPTION
At one time I was maintaining my own fork of this Zeek package because Seth's was not updated to work with Zeek v3.x. Yesterday I noticed that he'd updated his, so I deleted my fork, which the link checker flagged.