### PR TITLE
make fuse stable

### DIFF
--- a/proc/fuse/fuser.go
+++ b/proc/fuse/fuser.go
@@ -90,7 +90,7 @@ func (f *Fuser) finished() bool {
 
 func (f *Fuser) finish() error {
 	uber := newSchema()
-	// typeSlots provides a map from a type ID to a slice of integers
+	// typeSlots provides a map from a type to a slice of integers
 	// that represent the column position in the uber schema for each column
 	// of the input record type.
 	f.typeSlots = make(map[zng.Type][]int)

--- a/proc/fuse/fuser.go
+++ b/proc/fuse/fuser.go
@@ -16,13 +16,13 @@ type Fuser struct {
 	zctx        *resolver.Context
 	memMaxBytes int
 
-	nbytes   int
-	recs     []*zng.Record
-	slotByID [][]int
-	slots    []slot
-	spiller  *spill.File
-	types    resolver.Slice
-	uberType *zng.TypeRecord
+	nbytes    int
+	recs      []*zng.Record
+	typeSlots map[zng.Type][]int
+	slots     []slot
+	spiller   *spill.File
+	types     map[zng.Type]int
+	uberType  *zng.TypeRecord
 }
 
 type slot struct {
@@ -34,7 +34,11 @@ type slot struct {
 // their cumulative size (measured in zcode.Bytes length) exceeds memMaxBytes,
 // at which point it buffers them in a temporary file.
 func NewFuser(zctx *resolver.Context, memMaxBytes int) *Fuser {
-	return &Fuser{zctx: zctx, memMaxBytes: memMaxBytes}
+	return &Fuser{
+		zctx:        zctx,
+		memMaxBytes: memMaxBytes,
+		types:       make(map[zng.Type]int),
+	}
 }
 
 // Close removes the receiver's temporary file if it created one.
@@ -50,10 +54,8 @@ func (f *Fuser) Write(rec *zng.Record) error {
 	if f.finished() {
 		panic("fuser: write after read")
 	}
-	id := rec.Type.ID()
-	typ := f.types.Lookup(id)
-	if typ == nil {
-		f.types.Enter(id, rec.Type)
+	if _, ok := f.types[rec.Type]; !ok {
+		f.types[rec.Type] = len(f.types)
 	}
 	if f.spiller != nil {
 		return f.spiller.Write(rec)
@@ -83,19 +85,18 @@ func (f *Fuser) stash(rec *zng.Record) error {
 }
 
 func (f *Fuser) finished() bool {
-	return f.slotByID != nil
+	return f.typeSlots != nil
 }
 
 func (f *Fuser) finish() error {
 	uber := newSchema()
-	// slotByID provides a map from a type ID to a slice of integers
+	// typeSlots provides a map from a type ID to a slice of integers
 	// that represent the column position in the uber schema for each column
 	// of the input record type.
-	f.slotByID = make([][]int, len(f.types))
-	for _, typ := range f.types {
+	f.typeSlots = make(map[zng.Type][]int)
+	for _, typ := range typesInOrder(f.types) {
 		if typ != nil {
-			id := typ.ID()
-			f.slotByID[id] = uber.mixin(zng.AliasedType(typ).(*zng.TypeRecord))
+			f.typeSlots[typ] = uber.mixin(zng.AliasedType(typ).(*zng.TypeRecord))
 		}
 	}
 	var err error
@@ -113,6 +114,17 @@ func (f *Fuser) finish() error {
 	return nil
 }
 
+func typesInOrder(in map[zng.Type]int) []zng.Type {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]zng.Type, len(in))
+	for typ, position := range in {
+		out[position] = typ
+	}
+	return out
+}
+
 // Read returns the next buffered record after transforming it to the unified
 // schema.
 func (f *Fuser) Read() (*zng.Record, error) {
@@ -128,7 +140,7 @@ func (f *Fuser) Read() (*zng.Record, error) {
 	for k := range f.slots {
 		f.slots[k].zv = nil
 	}
-	slotList := f.slotByID[rec.Type.ID()]
+	slotList := f.typeSlots[rec.Type]
 	it := rec.Raw.Iter()
 	for _, slot := range slotList {
 		zv, _, err := it.Next()

--- a/zql/docs/processors/README.md
+++ b/zql/docs/processors/README.md
@@ -216,12 +216,12 @@ zq -f csv 'ts < 1521911721 | fuse' stats.log.gz weird.log.gz
 
 #### Output:
 ```zq-output
-_path,ts,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,name,addl,notice,peer,mem,pkts_proc,bytes_recv,pkts_dropped,pkts_link,pkt_lag,events_proc,events_queued,active_tcp_conns,active_udp_conns,active_icmp_conns,tcp_conns,udp_conns,icmp_conns,timers,active_timers,files,active_files,dns_requests,active_dns_requests,reassem_tcp_size,reassem_file_size,reassem_frag_size,reassem_unknown_size
-stats,2018-03-24T17:15:20.600725Z,,,,,,,,,zeek,74,26,29375,,,,404,11,1,0,0,1,0,0,36,32,0,0,0,0,1528,0,0,0
-weird,2018-03-24T17:15:20.600843Z,C1zOivgBT6dBmknqk,10.47.1.152,49562,23.217.103.245,80,TCP_ack_underflow_or_misorder,,F,zeek,,,,,,,,,,,,,,,,,,,,,,,,
-weird,2018-03-24T17:15:20.608108Z,,,,,,truncated_header,,F,zeek,,,,,,,,,,,,,,,,,,,,,,,,
-weird,2018-03-24T17:15:20.610033Z,C45Ff03lESjMQQQej1,10.47.5.155,40712,91.189.91.23,80,above_hole_data_without_any_acks,,F,zeek,,,,,,,,,,,,,,,,,,,,,,,,
-weird,2018-03-24T17:15:20.742818Z,Cs7J9j2xFQcazrg7Nc,10.47.8.100,5900,10.129.53.65,58485,connection_originator_SYN_ack,,F,zeek,,,,,,,,,,,,,,,,,,,,,,,,
+_path,ts,peer,mem,pkts_proc,bytes_recv,pkts_dropped,pkts_link,pkt_lag,events_proc,events_queued,active_tcp_conns,active_udp_conns,active_icmp_conns,tcp_conns,udp_conns,icmp_conns,timers,active_timers,files,active_files,dns_requests,active_dns_requests,reassem_tcp_size,reassem_file_size,reassem_frag_size,reassem_unknown_size,uid,id.orig_h,id.orig_p,id.resp_h,id.resp_p,name,addl,notice
+stats,2018-03-24T17:15:20.600725Z,zeek,74,26,29375,,,,404,11,1,0,0,1,0,0,36,32,0,0,0,0,1528,0,0,0,,,,,,,,
+weird,2018-03-24T17:15:20.600843Z,zeek,,,,,,,,,,,,,,,,,,,,,,,,,C1zOivgBT6dBmknqk,10.47.1.152,49562,23.217.103.245,80,TCP_ack_underflow_or_misorder,,F
+weird,2018-03-24T17:15:20.608108Z,zeek,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,truncated_header,,F
+weird,2018-03-24T17:15:20.610033Z,zeek,,,,,,,,,,,,,,,,,,,,,,,,,C45Ff03lESjMQQQej1,10.47.5.155,40712,91.189.91.23,80,above_hole_data_without_any_acks,,F
+weird,2018-03-24T17:15:20.742818Z,zeek,,,,,,,,,,,,,,,,,,,,,,,,,Cs7J9j2xFQcazrg7Nc,10.47.8.100,5900,10.129.53.65,58485,connection_originator_SYN_ack,,F
 ```
 
 Other output formats invoked via `zq -f` that benefit greatly from the use of `fuse` include `table` and `zeek`.


### PR DESCRIPTION
This commit changes the fuser so the output type columns of
the union schema are stable.  Previously, the column order
was dependent on the type IDs, which could be non-deterministic
when scanning parallel inputs.  The new code determines the
column order from the order of the types encountered in the
incoming stream.

This fix will address intermittent CI failures due to this indeterminacy.

Fixes #1702 