### PR TITLE
Ingest shaper

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -161,6 +161,7 @@ type LogPostRequest struct {
 	Paths          []string             `json:"paths"`
 	StopErr        bool                 `json:"stop_err"`
 	JSONTypeConfig *ndjsonio.TypeConfig `json:"json_type_config"`
+	Shaper         json.RawMessage      `json:"shaper,omitempty"`
 }
 
 type LogPostWarning struct {

--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -358,7 +358,7 @@ type LogPostOpts struct {
 	Shaper    ast.Proc
 }
 
-func (c *Connection) LogPostPath(ctx context.Context, space api.SpaceID, opts LogPostOpts, paths ...string) error {
+func (c *Connection) LogPostPath(ctx context.Context, space api.SpaceID, opts *LogPostOpts, paths ...string) error {
 	stream, err := c.LogPostPathStream(ctx, space, opts, paths...)
 	if err != nil {
 		return err
@@ -370,13 +370,13 @@ func (c *Connection) LogPostPath(ctx context.Context, space api.SpaceID, opts Lo
 	return payloads.Error()
 }
 
-func (c *Connection) LogPostPathStream(ctx context.Context, space api.SpaceID, opts LogPostOpts, paths ...string) (*Stream, error) {
+func (c *Connection) LogPostPathStream(ctx context.Context, space api.SpaceID, opts *LogPostOpts, paths ...string) (*Stream, error) {
 	body := api.LogPostRequest{
 		Paths:          paths,
 		JSONTypeConfig: opts.JSON,
 		StopErr:        opts.StopError,
 	}
-	if opts.Shaper != nil {
+	if opts != nil && opts.Shaper != nil {
 		raw, err := json.Marshal(opts.Shaper)
 		if err != nil {
 			return nil, err

--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -417,6 +417,9 @@ func (c *Connection) LogPostWriter(ctx context.Context, space api.SpaceID, opts 
 		SetResult(&api.LogPostResponse{}).
 		SetHeader("Content-Type", writer.ContentType())
 	if opts != nil {
+		if opts.Shaper != nil {
+			writer.SetShaper(opts.Shaper)
+		}
 		if opts.StopError {
 			req.SetQueryParam("stop_err", "true")
 		}

--- a/cmd/zapi/cmd/post/flags.go
+++ b/cmd/zapi/cmd/post/flags.go
@@ -3,7 +3,6 @@ package post
 import (
 	"errors"
 	"flag"
-	"fmt"
 
 	"github.com/brimsec/zq/api/client"
 	"github.com/brimsec/zq/ast"
@@ -27,12 +26,10 @@ func (f *postFlags) SetFlags(fs *flag.FlagSet) {
 
 func (f *postFlags) Init() error {
 	c := f.cmd
-	fmt.Printf("postflags init, shaper is %s\n", f.shaper)
 	if err := c.Init(&f.SpaceCreateFlags); err != nil {
 		return err
 	}
 	if f.shaper != "" {
-		fmt.Printf("shaper is %s\n", f.shaper)
 		ast, err := zql.ParseProc(f.shaper)
 		if err != nil {
 			return err

--- a/cmd/zapi/cmd/post/flags.go
+++ b/cmd/zapi/cmd/post/flags.go
@@ -3,33 +3,47 @@ package post
 import (
 	"errors"
 	"flag"
+	"fmt"
 
 	"github.com/brimsec/zq/api/client"
+	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/zql"
 )
 
 type postFlags struct {
 	cmd.SpaceCreateFlags
-	force bool
-	cmd   *cmd.Command
+	force     bool
+	shaper    string
+	shaperAST ast.Proc
+	cmd       *cmd.Command
 }
 
 func (f *postFlags) SetFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&f.force, "f", false, "create space if specified space does not exist")
+	fs.StringVar(&f.shaper, "z", "", "Z shaper script to apply to data before storing")
 	f.SpaceCreateFlags.SetFlags(fs)
 }
 
 func (f *postFlags) Init() error {
 	c := f.cmd
+	fmt.Printf("postflags init, shaper is %s\n", f.shaper)
 	if err := c.Init(&f.SpaceCreateFlags); err != nil {
 		return err
+	}
+	if f.shaper != "" {
+		fmt.Printf("shaper is %s\n", f.shaper)
+		ast, err := zql.ParseProc(f.shaper)
+		if err != nil {
+			return err
+		}
+		f.shaperAST = ast
 	}
 	if !f.force {
 		return nil
 	} else if c.Spacename == "" {
 		return errors.New("if -f flag is enabled, a space name must specified")
 	}
-
 	sp, err := f.SpaceCreateFlags.Create(c.Context(), c.Connection(), c.Spacename)
 	if err != nil {
 		if err == client.ErrSpaceExists {

--- a/cmd/zapi/cmd/post/path.go
+++ b/cmd/zapi/cmd/post/path.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/brimsec/zq/api"
+	"github.com/brimsec/zq/api/client"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/brimsec/zq/cmd/zapi/format"
 	"github.com/brimsec/zq/pkg/display"
@@ -71,7 +72,8 @@ func (c *PostPathCommand) Run(args []string) (err error) {
 		return err
 	}
 	c.start = time.Now()
-	stream, err := c.Connection().LogPostPathStream(c.Context(), id, nil, paths...)
+	opts := client.LogPostOpts{Shaper: c.postFlags.shaperAST}
+	stream, err := c.Connection().LogPostPathStream(c.Context(), id, opts, paths...)
 	if err != nil {
 		return err
 	}

--- a/cmd/zapi/cmd/post/path.go
+++ b/cmd/zapi/cmd/post/path.go
@@ -72,7 +72,7 @@ func (c *PostPathCommand) Run(args []string) (err error) {
 		return err
 	}
 	c.start = time.Now()
-	opts := client.LogPostOpts{Shaper: c.postFlags.shaperAST}
+	opts := &client.LogPostOpts{Shaper: c.postFlags.shaperAST}
 	stream, err := c.Connection().LogPostPathStream(c.Context(), id, opts, paths...)
 	if err != nil {
 		return err

--- a/cmd/zapi/cmd/post/post.go
+++ b/cmd/zapi/cmd/post/post.go
@@ -70,7 +70,8 @@ func (c *PostCommand) Run(args []string) (err error) {
 	}
 	c.start = time.Now()
 	conn := c.Connection()
-	res, err := conn.LogPostWriter(c.Context(), id, &client.LogPostOpts{Shaper: c.postFlags.shaperAST}, c.logwriter)
+	opts := &client.LogPostOpts{Shaper: c.postFlags.shaperAST}
+	res, err := conn.LogPostWriter(c.Context(), id, opts, c.logwriter)
 	if err != nil {
 		if c.Context().Err() != nil {
 			fmt.Println("post aborted")

--- a/cmd/zapi/cmd/post/post.go
+++ b/cmd/zapi/cmd/post/post.go
@@ -55,9 +55,6 @@ func (c *PostCommand) Run(args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	if c.postFlags.shaperAST != nil {
-		c.logwriter.SetShaper(c.postFlags.shaperAST)
-	}
 	var out io.Writer
 	var dp *display.Display
 	if !c.NoFancy {
@@ -73,7 +70,7 @@ func (c *PostCommand) Run(args []string) (err error) {
 	}
 	c.start = time.Now()
 	conn := c.Connection()
-	res, err := conn.LogPostWriter(c.Context(), id, nil, c.logwriter)
+	res, err := conn.LogPostWriter(c.Context(), id, &client.LogPostOpts{Shaper: c.postFlags.shaperAST}, c.logwriter)
 	if err != nil {
 		if c.Context().Err() != nil {
 			fmt.Println("post aborted")

--- a/cmd/zapi/cmd/post/post.go
+++ b/cmd/zapi/cmd/post/post.go
@@ -55,6 +55,9 @@ func (c *PostCommand) Run(args []string) (err error) {
 	if err != nil {
 		return err
 	}
+	if c.postFlags.shaperAST != nil {
+		c.logwriter.SetShaper(c.postFlags.shaperAST)
+	}
 	var out io.Writer
 	var dp *display.Display
 	if !c.NoFancy {

--- a/zbuf/warning.go
+++ b/zbuf/warning.go
@@ -18,7 +18,7 @@ type WarningReader struct {
 // NewWarningReader returns a Reader that reads from zr.  Any error
 // encountered results in a call to w with the warning as prameter, and
 // then a nil *zng.Record and nil error are returned.
-func NewWarningReader(zr Reader, w Warner) *WarningReader {
+func NewWarningReader(zr Reader, w Warner) Reader {
 	return &WarningReader{zr: zr, wn: w}
 }
 

--- a/ztests/suite/zqd/zapi-post-shape.yaml
+++ b/ztests/suite/zqd/zapi-post-shape.yaml
@@ -1,0 +1,23 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new test
+  zapi -h $ZQD_HOST -s test post -z "put ip=ip:ip" in.tzng in.tzng
+  zapi -h $ZQD_HOST -s test get -f zson > out.zson
+
+inputs:
+  - name: services.sh
+    source: services.sh
+  - name: in.tzng
+    data: |
+      #0:record[ip:string]
+      0:[1.1.1.1;]
+
+outputs:
+  - name: out.zson
+    data: |
+      {
+          ip: 1.1.1.1
+      } (=0)
+      {
+          ip: 1.1.1.1
+      } (0)

--- a/ztests/suite/zqd/zapi-postpath-shape.yaml
+++ b/ztests/suite/zqd/zapi-postpath-shape.yaml
@@ -1,0 +1,23 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new test
+  zapi -h $ZQD_HOST -s test postpath -z "put ip=ip:ip" in.tzng in.tzng
+  zapi -h $ZQD_HOST -s test get -f zson > out.zson
+
+inputs:
+  - name: services.sh
+    source: services.sh
+  - name: in.tzng
+    data: |
+      #0:record[ip:string]
+      0:[1.1.1.1;]
+
+outputs:
+  - name: out.zson
+    data: |
+      {
+          ip: 1.1.1.1
+      } (=0)
+      {
+          ip: 1.1.1.1
+      } (0)


### PR DESCRIPTION
This commit adds support for a running Z "shaper" script on incoming logs. This facility is intended for ETL tasks such as transforming record layouts and field names, casting leaf types, or policing incoming types against a set of admissible schemas. (Z script does not quite yet have the support for much of this, but that is imminent).

Closes #1833 