### PR TITLE
archive: Immutable local cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/google/gopacket v1.1.17
 	github.com/gorilla/mux v1.7.5-0.20200711200521-98cb6bf42e08
 	github.com/gosuri/uilive v0.0.4
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.10.3 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
@@ -30,6 +31,7 @@ require (
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/client_model v0.2.0
 	github.com/segmentio/ksuid v1.0.2
 	github.com/stretchr/testify v1.6.1
 	github.com/xitongsys/parquet-go v1.5.3-0.20200514000040-789bba367841

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+
 github.com/hashicorp/go-uuid v0.0.0-20180228145832-27454136f036/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/influxdata/influxdb v1.7.6/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=

--- a/pkg/iosrc/mux.go
+++ b/pkg/iosrc/mux.go
@@ -1,0 +1,144 @@
+package iosrc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// MuxSource is a Source that routes each function call to the correct Source
+// based off the provided URI's scheme.
+type MuxSource struct {
+	schemes map[string]Source
+}
+
+func NewMuxSource(m map[string]Source) *MuxSource {
+	return &MuxSource{m}
+}
+
+func (m *MuxSource) AddScheme(scheme string, source Source) {
+	m.schemes[scheme] = source
+}
+
+func getScheme(uri URI) string {
+	if uri.Scheme == "" {
+		return FileScheme
+	}
+	return uri.Scheme
+}
+
+func (m *MuxSource) GetSource(u URI) (Source, error) {
+	scheme := getScheme(u)
+	source, ok := m.schemes[scheme]
+	if !ok {
+		return nil, fmt.Errorf("unknown scheme: %q", scheme)
+	}
+	return source, nil
+}
+
+func (m *MuxSource) NewReader(ctx context.Context, uri URI) (Reader, error) {
+	source, err := m.GetSource(uri)
+	if err != nil {
+		return nil, err
+	}
+	return source.NewReader(ctx, uri)
+}
+
+func (m *MuxSource) NewWriter(ctx context.Context, uri URI) (io.WriteCloser, error) {
+	source, err := m.GetSource(uri)
+	if err != nil {
+		return nil, err
+	}
+	return source.NewWriter(ctx, uri)
+}
+
+func (m *MuxSource) ReadFile(ctx context.Context, uri URI) ([]byte, error) {
+	source, err := m.GetSource(uri)
+	if err != nil {
+		return nil, err
+	}
+	return source.ReadFile(ctx, uri)
+}
+
+func (m *MuxSource) WriteFile(ctx context.Context, uri URI, d []byte) error {
+	source, err := m.GetSource(uri)
+	if err != nil {
+		return err
+	}
+	return source.WriteFile(ctx, d, uri)
+}
+
+func (m *MuxSource) Exists(ctx context.Context, uri URI) (bool, error) {
+	source, err := m.GetSource(uri)
+	if err != nil {
+		return false, err
+	}
+	return source.Exists(ctx, uri)
+}
+
+func (m *MuxSource) Remove(ctx context.Context, uri URI) error {
+	source, err := m.GetSource(uri)
+	if err != nil {
+		return err
+	}
+	return source.Remove(ctx, uri)
+}
+
+func (m *MuxSource) RemoveAll(ctx context.Context, uri URI) error {
+	source, err := m.GetSource(uri)
+	if err != nil {
+		return err
+	}
+	return source.RemoveAll(ctx, uri)
+}
+
+func (m *MuxSource) Stat(ctx context.Context, uri URI) (Info, error) {
+	source, err := m.GetSource(uri)
+	if err != nil {
+		return nil, err
+	}
+	return source.Stat(ctx, uri)
+}
+
+func (m *MuxSource) ReadDir(ctx context.Context, uri URI) ([]Info, error) {
+	source, err := m.GetSource(uri)
+	if err != nil {
+		return nil, err
+	}
+	return source.ReadDir(ctx, uri)
+}
+
+func (m *MuxSource) Replace(ctx context.Context, uri URI, fn func(w io.Writer) error) error {
+	src, err := m.GetSource(uri)
+	if err != nil {
+		return err
+	}
+	replacerAble, ok := src.(ReplacerAble)
+	if !ok {
+		return errors.New("source does not support replacement")
+	}
+	r, err := replacerAble.NewReplacer(ctx, uri)
+	if err != nil {
+		return err
+	}
+	if err := fn(r); err != nil {
+		r.Abort()
+		return err
+	}
+	return r.Close()
+}
+
+// MkdirAll will run Source.MkdirAll on the provided URI if the URI's source
+// is a DirMaker, otherwise it will do nothing.
+func (m *MuxSource) MkdirAll(uri URI, mode os.FileMode) error {
+	src, err := m.GetSource(uri)
+	if err != nil {
+		return err
+	}
+	if mkr, ok := src.(DirMaker); ok {
+		err = mkr.MkdirAll(uri, mode)
+	}
+	return err
+}

--- a/pkg/promtest/promtest.go
+++ b/pkg/promtest/promtest.go
@@ -1,0 +1,42 @@
+package promtest
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func CounterValue(t *testing.T, g prometheus.Gatherer, name string, labels prometheus.Labels) float64 {
+	metricFamilies, err := g.Gather()
+	if err != nil {
+		t.Error(err)
+		return 0
+	}
+
+	for _, mf := range metricFamilies {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if labelsEqual(m.GetLabel(), labels) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+
+	t.Errorf("metric %q not found", name)
+	return 0
+}
+
+func labelsEqual(pairs []*dto.LabelPair, labels prometheus.Labels) bool {
+	if len(pairs) != len(labels) {
+		return false
+	}
+	for _, pair := range pairs {
+		if name, ok := labels[pair.GetName()]; !ok || name != pair.GetValue() {
+			return false
+		}
+	}
+	return true
+}

--- a/ppl/archive/immcache/immcache.go
+++ b/ppl/archive/immcache/immcache.go
@@ -4,6 +4,7 @@ package immcache
 
 import (
 	"context"
+	"flag"
 
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,6 +19,10 @@ type Config struct {
 	// local lru cache used to speed up searches. Values less than or equal to 0
 	// (default), disables local caching of immutable files.
 	LocalCacheSize int
+}
+
+func (c *Config) SetFlags(fs *flag.FlagSet) {
+	fs.IntVar(&c.LocalCacheSize, "immcache.localsize", 0, "enables local caching of up to N small files (disabled if 0)")
 }
 
 func New(conf Config, reg prometheus.Registerer) (ImmutableCache, error) {

--- a/ppl/archive/immcache/immcache.go
+++ b/ppl/archive/immcache/immcache.go
@@ -1,0 +1,28 @@
+// Package immcache contains facilities for caching immutable files for an
+// archive.
+package immcache
+
+import (
+	"context"
+
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type ImmutableCache interface {
+	ReadFile(context.Context, iosrc.URI) ([]byte, error)
+}
+
+type Config struct {
+	// LocalCacheSize specifies the number of immutable files to keep in a
+	// local lru cache used to speed up searches. Values less than or equal to 0
+	// (default), disables local caching of immutable files.
+	LocalCacheSize int
+}
+
+func New(conf Config, reg prometheus.Registerer) (ImmutableCache, error) {
+	if conf.LocalCacheSize > 0 {
+		return NewLocalCache(conf.LocalCacheSize, reg)
+	}
+	return nil, nil
+}

--- a/ppl/archive/immcache/local.go
+++ b/ppl/archive/immcache/local.go
@@ -1,0 +1,61 @@
+package immcache
+
+import (
+	"context"
+	"path"
+
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/ppl/archive/chunk"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type LocalCache struct {
+	lru    *lru.ARCCache
+	hits   *prometheus.CounterVec
+	misses *prometheus.CounterVec
+}
+
+func NewLocalCache(size int, registerer prometheus.Registerer) (*LocalCache, error) {
+	lru, err := lru.NewARC(size)
+	if err != nil {
+		return nil, err
+	}
+	if registerer == nil {
+		registerer = prometheus.NewRegistry()
+	}
+	factory := promauto.With(registerer)
+	return &LocalCache{
+		lru: lru,
+		hits: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "archive_cache_hits_total",
+				Help: "Number of hits for a cache lookup.",
+			},
+			[]string{"kind"},
+		),
+		misses: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "archive_cache_misses_total",
+				Help: "Number of misses for a cache lookup.",
+			},
+			[]string{"kind"},
+		),
+	}, nil
+}
+
+func (c *LocalCache) ReadFile(ctx context.Context, u iosrc.URI) ([]byte, error) {
+	kind, _, _ := chunk.FileMatch(path.Base(u.Path))
+	if v, ok := c.lru.Get(u.String()); ok {
+		c.hits.WithLabelValues(kind.Description()).Inc()
+		return v.([]byte), nil
+	}
+	b, err := iosrc.ReadFile(ctx, u)
+	if err != nil {
+		return nil, err
+	}
+	c.lru.Add(u.String(), b)
+	c.misses.WithLabelValues(kind.Description()).Inc()
+	return b, nil
+}

--- a/ppl/archive/multisource.go
+++ b/ppl/archive/multisource.go
@@ -153,7 +153,13 @@ func (m *spanMultiSource) SourceFromRequest(ctx context.Context, req *api.Worker
 		}
 		uri := tsdir.path(m.ark)
 		mdPath := chunk.MetadataPath(uri, id)
-		md, err := chunk.ReadMetadata(ctx, mdPath, m.ark.DataOrder)
+
+		b, err := m.ark.immfiles.ReadFile(ctx, mdPath)
+		if err != nil {
+			return nil, err
+		}
+
+		md, err := chunk.UnmarshalMetadata(b, m.ark.DataOrder)
 		if err != nil {
 			return nil, zqe.E("failed to read chunk metadata from %s: %w", mdPath.String(), err)
 		}

--- a/ppl/archive/walk.go
+++ b/ppl/archive/walk.go
@@ -118,7 +118,12 @@ func tsDirEntriesToChunks(ctx context.Context, ark *Archive, filterSpan nano.Spa
 		}
 		dir := tsDir.path(ark)
 		mdPath := chunk.MetadataPath(dir, id)
-		md, err := chunk.ReadMetadata(ctx, mdPath, ark.DataOrder)
+		b, err := ark.immfiles.ReadFile(ctx, mdPath)
+		if err != nil {
+			return nil, err
+		}
+
+		md, err := chunk.UnmarshalMetadata(b, ark.DataOrder)
 		if err != nil {
 			if zqe.IsNotFound(err) {
 				continue

--- a/ppl/cmd/zqd/listen/command.go
+++ b/ppl/cmd/zqd/listen/command.go
@@ -71,6 +71,7 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 	c.conf.Auth.SetFlags(f)
 	c.conf.Worker.SetFlags(f)
 	c.conf.DB.SetFlags(f)
+	c.conf.ImmutableCache.SetFlags(f)
 	c.conf.Version = cli.Version
 	f.IntVar(&c.brimfd, "brimfd", -1, "pipe read fd passed by brim to signal brim closure")
 	f.StringVar(&c.configfile, "config", "", "path to zqd config file")

--- a/ppl/zqd/core.go
+++ b/ppl/zqd/core.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/ppl/archive/immcache"
 	"github.com/brimsec/zq/ppl/zqd/apiserver"
 	"github.com/brimsec/zq/ppl/zqd/db"
 	"github.com/brimsec/zq/ppl/zqd/pcapanalyzer"
@@ -37,13 +38,14 @@ const indexPage = `
 </html>`
 
 type Config struct {
-	Auth        AuthConfig
-	DB          db.Config
-	Logger      *zap.Logger
-	Personality string
-	Root        string
-	Version     string
-	Worker      worker.WorkerConfig
+	Auth           AuthConfig
+	DB             db.Config
+	ImmutableCache immcache.Config
+	Logger         *zap.Logger
+	Personality    string
+	Root           string
+	Version        string
+	Worker         worker.WorkerConfig
 
 	Suricata pcapanalyzer.Launcher
 	Zeek     pcapanalyzer.Launcher
@@ -156,7 +158,11 @@ func (c *Core) addAPIServerRoutes(ctx context.Context, conf Config) (err error) 
 	if err != nil {
 		return err
 	}
-	if c.mgr, err = apiserver.NewManager(ctx, conf.Logger, c.registry, c.root, c.db); err != nil {
+	icache, err := immcache.New(conf.ImmutableCache, c.registry)
+	if err != nil {
+		return err
+	}
+	if c.mgr, err = apiserver.NewManager(ctx, conf.Logger, c.registry, c.root, c.db, icache); err != nil {
 		return err
 	}
 	c.authhandle("/ast", handleASTPost).Methods("POST")

--- a/ppl/zqd/db/filedb/oldconfig/oldconfig_test.go
+++ b/ppl/zqd/db/filedb/oldconfig/oldconfig_test.go
@@ -144,7 +144,7 @@ func (tm *testMigration) manager() *apiserver.Manager {
 	if tm.mgr == nil {
 		filedb, err := filedb.Open(context.Background(), zap.NewNop(), tm.root)
 		require.NoError(tm.T, err)
-		mgr, err := apiserver.NewManager(context.Background(), zap.NewNop(), prometheus.NewRegistry(), tm.root, filedb)
+		mgr, err := apiserver.NewManager(context.Background(), zap.NewNop(), prometheus.NewRegistry(), tm.root, filedb, nil)
 		require.NoError(tm.T, err)
 		tm.mgr = mgr
 	}

--- a/ppl/zqd/storage/archivestore/archivestore.go
+++ b/ppl/zqd/storage/archivestore/archivestore.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/ppl/archive"
 	"github.com/brimsec/zq/ppl/archive/chunk"
+	"github.com/brimsec/zq/ppl/archive/immcache"
 	"github.com/brimsec/zq/ppl/archive/index"
 	"github.com/brimsec/zq/ppl/zqd/storage"
 	"github.com/brimsec/zq/zbuf"
@@ -18,12 +19,14 @@ import (
 	"go.uber.org/zap"
 )
 
-func Load(ctx context.Context, path iosrc.URI, notifier WriteNotifier, cfg *api.ArchiveConfig) (*Storage, error) {
+func Load(ctx context.Context, path iosrc.URI, notifier WriteNotifier, cfg *api.ArchiveConfig, immcache immcache.ImmutableCache) (*Storage, error) {
 	co := &archive.CreateOptions{}
 	if cfg != nil && cfg.CreateOptions != nil {
 		co.LogSizeThreshold = cfg.CreateOptions.LogSizeThreshold
 	}
-	oo := &archive.OpenOptions{}
+	oo := &archive.OpenOptions{
+		ImmutableCache: immcache,
+	}
 	if cfg != nil && cfg.OpenOptions != nil {
 		oo.LogFilter = cfg.OpenOptions.LogFilter
 	}

--- a/ppl/zqd/ztests/cache-local.yaml
+++ b/ppl/zqd/ztests/cache-local.yaml
@@ -6,10 +6,12 @@ script: |
   zapi -h $ZQD_HOST -s testsp get -f text "count()"
   echo ===
   zapi -h $ZQD_HOST -s testsp get -f text "count()"
+  echo ===
+  curl $ZQD_HOST/metrics | grep archive_cache
 
 inputs:
   - name: babble.tzng
-    source: ../../../ztests/suite/data/babble.tzng
+    source: ../../../ztests/suite/data/babble-sorted.tzng
   - name: services.sh
     source: services.sh
 
@@ -21,3 +23,10 @@ outputs:
       1000
       ===
       1000
+      ===
+      # HELP archive_cache_hits_total Number of hits for a cache lookup.
+      # TYPE archive_cache_hits_total counter
+      archive_cache_hits_total{kind="metadata"} 4
+      # HELP archive_cache_misses_total Number of misses for a cache lookup.
+      # TYPE archive_cache_misses_total counter
+      archive_cache_misses_total{kind="metadata"} 2

--- a/ppl/zqd/ztests/cache-local.yaml
+++ b/ppl/zqd/ztests/cache-local.yaml
@@ -1,0 +1,23 @@
+script: |
+  ZQD_EXTRA_FLAGS=-immcache.localsize=128 source services.sh
+  zapi -h $ZQD_HOST new -d ./root -k archivestore -thresh 20KiB testsp
+  zapi -h $ZQD_HOST -s testsp post babble.tzng >/dev/null
+  echo ===
+  zapi -h $ZQD_HOST -s testsp get -f text "count()"
+  echo ===
+  zapi -h $ZQD_HOST -s testsp get -f text "count()"
+
+inputs:
+  - name: babble.tzng
+    source: ../../../ztests/suite/data/babble.tzng
+  - name: services.sh
+    source: services.sh
+
+outputs:
+  - name: stdout
+    data: |
+      testsp: space created
+      ===
+      1000
+      ===
+      1000


### PR DESCRIPTION
Add ability to enable local caching of small immutable files (currently this is
only chunk metadata) in an archive. Add prometheus metrics for tracking cache
hits and misses on gets for small files.

Closes #1898