### PR TITLE
Update Zeek Compatibility doc and add tests

### DIFF
--- a/zng/docs/zeek-compat.md
+++ b/zng/docs/zeek-compat.md
@@ -79,38 +79,38 @@ $ cat zeek_types.log
 #types	bool	count	int	double	time	interval	string	string	port	addr	subnet	enum	set[string]	vector[string]	string	count
 T	123	456	123.4560	1592502151.123456	123.456	smile\xf0\x9f\x98\x81smile	\x09\x07\x04	80	127.0.0.1	10.0.0.0/8	tcp	things,in,a,set	order,is,important	Jeanne	122
 
-$ zq -f zson zeek_types.log
+$ zq -f zson zeek_types.log | tee zeek_types.zson
 {
-    my_bool: T,
+    my_bool: true,
     my_count: 123 (uint64),
     my_int: 456,
-    my_double: 123.456,
+    my_double: 1.23456e+02,
     my_time: 2020-06-18T17:42:31.123456Z,
     my_interval: 2m3.456s (duration),
     my_printable_string: "smile😁smile" (bstring),
-    my_bytes_string: "\x09\x07\x04" (bstring),
-    my_port: 80 (uint16) (=port),
+    my_bytes_string: "\t\x07\x04" (bstring),
+    my_port: 80 (port=(uint16)),
     my_addr: 127.0.0.1,
     my_subnet: 10.0.0.0/8,
     my_enum: "tcp" (=zenum),
     my_set: |[
-        "a",
-        "in",
-        "set",
-        "things"
-    ]| (|[bstring]| (=23)),
+        "a" (bstring),
+        "in" (bstring),
+        "set" (bstring),
+        "things" (bstring)
+    ]| (=0),
     my_vector: [
-        "order",
-        "is",
-        "important"
-    ] ([bstring] (=24)),
+        "order" (bstring),
+        "is" (bstring),
+        "important" (bstring)
+    ] (=1),
     my_record: {
         name: "Jeanne" (bstring),
         age: 122 (uint64)
-    } (=25)
-} (=26)
+    } (=2)
+} (=3)
 
-$ zq -t zeek_types.log | zq -f zeek -
+$ zq -i zson -f zeek zeek_types.zson
 #separator \x09
 #set_separator	,
 #empty_field	(empty)
@@ -119,9 +119,6 @@ $ zq -t zeek_types.log | zq -f zeek -
 #types	bool	count	int	double	time	interval	string	string	port	addr	subnet	enum	set[string]	vector[string]	string	count
 T	123	456	123.456	1592502151.123456	123.456	smile\xf0\x9f\x98\x81smile	\x09\x07\x04	80	127.0.0.1	10.0.0.0/8	tcp	a,in,set,things	order,is,important	Jeanne	122
 ```
-
-> TBD: we don't yet have a ZSON reader so we can update the above example yet.
-> See issue #1679
 
 ## Type-Specific Details
 
@@ -132,7 +129,7 @@ exist) may handle these differently.
 
 Multiple Zeek types discussed below are represented via a
 [type definition](zson.md#25-type-definitions) to one of ZSON's
-[primitive types](zson.md#2-primitive-types). The use of the ZSON type names maintains
+[primitive types](zson.md#33-primitive-values). The use of the ZSON type names maintains
 the history of the field's original Zeek type such that `zq` may restore it
 if/when the field may be later output again in Zeek format. Knowledge of its
 original Zeek type may also enable special operations in ZQL that are unique to
@@ -222,7 +219,7 @@ down in the record hierarchy. Revisiting the data from our
 example:
 
 ```
-$ zq -t zeek_types.log | zq -f zeek "cut my_record" -
+$ zq -i zson -f zeek 'cut my_record' zeek_types.zson
 #separator \x09
 #set_separator	,
 #empty_field	(empty)

--- a/zson/ztests/cut-record.yaml
+++ b/zson/ztests/cut-record.yaml
@@ -1,0 +1,48 @@
+# If you change the test below after a change to make it pass, make sure the
+# input/output are still in sync with what's at zng/docs/zeek-compat.md.
+
+script: zq -i zson -f zeek "cut my_record" zeek_types.zson
+
+inputs:
+  - name: zeek_types.zson
+    data: |
+      {
+          my_bool: true,
+          my_count: 123 (uint64),
+          my_int: 456,
+          my_double: 1.23456e+02,
+          my_time: 2020-06-18T17:42:31.123456Z,
+          my_interval: 2m3.456s (duration),
+          my_printable_string: "smile😁smile" (bstring),
+          my_bytes_string: "\t\x07\x04" (bstring),
+          my_port: 80 (port=(uint16)),
+          my_addr: 127.0.0.1,
+          my_subnet: 10.0.0.0/8,
+          my_enum: "tcp" (=zenum),
+          my_set: |[
+              "a" (bstring),
+              "in" (bstring),
+              "set" (bstring),
+              "things" (bstring)
+          ]| (=0),
+          my_vector: [
+              "order" (bstring),
+              "is" (bstring),
+              "important" (bstring)
+          ] (=1),
+          my_record: {
+              name: "Jeanne" (bstring),
+              age: 122 (uint64)
+          } (=2)
+      } (=3)
+
+outputs:
+  - name: stdout
+    data: |
+      #separator \x09
+      #set_separator	,
+      #empty_field	(empty)
+      #unset_field	-
+      #fields	my_record.name	my_record.age
+      #types	string	count
+      Jeanne	122

