### PR TITLE
zqd listen: call logger.Sync on exit

### DIFF
--- a/ppl/cmd/zqd/listen/command.go
+++ b/ppl/cmd/zqd/listen/command.go
@@ -94,6 +94,7 @@ func (c *Command) Run(args []string) error {
 	if err := c.init(); err != nil {
 		return err
 	}
+	defer c.logger.Sync()
 	openFilesLimit, err := rlimit.RaiseOpenFilesLimit()
 	if err != nil {
 		c.logger.Warn("Raising open files limit failed", zap.Error(err))


### PR DESCRIPTION
According to the zap docs for logger.Sync:

Sync calls the underlying Core's Sync method, flushing any buffered log
entries. Applications should take care to call Sync before exiting.

https://pkg.go.dev/go.uber.org/zap#Logger.Sync

Do this in the listen command for zqd.