### PR TITLE
add new command zident for user operations in Auth0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4
 	github.com/peterh/liner v1.1.0
 	github.com/pierrec/lz4/v4 v4.1.0
-	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
+	github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.7.1
 	github.com/segmentio/ksuid v1.0.2
@@ -42,7 +42,7 @@ require (
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
 	golang.org/x/text v0.3.3
-	golang.org/x/tools v0.0.0-20200825202427-b303f430e36d // indirect
+	gopkg.in/auth0.v5 v5.5.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZ
 cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOYc=
 cloud.google.com/go v0.63.0/go.mod h1:GmezbQc7T2snqkEXWfZ0sy0VfkB/ivI2DdtJL2DEmlg=
 cloud.google.com/go v0.64.0/go.mod h1:xfORb36jGvE+6EexW71nMEtL025s3x6xvuYUKM4JLv4=
+cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
@@ -42,6 +43,8 @@ github.com/ClickHouse/clickhouse-go v1.3.12/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhH
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 h1:ygIc8M6trr62pF5DucadTWGdEB4mEyvzi0e2nbcmcyA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/PuerkitoBio/rehttp v1.0.0 h1:aJ7A7YI2lIvOxcJVeUZY4P6R7kKZtLeONjgyKGwOIu8=
+github.com/PuerkitoBio/rehttp v1.0.0/go.mod h1:ItsOiHl4XeMOV3rzbZqQRjLc3QQxbE6391/9iNG7rE8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -59,6 +62,10 @@ github.com/aws/aws-sdk-go v1.30.19 h1:vRwsYgbUvC25Cb3oKXTyTYk3R5n1LRVk8zbvL4inWs
 github.com/aws/aws-sdk-go v1.30.19/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f h1:y06x6vGnFYfXUoVMbrcP1Uzpj4JG01eB5vRps9G8agM=
 github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f/go.mod h1:2stgcRjl6QmW+gU2h5E7BQXg4HU0gzxKWDuT5HviN9s=
+github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
+github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
+github.com/benbjohnson/clock v1.0.3 h1:vkLuvpK4fmtSCuo60+yC63p7y0BmQ8gm5ZXGuBCJyXg=
+github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -109,6 +116,8 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -352,6 +361,8 @@ github.com/pierrec/lz4/v4 v4.1.0 h1:vhiKjm9Npt49Up5EbHg5C/gjum3rWjmcjGnOK+wDeok=
 github.com/pierrec/lz4/v4 v4.1.0/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
+github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23 h1:dofHuld+js7eKSemxqTVIo8yRlpRw+H1SdpzZxWruBc=
+github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -540,6 +551,7 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201029221708-28c70e62bb1d/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -552,6 +564,8 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43 h1:ld7aEMNHoBnnDAX15v1T6z31v8HwR2A9FYOuAhWqkwc=
+golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -705,6 +719,7 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -736,6 +751,7 @@ google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200911024640-645f7a48b24f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201030142918-24207fddd1c3 h1:sg8vLDNIxFPHTchfhH1E3AI32BL3f23oie38xUWnJM8=
 google.golang.org/genproto v0.0.0-20201030142918-24207fddd1c3/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -766,6 +782,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
+gopkg.in/auth0.v5 v5.5.0 h1:MfBLkPKtNUjCvseyiq38uFGgYZC7QwzBA/H6iHOAL08=
+gopkg.in/auth0.v5 v5.5.0/go.mod h1:jVm6ZyPgF3Y1XpY4SPMPQM9NtRl8o3o/e2OuezsX97E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/ppl/cmd/zident/main.go
+++ b/ppl/cmd/zident/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/brimsec/zq/ppl/cmd/zident/root"
+	_ "github.com/brimsec/zq/ppl/cmd/zident/user"
+)
+
+func main() {
+	if _, err := root.Zident.ExecRoot(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}

--- a/ppl/cmd/zident/root/command.go
+++ b/ppl/cmd/zident/root/command.go
@@ -1,0 +1,34 @@
+package root
+
+import (
+	"flag"
+
+	"github.com/mccanne/charm"
+)
+
+var Zident = &charm.Spec{
+	Name:  "zident",
+	Usage: "zident [global options] command [options] [arguments...]",
+	Short: "tenant and user utility",
+	Long: `
+zident is a utility to interact with the systems used for tenant and user
+authentication and authorization in a zqd service instance.
+`,
+	New: New,
+}
+
+type Command struct {
+	charm.Command
+}
+
+func init() {
+	Zident.Add(charm.Help)
+}
+
+func New(_ charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	return &Command{}, nil
+}
+
+func (c *Command) Run(args []string) error {
+	return charm.ErrNoRun
+}

--- a/ppl/cmd/zident/user/new.go
+++ b/ppl/cmd/zident/user/new.go
@@ -1,0 +1,91 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/brimsec/zq/ppl/cmd/zident/root"
+	"github.com/mccanne/charm"
+	"gopkg.in/auth0.v5"
+	"gopkg.in/auth0.v5/management"
+)
+
+var NewUser = &charm.Spec{
+	Name:  "new",
+	Usage: "zident user new",
+	Short: "create new user",
+	Long: `
+Creates a new user in Auth0.
+
+See 'zident help user' for required authentication.
+`,
+	New: NewNewCommand,
+}
+
+type NewCommand struct {
+	*root.Command
+	a0cfg         auth0ClientConfig
+	email         string
+	emailVerified bool
+	tenantID      string
+}
+
+func NewNewCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &NewCommand{Command: parent.(*Command).Command}
+	f.StringVar(&c.email, "email", "", "email address of new user")
+	f.StringVar(&c.tenantID, "tenantid", "", "tenant_id to set instead of creating one")
+	return c, nil
+}
+
+func (c *NewCommand) Run(_ []string) error {
+	if err := c.a0cfg.FromEnv(); err != nil {
+		return err
+	}
+	if c.email == "" {
+		return errors.New("must specify an email address")
+	}
+
+	var tenantID string
+	if c.tenantID != "" {
+		if err := validTenantID(c.tenantID); err != nil {
+			return err
+		}
+		tenantID = c.tenantID
+	} else {
+		tenantID = newTenantID()
+	}
+
+	userID := newUserID()
+
+	m, err := management.New(c.a0cfg.domain.String(),
+		management.WithClientCredentials(c.a0cfg.clientId, c.a0cfg.clientSecret))
+	if err != nil {
+		return err
+	}
+	u := &management.User{
+		Connection: auth0.String(c.a0cfg.connection),
+		Email:      auth0.String(c.email),
+		// We don't send a verification email the users response to the password
+		// reset email will verify their address.
+		VerifyEmail: auth0.Bool(false),
+		Password:    auth0.String(newPassword()),
+		AppMetadata: map[string]interface{}{
+			"brim_tenant_id": tenantID,
+			"brim_user_id":   userID,
+		},
+	}
+	if err := m.User.Create(u, management.Context(context.TODO())); err != nil {
+		return err
+	}
+	// Ensure request password is cleared, in case this user struct is logged.
+	u.Password = nil
+
+	if err := triggerChangePassword(context.TODO(), c.a0cfg, c.email); err != nil {
+		return err
+	}
+
+	fmt.Println("User created")
+	return nil
+}

