### PR TITLE
remove redundant ordered merging during archive pcap ingest

### DIFF
--- a/ppl/zqd/ingest/archivepcap.go
+++ b/ppl/zqd/ingest/archivepcap.go
@@ -110,12 +110,8 @@ func (p *archivePcapOp) run(ctx context.Context) error {
 		return err
 	}
 	defer zbuf.CloseReaders(zreaders)
-	merger, err := zbuf.MergeReadersByTsAsReader(ctx, zreaders, p.store.NativeOrder())
-	if err != nil {
-		p.writer.Close()
-		return err
-	}
-	if err := zbuf.CopyWithContext(ctx, p.writer, merger); err != nil {
+	combiner := zbuf.NewCombiner(ctx, zreaders)
+	if err := zbuf.CopyWithContext(ctx, p.writer, combiner); err != nil {
 		p.writer.Close()
 		return err
 	}

--- a/zbuf/combiner.go
+++ b/zbuf/combiner.go
@@ -1,0 +1,85 @@
+package zbuf
+
+import (
+	"context"
+	"sync"
+
+	"github.com/brimsec/zq/zng"
+)
+
+// A Combiner is a Reader that returns records by reading from multiple Readers.
+type Combiner struct {
+	cancel  context.CancelFunc
+	ctx     context.Context
+	done    []bool
+	once    sync.Once
+	readers []Reader
+	results chan combinerResult
+}
+
+func NewCombiner(ctx context.Context, readers []Reader) *Combiner {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Combiner{
+		cancel:  cancel,
+		ctx:     ctx,
+		done:    make([]bool, len(readers)),
+		readers: readers,
+		results: make(chan combinerResult),
+	}
+}
+
+type combinerResult struct {
+	err error
+	idx int
+	rec *zng.Record
+}
+
+func (c *Combiner) run() {
+	for i := range c.readers {
+		idx := i
+		go func() {
+			for {
+				rec, err := c.readers[idx].Read()
+				select {
+				case c.results <- combinerResult{err, idx, rec}:
+					if rec == nil || err != nil {
+						return
+					}
+				case <-c.ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+}
+
+func (c *Combiner) finished() bool {
+	for i := range c.done {
+		if !c.done[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (c *Combiner) Read() (*zng.Record, error) {
+	c.once.Do(c.run)
+	for {
+		select {
+		case r := <-c.results:
+			if r.err != nil {
+				c.cancel()
+				return nil, r.err
+			}
+			if r.rec != nil {
+				return r.rec, nil
+			}
+			c.done[r.idx] = true
+			if c.finished() {
+				return nil, nil
+			}
+		case <-c.ctx.Done():
+			return nil, c.ctx.Err()
+		}
+	}
+}

--- a/zbuf/combiner.go
+++ b/zbuf/combiner.go
@@ -76,6 +76,7 @@ func (c *Combiner) Read() (*zng.Record, error) {
 			}
 			c.done[r.idx] = true
 			if c.finished() {
+				c.cancel()
 				return nil, nil
 			}
 		case <-c.ctx.Done():


### PR DESCRIPTION
We sort data during the Write calls to archive.Writer, so an ordered
merge beforehand is unnecessary. Additionally, since the underlying
streams of records from the zeek and suricata analyzers are not
necessarily in order, it can cause records to not appear progressively
during pcap ingest (#1971).
