### PR TITLE
add hidden zapi auth subcommand

### DIFF
--- a/cmd/zapi/cmd/auth/command.go
+++ b/cmd/zapi/cmd/auth/command.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"flag"
+
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/mccanne/charm"
+)
+
+var Auth = &charm.Spec{
+	Name:  "auth",
+	Usage: "auth [subcommand]",
+	Short: "authentication and authorization related commands",
+	Long:  ``,
+	New:   New,
+	// Marking auth & subcommands hidden until support plumbed through all
+	// operations, see zq#1887 .
+	Hidden: true,
+}
+
+func init() {
+	Auth.Add(Login)
+	Auth.Add(Logout)
+	Auth.Add(Method)
+	Auth.Add(Verify)
+	cmd.CLI.Add(Auth)
+}
+
+type Command struct {
+	*cmd.Command
+	AuthToken string
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	return &Command{Command: parent.(*cmd.Command)}, nil
+}
+
+func (c *Command) Run(args []string) error {
+	return charm.ErrNoRun
+}

--- a/cmd/zapi/cmd/auth/devauth/devauthflow.go
+++ b/cmd/zapi/cmd/auth/devauth/devauthflow.go
@@ -1,0 +1,166 @@
+package devauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+)
+
+type Config struct {
+	Audience   string
+	ClientID   string
+	Domain     string
+	Scope      string
+	UserPrompt func(UserCodePrompt) error
+}
+
+type UserCodePrompt struct {
+	UserCode        string
+	VerificationURL string
+}
+
+type Result struct {
+	AccessToken  string
+	RefreshToken string
+	IDToken      string
+	Expiration   time.Time
+}
+
+// DeviceAuthorizationFlow implements the Auth0 device authorization flow
+// described at:
+// https://auth0.com/docs/flows/call-your-api-using-the-device-authorization-flow
+// https://auth0.com/docs/api/authentication#device-authorization-flow
+func DeviceAuthorizationFlow(ctx context.Context, cfg Config) (Result, error) {
+	d, err := newFlow(ctx, cfg)
+	if err != nil {
+		return Result{}, err
+	}
+
+	dcr, err := d.getDeviceCode()
+	if err != nil {
+		return Result{}, err
+	}
+
+	if err := cfg.UserPrompt(UserCodePrompt{
+		UserCode:        dcr.UserCode,
+		VerificationURL: dcr.VerificationURIComplete,
+	}); err != nil {
+		return Result{}, err
+	}
+
+	return d.pollForResult(dcr)
+}
+
+type daFlow struct {
+	cfg  Config
+	ctx  context.Context
+	rcli *resty.Client
+}
+
+func newFlow(ctx context.Context, cfg Config) (*daFlow, error) {
+	if cfg.UserPrompt == nil {
+		return nil, errors.New("no user prompt configured for device authorization")
+	}
+	if _, err := url.Parse(cfg.Domain); err != nil {
+		return nil, fmt.Errorf("invalid auth0 domain url: %w", err)
+	}
+	return &daFlow{
+		cfg: cfg,
+		ctx: ctx,
+		rcli: resty.New().
+			SetError(auth0Error{}).
+			SetHostURL(cfg.Domain).
+			OnAfterResponse(func(cli *resty.Client, resp *resty.Response) error {
+				if resp.IsSuccess() {
+					return nil
+				}
+				if err := resp.Error(); err != nil {
+					return err.(*auth0Error)
+				}
+				return fmt.Errorf("status code %d: %v", resp.StatusCode(), resp.String())
+			}),
+	}, nil
+}
+
+type auth0Error struct {
+	Kind             string `json:"error"` // renamed to avoid Error() clash
+	ErrorDescription string `json:"error_description"`
+}
+
+func (e *auth0Error) Error() string {
+	return fmt.Sprintf("auth0 error: %v description: %v", e.Kind, e.ErrorDescription)
+}
+
+type deviceCodeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+}
+
+func (d *daFlow) getDeviceCode() (deviceCodeResponse, error) {
+	res, err := d.rcli.NewRequest().
+		SetContext(d.ctx).
+		SetFormData(map[string]string{
+			"client_id": d.cfg.ClientID,
+			"scope":     d.cfg.Scope,
+			"audience":  d.cfg.Audience,
+		}).
+		SetResult(deviceCodeResponse{}).
+		Post("/oauth/device/code")
+	if err != nil {
+		return deviceCodeResponse{}, err
+	}
+	return *res.Result().(*deviceCodeResponse), nil
+}
+
+func (d *daFlow) pollForResult(dcr deviceCodeResponse) (Result, error) {
+	type auth0res struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
+		TokenType    string `json:"token_type"`
+		ExpiresIn    int    `json:"expires_in"`
+	}
+
+	delay := time.Duration(dcr.Interval) * time.Second
+	if delay <= 0 {
+		delay = time.Second
+	}
+
+	for {
+		select {
+		case <-time.After(delay):
+		case <-d.ctx.Done():
+			return Result{}, d.ctx.Err()
+		}
+		r, err := d.rcli.NewRequest().
+			SetContext(d.ctx).
+			SetFormData(map[string]string{
+				"grant_type":  "urn:ietf:params:oauth:grant-type:device_code",
+				"device_code": dcr.DeviceCode,
+				"client_id":   d.cfg.ClientID,
+			}).
+			SetResult(auth0res{}).
+			Post("/oauth/token")
+		if err != nil {
+			if aerr, ok := err.(*auth0Error); ok && aerr.Kind == "authorization_pending" {
+				continue
+			}
+			return Result{}, err
+		}
+		res := r.Result().(*auth0res)
+		return Result{
+			AccessToken:  res.AccessToken,
+			RefreshToken: res.RefreshToken,
+			IDToken:      res.IDToken,
+			Expiration:   time.Now().Add(time.Duration(res.ExpiresIn) * time.Second),
+		}, nil
+	}
+}

