### PR TITLE
Add "source" field to JSON typing config for Zeek "weird" events

### DIFF
--- a/zeek/types.json
+++ b/zeek/types.json
@@ -3443,6 +3443,10 @@
         "type": "bstring"
       },
       {
+        "name": "source",
+        "type": "bstring"
+      },
+      {
         "name": "_write_ts",
         "type": "time"
       }


### PR DESCRIPTION
I compiled Zeek 4.0.0-rc1 and ran [print-types.zeek](https://github.com/brimsec/zeek/blob/master/brim/print-types.zeek) against it and found they've added one additional field beyond what we were covering in Zeek 3.x: A `source` field in `weird` events. While our current JSON typing system is hopefully not long for this earth, since users may start using Zeek 4.x before the new approach is complete, I've added the additional field here.

This is a companion PR to https://github.com/brimsec/brim/pull/1307 on the Brim side.