### PR TITLE
WarningReader: always return nil records after err

### DIFF
--- a/zbuf/warning.go
+++ b/zbuf/warning.go
@@ -11,8 +11,9 @@ type Warner interface {
 }
 
 type WarningReader struct {
-	zr Reader
-	wn Warner
+	zr    Reader
+	wn    Warner
+	erred bool
 }
 
 // NewWarningReader returns a Reader that reads from zr.  Any error
@@ -23,9 +24,13 @@ func NewWarningReader(zr Reader, w Warner) Reader {
 }
 
 func (w *WarningReader) Read() (*zng.Record, error) {
+	if w.erred {
+		return nil, nil
+	}
 	rec, err := w.zr.Read()
 	if err != nil {
 		w.wn.Warn(fmt.Sprintf("%s: %s", w.zr, err))
+		w.erred = true
 		return nil, nil
 	}
 	return rec, nil

--- a/ztests/suite/zqd/zapi-postpath-errors.yaml
+++ b/ztests/suite/zqd/zapi-postpath-errors.yaml
@@ -1,0 +1,22 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new test
+  zapi -h $ZQD_HOST -s test postpath bad.tzng
+  zapi -h $ZQD_HOST -s test get -f zson "count()" > out.zson
+
+inputs:
+  - name: services.sh
+    source: services.sh
+  - name: bad.tzng
+    data: |
+      #0:record[ip:string]
+      0:[1.1.1.1;]
+      0:[1.1.1.1;
+      0:[1.1.1.1;]
+
+outputs:
+  - name: out.zson
+    data: |
+      {
+          count: 1 (uint64)
+      } (=0)


### PR DESCRIPTION
While working on #1895 I ran into some unexpected zqd behavior (illustrated in the yaml test) when posting to the `log/paths` endpoint: records continue to be read after a bad line. This is not the case with the `/log` endpoint.

The bug is caused by an interaction between `zbuf.WarningReader` and `zbuf.ReadBatch`. WarningReader returns `nil, nil` after encountering an error, which means that [no records remain](https://github.com/brimsec/zq/blob/ad3def60a92b30a748d8c3f82a3831f7b45a8d52/zbuf/zbuf.go#L13). But if called subsequently, it does return more records. This trips up zbuf.ReadBatch, which needs to read two consecutive `nil` records [in order to return a nil batch](https://github.com/brimsec/zq/blob/ad3def60a92b30a748d8c3f82a3831f7b45a8d52/zbuf/batch.go#L41). 

(Arguably ReadBatch should also be adjusted ... but it doesn't seem entirely unreasonable to call an EOF'd reader a second time).