### PR TITLE
Propagate request ID

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,15 @@ import (
 	"github.com/brimsec/zq/zio/ndjsonio"
 	"github.com/brimsec/zq/zio/zjsonio"
 )
+
+const RequestIDHeader = "X-Request-ID"
+
+func RequestIDFromContext(ctx context.Context) string {
+	if v := ctx.Value(RequestIDHeader); v != nil {
+		return v.(string)
+	}
+	return ""
+}
 
 type Error struct {
 	Type    string      `json:"type"`

--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -134,7 +134,11 @@ func (c *Connection) SetURL(u string) {
 }
 
 func (c *Connection) Request(ctx context.Context) *resty.Request {
-	return c.client.R().SetContext(ctx)
+	req := c.client.R().SetContext(ctx)
+	if requestID := api.RequestIDFromContext(ctx); requestID != "" {
+		req = req.SetHeader(api.RequestIDHeader, requestID)
+	}
+	return req
 }
 
 // Ping checks to see if the server and measure the time it takes to

--- a/ppl/zqd/auth.go
+++ b/ppl/zqd/auth.go
@@ -119,7 +119,7 @@ func newAuthenticator(ctx context.Context, logger *zap.Logger, registerer promet
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, errstr string) {
 			unauthorized.Inc()
 			logger.Info("unauthorized request",
-				zap.String("request_id", getRequestID(r.Context())),
+				zap.String("request_id", api.RequestIDFromContext(r.Context())),
 				zap.String("error", errstr))
 			http.Error(w, errstr, http.StatusUnauthorized)
 		},

--- a/ppl/zqd/core.go
+++ b/ppl/zqd/core.go
@@ -245,7 +245,7 @@ func (c *Core) nextTaskID() int64 {
 }
 
 func (c *Core) requestLogger(r *http.Request) *zap.Logger {
-	return c.logger.With(zap.String("request_id", getRequestID(r.Context())))
+	return c.logger.With(zap.String("request_id", api.RequestIDFromContext(r.Context())))
 }
 
 func (c *Core) WorkerRegistration(ctx context.Context, srvAddr string, conf worker.WorkerConfig) error {

--- a/ppl/zqd/handlers_test.go
+++ b/ppl/zqd/handlers_test.go
@@ -395,8 +395,8 @@ func TestRequestID(t *testing.T) {
 		require.NoError(t, err)
 		res2, err := conn.Do(ctx, "GET", "/space", nil)
 		require.NoError(t, err)
-		assert.Equal(t, "1", res1.Header().Get("X-Request-ID"))
-		assert.Equal(t, "2", res2.Header().Get("X-Request-ID"))
+		assert.NotEqual(t, "", res1.Header().Get("X-Request-ID"))
+		assert.NotEqual(t, "", res2.Header().Get("X-Request-ID"))
 	})
 	t.Run("PropagatesID", func(t *testing.T) {
 		_, conn := newCore(t)


### PR DESCRIPTION
If the requestID is set in a passed context, used the requestID to set the
X-Request-ID header for any client requests made.

Also:
- In order to avoid requestID collisions in clustered environments, use ksuid
  to create unique request IDs instead of increasing ints.