### PR TITLE
move compiler entry points from package zql to package compiler

### DIFF
--- a/cmd/ast/ast.go
+++ b/cmd/ast/ast.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/zql"
 	"github.com/mccanne/charm"
 	"github.com/peterh/liner"
@@ -170,7 +171,7 @@ func parsePEGjs(z string) (string, error) {
 }
 
 func parseProc(z string) (string, error) {
-	proc, err := zql.ParseProc(z)
+	proc, err := compiler.ParseProc(z)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/zapi/cmd/get/get.go
+++ b/cmd/zapi/cmd/get/get.go
@@ -15,10 +15,10 @@ import (
 	"github.com/brimsec/zq/api/client"
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zql"
 	"github.com/mccanne/charm"
 )
 
@@ -170,7 +170,7 @@ func (c *Command) Run(args []string) error {
 
 // parseExpr creates an api.SearchRequest to be used with the client.
 func parseExpr(spaceID api.SpaceID, expr string) (*api.SearchRequest, error) {
-	search, err := zql.ParseProc(expr)
+	search, err := compiler.ParseProc(expr)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func parseExpr(spaceID api.SpaceID, expr string) (*api.SearchRequest, error) {
 // parseExprWithChunk creates an api.WorkerChunkRequest to be used with the client.
 func parseExprWithChunk(expr string, chunkPath string) (*api.WorkerChunkRequest, error) {
 	// This is only for testing using the -chunk flag
-	search, err := zql.ParseProc(expr)
+	search, err := compiler.ParseProc(expr)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/zapi/cmd/index/create.go
+++ b/cmd/zapi/cmd/index/create.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
-	"github.com/brimsec/zq/zql"
+	"github.com/brimsec/zq/compiler"
 	"github.com/mccanne/charm"
 )
 
@@ -70,7 +70,7 @@ func (c *CreateCmd) Run(args []string) error {
 		OutputFile: c.outputFile,
 	}
 	if c.zql != "" {
-		_, err := zql.ParseProc(c.zql)
+		_, err := compiler.ParseProc(c.zql)
 		if err != nil {
 			return err
 		}

--- a/cmd/zapi/cmd/post/flags.go
+++ b/cmd/zapi/cmd/post/flags.go
@@ -7,7 +7,7 @@ import (
 	"github.com/brimsec/zq/api/client"
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/cmd/zapi/cmd"
-	"github.com/brimsec/zq/zql"
+	"github.com/brimsec/zq/compiler"
 )
 
 type postFlags struct {
@@ -30,7 +30,7 @@ func (f *postFlags) Init() error {
 		return err
 	}
 	if f.shaper != "" {
-		ast, err := zql.ParseProc(f.shaper)
+		ast, err := compiler.ParseProc(f.shaper)
 		if err != nil {
 			return err
 		}

--- a/cmd/zq/zq.go
+++ b/cmd/zq/zq.go
@@ -10,13 +10,13 @@ import (
 	"github.com/brimsec/zq/cli/inputflags"
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cli/procflags"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/rlimit"
 	"github.com/brimsec/zq/pkg/s3io"
 	"github.com/brimsec/zq/pkg/signalctx"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/mccanne/charm"
 )
 
@@ -135,7 +135,7 @@ func (c *Command) Run(args []string) error {
 		zqlSrc = paths[0]
 		paths = paths[1:]
 	}
-	query, err := zql.ParseProc(zqlSrc)
+	query, err := compiler.ParseProc(zqlSrc)
 	if err != nil {
 		return fmt.Errorf("parse error: %s", err)
 	}

--- a/compiler/compile_test.go
+++ b/compiler/compile_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/field"
-	"github.com/brimsec/zq/zql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,7 +74,7 @@ func TestComputeColumns(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.zql, func(t *testing.T) {
-			query, err := zql.ParseProc(tc.zql)
+			query, err := ParseProc(tc.zql)
 			require.NoError(t, err)
 			// apply ReplaceGroupByProcDurationWithKey here because computeColumns
 			// will be applied after it when it is plugged into compilation.
@@ -150,7 +149,7 @@ func TestExpressionFields(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.expr, func(t *testing.T) {
-			e, err := zql.ParseExpression(tc.expr)
+			e, err := ParseExpression(tc.expr)
 			require.NoError(t, err)
 			f := expressionFields(e)
 			assert.Equal(t, tc.expected, f)
@@ -186,7 +185,7 @@ func TestBooleanExpressionFields(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.expr, func(t *testing.T) {
-			parsed, err := zql.ParseProc(tc.expr)
+			parsed, err := ParseProc(tc.expr)
 			require.NoError(t, err)
 			f := booleanExpressionFields(parsed.(*ast.FilterProc).Filter)
 			assert.Equal(t, tc.expected, f)
@@ -289,7 +288,7 @@ func TestParallelizeFlowgraph(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.zql, func(t *testing.T) {
-			query, err := zql.ParseProc(tc.zql)
+			query, err := ParseProc(tc.zql)
 			require.NoError(t, err)
 
 			ok := IsParallelizable(query.(*ast.SequentialProc), sf(tc.orderField), false)
@@ -298,7 +297,7 @@ func TestParallelizeFlowgraph(t *testing.T) {
 			parallelized, ok := Parallelize(query.(*ast.SequentialProc), 2, sf(tc.orderField), false)
 			require.Equal(t, ok, tc.zql != tc.expected)
 
-			expected, err := zql.ParseProc(tc.expected)
+			expected, err := ParseProc(tc.expected)
 			require.NoError(t, err)
 
 			// If the parallelized flowgraph includes a groupby, then adjust the expected AST by setting
@@ -324,12 +323,12 @@ func TestParallelizeFlowgraph(t *testing.T) {
 		orderField := "ts"
 		query := "* | cut ts, y, z | put x=y | rename y=z"
 		dquery := "(filter * | cut ts, y, z | put x=y | rename y=z; filter * | cut ts, y, z | put x=y | rename y=z)"
-		program, err := zql.ParseProc(query)
+		program, err := ParseProc(query)
 		require.NoError(t, err)
 		parallelized, ok := Parallelize(program.(*ast.SequentialProc), 2, sf(orderField), false)
 		require.True(t, ok)
 
-		expected, err := zql.ParseProc(dquery)
+		expected, err := ParseProc(dquery)
 		require.NoError(t, err)
 
 		// We can't express a pass proc in zql, so add it to the AST this way.
@@ -357,7 +356,7 @@ func TestSetGroupByProcInputSortDir(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.zql, func(t *testing.T) {
-			query, err := zql.ParseProc(tc.zql)
+			query, err := ParseProc(tc.zql)
 			require.NoError(t, err)
 			ReplaceGroupByProcDurationWithKey(query)
 			outputSorted := setGroupByProcInputSortDir(query, sf(tc.inputSortField), 1)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1,0 +1,50 @@
+package compiler
+
+import (
+	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/pkg/joe"
+	"github.com/brimsec/zq/zql"
+	"github.com/mitchellh/mapstructure"
+)
+
+// ParseProc() is an entry point for use from external go code,
+// mostly just a wrapper around Parse() that casts the return value.
+func ParseProc(query string, opts ...zql.Option) (ast.Proc, error) {
+	parsed, err := zql.Parse("", []byte(query), opts...)
+	if err != nil {
+		return nil, err
+	}
+	return ast.UnpackMap(nil, parsed)
+}
+
+func ParseExpression(expr string) (ast.Expression, error) {
+	m, err := zql.Parse("", []byte(expr), zql.Entrypoint("Expr"))
+	if err != nil {
+		return nil, err
+	}
+	node := joe.Convert(m)
+	ex, err := ast.UnpackExpression(node)
+	if err != nil {
+		return nil, err
+	}
+	c := &mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  ex,
+		Squash:  true,
+	}
+	dec, err := mapstructure.NewDecoder(c)
+	if err != nil {
+		return nil, err
+	}
+	return ex, dec.Decode(m)
+}
+
+// MustParseProc is functionally the same as ParseProc but panics if an error
+// is encountered.
+func MustParseProc(query string) ast.Proc {
+	proc, err := ParseProc(query)
+	if err != nil {
+		panic(err)
+	}
+	return proc
+}

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +38,7 @@ func TestCompileParents(t *testing.T) {
 		sources = append(sources, &proctest.RecordPuller{R: r})
 	}
 	t.Run("read two sources", func(t *testing.T) {
-		query, err := zql.ParseProc("(filter *; filter *) | filter *")
+		query, err := compiler.ParseProc("(filter *; filter *) | filter *")
 		require.NoError(t, err)
 
 		leaves, err := compiler.Compile(nil, query, pctx, sources)
@@ -52,7 +51,7 @@ func TestCompileParents(t *testing.T) {
 	})
 
 	t.Run("too few parents", func(t *testing.T) {
-		query, err := zql.ParseProc("(filter *; filter *; filter *) | filter *")
+		query, err := compiler.ParseProc("(filter *; filter *; filter *) | filter *")
 		require.NoError(t, err)
 
 		query.(*ast.SequentialProc).Procs = query.(*ast.SequentialProc).Procs[1:]
@@ -62,7 +61,7 @@ func TestCompileParents(t *testing.T) {
 	})
 
 	t.Run("too many parents", func(t *testing.T) {
-		query, err := zql.ParseProc("* | (filter *; filter *) | filter *")
+		query, err := compiler.ParseProc("* | (filter *; filter *) | filter *")
 		require.NoError(t, err)
 		_, err = compiler.Compile(nil, query, pctx, sources)
 		require.Error(t, err)
@@ -85,7 +84,7 @@ func TestCompileMergeDone(t *testing.T) {
 	pctx := &proc.Context{Context: context.Background(), TypeContext: zctx}
 	r := tzngio.NewReader(bytes.NewReader([]byte(input)), zctx)
 	src := &proctest.RecordPuller{R: r}
-	query, err := zql.ParseProc("(filter * ; head 1) | head 3")
+	query, err := compiler.ParseProc("(filter * ; head 1) | head 3")
 	require.NoError(t, err)
 
 	seq, ok := query.(*ast.SequentialProc)

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,7 +27,7 @@ func TestMuxDriver(t *testing.T) {
 #0:record[_path:string,ts:time]
 0:[conn;1425565514.419939;]`
 
-	query, err := zql.ParseProc("(tail 1; tail 1)")
+	query, err := compiler.ParseProc("(tail 1; tail 1)")
 	assert.NoError(t, err)
 
 	t.Run("muxed into one writer", func(t *testing.T) {

--- a/driver/parallel_test.go
+++ b/driver/parallel_test.go
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	"github.com/brimsec/zq/api"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -116,7 +116,7 @@ func TestParallelOrder(t *testing.T) {
 	t.Parallel()
 
 	// Use `v!=3` to trigger & verify empty rank handling in orderedWaiter.
-	query, err := zql.ParseProc("v!=3")
+	query, err := compiler.ParseProc("v!=3")
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
@@ -185,7 +185,7 @@ func (m *scannerCloseMS) SourceFromRequest(context.Context, *api.WorkerChunkRequ
 // TestScannerClose verifies that any open ScannerCloser's will be closed soon
 // after the MultiRun call finishes.
 func TestScannerClose(t *testing.T) {
-	query, err := zql.ParseProc("* | head 1")
+	query, err := compiler.ParseProc("* | head 1")
 	require.NoError(t, err)
 
 	var buf bytes.Buffer

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +43,7 @@ func parseOneRecord(zngsrc string) (*zng.Record, error) {
 }
 
 func compileExpr(s string) (expr.Evaluator, error) {
-	parsed, err := zql.ParseExpression(s)
+	parsed, err := compiler.ParseExpression(s)
 	if err != nil {
 		return nil, err
 	}

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +43,7 @@ func runCasesHelper(t *testing.T, tzng string, cases []testcase, expectBufferFil
 		t.Run(c.filter, func(t *testing.T) {
 			t.Helper()
 
-			proc, err := zql.ParseProc(c.filter)
+			proc, err := compiler.ParseProc(c.filter)
 			require.NoError(t, err, "filter: %q", c.filter)
 			filterExpr := proc.(*ast.FilterProc).Filter
 
@@ -503,7 +502,7 @@ func TestFilters(t *testing.T) {
 
 func TestBadFilter(t *testing.T) {
 	t.Parallel()
-	proc, err := zql.ParseProc(`s =~ \xa8*`)
+	proc, err := compiler.ParseProc(`s =~ \xa8*`)
 	require.NoError(t, err)
 	f := compiler.NewFilter(resolver.NewContext(), proc.(*ast.FilterProc).Filter)
 	_, err = f.AsFilter()

--- a/microindex/microindex_test.go
+++ b/microindex/microindex_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/microindex"
 	"github.com/brimsec/zq/pkg/iosrc"
@@ -16,7 +17,6 @@ import (
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -131,7 +131,7 @@ func TestCompare(t *testing.T) {
 			runtest(t, desc, "==", c.value, c.eql)
 		}
 	})
-	r, err := driver.NewReader(context.Background(), zql.MustParseProc("sort ts"), resolver.NewContext(), reader(records))
+	r, err := driver.NewReader(context.Background(), compiler.MustParseProc("sort ts"), resolver.NewContext(), reader(records))
 	require.NoError(t, err)
 	asc := buildAndOpen(t, r, microindex.Keys("ts"), microindex.Order(zbuf.OrderAsc))
 	t.Run("Ascending", func(t *testing.T) {

--- a/pkg/test/internal.go
+++ b/pkg/test/internal.go
@@ -6,13 +6,13 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 )
 
 type Internal struct {
@@ -47,7 +47,7 @@ func newEmitter(ofmt string) (*emitter.Bytes, error) {
 }
 
 func (i *Internal) Run() (string, error) {
-	program, err := zql.ParseProc(i.Query)
+	program, err := compiler.ParseProc(i.Query)
 	if err != nil {
 		return "", fmt.Errorf("parse error: %s (%s)", err, i.Query)
 	}

--- a/ppl/archive/index/rule.go
+++ b/ppl/archive/index/rule.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 )
 
 type RuleKind string
@@ -73,7 +73,7 @@ func UnmarshalRule(b []byte) (Rule, error) {
 
 func NewZqlRule(prog, name string, keys []field.Static) (Rule, error) {
 	// make sure it compiles
-	if _, err := zql.ParseProc(prog); err != nil {
+	if _, err := compiler.ParseProc(prog); err != nil {
 		return Rule{}, err
 	}
 	return Rule{
@@ -158,7 +158,7 @@ func (r Rule) fieldProc() (ast.Proc, error) {
 }
 
 func (r Rule) zqlProc() (ast.Proc, error) {
-	return zql.ParseProc(r.ZQL)
+	return compiler.ParseProc(r.ZQL)
 }
 
 func (r Rule) String() string {

--- a/ppl/cmd/zar/map/command.go
+++ b/ppl/cmd/zar/map/command.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cli/procflags"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/emitter"
 	"github.com/brimsec/zq/pkg/iosrc"
@@ -20,7 +21,6 @@ import (
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/mccanne/charm"
 )
 
@@ -71,7 +71,7 @@ func (c *Command) Run(args []string) error {
 	if len(args) == 0 {
 		return errors.New("zar map needs input arguments")
 	}
-	query, err := zql.ParseProc(args[0])
+	query, err := compiler.ParseProc(args[0])
 	if err != nil {
 		return err
 	}

--- a/ppl/cmd/zar/zq/command.go
+++ b/ppl/cmd/zar/zq/command.go
@@ -9,13 +9,13 @@ import (
 	"github.com/brimsec/zq/cli/outputflags"
 	"github.com/brimsec/zq/cli/procflags"
 	"github.com/brimsec/zq/cli/searchflags"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/rlimit"
 	"github.com/brimsec/zq/pkg/signalctx"
 	"github.com/brimsec/zq/ppl/archive"
 	"github.com/brimsec/zq/ppl/cmd/zar/root"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/mccanne/charm"
 )
 
@@ -70,7 +70,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 
-	query, err := zql.ParseProc(args[0])
+	query, err := compiler.ParseProc(args[0])
 	if err != nil {
 		return err
 	}

--- a/ppl/zqd/handlers.go
+++ b/ppl/zqd/handlers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/brimsec/zq/api"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/pcap"
 	"github.com/brimsec/zq/pkg/ctxio"
 	"github.com/brimsec/zq/ppl/zqd/ingest"
@@ -18,7 +19,6 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
-	"github.com/brimsec/zq/zql"
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
 )
@@ -80,7 +80,7 @@ func handleASTPost(c *Core, w http.ResponseWriter, r *http.Request) {
 	if !request(c, w, r, &req) {
 		return
 	}
-	proc, err := zql.ParseProc(req.ZQL)
+	proc, err := compiler.ParseProc(req.ZQL)
 	if err != nil {
 		respondError(c, w, r, zqe.ErrInvalid(err))
 		return

--- a/ppl/zqd/handlers_test.go
+++ b/ppl/zqd/handlers_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/api/client"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/nano"
@@ -31,7 +32,6 @@ import (
 	"github.com/brimsec/zq/zio/ndjsonio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,7 +79,7 @@ func TestSearchNoCtrl(t *testing.T) {
 	_, err = conn.LogPostReaders(context.Background(), sp.ID, nil, strings.NewReader(src))
 	require.NoError(t, err)
 
-	parsed, err := zql.ParseProc("*")
+	parsed, err := compiler.ParseProc("*")
 	require.NoError(t, err)
 	proc, err := json.Marshal(parsed)
 	require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestSearchError(t *testing.T) {
 	_, err = conn.LogPostReaders(context.Background(), sp.ID, nil, strings.NewReader(src))
 	require.NoError(t, err)
 
-	parsed, err := zql.ParseProc("*")
+	parsed, err := compiler.ParseProc("*")
 	require.NoError(t, err)
 	proc, err := json.Marshal(parsed)
 	require.NoError(t, err)
@@ -948,7 +948,7 @@ func indexSearch(t *testing.T, conn *client.Connection, space api.SpaceID, index
 // space, returning the tzng results along with a slice of all control
 // messages that were received.
 func search(t *testing.T, conn *client.Connection, space api.SpaceID, prog string) (string, []interface{}) {
-	parsed, err := zql.ParseProc(prog)
+	parsed, err := compiler.ParseProc(prog)
 	require.NoError(t, err)
 	proc, err := json.Marshal(parsed)
 	require.NoError(t, err)
@@ -981,7 +981,7 @@ func tzngCopy(t *testing.T, prog string, in string, outFormat string) string {
 	buf := bytes.NewBuffer(nil)
 	w, err := detector.LookupWriter(zio.NopCloser(buf), zio.WriterOpts{Format: outFormat})
 	require.NoError(t, err)
-	p := zql.MustParseProc(prog)
+	p := compiler.MustParseProc(prog)
 	err = driver.Copy(context.Background(), w, p, zctx, r, driver.Config{})
 	require.NoError(t, err)
 	return buf.String()

--- a/ppl/zqd/ingest/logtailer_test.go
+++ b/ppl/zqd/ingest/logtailer_test.go
@@ -9,15 +9,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/stretchr/testify/suite"
 )
 
-var sortTs = zql.MustParseProc("sort ts")
+var sortTs = compiler.MustParseProc("sort ts")
 
 const expected = `#0:record[ts:time]
 0:[0;]

--- a/ppl/zqd/ingest/pcap.go
+++ b/ppl/zqd/ingest/pcap.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/brimsec/zq/api"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/iosrc"
@@ -27,7 +28,6 @@ import (
 	"github.com/brimsec/zq/zio/ndjsonio"
 	"github.com/brimsec/zq/zio/zngio"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 )
 
 //go:generate go run ../../../zio/ndjsonio/typegenerator -o ./suricata.go -package ingest -var suricataTC ./suricata-types.json
@@ -43,7 +43,7 @@ type PcapOp interface {
 	Snap() <-chan struct{}
 }
 
-var suricataTransform = zql.MustParseProc("rename ts=timestamp")
+var suricataTransform = compiler.MustParseProc("rename ts=timestamp")
 
 type ClearableStore interface {
 	storage.Storage

--- a/ppl/zqd/storage/filestore/filestore.go
+++ b/ppl/zqd/storage/filestore/filestore.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/brimsec/zq/api"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/bufwriter"
 	"github.com/brimsec/zq/pkg/fs"
@@ -25,7 +26,6 @@ import (
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
-	"github.com/brimsec/zq/zql"
 	"go.uber.org/zap"
 	"golang.org/x/sync/semaphore"
 )
@@ -38,7 +38,7 @@ const (
 var (
 	ErrWriteInProgress = errors.New("another write is already in progress")
 
-	zngWriteProc = zql.MustParseProc("sort -r ts")
+	zngWriteProc = compiler.MustParseProc("sort -r ts")
 )
 
 func Load(path iosrc.URI, logger *zap.Logger) (*Storage, error) {

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -271,7 +270,7 @@ func TestGroupbySystem(t *testing.T) {
 }
 
 func compileGroupBy(code string) (*ast.GroupByProc, error) {
-	parsed, err := zql.ParseProc(code)
+	parsed, err := compiler.ParseProc(code)
 	if err != nil {
 		return nil, err
 	}
@@ -486,7 +485,7 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 	}
 
 	runOne := func(inputSortKey string) []string {
-		proc, err := zql.ParseProc("every 1s count() by ip")
+		proc, err := compiler.ParseProc("every 1s count() by ip")
 		assert.NoError(t, err)
 
 		zctx := resolver.NewContext()

--- a/proc/proctest/utils.go
+++ b/proc/proctest/utils.go
@@ -19,7 +19,6 @@ import (
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,7 +48,7 @@ func CompileTestProc(code string, pctx *proc.Context, parent proc.Interface) (pr
 	// a wildcard filter and then pull out just the proc we care
 	// about below.
 	prog := fmt.Sprintf("* | %s", code)
-	parsed, err := zql.ParseProc(prog)
+	parsed, err := compiler.ParseProc(prog)
 	if err != nil {
 		return nil, err
 	}

--- a/python/brim/src/zqext.go
+++ b/python/brim/src/zqext.go
@@ -11,7 +11,7 @@ import (
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
-	"github.com/brimsec/zq/zql"
+	"github.com/brimsec/zq/compiler"
 )
 
 // result converts an error into response structure expected
@@ -47,7 +47,7 @@ func doZqlFileEval(inquery, inpath, informat, outpath, outformat string) (err er
 	if outpath == "-" {
 		outpath = "/dev/stdout"
 	}
-	query, err := zql.ParseProc(inquery)
+	query, err := compiler.ParseProc(inquery)
 	if err != nil {
 		return err
 	}

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -5,53 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/brimsec/zq/ast"
-	"github.com/brimsec/zq/pkg/joe"
-	"github.com/mitchellh/mapstructure"
 )
-
-// ParseProc() is an entry point for use from external go code,
-// mostly just a wrapper around Parse() that casts the return value.
-func ParseProc(query string, opts ...Option) (ast.Proc, error) {
-	parsed, err := Parse("", []byte(query), opts...)
-	if err != nil {
-		return nil, err
-	}
-	return ast.UnpackMap(nil, parsed)
-}
-
-func ParseExpression(expr string) (ast.Expression, error) {
-	m, err := Parse("", []byte(expr), Entrypoint("Expr"))
-	if err != nil {
-		return nil, err
-	}
-	node := joe.Convert(m)
-	ex, err := ast.UnpackExpression(node)
-	if err != nil {
-		return nil, err
-	}
-	c := &mapstructure.DecoderConfig{
-		TagName: "json",
-		Result:  ex,
-		Squash:  true,
-	}
-	dec, err := mapstructure.NewDecoder(c)
-	if err != nil {
-		return nil, err
-	}
-	return ex, dec.Decode(m)
-}
-
-// MustParseProc is functionally the same as ParseProc but panics if an error
-// is encountered.
-func MustParseProc(query string) ast.Proc {
-	proc, err := ParseProc(query)
-	if err != nil {
-		panic(err)
-	}
-	return proc
-}
 
 func makeChain(first interface{}, restIn interface{}, op string) interface{} {
 	rest, ok := restIn.([]interface{})

--- a/zql/zql_test.go
+++ b/zql/zql_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/brimsec/zq/ast"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/zql"
 	"github.com/brimsec/zq/ztest"
@@ -48,7 +49,7 @@ func parsePEGjs(z string) ([]byte, error) {
 }
 
 func parseProc(z string) ([]byte, error) {
-	proc, err := zql.ParseProc(z)
+	proc, err := compiler.ParseProc(z)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +119,7 @@ func TestInvalid(t *testing.T) {
 // string from inside the AST.
 func parseString(in string) (string, error) {
 	code := fmt.Sprintf("s = \"%s\"", in)
-	tree, err := zql.ParseProc(code)
+	tree, err := compiler.ParseProc(code)
 	if err != nil {
 		return "", err
 	}

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -128,12 +128,12 @@ import (
 	"unicode/utf8"
 
 	"github.com/brimsec/zq/cli/outputflags"
+	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
-	"github.com/brimsec/zq/zql"
 	"github.com/pmezard/go-difflib/difflib"
 	"gopkg.in/yaml.v3"
 )
@@ -581,7 +581,7 @@ func runzq(path, ZQL string, outputFlags []string, inputs ...string) (string, st
 		// tests.
 		return outbuf.String(), errbuf.String(), err
 	}
-	proc, err := zql.ParseProc(ZQL)
+	proc, err := compiler.ParseProc(ZQL)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
This commit moves the entry points for compilation for the zql package
to the compiler package.  This will allow a future PR to put semantic
analysis behind the compiler entry points in a uniform way from within
the compiler package