### PR TITLE
archive: In process cache metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/gopacket v1.1.17
 	github.com/gorilla/mux v1.7.5-0.20200711200521-98cb6bf42e08
 	github.com/gosuri/uilive v0.0.4
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.10.3 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
@@ -31,6 +32,7 @@ require (
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
 	github.com/segmentio/ksuid v1.0.2
 	github.com/stretchr/testify v1.6.1
 	github.com/xitongsys/parquet-go v1.5.3-0.20200514000040-789bba367841

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+
 github.com/hashicorp/go-uuid v0.0.0-20180228145832-27454136f036/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/influxdata/influxdb v1.7.6/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=

--- a/pkg/promtest/promtest.go
+++ b/pkg/promtest/promtest.go
@@ -1,0 +1,42 @@
+package promtest
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func CounterValue(t *testing.T, g prometheus.Gatherer, name string, labels prometheus.Labels) float64 {
+	metricFamilies, err := g.Gather()
+	if err != nil {
+		t.Error(err)
+		return 0
+	}
+
+	for _, mf := range metricFamilies {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if labelsEqual(m.GetLabel(), labels) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+
+	t.Errorf("metric %q not found", name)
+	return 0
+}
+
+func labelsEqual(pairs []*dto.LabelPair, labels prometheus.Labels) bool {
+	if len(pairs) != len(labels) {
+		return false
+	}
+	for _, pair := range pairs {
+		if name, ok := labels[pair.GetName()]; !ok || name != pair.GetValue() {
+			return false
+		}
+	}
+	return true
+}

--- a/ppl/archive/archive_test.go
+++ b/ppl/archive/archive_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/brimsec/zq/microindex"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
+	"github.com/brimsec/zq/pkg/promtest"
 	"github.com/brimsec/zq/pkg/test"
 	"github.com/brimsec/zq/ppl/archive/chunk"
 	"github.com/brimsec/zq/ppl/archive/index"
@@ -21,6 +22,8 @@ import (
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zio/tzngio"
 	"github.com/brimsec/zq/zng/resolver"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -148,6 +151,30 @@ func TestOpenOptions(t *testing.T) {
 `
 	out = indexQuery(t, ark2, pattern, AddPath(DefaultAddPathField, false))
 	require.Equal(t, test.Trim(fmt.Sprintf(expFormat, ark1.Root.RelPath(chunk1.Path()))), out)
+}
+
+func TestMetadataCache(t *testing.T) {
+	datapath := t.TempDir()
+	createArchiveSpace(t, datapath, babble, nil)
+	reg := prometheus.NewRegistry()
+	ark, err := OpenArchive(datapath, &OpenOptions{
+		SmallFileCacheSize: 128,
+		Registerer:         reg,
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < 4; i++ {
+		count, err := RecordCount(context.Background(), ark)
+		require.NoError(t, err)
+		assert.EqualValues(t, 1000, count)
+	}
+
+	kind := prometheus.Labels{"kind": "metadata"}
+	misses := promtest.CounterValue(t, reg, "archive_cache_misses_total", kind)
+	hits := promtest.CounterValue(t, reg, "archive_cache_hits_total", kind)
+
+	assert.EqualValues(t, 2, misses)
+	assert.EqualValues(t, 6, hits)
 }
 
 func TestSeekIndex(t *testing.T) {

--- a/ppl/archive/multisource.go
+++ b/ppl/archive/multisource.go
@@ -129,7 +129,13 @@ func (m *spanMultiSource) SourceFromRequest(ctx context.Context, req *api.Worker
 		}
 		uri := tsdir.path(m.ark)
 		mdPath := chunk.MetadataPath(uri, id)
-		md, err := chunk.ReadMetadata(ctx, mdPath, m.ark.DataOrder)
+
+		b, err := m.ark.smlfs.ReadFile(ctx, mdPath)
+		if err != nil {
+			return nil, err
+		}
+
+		md, err := chunk.UnmarshalMetadata(b, m.ark.DataOrder)
 		if err != nil {
 			return nil, zqe.E("failed to read chunk metadata from %s: %w", mdPath.String(), err)
 		}

--- a/ppl/archive/smallfilecache.go
+++ b/ppl/archive/smallfilecache.go
@@ -1,0 +1,67 @@
+package archive
+
+import (
+	"context"
+	"path"
+
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/ppl/archive/chunk"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type smallFileGetter interface {
+	ReadFile(context.Context, iosrc.URI) ([]byte, error)
+}
+
+type smallFileCache struct {
+	getter smallFileGetter
+	lru    *lru.ARCCache
+	hits   *prometheus.CounterVec
+	misses *prometheus.CounterVec
+}
+
+func newSmallFileCache(size int, getter smallFileGetter, registerer prometheus.Registerer) (*smallFileCache, error) {
+	lru, err := lru.NewARC(size)
+	if err != nil {
+		return nil, err
+	}
+	if registerer == nil {
+		registerer = prometheus.NewRegistry()
+	}
+	factory := promauto.With(registerer)
+	return &smallFileCache{
+		getter: getter,
+		lru:    lru,
+		hits: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "archive_cache_hits_total",
+				Help: "Number of hits for a cache lookup.",
+			},
+			[]string{"kind"},
+		),
+		misses: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "archive_cache_misses_total",
+				Help: "Number of misses for a cache lookup.",
+			},
+			[]string{"kind"},
+		),
+	}, nil
+}
+
+func (c *smallFileCache) ReadFile(ctx context.Context, u iosrc.URI) ([]byte, error) {
+	kind, _, _ := chunk.FileMatch(path.Base(u.Path))
+	if v, ok := c.lru.Get(u.String()); ok {
+		c.hits.WithLabelValues(kind.Description()).Inc()
+		return v.([]byte), nil
+	}
+	b, err := c.getter.ReadFile(ctx, u)
+	if err != nil {
+		return nil, err
+	}
+	c.lru.Add(u.String(), b)
+	c.misses.WithLabelValues(kind.Description()).Inc()
+	return b, nil
+}

--- a/ppl/archive/walk.go
+++ b/ppl/archive/walk.go
@@ -118,7 +118,12 @@ func tsDirEntriesToChunks(ctx context.Context, ark *Archive, filterSpan nano.Spa
 		}
 		dir := tsDir.path(ark)
 		mdPath := chunk.MetadataPath(dir, id)
-		md, err := chunk.ReadMetadata(ctx, mdPath, ark.DataOrder)
+		b, err := ark.smlfs.ReadFile(ctx, mdPath)
+		if err != nil {
+			return nil, err
+		}
+
+		md, err := chunk.UnmarshalMetadata(b, ark.DataOrder)
 		if err != nil {
 			if zqe.IsNotFound(err) {
 				continue


### PR DESCRIPTION
Add archive.OpenOption, SmallFileCacheSize which if set will enable caching in
process of small files (currently this is only metadata). Add prometheus
metrics for tracking cache hits and misses on gets for small files.

TODO:

- [ ] Add zqd handler test

Closes #1898