### PR TITLE
Explicitly declare FileKind enum type

### DIFF
--- a/ppl/archive/chunk/chunk.go
+++ b/ppl/archive/chunk/chunk.go
@@ -19,9 +19,9 @@ type FileKind string
 
 const (
 	FileKindUnknown  FileKind = ""
-	FileKindData              = "d"
-	FileKindMetadata          = "m"
-	FileKindSeek              = "ts"
+	FileKindData     FileKind = "d"
+	FileKindMetadata FileKind = "m"
+	FileKindSeek     FileKind = "ts"
 )
 
 var fileRegex = regexp.MustCompile(`(d|m)-([0-9A-Za-z]{27}).zng$`)


### PR DESCRIPTION
The pattern where the go compiler infers the type for all members of a const
declaration group from the first declaration's type only works when using iota.
Explictly declare the type for all FileKind enums.