--- a/cmd/zapi/cmd/auth/login.go
+++ b/cmd/zapi/cmd/auth/login.go
@@ -1,0 +1,92 @@
+package auth
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/brimsec/zq/api"
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/brimsec/zq/cmd/zapi/cmd/auth/devauth"
+	"github.com/mccanne/charm"
+	"github.com/pkg/browser"
+)
+
+var Login = &charm.Spec{
+	Name:  "login",
+	Usage: "auth login",
+	Short: "login and save credentials for zqd service",
+	Long:  ``,
+	New:   NewLoginCommand,
+}
+
+type LoginCommand struct {
+	*Command
+	LaunchBrowser bool
+}
+
+func NewLoginCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &LoginCommand{Command: parent.(*Command)}
+	f.BoolVar(&c.LaunchBrowser, "launchbrowser", true, "automatically launch browser for verification")
+	return c, nil
+}
+
+func (c *LoginCommand) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
+	if len(args) > 0 {
+		return errors.New("login command takes no arguments")
+	}
+	conn := c.Connection()
+
+	method, err := conn.AuthMethod(c.Context())
+	if err != nil {
+		return fmt.Errorf("failed to obtain supported auth method: %w", err)
+	}
+	switch method.Kind {
+	case api.AuthMethodAuth0:
+	case api.AuthMethodNone:
+		return fmt.Errorf("zqd service at %v does not support authentication", c.Host)
+	default:
+		return fmt.Errorf("zqd service at %v supports unhandled authentication method: %v", c.Host, method.Kind)
+	}
+
+	dar, err := devauth.DeviceAuthorizationFlow(c.Context(), devauth.Config{
+		Audience: method.Auth0.Audience,
+		Domain:   method.Auth0.Domain,
+		ClientID: method.Auth0.ClientID,
+		Scope:    "openid profile email offline_access",
+		UserPrompt: func(res devauth.UserCodePrompt) error {
+			fmt.Println("Complete authentication at:", res.VerificationURL)
+			fmt.Println("User verification code:", res.UserCode)
+			if c.LaunchBrowser {
+				browser.OpenURL(res.VerificationURL)
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	cpath, err := cmd.UserStdCredentialsPath()
+	if err != nil {
+		return err
+	}
+	creds, err := cmd.LoadCredentials(cpath)
+	if err != nil {
+		return fmt.Errorf("failed to load credentials file: %w", err)
+	}
+	creds.AddTokens(c.Host, cmd.ServiceTokens{
+		Access:  dar.AccessToken,
+		ID:      dar.IDToken,
+		Refresh: dar.RefreshToken,
+	})
+	if err := cmd.SaveCredentials(cpath, creds); err != nil {
+		return fmt.Errorf("failed to save credentials file: %w", err)
+	}
+	fmt.Printf("Login successful, stored credentials for %s in %s\n", c.Host, cpath)
+	return nil
+}

--- a/cmd/zapi/cmd/auth/logout.go
+++ b/cmd/zapi/cmd/auth/logout.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/mccanne/charm"
+)
+
+var Logout = &charm.Spec{
+	Name:  "logout",
+	Usage: "auth logout",
+	Short: "remove saved credentials for zqd service",
+	Long:  ``,
+	New:   NewLogoutCommand,
+}
+
+type LogoutCommand struct {
+	*Command
+	LaunchBrowser bool
+}
+
+func NewLogoutCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	return &LogoutCommand{Command: parent.(*Command)}, nil
+}
+
+func (c *LogoutCommand) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
+	if len(args) > 0 {
+		return errors.New("logout command takes no arguments")
+	}
+
+	cpath, err := cmd.UserStdCredentialsPath()
+	if err != nil {
+		return err
+	}
+	svccreds, err := cmd.LoadCredentials(cpath)
+	if err != nil {
+		return fmt.Errorf("failed to load credentials file: %w", err)
+	}
+	svccreds.RemoveTokens(c.Host)
+	if err := cmd.SaveCredentials(cpath, svccreds); err != nil {
+		return fmt.Errorf("failed to save credentials file: %w", err)
+	}
+	fmt.Printf("Logout successful, cleared credentials for %s in %s\n", c.Host, cpath)
+	return nil
+}

