### PR TITLE
Notify slack when master workflow fails

### DIFF
--- a/.github/workflows/notify-master-failure.yml
+++ b/.github/workflows/notify-master-failure.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Inform Slack users at Brim HQ of the new artifact
+      - name: Notify Brim HQ of failure on master
         uses: tiloio/slack-webhook-action@v1.1.2
         with:
           slack_web_hook_url: ${{ secrets.SLACK_WEBHOOK_BRIMLABS_TEST }}

--- a/.github/workflows/notify-master-failure.yml
+++ b/.github/workflows/notify-master-failure.yml
@@ -1,0 +1,25 @@
+name: 'Notify master failure'
+
+on:
+  workflow_run:
+    branches: 
+      - master
+    workflows:
+      - '**'
+    types:
+      - completed
+
+jobs:
+  slackNotify:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inform Slack users at Brim HQ of the new artifact
+        uses: tiloio/slack-webhook-action@v1.1.2
+        with:
+          slack_web_hook_url: ${{ secrets.SLACK_WEBHOOK_BRIMLABS_TEST }}
+          slack_json: |
+            {
+              "username": "github-actions",
+              "text": "Workflow \"${{ github.event.workflow_run.name }}\" failed on master.\n${{ github.event.workflow_run.html_url }}"
+            }  


### PR DESCRIPTION
Add 'Notify master failure' github action which is triggered whenever
a workflow_run on branch master is completed. If the workflow failed the action
will notify the BrimHQ slack of the failure.

Closes #1963