### PR TITLE
Fix flaky fs.TailFile related tests

### DIFF
--- a/pkg/fs/tail_test.go
+++ b/pkg/fs/tail_test.go
@@ -2,30 +2,46 @@ package fs
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestTailFile(t *testing.T) {
+func TestTailFileWrite(t *testing.T) {
 	f, err := ioutil.TempFile("", "tailfile.log")
 	require.NoError(t, err)
 	t.Cleanup(func() { os.Remove(f.Name()) })
-	tf, err := TailFile(f.Name())
+	// Add timeout context less TFail fails to get a write events. Don't wait
+	// around forever.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	tf, err := TailFileWithContext(ctx, f.Name())
 	require.NoError(t, err)
 	buf := make([]byte, 100)
+	errCh := make(chan error)
 
 	for i := 0; i < 10; i++ {
 		str := fmt.Sprintf("line #%d\n", i)
-		_, err := f.WriteString(str)
-		require.NoError(t, err)
-		n, err := tf.Read(buf)
-		require.NoError(t, err)
+		go func() {
+			_, err := f.WriteString(str)
+			if err == nil {
+				// This is sync call must be done because otherwise for windows
+				// the fsnotify.Write event will not trigger. I am guessing
+				// because so little data is written for each call.
+				err = f.Sync()
+			}
+			errCh <- err
+		}()
+		n, errr := tf.Read(buf)
+		require.NoError(t, <-errCh)
+		require.NoError(t, errr)
 		assert.Equal(t, str, string(buf[:n]))
 	}
 	go require.NoError(t, tf.Stop())

--- a/pkg/fs/tail_test.go
+++ b/pkg/fs/tail_test.go
@@ -34,7 +34,7 @@ func TestTailFileWrite(t *testing.T) {
 			if err == nil {
 				// This sync call must be done because otherwise for windows
 				// the fsnotify.Write event will not trigger. I am guessing
-				// because so little data is written for each call.
+				// that's because so little data is written for each call.
 				err = f.Sync()
 			}
 			errCh <- err

--- a/pkg/fs/tail_test.go
+++ b/pkg/fs/tail_test.go
@@ -18,7 +18,7 @@ func TestTailFileWrite(t *testing.T) {
 	f, err := ioutil.TempFile("", "tailfile.log")
 	require.NoError(t, err)
 	t.Cleanup(func() { os.Remove(f.Name()) })
-	// Add timeout context less TFail fails to get a write events. Don't wait
+	// Add timeout context lest TFail fails to get a write event. Don't wait
 	// around forever.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()

--- a/pkg/fs/tail_test.go
+++ b/pkg/fs/tail_test.go
@@ -39,9 +39,9 @@ func TestTailFileWrite(t *testing.T) {
 			}
 			errCh <- err
 		}()
-		n, errr := tf.Read(buf)
+		n, err := tf.Read(buf)
+		require.NoError(t, err)
 		require.NoError(t, <-errCh)
-		require.NoError(t, errr)
 		assert.Equal(t, str, string(buf[:n]))
 	}
 	go require.NoError(t, tf.Stop())

--- a/pkg/fs/tail_test.go
+++ b/pkg/fs/tail_test.go
@@ -32,7 +32,7 @@ func TestTailFileWrite(t *testing.T) {
 		go func() {
 			_, err := f.WriteString(str)
 			if err == nil {
-				// This is sync call must be done because otherwise for windows
+				// This sync call must be done because otherwise for windows
 				// the fsnotify.Write event will not trigger. I am guessing
 				// because so little data is written for each call.
 				err = f.Sync()

--- a/ppl/zqd/ingest/logtailer_test.go
+++ b/ppl/zqd/ingest/logtailer_test.go
@@ -116,8 +116,7 @@ func (s *logTailerTSuite) createFile(name string) *os.File {
 	f, err := os.Create(filepath.Join(s.dir, name))
 	s.Require().NoError(err)
 	// Call sync to ensure fs events are sent in a timely matter.
-	err = f.Sync()
-	s.Require().NoError(err)
+	s.Require().NoError(f.Sync())
 	return f
 }
 
@@ -150,6 +149,12 @@ func (s *logTailerTSuite) write(files ...*os.File) {
 			s.Require().NoError(err)
 			i++
 		}
+	}
+	// Need to sync here as on windows the fsnotify event is not triggered
+	// unless this is done. Presumably this happens in cases when not enough
+	// data has been written the system has not flushed the file buffer to disk.
+	for _, f := range files {
+		s.Require().NoError(f.Sync())
 	}
 	s.Require().NoError(s.dr.Stop())
 }

--- a/ppl/zqd/ingest/logtailer_test.go
+++ b/ppl/zqd/ingest/logtailer_test.go
@@ -152,7 +152,7 @@ func (s *logTailerTSuite) write(files ...*os.File) {
 	}
 	// Need to sync here as on windows the fsnotify event is not triggered
 	// unless this is done. Presumably this happens in cases when not enough
-	// data has been written the system has not flushed the file buffer to disk.
+	// data has been written so the system has not flushed the file buffer to disk.
 	for _, f := range files {
 		s.Require().NoError(f.Sync())
 	}

--- a/ppl/zqd/ingest/logtailer_test.go
+++ b/ppl/zqd/ingest/logtailer_test.go
@@ -99,6 +99,7 @@ func (s *logTailerTSuite) TestInvalidFile() {
 	s.Require().NoError(err)
 	_, err = f1.WriteString("this is an invalid line\n")
 	s.Require().NoError(err)
+	s.Require().NoError(f1.Sync())
 	s.EqualError(<-errCh, "line 2: bad format")
 	s.NoError(s.dr.Stop())
 }


### PR DESCRIPTION
We've been experiencing some test failures on master due to the fact that
windows [1] (and sometimes linux [2]) appears to need an extra sync call in
order to trigger a "write" event on the file system event watcher.

Add some extra Sync calls in tests where needed and reformat the
TestTailFileWrite test to ensure its actually testing that write events are
triggered.

As also TailFileWithContext variant so the TestTailFileWrite tests fails sooner
should it not receive "write" events.

[1] https://github.com/brimsec/zq/runs/1601524036?check_suite_focus=true
[2] https://github.com/brimsec/zq/runs/1597423491?check_suite_focus=true
