### PR TITLE
expr.LookupValueCaster(): change argument type and rename 

### DIFF
--- a/expr/cast.go
+++ b/expr/cast.go
@@ -9,37 +9,37 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
-type ValueCaster func(zv zng.Value) (zng.Value, error)
+type PrimitiveCaster func(zv zng.Value) (zng.Value, error)
 
-func LookupValueCaster(typ string) ValueCaster {
+func LookupPrimitiveCaster(typ zng.Type) PrimitiveCaster {
 	switch typ {
-	case "int8":
+	case zng.TypeInt8:
 		return castToInt8
-	case "int16":
+	case zng.TypeInt16:
 		return castToInt16
-	case "int32":
+	case zng.TypeInt32:
 		return castToInt32
-	case "int64":
+	case zng.TypeInt64:
 		return castToInt64
-	case "uint8":
+	case zng.TypeUint8:
 		return castToUint8
-	case "uint16":
+	case zng.TypeUint16:
 		return castToUint16
-	case "uint32":
+	case zng.TypeUint32:
 		return castToUint32
-	case "uint64":
+	case zng.TypeUint64:
 		return castToUint64
-	case "float64":
+	case zng.TypeFloat64:
 		return castToFloat64
-	case "ip":
+	case zng.TypeIP:
 		return castToIP
-	case "time":
+	case zng.TypeTime:
 		return castToTime
-	case "string":
+	case zng.TypeString:
 		return castToString
-	case "bstring":
+	case zng.TypeBstring:
 		return castToBstring
-	case "bytes":
+	case zng.TypeBytes:
 		return castToBytes
 	default:
 		return nil

--- a/expr/eval.go
+++ b/expr/eval.go
@@ -708,21 +708,22 @@ func (c *Call) Eval(rec *zng.Record) (zng.Value, error) {
 	return c.fn.Call(c.args)
 }
 
-func NewCast(expr Evaluator, typ string) (Evaluator, error) {
+func NewCast(expr Evaluator, styp string) (Evaluator, error) {
 	// XXX should handle alias casts... need type context.
 	// compile is going to need a local type context to create literals
 	// of complex types?
-	vc := LookupValueCaster(typ)
-	if vc == nil {
+	typ := zng.LookupPrimitive(styp)
+	c := LookupPrimitiveCaster(typ)
+	if c == nil {
 		// XXX See issue #1572.   To implement aliascast here.
-		return nil, fmt.Errorf("cast to %s not implemeneted", typ)
+		return nil, fmt.Errorf("cast to %s not implemeneted", styp)
 	}
-	return &evalCast{expr, vc}, nil
+	return &evalCast{expr, c}, nil
 }
 
 type evalCast struct {
 	expr   Evaluator
-	caster ValueCaster
+	caster PrimitiveCaster
 }
 
 func (c *evalCast) Eval(rec *zng.Record) (zng.Value, error) {


### PR DESCRIPTION
This commit changes `expr.LookupValueCaster()` to take a zng.Type rather than the string representation of the type. This is needed so that the forthcoming `cast()` function (now mostly working on branch shaping-function-cast) can call with the various leaf zng.Type's found during record traversal.

Also, while I was making this change, I realized ValueCaster is misleading and changed the name to PrimitiveCaster.