### PR TITLE
zqd listen: Reformat startup logs

### DIFF
--- a/ppl/cmd/zqd/listen/command.go
+++ b/ppl/cmd/zqd/listen/command.go
@@ -98,6 +98,8 @@ func (c *Command) Run(args []string) error {
 	if err != nil {
 		c.logger.Warn("Raising open files limit failed", zap.Error(err))
 	}
+	c.conf.Logger.Info("Open files limit raised", zap.Uint64("limit", openFilesLimit))
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if c.brimfd != -1 {
@@ -110,13 +112,7 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	defer core.Shutdown()
-	c.logger.Info("Starting",
-		zap.String("datadir", c.conf.Root),
-		zap.Uint64("open_files_limit", openFilesLimit),
-		zap.String("personality", c.conf.Personality),
-		zap.Bool("suricata_supported", core.HasSuricata()),
-		zap.Bool("zeek_supported", core.HasZeek()),
-	)
+
 	if c.suricataUpdater != nil {
 		c.launchSuricataUpdate(ctx)
 	}

--- a/ppl/zqd/apiserver/manager.go
+++ b/ppl/zqd/apiserver/manager.go
@@ -42,7 +42,7 @@ type Manager struct {
 func NewManager(ctx context.Context, logger *zap.Logger, registerer prometheus.Registerer, root iosrc.URI, db db.DB) (*Manager, error) {
 	factory := promauto.With(registerer)
 	m := &Manager{
-		logger:   logger.Named("manager").With(zap.String("root", root.String())),
+		logger:   logger.Named("manager"),
 		rootPath: root,
 		db:       db,
 
@@ -60,7 +60,7 @@ func NewManager(ctx context.Context, logger *zap.Logger, registerer prometheus.R
 	}
 	m.compactor = newCompactor(m)
 	m.spawnAlphaMigrations(ctx)
-	m.logger.Info("Loaded")
+	m.logger.Info("Loaded", zap.String("root", root.String()))
 	return m, nil
 }
 

--- a/ppl/zqd/apiserver/manager.go
+++ b/ppl/zqd/apiserver/manager.go
@@ -39,15 +39,10 @@ type Manager struct {
 	deleted prometheus.Counter
 }
 
-func NewManager(ctx context.Context, logger *zap.Logger, registerer prometheus.Registerer, root iosrc.URI, dbconf db.Config) (*Manager, error) {
-	db, err := db.Open(ctx, logger, dbconf, root)
-	if err != nil {
-		return nil, err
-	}
-
+func NewManager(ctx context.Context, logger *zap.Logger, registerer prometheus.Registerer, root iosrc.URI, db db.DB) (*Manager, error) {
 	factory := promauto.With(registerer)
 	m := &Manager{
-		logger:   logger,
+		logger:   logger.Named("manager").With(zap.String("root", root.String())),
 		rootPath: root,
 		db:       db,
 
@@ -65,6 +60,7 @@ func NewManager(ctx context.Context, logger *zap.Logger, registerer prometheus.R
 	}
 	m.compactor = newCompactor(m)
 	m.spawnAlphaMigrations(ctx)
+	m.logger.Info("Loaded")
 	return m, nil
 }
 

--- a/ppl/zqd/db/db.go
+++ b/ppl/zqd/db/db.go
@@ -35,7 +35,7 @@ type Config struct {
 }
 
 func Open(ctx context.Context, logger *zap.Logger, conf Config, root iosrc.URI) (DB, error) {
-	logger = logger.Named("db")
+	logger = logger.Named("database")
 	switch conf.Kind {
 	case DBFile, DBUnspecified:
 		return filedb.Open(ctx, logger, root)

--- a/ppl/zqd/db/db.go
+++ b/ppl/zqd/db/db.go
@@ -35,11 +35,14 @@ type Config struct {
 }
 
 func Open(ctx context.Context, logger *zap.Logger, conf Config, root iosrc.URI) (DB, error) {
+	logger = logger.Named("db")
 	switch conf.Kind {
 	case DBFile, DBUnspecified:
 		return filedb.Open(ctx, logger, root)
+
 	case DBPostgres:
-		return postgresdb.Open(ctx, conf.Postgres)
+		return postgresdb.Open(ctx, logger, conf.Postgres)
+
 	default:
 		return nil, fmt.Errorf("db.Open: unknown DBKind %q", conf.Kind)
 	}

--- a/ppl/zqd/db/filedb/filedb.go
+++ b/ppl/zqd/db/filedb/filedb.go
@@ -28,16 +28,12 @@ func Create(ctx context.Context, logger *zap.Logger, path iosrc.URI, rows []sche
 	if err := db.save(ctx, rows); err != nil {
 		return nil, err
 	}
-	db.logger.Info("Created")
+	db.logger.Info("Created", zap.String("kind", "file"), zap.String("uri", path.String()))
 	return db, nil
 }
 
 func Open(ctx context.Context, logger *zap.Logger, root iosrc.URI) (*FileDB, error) {
 	dburi := root.AppendPath(dbname)
-	logger = logger.With(
-		zap.String("kind", "file"),
-		zap.String("uri", dburi.String()),
-	)
 	exists, err := iosrc.Exists(ctx, dburi)
 	if err != nil {
 		return nil, err
@@ -89,7 +85,7 @@ func open(ctx context.Context, logger *zap.Logger, path iosrc.URI) (*FileDB, err
 	if _, err := db.load(ctx); err != nil {
 		return nil, err
 	}
-	db.logger.Info("Loaded")
+	db.logger.Info("Loaded", zap.String("kind", "file"), zap.String("uri", path.String()))
 	return db, nil
 }
 

--- a/ppl/zqd/db/filedb/oldconfig/oldconfig_test.go
+++ b/ppl/zqd/db/filedb/oldconfig/oldconfig_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/ppl/zqd/apiserver"
-	"github.com/brimsec/zq/ppl/zqd/db"
+	"github.com/brimsec/zq/ppl/zqd/db/filedb"
 	"github.com/brimsec/zq/ppl/zqd/db/filedb/oldconfig"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -142,7 +142,9 @@ func (tm *testMigration) initRoot() {
 
 func (tm *testMigration) manager() *apiserver.Manager {
 	if tm.mgr == nil {
-		mgr, err := apiserver.NewManager(context.Background(), zap.NewNop(), prometheus.NewRegistry(), tm.root, db.Config{Kind: "file"})
+		filedb, err := filedb.Open(context.Background(), zap.NewNop(), tm.root)
+		require.NoError(tm.T, err)
+		mgr, err := apiserver.NewManager(context.Background(), zap.NewNop(), prometheus.NewRegistry(), tm.root, filedb)
 		require.NoError(tm.T, err)
 		tm.mgr = mgr
 	}

--- a/ppl/zqd/db/postgresdb/config.go
+++ b/ppl/zqd/db/postgresdb/config.go
@@ -51,11 +51,7 @@ func (c Config) String() string {
 // StringRedacted is the same as string except password and a username are
 // redacted. This should be used in logs.
 func (c Config) StringRedacted() string {
-	if c.Password != "" {
-		c.Password = strings.Repeat("*", 5)
-	}
-	if c.User != "" {
-		c.User = string(c.User[0]) + strings.Repeat("*", 4)
-	}
+	c.Password = strings.Repeat("*", 5)
+	c.User = strings.Repeat("*", 5)
 	return c.String()
 }

--- a/ppl/zqd/db/postgresdb/config.go
+++ b/ppl/zqd/db/postgresdb/config.go
@@ -2,6 +2,7 @@ package postgresdb
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/go-pg/pg/v10"
 )
@@ -45,4 +46,16 @@ func (c Config) String() string {
 		str += "?" + params.Encode()
 	}
 	return str
+}
+
+// StringRedacted is the same as string except password and a username are
+// redacted. This should be used in logs.
+func (c Config) StringRedacted() string {
+	if c.Password != "" {
+		c.Password = strings.Repeat("*", 5)
+	}
+	if c.User != "" {
+		c.User = string(c.User[0]) + strings.Repeat("*", 4)
+	}
+	return c.String()
 }

--- a/ppl/zqd/db/postgresdb/postgresdb.go
+++ b/ppl/zqd/db/postgresdb/postgresdb.go
@@ -17,15 +17,11 @@ type PostgresDB struct {
 }
 
 func Open(ctx context.Context, logger *zap.Logger, conf Config) (*PostgresDB, error) {
-	logger = logger.With(
-		zap.String("kind", "postgres"),
-		zap.String("uri", conf.StringRedacted()),
-	)
 	db := pg.Connect(&conf.Options)
 	if err := db.Ping(ctx); err != nil {
 		return nil, err
 	}
-	logger.Info("Connected")
+	logger.Info("Connected", zap.String("kind", "postgres"), zap.String("uri", conf.StringRedacted()))
 	return &PostgresDB{db, logger}, nil
 }
 

--- a/ppl/zqd/db/postgresdb/postgresdb.go
+++ b/ppl/zqd/db/postgresdb/postgresdb.go
@@ -8,18 +8,25 @@ import (
 	"github.com/brimsec/zq/ppl/zqd/db/schema"
 	"github.com/brimsec/zq/zqe"
 	"github.com/go-pg/pg/v10"
+	"go.uber.org/zap"
 )
 
 type PostgresDB struct {
-	db *pg.DB
+	db     *pg.DB
+	logger *zap.Logger
 }
 
-func Open(ctx context.Context, conf Config) (*PostgresDB, error) {
+func Open(ctx context.Context, logger *zap.Logger, conf Config) (*PostgresDB, error) {
+	logger = logger.With(
+		zap.String("kind", "postgres"),
+		zap.String("uri", conf.StringRedacted()),
+	)
 	db := pg.Connect(&conf.Options)
 	if err := db.Ping(ctx); err != nil {
 		return nil, err
 	}
-	return &PostgresDB{db}, nil
+	logger.Info("Connected")
+	return &PostgresDB{db, logger}, nil
 }
 
 func (d *PostgresDB) CreateSpace(ctx context.Context, row schema.SpaceRow) error {


### PR DESCRIPTION
Create a named logger for manager, db and core and log when each of these
services has started, along with configuration.

Most important here is the "Connected" log line for the db logger, which prints out a password/username redacted version of the connection url used.

Closes #1947