### PR TITLE
initial multitenancy support

### DIFF
--- a/cmd/zapi/cmd/auth/command.go
+++ b/cmd/zapi/cmd/auth/command.go
@@ -22,6 +22,7 @@ func init() {
 	Auth.Add(Login)
 	Auth.Add(Logout)
 	Auth.Add(Method)
+	Auth.Add(Store)
 	Auth.Add(Verify)
 	cmd.CLI.Add(Auth)
 }

--- a/cmd/zapi/cmd/auth/login.go
+++ b/cmd/zapi/cmd/auth/login.go
@@ -71,11 +71,7 @@ func (c *LoginCommand) Run(args []string) error {
 		return err
 	}
 
-	cpath, err := cmd.UserStdCredentialsPath()
-	if err != nil {
-		return err
-	}
-	creds, err := cmd.LoadCredentials(cpath)
+	creds, err := c.LocalConfig.LoadCredentials()
 	if err != nil {
 		return fmt.Errorf("failed to load credentials file: %w", err)
 	}
@@ -84,9 +80,9 @@ func (c *LoginCommand) Run(args []string) error {
 		ID:      dar.IDToken,
 		Refresh: dar.RefreshToken,
 	})
-	if err := cmd.SaveCredentials(cpath, creds); err != nil {
+	if err := c.LocalConfig.SaveCredentials(creds); err != nil {
 		return fmt.Errorf("failed to save credentials file: %w", err)
 	}
-	fmt.Printf("Login successful, stored credentials for %s in %s\n", c.Host, cpath)
+	fmt.Printf("Login successful, stored credentials for %s\n", c.Host)
 	return nil
 }

--- a/cmd/zapi/cmd/auth/logout.go
+++ b/cmd/zapi/cmd/auth/logout.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/brimsec/zq/cmd/zapi/cmd"
 	"github.com/mccanne/charm"
 )
 
@@ -35,18 +34,14 @@ func (c *LogoutCommand) Run(args []string) error {
 		return errors.New("logout command takes no arguments")
 	}
 
-	cpath, err := cmd.UserStdCredentialsPath()
-	if err != nil {
-		return err
-	}
-	svccreds, err := cmd.LoadCredentials(cpath)
+	creds, err := c.LocalConfig.LoadCredentials()
 	if err != nil {
 		return fmt.Errorf("failed to load credentials file: %w", err)
 	}
-	svccreds.RemoveTokens(c.Host)
-	if err := cmd.SaveCredentials(cpath, svccreds); err != nil {
+	creds.RemoveTokens(c.Host)
+	if err := c.LocalConfig.SaveCredentials(creds); err != nil {
 		return fmt.Errorf("failed to save credentials file: %w", err)
 	}
-	fmt.Printf("Logout successful, cleared credentials for %s in %s\n", c.Host, cpath)
+	fmt.Printf("Logout successful, cleared credentials for %s\n", c.Host)
 	return nil
 }

--- a/cmd/zapi/cmd/auth/store.go
+++ b/cmd/zapi/cmd/auth/store.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/mccanne/charm"
+)
+
+var Store = &charm.Spec{
+	Name:   "store",
+	Usage:  "auth store",
+	Short:  "store raw tokens",
+	Long:   ``,
+	New:    NewStore,
+	Hidden: true,
+}
+
+type StoreCommand struct {
+	*Command
+
+	accessToken string
+}
+
+func NewStore(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
+	c := &StoreCommand{Command: parent.(*Command)}
+	f.StringVar(&c.accessToken, "access", "", "raw access token as string")
+	return c, nil
+}
+
+func (c *StoreCommand) Run(args []string) error {
+	if len(args) > 0 {
+		return errors.New("store command takes no arguments")
+	}
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
+
+	creds, err := c.LocalConfig.LoadCredentials()
+	if err != nil {
+		return fmt.Errorf("failed to load credentials file: %w", err)
+	}
+	tokens, _ := creds.ServiceTokens(c.Host)
+	tokens.Access = c.accessToken
+	creds.AddTokens(c.Host, tokens)
+
+	if err := c.LocalConfig.SaveCredentials(creds); err != nil {
+		return fmt.Errorf("failed to save credentials file: %w", err)
+	}
+	return nil
+}

--- a/cmd/zapi/cmd/cli.go
+++ b/cmd/zapi/cmd/cli.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"syscall"
 
