### PR TITLE
Fix flaky postpcap stats test

### DIFF
--- a/cmd/zapi/cmd/post/pcap.go
+++ b/cmd/zapi/cmd/post/pcap.go
@@ -124,11 +124,8 @@ func (c *PostPcapCommand) Display(w io.Writer) bool {
 func (c *PostPcapCommand) printStats() {
 	if c.stats {
 		w := tabwriter.NewWriter(os.Stderr, 0, 0, 1, ' ', 0)
-		// truncate bytes written for tests
-		rbw := c.lastStatus.RecordBytesWritten
-		rbw = (rbw / 100) * 100
 		fmt.Fprintf(w, "data chunks written:\t%d\n", c.lastStatus.DataChunksWritten)
-		fmt.Fprintf(w, "record bytes written:\t%s\n", format.Bytes(rbw))
+		fmt.Fprintf(w, "record bytes written:\t%s\n", format.Bytes(c.lastStatus.RecordBytesWritten))
 		fmt.Fprintf(w, "records written:\t%d\n", c.lastStatus.RecordsWritten)
 		w.Flush()
 	}

--- a/ztests/suite/zqd/archivestore/postpcap-stats.yaml
+++ b/ztests/suite/zqd/archivestore/postpcap-stats.yaml
@@ -10,7 +10,7 @@ inputs:
 
 outputs:
   - name: stderr
-    data: |
+    regexp: |
       data chunks written:  1
-      record bytes written: 1.40KB
+      record bytes written: 1.[0-9]{2}KB
       records written:      10


### PR DESCRIPTION
Use regexp on the test which better accounts for the fluctuating size of record
bytes written (caused by zeek ids).

Also remove the hack to truncate the byte values needed to make this test
originally pass.