### PR TITLE
Use postpath so zqd will pull from S3 URL

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -99,7 +99,7 @@ jobs:
           time zapi ls
           time zapi new -k archivestore -d $ZQD_DATA_URI $SPACE
           # Post an archive of about 1.6 GB to run test queries.
-          time zapi -s $SPACE post s3://brim-sampledata/wrccdc/zeek-logs/files.log.gz
+          time zapi -s $SPACE postpath s3://brim-sampledata/wrccdc/zeek-logs/files.log.gz
           # There should be 4 workers running now.
           [[ 4 == $(curl http://localhost:8020/recruiter/listfree | jq -r ".workers | length") ]]
           mkdir testlog


### PR DESCRIPTION
I was mimicking the `eks-test-zapi-1` steps in `cd.yaml` in my local testing and at first didn't notice the use of `post` instead of `postpath`. Since `post` is a "streaming" approach, invoking it with an S3 URL has the side effect of pulling the log data down from S3 to the client and then streaming it back up (slow!), whereas `postpath` smuggles the S3 URL to `zqd` and lets it do the download itself (locally/faster).

When I'm tunneled into the cluster, this has a significant impact on the time to post the logs. Repro is with cluster at `zq` commit `7d3f886c` and `zapi` commit `b928e539`.

```
$ zapi ls
Handling connection for 9867
no spaces exist

$ zapi new -k archivestore -d $ZQD_DATA_URI $SPACE
Handling connection for 9867
wrccdc: space created

$ time zapi -s $SPACE post s3://brim-sampledata/wrccdc/zeek-logs/files.log.gz
  0.0% 0B/849.9MB
posted 849.9MB in 6m56.221791628s

real	6m56.978s
user	0m5.719s
sys	0m8.706s

$ zapi rm $SPACE
Handling connection for 9867
wrccdc: space removed

$ zapi new -k archivestore -d $ZQD_DATA_URI $SPACE
Handling connection for 9867
wrccdc: space created

$ time zapi -s $SPACE postpath s3://brim-sampledata/wrccdc/zeek-logs/files.log.gz
posting...
100.0% 849.9MB/849.9MB
posted 849.9MB in 2m16.575776274s

real	2m16.842s
user	0m0.044s
sys	0m0.048s
```