--- a/zson/ztests/zeek-to-zson.yaml
+++ b/zson/ztests/zeek-to-zson.yaml
@@ -1,0 +1,48 @@
+# If you change the test below after a change to make it pass, make sure the
+# input/output are still in sync with what's at zng/docs/zeek-compat.md.
+
+script: zq -f zson zeek_types.log
+
+inputs:
+  - name: zeek_types.log
+    data: |
+      #separator \x09
+      #set_separator	,
+      #empty_field	(empty)
+      #unset_field	-
+      #fields	my_bool	my_count	my_int	my_double	my_time	my_interval	my_printable_string	my_bytes_string	my_port	my_addr	my_subnet	my_enum	my_set	my_vector	my_record.name	my_record.age
+      #types	bool	count	int	double	time	interval	string	string	port	addr	subnet	enum	set[string]	vector[string]	string	count
+      T	123	456	123.4560	1592502151.123456	123.456	smile\xf0\x9f\x98\x81smile	\x09\x07\x04	80	127.0.0.1	10.0.0.0/8	tcp	things,in,a,set	order,is,important	Jeanne	122
+
+outputs:
+  - name: stdout
+    data: |
+      {
+          my_bool: true,
+          my_count: 123 (uint64),
+          my_int: 456,
+          my_double: 1.23456e+02,
+          my_time: 2020-06-18T17:42:31.123456Z,
+          my_interval: 2m3.456s (duration),
+          my_printable_string: "smile😁smile" (bstring),
+          my_bytes_string: "\t\x07\x04" (bstring),
+          my_port: 80 (port=(uint16)),
+          my_addr: 127.0.0.1,
+          my_subnet: 10.0.0.0/8,
+          my_enum: "tcp" (=zenum),
+          my_set: |[
+              "a" (bstring),
+              "in" (bstring),
+              "set" (bstring),
+              "things" (bstring)
+          ]| (=0),
+          my_vector: [
+              "order" (bstring),
+              "is" (bstring),
+              "important" (bstring)
+          ] (=1),
+          my_record: {
+              name: "Jeanne" (bstring),
+              age: 122 (uint64)
+          } (=2)
+      } (=3)

--- a/zson/ztests/zson-to-zeek.yaml
+++ b/zson/ztests/zson-to-zeek.yaml
@@ -1,0 +1,48 @@
+# If you change the test below after a change to make it pass, make sure the
+# input/output are still in sync with what's at zng/docs/zeek-compat.md.
+
+script: zq -i zson -f zeek zeek_types.zson
+
+inputs:
+  - name: zeek_types.zson
+    data: |
+      {
+          my_bool: true,
+          my_count: 123 (uint64),
+          my_int: 456,
+          my_double: 1.23456e+02,
+          my_time: 2020-06-18T17:42:31.123456Z,
+          my_interval: 2m3.456s (duration),
+          my_printable_string: "smile😁smile" (bstring),
+          my_bytes_string: "\t\x07\x04" (bstring),
+          my_port: 80 (port=(uint16)),
+          my_addr: 127.0.0.1,
+          my_subnet: 10.0.0.0/8,
+          my_enum: "tcp" (=zenum),
+          my_set: |[
+              "a" (bstring),
+              "in" (bstring),
+              "set" (bstring),
+              "things" (bstring)
+          ]| (=0),
+          my_vector: [
+              "order" (bstring),
+              "is" (bstring),
+              "important" (bstring)
+          ] (=1),
+          my_record: {
+              name: "Jeanne" (bstring),
+              age: 122 (uint64)
+          } (=2)
+      } (=3)
+
+outputs:
+  - name: stdout
+    data: |
+      #separator \x09
+      #set_separator	,
+      #empty_field	(empty)
+      #unset_field	-
+      #fields	my_bool	my_count	my_int	my_double	my_time	my_interval	my_printable_string	my_bytes_string	my_port	my_addr	my_subnet	my_enum	my_set	my_vector	my_record.name	my_record.age
+      #types	bool	count	int	double	time	interval	string	string	port	addr	subnet	enum	set[string]	vector[string]	string	count
+      T	123	456	123.456	1592502151.123456	123.456	smile\xf0\x9f\x98\x81smile	\x09\x07\x04	80	127.0.0.1	10.0.0.0/8	tcp	a,in,set,things	order,is,important	Jeanne	122


### PR DESCRIPTION
While [adding ZSON sample data](https://github.com/brimsec/zq-sample-data/pull/18) I saw a note-to-self to make sure we update this Zeek Compatibility doc as well. The last update to this doc pre-dated the ZSON reader and also had older ZSON sample output, so I've updated it to the ZSON that's output by the GA `zq` tagged `v0.27.1` that was just released. I also added some ztests to make sure these don't get out of sync again.