@@ -58,18 +59,20 @@ func New(f *flag.FlagSet) (charm.Command, error) {
 	f.Var(&c.spaceID, "id", "<space_id>")
 	f.BoolVar(&c.NoFancy, "nofancy", c.NoFancy, "disable fancy CLI output (true if stdout is not a tty)")
 	c.cli.SetFlags(f)
+	c.LocalConfig.SetFlags(f)
 
 	return c, nil
 }
 
 type Command struct {
-	conn      *client.Connection
-	Host      string
-	Spacename string
-	NoFancy   bool
-	ctx       *signalCtx
-	spaceID   api.SpaceID
-	cli       cli.Flags
+	Host        string
+	LocalConfig localConfigFlags
+	NoFancy     bool
+	Spacename   string
+	cli         cli.Flags
+	conn        *client.Connection
+	ctx         *signalCtx
+	spaceID     api.SpaceID
 }
 
 func (c *Command) Context() context.Context {
@@ -78,9 +81,6 @@ func (c *Command) Context() context.Context {
 
 // Connection returns a central client.Connection instance.
 func (c *Command) Connection() *client.Connection {
-	if c.conn == nil {
-		c.conn = client.NewConnectionTo("http://" + c.Host)
-	}
 	return c.conn
 }
 
@@ -103,6 +103,19 @@ func (c *Command) Cleanup() {
 }
 
 func (c *Command) Init(all ...cli.Initializer) error {
+	if _, _, err := net.SplitHostPort(c.Host); err == nil {
+		c.Host = "http://" + c.Host
+	}
+	c.conn = client.NewConnectionTo(c.Host)
+
+	creds, err := c.LocalConfig.LoadCredentials()
+	if err != nil {
+		return err
+	}
+	if tokens, ok := creds.ServiceTokens(c.Host); ok {
+		c.conn.SetAuthToken(tokens.Access)
+	}
+
 	return c.cli.Init(all...)
 }
 

--- a/cmd/zapi/cmd/cli.go
+++ b/cmd/zapi/cmd/cli.go
@@ -66,7 +66,7 @@ func New(f *flag.FlagSet) (charm.Command, error) {
 
 type Command struct {
 	Host        string
-	LocalConfig localConfigFlags
+	LocalConfig LocalConfigFlags
 	NoFancy     bool
 	Spacename   string
 	cli         cli.Flags

--- a/cmd/zapi/cmd/credentials.go
+++ b/cmd/zapi/cmd/credentials.go
@@ -14,15 +14,15 @@ const (
 	credsFileName     = "credentials.json"
 )
 
-type localConfigFlags struct {
+type LocalConfigFlags struct {
 	configPath string
 }
 
-func (f *localConfigFlags) SetFlags(fs *flag.FlagSet) {
+func (f *LocalConfigFlags) SetFlags(fs *flag.FlagSet) {
 	fs.StringVar(&f.configPath, "configpath", "", "directory to store local configuration and credentials")
 }
 
-func (f *localConfigFlags) credentialsPath() (string, error) {
+func (f *LocalConfigFlags) credentialsPath() (string, error) {
 	if f.configPath != "" {
 		return filepath.Abs(filepath.Join(f.configPath, credsFileName))
 	}
@@ -33,7 +33,7 @@ func (f *localConfigFlags) credentialsPath() (string, error) {
 	return filepath.Join(c, zapiConfigDirName, credsFileName), nil
 }
 
-func (f *localConfigFlags) LoadCredentials() (*Credentials, error) {
+func (f *LocalConfigFlags) LoadCredentials() (*Credentials, error) {
 	cpath, err := f.credentialsPath()
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func (f *localConfigFlags) LoadCredentials() (*Credentials, error) {
 	return &cf, nil
 }
 
-func (f *localConfigFlags) SaveCredentials(cf *Credentials) error {
+func (f *LocalConfigFlags) SaveCredentials(cf *Credentials) error {
 	cpath, err := f.credentialsPath()
 	if err != nil {
 		return err

--- a/cmd/zapi/cmd/index/create.go
+++ b/cmd/zapi/cmd/index/create.go
@@ -60,6 +60,10 @@ func (c *CreateCmd) Run(args []string) error {
 	if len(args) == 0 && c.zql == "" {
 		return errors.New("zapi index create: one or more indexing patterns must be specified")
 	}
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
 	id, err := c.SpaceID()
 	if err != nil {
 		return err

--- a/cmd/zapi/cmd/index/find.go
+++ b/cmd/zapi/cmd/index/find.go
@@ -73,6 +73,10 @@ func NewFind(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *FindCmd) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
 	req := api.IndexSearchRequest{IndexName: c.indexFile, Patterns: args}
 	id, err := c.SpaceID()
 	if err != nil {

--- a/cmd/zapi/cmd/info/info.go
+++ b/cmd/zapi/cmd/info/info.go
@@ -41,6 +41,10 @@ func New(parent charm.Command, flags *flag.FlagSet) (charm.Command, error) {
 // Run lists all spaces in the current zqd host or if a parameter
 // is provided (in glob style) lists the info about that space.
 func (c *Command) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
 	conn := c.Connection()
 	var ids []api.SpaceID
 	if len(args) > 0 {

--- a/cmd/zapi/cmd/info/ls.go
+++ b/cmd/zapi/cmd/info/ls.go
@@ -38,6 +38,10 @@ func NewLs(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 // Run lists all spaces in the current zqd host or if a parameter
 // is provided (in glob style) lists the info about that space.
 func (c *LsCommand) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
 	conn := c.Connection()
 	matches, err := cmd.SpaceGlob(c.Context(), conn, args...)
 	if err != nil {

--- a/cmd/zapi/cmd/new/new.go
+++ b/cmd/zapi/cmd/new/new.go
@@ -40,6 +40,7 @@ func (c *Command) Run(args []string) error {
 	if len(args) != 1 {
 		return errors.New("must specify a space name")
 	}
+	defer c.Cleanup()
 	if err := c.Init(&c.createFlags); err != nil {
 		return err
 	}

--- a/cmd/zapi/cmd/newsubspace/newsubspace.go
+++ b/cmd/zapi/cmd/newsubspace/newsubspace.go
@@ -39,6 +39,10 @@ func (c *Command) Run(args []string) error {
 	if len(args) == 0 {
 		return errors.New("must specify at least one log from parent")
 	}
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
 	conn := c.Connection()
 	req := api.SubspacePostRequest{
 		Name: c.name,

--- a/cmd/zapi/cmd/post/path.go
+++ b/cmd/zapi/cmd/post/path.go
@@ -51,6 +51,7 @@ func (c *PostPathCommand) Run(args []string) (err error) {
 	if len(args) == 0 {
 		return errors.New("path arg(s) required")
 	}
+	defer c.Cleanup()
 	if err := c.Init(&c.postFlags); err != nil {
 		return err
 	}

--- a/cmd/zapi/cmd/post/pcap.go
+++ b/cmd/zapi/cmd/post/pcap.go
@@ -54,6 +54,7 @@ func (c *PostPcapCommand) Run(args []string) (err error) {
 	if len(args) == 0 {
 		return errors.New("path arg required")
 	}
+	defer c.Cleanup()
 	if err := c.Init(&c.postFlags); err != nil {
 		return err
 	}

--- a/cmd/zapi/cmd/post/post.go
+++ b/cmd/zapi/cmd/post/post.go
@@ -44,6 +44,7 @@ func (c *PostCommand) Run(args []string) (err error) {
 	if len(args) == 0 {
 		return errors.New("path arg(s) required")
 	}
+	defer c.Cleanup()
 	if err := c.Init(&c.postFlags); err != nil {
 		return err
 	}

--- a/cmd/zapi/cmd/rename/rename.go
+++ b/cmd/zapi/cmd/rename/rename.go
@@ -32,6 +32,10 @@ func (c *Command) Run(args []string) error {
 	if len(args) != 2 {
 		return errors.New("expected <old_name> <new_name>")
 	}
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
 	oldname := args[0]
 	newname := args[1]
 	id, err := cmd.GetSpaceID(c.Context(), c.Connection(), oldname)

--- a/cmd/zapi/cmd/rm/rm.go
+++ b/cmd/zapi/cmd/rm/rm.go
@@ -34,6 +34,10 @@ func (c *Command) Run(args []string) error {
 	if len(args) == 1 {
 		c.Spacename = args[0]
 	}
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
 	id, err := c.SpaceID()
 	if err != nil {
 		return err

--- a/cmd/zapi/cmd/version/command.go
+++ b/cmd/zapi/cmd/version/command.go
@@ -34,10 +34,14 @@ func New(parent charm.Command, flags *flag.FlagSet) (charm.Command, error) {
 // Run lists all spaces in the current zqd host or if a parameter
 // is provided (in glob style) lists the info about that space.
 func (c *Command) Run(args []string) error {
-	conn := c.Connection()
 	if len(args) > 0 {
-		return errors.New("version command takes no arguemtns")
+		return errors.New("version command takes no arguments")
 	}
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
+	conn := c.Connection()
 	version, err := conn.Version(c.Context())
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4
 	github.com/alexbrainman/ps v0.0.0-20171229230509-b3e1b4a15894
 	github.com/apache/thrift v0.0.0-20181112125854-24918abba929
-	github.com/auth0/go-jwt-middleware v0.0.0-20201030150249-d783b5c46b39
 	github.com/aws/aws-sdk-go v1.30.19
 	github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f
 	github.com/buger/jsonparser v0.0.0-20191004114745-ee4c978eae7e

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,6 @@ github.com/alexbrainman/ps v0.0.0-20171229230509-b3e1b4a15894/go.mod h1:Wgrp3f69
 github.com/apache/arrow/go/arrow v0.0.0-20200601151325-b2287a20f230/go.mod h1:QNYViu/X0HXDHw7m3KXzWSVXIbfUvJqBFe6Gj8/pYA0=
 github.com/apache/thrift v0.0.0-20181112125854-24918abba929 h1:ubPe2yRkS6A/X37s0TVGfuN42NV2h0BlzWj0X76RoUw=
 github.com/apache/thrift v0.0.0-20181112125854-24918abba929/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/auth0/go-jwt-middleware v0.0.0-20201030150249-d783b5c46b39 h1:FXGfTw25KQECao75qgpoCttPz8VTwKkQTi2L0iGh9Vk=
-github.com/auth0/go-jwt-middleware v0.0.0-20201030150249-d783b5c46b39/go.mod h1:mF0ip7kTEFtnhBJbd/gJe62US3jykNN+dcZoZakJCCA=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.30.19 h1:vRwsYgbUvC25Cb3oKXTyTYk3R5n1LRVk8zbvL4inWsc=
 github.com/aws/aws-sdk-go v1.30.19/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
@@ -82,7 +80,6 @@ github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20190925194419-606b3d062051/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
-github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/colinmarc/hdfs/v2 v2.1.1/go.mod h1:M3x+k8UKKmxtFu++uAZ0OtDU8jR3jnaZIAc6yK4Ue0c=
 github.com/containerd/containerd v1.4.0/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.4.1 h1:pASeJT3R3YyVn+94qEPk0SnU1OQ20Jd/T+SPKy9xehY=
@@ -125,7 +122,6 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
-github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-pg/pg/v10 v10.7.3 h1:oL/Hz5MJie/9epmwxlZjfReO+2wlLPOK6BeGb9I+XHk=
 github.com/go-pg/pg/v10 v10.7.3/go.mod h1:UsDYtA+ihbBNX1OeIvDejxkL4RXzL3wsZYoEv5NUEqM=
 github.com/go-pg/zerochecker v0.2.0 h1:pp7f72c3DobMWOb2ErtZsnrPaSvHd2W4o9//8HtF4mU=
@@ -207,9 +203,6 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 h1:l5lAOZEym3oK3SQ2HBHWsJUfbNBiTXJDeW2QDxw9AQ0=
-github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
@@ -265,8 +258,6 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
-github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/k0kubun/pp v2.3.0+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
@@ -389,11 +380,6 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
-github.com/smartystreets/assertions v1.1.0 h1:MkTeG1DMwsrdH7QtLXy5W+fUxWq+vmb6cLmyJ7aRtF0=
-github.com/smartystreets/assertions v1.1.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
-github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
-github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/snowflakedb/glog v0.0.0-20180824191149-f5055e6f21ce/go.mod h1:EB/w24pR5VKI60ecFnKqXzxX3dOorz1rnVicQTQrGM0=
 github.com/snowflakedb/gosnowflake v1.3.5/go.mod h1:13Ky+lxzIm3VqNDZJdyvu9MCGy+WgRdYFdXp96UcLZU=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -411,8 +397,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc h1:9lRDQMhESg+zvGYmW5DyG0UqvY96Bu5QYsTLvCHdrgo=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc/go.mod h1:bciPuU6GHm1iF1pBvUfxfsH0Wmnc2VbpgvbI9ZWuIRs=
-github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=
-github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/vmihailenco/bufpool v0.1.11 h1:gOq2WmBrq0i2yW5QJ16ykccQ4wH9UyEsgLm6czKAd94=
 github.com/vmihailenco/bufpool v0.1.11/go.mod h1:AFf/MOy3l2CFTKbxwt0mp2MwnqjNEs5H/UxrkA5jxTQ=
 github.com/vmihailenco/msgpack/v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
@@ -630,7 +614,6 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190425163242-31fd60d6bfdc/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=

--- a/ppl/cmd/gentoken/gentoken.go
+++ b/ppl/cmd/gentoken/gentoken.go
@@ -12,8 +12,8 @@ import (
 )
 
 var CLI = &charm.Spec{
-	Name:  "testtoken",
-	Usage: "testtoken",
+	Name:  "gentoken",
+	Usage: "gentoken",
 	Short: "generate access token to test zqd auth",
 	New:   New,
 }
@@ -42,7 +42,7 @@ func New(_ charm.Command, fs *flag.FlagSet) (charm.Command, error) {
 
 func (c *Command) Run(args []string) error {
 	if len(args) > 0 {
-		return errors.New("testtoken takes no arguments")
+		return errors.New("gentoken takes no arguments")
 	}
 	if c.privateKeyFile == "" {
 		return errors.New("must specify a keyfile")

--- a/ppl/cmd/testtoken/testtoken.go
+++ b/ppl/cmd/testtoken/testtoken.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/brimsec/zq/ppl/zqd/auth"
+	"github.com/mccanne/charm"
+)
+
+var CLI = &charm.Spec{
+	Name:  "testtoken",
+	Usage: "testtoken",
+	Short: "generate access token to test zqd auth",
+	New:   New,
+}
+
+type Command struct {
+	charm.Command
+
+	domain         string
+	expiration     time.Duration
+	privateKeyFile string
+	keyID          string
+	tenantID       string
+	userID         string
+}
+
+func New(_ charm.Command, fs *flag.FlagSet) (charm.Command, error) {
+	c := &Command{}
+	fs.StringVar(&c.domain, "domain", "", "domain to use to generate token issuer")
+	fs.DurationVar(&c.expiration, "expiration", 4*time.Hour, "expiry duration for generated token")
+	fs.StringVar(&c.privateKeyFile, "privatekeyfile", "", "path of file containing private key (required)")
+	fs.StringVar(&c.keyID, "keyid", "", "key identifier")
+	fs.StringVar(&c.tenantID, "tenantid", "", "tenant ID claim in generated token")
+	fs.StringVar(&c.userID, "userid", "", "user ID claim in generated token")
+	return c, nil
+}
+
+func (c *Command) Run(args []string) error {
+	if len(args) > 0 {
+		return errors.New("testtoken takes no arguments")
+	}
+	if c.privateKeyFile == "" {
+		return errors.New("must specify a keyfile")
+	}
+	token, err := auth.GenerateAccessToken(c.keyID, c.privateKeyFile, c.expiration, c.domain, auth.TenantID(c.tenantID), auth.UserID(c.userID))
+	if err != nil {
+		return fmt.Errorf("GenerateAccessToken failed: %w", err)
+	}
+	fmt.Println(token)
+	return nil
+}
+
+func main() {
+	CLI.Add(charm.Help)
+	_, err := CLI.ExecRoot(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}

--- a/ppl/zqd/apiserver/manager.go
+++ b/ppl/zqd/apiserver/manager.go
@@ -129,7 +129,7 @@ func (m *Manager) CreateSpace(ctx context.Context, req api.SpacePostRequest) (ap
 		return api.Space{}, zqe.E(zqe.Invalid, "cannot create file storage space on non-file backed data path")
 	}
 
-	ident := auth.IdentifyFromContext(ctx)
+	ident := auth.IdentityFromContext(ctx)
 	row := schema.SpaceRow{
 		ID:       id,
 		Name:     req.Name,
@@ -180,7 +180,7 @@ func (m *Manager) CreateSubspace(ctx context.Context, parentID api.SpaceID, req 
 	if _, err := m.getStorage(ctx, id, parent.DataURI, cfg); err != nil {
 		return api.Space{}, zqe.ErrInvalid("invalid subspace storage config: %w", err)
 	}
-	ident := auth.IdentifyFromContext(ctx)
+	ident := auth.IdentityFromContext(ctx)
 	row := schema.SpaceRow{
 		ID:       id,
 		ParentID: parentID,
@@ -316,7 +316,7 @@ func (m *Manager) getSpacePermCheck(ctx context.Context, id api.SpaceID) (schema
 	if err != nil {
 		return schema.SpaceRow{}, err
 	}
-	ident := auth.IdentifyFromContext(ctx)
+	ident := auth.IdentityFromContext(ctx)
 	if sr.TenantID != ident.TenantID {
 		return schema.SpaceRow{}, zqe.ErrForbidden()
 	}
@@ -332,7 +332,7 @@ func (m *Manager) GetSpace(ctx context.Context, id api.SpaceID) (api.SpaceInfo, 
 }
 
 func (m *Manager) ListSpaces(ctx context.Context) ([]api.Space, error) {
-	ident := auth.IdentifyFromContext(ctx)
+	ident := auth.IdentityFromContext(ctx)
 	rows, err := m.db.ListSpaces(ctx, ident.TenantID)
 	if err != nil {
 		return nil, err

--- a/ppl/zqd/auth.go
+++ b/ppl/zqd/auth.go
@@ -73,14 +73,14 @@ func (a *Auth0Authenticator) Middleware(next http.Handler) http.Handler {
 		token, ident, err := a.validator.ValidateRequest(r)
 		if err != nil {
 			a.unauthorized.Inc()
-			a.logger.Info("unauthorized request",
+			a.logger.Info("Unauthorized request",
 				zap.String("request_id", api.RequestIDFromContext(r.Context())),
 				zap.Error(err))
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}
-		ctx := auth.AuthTokenToContext(r.Context(), token)
-		ctx = auth.IdentityToContext(ctx, ident)
+		ctx := auth.ContextWithAuthToken(r.Context(), token)
+		ctx = auth.ContextWithIdentity(ctx, ident)
 		r = r.WithContext(ctx)
 		next.ServeHTTP(w, r)
 	})

--- a/ppl/zqd/auth.go
+++ b/ppl/zqd/auth.go
@@ -2,33 +2,15 @@ package zqd
 
 import (
 	"context"
-	"crypto/rsa"
 	"errors"
 	"flag"
-	"fmt"
 	"net/http"
-	"net/url"
-	"time"
 
-	jwtmiddleware "github.com/auth0/go-jwt-middleware"
 	"github.com/brimsec/zq/api"
-	"github.com/brimsec/zq/pkg/fs"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/brimsec/zq/ppl/zqd/auth"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap"
-)
-
-const (
-	// AudienceClaimValue is the value of the "aud" standard claim that clients
-	// should use when requesting access tokens for this api.
-	// Though formatted as a URL, it does not need to be a reachable location.
-	AudienceClaimValue = "https://app.brimsecurity.com"
-
-	// These are the namespaced custom claims we expect on any JWT
-	// access token.
-	TenantIDClaim = AudienceClaimValue + "/tenant_id"
-	UserIDClaim   = AudienceClaimValue + "/user_id"
 )
 
 type AuthConfig struct {
@@ -49,176 +31,61 @@ func (c *AuthConfig) SetFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.JWKSPath, "auth.jwkspath", "", "path to JSON Web Key Set file")
 }
 
-func (c *AuthConfig) Validate() (*url.URL, error) {
-	if !c.Enabled {
-		return nil, nil
-	}
-	if c.ClientID == "" || c.Domain == "" || c.JWKSPath == "" {
-		return nil, errors.New("auth.clientid, auth.domain, and auth.jwkspath must be set when auth enabled")
-	}
-	u, err := url.Parse(c.Domain)
-	if err != nil {
-		return nil, fmt.Errorf("bad auth.domain URL: %w", err)
-	}
-	return u, nil
-}
-
 type Auth0Authenticator struct {
-	checker        *jwtmiddleware.JWTMiddleware
+	logger         *zap.Logger
 	methodResponse api.AuthMethodResponse
+	unauthorized   prometheus.Counter
+	validator      *auth.TokenValidator
 }
 
-// newAuthenticator returns an Auth0Authenticator that checks for a JWT signed
+// NewAuthenticator returns an Auth0Authenticator that checks for a JWT signed
 // by a key referenced in the JWKS file, has the required audience and issuer
 // claims, and contains claims for a brim tenant and user id.
-func newAuthenticator(ctx context.Context, logger *zap.Logger, registerer prometheus.Registerer, config AuthConfig) (*Auth0Authenticator, error) {
-	domainURL, err := config.Validate()
+func NewAuthenticator(ctx context.Context, logger *zap.Logger, registerer prometheus.Registerer, config AuthConfig) (*Auth0Authenticator, error) {
+	if config.ClientID == "" || config.Domain == "" || config.JWKSPath == "" {
+		return nil, errors.New("auth.clientid, auth.domain, and auth.jwkspath must be set when auth enabled")
+	}
+	validator, err := auth.NewTokenValidator(config.Domain, config.JWKSPath)
 	if err != nil {
 		return nil, err
-	}
-	// Auth0 issuer is always the domain URL with trailing "/".
-	// https://auth0.com/docs/tokens/access-tokens/get-access-tokens#custom-domains-and-the-management-api
-	expectedIssuer := domainURL.String() + "/"
-	keys, err := loadPublicKeys(config.JWKSPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load JWKS file: %w", err)
 	}
 	unauthorized := promauto.With(registerer).NewCounter(prometheus.CounterOpts{
 		Name: "request_errors_unauthorized_total",
 		Help: "Number of request errors due to bad or missing authorization.",
 	})
-	checker := jwtmiddleware.New(jwtmiddleware.Options{
-		ValidationKeyGetter: func(token *jwt.Token) (interface{}, error) {
-			claims := token.Claims.(jwt.MapClaims)
-			// jwt-go (called from jwtmiddleware) verifies any expiry claim, but
-			// will not fail if the expiry claim is missing. The call here with
-			// req=true ensures that the claim is both present and valid.
-			if !claims.VerifyExpiresAt(time.Now().Unix(), true) {
-				return token, errors.New("invalid expiration")
-			}
-			if !claims.VerifyIssuer(expectedIssuer, true) {
-				return token, errors.New("invalid issuer")
-			}
-			if !verifyAPIAudience(claims) {
-				return token, errors.New("invalid audience")
-			}
-			if tid, _ := claims[TenantIDClaim].(string); tid == "" {
-				return token, errors.New("missing tenant id")
-			}
-			if uid, _ := claims[UserIDClaim].(string); uid == "" {
-				return token, errors.New("missing user id")
-			}
-			tokenKeyID, _ := token.Header["kid"].(string)
-			key, ok := keys[tokenKeyID]
-			if !ok {
-				return token, errors.New("unknown token key id")
-			}
-			return key, nil
-		},
-		UserProperty: authTokenContextValue,
-		ErrorHandler: func(w http.ResponseWriter, r *http.Request, errstr string) {
-			unauthorized.Inc()
-			logger.Info("unauthorized request",
-				zap.String("request_id", api.RequestIDFromContext(r.Context())),
-				zap.String("error", errstr))
-			http.Error(w, errstr, http.StatusUnauthorized)
-		},
-		SigningMethod: jwt.SigningMethodRS256,
-	})
 	return &Auth0Authenticator{
-		checker: checker,
+		logger: logger.Named("auth"),
 		methodResponse: api.AuthMethodResponse{
 			Kind: api.AuthMethodAuth0,
 			Auth0: &api.AuthMethodAuth0Details{
-				Audience: AudienceClaimValue,
+				Audience: auth.AudienceClaimValue,
 				Domain:   config.Domain,
 				ClientID: config.ClientID,
 			},
 		},
+		unauthorized: unauthorized,
+		validator:    validator,
 	}, nil
 }
 
 func (a *Auth0Authenticator) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if a.checker.CheckJWT(w, r) != nil {
-			// response sent by jwtmiddleware.Options.ErrorHandler
+		token, ident, err := a.validator.ValidateRequest(r)
+		if err != nil {
+			a.unauthorized.Inc()
+			a.logger.Info("unauthorized request",
+				zap.String("request_id", api.RequestIDFromContext(r.Context())),
+				zap.Error(err))
+			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}
+		ctx := auth.AuthTokenToContext(r.Context(), token)
+		ctx = auth.IdentityToContext(ctx, ident)
+		r = r.WithContext(ctx)
 		next.ServeHTTP(w, r)
 	})
 }
 
 func (a *Auth0Authenticator) MethodResponse() api.AuthMethodResponse {
 	return a.methodResponse
-}
-
-func verifyAPIAudience(claims jwt.MapClaims) bool {
-	// Audience claim may either be a string, or a slice of interfaces that are
-	// strings.
-	// https://auth0.com/docs/tokens/access-tokens/get-access-tokens#multiple-audiences
-	if str, ok := claims["aud"].(string); ok {
-		return str == AudienceClaimValue
-	}
-	if arr, ok := claims["aud"].([]interface{}); ok {
-		for _, a := range arr {
-			s, _ := a.(string)
-			if s == AudienceClaimValue {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// authTokenContextValue is the string the jwtmiddleware library uses to
-// store the validated & parsed JWT in a request's context.
-const authTokenContextValue = "zqd-core-auth-token"
-
-type Identity struct {
-	TenantID string
-	UserID   string
-}
-
-func IdentifyFromContext(ctx context.Context) (Identity, bool) {
-	var token *jwt.Token
-	if token = ctx.Value(authTokenContextValue).(*jwt.Token); token == nil {
-		return Identity{}, false
-	}
-	mc := token.Claims.(jwt.MapClaims)
-	tid := mc[TenantIDClaim].(string)
-	uid := mc[UserIDClaim].(string)
-	return Identity{TenantID: tid, UserID: uid}, true
-}
-
-// jwks matches the format of a JSON Web Key Set file:
-// https://auth0.com/docs/tokens/json-web-tokens/json-web-key-sets
-type jwks struct {
-	Keys []struct {
-		Kty string   `json:"kty"`
-		Kid string   `json:"kid"`
-		Use string   `json:"use"`
-		N   string   `json:"n"`
-		E   string   `json:"e"`
-		X5c []string `json:"x5c"`
-	} `json:"keys"`
-}
-
-func loadPublicKeys(jwkspath string) (map[string]*rsa.PublicKey, error) {
-	var jwks jwks
-	if err := fs.UnmarshalJSONFile(jwkspath, &jwks); err != nil {
-		return nil, err
-	}
-	keys := make(map[string]*rsa.PublicKey)
-	for _, jwk := range jwks.Keys {
-		if len(jwk.X5c) == 0 {
-			continue
-		}
-		cert := "-----BEGIN CERTIFICATE-----\n" + jwk.X5c[0] + "\n-----END CERTIFICATE-----"
-		public, err := jwt.ParseRSAPublicKeyFromPEM([]byte(cert))
-		if err != nil {
-			return nil, err
-		}
-		keys[jwk.Kid] = public
-	}
-	return keys, nil
 }

--- a/ppl/zqd/auth/auth.go
+++ b/ppl/zqd/auth/auth.go
@@ -19,7 +19,7 @@ type Identity struct {
 
 type identityKey struct{}
 
-func IdentifyFromContext(ctx context.Context) Identity {
+func IdentityFromContext(ctx context.Context) Identity {
 	ident, ok := ctx.Value(identityKey{}).(Identity)
 	if !ok {
 		return Identity{TenantID: AnonymousTenantID, UserID: AnonymousUserID}
@@ -27,17 +27,17 @@ func IdentifyFromContext(ctx context.Context) Identity {
 	return ident
 }
 
-func IdentityToContext(ctx context.Context, ident Identity) context.Context {
+func ContextWithIdentity(ctx context.Context, ident Identity) context.Context {
 	return context.WithValue(ctx, identityKey{}, ident)
 }
 
-type jwtKey struct{}
+type authTokenKey struct{}
 
 func AuthTokenFromContext(ctx context.Context) (string, bool) {
-	token, ok := ctx.Value(jwtKey{}).(string)
+	token, ok := ctx.Value(authTokenKey{}).(string)
 	return token, ok
 }
 
-func AuthTokenToContext(ctx context.Context, token string) context.Context {
-	return context.WithValue(ctx, jwtKey{}, token)
+func ContextWithAuthToken(ctx context.Context, token string) context.Context {
+	return context.WithValue(ctx, authTokenKey{}, token)
 }

--- a/ppl/zqd/auth/auth.go
+++ b/ppl/zqd/auth/auth.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"context"
+)
+
+type TenantID string
+type UserID string
+
+const (
+	AnonymousTenantID TenantID = "tenant_000000000000000000000000001"
+	AnonymousUserID   UserID   = "user_000000000000000000000000001"
+)
+
+type Identity struct {
+	TenantID TenantID
+	UserID   UserID
+}
+
+type identityKey struct{}
+
+func IdentifyFromContext(ctx context.Context) Identity {
+	ident, ok := ctx.Value(identityKey{}).(Identity)
+	if !ok {
+		return Identity{TenantID: AnonymousTenantID, UserID: AnonymousUserID}
+	}
+	return ident
+}
+
+func IdentityToContext(ctx context.Context, ident Identity) context.Context {
+	return context.WithValue(ctx, identityKey{}, ident)
+}
+
+type jwtKey struct{}
+
+func AuthTokenFromContext(ctx context.Context) (string, bool) {
+	token, ok := ctx.Value(jwtKey{}).(string)
+	return token, ok
+}
+
+func AuthTokenToContext(ctx context.Context, token string) context.Context {
+	return context.WithValue(ctx, jwtKey{}, token)
+}

--- a/ppl/zqd/auth/generator.go
+++ b/ppl/zqd/auth/generator.go
@@ -34,7 +34,7 @@ func makeToken(keyID string, keyFile string, claims jwt.MapClaims) (string, erro
 func GenerateAccessToken(keyID string, privateKeyFile string, expiration time.Duration, domain string, tenantID TenantID, userID UserID) (string, error) {
 	dstr, err := url.Parse(domain)
 	if err != nil {
-		return "", fmt.Errorf("domain should be url")
+		return "", fmt.Errorf("bad domain URL: %w", err)
 	}
 	return makeToken(keyID, privateKeyFile, jwt.MapClaims{
 		"aud":         AudienceClaimValue,

--- a/ppl/zqd/auth/generator.go
+++ b/ppl/zqd/auth/generator.go
@@ -1,0 +1,46 @@
+package auth
+
+import (
+	"crypto/rsa"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+func loadPrivateKey(keyFile string) (*rsa.PrivateKey, error) {
+	b, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+	return jwt.ParseRSAPrivateKeyFromPEM(b)
+}
+
+func makeToken(keyID string, keyFile string, claims jwt.MapClaims) (string, error) {
+	privateKey, err := loadPrivateKey(keyFile)
+	if err != nil {
+		return "", err
+	}
+	token := jwt.New(jwt.SigningMethodRS256)
+	token.Claims = claims
+	token.Header["kid"] = keyID
+	return token.SignedString(privateKey)
+}
+
+// GenerateAccessToken creates a JWT in string format with the expected audience,
+// issuer, and claims to pass zqd authentication checks.
+func GenerateAccessToken(keyID string, privateKeyFile string, expiration time.Duration, domain string, tenantID TenantID, userID UserID) (string, error) {
+	dstr, err := url.Parse(domain)
+	if err != nil {
+		return "", fmt.Errorf("domain should be url")
+	}
+	return makeToken(keyID, privateKeyFile, jwt.MapClaims{
+		"aud":         AudienceClaimValue,
+		"exp":         time.Now().Add(expiration).Unix(),
+		"iss":         dstr.String() + "/",
+		TenantIDClaim: string(tenantID),
+		UserIDClaim:   string(userID),
+	})
+}

--- a/ppl/zqd/auth/validator.go
+++ b/ppl/zqd/auth/validator.go
@@ -1,0 +1,168 @@
+package auth
+
+import (
+	"crypto/rsa"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/brimsec/zq/pkg/fs"
+	"github.com/brimsec/zq/zqe"
+	"github.com/dgrijalva/jwt-go"
+)
+
+const (
+	// AudienceClaimValue is the value of the "aud" standard claim that clients
+	// should use when requesting access tokens for this api.
+	// Though formatted as a URL, it does not need to be a reachable location.
+	AudienceClaimValue = "https://app.brimsecurity.com"
+
+	// These are the namespaced custom claims we expect on any JWT
+	// access token.
+	TenantIDClaim = AudienceClaimValue + "/tenant_id"
+	UserIDClaim   = AudienceClaimValue + "/user_id"
+)
+
+type TokenValidator struct {
+	keyGetter      jwt.Keyfunc
+	expectedIssuer string
+}
+
+func NewTokenValidator(domain, jwksPath string) (*TokenValidator, error) {
+	domainURL, err := url.Parse(domain)
+	if err != nil {
+		return nil, fmt.Errorf("bad auth.domain URL: %w", err)
+	}
+	keys, err := loadPublicKeys(jwksPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load JWKS file: %w", err)
+	}
+	// Auth0 issuer is always the domain URL with trailing "/".
+	// https://auth0.com/docs/tokens/access-tokens/get-access-tokens#custom-domains-and-the-management-api
+	expectedIssuer := domainURL.String() + "/"
+	keyGetter := func(token *jwt.Token) (interface{}, error) {
+		tokenKeyID, _ := token.Header["kid"].(string)
+		key, ok := keys[tokenKeyID]
+		if !ok {
+			return token, errors.New("unknown token key id")
+		}
+		return key, nil
+	}
+	return &TokenValidator{
+		expectedIssuer: expectedIssuer,
+		keyGetter:      keyGetter,
+	}, nil
+}
+
+func getBearerToken(r *http.Request) string {
+	hdr := r.Header.Get("Authorization")
+	if hdr == "" {
+		return ""
+	}
+	s := strings.Fields(hdr)
+	if len(s) != 2 || strings.ToLower(s[0]) != "bearer" {
+		return ""
+	}
+	return s[1]
+}
+
+func (v *TokenValidator) ValidateRequest(r *http.Request) (string, Identity, error) {
+	token := getBearerToken(r)
+	ident, err := v.Validate(token)
+	if err != nil {
+		return "", Identity{}, err
+	}
+	return token, ident, nil
+}
+
+func (v *TokenValidator) Validate(token string) (Identity, error) {
+	if token == "" {
+		return Identity{}, zqe.ErrNoCredentials()
+	}
+	parsed, err := jwt.Parse(token, v.keyGetter)
+	if err != nil || !parsed.Valid {
+		return Identity{}, zqe.ErrNoCredentials("invalid token")
+	}
+	if parsed.Header["alg"] != jwt.SigningMethodRS256.Alg() {
+		return Identity{}, zqe.ErrNoCredentials("invalid signing method")
+	}
+	claims := parsed.Claims.(jwt.MapClaims)
+	// jwt-go verifies any expiry claim, but will not fail if the expiry claim
+	// is missing. The call here with req=true ensures that the claim is both
+	// present and valid.
+	if !claims.VerifyExpiresAt(time.Now().Unix(), true) {
+		return Identity{}, zqe.ErrNoCredentials("invalid expiration")
+	}
+	if !claims.VerifyIssuer(v.expectedIssuer, true) {
+		return Identity{}, zqe.ErrNoCredentials("invalid issuer")
+	}
+	if !verifyAPIAudience(claims) {
+		return Identity{}, zqe.ErrNoCredentials("invalid audience")
+	}
+	tid, _ := claims[TenantIDClaim].(string)
+	if tid == "" || TenantID(tid) == AnonymousTenantID {
+		return Identity{}, zqe.ErrNoCredentials("invalid tenant id")
+	}
+	uid, _ := claims[UserIDClaim].(string)
+	if uid == "" || UserID(uid) == AnonymousUserID {
+		return Identity{}, zqe.ErrNoCredentials("invalid user id")
+	}
+	return Identity{
+		TenantID: TenantID(tid),
+		UserID:   UserID(uid),
+	}, nil
+}
+
+func verifyAPIAudience(claims jwt.MapClaims) bool {
+	// Audience claim may either be a string, or a slice of interfaces that are
+	// strings.
+	// https://auth0.com/docs/tokens/access-tokens/get-access-tokens#multiple-audiences
+	if str, ok := claims["aud"].(string); ok {
+		return str == AudienceClaimValue
+	}
+	if arr, ok := claims["aud"].([]interface{}); ok {
+		for _, a := range arr {
+			s, _ := a.(string)
+			if s == AudienceClaimValue {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// jwks matches the format of a JSON Web Key Set file:
+// https://auth0.com/docs/tokens/json-web-tokens/json-web-key-sets
+type jwks struct {
+	Keys []struct {
+		Kty string   `json:"kty"`
+		Kid string   `json:"kid"`
+		Use string   `json:"use"`
+		N   string   `json:"n"`
+		E   string   `json:"e"`
+		X5c []string `json:"x5c"`
+	} `json:"keys"`
+}
+
+func loadPublicKeys(jwkspath string) (map[string]*rsa.PublicKey, error) {
+	var jwks jwks
+	if err := fs.UnmarshalJSONFile(jwkspath, &jwks); err != nil {
+		return nil, err
+	}
+	keys := make(map[string]*rsa.PublicKey)
+	for _, jwk := range jwks.Keys {
+		if len(jwk.X5c) == 0 {
+			continue
+		}
+		cert := "-----BEGIN CERTIFICATE-----\n" + jwk.X5c[0] + "\n-----END CERTIFICATE-----"
+		public, err := jwt.ParseRSAPublicKeyFromPEM([]byte(cert))
+		if err != nil {
+			return nil, err
+		}
+		keys[jwk.Kid] = public
+	}
+	return keys, nil
+}

--- a/ppl/zqd/auth/validator_test.go
+++ b/ppl/zqd/auth/validator_test.go
@@ -1,0 +1,224 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testKeyID    = "testkey"
+	testKeyFile  = "../testdata/auth-private-key"
+	testJWKSFile = "../testdata/auth-public-jwks.json"
+)
+
+func testValidator(t *testing.T) *TokenValidator {
+	v, err := NewTokenValidator("https://testdomain", testJWKSFile)
+	require.NoError(t, err)
+	return v
+}
+
+func makeTestToken(t *testing.T, claims jwt.MapClaims) string {
+	token, err := makeToken(testKeyID, testKeyFile, claims)
+	require.NoError(t, err)
+	return token
+}
+
+func TestValidate(t *testing.T) {
+	expectedIdent := Identity{
+		TenantID: "test_tenant_id",
+		UserID:   "test_user_id",
+	}
+	token, err := GenerateAccessToken(testKeyID, testKeyFile, 1*time.Hour,
+		"https://testdomain", "test_tenant_id", "test_user_id")
+	require.NoError(t, err)
+	validator := testValidator(t)
+
+	ident, err := validator.Validate(token)
+	require.NoError(t, err)
+	require.Equal(t, expectedIdent, ident)
+
+	req, err := http.NewRequest("GET", "https://testdomain", nil)
+	require.NoError(t, err)
+	req.Header.Add("Authorization", "Bearer "+token)
+	tokstr, ident, err := validator.ValidateRequest(req)
+	require.Equal(t, expectedIdent, ident)
+	require.Equal(t, token, tokstr)
+
+	req, err = http.NewRequest("GET", "https://testdomain", nil)
+	require.NoError(t, err)
+	tokstr, ident, err = validator.ValidateRequest(req)
+	require.Error(t, err)
+}
+
+func TestBadClaims(t *testing.T) {
+	var cases = []struct {
+		name  string
+		token string
+	}{
+		{
+			name: "missing audience",
+			token: makeTestToken(t, jwt.MapClaims{
+				"exp":         time.Now().Add(1 * time.Hour).Unix(),
+				"iss":         "https://testdomain/",
+				TenantIDClaim: "test_tenant_id",
+				UserIDClaim:   "test_user_id",
+			}),
+		},
+		{
+			name: "invalid audience",
+			token: makeTestToken(t, jwt.MapClaims{
+				"aud":         "foo",
+				"exp":         time.Now().Add(1 * time.Hour).Unix(),
+				"iss":         "https://testdomain/",
+				TenantIDClaim: "test_tenant_id",
+				UserIDClaim:   "test_user_id",
+			}),
+		},
+		{
+			name: "missing expiration",
+			token: makeTestToken(t, jwt.MapClaims{
+				"aud":         AudienceClaimValue,
+				"iss":         "https://testdomain/",
+				TenantIDClaim: "test_tenant_id",
+				UserIDClaim:   "test_user_id",
+			}),
+		},
+		{
+			name: "expired expiration",
+			token: makeTestToken(t, jwt.MapClaims{
+				"aud":         AudienceClaimValue,
+				"exp":         time.Now().Add(-1 * time.Hour).Unix(),
+				"iss":         "https://testdomain/",
+				TenantIDClaim: "test_tenant_id",
+				UserIDClaim:   "test_user_id",
+			}),
+		},
+		{
+			name: "missing issuer",
+			token: makeTestToken(t, jwt.MapClaims{
+				"aud":         AudienceClaimValue,
+				"exp":         time.Now().Add(1 * time.Hour).Unix(),
+				TenantIDClaim: "test_tenant_id",
+				UserIDClaim:   "test_user_id",
+			}),
+		},
+		{
+			name: "invalid issuer",
+			token: makeTestToken(t, jwt.MapClaims{
+				"aud":         AudienceClaimValue,
+				"exp":         time.Now().Add(1 * time.Hour).Unix(),
+				"iss":         "foo",
+				TenantIDClaim: "test_tenant_id",
+				UserIDClaim:   "test_user_id",
+			}),
+		},
+		{
+			name: "missing user id",
+			token: makeTestToken(t, jwt.MapClaims{
+				"aud":         AudienceClaimValue,
+				"exp":         time.Now().Add(1 * time.Hour).Unix(),
+				"iss":         "https://testdomain/",
+				TenantIDClaim: "test_tenant_id",
+			}),
+		},
+		{
+			name: "anonymous user id",
+			token: makeTestToken(t, jwt.MapClaims{
+				"aud":         AudienceClaimValue,
+				"exp":         time.Now().Add(1 * time.Hour).Unix(),
+				"iss":         "https://testdomain/",
+				TenantIDClaim: "test_tenant_id",
+				UserIDClaim:   AnonymousUserID,
+			}),
+		},
+		{
+			name: "missing tenant id",
+			token: makeTestToken(t, jwt.MapClaims{
+				"aud":       AudienceClaimValue,
+				"exp":       time.Now().Add(1 * time.Hour).Unix(),
+				"iss":       "https://testdomain/",
+				UserIDClaim: "test_user_id",
+			}),
+		},
+		{
+			name: "anonymous user id",
+			token: makeTestToken(t, jwt.MapClaims{
+				"aud":         AudienceClaimValue,
+				"exp":         time.Now().Add(1 * time.Hour).Unix(),
+				"iss":         "https://testdomain/",
+				TenantIDClaim: AnonymousTenantID,
+				UserIDClaim:   "test_user_id",
+			}),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v := testValidator(t)
+			_, err := v.Validate(c.token)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestKeyID(t *testing.T) {
+	claims := jwt.MapClaims{
+		"aud":         AudienceClaimValue,
+		"exp":         time.Now().Add(1 * time.Hour).Unix(),
+		"iss":         "https://testdomain/",
+		TenantIDClaim: "test_tenant_id",
+		UserIDClaim:   "test_user_id",
+	}
+	privateKey, err := loadPrivateKey(testKeyFile)
+	require.NoError(t, err)
+	v := testValidator(t)
+
+	// Bad key id
+	token := jwt.New(jwt.SigningMethodRS256)
+	token.Claims = claims
+	token.Header["kid"] = "foo"
+	tokenString, err := token.SignedString(privateKey)
+	require.NoError(t, err)
+	_, err = v.Validate(tokenString)
+	require.Error(t, err)
+
+	// No key id
+	token = jwt.New(jwt.SigningMethodRS256)
+	token.Claims = claims
+	tokenString, err = token.SignedString(privateKey)
+	require.NoError(t, err)
+	_, err = v.Validate(tokenString)
+	require.Error(t, err)
+}
+
+func TestAudienceSlice(t *testing.T) {
+	expectedIdent := Identity{
+		TenantID: "test_tenant_id",
+		UserID:   "test_user_id",
+	}
+	token := makeTestToken(t, jwt.MapClaims{
+		"aud":         []string{AudienceClaimValue, "foobar"},
+		"exp":         time.Now().Add(1 * time.Hour).Unix(),
+		"iss":         "https://testdomain/",
+		TenantIDClaim: "test_tenant_id",
+		UserIDClaim:   "test_user_id",
+	})
+	validator := testValidator(t)
+	ident, err := validator.Validate(token)
+	require.NoError(t, err)
+	require.Equal(t, expectedIdent, ident)
+
+	token = makeTestToken(t, jwt.MapClaims{
+		"aud":         []string{"foo", "bar"},
+		"exp":         time.Now().Add(1 * time.Hour).Unix(),
+		"iss":         "https://testdomain/",
+		TenantIDClaim: "test_tenant_id",
+		UserIDClaim:   "test_user_id",
+	})
+	_, err = validator.Validate(token)
+	require.Error(t, err)
+}

--- a/ppl/zqd/auth/validator_test.go
+++ b/ppl/zqd/auth/validator_test.go
@@ -21,7 +21,7 @@ func testValidator(t *testing.T) *TokenValidator {
 	return v
 }
 
-func makeTestToken(t *testing.T, claims jwt.MapClaims) string {
+func genToken(t *testing.T, claims jwt.MapClaims) string {
 	token, err := makeToken(testKeyID, testKeyFile, claims)
 	require.NoError(t, err)
 	return token
@@ -61,7 +61,7 @@ func TestBadClaims(t *testing.T) {
 	}{
 		{
 			name: "missing audience",
-			token: makeTestToken(t, jwt.MapClaims{
+			token: genToken(t, jwt.MapClaims{
 				"exp":         time.Now().Add(1 * time.Hour).Unix(),
 				"iss":         "https://testdomain/",
 				TenantIDClaim: "test_tenant_id",
@@ -70,7 +70,7 @@ func TestBadClaims(t *testing.T) {
 		},
 		{
 			name: "invalid audience",
-			token: makeTestToken(t, jwt.MapClaims{
+			token: genToken(t, jwt.MapClaims{
 				"aud":         "foo",
 				"exp":         time.Now().Add(1 * time.Hour).Unix(),
 				"iss":         "https://testdomain/",
@@ -80,7 +80,7 @@ func TestBadClaims(t *testing.T) {
 		},
 		{
 			name: "missing expiration",
-			token: makeTestToken(t, jwt.MapClaims{
+			token: genToken(t, jwt.MapClaims{
 				"aud":         AudienceClaimValue,
 				"iss":         "https://testdomain/",
 				TenantIDClaim: "test_tenant_id",
@@ -89,7 +89,7 @@ func TestBadClaims(t *testing.T) {
 		},
 		{
 			name: "expired expiration",
-			token: makeTestToken(t, jwt.MapClaims{
+			token: genToken(t, jwt.MapClaims{
 				"aud":         AudienceClaimValue,
 				"exp":         time.Now().Add(-1 * time.Hour).Unix(),
 				"iss":         "https://testdomain/",
@@ -99,7 +99,7 @@ func TestBadClaims(t *testing.T) {
 		},
 		{
 			name: "missing issuer",
-			token: makeTestToken(t, jwt.MapClaims{
+			token: genToken(t, jwt.MapClaims{
 				"aud":         AudienceClaimValue,
 				"exp":         time.Now().Add(1 * time.Hour).Unix(),
 				TenantIDClaim: "test_tenant_id",
@@ -108,7 +108,7 @@ func TestBadClaims(t *testing.T) {
 		},
 		{
 			name: "invalid issuer",
-			token: makeTestToken(t, jwt.MapClaims{
+			token: genToken(t, jwt.MapClaims{
 				"aud":         AudienceClaimValue,
 				"exp":         time.Now().Add(1 * time.Hour).Unix(),
 				"iss":         "foo",
@@ -118,7 +118,7 @@ func TestBadClaims(t *testing.T) {
 		},
 		{
 			name: "missing user id",
-			token: makeTestToken(t, jwt.MapClaims{
+			token: genToken(t, jwt.MapClaims{
 				"aud":         AudienceClaimValue,
 				"exp":         time.Now().Add(1 * time.Hour).Unix(),
 				"iss":         "https://testdomain/",
@@ -127,7 +127,7 @@ func TestBadClaims(t *testing.T) {
 		},
 		{
 			name: "anonymous user id",
-			token: makeTestToken(t, jwt.MapClaims{
+			token: genToken(t, jwt.MapClaims{
 				"aud":         AudienceClaimValue,
 				"exp":         time.Now().Add(1 * time.Hour).Unix(),
 				"iss":         "https://testdomain/",
@@ -137,7 +137,7 @@ func TestBadClaims(t *testing.T) {
 		},
 		{
 			name: "missing tenant id",
-			token: makeTestToken(t, jwt.MapClaims{
+			token: genToken(t, jwt.MapClaims{
 				"aud":       AudienceClaimValue,
 				"exp":       time.Now().Add(1 * time.Hour).Unix(),
 				"iss":       "https://testdomain/",
@@ -146,7 +146,7 @@ func TestBadClaims(t *testing.T) {
 		},
 		{
 			name: "anonymous user id",
-			token: makeTestToken(t, jwt.MapClaims{
+			token: genToken(t, jwt.MapClaims{
 				"aud":         AudienceClaimValue,
 				"exp":         time.Now().Add(1 * time.Hour).Unix(),
 				"iss":         "https://testdomain/",
@@ -200,7 +200,7 @@ func TestAudienceSlice(t *testing.T) {
 		TenantID: "test_tenant_id",
 		UserID:   "test_user_id",
 	}
-	token := makeTestToken(t, jwt.MapClaims{
+	token := genToken(t, jwt.MapClaims{
 		"aud":         []string{AudienceClaimValue, "foobar"},
 		"exp":         time.Now().Add(1 * time.Hour).Unix(),
 		"iss":         "https://testdomain/",
@@ -212,7 +212,7 @@ func TestAudienceSlice(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedIdent, ident)
 
-	token = makeTestToken(t, jwt.MapClaims{
+	token = genToken(t, jwt.MapClaims{
 		"aud":         []string{"foo", "bar"},
 		"exp":         time.Now().Add(1 * time.Hour).Unix(),
 		"iss":         "https://testdomain/",

--- a/ppl/zqd/auth_test.go
+++ b/ppl/zqd/auth_test.go
@@ -26,7 +26,7 @@ func testAuthConfig() zqd.AuthConfig {
 	}
 }
 
-func makeTestToken(t *testing.T, tenantID auth.TenantID, userID auth.UserID) string {
+func genToken(t *testing.T, tenantID auth.TenantID, userID auth.UserID) string {
 	ac := testAuthConfig()
 	token, err := auth.GenerateAccessToken("testkey", "testdata/auth-private-key",
 		1*time.Hour, ac.Domain, tenantID, userID)
@@ -67,7 +67,7 @@ func TestAuthIdentity(t *testing.T) {
 	require.True(t, errors.As(err, &identErr))
 	require.Equal(t, http.StatusUnauthorized, identErr.StatusCode())
 
-	token := makeTestToken(t, "test_tenant_id", "test_user_id")
+	token := genToken(t, "test_tenant_id", "test_user_id")
 	conn.SetAuthToken(token)
 	res, err := conn.AuthIdentity(context.Background())
 	require.NoError(t, err)

--- a/ppl/zqd/core.go
+++ b/ppl/zqd/core.go
@@ -49,10 +49,6 @@ type Config struct {
 	Zeek     pcapanalyzer.Launcher
 }
 
-type middleware interface {
-	Middleware(next http.Handler) http.Handler
-}
-
 type Core struct {
 	auth       *Auth0Authenticator
 	db         db.DB
@@ -81,10 +77,10 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(prometheus.NewGoCollector())
 
-	var auth *Auth0Authenticator
+	var authenticator *Auth0Authenticator
 	if conf.Auth.Enabled {
 		var err error
-		if auth, err = newAuthenticator(ctx, conf.Logger, registry, conf.Auth); err != nil {
+		if authenticator, err = NewAuthenticator(ctx, conf.Logger, registry, conf.Auth); err != nil {
 			return nil, err
 		}
 	}
@@ -116,7 +112,7 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 	}
 
 	c := &Core{
-		auth:     auth,
+		auth:     authenticator,
 		logger:   conf.Logger.Named("core").With(zap.String("personality", personality)),
 		registry: registry,
 		router:   router,

--- a/ppl/zqd/db/db.go
+++ b/ppl/zqd/db/db.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/ppl/zqd/auth"
 	"github.com/brimsec/zq/ppl/zqd/db/filedb"
 	"github.com/brimsec/zq/ppl/zqd/db/postgresdb"
 	"github.com/brimsec/zq/ppl/zqd/db/schema"
@@ -17,7 +18,7 @@ type DB interface {
 	CreateSpace(context.Context, schema.SpaceRow) error
 	CreateSubspace(context.Context, schema.SpaceRow) error
 	GetSpace(context.Context, api.SpaceID) (schema.SpaceRow, error)
-	ListSpaces(context.Context) ([]schema.SpaceRow, error)
+	ListSpaces(context.Context, auth.TenantID) ([]schema.SpaceRow, error)
 	UpdateSpaceName(context.Context, api.SpaceID, string) error
 	DeleteSpace(context.Context, api.SpaceID) error
 }

--- a/ppl/zqd/db/filedb/filedb.go
+++ b/ppl/zqd/db/filedb/filedb.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/pkg/iosrc"
-	"github.com/brimsec/zq/ppl/zqd/db/filedb/oldconfig"
+	"github.com/brimsec/zq/ppl/zqd/auth"
 	"github.com/brimsec/zq/ppl/zqd/db/schema"
 	"github.com/brimsec/zq/zqe"
 	"go.uber.org/zap"
@@ -23,77 +23,19 @@ type FileDB struct {
 	path   iosrc.URI
 }
 
-func Create(ctx context.Context, logger *zap.Logger, path iosrc.URI, rows []schema.SpaceRow) (*FileDB, error) {
-	db := &FileDB{path: path, logger: logger}
-	if err := db.save(ctx, rows); err != nil {
-		return nil, err
-	}
-	db.logger.Info("Created", zap.String("kind", "file"), zap.String("uri", path.String()))
-	return db, nil
-}
-
 func Open(ctx context.Context, logger *zap.Logger, root iosrc.URI) (*FileDB, error) {
+	if err := migrateOldConfig(ctx, logger, root); err != nil {
+		logger.Error("Error migrating old multifile configuration", zap.Error(err))
+		return nil, err
+	}
 	dburi := root.AppendPath(dbname)
-	exists, err := iosrc.Exists(ctx, dburi)
-	if err != nil {
+	if err := migrateFileDatabase(ctx, dburi); err != nil {
+		logger.Error("Error migrating database file", zap.Error(err))
 		return nil, err
 	}
-	if exists {
-		return open(ctx, logger, dburi)
-	}
-
-	// Since the dbfile doesn't exist, we check if we need to migrate the older
-	// per-space config files into a new dbfile.
-	configs, err := oldconfig.LoadConfigs(ctx, logger, root)
-	if err != nil {
-		return nil, err
-	}
-	var rows []schema.SpaceRow
-	for id, config := range configs {
-		datauri := config.DataURI
-		if datauri.IsZero() {
-			datauri = root.AppendPath(string(id))
-		}
-		rows = append(rows, schema.SpaceRow{
-			ID:      id,
-			Name:    config.Name,
-			DataURI: datauri,
-			Storage: config.Storage,
-		})
-		for _, subcfg := range config.Subspaces {
-			openopts := subcfg.OpenOptions
-			rows = append(rows, schema.SpaceRow{
-				ID:       subcfg.ID,
-				ParentID: id,
-				Name:     subcfg.Name,
-				DataURI:  datauri,
-				Storage: api.StorageConfig{
-					Kind: api.ArchiveStore,
-					Archive: &api.ArchiveConfig{
-						OpenOptions: &openopts,
-					},
-				},
-			})
-		}
-	}
-	return Create(ctx, logger, dburi, rows)
-}
-
-func open(ctx context.Context, logger *zap.Logger, path iosrc.URI) (*FileDB, error) {
-	db := &FileDB{path: path, logger: logger}
-	// Verify file exists & is readable.
-	if _, err := db.load(ctx); err != nil {
-		return nil, err
-	}
-	db.logger.Info("Loaded", zap.String("kind", "file"), zap.String("uri", path.String()))
+	db := &FileDB{path: dburi, logger: logger}
+	db.logger.Info("Loaded", zap.String("kind", "file"), zap.String("uri", dburi.String()))
 	return db, nil
-}
-
-const dbversion = 4
-
-type dbdataV4 struct {
-	Version   int               `json:"version"`
-	SpaceRows []schema.SpaceRow `json:"space_rows"`
 }
 
 func (db *FileDB) load(ctx context.Context) ([]schema.SpaceRow, error) {
@@ -101,20 +43,20 @@ func (db *FileDB) load(ctx context.Context) ([]schema.SpaceRow, error) {
 	if err != nil {
 		return nil, err
 	}
-	var data dbdataV4
+	var data dbdata
 	if err := json.Unmarshal(b, &data); err != nil {
 		return nil, err
 	}
-	if data.Version != dbversion {
-		return nil, fmt.Errorf("expected db version %d, found %d", dbversion, data.Version)
+	if data.Version != currentVersion {
+		return nil, fmt.Errorf("expected db version %d, found %d", currentVersion, data.Version)
 	}
 	return data.SpaceRows, nil
 }
 
 func (db *FileDB) save(ctx context.Context, lcs []schema.SpaceRow) error {
 	return iosrc.Replace(ctx, db.path, func(w io.Writer) error {
-		return json.NewEncoder(w).Encode(dbdataV4{
-			Version:   dbversion,
+		return json.NewEncoder(w).Encode(dbdata{
+			Version:   currentVersion,
 			SpaceRows: lcs,
 		})
 	})
@@ -133,11 +75,14 @@ func (db *FileDB) CreateSpace(ctx context.Context, row schema.SpaceRow) error {
 	}
 
 	for _, r := range rows {
-		if row.Name == r.Name {
-			return zqe.ErrConflict("space with name '%s' already exists", row.Name)
-		}
 		if row.ID == r.ID {
 			return zqe.ErrExists()
+		}
+		if r.TenantID != row.TenantID {
+			continue
+		}
+		if row.Name == r.Name {
+			return zqe.ErrConflict("space with name '%s' already exists", row.Name)
 		}
 	}
 
@@ -161,11 +106,14 @@ func (db *FileDB) CreateSubspace(ctx context.Context, row schema.SpaceRow) error
 
 	parentIdx := -1
 	for i, r := range rows {
-		if row.Name == r.Name {
-			return zqe.ErrConflict("space with name '%s' already exists", row.Name)
-		}
 		if row.ID == r.ID {
 			return zqe.ErrExists()
+		}
+		if r.TenantID != row.TenantID {
+			continue
+		}
+		if row.Name == r.Name {
+			return zqe.ErrConflict("space with name '%s' already exists", row.Name)
 		}
 		if row.ParentID == r.ID {
 			parentIdx = i
@@ -193,10 +141,20 @@ func (db *FileDB) GetSpace(ctx context.Context, id api.SpaceID) (schema.SpaceRow
 	return schema.SpaceRow{}, zqe.ErrNotFound()
 }
 
-func (db *FileDB) ListSpaces(ctx context.Context) ([]schema.SpaceRow, error) {
+func (db *FileDB) ListSpaces(ctx context.Context, tenantID auth.TenantID) ([]schema.SpaceRow, error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	return db.load(ctx)
+	all, err := db.load(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var rows []schema.SpaceRow
+	for _, r := range all {
+		if r.TenantID == tenantID {
+			rows = append(rows, r)
+		}
+	}
+	return rows, nil
 }
 
 func (db *FileDB) UpdateSpaceName(ctx context.Context, id api.SpaceID, name string) error {
@@ -208,17 +166,22 @@ func (db *FileDB) UpdateSpaceName(ctx context.Context, id api.SpaceID, name stri
 	}
 
 	idx := -1
-	for i := range rows {
-		if rows[i].ID == id {
+	for i, r := range rows {
+		if r.ID == id {
 			idx = i
-			continue
-		}
-		if rows[i].Name == name {
-			return zqe.ErrConflict("space with name '%s' already exists", name)
+			break
 		}
 	}
 	if idx == -1 {
 		return zqe.ErrNotFound()
+	}
+	for _, r := range rows {
+		if r.TenantID != rows[idx].TenantID {
+			continue
+		}
+		if r.Name == name {
+			return zqe.ErrConflict("space with name '%s' already exists", name)
+		}
 	}
 
 	rows[idx].Name = name

--- a/ppl/zqd/db/filedb/migrate.go
+++ b/ppl/zqd/db/filedb/migrate.go
@@ -1,0 +1,142 @@
+package filedb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/brimsec/zq/api"
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/ppl/zqd/auth"
+	"github.com/brimsec/zq/ppl/zqd/db/filedb/oldconfig"
+	"github.com/brimsec/zq/ppl/zqd/db/schema"
+	"github.com/brimsec/zq/zqe"
+	"go.uber.org/zap"
+)
+
+const currentVersion = 5
+
+type dbdata struct {
+	Version   int               `json:"version"`
+	SpaceRows []schema.SpaceRow `json:"space_rows"`
+}
+
+func migrateOldConfig(ctx context.Context, logger *zap.Logger, root iosrc.URI) error {
+	dburi := root.AppendPath(dbname)
+	exists, err := iosrc.Exists(ctx, dburi)
+	if err != nil || exists {
+		return err
+	}
+
+	// Since the dbfile doesn't exist, we check if we need to migrate the older
+	// per-space config files into a new dbfile.
+	configs, err := oldconfig.LoadConfigs(ctx, logger, root)
+	if err != nil {
+		return err
+	}
+	var rows []rowV4
+	for id, config := range configs {
+		datauri := config.DataURI
+		if datauri.IsZero() {
+			datauri = root.AppendPath(string(id))
+		}
+		rows = append(rows, rowV4{
+			ID:      id,
+			Name:    config.Name,
+			DataURI: datauri,
+			Storage: config.Storage,
+		})
+		for _, subcfg := range config.Subspaces {
+			openopts := subcfg.OpenOptions
+			rows = append(rows, rowV4{
+				ID:       subcfg.ID,
+				ParentID: id,
+				Name:     subcfg.Name,
+				DataURI:  datauri,
+				Storage: api.StorageConfig{
+					Kind: api.ArchiveStore,
+					Archive: &api.ArchiveConfig{
+						OpenOptions: &openopts,
+					},
+				},
+			})
+		}
+	}
+	return iosrc.Replace(ctx, dburi, func(w io.Writer) error {
+		return json.NewEncoder(w).Encode(dbdataV4{
+			Version:   4,
+			SpaceRows: rows,
+		})
+	})
+}
+
+func migrateFileDatabase(ctx context.Context, dburi iosrc.URI) error {
+	data, err := iosrc.ReadFile(ctx, dburi)
+	if err != nil {
+		if zqe.IsNotFound(err) {
+			return iosrc.Replace(ctx, dburi, func(w io.Writer) error {
+				return json.NewEncoder(w).Encode(dbdata{
+					Version: currentVersion,
+				})
+			})
+		}
+		return err
+	}
+	var vc struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal(data, &vc); err != nil {
+		return err
+	}
+	var migrator func([]byte) (int, []byte, error)
+	version := vc.Version
+	for version < currentVersion {
+		switch version {
+		case 4:
+			migrator = migrateV5
+		default:
+			return fmt.Errorf("unsupported database version %d", version)
+		}
+		var err error
+		if version, data, err = migrator(data); err != nil {
+			return err
+		}
+	}
+	return iosrc.WriteFile(ctx, dburi, data)
+}
+
+type dbdataV4 struct {
+	Version   int     `json:"version"`
+	SpaceRows []rowV4 `json:"space_rows"`
+}
+
+type rowV4 struct {
+	ID       api.SpaceID       `json:"id"`
+	DataURI  iosrc.URI         `json:"data_uri"`
+	Name     string            `json:"name"`
+	ParentID api.SpaceID       `json:"parent_id"`
+	Storage  api.StorageConfig `json:"storage"`
+}
+
+func migrateV5(data []byte) (int, []byte, error) {
+	var dbv4 dbdataV4
+	if err := json.Unmarshal(data, &dbv4); err != nil {
+		return 0, nil, err
+	}
+	var db dbdata
+	db.Version = 5
+	db.SpaceRows = make([]schema.SpaceRow, 0, len(dbv4.SpaceRows))
+	for _, r := range dbv4.SpaceRows {
+		db.SpaceRows = append(db.SpaceRows, schema.SpaceRow{
+			TenantID: auth.AnonymousTenantID,
+			ID:       r.ID,
+			DataURI:  r.DataURI,
+			Name:     r.Name,
+			ParentID: r.ParentID,
+			Storage:  r.Storage,
+		})
+	}
+	data, err := json.Marshal(db)
+	return 5, data, err
+}

--- a/ppl/zqd/db/postgresdb/migrations/20210119172011_add_tenant_id.down.sql
+++ b/ppl/zqd/db/postgresdb/migrations/20210119172011_add_tenant_id.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE space DROP CONSTRAINT space_name_key;
+ALTER TABLE space ADD CONSTRAINT space_name_key UNIQUE (name);
+ALTER TABLE space DROP tenant_id;

--- a/ppl/zqd/db/postgresdb/migrations/20210119172011_add_tenant_id.up.sql
+++ b/ppl/zqd/db/postgresdb/migrations/20210119172011_add_tenant_id.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE space ADD tenant_id text;
+ALTER TABLE space DROP CONSTRAINT space_name_key;
+ALTER TABLE space ADD CONSTRAINT space_name_key UNIQUE (tenant_id, name);

--- a/ppl/zqd/db/postgresdb/postgresdb.go
+++ b/ppl/zqd/db/postgresdb/postgresdb.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/brimsec/zq/api"
+	"github.com/brimsec/zq/ppl/zqd/auth"
 	"github.com/brimsec/zq/ppl/zqd/db/schema"
 	"github.com/brimsec/zq/zqe"
 	"github.com/go-pg/pg/v10"
@@ -61,9 +62,9 @@ func (d *PostgresDB) GetSpace(ctx context.Context, id api.SpaceID) (schema.Space
 	return space, err
 }
 
-func (d *PostgresDB) ListSpaces(ctx context.Context) ([]schema.SpaceRow, error) {
+func (d *PostgresDB) ListSpaces(ctx context.Context, tenantID auth.TenantID) ([]schema.SpaceRow, error) {
 	var spaces []schema.SpaceRow
-	_, err := d.db.QueryContext(ctx, &spaces, "SELECT * FROM space")
+	_, err := d.db.QueryContext(ctx, &spaces, "SELECT * FROM space WHERE tenant_id = ?", tenantID)
 	return spaces, err
 }
 

--- a/ppl/zqd/db/postgresdb/ztests/rename.yaml
+++ b/ppl/zqd/db/postgresdb/ztests/rename.yaml
@@ -23,7 +23,7 @@ outputs:
     data: |
       testsp: space created
       ===
-      testsp: space renamed to newname
+      space renamed to newname
       ===
       newname
   - name: stderr

--- a/ppl/zqd/db/postgresdb/ztests/startup.sh
+++ b/ppl/zqd/db/postgresdb/ztests/startup.sh
@@ -24,7 +24,7 @@ zqd listen -l=localhost:0 \
   -portfile="$portdir/zqd" \
   -db.kind="postgres" \
   -db.postgres.url=$PG_TEST \
-  -db.postgres.database=$dbname &> zqd.log &
+  -db.postgres.database=$dbname $ZQD_EXTRA_FLAGS &> zqd.log &
 
 zqdpid=$!
 awaitfile $portdir/zqd

--- a/ppl/zqd/db/postgresdb/ztests/tenant.yaml
+++ b/ppl/zqd/db/postgresdb/ztests/tenant.yaml
@@ -1,0 +1,81 @@
+tag: postgres
+
+script: |
+  ZQD_EXTRA_FLAGS="-auth.enabled=true -auth.clientid=testclient -auth.domain=https://testdomain -auth.jwkspath=./auth-public-jwks.json" source startup.sh
+  zapi -h $ZQD_HOST -configpath ./user1 auth store -access \
+    $(testtoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant1 -userid user1)
+  zapi -h $ZQD_HOST -configpath ./user2 auth store -access \
+    $(testtoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant2 -userid user2)
+  echo ===
+  zapi -configpath ./user1 -h $ZQD_HOST auth verify
+  echo ===
+  zapi -configpath ./user2 -h $ZQD_HOST auth verify
+  echo ===
+  zapi -configpath ./user1 -h $ZQD_HOST new testsp0
+  zapi -configpath ./user1 -h $ZQD_HOST new testsp1
+  zapi -configpath ./user2 -h $ZQD_HOST new testsp0
+  zapi -configpath ./user2 -h $ZQD_HOST new testsp2
+  export USER1_SP1=$(zapi -configpath ./user1 -h $ZQD_HOST info testsp1 | grep "id:" | head -n 1 | awk '{print $2}')
+  export USER2_SP2=$(zapi -configpath ./user2 -h $ZQD_HOST info testsp2| grep "id:" | head -n 1 | awk '{print $2}')
+  export USER1_SP0=$(zapi -configpath ./user1 -h $ZQD_HOST info testsp0 | grep "id:" | head -n 1 | awk '{print $2}')
+  export USER2_SP0=$(zapi -configpath ./user2 -h $ZQD_HOST info testsp0 | grep "id:" | head -n 1 | awk '{print $2}')
+  echo ===
+  echo user1 ls
+  zapi -configpath ./user1 -h $ZQD_HOST ls
+  echo ===
+  echo user2 ls
+  zapi -configpath ./user2 -h $ZQD_HOST ls
+  echo ===
+  echo user1 info
+  zapi -configpath ./user1 -h $ZQD_HOST -id $USER2_SP0 info 2>&1
+  echo ===
+  echo user1 rename
+  zapi -configpath ./user1 -h $ZQD_HOST -id $USER2_SP0 rename newname 2>&1
+  echo ===
+  echo user1 rm
+  zapi -configpath ./user1 -h $ZQD_HOST -id $USER2_SP0 rm 2>&1
+
+
+inputs:
+  - name: startup.sh
+    source: startup.sh
+  - name: migrations
+    symlink: ../migrations
+  - name: auth-public-jwks.json
+    source: ../../../testdata/auth-public-jwks.json
+  - name: auth-private-key
+    source: ../../../testdata/auth-private-key
+
+outputs:
+  - name: stdout
+    data: |
+      ===
+      {
+      	"tenant_id": "tenant1",
+      	"user_id": "user1"
+      }
+      ===
+      {
+      	"tenant_id": "tenant2",
+      	"user_id": "user2"
+      }
+      ===
+      testsp0: space created
+      testsp1: space created
+      testsp0: space created
+      testsp2: space created
+      ===
+      user1 ls
+      testsp0   testsp1
+      ===
+      user2 ls
+      testsp0   testsp2
+      ===
+      user1 info
+      status code 403: forbidden
+      ===
+      user1 rename
+      status code 403: forbidden
+      ===
+      user1 rm
+      status code 403: forbidden

--- a/ppl/zqd/db/postgresdb/ztests/tenant.yaml
+++ b/ppl/zqd/db/postgresdb/ztests/tenant.yaml
@@ -3,9 +3,9 @@ tag: postgres
 script: |
   ZQD_EXTRA_FLAGS="-auth.enabled=true -auth.clientid=testclient -auth.domain=https://testdomain -auth.jwkspath=./auth-public-jwks.json" source startup.sh
   zapi -h $ZQD_HOST -configpath ./user1 auth store -access \
-    $(testtoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant1 -userid user1)
+    $(gentoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant1 -userid user1)
   zapi -h $ZQD_HOST -configpath ./user2 auth store -access \
-    $(testtoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant2 -userid user2)
+    $(gentoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant2 -userid user2)
   echo ===
   zapi -configpath ./user1 -h $ZQD_HOST auth verify
   echo ===

--- a/ppl/zqd/db/postgresdb/ztests/tenant.yaml
+++ b/ppl/zqd/db/postgresdb/ztests/tenant.yaml
@@ -1,37 +1,44 @@
 tag: postgres
 
 script: |
+  # Start an authentication enabled zqd, and create 2 separate access tokens
+  # representing different users in different tenants.
   ZQD_EXTRA_FLAGS="-auth.enabled=true -auth.clientid=testclient -auth.domain=https://testdomain -auth.jwkspath=./auth-public-jwks.json" source startup.sh
   zapi -h $ZQD_HOST -configpath ./user1 auth store -access \
     $(gentoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant1 -userid user1)
   zapi -h $ZQD_HOST -configpath ./user2 auth store -access \
     $(gentoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant2 -userid user2)
-  echo ===
   zapi -configpath ./user1 -h $ZQD_HOST auth verify
-  echo ===
   zapi -configpath ./user2 -h $ZQD_HOST auth verify
   echo ===
+  # Create 2 spaces for each user, using the same name for one of the spaces,
+  # export their space id for later usage.
   zapi -configpath ./user1 -h $ZQD_HOST new testsp0
-  zapi -configpath ./user1 -h $ZQD_HOST new testsp1
-  zapi -configpath ./user2 -h $ZQD_HOST new testsp0
-  zapi -configpath ./user2 -h $ZQD_HOST new testsp2
-  export USER1_SP1=$(zapi -configpath ./user1 -h $ZQD_HOST info testsp1 | grep "id:" | head -n 1 | awk '{print $2}')
-  export USER2_SP2=$(zapi -configpath ./user2 -h $ZQD_HOST info testsp2| grep "id:" | head -n 1 | awk '{print $2}')
   export USER1_SP0=$(zapi -configpath ./user1 -h $ZQD_HOST info testsp0 | grep "id:" | head -n 1 | awk '{print $2}')
+  zapi -configpath ./user1 -h $ZQD_HOST new testsp1
+  export USER1_SP1=$(zapi -configpath ./user1 -h $ZQD_HOST info testsp1 | grep "id:" | head -n 1 | awk '{print $2}')
+  zapi -configpath ./user2 -h $ZQD_HOST new testsp0
   export USER2_SP0=$(zapi -configpath ./user2 -h $ZQD_HOST info testsp0 | grep "id:" | head -n 1 | awk '{print $2}')
+  zapi -configpath ./user2 -h $ZQD_HOST new testsp2
+  export USER2_SP2=$(zapi -configpath ./user2 -h $ZQD_HOST info testsp2| grep "id:" | head -n 1 | awk '{print $2}')
   echo ===
+  # List the spaces for each user, and verify that they see only the spaces
+  # that they created.
   echo user1 ls
   zapi -configpath ./user1 -h $ZQD_HOST ls
   echo ===
   echo user2 ls
   zapi -configpath ./user2 -h $ZQD_HOST ls
   echo ===
+  # User1 should not be able to access user2's space.
   echo user1 info
   zapi -configpath ./user1 -h $ZQD_HOST -id $USER2_SP0 info 2>&1
   echo ===
+  # User1 should not be able to rename user2's space.
   echo user1 rename
   zapi -configpath ./user1 -h $ZQD_HOST -id $USER2_SP0 rename newname 2>&1
   echo ===
+  # User1 should not be able to remove user2's space.
   echo user1 rm
   zapi -configpath ./user1 -h $ZQD_HOST -id $USER2_SP0 rm 2>&1
 
@@ -49,12 +56,10 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      ===
       {
       	"tenant_id": "tenant1",
       	"user_id": "user1"
       }
-      ===
       {
       	"tenant_id": "tenant2",
       	"user_id": "user2"

--- a/ppl/zqd/db/schema/spacerow.go
+++ b/ppl/zqd/db/schema/spacerow.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/ppl/zqd/auth"
 	"github.com/segmentio/ksuid"
 )
 
@@ -17,6 +18,7 @@ type SpaceRow struct {
 	Name      string            `json:"name"`
 	ParentID  api.SpaceID       `json:"parent_id"`
 	Storage   api.StorageConfig `json:"storage"`
+	TenantID  auth.TenantID     `json:"tenant_id"`
 }
 
 func NewSpaceID() api.SpaceID {

--- a/ppl/zqd/handlers.go
+++ b/ppl/zqd/handlers.go
@@ -595,7 +595,7 @@ func extractSpaceID(c *Core, w http.ResponseWriter, r *http.Request) (api.SpaceI
 }
 
 func handleAuthIdentityGet(c *Core, w http.ResponseWriter, r *http.Request) {
-	ident := auth.IdentifyFromContext(r.Context())
+	ident := auth.IdentityFromContext(r.Context())
 	respond(c, w, r, http.StatusOK, api.AuthIdentityResponse{
 		TenantID: string(ident.TenantID),
 		UserID:   string(ident.UserID),

--- a/ppl/zqd/handlers.go
+++ b/ppl/zqd/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/pcap"
 	"github.com/brimsec/zq/pkg/ctxio"
+	"github.com/brimsec/zq/ppl/zqd/auth"
 	"github.com/brimsec/zq/ppl/zqd/ingest"
 	"github.com/brimsec/zq/ppl/zqd/jsonpipe"
 	"github.com/brimsec/zq/ppl/zqd/search"
@@ -46,6 +47,8 @@ func errorResponse(e error) (status int, ae *api.Error) {
 		status = http.StatusConflict
 	case zqe.NoCredentials:
 		status = http.StatusUnauthorized
+	case zqe.Forbidden:
+		status = http.StatusForbidden
 	}
 
 	ae.Kind = ze.Kind.String()
@@ -592,14 +595,10 @@ func extractSpaceID(c *Core, w http.ResponseWriter, r *http.Request) (api.SpaceI
 }
 
 func handleAuthIdentityGet(c *Core, w http.ResponseWriter, r *http.Request) {
-	ident, ok := IdentifyFromContext(r.Context())
-	if !ok {
-		respondError(c, w, r, zqe.ErrInvalid("no valid credentials"))
-		return
-	}
+	ident := auth.IdentifyFromContext(r.Context())
 	respond(c, w, r, http.StatusOK, api.AuthIdentityResponse{
-		TenantID: ident.TenantID,
-		UserID:   ident.UserID,
+		TenantID: string(ident.TenantID),
+		UserID:   string(ident.UserID),
 	})
 }
 

--- a/ppl/zqd/ztests/auth/tenant.yaml
+++ b/ppl/zqd/ztests/auth/tenant.yaml
@@ -1,9 +1,9 @@
 script: |
   ZQD_EXTRA_FLAGS="-auth.enabled=true -auth.clientid=testclient -auth.domain=https://testdomain -auth.jwkspath=./auth-public-jwks.json" source services.sh
   zapi -h $ZQD_HOST -configpath ./user1 auth store -access \
-    $(testtoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant1 -userid user1)
+    $(gentoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant1 -userid user1)
   zapi -h $ZQD_HOST -configpath ./user2 auth store -access \
-    $(testtoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant2 -userid user2)
+    $(gentoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant2 -userid user2)
   echo ===
   zapi -configpath ./user1 -h $ZQD_HOST auth verify
   echo ===

--- a/ppl/zqd/ztests/auth/tenant.yaml
+++ b/ppl/zqd/ztests/auth/tenant.yaml
@@ -1,0 +1,77 @@
+script: |
+  ZQD_EXTRA_FLAGS="-auth.enabled=true -auth.clientid=testclient -auth.domain=https://testdomain -auth.jwkspath=./auth-public-jwks.json" source services.sh
+  zapi -h $ZQD_HOST -configpath ./user1 auth store -access \
+    $(testtoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant1 -userid user1)
+  zapi -h $ZQD_HOST -configpath ./user2 auth store -access \
+    $(testtoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant2 -userid user2)
+  echo ===
+  zapi -configpath ./user1 -h $ZQD_HOST auth verify
+  echo ===
+  zapi -configpath ./user2 -h $ZQD_HOST auth verify
+  echo ===
+  zapi -configpath ./user1 -h $ZQD_HOST new testsp0
+  zapi -configpath ./user1 -h $ZQD_HOST new testsp1
+  zapi -configpath ./user2 -h $ZQD_HOST new testsp0
+  zapi -configpath ./user2 -h $ZQD_HOST new testsp2
+  export USER1_SP1=$(zapi -configpath ./user1 -h $ZQD_HOST info testsp1 | grep "id:" | head -n 1 | awk '{print $2}')
+  export USER2_SP2=$(zapi -configpath ./user2 -h $ZQD_HOST info testsp2| grep "id:" | head -n 1 | awk '{print $2}')
+  export USER1_SP0=$(zapi -configpath ./user1 -h $ZQD_HOST info testsp0 | grep "id:" | head -n 1 | awk '{print $2}')
+  export USER2_SP0=$(zapi -configpath ./user2 -h $ZQD_HOST info testsp0 | grep "id:" | head -n 1 | awk '{print $2}')
+  echo ===
+  echo user1 ls
+  zapi -configpath ./user1 -h $ZQD_HOST ls
+  echo ===
+  echo user2 ls
+  zapi -configpath ./user2 -h $ZQD_HOST ls
+  echo ===
+  echo user1 info
+  zapi -configpath ./user1 -h $ZQD_HOST -id $USER2_SP0 info 2>&1
+  echo ===
+  echo user1 rename
+  zapi -configpath ./user1 -h $ZQD_HOST -id $USER2_SP0 rename newname 2>&1
+  echo ===
+  echo user1 rm
+  zapi -configpath ./user1 -h $ZQD_HOST -id $USER2_SP0 rm 2>&1
+
+
+inputs:
+  - name: services.sh
+    source: ../services.sh
+  - name: auth-public-jwks.json
+    source: ../../testdata/auth-public-jwks.json
+  - name: auth-private-key
+    source: ../../testdata/auth-private-key
+
+outputs:
+  - name: stdout
+    data: |
+      ===
+      {
+      	"tenant_id": "tenant1",
+      	"user_id": "user1"
+      }
+      ===
+      {
+      	"tenant_id": "tenant2",
+      	"user_id": "user2"
+      }
+      ===
+      testsp0: space created
+      testsp1: space created
+      testsp0: space created
+      testsp2: space created
+      ===
+      user1 ls
+      testsp0   testsp1
+      ===
+      user2 ls
+      testsp0   testsp2
+      ===
+      user1 info
+      status code 403: forbidden
+      ===
+      user1 rename
+      status code 403: forbidden
+      ===
+      user1 rm
+      status code 403: forbidden

--- a/ppl/zqd/ztests/auth/tenant.yaml
+++ b/ppl/zqd/ztests/auth/tenant.yaml
@@ -1,35 +1,42 @@
 script: |
+  # Start an authentication enabled zqd, and create 2 separate access tokens
+  # representing different users in different tenants.
   ZQD_EXTRA_FLAGS="-auth.enabled=true -auth.clientid=testclient -auth.domain=https://testdomain -auth.jwkspath=./auth-public-jwks.json" source services.sh
   zapi -h $ZQD_HOST -configpath ./user1 auth store -access \
     $(gentoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant1 -userid user1)
   zapi -h $ZQD_HOST -configpath ./user2 auth store -access \
     $(gentoken -domain https://testdomain -privatekeyfile ./auth-private-key -keyid testkey -tenantid tenant2 -userid user2)
-  echo ===
   zapi -configpath ./user1 -h $ZQD_HOST auth verify
-  echo ===
   zapi -configpath ./user2 -h $ZQD_HOST auth verify
   echo ===
+  # Create 2 spaces for each user, using the same name for one of the spaces,
+  # export their space id for later usage.
   zapi -configpath ./user1 -h $ZQD_HOST new testsp0
-  zapi -configpath ./user1 -h $ZQD_HOST new testsp1
-  zapi -configpath ./user2 -h $ZQD_HOST new testsp0
-  zapi -configpath ./user2 -h $ZQD_HOST new testsp2
-  export USER1_SP1=$(zapi -configpath ./user1 -h $ZQD_HOST info testsp1 | grep "id:" | head -n 1 | awk '{print $2}')
-  export USER2_SP2=$(zapi -configpath ./user2 -h $ZQD_HOST info testsp2| grep "id:" | head -n 1 | awk '{print $2}')
   export USER1_SP0=$(zapi -configpath ./user1 -h $ZQD_HOST info testsp0 | grep "id:" | head -n 1 | awk '{print $2}')
+  zapi -configpath ./user1 -h $ZQD_HOST new testsp1
+  export USER1_SP1=$(zapi -configpath ./user1 -h $ZQD_HOST info testsp1 | grep "id:" | head -n 1 | awk '{print $2}')
+  zapi -configpath ./user2 -h $ZQD_HOST new testsp0
   export USER2_SP0=$(zapi -configpath ./user2 -h $ZQD_HOST info testsp0 | grep "id:" | head -n 1 | awk '{print $2}')
+  zapi -configpath ./user2 -h $ZQD_HOST new testsp2
+  export USER2_SP2=$(zapi -configpath ./user2 -h $ZQD_HOST info testsp2| grep "id:" | head -n 1 | awk '{print $2}')
   echo ===
+  # List the spaces for each user, and verify that they see only the spaces
+  # that they created.
   echo user1 ls
   zapi -configpath ./user1 -h $ZQD_HOST ls
   echo ===
   echo user2 ls
   zapi -configpath ./user2 -h $ZQD_HOST ls
   echo ===
+  # User1 should not be able to access user2's space.
   echo user1 info
   zapi -configpath ./user1 -h $ZQD_HOST -id $USER2_SP0 info 2>&1
   echo ===
+  # User1 should not be able to rename user2's space.
   echo user1 rename
   zapi -configpath ./user1 -h $ZQD_HOST -id $USER2_SP0 rename newname 2>&1
   echo ===
+  # User1 should not be able to remove user2's space.
   echo user1 rm
   zapi -configpath ./user1 -h $ZQD_HOST -id $USER2_SP0 rm 2>&1
 
@@ -45,12 +52,10 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      ===
       {
       	"tenant_id": "tenant1",
       	"user_id": "user1"
       }
-      ===
       {
       	"tenant_id": "tenant2",
       	"user_id": "user2"

--- a/zqe/error.go
+++ b/zqe/error.go
@@ -22,6 +22,7 @@ const (
 	Invalid
 	NotFound
 	NoCredentials
+	Forbidden
 )
 
 func (k Kind) String() string {
@@ -38,6 +39,8 @@ func (k Kind) String() string {
 		return "item does not exist"
 	case NoCredentials:
 		return "missing authentication credentials"
+	case Forbidden:
+		return "forbidden"
 	}
 	return "unknown error kind"
 }
@@ -135,11 +138,13 @@ func IsKind(err error, k Kind) bool {
 	return errors.As(err, &zerr) && zerr.Kind == k
 }
 
-func IsOther(err error) bool    { return IsKind(err, Other) }
-func IsConflict(err error) bool { return IsKind(err, Conflict) }
-func IsExists(err error) bool   { return IsKind(err, Exists) }
-func IsInvalid(err error) bool  { return IsKind(err, Invalid) }
-func IsNotFound(err error) bool { return IsKind(err, NotFound) }
+func IsOther(err error) bool            { return IsKind(err, Other) }
+func IsConflict(err error) bool         { return IsKind(err, Conflict) }
+func IsExists(err error) bool           { return IsKind(err, Exists) }
+func IsInvalid(err error) bool          { return IsKind(err, Invalid) }
+func IsNotFound(err error) bool         { return IsKind(err, NotFound) }
+func IsErrNoCredentials(err error) bool { return IsKind(err, NoCredentials) }
+func IsForbidden(err error) bool        { return IsKind(err, Forbidden) }
 
 func ErrOther(args ...interface{}) error         { return errKind(Other, args) }
 func ErrConflict(args ...interface{}) error      { return errKind(Conflict, args) }
@@ -147,6 +152,7 @@ func ErrExists(args ...interface{}) error        { return errKind(Exists, args) 
 func ErrInvalid(args ...interface{}) error       { return errKind(Invalid, args) }
 func ErrNotFound(args ...interface{}) error      { return errKind(NotFound, args) }
 func ErrNoCredentials(args ...interface{}) error { return errKind(NoCredentials, args) }
+func ErrForbidden(args ...interface{}) error     { return errKind(Forbidden, args) }
 
 func errKind(k Kind, args []interface{}) error {
 	args = append([]interface{}{k}, args...)

--- a/zqe/error.go
+++ b/zqe/error.go
@@ -19,28 +19,28 @@ const (
 	Other Kind = iota
 	Conflict
 	Exists
-	Invalid
-	NotFound
-	NoCredentials
 	Forbidden
+	Invalid
+	NoCredentials
+	NotFound
 )
 
 func (k Kind) String() string {
 	switch k {
-	case Other:
-		return "other error"
 	case Conflict:
 		return "conflict with pending operation"
-	case Invalid:
-		return "invalid operation"
 	case Exists:
 		return "item already exists"
-	case NotFound:
-		return "item does not exist"
-	case NoCredentials:
-		return "missing authentication credentials"
+	case Invalid:
+		return "invalid operation"
 	case Forbidden:
 		return "forbidden"
+	case NoCredentials:
+		return "missing authentication credentials"
+	case NotFound:
+		return "item does not exist"
+	case Other:
+		return "other error"
 	}
 	return "unknown error kind"
 }
@@ -138,21 +138,21 @@ func IsKind(err error, k Kind) bool {
 	return errors.As(err, &zerr) && zerr.Kind == k
 }
 
-func IsOther(err error) bool            { return IsKind(err, Other) }
-func IsConflict(err error) bool         { return IsKind(err, Conflict) }
-func IsExists(err error) bool           { return IsKind(err, Exists) }
-func IsInvalid(err error) bool          { return IsKind(err, Invalid) }
-func IsNotFound(err error) bool         { return IsKind(err, NotFound) }
-func IsErrNoCredentials(err error) bool { return IsKind(err, NoCredentials) }
-func IsForbidden(err error) bool        { return IsKind(err, Forbidden) }
+func IsConflict(err error) bool      { return IsKind(err, Conflict) }
+func IsExists(err error) bool        { return IsKind(err, Exists) }
+func IsForbidden(err error) bool     { return IsKind(err, Forbidden) }
+func IsInvalid(err error) bool       { return IsKind(err, Invalid) }
+func IsNoCredentials(err error) bool { return IsKind(err, NoCredentials) }
+func IsNotFound(err error) bool      { return IsKind(err, NotFound) }
+func IsOther(err error) bool         { return IsKind(err, Other) }
 
-func ErrOther(args ...interface{}) error         { return errKind(Other, args) }
 func ErrConflict(args ...interface{}) error      { return errKind(Conflict, args) }
 func ErrExists(args ...interface{}) error        { return errKind(Exists, args) }
-func ErrInvalid(args ...interface{}) error       { return errKind(Invalid, args) }
-func ErrNotFound(args ...interface{}) error      { return errKind(NotFound, args) }
-func ErrNoCredentials(args ...interface{}) error { return errKind(NoCredentials, args) }
 func ErrForbidden(args ...interface{}) error     { return errKind(Forbidden, args) }
+func ErrInvalid(args ...interface{}) error       { return errKind(Invalid, args) }
+func ErrNoCredentials(args ...interface{}) error { return errKind(NoCredentials, args) }
+func ErrNotFound(args ...interface{}) error      { return errKind(NotFound, args) }
+func ErrOther(args ...interface{}) error         { return errKind(Other, args) }
 
 func errKind(k Kind, args []interface{}) error {
 	args = append([]interface{}{k}, args...)

--- a/ztest/shell.go
+++ b/ztest/shell.go
@@ -23,6 +23,7 @@ func RunShell(dir *Dir, bindir, script string, stdin io.Reader, useenvs []string
 		}
 	}
 
+	cmd.Env = append(cmd.Env, "HOME="+dir.Path())
 	cmd.Env = append(cmd.Env, "PATH=/bin:/usr/bin:"+bindir)
 	cmd.Dir = dir.Path()
 	cmd.Stdin = stdin


### PR DESCRIPTION
This changes adds initial multitenancy support to zqd.

The high level summary is that when requests are issued to zqd, those requests will have an associated identity, either specified by an authenticated JWT, or the "anonymous" identity. When a space is created, the tenant id of the creating identity is stored with it. Only users with the same tenant id will be allowed to interact with the space. When a list of spaces is requested, the tenant id is used as a filter in the returned spaces.

The token validation and context interaction parts of auth moved into a separate package from package zqd & api. I dropped the dependency on the auth0 jwt middleware, as it was just a thin wrapper around the go-jwt 'jwt.Parse' call. The validation code is better tested here with the new Go tests, and I wrote those guided by looking at test coverage results in my IDE.

zapi gets a new flag, `-configpath`, used to set where it looks for its configuration holding directory. It defaults to os.UserConfigDir, which is $HOME/.config for Linux systems. To aid this change, I made sure that the $HOME variable is set during ztests; it's set to the temporary directory where the ztest is run.

With this change, it's always possible to call `auth.IdentityFromContext`. When zqd is run without authentication enabled, it will always return an identity with the anonymous user and tenant values.

I added migrations to the file and postgres database implementations, adding a column for "tenant_id", which is set to the anonymous tenant value by default.

I added ztests that verify the tenant handling when zqd is backed by either a filedb or postgres. The ztests uses a new utility, "testtoken", to generate a signed JWT using the public/private test key pair in zqd/testdata.


