### PR TITLE
pcappost suricata ztest: empty stderr

### DIFF
--- a/ppl/zqd/ztests/pcap/postpcap-suricata.yaml
+++ b/ppl/zqd/ztests/pcap/postpcap-suricata.yaml
@@ -23,6 +23,5 @@ outputs:
       ===
       #0:record[count:uint64]
       0:[379;]
-
   - name: stderr
     data: ""

--- a/ppl/zqd/ztests/pcap/postpcap-suricata.yaml
+++ b/ppl/zqd/ztests/pcap/postpcap-suricata.yaml
@@ -23,3 +23,6 @@ outputs:
       ===
       #0:record[count:uint64]
       0:[379;]
+
+  - name: stderr
+    data: ""


### PR DESCRIPTION
Make ztest for pcappost-suricata assume the result for stderr is an empty
string. This will (hopefully) give us more information should (when) this flaky
test fails again.

Reference: #2016