### PR TITLE
fix flattener for nested nulls

### DIFF
--- a/zcode/bytes.go
+++ b/zcode/bytes.go
@@ -128,6 +128,12 @@ func AppendPrimitive(dst Bytes, val []byte) Bytes {
 	return append(dst, val...)
 }
 
+// AppendNull appends a null value to dst as either a primitive or container
+// value and returns the extended buffer.
+func AppendNull(dst Bytes) Bytes {
+	return AppendUvarint(dst, tagNull)
+}
+
 // AppendUvarint is like encoding/binary.PutUvarint but appends to dst instead
 // of writing into it.
 func AppendUvarint(dst []byte, u64 uint64) []byte {

--- a/zio/csvio/ztests/null-nested.yaml
+++ b/zio/csvio/ztests/null-nested.yaml
@@ -1,0 +1,14 @@
+zql: '*'
+
+input: |
+  #0:record[a:record[b:record[a1:array[string],a2:array[string]]]]
+  0:[-;]
+  #1:record[s:string]
+  1:[x;]
+
+output-flags: -f csv
+
+output: |+
+  a.b.a1,a.b.a2,s
+  ,,
+  ,,x

--- a/zng/flattener/flattener.go
+++ b/zng/flattener/flattener.go
@@ -29,8 +29,16 @@ func New(zctx *resolver.Context) *Flattener {
 
 func recode(dst zcode.Bytes, typ *zng.TypeRecord, in zcode.Bytes) (zcode.Bytes, error) {
 	if in == nil {
-		for k := 0; k < len(typ.Columns); k++ {
-			dst = zcode.AppendPrimitive(dst, nil)
+		for _, col := range typ.Columns {
+			if typ, ok := col.Type.(*zng.TypeRecord); ok {
+				var err error
+				dst, err = recode(dst, typ, nil)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				dst = zcode.AppendNull(dst)
+			}
 		}
 		return dst, nil
 	}


### PR DESCRIPTION
This commit fixes a bug in the flattener where nested nulls were
not properly output for every column in the flattened record
(i.e., a null value for an embedded record did not properly recurse
into the nested record so only one null value was output instead
of a null for each flattened value).

While fixing this we added zcode.AppendNull() to clarify that the API
for appending null is the same for primitives and containers.

There are also some type context problems I noticed in fuse and the 
csv writer but these can be fixed later since the code happens to work 
as is (see #1953)

Fixes #1942