### PR TITLE
Invoke fuse for CSV output

### DIFF
--- a/cli/outputflags/flags.go
+++ b/cli/outputflags/flags.go
@@ -28,6 +28,7 @@ func (f *Flags) Options() zio.WriterOpts {
 
 func (f *Flags) setFlags(fs *flag.FlagSet) {
 	// zio stuff
+	fs.BoolVar(&f.CSVFuse, "csvfuse", true, "fuse records for csv output")
 	fs.BoolVar(&f.UTF8, "U", false, "display zeek strings as UTF-8")
 	fs.BoolVar(&f.Text.ShowTypes, "T", false, "display field types in text output")
 	fs.BoolVar(&f.Text.ShowFields, "F", false, "display field names in text output")

--- a/proc/fuse/writer.go
+++ b/proc/fuse/writer.go
@@ -1,0 +1,31 @@
+package fuse
+
+import (
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+func WriteCloser(wc zbuf.WriteCloser) zbuf.WriteCloser {
+	return &writeCloser{wc, NewFuser(resolver.NewContext(), MemMaxBytes)}
+}
+
+type writeCloser struct {
+	wc    zbuf.WriteCloser
+	fuser *Fuser
+}
+
+func (w *writeCloser) Write(rec *zng.Record) error {
+	return w.fuser.Write(rec)
+}
+
+func (w *writeCloser) Close() error {
+	err := zbuf.Copy(w.wc, w.fuser)
+	if err2 := w.fuser.Close(); err == nil {
+		err = err2
+	}
+	if err2 := w.wc.Close(); err == nil {
+		err = err2
+	}
+	return err
+}

--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"time"
 
+	"github.com/brimsec/zq/proc/fuse"
+	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/flattener"
 	"github.com/brimsec/zq/zng/resolver"
@@ -22,18 +24,28 @@ type Writer struct {
 	first      *zng.TypeRecord
 }
 
-func NewWriter(w io.WriteCloser, utf8, epochDates bool) *Writer {
+type WriterOpts struct {
+	EpochDates bool
+	Fuse       bool
+	UTF8       bool
+}
+
+func NewWriter(w io.WriteCloser, opts WriterOpts) zbuf.WriteCloser {
 	format := zng.OutFormatZeekAscii
-	if utf8 {
+	if opts.UTF8 {
 		format = zng.OutFormatZeek
 	}
-	return &Writer{
+	zw := &Writer{
 		writer:     w,
-		epochDates: epochDates,
+		epochDates: opts.EpochDates,
 		encoder:    csv.NewWriter(w),
 		flattener:  flattener.New(resolver.NewContext()),
 		format:     format,
 	}
+	if opts.Fuse {
+		return fuse.WriteCloser(zw)
+	}
+	return zw
 }
 
 func (w *Writer) Close() error {

--- a/zio/csvio/ztests/csvfuse-default.yaml
+++ b/zio/csvio/ztests/csvfuse-default.yaml
@@ -1,0 +1,14 @@
+zql: '*'
+
+input: |
+  #0:record[a:string]
+  0:[hello;]
+  #1:record[b:int32]
+  1:[123;]
+
+output-flags: -f csv
+
+output: |
+  a,b
+  hello,
+  ,123

--- a/zio/csvio/ztests/csvfuse-false.yaml
+++ b/zio/csvio/ztests/csvfuse-false.yaml
@@ -1,0 +1,15 @@
+zql: '*'
+
+input: |
+  #0:record[a:string]
+  0:[hello;]
+  #1:record[b:int32]
+  1:[123;]
+
+output-flags: -f csv -csvfuse=false
+
+output: |
+  a
+  hello
+
+errorRE: csv output requires uniform records but different types encountered

--- a/zio/csvio/ztests/csvfuse-true.yaml
+++ b/zio/csvio/ztests/csvfuse-true.yaml
@@ -1,0 +1,14 @@
+zql: '*'
+
+input: |
+  #0:record[a:string]
+  0:[hello;]
+  #1:record[b:int32]
+  1:[123;]
+
+output-flags: -f csv -csvfuse=true
+
+output: |
+  a,b
+  hello,
+  ,123

--- a/zio/detector/lookup.go
+++ b/zio/detector/lookup.go
@@ -58,7 +58,11 @@ func LookupWriter(w io.WriteCloser, opts zio.WriterOpts) (zbuf.WriteCloser, erro
 	case "table":
 		return tableio.NewWriter(w, opts.UTF8, opts.EpochDates), nil
 	case "csv":
-		return csvio.NewWriter(w, opts.UTF8, opts.EpochDates), nil
+		return csvio.NewWriter(w, csvio.WriterOpts{
+			EpochDates: opts.EpochDates,
+			Fuse:       opts.CSVFuse,
+			UTF8:       opts.UTF8,
+		}), nil
 	default:
 		return nil, fmt.Errorf("unknown format: %s", opts.Format)
 	}

--- a/zio/zio.go
+++ b/zio/zio.go
@@ -19,6 +19,7 @@ type ReaderOpts struct {
 }
 
 type WriterOpts struct {
+	CSVFuse    bool
 	Format     string
 	UTF8       bool
 	EpochDates bool

--- a/ztests/suite/zqd/csv-fuse.yaml
+++ b/ztests/suite/zqd/csv-fuse.yaml
@@ -16,5 +16,7 @@ inputs:
 
 outputs:
   - name: out.csv
-    regexp: |
-      .*query error: csv output requires uniform records.*
+    data: |
+      a,b
+      hello,
+      ,123


### PR DESCRIPTION
Send records through a `fuse.Fuser` for
1. /search?format=csv` in `zqd`
2. `zq -f csv` unless `-csvfuse=false`

Depends on #1880.

Closes #1271.