--- a/ppl/cmd/zident/user/resetpassword.go
+++ b/ppl/cmd/zident/user/resetpassword.go
@@ -1,0 +1,60 @@
+package user
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/brimsec/zq/ppl/cmd/zident/root"
+	"github.com/mccanne/charm"
+	"gopkg.in/auth0.v5/management"
+)
+
+var ResetPassword = &charm.Spec{
+	Name:  "resetpassword",
+	Usage: "zident user [global options] resetpassword",
+	Short: "send change password email for user",
+	Long: `
+Triggers a password reset email for a user.
+
+See 'zident help user' for required authentication.
+`,
+	New: NewResetPasswordCommand,
+}
+
+type ResetPasswordCommand struct {
+	*root.Command
+	a0cfg       auth0ClientConfig
+	searchFlags searchFlags
+}
+
+func NewResetPasswordCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &ResetPasswordCommand{Command: parent.(*Command).Command}
+	c.searchFlags.SetFlags(f)
+	return c, nil
+}
+
+func (c *ResetPasswordCommand) Run(_ []string) error {
+	if err := c.a0cfg.FromEnv(); err != nil {
+		return err
+	}
+
+	m, err := management.New(c.a0cfg.domain.String(),
+		management.WithClientCredentials(c.a0cfg.clientId, c.a0cfg.clientSecret))
+	if err != nil {
+		return err
+	}
+
+	u, err := findUser(context.TODO(), m, c.searchFlags)
+	if err != nil {
+		return err
+	}
+	user := userOutput(u)
+
+	if err := triggerChangePassword(context.TODO(), c.a0cfg, user.Email); err != nil {
+		return err
+	}
+
+	fmt.Println("Password change email triggered")
+	return nil
+}

