### PR TITLE
Listen on 127.0.0.1 in pkg/httpd tests

### DIFF
--- a/pkg/httpd/server_test.go
+++ b/pkg/httpd/server_test.go
@@ -21,7 +21,7 @@ func TestRequestContextClosure(t *testing.T) {
 		<-ctx.Done()
 		errCh <- ctx.Err()
 	})
-	srv := httpd.New("", h)
+	srv := httpd.New("127.0.0.1:", h)
 	ctx, cancel := context.WithCancel(context.Background())
 	require.NoError(t, srv.Start(ctx))
 	res, err := http.Get(fmt.Sprintf("http://%s/", srv.Addr()))
@@ -47,7 +47,7 @@ func TestDeadlineExceeded(t *testing.T) {
 		time.Sleep(time.Second * 5) // Essentially sleep forever.
 
 	})
-	srv := httpd.New("", h)
+	srv := httpd.New("127.0.0.1:", h)
 	ctx, cancel := context.WithCancel(context.Background())
 	require.NoError(t, srv.Start(ctx))
 	_, err := http.Get(fmt.Sprintf("http://%s/", srv.Addr()))


### PR DESCRIPTION
On macOS, if the firewall is enabled, running the pkg/httpd tests
triggers a "Do you want the application “httpd.test” to accept incoming
network connections?" dialog because the tests listen on 0.0.0.0.
Stifle the dialog by listening on 127.0.0.1 instead.