### PR TITLE
Fix Zeek record unflattening for field with record prefix

### DIFF
--- a/zio/zeekio/parser.go
+++ b/zio/zeekio/parser.go
@@ -201,7 +201,7 @@ func unflattenRecord(zctx *resolver.Context, cols []zng.Column) ([]zng.Column, e
 			prefix = cols[0].Name[:dot]
 		}
 		for i := range cols {
-			if !strings.HasPrefix(cols[i].Name, prefix) {
+			if !strings.HasPrefix(cols[i].Name, prefix+".") {
 				break
 			}
 			trimmed := strings.TrimPrefix(cols[i].Name, prefix+".")

--- a/zio/zeekio/ztests/nested-record-name-is-prefix-of-another-field.yaml
+++ b/zio/zeekio/ztests/nested-record-name-is-prefix-of-another-field.yaml
@@ -1,0 +1,18 @@
+zql: '*'
+
+input: |
+  #separator \x09
+  #set_separator	,
+  #empty_field	(empty)
+  #unset_field	-
+  #path	socks
+  #open	2018-11-13-16-15-26
+  #fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	version	user	password	status	request.host	request.name	request_p	bound.host	bound.name	bound_p
+  #types	time	string	addr	port	addr	port	count	string	string	string	addr	string	port	addr	string	port
+  1521932484.182433	C8Yyb34kUAKDIM5ff1	10.199.194.15	39041	10.47.8.251	7777	5	-	-	connection not allowed by ruleset	-	-	-	-	google.com	0
+
+output: |
+  #port=uint16
+  #0:record[_path:string,ts:time,uid:bstring,id:record[orig_h:ip,orig_p:port,resp_h:ip,resp_p:port],version:uint64,user:bstring,password:bstring,status:bstring,request:record[host:ip,name:bstring],request_p:port,bound:record[host:ip,name:bstring],bound_p:port]
+  0:[socks;1521932484.182433;C8Yyb34kUAKDIM5ff1;[10.199.194.15;39041;10.47.8.251;7777;]5;-;-;connection not allowed by ruleset;[-;-;]-;[-;google.com;]0;]
+  


### PR DESCRIPTION
Zeek record unflattening incorrectly considers a field to be part of a
nested record if the nested record name is a prefix of the field name,
causing zio/zeekio.Reader to include bound_p in the bound record and
request_p in the request record when reading a SOCKS log.  Fix this in
zio/zeekio.unflattenRecord.

Fixes #1914.