### PR TITLE
Remove dataSrc from Archive

### DIFF
--- a/ppl/archive/schema.go
+++ b/ppl/archive/schema.go
@@ -95,7 +95,6 @@ type Archive struct {
 	DataOrder        zbuf.Order
 	LogSizeThreshold int64
 	LogFilter        []ksuid.KSUID
-	dataSrc          iosrc.Source
 }
 
 func (ark *Archive) metaWrite() error {
@@ -137,8 +136,7 @@ func (ark *Archive) ReadDefinitions(ctx context.Context) (index.Definitions, err
 }
 
 type OpenOptions struct {
-	LogFilter  []string
-	DataSource iosrc.Source
+	LogFilter []string
 }
 
 func OpenArchive(rpath string, oo *OpenOptions) (*Archive, error) {
@@ -173,13 +171,6 @@ func openArchive(ctx context.Context, root iosrc.URI, oo *OpenOptions) (*Archive
 		Root:             root,
 	}
 
-	if oo != nil && oo.DataSource != nil {
-		ark.dataSrc = oo.DataSource
-	} else {
-		if ark.dataSrc, err = iosrc.GetSource(dpuri); err != nil {
-			return nil, err
-		}
-	}
 	if oo != nil {
 		for _, l := range oo.LogFilter {
 			_, id, ok := chunk.FileMatch(l)

--- a/ppl/archive/walk.go
+++ b/ppl/archive/walk.go
@@ -156,7 +156,7 @@ func Walk(ctx context.Context, ark *Archive, v Visitor) error {
 // each such directory and all of its contents.
 func RmDirs(ctx context.Context, ark *Archive) error {
 	return Walk(ctx, ark, func(chunk chunk.Chunk) error {
-		return ark.dataSrc.RemoveAll(ctx, chunk.ZarDir())
+		return iosrc.RemoveAll(ctx, chunk.ZarDir())
 	})
 }
 


### PR DESCRIPTION
Was not really being used. The convention is to call iosrc on the uri directly.