--- a/ppl/cmd/zident/user/search.go
+++ b/ppl/cmd/zident/user/search.go
@@ -1,0 +1,52 @@
+package user
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/brimsec/zq/ppl/cmd/zident/root"
+	"github.com/mccanne/charm"
+	"gopkg.in/auth0.v5/management"
+)
+
+var Search = &charm.Spec{
+	Name:  "search",
+	Usage: "zident user [global options] search",
+	Short: "search for users",
+	Long: `
+Searches for users in Auth0.
+
+See 'zident help user' for required authentication.
+`,
+	New: NewSearchCommand,
+}
+
+type SearchCommand struct {
+	*root.Command
+	a0cfg       auth0ClientConfig
+	searchFlags searchFlags
+}
+
+func NewSearchCommand(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &SearchCommand{Command: parent.(*Command).Command}
+	c.searchFlags.SetFlags(f)
+	return c, nil
+}
+
+func (c *SearchCommand) Run(_ []string) error {
+	if err := c.a0cfg.FromEnv(); err != nil {
+		return err
+	}
+
+	m, err := management.New(c.a0cfg.domain.String(),
+		management.WithClientCredentials(c.a0cfg.clientId, c.a0cfg.clientSecret))
+	if err != nil {
+		return err
+	}
+
+	return streamUsers(context.TODO(), m, c.searchFlags, true, func(user *management.User) error {
+		fmt.Printf("%+v\n", userOutput(user))
+		return nil
+	})
+}

