### PR TITLE
Replace zbuf.ReadBatch with zbuf.NewPuller

### DIFF
--- a/driver/parallel_test.go
+++ b/driver/parallel_test.go
@@ -145,7 +145,7 @@ type noEndScanner struct {
 
 func (rp *noEndScanner) Pull() (zbuf.Batch, error) {
 	r := tzngio.NewReader(strings.NewReader(rp.input), rp.zctx)
-	return zbuf.ReadBatch(r, 1)
+	return zbuf.NewPuller(r, 1).Pull()
 }
 
 func (rp *noEndScanner) Stats() *zbuf.ScannerStats {

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -34,7 +34,7 @@ func runCasesHelper(t *testing.T, tzng string, cases []testcase, expectBufferFil
 	t.Helper()
 
 	zctx := resolver.NewContext()
-	batch, err := zbuf.ReadBatch(tzngio.NewReader(strings.NewReader(tzng), zctx), 2)
+	batch, err := zbuf.NewPuller(tzngio.NewReader(strings.NewReader(tzng), zctx), 2).Pull()
 	require.NoError(t, err, "tzng: %q", tzng)
 	require.Exactly(t, 1, batch.Length(), "tzng: %q", tzng)
 	rec := batch.Index(0)

--- a/ppl/zqd/search/output.go
+++ b/ppl/zqd/search/output.go
@@ -25,9 +25,10 @@ func SendFromReader(out Output, r zbuf.Reader) (err error) {
 		err = out.End(&api.TaskEnd{"TaskEnd", 0, nil})
 	}()
 
+	p := zbuf.NewPuller(r, DefaultMTU)
 	for {
 		var b zbuf.Batch
-		if b, err = zbuf.ReadBatch(r, DefaultMTU); err != nil {
+		if b, err = p.Pull(); err != nil {
 			return
 		}
 		if b == nil {

--- a/ppl/zqd/ztests/zapi-postpath-errors.yaml
+++ b/ppl/zqd/ztests/zapi-postpath-errors.yaml
@@ -1,0 +1,22 @@
+script: |
+  source services.sh
+  zapi -h $ZQD_HOST new test
+  zapi -h $ZQD_HOST -s test postpath bad.tzng
+  zapi -h $ZQD_HOST -s test get -f zson "count()" > out.zson
+
+inputs:
+  - name: services.sh
+    source: services.sh
+  - name: bad.tzng
+    data: |
+      #0:record[ip:string]
+      0:[1.1.1.1;]
+      0:[1.1.1.1;
+      0:[1.1.1.1;]
+
+outputs:
+  - name: out.zson
+    data: |
+      {
+          count: 1 (uint64)
+      } (=0)

--- a/proc/sort/sort.go
+++ b/proc/sort/sort.go
@@ -77,9 +77,10 @@ func (p *Proc) sortLoop() {
 	}
 	defer runManager.Cleanup()
 	p.warnAboutUnseenFields()
+	puller := zbuf.NewPuller(runManager, 100)
 	for p.pctx.Err() == nil {
 		// Reading from runManager merges the runs.
-		b, err := zbuf.ReadBatch(runManager, 100)
+		b, err := puller.Pull()
 		p.sendResult(b, err)
 		if b == nil || err != nil {
 			return


### PR DESCRIPTION
zbuf.ReadBatch can signal EOS in two ways: by returning a nil batch and
nil error or a short batch and nil error.  This undocumented behavior
leads to a bug in zbuf.Scanner.Pull, which does not check for a short
batch.  Fix the bug by replacing ReadBatch with zbuf.NewPuller.

Alternative to #1894 (from which `ppl/zqd/ztests/zapi-postpath-errors.yaml` is copied).