### PR TITLE
print any log files when awaitfile fails

### DIFF
--- a/ppl/zqd/ztests/common.sh
+++ b/ppl/zqd/ztests/common.sh
@@ -7,10 +7,10 @@ function awaitfile {
     let i+=1
     if [ $i -gt 5 ]; then
       echo "timed out waiting for file \"$file\" to appear"
-      echo "minio log:"
-      cat minio.log
-      echo "zqd log:"
-      cat zqd.log
+      for f in *.log ; do
+        echo logfile: $f
+        cat $f
+      done
       exit 1
     fi
     sleep 1


### PR DESCRIPTION
When `awaitfile` fails, typically because of a failure of a zqd instance to start, make sure to output any .log files found. This will capture the log files for the zqd root, recruiter, and worker instances in some of the ztests that verify distributed queries.