--- a/ppl/cmd/zident/user/user.go
+++ b/ppl/cmd/zident/user/user.go
@@ -1,0 +1,232 @@
+package user
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/brimsec/zq/ppl/cmd/zident/root"
+	"github.com/go-resty/resty/v2"
+	"github.com/mccanne/charm"
+	"github.com/segmentio/ksuid"
+	"go.uber.org/multierr"
+	"gopkg.in/auth0.v5/management"
+)
+
+const auth0DefaultConnection = "Username-Password-Authentication"
+
+type auth0ClientConfig struct {
+	clientId     string
+	clientSecret string
+	connection   string
+	domain       url.URL
+}
+
+func (c *auth0ClientConfig) FromEnv() error {
+	var err error
+	if c.clientId = os.Getenv("AUTH0_CLIENT_ID"); c.clientId == "" {
+		err = multierr.Append(err, errors.New("AUTH0_CLIENT_ID not set"))
+	}
+	if c.clientSecret = os.Getenv("AUTH0_CLIENT_SECRET"); c.clientSecret == "" {
+		err = multierr.Append(err, errors.New("AUTH0_CLIENT_SECRET not set"))
+	}
+	if c.connection = os.Getenv("AUTH0_CONNECTION"); c.connection == "" {
+		err = multierr.Append(err, errors.New("AUTH0_CONNECTION not set"))
+	}
+	domain := os.Getenv("AUTH0_DOMAIN")
+	if domain == "" {
+		err = multierr.Append(err, errors.New("AUTH0_DOMAIN not set"))
+	} else {
+		u, err := url.Parse(domain)
+		if err != nil {
+			err = multierr.Append(err, errors.New("AUTH0_DOMAIN is not a URL"))
+		} else {
+			c.domain = *u
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("unable to configure auth0 client: %w", err)
+	}
+	return nil
+}
+
+type searchFlags struct {
+	email    string
+	tenantID string
+	userID   string
+}
+
+func (f *searchFlags) SetFlags(fs *flag.FlagSet) {
+	fs.StringVar(&f.email, "email", "", "search by email address")
+	fs.StringVar(&f.tenantID, "tenantid", "", "search by tenant ID")
+	fs.StringVar(&f.userID, "userid", "", "search by user ID")
+}
+
+func findUser(ctx context.Context, m *management.Management, f searchFlags) (*management.User, error) {
+	var user *management.User
+	if err := streamUsers(ctx, m, f, false, func(u *management.User) error {
+		user = u
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, errors.New("no user found")
+	}
+	return user, nil
+}
+
+func streamUsers(ctx context.Context, m *management.Management, f searchFlags, allowMultiple bool, fn func(*management.User) error) error {
+	// Auth0 user search syntax documented here:
+	// https://auth0.com/docs/users/user-search/user-search-query-syntax
+	var sstr []string
+	if f.email != "" {
+		sstr = append(sstr, fmt.Sprintf(`email:%s`, f.email))
+	}
+	if f.userID != "" {
+		sstr = append(sstr, fmt.Sprintf(`app_metadata.brim_user_id:%s`, f.userID))
+	}
+	if f.tenantID != "" {
+		sstr = append(sstr, fmt.Sprintf(`app_metadata.brim_tenant_id:%s`, f.tenantID))
+	}
+	query := management.Query(strings.Join(sstr, " AND "))
+
+	var page int
+	for {
+		res, err := m.User.Search(query,
+			management.Context(ctx),
+			management.Page(page))
+		if err != nil {
+			return err
+		}
+		if !allowMultiple && (len(res.Users) > 1 || res.HasNext()) {
+			return errors.New("multiple users returned for search")
+		}
+		for _, user := range res.Users {
+			if err := fn(user); err != nil {
+				return err
+			}
+		}
+		if !res.HasNext() {
+			break
+		}
+		page++
+	}
+	return nil
+}
+
+type userOutputFields struct {
+	Email    string `json:"email"`
+	TenantID string `json:"tenant_id"`
+	UserID   string `json:"user_id"`
+}
+
+func userOutput(u *management.User) userOutputFields {
+	var email string
+	if u.Email != nil {
+		email = *u.Email
+	}
+	var userID string
+	if s, ok := u.AppMetadata["brim_user_id"].(string); ok {
+		userID = s
+	}
+	var tenantID string
+	if s, ok := u.AppMetadata["brim_tenant_id"].(string); ok {
+		tenantID = s
+	}
+	return userOutputFields{
+		Email:    email,
+		UserID:   userID,
+		TenantID: tenantID,
+	}
+}
+
+func triggerChangePassword(ctx context.Context, a0cfg auth0ClientConfig, email string) error {
+	type changePassword struct {
+		Email      string `json:"email"`
+		ClientID   string `json:"client_id"`
+		Connection string `json:"connection"`
+	}
+	resp, err := resty.New().R().
+		SetContext(ctx).
+		SetBody(changePassword{
+			Email:      email,
+			ClientID:   a0cfg.clientId,
+			Connection: a0cfg.connection,
+		}).
+		Post(a0cfg.domain.String() + "/dbconnections/change_password")
+	if err != nil {
+		return err
+	}
+	if !resp.IsSuccess() {
+		return fmt.Errorf("failed to issue change password request: %v %v", resp.StatusCode(), string(resp.Body()))
+	}
+	return nil
+}
+
+func newTenantID() string {
+	return "tenant_" + ksuid.New().String()
+}
+
+func validTenantID(s string) error {
+	if !strings.HasPrefix(s, "tenant_") || len(s) != 34 {
+		return errors.New("tenant id must start with \"tenant_\" and be 34 characters long")
+	}
+	return nil
+}
+
+func newUserID() string {
+	return "user_" + ksuid.New().String()
+}
+
+func newPassword() string {
+	buf := make([]byte, 16)
+	_, err := rand.Read(buf)
+	if err != nil {
+		panic(err)
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+var User = &charm.Spec{
+	Name:  "user",
+	Usage: "zident [global options] user command [options] [arguments...]",
+	Short: "Create or edit users for a zqd service.",
+	Long: `
+zident user commands are used to create or edit user information in an Auth0 
+tenant that will be used by a zqd service. The following environment variables
+must be set with correct values for the Auth0 tenant and client in order to 
+authenticate with the Auth0 management API: AUTH0_CLIENT_ID,
+AUTH0_CLIENT_SECRET, AUTH0_DOMAIN, and AUTH0_CONNECTION.
+`,
+	New: New,
+}
+
+type Command struct {
+	*root.Command
+}
+
+func init() {
+	User.Add(NewUser)
+	User.Add(ResetPassword)
+	User.Add(Search)
+	root.Zident.Add(User)
+}
+
+func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &Command{Command: parent.(*root.Command)}
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	if len(args) == 0 {
+		return root.Zident.Exec(c, []string{"help", "user"})
+	}
+	return charm.ErrNoRun
+}


### PR DESCRIPTION
This adds a new command, zident, for user and tenant administration.
This initial checkin supports user operations, including creating a new
user, triggering a password reset for a user, and searching for users
with an email, user id, or tenant id.