### PR TITLE
improve errors on failed metadata read/write

### DIFF
--- a/ppl/archive/chunk/writer.go
+++ b/ppl/archive/chunk/writer.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/brimsec/zq/pkg/bufwriter"
@@ -146,9 +147,10 @@ func (cw *Writer) CloseWithTs(ctx context.Context, firstTs, lastTs nano.Ts) erro
 		Masks:       cw.masks,
 		Size:        cw.dataFileWriter.Position(),
 	}
-	if err := metadata.Write(ctx, MetadataPath(cw.dir, cw.id), cw.order); err != nil {
+	mdPath := MetadataPath(cw.dir, cw.id)
+	if err := metadata.Write(ctx, mdPath, cw.order); err != nil {
 		cw.Abort()
-		return err
+		return fmt.Errorf("failed to write chunk metadata to %v: %w", mdPath, err)
 	}
 	if err := cw.seekIndex.Close(); err != nil {
 		cw.Abort()

--- a/ppl/archive/walk.go
+++ b/ppl/archive/walk.go
@@ -117,12 +117,13 @@ func tsDirEntriesToChunks(ctx context.Context, ark *Archive, filterSpan nano.Spa
 			continue
 		}
 		dir := tsDir.path(ark)
-		md, err := chunk.ReadMetadata(ctx, chunk.MetadataPath(dir, id), ark.DataOrder)
+		mdPath := chunk.MetadataPath(dir, id)
+		md, err := chunk.ReadMetadata(ctx, mdPath, ark.DataOrder)
 		if err != nil {
 			if zqe.IsNotFound(err) {
 				continue
 			}
-			return nil, err
+			return nil, fmt.Errorf("failed to read chunk metadata from %v: %w", mdPath, err)
 		}
 		chunk := md.Chunk(dir, id)
 		if !filterSpan.Overlaps(chunk.Span()) {


### PR DESCRIPTION
Ensure that errors on the main read/write paths for chunk metadata include the uri of the metadata location.
