### PR TITLE
tighten whitespace in zson -pretty=0 output

### DIFF
--- a/zson/formatter.go
+++ b/zson/formatter.go
@@ -156,7 +156,10 @@ func (f *Formatter) formatRecord(indent int, typ *zng.TypeRecord, bytes zcode.By
 		}
 		f.build(sep)
 		f.indent(indent, zng.QuotedName(field.Name))
-		f.build(": ")
+		f.build(":")
+		if f.tab > 0 {
+			f.build(" ")
+		}
 		if err := f.formatValue(indent, field.Type, bytes, known, true); err != nil {
 			return err
 		}

--- a/zson/marshal_test.go
+++ b/zson/marshal_test.go
@@ -31,9 +31,9 @@ func (a *Animal) Color() string { return a.MyColor }
 
 func TestInterfaceMarshal(t *testing.T) {
 	rose := Thing(&Plant{"red"})
-	expectedRose := `{MyColor: "red"} (=Plant)`
+	expectedRose := `{MyColor:"red"} (=Plant)`
 	flamingo := Thing(&Animal{"pink"})
-	expectedFlamingo := `{MyColor: "pink"} (=Animal)`
+	expectedFlamingo := `{MyColor:"pink"} (=Animal)`
 
 	m := zson.NewMarshaler()
 	m.Decorate(zson.StyleSimple)

--- a/zson/ztests/mixed-array.yaml
+++ b/zson/ztests/mixed-array.yaml
@@ -11,6 +11,6 @@ inputs:
 outputs:
   - name: stdout
     data: |
-      {version: [1 (0=((int64,string))),"b" (0),2 (0)] (=1)} (=2)
-      {version: [8,3]} (2)
-      {version: ["hello","goodbye"]} (2)
+      {version:[1 (0=((int64,string))),"b" (0),2 (0)] (=1)} (=2)
+      {version:[8,3]} (2)
+      {version:["hello","goodbye"]} (2)

--- a/zson/ztests/mu.yaml
+++ b/zson/ztests/mu.yaml
@@ -4,9 +4,9 @@ script: |
 inputs:
   - name: in.zson
     data: |
-      { d: 486µs (duration) } (=0)
+      { d:486µs (duration) } (=0)
 
 outputs:
   - name: stdout
     data: |
-      {d: 486µs (duration)} (=0)
+      {d:486µs (duration)} (=0)

--- a/zson/ztests/type-name.yaml
+++ b/zson/ztests/type-name.yaml
@@ -4,11 +4,11 @@ script: |
 inputs:
   - name: in.zson
     data: |
-      {s: "hello, world"} (=github.com/acme/foo.Bar)
-      {s: "goodnight, gracie"} (github.com/acme/foo.Bar)
+      {s:"hello, world"} (=github.com/acme/foo.Bar)
+      {s:"goodnight, gracie"} (github.com/acme/foo.Bar)
 
 outputs:
   - name: stdout
     data: |
-      {s: "hello, world"} (=github.com/acme/foo.Bar)
-      {s: "goodnight, gracie"} (github.com/acme/foo.Bar)
+      {s:"hello, world"} (=github.com/acme/foo.Bar)
+      {s:"goodnight, gracie"} (github.com/acme/foo.Bar)


### PR DESCRIPTION
This commit changes the zson formatter to drop the space after
a field colon when pretty printing is disabled.  The space between
a value and a type decorator is retained, but otherwise, all
spaces should be gone now for line-delimited zson output.

Closes #1993