### PR TITLE
zqd logger: Stacktrace on warn and up

### DIFF
--- a/ppl/cmd/zqd/listen/command.go
+++ b/ppl/cmd/zqd/listen/command.go
@@ -262,9 +262,9 @@ func (c *Command) initLogger() error {
 	if err != nil {
 		return err
 	}
+	opts := []zap.Option{zap.AddStacktrace(zapcore.WarnLevel)}
 	// If the development mode is on, calls to logger.DPanic will cause a panic
 	// whereas in production would result in an error.
-	var opts []zap.Option
 	if c.devMode {
 		opts = append(opts, zap.Development())
 	}


### PR DESCRIPTION
Currently the production/default logging config only prints Stacktraces on
error level log messages. Change this so Stacktraces are printed on warn level
as well by default.

Refers to #1989