--- a/cmd/zapi/cmd/auth/method.go
+++ b/cmd/zapi/cmd/auth/method.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/mccanne/charm"
+)
+
+var Method = &charm.Spec{
+	Name:  "method",
+	Usage: "auth method",
+	Short: "display auth method supported by zqd service",
+	Long:  ``,
+	New:   NewMethod,
+}
+
+type MethodCommand struct {
+	*Command
+}
+
+func NewMethod(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	return &MethodCommand{Command: parent.(*Command)}, nil
+}
+
+func (c *MethodCommand) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
+	if len(args) > 0 {
+		return errors.New("method command takes no arguments")
+	}
+	conn := c.Connection()
+	res, err := conn.AuthMethod(c.Context())
+	if err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(res, "", "\t")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
+	return nil
+}

--- a/cmd/zapi/cmd/auth/verify.go
+++ b/cmd/zapi/cmd/auth/verify.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/brimsec/zq/cmd/zapi/cmd"
+	"github.com/mccanne/charm"
+)
+
+var Verify = &charm.Spec{
+	Name:  "verify",
+	Usage: "auth verify",
+	Short: "verify authentication credentials",
+	Long:  ``,
+	New:   NewVerify,
+}
+
+type VerifyCommand struct {
+	*Command
+}
+
+func NewVerify(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	return &VerifyCommand{Command: parent.(*Command)}, nil
+}
+
+func LoadServiceCredentials(serviceURL string) (cmd.ServiceTokens, error) {
+	cpath, err := cmd.UserStdCredentialsPath()
+	if err != nil {
+		return cmd.ServiceTokens{}, err
+	}
+	svccreds, err := cmd.LoadCredentials(cpath)
+	if err != nil {
+		return cmd.ServiceTokens{}, fmt.Errorf("failed to load credentials file: %w", err)
+	}
+	creds, ok := svccreds.ServiceTokens(serviceURL)
+	if !ok {
+		return cmd.ServiceTokens{}, fmt.Errorf("no stored credentials for %v", serviceURL)
+	}
+	return creds, nil
+}
+
+func (c *VerifyCommand) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
+	if len(args) > 0 {
+		return errors.New("verify command takes no arguments")
+	}
+	conn := c.Connection()
+
+	creds, err := LoadServiceCredentials(c.Host)
+	if err != nil {
+		return err
+	}
+	conn.SetAuthToken(creds.Access)
+
+	res, err := conn.AuthIdentity(c.Context())
+	if err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(res, "", "\t")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
+	return nil
+}

