### PR TITLE
use helm upgrade -i for helm-install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ kubectl-config:
 	kubectl config use-context zqtest
 
 helm-install:
-	helm install zsrv charts/zservice \
+	helm upgrade -i zsrv charts/zservice \
 	--set datauri=$(ZQD_DATA_URI) \
 	--set global.AWSRegion=us-east-2 \
 	--set global.image.repository=$(ZQD_ECR_HOST)/ \


### PR DESCRIPTION
Using `helm upgrade -i` makes it convenient to work in a develop/deploy/debug loop like:
```
$ # debug/edit
$ make docker-push-ecr
$ make helm-install
$ # debug/edit
$ make docker-push-ecr
$ make helm-install
...
```
