### PR TITLE
Init apiserver.Manager only when needed

### DIFF
--- a/ppl/zqd/core.go
+++ b/ppl/zqd/core.go
@@ -217,7 +217,9 @@ func (c *Core) Root() iosrc.URI {
 }
 
 func (c *Core) Shutdown() {
-	c.mgr.Shutdown()
+	if c.mgr != nil {
+		c.mgr.Shutdown()
+	}
 }
 
 func (c *Core) nextTaskID() int64 {

--- a/ppl/zqd/core.go
+++ b/ppl/zqd/core.go
@@ -143,10 +143,10 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 func (c *Core) addAPIServerRoutes(ctx context.Context, conf Config) (err error) {
 	c.root, err = iosrc.ParseURI(conf.Root)
 	if err != nil {
-		return
+		return err
 	}
 	if c.mgr, err = apiserver.NewManager(ctx, conf.Logger, c.registry, c.root, conf.DB); err != nil {
-		return
+		return err
 	}
 	c.authhandle("/ast", handleASTPost).Methods("POST")
 	c.authhandle("/auth/identity", handleIdentityGet).Methods("GET")


### PR DESCRIPTION
No reason to init apiserver.Manager when the personalities worker and recruiter
have no use for them. Only init apiserver.Manager for personalities that serve
the api server routes.

Closes #1935