### PR TITLE
Enhanced compaction logging

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - compaction-logging
 
 jobs:
   pre-clean:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -117,9 +117,9 @@ jobs:
         run: |
           set -x
           ZQD_DATA_URI=s3://zq-ci-test/$(date +%y-%m-%d).${{ github.run_number }}
-          kubectl logs -c zqd -l app.kubernetes.io/instance=recruiter > testlog/recruiter.log
-          kubectl logs -c zqd -l app.kubernetes.io/instance=root > testlog/root.log
-          kubectl logs -c zqd -l app.kubernetes.io/instance=worker > testlog/worker.log
+          kubectl logs --tail -1 -c zqd -l app.kubernetes.io/instance=recruiter > testlog/recruiter.log
+          kubectl logs --tail -1 -c zqd -l app.kubernetes.io/instance=root > testlog/root.log
+          kubectl logs --tail -1 -c zqd -l app.kubernetes.io/instance=worker > testlog/worker.log
           kubectl delete ns ci-${{ github.run_number }}
       - name: Save logs as artifact
         if: ${{ always() }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - compaction-logging
 
 jobs:
   pre-clean:

--- a/ppl/archive/chunk/chunk.go
+++ b/ppl/archive/chunk/chunk.go
@@ -79,6 +79,15 @@ func (c Chunk) Path() iosrc.URI {
 	return c.Dir.AppendPath(c.FileName())
 }
 
+// MaskedPaths returns a list of the iosrc.URIs of chunks that this chunk masks.
+func (c Chunk) MaskedPaths() []iosrc.URI {
+	paths := make([]iosrc.URI, len(c.Masks))
+	for i, m := range c.Masks {
+		paths[i] = ChunkPath(c.Dir, m)
+	}
+	return paths
+}
+
 func (c Chunk) SeekIndexPath() iosrc.URI {
 	return chunkSeekIndexPath(c.Dir, c.Id)
 }

--- a/ppl/cmd/zar/compact/command.go
+++ b/ppl/cmd/zar/compact/command.go
@@ -44,11 +44,11 @@ func (c *Command) Run(args []string) error {
 		return err
 	}
 	ctx := context.TODO()
-	if err := archive.Compact(ctx, ark); err != nil {
+	if err := archive.Compact(ctx, ark, nil); err != nil {
 		return err
 	}
 	if c.purge {
-		return archive.Purge(ctx, ark)
+		return archive.Purge(ctx, ark, nil)
 	}
 	return nil
 }

--- a/ppl/zqd/apiserver/compactor.go
+++ b/ppl/zqd/apiserver/compactor.go
@@ -95,7 +95,7 @@ func (c *compactor) compact(ctx context.Context, id api.SpaceID) {
 	}
 	logger.Info("Compaction started")
 	start := time.Now()
-	if err := store.Compact(ctx); err != nil {
+	if err := store.Compact(ctx, logger); err != nil {
 		if err == context.Canceled {
 			logger.Info("Compaction canceled")
 		} else {

--- a/ppl/zqd/storage/archivestore/archivestore.go
+++ b/ppl/zqd/storage/archivestore/archivestore.go
@@ -14,6 +14,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
+	"go.uber.org/zap"
 )
 
 func Load(ctx context.Context, path iosrc.URI, notifier WriteNotifier, cfg *api.ArchiveConfig) (*Storage, error) {
@@ -148,9 +149,9 @@ func (s *Storage) ArchiveStat(ctx context.Context, zctx *resolver.Context) (zbuf
 	return archive.Stat(ctx, zctx, s.ark)
 }
 
-func (s *Storage) Compact(ctx context.Context) error {
-	if err := archive.Compact(ctx, s.ark); err != nil {
+func (s *Storage) Compact(ctx context.Context, logger *zap.Logger) error {
+	if err := archive.Compact(ctx, s.ark, logger); err != nil {
 		return err
 	}
-	return archive.Purge(ctx, s.ark)
+	return archive.Purge(ctx, s.ark, logger)
 }


### PR DESCRIPTION
#1960 made it clear that more logging is needed around
compaction/purge to diagnose the error. Add logs that indicate the chunks
created/masked during compaction and the chunks removed during purge.