--- a/cmd/zapi/cmd/credentials.go
+++ b/cmd/zapi/cmd/credentials.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/brimsec/zq/pkg/fs"
+)
+
+const (
+	zapiConfigDirName = "zapi"
+	credsFileName     = "credentials.json"
+)
+
+func LoadCredentials(path string) (*Credentials, error) {
+	var cf Credentials
+	if err := fs.UnmarshalJSONFile(path, &cf); err != nil {
+		if os.IsNotExist(err) {
+			return &Credentials{}, nil
+		}
+		return nil, err
+	}
+	return &cf, nil
+}
+
+func SaveCredentials(path string, cf *Credentials) error {
+	return fs.MarshalJSONFile(cf, path, 0600)
+}
+
+func UserStdCredentialsPath() (string, error) {
+	c, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	zcd := filepath.Join(c, zapiConfigDirName)
+	if err := os.MkdirAll(zcd, 0777); err != nil {
+		return "", err
+	}
+	return path.Join(zcd, credsFileName), nil
+}
+
+type ServiceInfo struct {
+	Endpoint string        `json:"endpoint"`
+	Tokens   ServiceTokens `json:"tokens"`
+}
+
+type ServiceTokens struct {
+	Access  string `json:"access"`
+	ID      string `json:"id"`
+	Refresh string `json:"refresh"`
+}
+
+type Credentials struct {
+	Version  int           `json:"version"`
+	Services []ServiceInfo `json:"services"`
+}
+
+func (c *Credentials) ServiceTokens(url string) (ServiceTokens, bool) {
+	for _, s := range c.Services {
+		if s.Endpoint == url {
+			return s.Tokens, true
+		}
+	}
+	return ServiceTokens{}, false
+}
+
+func (c *Credentials) AddTokens(u string, sc ServiceTokens) {
+	svcs := make([]ServiceInfo, 0, len(c.Services)+1)
+	for _, s := range c.Services {
+		if s.Endpoint != u {
+			svcs = append(svcs, s)
+		}
+	}
+	svcs = append(svcs, ServiceInfo{
+		Endpoint: u,
+		Tokens:   sc,
+	})
+	c.Services = svcs
+}
+
+func (c *Credentials) RemoveTokens(u string) {
+	svcs := make([]ServiceInfo, 0, len(c.Services))
+	for _, s := range c.Services {
+		if s.Endpoint != u {
+			svcs = append(svcs, s)
+		}
+	}
+	c.Services = svcs
+}

--- a/cmd/zapi/main.go
+++ b/cmd/zapi/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/brimsec/zq/cmd/zapi/cmd"
+	_ "github.com/brimsec/zq/cmd/zapi/cmd/auth"
 	_ "github.com/brimsec/zq/cmd/zapi/cmd/get"
 	_ "github.com/brimsec/zq/cmd/zapi/cmd/index"
 	_ "github.com/brimsec/zq/cmd/zapi/cmd/info"

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4
 	github.com/peterh/liner v1.1.0
 	github.com/pierrec/lz4/v4 v4.1.0
+	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.7.1
 	github.com/segmentio/ksuid v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -350,6 +350,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4/v4 v4.1.0 h1:vhiKjm9Npt49Up5EbHg5C/gjum3rWjmcjGnOK+wDeok=
 github.com/pierrec/lz4/v4 v4.1.0/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
This adds a few auth related commands for zapi, hidden for now since the authentication is not wired for any other commands than these, including:
* auth login: implements the 'Device Authorization' flow using the Auth0 information reported back from the `/auth/method` api call, launching a browser automatically (by default) for login, and saves the tokens for the zqd endppoint in a local file for later 
usage.
* auth logout: removes the credentials stored for the zqd endpoint
* auth verify: hits the `/auth/identity` api to verify the stored token
* auth method: reports the authentication information sent back from the server

There's still more work to come, including wiring auth for other operations, handling token refreshing, testing, etc. , but I thought I'd put this up now as-is since its a useful milestone.

Here's a video showing it all in action against a test Auth0 tenant:
https://user-images.githubusercontent.com/704945/103917728-c988df00-50c2-11eb-8c28-5ad4faae07c0.mov

