### PR TITLE
seekindex test: Remove sort ascending

### DIFF
--- a/ppl/archive/archive_test.go
+++ b/ppl/archive/archive_test.go
@@ -160,15 +160,12 @@ func TestSeekIndex(t *testing.T) {
 	defer func() {
 		ImportStreamRecordsMax = orig
 	}()
-	createArchiveSpace(t, datapath, babble, &CreateOptions{
-		// Must use SortAscending: true until zq#1329 is addressed.
-		SortAscending: true,
-	})
+	createArchiveSpace(t, datapath, babble, nil)
 	_, err = OpenArchive(datapath, &OpenOptions{})
 	require.NoError(t, err)
 
 	first1 := nano.Ts(1587508830068523240)
-	var idxUri iosrc.URI
+	var idxURI iosrc.URI
 	err = filepath.Walk(datapath, func(p string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -184,13 +181,13 @@ func TestSeekIndex(t *testing.T) {
 				return err
 			}
 			if chunk.First == first1 {
-				idxUri = chunk.SeekIndexPath()
+				idxURI = chunk.SeekIndexPath()
 			}
 		}
 		return nil
 	})
 	require.NoError(t, err)
-	finder, err := microindex.NewFinder(context.Background(), resolver.NewContext(), idxUri)
+	finder, err := microindex.NewFinder(context.Background(), resolver.NewContext(), idxURI)
 	require.NoError(t, err)
 	keys, err := finder.ParseKeys("1587508851")
 	require.NoError(t, err)

--- a/ppl/archive/archive_test.go
+++ b/ppl/archive/archive_test.go
@@ -151,9 +151,7 @@ func TestOpenOptions(t *testing.T) {
 }
 
 func TestSeekIndex(t *testing.T) {
-	datapath, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(datapath)
+	datapath := t.TempDir()
 
 	orig := ImportStreamRecordsMax
 	ImportStreamRecordsMax = 1
@@ -161,10 +159,10 @@ func TestSeekIndex(t *testing.T) {
 		ImportStreamRecordsMax = orig
 	}()
 	createArchiveSpace(t, datapath, babble, nil)
-	_, err = OpenArchive(datapath, &OpenOptions{})
+	_, err := OpenArchive(datapath, &OpenOptions{})
 	require.NoError(t, err)
 
-	first1 := nano.Ts(1587508830068523240)
+	first1 := nano.Ts(1587513592062544400)
 	var idxURI iosrc.URI
 	err = filepath.Walk(datapath, func(p string, fi os.FileInfo, err error) error {
 		if err != nil {
@@ -176,7 +174,7 @@ func TestSeekIndex(t *testing.T) {
 				return err
 			}
 			uri.Path = path.Dir(uri.Path)
-			chunk, err := chunk.Open(context.Background(), uri, id, zbuf.OrderAsc)
+			chunk, err := chunk.Open(context.Background(), uri, id, zbuf.OrderDesc)
 			if err != nil {
 				return err
 			}
@@ -200,7 +198,7 @@ func TestSeekIndex(t *testing.T) {
 
 	exp := `
 #0:record[ts:time,offset:int64]
-0:[1587508850.06466032;202;]
+0:[1587508850.06466032;23795;]
 `
 	require.Equal(t, test.Trim(exp), buf.String())
 }

--- a/ppl/archive/archive_test.go
+++ b/ppl/archive/archive_test.go
@@ -191,6 +191,7 @@ func TestSeekIndex(t *testing.T) {
 	require.NoError(t, err)
 	rec, err := finder.ClosestLTE(keys)
 	require.NoError(t, err)
+	require.NoError(t, finder.Close())
 
 	var buf bytes.Buffer
 	w := tzngio.NewWriter(zio.NopCloser(&buf))


### PR DESCRIPTION
As brimsec/zq#1329 is closed, we no longer need the sort ascending for this
test. Set test open options to default.