### PR TITLE
allow greek mu in zson primitive

### DIFF
--- a/zson/lexer.go
+++ b/zson/lexer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/brimsec/zq/zng"
 )
 
-const primitiveRE = `^(([0-9a-fA-Fx_\$\-\+:eEnumsh./TZ]+)|true|false|null)`
+const primitiveRE = `^(([0-9a-fA-Fx_\$\-\+:eEnumsh./TZµ]+)|true|false|null)`
 const indentationRE = `\n\s*`
 
 type Lexer struct {

--- a/zson/ztests/mu.yaml
+++ b/zson/ztests/mu.yaml
@@ -1,0 +1,12 @@
+script: |
+  zq -f zson -i zson -pretty=0 in.zson
+
+inputs:
+  - name: in.zson
+    data: |
+      { d: 486µs (duration) } (=0)
+
+outputs:
+  - name: stdout
+    data: |
+      {d: 486µs (duration)} (=0)


### PR DESCRIPTION
This commit changes the regexp in the zson scanner to accept
the greek letter mu so that µs will be accepted as a duration.

Fixes #1966 