### PR TITLE
change parallel graph syntax to use "split" and fat arrows

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -38,7 +38,7 @@ func TestCompileParents(t *testing.T) {
 		sources = append(sources, &proctest.RecordPuller{R: r})
 	}
 	t.Run("read two sources", func(t *testing.T) {
-		query, err := compiler.ParseProc("(filter *; filter *) | filter *")
+		query, err := compiler.ParseProc("split (=>filter * =>filter *) | filter *")
 		require.NoError(t, err)
 
 		leaves, err := compiler.Compile(nil, query, pctx, sources)
@@ -51,7 +51,7 @@ func TestCompileParents(t *testing.T) {
 	})
 
 	t.Run("too few parents", func(t *testing.T) {
-		query, err := compiler.ParseProc("(filter *; filter *; filter *) | filter *")
+		query, err := compiler.ParseProc("split (=>filter * =>filter * =>filter *) | filter *")
 		require.NoError(t, err)
 
 		query.(*ast.SequentialProc).Procs = query.(*ast.SequentialProc).Procs[1:]
@@ -61,7 +61,7 @@ func TestCompileParents(t *testing.T) {
 	})
 
 	t.Run("too many parents", func(t *testing.T) {
-		query, err := compiler.ParseProc("* | (filter *; filter *) | filter *")
+		query, err := compiler.ParseProc("* | split(=>filter * =>filter *) | filter *")
 		require.NoError(t, err)
 		_, err = compiler.Compile(nil, query, pctx, sources)
 		require.Error(t, err)
@@ -84,7 +84,7 @@ func TestCompileMergeDone(t *testing.T) {
 	pctx := &proc.Context{Context: context.Background(), TypeContext: zctx}
 	r := tzngio.NewReader(bytes.NewReader([]byte(input)), zctx)
 	src := &proctest.RecordPuller{R: r}
-	query, err := compiler.ParseProc("(filter * ; head 1) | head 3")
+	query, err := compiler.ParseProc("split(=>filter * =>head 1) | head 3")
 	require.NoError(t, err)
 
 	seq, ok := query.(*ast.SequentialProc)

--- a/compiler/parallelize_test.go
+++ b/compiler/parallelize_test.go
@@ -35,79 +35,79 @@ func TestParallelizeFlowgraph(t *testing.T) {
 		{
 			"* | uniq",
 			"ts",
-			"(filter *; filter *) | uniq",
+			"split (=>filter * =>filter *) | uniq",
 			"ts",
 		},
 		{
 			"* | cut ts, foo=x | uniq",
 			"ts",
-			"(filter * | cut ts, foo=x; filter * | cut ts, foo=x) | uniq",
+			"split (=>filter * | cut ts, foo=x =>filter * | cut ts, foo=x) | uniq",
 			"ts",
 		},
 		{
 			"* | drop x | uniq",
 			"ts",
-			"(filter * | drop x; filter * | drop x) | uniq",
+			"split (=> filter * | drop x =>filter * | drop x) | uniq",
 			"ts",
 		},
 		{
 			"* | put ts=foo | rename foo=boo",
 			"ts",
-			"(filter *; filter *) | put ts=foo | rename foo=boo",
+			"split (=>filter * =>filter *) | put ts=foo | rename foo=boo",
 			"ts",
 		},
 		{
 			"* | put ts=foo | rename foo=boo | count()",
 			"ts",
-			"(filter * | put ts=foo | rename foo=boo | count(); filter * | put ts=foo | rename foo=boo | count()) | count()",
+			"split (=>filter * | put ts=foo | rename foo=boo | count() =>filter * | put ts=foo | rename foo=boo | count()) | count()",
 			"",
 		},
 		{
 			"* | put ts=foo | rename foo=boo | sort",
 			"ts",
-			"(filter * | put ts=foo | rename foo=boo; filter * | put ts=foo | rename foo=boo) | sort",
+			"split (=>filter * | put ts=foo | rename foo=boo =>filter * | put ts=foo | rename foo=boo) | sort",
 			"",
 		},
 		{
 			"* | put x=foo | rename foo=boo | uniq",
 			"ts",
-			"(filter * | put x=foo | rename foo=boo; filter * | put x=foo | rename foo=boo) | uniq",
+			"split (=>filter * | put x=foo | rename foo=boo =>filter * | put x=foo | rename foo=boo) | uniq",
 			"ts",
 		},
 		{
 			"* | sort x | uniq",
 			"ts",
-			"(filter * | sort x; filter * | sort x) | uniq",
+			"split (=>filter * | sort x =>filter * | sort x) | uniq",
 			"x",
 		},
 		{
 			"* | sort | uniq",
 			"ts",
-			"(filter *; filter *) | sort | uniq",
+			"split (=>filter * =>filter *) | sort | uniq",
 			"",
 		},
 		{
 			"* | put x=y | countdistinct(x) by y | uniq",
 			"ts",
-			" (filter * | put x=y | countdistinct(x) by y  ; filter * | put x=y | countdistinct(x) by y) | countdistinct(x) by y | uniq",
+			"split (=>filter * | put x=y | countdistinct(x) by y  =>filter * | put x=y | countdistinct(x) by y) | countdistinct(x) by y | uniq",
 			"",
 		},
 		{
 			"* | count() by y",
 			"ts",
-			"(filter * | count() by y; filter * | count() by y) | count() by y",
+			"split (=>filter * | count() by y =>filter * | count() by y) | count() by y",
 			"",
 		},
 		{
 			"* | every 1h count() by y",
 			"",
-			"(filter * | every 1h count() by y; filter * | every 1h count() by y) | every 1h count() by y",
+			"split (=>filter * | every 1h count() by y =>filter * | every 1h count() by y) | every 1h count() by y",
 			"ts",
 		},
 		{
 			"* | put a=1 | tail",
 			"ts",
-			"(filter * | put a=1 | tail; filter * | put a=1 | tail) | tail",
+			"split (=>filter * | put a=1 | tail =>filter * | put a=1 | tail) | tail",
 			"ts",
 		},
 	}
@@ -147,7 +147,7 @@ func TestParallelizeFlowgraph(t *testing.T) {
 	t.Run("* | cut ts, y, z | put x=y | rename y=z", func(t *testing.T) {
 		orderField := "ts"
 		query := "* | cut ts, y, z | put x=y | rename y=z"
-		dquery := "(filter * | cut ts, y, z | put x=y | rename y=z; filter * | cut ts, y, z | put x=y | rename y=z)"
+		dquery := "split (=>filter * | cut ts, y, z | put x=y | rename y=z =>filter * | cut ts, y, z | put x=y | rename y=z)"
 		program, err := ParseProc(query)
 		require.NoError(t, err)
 		parallelized, ok := Parallelize(program.(*ast.SequentialProc), 2, sf(orderField), false)

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -27,7 +27,7 @@ func TestMuxDriver(t *testing.T) {
 #0:record[_path:string,ts:time]
 0:[conn;1425565514.419939;]`
 
-	query, err := compiler.ParseProc("(tail 1; tail 1)")
+	query, err := compiler.ParseProc("split (=>tail 1 =>tail 1)")
 	assert.NoError(t, err)
 
 	t.Run("muxed into one writer", func(t *testing.T) {

--- a/driver/ztests/parallel-err.yaml
+++ b/driver/ztests/parallel-err.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -P -t '( put k=a+10 ; put k=b+20) | sort k' A.tzng
+  zq -P -t 'split ( => put k=a+10 => put k=b+20) | sort k' A.tzng
 
 inputs:
   - name: A.tzng

--- a/driver/ztests/parallel-stdin.yaml
+++ b/driver/ztests/parallel-stdin.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -P -t '( put k=a+10 ; put k=b+20) | sort k' - B.tzng
+  zq -P -t 'split ( => put k=a+10 => put k=b+20) | sort k' - B.tzng
 
 inputs:
   - name: stdin

--- a/driver/ztests/parallel.yaml
+++ b/driver/ztests/parallel.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -P -t '( put k=a+10 ; put k=b+20) | sort k' A.tzng B.tzng
+  zq -P -t 'split ( => put k=a+10 => put k=b+20) | sort k' A.tzng B.tzng
 
 inputs:
   - name: A.tzng

--- a/proc/join/ztests/empty-inner.yaml
+++ b/proc/join/ztests/empty-inner.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -P -t '( filter * ; filter *) | join a=b hit=sc | sort a' A.tzng C.tzng
+  zq -P -t 'split ( => filter * => filter *) | join a=b hit=sc | sort a' A.tzng C.tzng
 
 inputs:
   - name: A.tzng

--- a/proc/join/ztests/left.yaml
+++ b/proc/join/ztests/left.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -P -t '( filter * ; filter * ) | join a=b hit=sb | sort a' A.tzng B.tzng
+  zq -P -t 'split ( => filter * => filter * ) | join a=b hit=sb | sort a' A.tzng B.tzng
   echo ===
   zq -P -t 'join a=b hit=sb | sort a' A.tzng B.tzng
 

--- a/zql/valid.zql
+++ b/zql/valid.zql
@@ -7,9 +7,9 @@ foo | count()
 _path=conn
 _path=conn id.resp_p=80
 * | count(), sum(foo)
-* | (count() by _path; count() by addr)
+* | split (=>count() by _path =>count() by addr)
 * | count() by _path | count() by addr
-* | (count() by _path; sort) | (count() by addr)
+* | split (=>count() by _path =>sort) | split (=>count() by addr)
 * | sort -r
 * | sort -r a, b, c
 * | sort -r a, b, c

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -397,10 +397,14 @@ function peg$parse(input, options) {
       peg$c51 = "|",
       peg$c52 = peg$literalExpectation("|", false),
       peg$c53 = function(p) { return p },
-      peg$c54 = function(proc) {
+      peg$c54 = "split",
+      peg$c55 = peg$literalExpectation("split", false),
+      peg$c56 = "=>",
+      peg$c57 = peg$literalExpectation("=>", false),
+      peg$c58 = function(proc) {
             return proc
           },
-      peg$c55 = function(first, rest) {
+      peg$c59 = function(first, rest) {
             let fp = {"op": "SequentialProc", "procs": first};
             if (rest) {
               return {"op": "ParallelProc", "procs": [fp, ... rest]}
@@ -408,69 +412,69 @@ function peg$parse(input, options) {
               return fp
             }
           },
-      peg$c56 = ";",
-      peg$c57 = peg$literalExpectation(";", false),
-      peg$c58 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
-      peg$c59 = function(every, keys, limit) {
+      peg$c60 = ";",
+      peg$c61 = peg$literalExpectation(";", false),
+      peg$c62 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
+      peg$c63 = function(every, keys, limit) {
             return {"op": "GroupByProc", "keys": keys, "reducers": null, "duration": every, "limit": limit}
           },
-      peg$c60 = function(every, reducers, keys, limit) {
+      peg$c64 = function(every, reducers, keys, limit) {
             let p = {"op": "GroupByProc", "keys": null, "reducers": reducers, "duration": every, "limit": limit};
             if (keys) {
               p["keys"] = keys[1];
             }
             return p
           },
-      peg$c61 = "every",
-      peg$c62 = peg$literalExpectation("every", true),
-      peg$c63 = function(dur) { return dur },
-      peg$c64 = "by",
-      peg$c65 = peg$literalExpectation("by", true),
-      peg$c66 = function(columns) { return columns },
-      peg$c67 = "with",
-      peg$c68 = peg$literalExpectation("with", false),
-      peg$c69 = "-limit",
-      peg$c70 = peg$literalExpectation("-limit", false),
-      peg$c71 = function(limit) { return limit },
-      peg$c72 = "",
-      peg$c73 = function() { return 0 },
-      peg$c74 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c75 = ",",
-      peg$c76 = peg$literalExpectation(",", false),
-      peg$c77 = function(first, expr) { return expr },
-      peg$c78 = function(first, rest) {
+      peg$c65 = "every",
+      peg$c66 = peg$literalExpectation("every", true),
+      peg$c67 = function(dur) { return dur },
+      peg$c68 = "by",
+      peg$c69 = peg$literalExpectation("by", true),
+      peg$c70 = function(columns) { return columns },
+      peg$c71 = "with",
+      peg$c72 = peg$literalExpectation("with", false),
+      peg$c73 = "-limit",
+      peg$c74 = peg$literalExpectation("-limit", false),
+      peg$c75 = function(limit) { return limit },
+      peg$c76 = "",
+      peg$c77 = function() { return 0 },
+      peg$c78 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c79 = ",",
+      peg$c80 = peg$literalExpectation(",", false),
+      peg$c81 = function(first, expr) { return expr },
+      peg$c82 = function(first, rest) {
             return [first, ... rest]
           },
-      peg$c79 = "=",
-      peg$c80 = peg$literalExpectation("=", false),
-      peg$c81 = function(lval, reducer) {
+      peg$c83 = "=",
+      peg$c84 = peg$literalExpectation("=", false),
+      peg$c85 = function(lval, reducer) {
             return {"op": "Assignment", "lhs": lval, "rhs": reducer}
           },
-      peg$c82 = function(reducer) {
+      peg$c86 = function(reducer) {
             return {"op": "Assignment", "lhs": null, "rhs": reducer}
           },
-      peg$c83 = "not",
-      peg$c84 = peg$literalExpectation("not", false),
-      peg$c85 = function(op, expr, where) {
+      peg$c87 = "not",
+      peg$c88 = peg$literalExpectation("not", false),
+      peg$c89 = function(op, expr, where) {
             let r = {"op": "Reducer", "operator": op, "expr": null, "where":where};
             if (expr) {
               r["expr"] = expr;
             }
             return r
           },
-      peg$c86 = "where",
-      peg$c87 = peg$literalExpectation("where", false),
-      peg$c88 = function(first, rest) {
+      peg$c90 = "where",
+      peg$c91 = peg$literalExpectation("where", false),
+      peg$c92 = function(first, rest) {
             let result = [first];
             for(let  r of rest) {
               result.push( r[3]);
             }
             return result
           },
-      peg$c89 = "sort",
-      peg$c90 = peg$literalExpectation("sort", true),
-      peg$c91 = function(args, l) { return l },
-      peg$c92 = function(args, list) {
+      peg$c93 = "sort",
+      peg$c94 = peg$literalExpectation("sort", true),
+      peg$c95 = function(args, l) { return l },
+      peg$c96 = function(args, list) {
             let argm = args;
             let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false};
             if ( "r" in argm) {
@@ -483,26 +487,26 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c93 = function(a) { return a },
-      peg$c94 = function(args) { return makeArgMap(args) },
-      peg$c95 = "-r",
-      peg$c96 = peg$literalExpectation("-r", false),
-      peg$c97 = function() { return {"name": "r", "value": null} },
-      peg$c98 = "-nulls",
-      peg$c99 = peg$literalExpectation("-nulls", false),
-      peg$c100 = "first",
-      peg$c101 = peg$literalExpectation("first", false),
-      peg$c102 = "last",
-      peg$c103 = peg$literalExpectation("last", false),
-      peg$c104 = function() { return text() },
-      peg$c105 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c106 = "top",
-      peg$c107 = peg$literalExpectation("top", true),
-      peg$c108 = function(n) { return n},
-      peg$c109 = "-flush",
-      peg$c110 = peg$literalExpectation("-flush", false),
-      peg$c111 = function(limit, flush, f) { return f },
-      peg$c112 = function(limit, flush, fields) {
+      peg$c97 = function(a) { return a },
+      peg$c98 = function(args) { return makeArgMap(args) },
+      peg$c99 = "-r",
+      peg$c100 = peg$literalExpectation("-r", false),
+      peg$c101 = function() { return {"name": "r", "value": null} },
+      peg$c102 = "-nulls",
+      peg$c103 = peg$literalExpectation("-nulls", false),
+      peg$c104 = "first",
+      peg$c105 = peg$literalExpectation("first", false),
+      peg$c106 = "last",
+      peg$c107 = peg$literalExpectation("last", false),
+      peg$c108 = function() { return text() },
+      peg$c109 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c110 = "top",
+      peg$c111 = peg$literalExpectation("top", true),
+      peg$c112 = function(n) { return n},
+      peg$c113 = "-flush",
+      peg$c114 = peg$literalExpectation("-flush", false),
+      peg$c115 = function(limit, flush, f) { return f },
+      peg$c116 = function(limit, flush, fields) {
             let proc = {"op": "TopProc", "limit": 0, "fields": null, "flush": false};
             if (limit) {
               proc["limit"] = limit;
@@ -515,9 +519,9 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c113 = "cut",
-      peg$c114 = peg$literalExpectation("cut", true),
-      peg$c115 = function(args, columns) {
+      peg$c117 = "cut",
+      peg$c118 = peg$literalExpectation("cut", true),
+      peg$c119 = function(args, columns) {
             let argm = args;
             let proc = {"op": "CutProc", "fields": columns, "complement": false};
             if ( "c" in argm) {
@@ -525,77 +529,77 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c116 = "-c",
-      peg$c117 = peg$literalExpectation("-c", false),
-      peg$c118 = function() { return {"name": "c", "value": null} },
-      peg$c119 = function(args) {
+      peg$c120 = "-c",
+      peg$c121 = peg$literalExpectation("-c", false),
+      peg$c122 = function() { return {"name": "c", "value": null} },
+      peg$c123 = function(args) {
             return makeArgMap(args)
           },
-      peg$c120 = "pick",
-      peg$c121 = peg$literalExpectation("pick", true),
-      peg$c122 = function(columns) {
+      peg$c124 = "pick",
+      peg$c125 = peg$literalExpectation("pick", true),
+      peg$c126 = function(columns) {
             return {"op": "PickProc", "fields": columns}
           },
-      peg$c123 = "drop",
-      peg$c124 = peg$literalExpectation("drop", true),
-      peg$c125 = function(columns) {
+      peg$c127 = "drop",
+      peg$c128 = peg$literalExpectation("drop", true),
+      peg$c129 = function(columns) {
             return {"op": "DropProc", "fields": columns}
           },
-      peg$c126 = "head",
-      peg$c127 = peg$literalExpectation("head", true),
-      peg$c128 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c129 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c130 = "tail",
-      peg$c131 = peg$literalExpectation("tail", true),
-      peg$c132 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c133 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c134 = "filter",
-      peg$c135 = peg$literalExpectation("filter", true),
-      peg$c136 = "uniq",
-      peg$c137 = peg$literalExpectation("uniq", true),
-      peg$c138 = function() {
+      peg$c130 = "head",
+      peg$c131 = peg$literalExpectation("head", true),
+      peg$c132 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c133 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c134 = "tail",
+      peg$c135 = peg$literalExpectation("tail", true),
+      peg$c136 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c137 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c138 = "filter",
+      peg$c139 = peg$literalExpectation("filter", true),
+      peg$c140 = "uniq",
+      peg$c141 = peg$literalExpectation("uniq", true),
+      peg$c142 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c139 = function() {
+      peg$c143 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c140 = "put",
-      peg$c141 = peg$literalExpectation("put", true),
-      peg$c142 = function(columns) {
+      peg$c144 = "put",
+      peg$c145 = peg$literalExpectation("put", true),
+      peg$c146 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c143 = "rename",
-      peg$c144 = peg$literalExpectation("rename", true),
-      peg$c145 = function(first, cl) { return cl },
-      peg$c146 = function(first, rest) {
+      peg$c147 = "rename",
+      peg$c148 = peg$literalExpectation("rename", true),
+      peg$c149 = function(first, cl) { return cl },
+      peg$c150 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c147 = "fuse",
-      peg$c148 = peg$literalExpectation("fuse", true),
-      peg$c149 = function() {
+      peg$c151 = "fuse",
+      peg$c152 = peg$literalExpectation("fuse", true),
+      peg$c153 = function() {
             return {"op": "FuseProc"}
           },
-      peg$c150 = "join",
-      peg$c151 = peg$literalExpectation("join", true),
-      peg$c152 = function(leftKey, rightKey, columns) {
+      peg$c154 = "join",
+      peg$c155 = peg$literalExpectation("join", true),
+      peg$c156 = function(leftKey, rightKey, columns) {
             let proc = {"op": "JoinProc", "left_key": leftKey, "right_key": rightKey, "clauses": null};
             if (columns) {
               proc["clauses"] = columns[1];
             }
             return proc
           },
-      peg$c153 = function(key, columns) {
+      peg$c157 = function(key, columns) {
             let proc = {"op": "JoinProc", "left_key": key, "right_key": key, "clauses": null};
             if (columns) {
               proc["clauses"] = columns[1];
             }
             return proc
           },
-      peg$c154 = ".",
-      peg$c155 = peg$literalExpectation(".", false),
-      peg$c156 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
-      peg$c157 = function() { return {"op": "RootRecord"} },
-      peg$c158 = function(first, rest) {
+      peg$c158 = ".",
+      peg$c159 = peg$literalExpectation(".", false),
+      peg$c160 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
+      peg$c161 = function() { return {"op": "RootRecord"} },
+      peg$c162 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -604,269 +608,269 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c159 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c160 = "?",
-      peg$c161 = peg$literalExpectation("?", false),
-      peg$c162 = ":",
-      peg$c163 = peg$literalExpectation(":", false),
-      peg$c164 = function(condition, thenClause, elseClause) {
+      peg$c163 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c164 = "?",
+      peg$c165 = peg$literalExpectation("?", false),
+      peg$c166 = ":",
+      peg$c167 = peg$literalExpectation(":", false),
+      peg$c168 = function(condition, thenClause, elseClause) {
             return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c165 = function(first, op, expr) { return [op, expr] },
-      peg$c166 = function(first, rest) {
+      peg$c169 = function(first, op, expr) { return [op, expr] },
+      peg$c170 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c167 = function(first, comp, expr) { return [comp, expr] },
-      peg$c168 = "=~",
-      peg$c169 = peg$literalExpectation("=~", false),
-      peg$c170 = "!~",
-      peg$c171 = peg$literalExpectation("!~", false),
-      peg$c172 = "!=",
-      peg$c173 = peg$literalExpectation("!=", false),
-      peg$c174 = "in",
-      peg$c175 = peg$literalExpectation("in", false),
-      peg$c176 = "<=",
-      peg$c177 = peg$literalExpectation("<=", false),
-      peg$c178 = "<",
-      peg$c179 = peg$literalExpectation("<", false),
-      peg$c180 = ">=",
-      peg$c181 = peg$literalExpectation(">=", false),
-      peg$c182 = ">",
-      peg$c183 = peg$literalExpectation(">", false),
-      peg$c184 = "+",
-      peg$c185 = peg$literalExpectation("+", false),
-      peg$c186 = "/",
-      peg$c187 = peg$literalExpectation("/", false),
-      peg$c188 = function(e) {
+      peg$c171 = function(first, comp, expr) { return [comp, expr] },
+      peg$c172 = "=~",
+      peg$c173 = peg$literalExpectation("=~", false),
+      peg$c174 = "!~",
+      peg$c175 = peg$literalExpectation("!~", false),
+      peg$c176 = "!=",
+      peg$c177 = peg$literalExpectation("!=", false),
+      peg$c178 = "in",
+      peg$c179 = peg$literalExpectation("in", false),
+      peg$c180 = "<=",
+      peg$c181 = peg$literalExpectation("<=", false),
+      peg$c182 = "<",
+      peg$c183 = peg$literalExpectation("<", false),
+      peg$c184 = ">=",
+      peg$c185 = peg$literalExpectation(">=", false),
+      peg$c186 = ">",
+      peg$c187 = peg$literalExpectation(">", false),
+      peg$c188 = "+",
+      peg$c189 = peg$literalExpectation("+", false),
+      peg$c190 = "/",
+      peg$c191 = peg$literalExpectation("/", false),
+      peg$c192 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c189 = function(e, typ) { return typ },
-      peg$c190 = function(e, typ) {
+      peg$c193 = function(e, typ) { return typ },
+      peg$c194 = function(e, typ) {
             return {"op": "CastExpr", "expr": e, "type": typ}
           },
-      peg$c191 = "bytes",
-      peg$c192 = peg$literalExpectation("bytes", false),
-      peg$c193 = "uint8",
-      peg$c194 = peg$literalExpectation("uint8", false),
-      peg$c195 = "uint16",
-      peg$c196 = peg$literalExpectation("uint16", false),
-      peg$c197 = "uint32",
-      peg$c198 = peg$literalExpectation("uint32", false),
-      peg$c199 = "uint64",
-      peg$c200 = peg$literalExpectation("uint64", false),
-      peg$c201 = "int8",
-      peg$c202 = peg$literalExpectation("int8", false),
-      peg$c203 = "int16",
-      peg$c204 = peg$literalExpectation("int16", false),
-      peg$c205 = "int32",
-      peg$c206 = peg$literalExpectation("int32", false),
-      peg$c207 = "int64",
-      peg$c208 = peg$literalExpectation("int64", false),
-      peg$c209 = "duration",
-      peg$c210 = peg$literalExpectation("duration", false),
-      peg$c211 = "time",
-      peg$c212 = peg$literalExpectation("time", false),
-      peg$c213 = "float64",
-      peg$c214 = peg$literalExpectation("float64", false),
-      peg$c215 = "bool",
-      peg$c216 = peg$literalExpectation("bool", false),
-      peg$c217 = "string",
-      peg$c218 = peg$literalExpectation("string", false),
-      peg$c219 = "bstring",
-      peg$c220 = peg$literalExpectation("bstring", false),
-      peg$c221 = "ip",
-      peg$c222 = peg$literalExpectation("ip", false),
-      peg$c223 = "net",
-      peg$c224 = peg$literalExpectation("net", false),
-      peg$c225 = "type",
-      peg$c226 = peg$literalExpectation("type", false),
-      peg$c227 = "error",
-      peg$c228 = peg$literalExpectation("error", false),
-      peg$c229 = function(first, rest) {
+      peg$c195 = "bytes",
+      peg$c196 = peg$literalExpectation("bytes", false),
+      peg$c197 = "uint8",
+      peg$c198 = peg$literalExpectation("uint8", false),
+      peg$c199 = "uint16",
+      peg$c200 = peg$literalExpectation("uint16", false),
+      peg$c201 = "uint32",
+      peg$c202 = peg$literalExpectation("uint32", false),
+      peg$c203 = "uint64",
+      peg$c204 = peg$literalExpectation("uint64", false),
+      peg$c205 = "int8",
+      peg$c206 = peg$literalExpectation("int8", false),
+      peg$c207 = "int16",
+      peg$c208 = peg$literalExpectation("int16", false),
+      peg$c209 = "int32",
+      peg$c210 = peg$literalExpectation("int32", false),
+      peg$c211 = "int64",
+      peg$c212 = peg$literalExpectation("int64", false),
+      peg$c213 = "duration",
+      peg$c214 = peg$literalExpectation("duration", false),
+      peg$c215 = "time",
+      peg$c216 = peg$literalExpectation("time", false),
+      peg$c217 = "float64",
+      peg$c218 = peg$literalExpectation("float64", false),
+      peg$c219 = "bool",
+      peg$c220 = peg$literalExpectation("bool", false),
+      peg$c221 = "string",
+      peg$c222 = peg$literalExpectation("string", false),
+      peg$c223 = "bstring",
+      peg$c224 = peg$literalExpectation("bstring", false),
+      peg$c225 = "ip",
+      peg$c226 = peg$literalExpectation("ip", false),
+      peg$c227 = "net",
+      peg$c228 = peg$literalExpectation("net", false),
+      peg$c229 = "type",
+      peg$c230 = peg$literalExpectation("type", false),
+      peg$c231 = "error",
+      peg$c232 = peg$literalExpectation("error", false),
+      peg$c233 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c230 = function(fn, args) {
+      peg$c234 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c231 = function(first, e) { return e },
-      peg$c232 = function() { return [] },
-      peg$c233 = "[",
-      peg$c234 = peg$literalExpectation("[", false),
-      peg$c235 = "]",
-      peg$c236 = peg$literalExpectation("]", false),
-      peg$c237 = function(expr) { return ["[", expr] },
-      peg$c238 = function(id) { return [".", id] },
-      peg$c239 = "and",
-      peg$c240 = peg$literalExpectation("and", true),
-      peg$c241 = "or",
-      peg$c242 = peg$literalExpectation("or", true),
-      peg$c243 = peg$literalExpectation("in", true),
-      peg$c244 = peg$literalExpectation("not", true),
-      peg$c245 = /^[A-Za-z_$]/,
-      peg$c246 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c247 = /^[0-9]/,
-      peg$c248 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c249 = function() { return {"op": "Identifier", "name": text()} },
-      peg$c250 = peg$literalExpectation("and", false),
-      peg$c251 = "seconds",
-      peg$c252 = peg$literalExpectation("seconds", false),
-      peg$c253 = "second",
-      peg$c254 = peg$literalExpectation("second", false),
-      peg$c255 = "secs",
-      peg$c256 = peg$literalExpectation("secs", false),
-      peg$c257 = "sec",
-      peg$c258 = peg$literalExpectation("sec", false),
-      peg$c259 = "s",
-      peg$c260 = peg$literalExpectation("s", false),
-      peg$c261 = "minutes",
-      peg$c262 = peg$literalExpectation("minutes", false),
-      peg$c263 = "minute",
-      peg$c264 = peg$literalExpectation("minute", false),
-      peg$c265 = "mins",
-      peg$c266 = peg$literalExpectation("mins", false),
-      peg$c267 = "min",
-      peg$c268 = peg$literalExpectation("min", false),
-      peg$c269 = "m",
-      peg$c270 = peg$literalExpectation("m", false),
-      peg$c271 = "hours",
-      peg$c272 = peg$literalExpectation("hours", false),
-      peg$c273 = "hrs",
-      peg$c274 = peg$literalExpectation("hrs", false),
-      peg$c275 = "hr",
-      peg$c276 = peg$literalExpectation("hr", false),
-      peg$c277 = "h",
-      peg$c278 = peg$literalExpectation("h", false),
-      peg$c279 = "hour",
-      peg$c280 = peg$literalExpectation("hour", false),
-      peg$c281 = "days",
-      peg$c282 = peg$literalExpectation("days", false),
-      peg$c283 = "day",
-      peg$c284 = peg$literalExpectation("day", false),
-      peg$c285 = "d",
-      peg$c286 = peg$literalExpectation("d", false),
-      peg$c287 = "weeks",
-      peg$c288 = peg$literalExpectation("weeks", false),
-      peg$c289 = "week",
-      peg$c290 = peg$literalExpectation("week", false),
-      peg$c291 = "wks",
-      peg$c292 = peg$literalExpectation("wks", false),
-      peg$c293 = "wk",
-      peg$c294 = peg$literalExpectation("wk", false),
-      peg$c295 = "w",
-      peg$c296 = peg$literalExpectation("w", false),
-      peg$c297 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c298 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c299 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c300 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c301 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c302 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c303 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c304 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c305 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c306 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c307 = function(a, b) {
+      peg$c235 = function(first, e) { return e },
+      peg$c236 = function() { return [] },
+      peg$c237 = "[",
+      peg$c238 = peg$literalExpectation("[", false),
+      peg$c239 = "]",
+      peg$c240 = peg$literalExpectation("]", false),
+      peg$c241 = function(expr) { return ["[", expr] },
+      peg$c242 = function(id) { return [".", id] },
+      peg$c243 = "and",
+      peg$c244 = peg$literalExpectation("and", true),
+      peg$c245 = "or",
+      peg$c246 = peg$literalExpectation("or", true),
+      peg$c247 = peg$literalExpectation("in", true),
+      peg$c248 = peg$literalExpectation("not", true),
+      peg$c249 = /^[A-Za-z_$]/,
+      peg$c250 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c251 = /^[0-9]/,
+      peg$c252 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c253 = function() { return {"op": "Identifier", "name": text()} },
+      peg$c254 = peg$literalExpectation("and", false),
+      peg$c255 = "seconds",
+      peg$c256 = peg$literalExpectation("seconds", false),
+      peg$c257 = "second",
+      peg$c258 = peg$literalExpectation("second", false),
+      peg$c259 = "secs",
+      peg$c260 = peg$literalExpectation("secs", false),
+      peg$c261 = "sec",
+      peg$c262 = peg$literalExpectation("sec", false),
+      peg$c263 = "s",
+      peg$c264 = peg$literalExpectation("s", false),
+      peg$c265 = "minutes",
+      peg$c266 = peg$literalExpectation("minutes", false),
+      peg$c267 = "minute",
+      peg$c268 = peg$literalExpectation("minute", false),
+      peg$c269 = "mins",
+      peg$c270 = peg$literalExpectation("mins", false),
+      peg$c271 = "min",
+      peg$c272 = peg$literalExpectation("min", false),
+      peg$c273 = "m",
+      peg$c274 = peg$literalExpectation("m", false),
+      peg$c275 = "hours",
+      peg$c276 = peg$literalExpectation("hours", false),
+      peg$c277 = "hrs",
+      peg$c278 = peg$literalExpectation("hrs", false),
+      peg$c279 = "hr",
+      peg$c280 = peg$literalExpectation("hr", false),
+      peg$c281 = "h",
+      peg$c282 = peg$literalExpectation("h", false),
+      peg$c283 = "hour",
+      peg$c284 = peg$literalExpectation("hour", false),
+      peg$c285 = "days",
+      peg$c286 = peg$literalExpectation("days", false),
+      peg$c287 = "day",
+      peg$c288 = peg$literalExpectation("day", false),
+      peg$c289 = "d",
+      peg$c290 = peg$literalExpectation("d", false),
+      peg$c291 = "weeks",
+      peg$c292 = peg$literalExpectation("weeks", false),
+      peg$c293 = "week",
+      peg$c294 = peg$literalExpectation("week", false),
+      peg$c295 = "wks",
+      peg$c296 = peg$literalExpectation("wks", false),
+      peg$c297 = "wk",
+      peg$c298 = peg$literalExpectation("wk", false),
+      peg$c299 = "w",
+      peg$c300 = peg$literalExpectation("w", false),
+      peg$c301 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c302 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c303 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c304 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c305 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c306 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c307 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c308 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c309 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c310 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c311 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c308 = "::",
-      peg$c309 = peg$literalExpectation("::", false),
-      peg$c310 = function(a, b, d, e) {
+      peg$c312 = "::",
+      peg$c313 = peg$literalExpectation("::", false),
+      peg$c314 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c311 = function(a, b) {
+      peg$c315 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c312 = function(a, b) {
+      peg$c316 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c313 = function() {
+      peg$c317 = function() {
             return "::"
           },
-      peg$c314 = function(v) { return ":" + v },
-      peg$c315 = function(v) { return v + ":" },
-      peg$c316 = function(a, m) {
+      peg$c318 = function(v) { return ":" + v },
+      peg$c319 = function(v) { return v + ":" },
+      peg$c320 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c317 = function(a, m) {
+      peg$c321 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c318 = function(s) { return parseInt(s) },
-      peg$c319 = function() {
+      peg$c322 = function(s) { return parseInt(s) },
+      peg$c323 = function() {
             return text()
           },
-      peg$c320 = "e",
-      peg$c321 = peg$literalExpectation("e", true),
-      peg$c322 = /^[+\-]/,
-      peg$c323 = peg$classExpectation(["+", "-"], false, false),
-      peg$c324 = /^[0-9a-fA-F]/,
-      peg$c325 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c326 = function(chars) { return joinChars(chars) },
-      peg$c327 = "\\",
-      peg$c328 = peg$literalExpectation("\\", false),
-      peg$c329 = /^[\0-\x1F\\(),!><="|';:]/,
-      peg$c330 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
-      peg$c331 = peg$anyExpectation(),
-      peg$c332 = "\"",
-      peg$c333 = peg$literalExpectation("\"", false),
-      peg$c334 = function(v) { return joinChars(v) },
-      peg$c335 = "'",
-      peg$c336 = peg$literalExpectation("'", false),
-      peg$c337 = "x",
-      peg$c338 = peg$literalExpectation("x", false),
-      peg$c339 = function() { return "\\" + text() },
-      peg$c340 = "b",
-      peg$c341 = peg$literalExpectation("b", false),
-      peg$c342 = function() { return "\b" },
-      peg$c343 = "f",
-      peg$c344 = peg$literalExpectation("f", false),
-      peg$c345 = function() { return "\f" },
-      peg$c346 = "n",
-      peg$c347 = peg$literalExpectation("n", false),
-      peg$c348 = function() { return "\n" },
-      peg$c349 = "r",
-      peg$c350 = peg$literalExpectation("r", false),
-      peg$c351 = function() { return "\r" },
-      peg$c352 = "t",
-      peg$c353 = peg$literalExpectation("t", false),
-      peg$c354 = function() { return "\t" },
-      peg$c355 = "v",
-      peg$c356 = peg$literalExpectation("v", false),
-      peg$c357 = function() { return "\v" },
-      peg$c358 = function() { return "=" },
-      peg$c359 = function() { return "\\*" },
-      peg$c360 = "u",
-      peg$c361 = peg$literalExpectation("u", false),
-      peg$c362 = function(chars) {
+      peg$c324 = "e",
+      peg$c325 = peg$literalExpectation("e", true),
+      peg$c326 = /^[+\-]/,
+      peg$c327 = peg$classExpectation(["+", "-"], false, false),
+      peg$c328 = /^[0-9a-fA-F]/,
+      peg$c329 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c330 = function(chars) { return joinChars(chars) },
+      peg$c331 = "\\",
+      peg$c332 = peg$literalExpectation("\\", false),
+      peg$c333 = /^[\0-\x1F\\(),!><="|';:]/,
+      peg$c334 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
+      peg$c335 = peg$anyExpectation(),
+      peg$c336 = "\"",
+      peg$c337 = peg$literalExpectation("\"", false),
+      peg$c338 = function(v) { return joinChars(v) },
+      peg$c339 = "'",
+      peg$c340 = peg$literalExpectation("'", false),
+      peg$c341 = "x",
+      peg$c342 = peg$literalExpectation("x", false),
+      peg$c343 = function() { return "\\" + text() },
+      peg$c344 = "b",
+      peg$c345 = peg$literalExpectation("b", false),
+      peg$c346 = function() { return "\b" },
+      peg$c347 = "f",
+      peg$c348 = peg$literalExpectation("f", false),
+      peg$c349 = function() { return "\f" },
+      peg$c350 = "n",
+      peg$c351 = peg$literalExpectation("n", false),
+      peg$c352 = function() { return "\n" },
+      peg$c353 = "r",
+      peg$c354 = peg$literalExpectation("r", false),
+      peg$c355 = function() { return "\r" },
+      peg$c356 = "t",
+      peg$c357 = peg$literalExpectation("t", false),
+      peg$c358 = function() { return "\t" },
+      peg$c359 = "v",
+      peg$c360 = peg$literalExpectation("v", false),
+      peg$c361 = function() { return "\v" },
+      peg$c362 = function() { return "=" },
+      peg$c363 = function() { return "\\*" },
+      peg$c364 = "u",
+      peg$c365 = peg$literalExpectation("u", false),
+      peg$c366 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c363 = "{",
-      peg$c364 = peg$literalExpectation("{", false),
-      peg$c365 = "}",
-      peg$c366 = peg$literalExpectation("}", false),
-      peg$c367 = function(body) { return body },
-      peg$c368 = /^[^\/\\]/,
-      peg$c369 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c370 = "\\/",
-      peg$c371 = peg$literalExpectation("\\/", false),
-      peg$c372 = /^[\0-\x1F\\]/,
-      peg$c373 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c374 = peg$otherExpectation("whitespace"),
-      peg$c375 = "\t",
-      peg$c376 = peg$literalExpectation("\t", false),
-      peg$c377 = "\x0B",
-      peg$c378 = peg$literalExpectation("\x0B", false),
-      peg$c379 = "\f",
-      peg$c380 = peg$literalExpectation("\f", false),
-      peg$c381 = " ",
-      peg$c382 = peg$literalExpectation(" ", false),
-      peg$c383 = "\xA0",
-      peg$c384 = peg$literalExpectation("\xA0", false),
-      peg$c385 = "\uFEFF",
-      peg$c386 = peg$literalExpectation("\uFEFF", false),
-      peg$c387 = /^[\n\r\u2028\u2029]/,
-      peg$c388 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c389 = peg$otherExpectation("comment"),
-      peg$c394 = "//",
-      peg$c395 = peg$literalExpectation("//", false),
+      peg$c367 = "{",
+      peg$c368 = peg$literalExpectation("{", false),
+      peg$c369 = "}",
+      peg$c370 = peg$literalExpectation("}", false),
+      peg$c371 = function(body) { return body },
+      peg$c372 = /^[^\/\\]/,
+      peg$c373 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c374 = "\\/",
+      peg$c375 = peg$literalExpectation("\\/", false),
+      peg$c376 = /^[\0-\x1F\\]/,
+      peg$c377 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c378 = peg$otherExpectation("whitespace"),
+      peg$c379 = "\t",
+      peg$c380 = peg$literalExpectation("\t", false),
+      peg$c381 = "\x0B",
+      peg$c382 = peg$literalExpectation("\x0B", false),
+      peg$c383 = "\f",
+      peg$c384 = peg$literalExpectation("\f", false),
+      peg$c385 = " ",
+      peg$c386 = peg$literalExpectation(" ", false),
+      peg$c387 = "\xA0",
+      peg$c388 = peg$literalExpectation("\xA0", false),
+      peg$c389 = "\uFEFF",
+      peg$c390 = peg$literalExpectation("\uFEFF", false),
+      peg$c391 = /^[\n\r\u2028\u2029]/,
+      peg$c392 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c393 = peg$otherExpectation("comment"),
+      peg$c398 = "//",
+      peg$c399 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -2115,38 +2119,68 @@ function peg$parse(input, options) {
   }
 
   function peg$parseProc() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$parseNamedProc();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseGroupByProc();
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c14;
-          peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c15); }
-        }
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parse__();
-          if (s2 !== peg$FAILED) {
-            s3 = peg$parseProcs();
-            if (s3 !== peg$FAILED) {
-              s4 = peg$parse__();
-              if (s4 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c16;
-                  peg$currPos++;
-                } else {
-                  s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c17); }
-                }
-                if (s5 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c54(s3);
-                  s0 = s1;
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 5) === peg$c54) {
+        s1 = peg$c54;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse__();
+        if (s2 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 40) {
+            s3 = peg$c14;
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c15); }
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse__();
+            if (s4 !== peg$FAILED) {
+              if (input.substr(peg$currPos, 2) === peg$c56) {
+                s5 = peg$c56;
+                peg$currPos += 2;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c57); }
+              }
+              if (s5 !== peg$FAILED) {
+                s6 = peg$parse__();
+                if (s6 !== peg$FAILED) {
+                  s7 = peg$parseProcs();
+                  if (s7 !== peg$FAILED) {
+                    s8 = peg$parse__();
+                    if (s8 !== peg$FAILED) {
+                      if (input.charCodeAt(peg$currPos) === 41) {
+                        s9 = peg$c16;
+                        peg$currPos++;
+                      } else {
+                        s9 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                      }
+                      if (s9 !== peg$FAILED) {
+                        peg$savedPos = s0;
+                        s1 = peg$c58(s7);
+                        s0 = s1;
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -2167,6 +2201,12 @@ function peg$parse(input, options) {
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseGroupByProc();
       }
     }
 
@@ -2187,7 +2227,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c55(s1, s2);
+        s1 = peg$c59(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2202,26 +2242,47 @@ function peg$parse(input, options) {
   }
 
   function peg$parseParallelTail() {
-    var s0, s1, s2, s3, s4;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 59) {
-        s2 = peg$c56;
+        s2 = peg$c60;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c57); }
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+      }
+      if (s2 === peg$FAILED) {
+        s2 = null;
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseSequentialProcs();
+          if (input.substr(peg$currPos, 2) === peg$c56) {
+            s4 = peg$c56;
+            peg$currPos += 2;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c57); }
+          }
           if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c58(s4);
-            s0 = s1;
+            s5 = peg$parse__();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parseSequentialProcs();
+              if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c62(s6);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -2256,7 +2317,7 @@ function peg$parse(input, options) {
         s3 = peg$parseLimitArg();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c59(s1, s2, s3);
+          s1 = peg$c63(s1, s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2304,7 +2365,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c60(s1, s2, s3, s4);
+              s1 = peg$c64(s1, s2, s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2331,12 +2392,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c61) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c65) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+      if (peg$silentFails === 0) { peg$fail(peg$c66); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2346,7 +2407,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c63(s3);
+            s1 = peg$c67(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2372,12 +2433,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c64) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c68) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c65); }
+      if (peg$silentFails === 0) { peg$fail(peg$c69); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2385,7 +2446,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c66(s3);
+          s1 = peg$c70(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2409,22 +2470,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c67) {
-        s2 = peg$c67;
+      if (input.substr(peg$currPos, 4) === peg$c71) {
+        s2 = peg$c71;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c72); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c69) {
-            s4 = peg$c69;
+          if (input.substr(peg$currPos, 6) === peg$c73) {
+            s4 = peg$c73;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c70); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -2432,7 +2493,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c71(s6);
+                s1 = peg$c75(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2460,10 +2521,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c72;
+      s1 = peg$c76;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c73();
+        s1 = peg$c77();
       }
       s0 = s1;
     }
@@ -2480,7 +2541,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c74(s1);
+        s1 = peg$c78(s1);
       }
       s0 = s1;
     }
@@ -2499,11 +2560,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c79;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2511,7 +2572,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c77(s1, s7);
+              s4 = peg$c81(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2535,11 +2596,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c79;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2547,7 +2608,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c77(s1, s7);
+                s4 = peg$c81(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2568,7 +2629,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c78(s1, s2);
+        s1 = peg$c82(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2591,11 +2652,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c79;
+          s3 = peg$c83;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c84); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -2603,7 +2664,7 @@ function peg$parse(input, options) {
             s5 = peg$parseReducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c81(s1, s5);
+              s1 = peg$c85(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2630,7 +2691,7 @@ function peg$parse(input, options) {
       s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c82(s1);
+        s1 = peg$c86(s1);
       }
       s0 = s1;
     }
@@ -2644,12 +2705,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
-    if (input.substr(peg$currPos, 3) === peg$c83) {
-      s2 = peg$c83;
+    if (input.substr(peg$currPos, 3) === peg$c87) {
+      s2 = peg$c87;
       peg$currPos += 3;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c84); }
+      if (peg$silentFails === 0) { peg$fail(peg$c88); }
     }
     if (s2 === peg$FAILED) {
       if (input.substr(peg$currPos, 3) === peg$c26) {
@@ -2703,7 +2764,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c85(s2, s6, s9);
+                      s1 = peg$c89(s2, s6, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -2751,12 +2812,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c86) {
-        s2 = peg$c86;
+      if (input.substr(peg$currPos, 5) === peg$c90) {
+        s2 = peg$c90;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c87); }
+        if (peg$silentFails === 0) { peg$fail(peg$c91); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -2797,11 +2858,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c79;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2832,11 +2893,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c79;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2864,7 +2925,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c88(s1, s2);
+        s1 = peg$c92(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2926,12 +2987,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c89) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c93) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c90); }
+      if (peg$silentFails === 0) { peg$fail(peg$c94); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -2942,7 +3003,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c91(s2, s5);
+            s4 = peg$c95(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2957,7 +3018,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c92(s2, s3);
+          s1 = peg$c96(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2986,7 +3047,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c93(s4);
+        s3 = peg$c97(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3004,7 +3065,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c93(s4);
+          s3 = peg$c97(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3017,7 +3078,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c94(s1);
+      s1 = peg$c98(s1);
     }
     s0 = s1;
 
@@ -3028,55 +3089,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c95) {
-      s1 = peg$c95;
+    if (input.substr(peg$currPos, 2) === peg$c99) {
+      s1 = peg$c99;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c96); }
+      if (peg$silentFails === 0) { peg$fail(peg$c100); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c97();
+      s1 = peg$c101();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c98) {
-        s1 = peg$c98;
+      if (input.substr(peg$currPos, 6) === peg$c102) {
+        s1 = peg$c102;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        if (peg$silentFails === 0) { peg$fail(peg$c103); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c100) {
-            s4 = peg$c100;
+          if (input.substr(peg$currPos, 5) === peg$c104) {
+            s4 = peg$c104;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c105); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c102) {
-              s4 = peg$c102;
+            if (input.substr(peg$currPos, 4) === peg$c106) {
+              s4 = peg$c106;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c103); }
+              if (peg$silentFails === 0) { peg$fail(peg$c107); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c104();
+            s4 = peg$c108();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c105(s3);
+            s1 = peg$c109(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3099,12 +3160,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c106) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c110) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c107); }
+      if (peg$silentFails === 0) { peg$fail(peg$c111); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -3113,7 +3174,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c108(s4);
+          s3 = peg$c112(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3130,12 +3191,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c109) {
-            s5 = peg$c109;
+          if (input.substr(peg$currPos, 6) === peg$c113) {
+            s5 = peg$c113;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3158,7 +3219,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c111(s2, s3, s6);
+              s5 = peg$c115(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3173,7 +3234,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c112(s2, s3, s4);
+            s1 = peg$c116(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3199,12 +3260,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c113) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c117) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c114); }
+      if (peg$silentFails === 0) { peg$fail(peg$c118); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseCutArgs();
@@ -3214,7 +3275,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFlexAssignments();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c115(s2, s4);
+            s1 = peg$c119(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3244,16 +3305,16 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     s3 = peg$parse_();
     if (s3 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c116) {
-        s4 = peg$c116;
+      if (input.substr(peg$currPos, 2) === peg$c120) {
+        s4 = peg$c120;
         peg$currPos += 2;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c117); }
+        if (peg$silentFails === 0) { peg$fail(peg$c121); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c118();
+        s3 = peg$c122();
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3268,16 +3329,16 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c116) {
-          s4 = peg$c116;
+        if (input.substr(peg$currPos, 2) === peg$c120) {
+          s4 = peg$c120;
           peg$currPos += 2;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c117); }
+          if (peg$silentFails === 0) { peg$fail(peg$c121); }
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c118();
+          s3 = peg$c122();
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3290,7 +3351,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c119(s1);
+      s1 = peg$c123(s1);
     }
     s0 = s1;
 
@@ -3301,12 +3362,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c120) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c124) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c121); }
+      if (peg$silentFails === 0) { peg$fail(peg$c125); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3314,7 +3375,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c122(s3);
+          s1 = peg$c126(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3336,12 +3397,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c123) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c127) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c124); }
+      if (peg$silentFails === 0) { peg$fail(peg$c128); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3349,7 +3410,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFieldExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c125(s3);
+          s1 = peg$c129(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3368,56 +3429,6 @@ function peg$parse(input, options) {
   }
 
   function peg$parseHeadProc() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c126) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c127); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseUInt();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c128(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c126) {
-        s1 = input.substr(peg$currPos, 4);
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c127); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c129();
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseTailProc() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -3467,16 +3478,66 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseTailProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c134) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c135); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseUInt();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c136(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c134) {
+        s1 = input.substr(peg$currPos, 4);
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c135); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c137();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
   function peg$parseFilterProc() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c134) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c138) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c135); }
+      if (peg$silentFails === 0) { peg$fail(peg$c139); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3506,26 +3567,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c136) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c140) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c137); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c116) {
-          s3 = peg$c116;
+        if (input.substr(peg$currPos, 2) === peg$c120) {
+          s3 = peg$c120;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c117); }
+          if (peg$silentFails === 0) { peg$fail(peg$c121); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c138();
+          s1 = peg$c142();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3541,16 +3602,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c136) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c140) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c137); }
+        if (peg$silentFails === 0) { peg$fail(peg$c141); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c139();
+        s1 = peg$c143();
       }
       s0 = s1;
     }
@@ -3562,12 +3623,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c140) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c144) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c145); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3575,7 +3636,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c142(s3);
+          s1 = peg$c146(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3597,12 +3658,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c143) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c147) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c144); }
+      if (peg$silentFails === 0) { peg$fail(peg$c148); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3614,11 +3675,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c75;
+              s7 = peg$c79;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c76); }
+              if (peg$silentFails === 0) { peg$fail(peg$c80); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -3626,7 +3687,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c145(s3, s9);
+                  s6 = peg$c149(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -3650,11 +3711,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c75;
+                s7 = peg$c79;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                if (peg$silentFails === 0) { peg$fail(peg$c80); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -3662,7 +3723,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c145(s3, s9);
+                    s6 = peg$c149(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -3683,7 +3744,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c146(s3, s4);
+            s1 = peg$c150(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3709,16 +3770,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c147) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c151) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c152); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c149();
+      s1 = peg$c153();
     }
     s0 = s1;
 
@@ -3729,12 +3790,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      if (peg$silentFails === 0) { peg$fail(peg$c155); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3744,11 +3805,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 61) {
-              s5 = peg$c79;
+              s5 = peg$c83;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c80); }
+              if (peg$silentFails === 0) { peg$fail(peg$c84); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
@@ -3775,7 +3836,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c152(s3, s7, s8);
+                    s1 = peg$c156(s3, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3811,12 +3872,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c151); }
+        if (peg$silentFails === 0) { peg$fail(peg$c155); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -3843,7 +3904,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c153(s3, s4);
+              s1 = peg$c157(s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3915,11 +3976,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c154;
+      s1 = peg$c158;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+      if (peg$silentFails === 0) { peg$fail(peg$c159); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -3942,7 +4003,7 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifier();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c156(s3);
+          s1 = peg$c160(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3959,11 +4020,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c154;
+        s1 = peg$c158;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c159); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
@@ -3978,7 +4039,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c157();
+          s1 = peg$c161();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4004,11 +4065,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c79;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -4039,11 +4100,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c79;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -4071,7 +4132,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c162(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4096,11 +4157,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c79;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -4131,11 +4192,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c79;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -4163,7 +4224,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c162(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4186,11 +4247,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c79;
+          s3 = peg$c83;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c84); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4198,7 +4259,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c159(s1, s5);
+              s1 = peg$c163(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4241,11 +4302,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c160;
+          s3 = peg$c164;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c161); }
+          if (peg$silentFails === 0) { peg$fail(peg$c165); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4255,11 +4316,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c162;
+                  s7 = peg$c166;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c163); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c167); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -4267,7 +4328,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c164(s1, s5, s9);
+                      s1 = peg$c168(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4329,7 +4390,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c165(s1, s5, s7);
+              s4 = peg$c169(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4359,7 +4420,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c165(s1, s5, s7);
+                s4 = peg$c169(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4380,7 +4441,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c166(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4411,7 +4472,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c165(s1, s5, s7);
+              s4 = peg$c169(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4441,7 +4502,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c165(s1, s5, s7);
+                s4 = peg$c169(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4462,7 +4523,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c166(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4493,7 +4554,7 @@ function peg$parse(input, options) {
             s7 = peg$parseRelativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c167(s1, s5, s7);
+              s4 = peg$c171(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4523,7 +4584,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c167(s1, s5, s7);
+                s4 = peg$c171(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4544,7 +4605,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c166(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4562,43 +4623,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c168) {
-      s1 = peg$c168;
+    if (input.substr(peg$currPos, 2) === peg$c172) {
+      s1 = peg$c172;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c169); }
+      if (peg$silentFails === 0) { peg$fail(peg$c173); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c170) {
-        s1 = peg$c170;
+      if (input.substr(peg$currPos, 2) === peg$c174) {
+        s1 = peg$c174;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c171); }
+        if (peg$silentFails === 0) { peg$fail(peg$c175); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c79;
+          s1 = peg$c83;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c84); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c172) {
-            s1 = peg$c172;
+          if (input.substr(peg$currPos, 2) === peg$c176) {
+            s1 = peg$c176;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c173); }
+            if (peg$silentFails === 0) { peg$fail(peg$c177); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -4611,16 +4672,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c174) {
-        s1 = peg$c174;
+      if (input.substr(peg$currPos, 2) === peg$c178) {
+        s1 = peg$c178;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+        if (peg$silentFails === 0) { peg$fail(peg$c179); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c108();
       }
       s0 = s1;
     }
@@ -4645,7 +4706,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c165(s1, s5, s7);
+              s4 = peg$c169(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4675,7 +4736,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c165(s1, s5, s7);
+                s4 = peg$c169(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4696,7 +4757,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c166(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4714,43 +4775,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c176) {
-      s1 = peg$c176;
+    if (input.substr(peg$currPos, 2) === peg$c180) {
+      s1 = peg$c180;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c177); }
+      if (peg$silentFails === 0) { peg$fail(peg$c181); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c178;
+        s1 = peg$c182;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c183); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c180) {
-          s1 = peg$c180;
+        if (input.substr(peg$currPos, 2) === peg$c184) {
+          s1 = peg$c184;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c181); }
+          if (peg$silentFails === 0) { peg$fail(peg$c185); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c182;
+            s1 = peg$c186;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c183); }
+            if (peg$silentFails === 0) { peg$fail(peg$c187); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -4774,7 +4835,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c165(s1, s5, s7);
+              s4 = peg$c169(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4804,7 +4865,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c165(s1, s5, s7);
+                s4 = peg$c169(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4825,7 +4886,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c166(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4844,11 +4905,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c184;
+      s1 = peg$c188;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c185); }
+      if (peg$silentFails === 0) { peg$fail(peg$c189); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
@@ -4861,7 +4922,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -4885,7 +4946,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c165(s1, s5, s7);
+              s4 = peg$c169(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4915,7 +4976,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c165(s1, s5, s7);
+                s4 = peg$c169(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4936,7 +4997,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c166(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4963,16 +5024,16 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c186;
+        s1 = peg$c190;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c187); }
+        if (peg$silentFails === 0) { peg$fail(peg$c191); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -4996,7 +5057,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c188(s3);
+          s1 = peg$c192(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5025,17 +5086,17 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 58) {
-        s3 = peg$c162;
+        s3 = peg$c166;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c167); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parsePrimitiveType();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c189(s1, s4);
+          s3 = peg$c193(s1, s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -5047,7 +5108,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c190(s1, s2);
+        s1 = peg$c194(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5068,164 +5129,164 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c191) {
-      s1 = peg$c191;
+    if (input.substr(peg$currPos, 5) === peg$c195) {
+      s1 = peg$c195;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c192); }
+      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c193) {
-        s1 = peg$c193;
+      if (input.substr(peg$currPos, 5) === peg$c197) {
+        s1 = peg$c197;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c194); }
+        if (peg$silentFails === 0) { peg$fail(peg$c198); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c195) {
-          s1 = peg$c195;
+        if (input.substr(peg$currPos, 6) === peg$c199) {
+          s1 = peg$c199;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c196); }
+          if (peg$silentFails === 0) { peg$fail(peg$c200); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c197) {
-            s1 = peg$c197;
+          if (input.substr(peg$currPos, 6) === peg$c201) {
+            s1 = peg$c201;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c198); }
+            if (peg$silentFails === 0) { peg$fail(peg$c202); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c199) {
-              s1 = peg$c199;
+            if (input.substr(peg$currPos, 6) === peg$c203) {
+              s1 = peg$c203;
               peg$currPos += 6;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c200); }
+              if (peg$silentFails === 0) { peg$fail(peg$c204); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4) === peg$c201) {
-                s1 = peg$c201;
+              if (input.substr(peg$currPos, 4) === peg$c205) {
+                s1 = peg$c205;
                 peg$currPos += 4;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c202); }
+                if (peg$silentFails === 0) { peg$fail(peg$c206); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c203) {
-                  s1 = peg$c203;
+                if (input.substr(peg$currPos, 5) === peg$c207) {
+                  s1 = peg$c207;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c204); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c208); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c205) {
-                    s1 = peg$c205;
+                  if (input.substr(peg$currPos, 5) === peg$c209) {
+                    s1 = peg$c209;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c206); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c210); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c207) {
-                      s1 = peg$c207;
+                    if (input.substr(peg$currPos, 5) === peg$c211) {
+                      s1 = peg$c211;
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c208); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c212); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 8) === peg$c209) {
-                        s1 = peg$c209;
+                      if (input.substr(peg$currPos, 8) === peg$c213) {
+                        s1 = peg$c213;
                         peg$currPos += 8;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c210); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c214); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c211) {
-                          s1 = peg$c211;
+                        if (input.substr(peg$currPos, 4) === peg$c215) {
+                          s1 = peg$c215;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c212); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c216); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 7) === peg$c213) {
-                            s1 = peg$c213;
+                          if (input.substr(peg$currPos, 7) === peg$c217) {
+                            s1 = peg$c217;
                             peg$currPos += 7;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c214); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c218); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 4) === peg$c215) {
-                              s1 = peg$c215;
+                            if (input.substr(peg$currPos, 4) === peg$c219) {
+                              s1 = peg$c219;
                               peg$currPos += 4;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c220); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 5) === peg$c191) {
-                                s1 = peg$c191;
+                              if (input.substr(peg$currPos, 5) === peg$c195) {
+                                s1 = peg$c195;
                                 peg$currPos += 5;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c192); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c196); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 6) === peg$c217) {
-                                  s1 = peg$c217;
+                                if (input.substr(peg$currPos, 6) === peg$c221) {
+                                  s1 = peg$c221;
                                   peg$currPos += 6;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c218); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c222); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 7) === peg$c219) {
-                                    s1 = peg$c219;
+                                  if (input.substr(peg$currPos, 7) === peg$c223) {
+                                    s1 = peg$c223;
                                     peg$currPos += 7;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c220); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c224); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c221) {
-                                      s1 = peg$c221;
+                                    if (input.substr(peg$currPos, 2) === peg$c225) {
+                                      s1 = peg$c225;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c222); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c226); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c223) {
-                                        s1 = peg$c223;
+                                      if (input.substr(peg$currPos, 3) === peg$c227) {
+                                        s1 = peg$c227;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c224); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c228); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c225) {
-                                          s1 = peg$c225;
+                                        if (input.substr(peg$currPos, 4) === peg$c229) {
+                                          s1 = peg$c229;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c226); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c230); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 5) === peg$c227) {
-                                            s1 = peg$c227;
+                                          if (input.substr(peg$currPos, 5) === peg$c231) {
+                                            s1 = peg$c231;
                                             peg$currPos += 5;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c228); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c232); }
                                           }
                                           if (s1 === peg$FAILED) {
                                             if (input.substr(peg$currPos, 4) === peg$c47) {
@@ -5257,7 +5318,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -5278,7 +5339,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c229(s1, s2);
+        s1 = peg$c233(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5325,7 +5386,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c230(s1, s4);
+              s1 = peg$c234(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5361,11 +5422,11 @@ function peg$parse(input, options) {
       s3 = peg$parseIdentifierRest();
       if (s3 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c154;
+          s3 = peg$c158;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c159); }
         }
       }
       while (s3 !== peg$FAILED) {
@@ -5373,17 +5434,17 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifierRest();
         if (s3 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s3 = peg$c154;
+            s3 = peg$c158;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c155); }
+            if (peg$silentFails === 0) { peg$fail(peg$c159); }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c108();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5408,11 +5469,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c79;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5420,7 +5481,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c231(s1, s7);
+              s4 = peg$c235(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5444,11 +5505,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c79;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5456,7 +5517,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c231(s1, s7);
+                s4 = peg$c235(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5477,7 +5538,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c78(s1, s2);
+        s1 = peg$c82(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5492,7 +5553,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c232();
+        s1 = peg$c236();
       }
       s0 = s1;
     }
@@ -5514,7 +5575,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c229(s1, s2);
+        s1 = peg$c233(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5533,25 +5594,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c233;
+      s1 = peg$c237;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseConditionalExpr();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c235;
+          s3 = peg$c239;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c236); }
+          if (peg$silentFails === 0) { peg$fail(peg$c240); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c237(s2);
+          s1 = peg$c241(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5568,21 +5629,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c154;
+        s1 = peg$c158;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c159); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c154;
+          s3 = peg$c158;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c159); }
         }
         peg$silentFails--;
         if (s3 === peg$FAILED) {
@@ -5595,7 +5656,7 @@ function peg$parse(input, options) {
           s3 = peg$parseIdentifier();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c238(s3);
+            s1 = peg$c242(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5706,16 +5767,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c239) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c243) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -5726,16 +5787,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c241) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c245) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c242); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -5746,16 +5807,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c174) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c178) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c243); }
+      if (peg$silentFails === 0) { peg$fail(peg$c247); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -5766,16 +5827,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c83) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c87) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c248); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -5796,7 +5857,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c108();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5813,12 +5874,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c245.test(input.charAt(peg$currPos))) {
+    if (peg$c249.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c250); }
     }
 
     return s0;
@@ -5829,12 +5890,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c247.test(input.charAt(peg$currPos))) {
+      if (peg$c251.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c248); }
+        if (peg$silentFails === 0) { peg$fail(peg$c252); }
       }
     }
 
@@ -5855,7 +5916,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c249();
+        s1 = peg$c253();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5883,12 +5944,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c239) {
-                s3 = peg$c239;
+              if (input.substr(peg$currPos, 3) === peg$c243) {
+                s3 = peg$c243;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c250); }
+                if (peg$silentFails === 0) { peg$fail(peg$c254); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -5933,44 +5994,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c251) {
-      s0 = peg$c251;
+    if (input.substr(peg$currPos, 7) === peg$c255) {
+      s0 = peg$c255;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c252); }
+      if (peg$silentFails === 0) { peg$fail(peg$c256); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c253) {
-        s0 = peg$c253;
+      if (input.substr(peg$currPos, 6) === peg$c257) {
+        s0 = peg$c257;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c254); }
+        if (peg$silentFails === 0) { peg$fail(peg$c258); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c255) {
-          s0 = peg$c255;
+        if (input.substr(peg$currPos, 4) === peg$c259) {
+          s0 = peg$c259;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c256); }
+          if (peg$silentFails === 0) { peg$fail(peg$c260); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c257) {
-            s0 = peg$c257;
+          if (input.substr(peg$currPos, 3) === peg$c261) {
+            s0 = peg$c261;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c258); }
+            if (peg$silentFails === 0) { peg$fail(peg$c262); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c259;
+              s0 = peg$c263;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c260); }
+              if (peg$silentFails === 0) { peg$fail(peg$c264); }
             }
           }
         }
@@ -5983,44 +6044,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c261) {
-      s0 = peg$c261;
+    if (input.substr(peg$currPos, 7) === peg$c265) {
+      s0 = peg$c265;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c262); }
+      if (peg$silentFails === 0) { peg$fail(peg$c266); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c263) {
-        s0 = peg$c263;
+      if (input.substr(peg$currPos, 6) === peg$c267) {
+        s0 = peg$c267;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c264); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c265) {
-          s0 = peg$c265;
+        if (input.substr(peg$currPos, 4) === peg$c269) {
+          s0 = peg$c269;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c266); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c267) {
-            s0 = peg$c267;
+          if (input.substr(peg$currPos, 3) === peg$c271) {
+            s0 = peg$c271;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c268); }
+            if (peg$silentFails === 0) { peg$fail(peg$c272); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c269;
+              s0 = peg$c273;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c270); }
+              if (peg$silentFails === 0) { peg$fail(peg$c274); }
             }
           }
         }
@@ -6033,44 +6094,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c271) {
-      s0 = peg$c271;
+    if (input.substr(peg$currPos, 5) === peg$c275) {
+      s0 = peg$c275;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c272); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c273) {
-        s0 = peg$c273;
+      if (input.substr(peg$currPos, 3) === peg$c277) {
+        s0 = peg$c277;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c274); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c275) {
-          s0 = peg$c275;
+        if (input.substr(peg$currPos, 2) === peg$c279) {
+          s0 = peg$c279;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c276); }
+          if (peg$silentFails === 0) { peg$fail(peg$c280); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c277;
+            s0 = peg$c281;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c278); }
+            if (peg$silentFails === 0) { peg$fail(peg$c282); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c279) {
-              s0 = peg$c279;
+            if (input.substr(peg$currPos, 4) === peg$c283) {
+              s0 = peg$c283;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c280); }
+              if (peg$silentFails === 0) { peg$fail(peg$c284); }
             }
           }
         }
@@ -6083,28 +6144,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c281) {
-      s0 = peg$c281;
+    if (input.substr(peg$currPos, 4) === peg$c285) {
+      s0 = peg$c285;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c283) {
-        s0 = peg$c283;
+      if (input.substr(peg$currPos, 3) === peg$c287) {
+        s0 = peg$c287;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c288); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c285;
+          s0 = peg$c289;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+          if (peg$silentFails === 0) { peg$fail(peg$c290); }
         }
       }
     }
@@ -6115,44 +6176,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c287) {
-      s0 = peg$c287;
+    if (input.substr(peg$currPos, 5) === peg$c291) {
+      s0 = peg$c291;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c288); }
+      if (peg$silentFails === 0) { peg$fail(peg$c292); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c289) {
-        s0 = peg$c289;
+      if (input.substr(peg$currPos, 4) === peg$c293) {
+        s0 = peg$c293;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c290); }
+        if (peg$silentFails === 0) { peg$fail(peg$c294); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c291) {
-          s0 = peg$c291;
+        if (input.substr(peg$currPos, 3) === peg$c295) {
+          s0 = peg$c295;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c292); }
+          if (peg$silentFails === 0) { peg$fail(peg$c296); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c293) {
-            s0 = peg$c293;
+          if (input.substr(peg$currPos, 2) === peg$c297) {
+            s0 = peg$c297;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c294); }
+            if (peg$silentFails === 0) { peg$fail(peg$c298); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c295;
+              s0 = peg$c299;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c296); }
+              if (peg$silentFails === 0) { peg$fail(peg$c300); }
             }
           }
         }
@@ -6166,16 +6227,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c253) {
-      s1 = peg$c253;
+    if (input.substr(peg$currPos, 6) === peg$c257) {
+      s1 = peg$c257;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c254); }
+      if (peg$silentFails === 0) { peg$fail(peg$c258); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c297();
+      s1 = peg$c301();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6187,7 +6248,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c298(s1);
+            s1 = peg$c302(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6210,16 +6271,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c263) {
-      s1 = peg$c263;
+    if (input.substr(peg$currPos, 6) === peg$c267) {
+      s1 = peg$c267;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c299();
+      s1 = peg$c303();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6231,7 +6292,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c300(s1);
+            s1 = peg$c304(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6254,16 +6315,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c279) {
-      s1 = peg$c279;
+    if (input.substr(peg$currPos, 4) === peg$c283) {
+      s1 = peg$c283;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c284); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c301();
+      s1 = peg$c305();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6275,7 +6336,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c302(s1);
+            s1 = peg$c306(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6298,16 +6359,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c283) {
-      s1 = peg$c283;
+    if (input.substr(peg$currPos, 3) === peg$c287) {
+      s1 = peg$c287;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c284); }
+      if (peg$silentFails === 0) { peg$fail(peg$c288); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c303();
+      s1 = peg$c307();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6319,7 +6380,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c304(s1);
+            s1 = peg$c308(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6342,16 +6403,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c289) {
-      s1 = peg$c289;
+    if (input.substr(peg$currPos, 4) === peg$c293) {
+      s1 = peg$c293;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c290); }
+      if (peg$silentFails === 0) { peg$fail(peg$c294); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c305();
+      s1 = peg$c309();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6363,7 +6424,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c306(s1);
+            s1 = peg$c310(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6389,37 +6450,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c154;
+        s2 = peg$c158;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c159); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c154;
+            s4 = peg$c158;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c155); }
+            if (peg$silentFails === 0) { peg$fail(peg$c159); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c154;
+                s6 = peg$c158;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c155); }
+                if (peg$silentFails === 0) { peg$fail(peg$c159); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c104();
+                  s1 = peg$c108();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6471,7 +6532,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c307(s1, s2);
+        s1 = peg$c311(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6492,12 +6553,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c308) {
-            s3 = peg$c308;
+          if (input.substr(peg$currPos, 2) === peg$c312) {
+            s3 = peg$c312;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c309); }
+            if (peg$silentFails === 0) { peg$fail(peg$c313); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6510,7 +6571,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c310(s1, s2, s4, s5);
+                s1 = peg$c314(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6534,12 +6595,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c308) {
-          s1 = peg$c308;
+        if (input.substr(peg$currPos, 2) === peg$c312) {
+          s1 = peg$c312;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c309); }
+          if (peg$silentFails === 0) { peg$fail(peg$c313); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6552,7 +6613,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311(s2, s3);
+              s1 = peg$c315(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6577,16 +6638,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c308) {
-                s3 = peg$c308;
+              if (input.substr(peg$currPos, 2) === peg$c312) {
+                s3 = peg$c312;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c309); }
+                if (peg$silentFails === 0) { peg$fail(peg$c313); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c312(s1, s2);
+                s1 = peg$c316(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6602,16 +6663,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c308) {
-              s1 = peg$c308;
+            if (input.substr(peg$currPos, 2) === peg$c312) {
+              s1 = peg$c312;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c309); }
+              if (peg$silentFails === 0) { peg$fail(peg$c313); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c313();
+              s1 = peg$c317();
             }
             s0 = s1;
           }
@@ -6638,17 +6699,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c162;
+      s1 = peg$c166;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c163); }
+      if (peg$silentFails === 0) { peg$fail(peg$c167); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c314(s2);
+        s1 = peg$c318(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6669,15 +6730,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c162;
+        s2 = peg$c166;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c167); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c315(s1);
+        s1 = peg$c319(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6698,17 +6759,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c186;
+        s2 = peg$c190;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c187); }
+        if (peg$silentFails === 0) { peg$fail(peg$c191); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c316(s1, s3);
+          s1 = peg$c320(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6733,17 +6794,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c186;
+        s2 = peg$c190;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c187); }
+        if (peg$silentFails === 0) { peg$fail(peg$c191); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c317(s1, s3);
+          s1 = peg$c321(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6768,7 +6829,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c318(s1);
+      s1 = peg$c322(s1);
     }
     s0 = s1;
 
@@ -6791,22 +6852,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c247.test(input.charAt(peg$currPos))) {
+    if (peg$c251.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c248); }
+      if (peg$silentFails === 0) { peg$fail(peg$c252); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c247.test(input.charAt(peg$currPos))) {
+        if (peg$c251.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c248); }
+          if (peg$silentFails === 0) { peg$fail(peg$c252); }
         }
       }
     } else {
@@ -6814,7 +6875,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -6836,7 +6897,7 @@ function peg$parse(input, options) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c108();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6866,22 +6927,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c247.test(input.charAt(peg$currPos))) {
+      if (peg$c251.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c248); }
+        if (peg$silentFails === 0) { peg$fail(peg$c252); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c247.test(input.charAt(peg$currPos))) {
+          if (peg$c251.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c248); }
+            if (peg$silentFails === 0) { peg$fail(peg$c252); }
           }
         }
       } else {
@@ -6889,30 +6950,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c154;
+          s3 = peg$c158;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c159); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c247.test(input.charAt(peg$currPos))) {
+          if (peg$c251.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c248); }
+            if (peg$silentFails === 0) { peg$fail(peg$c252); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c247.test(input.charAt(peg$currPos))) {
+              if (peg$c251.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c248); }
+                if (peg$silentFails === 0) { peg$fail(peg$c252); }
               }
             }
           } else {
@@ -6925,7 +6986,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c319();
+              s1 = peg$c323();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6961,30 +7022,30 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c154;
+          s2 = peg$c158;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c159); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c247.test(input.charAt(peg$currPos))) {
+          if (peg$c251.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c248); }
+            if (peg$silentFails === 0) { peg$fail(peg$c252); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c247.test(input.charAt(peg$currPos))) {
+              if (peg$c251.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c248); }
+                if (peg$silentFails === 0) { peg$fail(peg$c252); }
               }
             }
           } else {
@@ -6997,7 +7058,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c319();
+              s1 = peg$c323();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7024,20 +7085,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c320) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c324) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c321); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c322.test(input.charAt(peg$currPos))) {
+      if (peg$c326.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c323); }
+        if (peg$silentFails === 0) { peg$fail(peg$c327); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -7079,7 +7140,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -7089,12 +7150,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c324.test(input.charAt(peg$currPos))) {
+    if (peg$c328.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c329); }
     }
 
     return s0;
@@ -7116,7 +7177,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c326(s1);
+      s1 = peg$c330(s1);
     }
     s0 = s1;
 
@@ -7128,11 +7189,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c327;
+      s1 = peg$c331;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c332); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
@@ -7155,12 +7216,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c329.test(input.charAt(peg$currPos))) {
+      if (peg$c333.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c330); }
+        if (peg$silentFails === 0) { peg$fail(peg$c334); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseWhiteSpace();
@@ -7178,11 +7239,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c331); }
+          if (peg$silentFails === 0) { peg$fail(peg$c335); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c104();
+          s1 = peg$c108();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7202,11 +7263,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c332;
+      s1 = peg$c336;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c333); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -7217,15 +7278,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c332;
+          s3 = peg$c336;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c333); }
+          if (peg$silentFails === 0) { peg$fail(peg$c337); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c334(s2);
+          s1 = peg$c338(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7242,11 +7303,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c335;
+        s1 = peg$c339;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c336); }
+        if (peg$silentFails === 0) { peg$fail(peg$c340); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7257,15 +7318,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c335;
+            s3 = peg$c339;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c336); }
+            if (peg$silentFails === 0) { peg$fail(peg$c340); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c334(s2);
+            s1 = peg$c338(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7291,11 +7352,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c332;
+      s2 = peg$c336;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c333); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -7313,11 +7374,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c331); }
+        if (peg$silentFails === 0) { peg$fail(peg$c335); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c108();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7330,11 +7391,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c327;
+        s1 = peg$c331;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c328); }
+        if (peg$silentFails === 0) { peg$fail(peg$c332); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -7362,11 +7423,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c335;
+      s2 = peg$c339;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c336); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -7384,11 +7445,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c331); }
+        if (peg$silentFails === 0) { peg$fail(peg$c335); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c108();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7401,11 +7462,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c327;
+        s1 = peg$c331;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c328); }
+        if (peg$silentFails === 0) { peg$fail(peg$c332); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -7431,11 +7492,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c337;
+      s1 = peg$c341;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c342); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -7443,7 +7504,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c339();
+          s1 = peg$c343();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7471,110 +7532,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c335;
+      s0 = peg$c339;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c336); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c332;
+        s0 = peg$c336;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c333); }
+        if (peg$silentFails === 0) { peg$fail(peg$c337); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c327;
+          s0 = peg$c331;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c328); }
+          if (peg$silentFails === 0) { peg$fail(peg$c332); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c340;
+            s1 = peg$c344;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c341); }
+            if (peg$silentFails === 0) { peg$fail(peg$c345); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c342();
+            s1 = peg$c346();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c343;
+              s1 = peg$c347;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c344); }
+              if (peg$silentFails === 0) { peg$fail(peg$c348); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c345();
+              s1 = peg$c349();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c346;
+                s1 = peg$c350;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c347); }
+                if (peg$silentFails === 0) { peg$fail(peg$c351); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c348();
+                s1 = peg$c352();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c349;
+                  s1 = peg$c353;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c350); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c354); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c351();
+                  s1 = peg$c355();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c352;
+                    s1 = peg$c356;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c353); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c357); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c354();
+                    s1 = peg$c358();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c355;
+                      s1 = peg$c359;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c360); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c357();
+                      s1 = peg$c361();
                     }
                     s0 = s1;
                   }
@@ -7594,15 +7655,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c79;
+      s1 = peg$c83;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c80); }
+      if (peg$silentFails === 0) { peg$fail(peg$c84); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c358();
+      s1 = peg$c362();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7616,7 +7677,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c359();
+        s1 = peg$c363();
       }
       s0 = s1;
     }
@@ -7629,11 +7690,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c360;
+      s1 = peg$c364;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7665,7 +7726,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c362(s2);
+        s1 = peg$c366(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7678,19 +7739,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c360;
+        s1 = peg$c364;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c361); }
+        if (peg$silentFails === 0) { peg$fail(peg$c365); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c363;
+          s2 = peg$c367;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c364); }
+          if (peg$silentFails === 0) { peg$fail(peg$c368); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7749,15 +7810,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c365;
+              s4 = peg$c369;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c366); }
+              if (peg$silentFails === 0) { peg$fail(peg$c370); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c362(s3);
+              s1 = peg$c366(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7785,25 +7846,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c186;
+      s1 = peg$c190;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c187); }
+      if (peg$silentFails === 0) { peg$fail(peg$c191); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c186;
+          s3 = peg$c190;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c187); }
+          if (peg$silentFails === 0) { peg$fail(peg$c191); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c367(s2);
+          s1 = peg$c371(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7826,39 +7887,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c368.test(input.charAt(peg$currPos))) {
+    if (peg$c372.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c369); }
+      if (peg$silentFails === 0) { peg$fail(peg$c373); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c370) {
-        s2 = peg$c370;
+      if (input.substr(peg$currPos, 2) === peg$c374) {
+        s2 = peg$c374;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c371); }
+        if (peg$silentFails === 0) { peg$fail(peg$c375); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c368.test(input.charAt(peg$currPos))) {
+        if (peg$c372.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c369); }
+          if (peg$silentFails === 0) { peg$fail(peg$c373); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c370) {
-            s2 = peg$c370;
+          if (input.substr(peg$currPos, 2) === peg$c374) {
+            s2 = peg$c374;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c371); }
+            if (peg$silentFails === 0) { peg$fail(peg$c375); }
           }
         }
       }
@@ -7867,7 +7928,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -7877,12 +7938,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c372.test(input.charAt(peg$currPos))) {
+    if (peg$c376.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c377); }
     }
 
     return s0;
@@ -7940,7 +8001,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c331); }
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
     }
 
     return s0;
@@ -7951,51 +8012,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c375;
+      s0 = peg$c379;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c376); }
+      if (peg$silentFails === 0) { peg$fail(peg$c380); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c377;
+        s0 = peg$c381;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c378); }
+        if (peg$silentFails === 0) { peg$fail(peg$c382); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c379;
+          s0 = peg$c383;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c380); }
+          if (peg$silentFails === 0) { peg$fail(peg$c384); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c381;
+            s0 = peg$c385;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c382); }
+            if (peg$silentFails === 0) { peg$fail(peg$c386); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c383;
+              s0 = peg$c387;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c384); }
+              if (peg$silentFails === 0) { peg$fail(peg$c388); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c385;
+                s0 = peg$c389;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c386); }
+                if (peg$silentFails === 0) { peg$fail(peg$c390); }
               }
             }
           }
@@ -8004,7 +8065,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c374); }
+      if (peg$silentFails === 0) { peg$fail(peg$c378); }
     }
 
     return s0;
@@ -8013,12 +8074,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c387.test(input.charAt(peg$currPos))) {
+    if (peg$c391.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+      if (peg$silentFails === 0) { peg$fail(peg$c392); }
     }
 
     return s0;
@@ -8031,7 +8092,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
 
     return s0;
@@ -8041,12 +8102,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c394) {
-      s1 = peg$c394;
+    if (input.substr(peg$currPos, 2) === peg$c398) {
+      s1 = peg$c398;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c395); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -8126,7 +8187,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c331); }
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -1126,72 +1126,90 @@ var g = &grammar{
 						pos:  position{line: 169, col: 5, offset: 5334},
 						name: "NamedProc",
 					},
-					&ruleRefExpr{
-						pos:  position{line: 170, col: 5, offset: 5348},
-						name: "GroupByProc",
-					},
 					&actionExpr{
-						pos: position{line: 171, col: 5, offset: 5364},
-						run: (*parser).callonProc4,
+						pos: position{line: 170, col: 5, offset: 5348},
+						run: (*parser).callonProc3,
 						expr: &seqExpr{
-							pos: position{line: 171, col: 5, offset: 5364},
+							pos: position{line: 170, col: 5, offset: 5348},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 171, col: 5, offset: 5364},
+									pos:        position{line: 170, col: 5, offset: 5348},
+									val:        "split",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 170, col: 13, offset: 5356},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 170, col: 16, offset: 5359},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 171, col: 9, offset: 5368},
+									pos:  position{line: 170, col: 20, offset: 5363},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 170, col: 23, offset: 5366},
+									val:        "=>",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 170, col: 28, offset: 5371},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 171, col: 12, offset: 5371},
+									pos:   position{line: 170, col: 31, offset: 5374},
 									label: "proc",
 									expr: &ruleRefExpr{
-										pos:  position{line: 171, col: 17, offset: 5376},
+										pos:  position{line: 170, col: 36, offset: 5379},
 										name: "Procs",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 171, col: 23, offset: 5382},
+									pos:  position{line: 170, col: 42, offset: 5385},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 171, col: 26, offset: 5385},
+									pos:        position{line: 170, col: 45, offset: 5388},
 									val:        ")",
 									ignoreCase: false,
 								},
 							},
 						},
 					},
+					&ruleRefExpr{
+						pos:  position{line: 173, col: 5, offset: 5427},
+						name: "GroupByProc",
+					},
 				},
 			},
 		},
 		{
 			name: "Procs",
-			pos:  position{line: 175, col: 1, offset: 5421},
+			pos:  position{line: 175, col: 1, offset: 5440},
 			expr: &actionExpr{
-				pos: position{line: 176, col: 5, offset: 5431},
+				pos: position{line: 176, col: 5, offset: 5450},
 				run: (*parser).callonProcs1,
 				expr: &seqExpr{
-					pos: position{line: 176, col: 5, offset: 5431},
+					pos: position{line: 176, col: 5, offset: 5450},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 176, col: 5, offset: 5431},
+							pos:   position{line: 176, col: 5, offset: 5450},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 176, col: 11, offset: 5437},
+								pos:  position{line: 176, col: 11, offset: 5456},
 								name: "SequentialProcs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 176, col: 27, offset: 5453},
+							pos:   position{line: 176, col: 27, offset: 5472},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 176, col: 32, offset: 5458},
+								pos: position{line: 176, col: 32, offset: 5477},
 								expr: &ruleRefExpr{
-									pos:  position{line: 176, col: 32, offset: 5458},
+									pos:  position{line: 176, col: 32, offset: 5477},
 									name: "ParallelTail",
 								},
 							},
@@ -1202,31 +1220,43 @@ var g = &grammar{
 		},
 		{
 			name: "ParallelTail",
-			pos:  position{line: 185, col: 1, offset: 5757},
+			pos:  position{line: 185, col: 1, offset: 5776},
 			expr: &actionExpr{
-				pos: position{line: 186, col: 5, offset: 5774},
+				pos: position{line: 186, col: 5, offset: 5793},
 				run: (*parser).callonParallelTail1,
 				expr: &seqExpr{
-					pos: position{line: 186, col: 5, offset: 5774},
+					pos: position{line: 186, col: 5, offset: 5793},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 5, offset: 5774},
+							pos:  position{line: 186, col: 5, offset: 5793},
+							name: "__",
+						},
+						&zeroOrOneExpr{
+							pos: position{line: 186, col: 8, offset: 5796},
+							expr: &litMatcher{
+								pos:        position{line: 186, col: 8, offset: 5796},
+								val:        ";",
+								ignoreCase: false,
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 186, col: 13, offset: 5801},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 186, col: 8, offset: 5777},
-							val:        ";",
+							pos:        position{line: 186, col: 16, offset: 5804},
+							val:        "=>",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 12, offset: 5781},
+							pos:  position{line: 186, col: 21, offset: 5809},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 186, col: 15, offset: 5784},
+							pos:   position{line: 186, col: 24, offset: 5812},
 							label: "ch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 186, col: 18, offset: 5787},
+								pos:  position{line: 186, col: 27, offset: 5815},
 								name: "SequentialProcs",
 							},
 						},
@@ -1236,40 +1266,40 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByProc",
-			pos:  position{line: 188, col: 1, offset: 5880},
+			pos:  position{line: 188, col: 1, offset: 5908},
 			expr: &choiceExpr{
-				pos: position{line: 189, col: 5, offset: 5896},
+				pos: position{line: 189, col: 5, offset: 5924},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 189, col: 5, offset: 5896},
+						pos: position{line: 189, col: 5, offset: 5924},
 						run: (*parser).callonGroupByProc2,
 						expr: &seqExpr{
-							pos: position{line: 189, col: 5, offset: 5896},
+							pos: position{line: 189, col: 5, offset: 5924},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 189, col: 5, offset: 5896},
+									pos:   position{line: 189, col: 5, offset: 5924},
 									label: "every",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 189, col: 11, offset: 5902},
+										pos: position{line: 189, col: 11, offset: 5930},
 										expr: &ruleRefExpr{
-											pos:  position{line: 189, col: 11, offset: 5902},
+											pos:  position{line: 189, col: 11, offset: 5930},
 											name: "EveryDur",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 189, col: 21, offset: 5912},
+									pos:   position{line: 189, col: 21, offset: 5940},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 189, col: 26, offset: 5917},
+										pos:  position{line: 189, col: 26, offset: 5945},
 										name: "GroupByKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 189, col: 38, offset: 5929},
+									pos:   position{line: 189, col: 38, offset: 5957},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 189, col: 44, offset: 5935},
+										pos:  position{line: 189, col: 44, offset: 5963},
 										name: "LimitArg",
 									},
 								},
@@ -1277,44 +1307,44 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 192, col: 5, offset: 6084},
+						pos: position{line: 192, col: 5, offset: 6112},
 						run: (*parser).callonGroupByProc11,
 						expr: &seqExpr{
-							pos: position{line: 192, col: 5, offset: 6084},
+							pos: position{line: 192, col: 5, offset: 6112},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 192, col: 5, offset: 6084},
+									pos:   position{line: 192, col: 5, offset: 6112},
 									label: "every",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 192, col: 11, offset: 6090},
+										pos: position{line: 192, col: 11, offset: 6118},
 										expr: &ruleRefExpr{
-											pos:  position{line: 192, col: 11, offset: 6090},
+											pos:  position{line: 192, col: 11, offset: 6118},
 											name: "EveryDur",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 192, col: 21, offset: 6100},
+									pos:   position{line: 192, col: 21, offset: 6128},
 									label: "reducers",
 									expr: &ruleRefExpr{
-										pos:  position{line: 192, col: 30, offset: 6109},
+										pos:  position{line: 192, col: 30, offset: 6137},
 										name: "Reducers",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 192, col: 39, offset: 6118},
+									pos:   position{line: 192, col: 39, offset: 6146},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 192, col: 44, offset: 6123},
+										pos: position{line: 192, col: 44, offset: 6151},
 										expr: &seqExpr{
-											pos: position{line: 192, col: 45, offset: 6124},
+											pos: position{line: 192, col: 45, offset: 6152},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 192, col: 45, offset: 6124},
+													pos:  position{line: 192, col: 45, offset: 6152},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 192, col: 47, offset: 6126},
+													pos:  position{line: 192, col: 47, offset: 6154},
 													name: "GroupByKeys",
 												},
 											},
@@ -1322,12 +1352,12 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 192, col: 61, offset: 6140},
+									pos:   position{line: 192, col: 61, offset: 6168},
 									label: "limit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 192, col: 67, offset: 6146},
+										pos: position{line: 192, col: 67, offset: 6174},
 										expr: &ruleRefExpr{
-											pos:  position{line: 192, col: 67, offset: 6146},
+											pos:  position{line: 192, col: 67, offset: 6174},
 											name: "LimitArg",
 										},
 									},
@@ -1340,32 +1370,32 @@ var g = &grammar{
 		},
 		{
 			name: "EveryDur",
-			pos:  position{line: 200, col: 1, offset: 6388},
+			pos:  position{line: 200, col: 1, offset: 6416},
 			expr: &actionExpr{
-				pos: position{line: 201, col: 5, offset: 6401},
+				pos: position{line: 201, col: 5, offset: 6429},
 				run: (*parser).callonEveryDur1,
 				expr: &seqExpr{
-					pos: position{line: 201, col: 5, offset: 6401},
+					pos: position{line: 201, col: 5, offset: 6429},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 201, col: 5, offset: 6401},
+							pos:        position{line: 201, col: 5, offset: 6429},
 							val:        "every",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 201, col: 14, offset: 6410},
+							pos:  position{line: 201, col: 14, offset: 6438},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 201, col: 16, offset: 6412},
+							pos:   position{line: 201, col: 16, offset: 6440},
 							label: "dur",
 							expr: &ruleRefExpr{
-								pos:  position{line: 201, col: 20, offset: 6416},
+								pos:  position{line: 201, col: 20, offset: 6444},
 								name: "Duration",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 201, col: 29, offset: 6425},
+							pos:  position{line: 201, col: 29, offset: 6453},
 							name: "_",
 						},
 					},
@@ -1374,27 +1404,27 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 203, col: 1, offset: 6448},
+			pos:  position{line: 203, col: 1, offset: 6476},
 			expr: &actionExpr{
-				pos: position{line: 204, col: 5, offset: 6464},
+				pos: position{line: 204, col: 5, offset: 6492},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 204, col: 5, offset: 6464},
+					pos: position{line: 204, col: 5, offset: 6492},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 204, col: 5, offset: 6464},
+							pos:        position{line: 204, col: 5, offset: 6492},
 							val:        "by",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 204, col: 11, offset: 6470},
+							pos:  position{line: 204, col: 11, offset: 6498},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 204, col: 13, offset: 6472},
+							pos:   position{line: 204, col: 13, offset: 6500},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 204, col: 21, offset: 6480},
+								pos:  position{line: 204, col: 21, offset: 6508},
 								name: "FlexAssignments",
 							},
 						},
@@ -1404,43 +1434,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 206, col: 1, offset: 6521},
+			pos:  position{line: 206, col: 1, offset: 6549},
 			expr: &choiceExpr{
-				pos: position{line: 207, col: 5, offset: 6534},
+				pos: position{line: 207, col: 5, offset: 6562},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 207, col: 5, offset: 6534},
+						pos: position{line: 207, col: 5, offset: 6562},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 207, col: 5, offset: 6534},
+							pos: position{line: 207, col: 5, offset: 6562},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 207, col: 5, offset: 6534},
+									pos:  position{line: 207, col: 5, offset: 6562},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 207, col: 7, offset: 6536},
+									pos:        position{line: 207, col: 7, offset: 6564},
 									val:        "with",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 207, col: 14, offset: 6543},
+									pos:  position{line: 207, col: 14, offset: 6571},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 207, col: 16, offset: 6545},
+									pos:        position{line: 207, col: 16, offset: 6573},
 									val:        "-limit",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 207, col: 25, offset: 6554},
+									pos:  position{line: 207, col: 25, offset: 6582},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 207, col: 27, offset: 6556},
+									pos:   position{line: 207, col: 27, offset: 6584},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 207, col: 33, offset: 6562},
+										pos:  position{line: 207, col: 33, offset: 6590},
 										name: "UInt",
 									},
 								},
@@ -1448,10 +1478,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 208, col: 5, offset: 6593},
+						pos: position{line: 208, col: 5, offset: 6621},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 208, col: 5, offset: 6593},
+							pos:        position{line: 208, col: 5, offset: 6621},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -1461,22 +1491,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 213, col: 1, offset: 6853},
+			pos:  position{line: 213, col: 1, offset: 6881},
 			expr: &choiceExpr{
-				pos: position{line: 214, col: 5, offset: 6872},
+				pos: position{line: 214, col: 5, offset: 6900},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 214, col: 5, offset: 6872},
+						pos:  position{line: 214, col: 5, offset: 6900},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 215, col: 5, offset: 6887},
+						pos: position{line: 215, col: 5, offset: 6915},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 215, col: 5, offset: 6887},
+							pos:   position{line: 215, col: 5, offset: 6915},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 215, col: 10, offset: 6892},
+								pos:  position{line: 215, col: 10, offset: 6920},
 								name: "Expr",
 							},
 						},
@@ -1486,50 +1516,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 217, col: 1, offset: 6982},
+			pos:  position{line: 217, col: 1, offset: 7010},
 			expr: &actionExpr{
-				pos: position{line: 218, col: 5, offset: 7002},
+				pos: position{line: 218, col: 5, offset: 7030},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 218, col: 5, offset: 7002},
+					pos: position{line: 218, col: 5, offset: 7030},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 218, col: 5, offset: 7002},
+							pos:   position{line: 218, col: 5, offset: 7030},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 218, col: 11, offset: 7008},
+								pos:  position{line: 218, col: 11, offset: 7036},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 218, col: 26, offset: 7023},
+							pos:   position{line: 218, col: 26, offset: 7051},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 218, col: 31, offset: 7028},
+								pos: position{line: 218, col: 31, offset: 7056},
 								expr: &actionExpr{
-									pos: position{line: 218, col: 32, offset: 7029},
+									pos: position{line: 218, col: 32, offset: 7057},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 218, col: 32, offset: 7029},
+										pos: position{line: 218, col: 32, offset: 7057},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 218, col: 32, offset: 7029},
+												pos:  position{line: 218, col: 32, offset: 7057},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 218, col: 35, offset: 7032},
+												pos:        position{line: 218, col: 35, offset: 7060},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 218, col: 39, offset: 7036},
+												pos:  position{line: 218, col: 39, offset: 7064},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 218, col: 42, offset: 7039},
+												pos:   position{line: 218, col: 42, offset: 7067},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 218, col: 47, offset: 7044},
+													pos:  position{line: 218, col: 47, offset: 7072},
 													name: "FlexAssignment",
 												},
 											},
@@ -1544,42 +1574,42 @@ var g = &grammar{
 		},
 		{
 			name: "ReducerAssignment",
-			pos:  position{line: 222, col: 1, offset: 7166},
+			pos:  position{line: 222, col: 1, offset: 7194},
 			expr: &choiceExpr{
-				pos: position{line: 223, col: 5, offset: 7188},
+				pos: position{line: 223, col: 5, offset: 7216},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 223, col: 5, offset: 7188},
+						pos: position{line: 223, col: 5, offset: 7216},
 						run: (*parser).callonReducerAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 223, col: 5, offset: 7188},
+							pos: position{line: 223, col: 5, offset: 7216},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 223, col: 5, offset: 7188},
+									pos:   position{line: 223, col: 5, offset: 7216},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 223, col: 10, offset: 7193},
+										pos:  position{line: 223, col: 10, offset: 7221},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 223, col: 15, offset: 7198},
+									pos:  position{line: 223, col: 15, offset: 7226},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 223, col: 18, offset: 7201},
+									pos:        position{line: 223, col: 18, offset: 7229},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 223, col: 22, offset: 7205},
+									pos:  position{line: 223, col: 22, offset: 7233},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 223, col: 25, offset: 7208},
+									pos:   position{line: 223, col: 25, offset: 7236},
 									label: "reducer",
 									expr: &ruleRefExpr{
-										pos:  position{line: 223, col: 33, offset: 7216},
+										pos:  position{line: 223, col: 33, offset: 7244},
 										name: "Reducer",
 									},
 								},
@@ -1587,13 +1617,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 226, col: 5, offset: 7326},
+						pos: position{line: 226, col: 5, offset: 7354},
 						run: (*parser).callonReducerAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 226, col: 5, offset: 7326},
+							pos:   position{line: 226, col: 5, offset: 7354},
 							label: "reducer",
 							expr: &ruleRefExpr{
-								pos:  position{line: 226, col: 13, offset: 7334},
+								pos:  position{line: 226, col: 13, offset: 7362},
 								name: "Reducer",
 							},
 						},
@@ -1603,25 +1633,25 @@ var g = &grammar{
 		},
 		{
 			name: "Reducer",
-			pos:  position{line: 230, col: 1, offset: 7440},
+			pos:  position{line: 230, col: 1, offset: 7468},
 			expr: &actionExpr{
-				pos: position{line: 231, col: 5, offset: 7452},
+				pos: position{line: 231, col: 5, offset: 7480},
 				run: (*parser).callonReducer1,
 				expr: &seqExpr{
-					pos: position{line: 231, col: 5, offset: 7452},
+					pos: position{line: 231, col: 5, offset: 7480},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 231, col: 5, offset: 7452},
+							pos: position{line: 231, col: 5, offset: 7480},
 							expr: &choiceExpr{
-								pos: position{line: 231, col: 7, offset: 7454},
+								pos: position{line: 231, col: 7, offset: 7482},
 								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 231, col: 7, offset: 7454},
+										pos:        position{line: 231, col: 7, offset: 7482},
 										val:        "not",
 										ignoreCase: false,
 									},
 									&litMatcher{
-										pos:        position{line: 231, col: 13, offset: 7460},
+										pos:        position{line: 231, col: 13, offset: 7488},
 										val:        "len",
 										ignoreCase: false,
 									},
@@ -1629,53 +1659,53 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 231, col: 20, offset: 7467},
+							pos:   position{line: 231, col: 20, offset: 7495},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 231, col: 23, offset: 7470},
+								pos:  position{line: 231, col: 23, offset: 7498},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 231, col: 38, offset: 7485},
+							pos:  position{line: 231, col: 38, offset: 7513},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 231, col: 41, offset: 7488},
+							pos:        position{line: 231, col: 41, offset: 7516},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 231, col: 45, offset: 7492},
+							pos:  position{line: 231, col: 45, offset: 7520},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 231, col: 48, offset: 7495},
+							pos:   position{line: 231, col: 48, offset: 7523},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 231, col: 53, offset: 7500},
+								pos: position{line: 231, col: 53, offset: 7528},
 								expr: &ruleRefExpr{
-									pos:  position{line: 231, col: 53, offset: 7500},
+									pos:  position{line: 231, col: 53, offset: 7528},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 231, col: 60, offset: 7507},
+							pos:  position{line: 231, col: 60, offset: 7535},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 231, col: 63, offset: 7510},
+							pos:        position{line: 231, col: 63, offset: 7538},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 231, col: 67, offset: 7514},
+							pos:   position{line: 231, col: 67, offset: 7542},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 231, col: 73, offset: 7520},
+								pos: position{line: 231, col: 73, offset: 7548},
 								expr: &ruleRefExpr{
-									pos:  position{line: 231, col: 73, offset: 7520},
+									pos:  position{line: 231, col: 73, offset: 7548},
 									name: "WhereClause",
 								},
 							},
@@ -1686,31 +1716,31 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 239, col: 1, offset: 7716},
+			pos:  position{line: 239, col: 1, offset: 7744},
 			expr: &actionExpr{
-				pos: position{line: 239, col: 15, offset: 7730},
+				pos: position{line: 239, col: 15, offset: 7758},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 239, col: 15, offset: 7730},
+					pos: position{line: 239, col: 15, offset: 7758},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 239, col: 15, offset: 7730},
+							pos:  position{line: 239, col: 15, offset: 7758},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 239, col: 17, offset: 7732},
+							pos:        position{line: 239, col: 17, offset: 7760},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 239, col: 25, offset: 7740},
+							pos:  position{line: 239, col: 25, offset: 7768},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 239, col: 27, offset: 7742},
+							pos:   position{line: 239, col: 27, offset: 7770},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 239, col: 32, offset: 7747},
+								pos:  position{line: 239, col: 32, offset: 7775},
 								name: "Expr",
 							},
 						},
@@ -1720,44 +1750,44 @@ var g = &grammar{
 		},
 		{
 			name: "Reducers",
-			pos:  position{line: 241, col: 1, offset: 7774},
+			pos:  position{line: 241, col: 1, offset: 7802},
 			expr: &actionExpr{
-				pos: position{line: 242, col: 5, offset: 7787},
+				pos: position{line: 242, col: 5, offset: 7815},
 				run: (*parser).callonReducers1,
 				expr: &seqExpr{
-					pos: position{line: 242, col: 5, offset: 7787},
+					pos: position{line: 242, col: 5, offset: 7815},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 242, col: 5, offset: 7787},
+							pos:   position{line: 242, col: 5, offset: 7815},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 242, col: 11, offset: 7793},
+								pos:  position{line: 242, col: 11, offset: 7821},
 								name: "ReducerAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 242, col: 29, offset: 7811},
+							pos:   position{line: 242, col: 29, offset: 7839},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 242, col: 34, offset: 7816},
+								pos: position{line: 242, col: 34, offset: 7844},
 								expr: &seqExpr{
-									pos: position{line: 242, col: 35, offset: 7817},
+									pos: position{line: 242, col: 35, offset: 7845},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 242, col: 35, offset: 7817},
+											pos:  position{line: 242, col: 35, offset: 7845},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 242, col: 38, offset: 7820},
+											pos:        position{line: 242, col: 38, offset: 7848},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 242, col: 42, offset: 7824},
+											pos:  position{line: 242, col: 42, offset: 7852},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 242, col: 45, offset: 7827},
+											pos:  position{line: 242, col: 45, offset: 7855},
 											name: "ReducerAssignment",
 										},
 									},
@@ -1770,60 +1800,60 @@ var g = &grammar{
 		},
 		{
 			name: "NamedProc",
-			pos:  position{line: 250, col: 1, offset: 8032},
+			pos:  position{line: 250, col: 1, offset: 8060},
 			expr: &choiceExpr{
-				pos: position{line: 251, col: 5, offset: 8046},
+				pos: position{line: 251, col: 5, offset: 8074},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 251, col: 5, offset: 8046},
+						pos:  position{line: 251, col: 5, offset: 8074},
 						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 252, col: 5, offset: 8059},
+						pos:  position{line: 252, col: 5, offset: 8087},
 						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 253, col: 5, offset: 8071},
+						pos:  position{line: 253, col: 5, offset: 8099},
 						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 254, col: 5, offset: 8083},
+						pos:  position{line: 254, col: 5, offset: 8111},
 						name: "PickProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 255, col: 5, offset: 8096},
+						pos:  position{line: 255, col: 5, offset: 8124},
 						name: "DropProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 256, col: 5, offset: 8109},
+						pos:  position{line: 256, col: 5, offset: 8137},
 						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 5, offset: 8122},
+						pos:  position{line: 257, col: 5, offset: 8150},
 						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 258, col: 5, offset: 8135},
+						pos:  position{line: 258, col: 5, offset: 8163},
 						name: "FilterProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 259, col: 5, offset: 8150},
+						pos:  position{line: 259, col: 5, offset: 8178},
 						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 260, col: 5, offset: 8163},
+						pos:  position{line: 260, col: 5, offset: 8191},
 						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 261, col: 5, offset: 8175},
+						pos:  position{line: 261, col: 5, offset: 8203},
 						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 262, col: 5, offset: 8190},
+						pos:  position{line: 262, col: 5, offset: 8218},
 						name: "FuseProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 263, col: 5, offset: 8203},
+						pos:  position{line: 263, col: 5, offset: 8231},
 						name: "JoinProc",
 					},
 				},
@@ -1831,46 +1861,46 @@ var g = &grammar{
 		},
 		{
 			name: "SortProc",
-			pos:  position{line: 265, col: 1, offset: 8213},
+			pos:  position{line: 265, col: 1, offset: 8241},
 			expr: &actionExpr{
-				pos: position{line: 266, col: 5, offset: 8226},
+				pos: position{line: 266, col: 5, offset: 8254},
 				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 266, col: 5, offset: 8226},
+					pos: position{line: 266, col: 5, offset: 8254},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 266, col: 5, offset: 8226},
+							pos:        position{line: 266, col: 5, offset: 8254},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 266, col: 13, offset: 8234},
+							pos:   position{line: 266, col: 13, offset: 8262},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 266, col: 18, offset: 8239},
+								pos:  position{line: 266, col: 18, offset: 8267},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 266, col: 27, offset: 8248},
+							pos:   position{line: 266, col: 27, offset: 8276},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 266, col: 32, offset: 8253},
+								pos: position{line: 266, col: 32, offset: 8281},
 								expr: &actionExpr{
-									pos: position{line: 266, col: 33, offset: 8254},
+									pos: position{line: 266, col: 33, offset: 8282},
 									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 266, col: 33, offset: 8254},
+										pos: position{line: 266, col: 33, offset: 8282},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 266, col: 33, offset: 8254},
+												pos:  position{line: 266, col: 33, offset: 8282},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 266, col: 35, offset: 8256},
+												pos:   position{line: 266, col: 35, offset: 8284},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 266, col: 37, offset: 8258},
+													pos:  position{line: 266, col: 37, offset: 8286},
 													name: "Exprs",
 												},
 											},
@@ -1885,30 +1915,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 280, col: 1, offset: 8677},
+			pos:  position{line: 280, col: 1, offset: 8705},
 			expr: &actionExpr{
-				pos: position{line: 280, col: 12, offset: 8688},
+				pos: position{line: 280, col: 12, offset: 8716},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 280, col: 12, offset: 8688},
+					pos:   position{line: 280, col: 12, offset: 8716},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 280, col: 17, offset: 8693},
+						pos: position{line: 280, col: 17, offset: 8721},
 						expr: &actionExpr{
-							pos: position{line: 280, col: 18, offset: 8694},
+							pos: position{line: 280, col: 18, offset: 8722},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 280, col: 18, offset: 8694},
+								pos: position{line: 280, col: 18, offset: 8722},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 280, col: 18, offset: 8694},
+										pos:  position{line: 280, col: 18, offset: 8722},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 280, col: 20, offset: 8696},
+										pos:   position{line: 280, col: 20, offset: 8724},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 280, col: 22, offset: 8698},
+											pos:  position{line: 280, col: 22, offset: 8726},
 											name: "SortArg",
 										},
 									},
@@ -1921,50 +1951,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 282, col: 1, offset: 8754},
+			pos:  position{line: 282, col: 1, offset: 8782},
 			expr: &choiceExpr{
-				pos: position{line: 283, col: 5, offset: 8766},
+				pos: position{line: 283, col: 5, offset: 8794},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 283, col: 5, offset: 8766},
+						pos: position{line: 283, col: 5, offset: 8794},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 283, col: 5, offset: 8766},
+							pos:        position{line: 283, col: 5, offset: 8794},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 284, col: 5, offset: 8841},
+						pos: position{line: 284, col: 5, offset: 8869},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 284, col: 5, offset: 8841},
+							pos: position{line: 284, col: 5, offset: 8869},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 284, col: 5, offset: 8841},
+									pos:        position{line: 284, col: 5, offset: 8869},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 284, col: 14, offset: 8850},
+									pos:  position{line: 284, col: 14, offset: 8878},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 284, col: 16, offset: 8852},
+									pos:   position{line: 284, col: 16, offset: 8880},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 284, col: 23, offset: 8859},
+										pos: position{line: 284, col: 23, offset: 8887},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 284, col: 24, offset: 8860},
+											pos: position{line: 284, col: 24, offset: 8888},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 284, col: 24, offset: 8860},
+													pos:        position{line: 284, col: 24, offset: 8888},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 284, col: 34, offset: 8870},
+													pos:        position{line: 284, col: 34, offset: 8898},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -1980,38 +2010,38 @@ var g = &grammar{
 		},
 		{
 			name: "TopProc",
-			pos:  position{line: 286, col: 1, offset: 8984},
+			pos:  position{line: 286, col: 1, offset: 9012},
 			expr: &actionExpr{
-				pos: position{line: 287, col: 5, offset: 8996},
+				pos: position{line: 287, col: 5, offset: 9024},
 				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 287, col: 5, offset: 8996},
+					pos: position{line: 287, col: 5, offset: 9024},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 287, col: 5, offset: 8996},
+							pos:        position{line: 287, col: 5, offset: 9024},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 287, col: 12, offset: 9003},
+							pos:   position{line: 287, col: 12, offset: 9031},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 287, col: 18, offset: 9009},
+								pos: position{line: 287, col: 18, offset: 9037},
 								expr: &actionExpr{
-									pos: position{line: 287, col: 19, offset: 9010},
+									pos: position{line: 287, col: 19, offset: 9038},
 									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 287, col: 19, offset: 9010},
+										pos: position{line: 287, col: 19, offset: 9038},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 287, col: 19, offset: 9010},
+												pos:  position{line: 287, col: 19, offset: 9038},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 287, col: 21, offset: 9012},
+												pos:   position{line: 287, col: 21, offset: 9040},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 287, col: 23, offset: 9014},
+													pos:  position{line: 287, col: 23, offset: 9042},
 													name: "UInt",
 												},
 											},
@@ -2021,19 +2051,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 287, col: 47, offset: 9038},
+							pos:   position{line: 287, col: 47, offset: 9066},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 287, col: 53, offset: 9044},
+								pos: position{line: 287, col: 53, offset: 9072},
 								expr: &seqExpr{
-									pos: position{line: 287, col: 54, offset: 9045},
+									pos: position{line: 287, col: 54, offset: 9073},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 287, col: 54, offset: 9045},
+											pos:  position{line: 287, col: 54, offset: 9073},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 287, col: 56, offset: 9047},
+											pos:        position{line: 287, col: 56, offset: 9075},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2042,25 +2072,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 287, col: 67, offset: 9058},
+							pos:   position{line: 287, col: 67, offset: 9086},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 287, col: 74, offset: 9065},
+								pos: position{line: 287, col: 74, offset: 9093},
 								expr: &actionExpr{
-									pos: position{line: 287, col: 75, offset: 9066},
+									pos: position{line: 287, col: 75, offset: 9094},
 									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 287, col: 75, offset: 9066},
+										pos: position{line: 287, col: 75, offset: 9094},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 287, col: 75, offset: 9066},
+												pos:  position{line: 287, col: 75, offset: 9094},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 287, col: 77, offset: 9068},
+												pos:   position{line: 287, col: 77, offset: 9096},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 287, col: 79, offset: 9070},
+													pos:  position{line: 287, col: 79, offset: 9098},
 													name: "FieldExprs",
 												},
 											},
@@ -2075,35 +2105,35 @@ var g = &grammar{
 		},
 		{
 			name: "CutProc",
-			pos:  position{line: 301, col: 1, offset: 9421},
+			pos:  position{line: 301, col: 1, offset: 9449},
 			expr: &actionExpr{
-				pos: position{line: 302, col: 5, offset: 9433},
+				pos: position{line: 302, col: 5, offset: 9461},
 				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 302, col: 5, offset: 9433},
+					pos: position{line: 302, col: 5, offset: 9461},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 302, col: 5, offset: 9433},
+							pos:        position{line: 302, col: 5, offset: 9461},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 302, col: 12, offset: 9440},
+							pos:   position{line: 302, col: 12, offset: 9468},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 302, col: 17, offset: 9445},
+								pos:  position{line: 302, col: 17, offset: 9473},
 								name: "CutArgs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 302, col: 25, offset: 9453},
+							pos:  position{line: 302, col: 25, offset: 9481},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 302, col: 27, offset: 9455},
+							pos:   position{line: 302, col: 27, offset: 9483},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 302, col: 35, offset: 9463},
+								pos:  position{line: 302, col: 35, offset: 9491},
 								name: "FlexAssignments",
 							},
 						},
@@ -2113,27 +2143,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutArgs",
-			pos:  position{line: 311, col: 1, offset: 9732},
+			pos:  position{line: 311, col: 1, offset: 9760},
 			expr: &actionExpr{
-				pos: position{line: 312, col: 5, offset: 9744},
+				pos: position{line: 312, col: 5, offset: 9772},
 				run: (*parser).callonCutArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 312, col: 5, offset: 9744},
+					pos:   position{line: 312, col: 5, offset: 9772},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 312, col: 10, offset: 9749},
+						pos: position{line: 312, col: 10, offset: 9777},
 						expr: &actionExpr{
-							pos: position{line: 312, col: 11, offset: 9750},
+							pos: position{line: 312, col: 11, offset: 9778},
 							run: (*parser).callonCutArgs4,
 							expr: &seqExpr{
-								pos: position{line: 312, col: 11, offset: 9750},
+								pos: position{line: 312, col: 11, offset: 9778},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 312, col: 11, offset: 9750},
+										pos:  position{line: 312, col: 11, offset: 9778},
 										name: "_",
 									},
 									&litMatcher{
-										pos:        position{line: 312, col: 13, offset: 9752},
+										pos:        position{line: 312, col: 13, offset: 9780},
 										val:        "-c",
 										ignoreCase: false,
 									},
@@ -2146,27 +2176,27 @@ var g = &grammar{
 		},
 		{
 			name: "PickProc",
-			pos:  position{line: 316, col: 1, offset: 9864},
+			pos:  position{line: 316, col: 1, offset: 9892},
 			expr: &actionExpr{
-				pos: position{line: 317, col: 5, offset: 9877},
+				pos: position{line: 317, col: 5, offset: 9905},
 				run: (*parser).callonPickProc1,
 				expr: &seqExpr{
-					pos: position{line: 317, col: 5, offset: 9877},
+					pos: position{line: 317, col: 5, offset: 9905},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 317, col: 5, offset: 9877},
+							pos:        position{line: 317, col: 5, offset: 9905},
 							val:        "pick",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 317, col: 13, offset: 9885},
+							pos:  position{line: 317, col: 13, offset: 9913},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 317, col: 15, offset: 9887},
+							pos:   position{line: 317, col: 15, offset: 9915},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 317, col: 23, offset: 9895},
+								pos:  position{line: 317, col: 23, offset: 9923},
 								name: "FlexAssignments",
 							},
 						},
@@ -2176,27 +2206,27 @@ var g = &grammar{
 		},
 		{
 			name: "DropProc",
-			pos:  position{line: 321, col: 1, offset: 9998},
+			pos:  position{line: 321, col: 1, offset: 10026},
 			expr: &actionExpr{
-				pos: position{line: 322, col: 5, offset: 10011},
+				pos: position{line: 322, col: 5, offset: 10039},
 				run: (*parser).callonDropProc1,
 				expr: &seqExpr{
-					pos: position{line: 322, col: 5, offset: 10011},
+					pos: position{line: 322, col: 5, offset: 10039},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 322, col: 5, offset: 10011},
+							pos:        position{line: 322, col: 5, offset: 10039},
 							val:        "drop",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 322, col: 13, offset: 10019},
+							pos:  position{line: 322, col: 13, offset: 10047},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 322, col: 15, offset: 10021},
+							pos:   position{line: 322, col: 15, offset: 10049},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 322, col: 23, offset: 10029},
+								pos:  position{line: 322, col: 23, offset: 10057},
 								name: "FieldExprs",
 							},
 						},
@@ -2206,30 +2236,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadProc",
-			pos:  position{line: 326, col: 1, offset: 10127},
+			pos:  position{line: 326, col: 1, offset: 10155},
 			expr: &choiceExpr{
-				pos: position{line: 327, col: 5, offset: 10140},
+				pos: position{line: 327, col: 5, offset: 10168},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 327, col: 5, offset: 10140},
+						pos: position{line: 327, col: 5, offset: 10168},
 						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 327, col: 5, offset: 10140},
+							pos: position{line: 327, col: 5, offset: 10168},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 327, col: 5, offset: 10140},
+									pos:        position{line: 327, col: 5, offset: 10168},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 327, col: 13, offset: 10148},
+									pos:  position{line: 327, col: 13, offset: 10176},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 327, col: 15, offset: 10150},
+									pos:   position{line: 327, col: 15, offset: 10178},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 327, col: 21, offset: 10156},
+										pos:  position{line: 327, col: 21, offset: 10184},
 										name: "UInt",
 									},
 								},
@@ -2237,10 +2267,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 328, col: 5, offset: 10238},
+						pos: position{line: 328, col: 5, offset: 10266},
 						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 328, col: 5, offset: 10238},
+							pos:        position{line: 328, col: 5, offset: 10266},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2250,30 +2280,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailProc",
-			pos:  position{line: 330, col: 1, offset: 10316},
+			pos:  position{line: 330, col: 1, offset: 10344},
 			expr: &choiceExpr{
-				pos: position{line: 331, col: 5, offset: 10329},
+				pos: position{line: 331, col: 5, offset: 10357},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 331, col: 5, offset: 10329},
+						pos: position{line: 331, col: 5, offset: 10357},
 						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 331, col: 5, offset: 10329},
+							pos: position{line: 331, col: 5, offset: 10357},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 331, col: 5, offset: 10329},
+									pos:        position{line: 331, col: 5, offset: 10357},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 331, col: 13, offset: 10337},
+									pos:  position{line: 331, col: 13, offset: 10365},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 331, col: 15, offset: 10339},
+									pos:   position{line: 331, col: 15, offset: 10367},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 331, col: 21, offset: 10345},
+										pos:  position{line: 331, col: 21, offset: 10373},
 										name: "UInt",
 									},
 								},
@@ -2281,10 +2311,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 332, col: 5, offset: 10427},
+						pos: position{line: 332, col: 5, offset: 10455},
 						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 332, col: 5, offset: 10427},
+							pos:        position{line: 332, col: 5, offset: 10455},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2294,27 +2324,27 @@ var g = &grammar{
 		},
 		{
 			name: "FilterProc",
-			pos:  position{line: 334, col: 1, offset: 10505},
+			pos:  position{line: 334, col: 1, offset: 10533},
 			expr: &actionExpr{
-				pos: position{line: 335, col: 5, offset: 10520},
+				pos: position{line: 335, col: 5, offset: 10548},
 				run: (*parser).callonFilterProc1,
 				expr: &seqExpr{
-					pos: position{line: 335, col: 5, offset: 10520},
+					pos: position{line: 335, col: 5, offset: 10548},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 335, col: 5, offset: 10520},
+							pos:        position{line: 335, col: 5, offset: 10548},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 335, col: 15, offset: 10530},
+							pos:  position{line: 335, col: 15, offset: 10558},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 335, col: 17, offset: 10532},
+							pos:   position{line: 335, col: 17, offset: 10560},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 335, col: 22, offset: 10537},
+								pos:  position{line: 335, col: 22, offset: 10565},
 								name: "SearchExpr",
 							},
 						},
@@ -2324,27 +2354,27 @@ var g = &grammar{
 		},
 		{
 			name: "UniqProc",
-			pos:  position{line: 339, col: 1, offset: 10634},
+			pos:  position{line: 339, col: 1, offset: 10662},
 			expr: &choiceExpr{
-				pos: position{line: 340, col: 5, offset: 10647},
+				pos: position{line: 340, col: 5, offset: 10675},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 340, col: 5, offset: 10647},
+						pos: position{line: 340, col: 5, offset: 10675},
 						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 340, col: 5, offset: 10647},
+							pos: position{line: 340, col: 5, offset: 10675},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 340, col: 5, offset: 10647},
+									pos:        position{line: 340, col: 5, offset: 10675},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 340, col: 13, offset: 10655},
+									pos:  position{line: 340, col: 13, offset: 10683},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 340, col: 15, offset: 10657},
+									pos:        position{line: 340, col: 15, offset: 10685},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2352,10 +2382,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 343, col: 5, offset: 10748},
+						pos: position{line: 343, col: 5, offset: 10776},
 						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 343, col: 5, offset: 10748},
+							pos:        position{line: 343, col: 5, offset: 10776},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2365,27 +2395,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutProc",
-			pos:  position{line: 347, col: 1, offset: 10840},
+			pos:  position{line: 347, col: 1, offset: 10868},
 			expr: &actionExpr{
-				pos: position{line: 348, col: 5, offset: 10852},
+				pos: position{line: 348, col: 5, offset: 10880},
 				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 348, col: 5, offset: 10852},
+					pos: position{line: 348, col: 5, offset: 10880},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 348, col: 5, offset: 10852},
+							pos:        position{line: 348, col: 5, offset: 10880},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 348, col: 12, offset: 10859},
+							pos:  position{line: 348, col: 12, offset: 10887},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 348, col: 14, offset: 10861},
+							pos:   position{line: 348, col: 14, offset: 10889},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 348, col: 22, offset: 10869},
+								pos:  position{line: 348, col: 22, offset: 10897},
 								name: "FlexAssignments",
 							},
 						},
@@ -2395,59 +2425,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameProc",
-			pos:  position{line: 352, col: 1, offset: 10972},
+			pos:  position{line: 352, col: 1, offset: 11000},
 			expr: &actionExpr{
-				pos: position{line: 353, col: 5, offset: 10987},
+				pos: position{line: 353, col: 5, offset: 11015},
 				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 353, col: 5, offset: 10987},
+					pos: position{line: 353, col: 5, offset: 11015},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 353, col: 5, offset: 10987},
+							pos:        position{line: 353, col: 5, offset: 11015},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 353, col: 15, offset: 10997},
+							pos:  position{line: 353, col: 15, offset: 11025},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 353, col: 17, offset: 10999},
+							pos:   position{line: 353, col: 17, offset: 11027},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 353, col: 23, offset: 11005},
+								pos:  position{line: 353, col: 23, offset: 11033},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 353, col: 34, offset: 11016},
+							pos:   position{line: 353, col: 34, offset: 11044},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 353, col: 39, offset: 11021},
+								pos: position{line: 353, col: 39, offset: 11049},
 								expr: &actionExpr{
-									pos: position{line: 353, col: 40, offset: 11022},
+									pos: position{line: 353, col: 40, offset: 11050},
 									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 353, col: 40, offset: 11022},
+										pos: position{line: 353, col: 40, offset: 11050},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 353, col: 40, offset: 11022},
+												pos:  position{line: 353, col: 40, offset: 11050},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 353, col: 43, offset: 11025},
+												pos:        position{line: 353, col: 43, offset: 11053},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 353, col: 47, offset: 11029},
+												pos:  position{line: 353, col: 47, offset: 11057},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 353, col: 50, offset: 11032},
+												pos:   position{line: 353, col: 50, offset: 11060},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 353, col: 53, offset: 11035},
+													pos:  position{line: 353, col: 53, offset: 11063},
 													name: "Assignment",
 												},
 											},
@@ -2462,12 +2492,12 @@ var g = &grammar{
 		},
 		{
 			name: "FuseProc",
-			pos:  position{line: 357, col: 1, offset: 11205},
+			pos:  position{line: 357, col: 1, offset: 11233},
 			expr: &actionExpr{
-				pos: position{line: 358, col: 5, offset: 11218},
+				pos: position{line: 358, col: 5, offset: 11246},
 				run: (*parser).callonFuseProc1,
 				expr: &litMatcher{
-					pos:        position{line: 358, col: 5, offset: 11218},
+					pos:        position{line: 358, col: 5, offset: 11246},
 					val:        "fuse",
 					ignoreCase: true,
 				},
@@ -2475,68 +2505,68 @@ var g = &grammar{
 		},
 		{
 			name: "JoinProc",
-			pos:  position{line: 362, col: 1, offset: 11294},
+			pos:  position{line: 362, col: 1, offset: 11322},
 			expr: &choiceExpr{
-				pos: position{line: 363, col: 5, offset: 11307},
+				pos: position{line: 363, col: 5, offset: 11335},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 363, col: 5, offset: 11307},
+						pos: position{line: 363, col: 5, offset: 11335},
 						run: (*parser).callonJoinProc2,
 						expr: &seqExpr{
-							pos: position{line: 363, col: 5, offset: 11307},
+							pos: position{line: 363, col: 5, offset: 11335},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 363, col: 5, offset: 11307},
+									pos:        position{line: 363, col: 5, offset: 11335},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 363, col: 13, offset: 11315},
+									pos:  position{line: 363, col: 13, offset: 11343},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 363, col: 15, offset: 11317},
+									pos:   position{line: 363, col: 15, offset: 11345},
 									label: "leftKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 363, col: 23, offset: 11325},
+										pos:  position{line: 363, col: 23, offset: 11353},
 										name: "JoinKey",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 363, col: 31, offset: 11333},
+									pos:  position{line: 363, col: 31, offset: 11361},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 363, col: 34, offset: 11336},
+									pos:        position{line: 363, col: 34, offset: 11364},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 363, col: 38, offset: 11340},
+									pos:  position{line: 363, col: 38, offset: 11368},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 363, col: 41, offset: 11343},
+									pos:   position{line: 363, col: 41, offset: 11371},
 									label: "rightKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 363, col: 50, offset: 11352},
+										pos:  position{line: 363, col: 50, offset: 11380},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 363, col: 58, offset: 11360},
+									pos:   position{line: 363, col: 58, offset: 11388},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 363, col: 66, offset: 11368},
+										pos: position{line: 363, col: 66, offset: 11396},
 										expr: &seqExpr{
-											pos: position{line: 363, col: 67, offset: 11369},
+											pos: position{line: 363, col: 67, offset: 11397},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 363, col: 67, offset: 11369},
+													pos:  position{line: 363, col: 67, offset: 11397},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 363, col: 69, offset: 11371},
+													pos:  position{line: 363, col: 69, offset: 11399},
 													name: "FlexAssignments",
 												},
 											},
@@ -2547,42 +2577,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 370, col: 5, offset: 11629},
+						pos: position{line: 370, col: 5, offset: 11657},
 						run: (*parser).callonJoinProc18,
 						expr: &seqExpr{
-							pos: position{line: 370, col: 5, offset: 11629},
+							pos: position{line: 370, col: 5, offset: 11657},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 370, col: 5, offset: 11629},
+									pos:        position{line: 370, col: 5, offset: 11657},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 370, col: 13, offset: 11637},
+									pos:  position{line: 370, col: 13, offset: 11665},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 370, col: 15, offset: 11639},
+									pos:   position{line: 370, col: 15, offset: 11667},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 370, col: 19, offset: 11643},
+										pos:  position{line: 370, col: 19, offset: 11671},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 370, col: 27, offset: 11651},
+									pos:   position{line: 370, col: 27, offset: 11679},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 370, col: 35, offset: 11659},
+										pos: position{line: 370, col: 35, offset: 11687},
 										expr: &seqExpr{
-											pos: position{line: 370, col: 36, offset: 11660},
+											pos: position{line: 370, col: 36, offset: 11688},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 370, col: 36, offset: 11660},
+													pos:  position{line: 370, col: 36, offset: 11688},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 370, col: 38, offset: 11662},
+													pos:  position{line: 370, col: 38, offset: 11690},
 													name: "FlexAssignments",
 												},
 											},
@@ -2597,35 +2627,35 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 378, col: 1, offset: 11908},
+			pos:  position{line: 378, col: 1, offset: 11936},
 			expr: &choiceExpr{
-				pos: position{line: 379, col: 5, offset: 11920},
+				pos: position{line: 379, col: 5, offset: 11948},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 379, col: 5, offset: 11920},
+						pos:  position{line: 379, col: 5, offset: 11948},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 380, col: 5, offset: 11929},
+						pos: position{line: 380, col: 5, offset: 11957},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 380, col: 5, offset: 11929},
+							pos: position{line: 380, col: 5, offset: 11957},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 380, col: 5, offset: 11929},
+									pos:        position{line: 380, col: 5, offset: 11957},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 380, col: 9, offset: 11933},
+									pos:   position{line: 380, col: 9, offset: 11961},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 380, col: 14, offset: 11938},
+										pos:  position{line: 380, col: 14, offset: 11966},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 380, col: 19, offset: 11943},
+									pos:        position{line: 380, col: 19, offset: 11971},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -2637,45 +2667,45 @@ var g = &grammar{
 		},
 		{
 			name: "RootField",
-			pos:  position{line: 382, col: 1, offset: 11969},
+			pos:  position{line: 382, col: 1, offset: 11997},
 			expr: &choiceExpr{
-				pos: position{line: 383, col: 5, offset: 11983},
+				pos: position{line: 383, col: 5, offset: 12011},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 383, col: 5, offset: 11983},
+						pos: position{line: 383, col: 5, offset: 12011},
 						run: (*parser).callonRootField2,
 						expr: &seqExpr{
-							pos: position{line: 383, col: 5, offset: 11983},
+							pos: position{line: 383, col: 5, offset: 12011},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 383, col: 5, offset: 11983},
+									pos: position{line: 383, col: 5, offset: 12011},
 									expr: &litMatcher{
-										pos:        position{line: 383, col: 5, offset: 11983},
+										pos:        position{line: 383, col: 5, offset: 12011},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&notExpr{
-									pos: position{line: 383, col: 10, offset: 11988},
+									pos: position{line: 383, col: 10, offset: 12016},
 									expr: &choiceExpr{
-										pos: position{line: 383, col: 12, offset: 11990},
+										pos: position{line: 383, col: 12, offset: 12018},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 383, col: 12, offset: 11990},
+												pos:  position{line: 383, col: 12, offset: 12018},
 												name: "BooleanLiteral",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 383, col: 29, offset: 12007},
+												pos:  position{line: 383, col: 29, offset: 12035},
 												name: "NullLiteral",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 383, col: 42, offset: 12020},
+									pos:   position{line: 383, col: 42, offset: 12048},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 383, col: 48, offset: 12026},
+										pos:  position{line: 383, col: 48, offset: 12054},
 										name: "Identifier",
 									},
 								},
@@ -2683,20 +2713,20 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 384, col: 5, offset: 12179},
+						pos: position{line: 384, col: 5, offset: 12207},
 						run: (*parser).callonRootField12,
 						expr: &seqExpr{
-							pos: position{line: 384, col: 5, offset: 12179},
+							pos: position{line: 384, col: 5, offset: 12207},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 384, col: 5, offset: 12179},
+									pos:        position{line: 384, col: 5, offset: 12207},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 384, col: 9, offset: 12183},
+									pos: position{line: 384, col: 9, offset: 12211},
 									expr: &ruleRefExpr{
-										pos:  position{line: 384, col: 11, offset: 12185},
+										pos:  position{line: 384, col: 11, offset: 12213},
 										name: "Identifier",
 									},
 								},
@@ -2708,60 +2738,60 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 386, col: 1, offset: 12258},
+			pos:  position{line: 386, col: 1, offset: 12286},
 			expr: &ruleRefExpr{
-				pos:  position{line: 386, col: 8, offset: 12265},
+				pos:  position{line: 386, col: 8, offset: 12293},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 388, col: 1, offset: 12276},
+			pos:  position{line: 388, col: 1, offset: 12304},
 			expr: &ruleRefExpr{
-				pos:  position{line: 388, col: 13, offset: 12288},
+				pos:  position{line: 388, col: 13, offset: 12316},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 390, col: 1, offset: 12294},
+			pos:  position{line: 390, col: 1, offset: 12322},
 			expr: &actionExpr{
-				pos: position{line: 391, col: 5, offset: 12309},
+				pos: position{line: 391, col: 5, offset: 12337},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 391, col: 5, offset: 12309},
+					pos: position{line: 391, col: 5, offset: 12337},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 391, col: 5, offset: 12309},
+							pos:   position{line: 391, col: 5, offset: 12337},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 391, col: 11, offset: 12315},
+								pos:  position{line: 391, col: 11, offset: 12343},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 391, col: 21, offset: 12325},
+							pos:   position{line: 391, col: 21, offset: 12353},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 391, col: 26, offset: 12330},
+								pos: position{line: 391, col: 26, offset: 12358},
 								expr: &seqExpr{
-									pos: position{line: 391, col: 27, offset: 12331},
+									pos: position{line: 391, col: 27, offset: 12359},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 391, col: 27, offset: 12331},
+											pos:  position{line: 391, col: 27, offset: 12359},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 391, col: 30, offset: 12334},
+											pos:        position{line: 391, col: 30, offset: 12362},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 391, col: 34, offset: 12338},
+											pos:  position{line: 391, col: 34, offset: 12366},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 391, col: 37, offset: 12341},
+											pos:  position{line: 391, col: 37, offset: 12369},
 											name: "FieldExpr",
 										},
 									},
@@ -2774,44 +2804,44 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 401, col: 1, offset: 12540},
+			pos:  position{line: 401, col: 1, offset: 12568},
 			expr: &actionExpr{
-				pos: position{line: 402, col: 5, offset: 12550},
+				pos: position{line: 402, col: 5, offset: 12578},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 402, col: 5, offset: 12550},
+					pos: position{line: 402, col: 5, offset: 12578},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 402, col: 5, offset: 12550},
+							pos:   position{line: 402, col: 5, offset: 12578},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 402, col: 11, offset: 12556},
+								pos:  position{line: 402, col: 11, offset: 12584},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 402, col: 16, offset: 12561},
+							pos:   position{line: 402, col: 16, offset: 12589},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 402, col: 21, offset: 12566},
+								pos: position{line: 402, col: 21, offset: 12594},
 								expr: &seqExpr{
-									pos: position{line: 402, col: 22, offset: 12567},
+									pos: position{line: 402, col: 22, offset: 12595},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 402, col: 22, offset: 12567},
+											pos:  position{line: 402, col: 22, offset: 12595},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 402, col: 25, offset: 12570},
+											pos:        position{line: 402, col: 25, offset: 12598},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 402, col: 29, offset: 12574},
+											pos:  position{line: 402, col: 29, offset: 12602},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 402, col: 32, offset: 12577},
+											pos:  position{line: 402, col: 32, offset: 12605},
 											name: "Expr",
 										},
 									},
@@ -2824,39 +2854,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 412, col: 1, offset: 12771},
+			pos:  position{line: 412, col: 1, offset: 12799},
 			expr: &actionExpr{
-				pos: position{line: 413, col: 5, offset: 12786},
+				pos: position{line: 413, col: 5, offset: 12814},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 413, col: 5, offset: 12786},
+					pos: position{line: 413, col: 5, offset: 12814},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 413, col: 5, offset: 12786},
+							pos:   position{line: 413, col: 5, offset: 12814},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 413, col: 9, offset: 12790},
+								pos:  position{line: 413, col: 9, offset: 12818},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 413, col: 14, offset: 12795},
+							pos:  position{line: 413, col: 14, offset: 12823},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 413, col: 17, offset: 12798},
+							pos:        position{line: 413, col: 17, offset: 12826},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 413, col: 21, offset: 12802},
+							pos:  position{line: 413, col: 21, offset: 12830},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 413, col: 24, offset: 12805},
+							pos:   position{line: 413, col: 24, offset: 12833},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 413, col: 28, offset: 12809},
+								pos:  position{line: 413, col: 28, offset: 12837},
 								name: "Expr",
 							},
 						},
@@ -2866,71 +2896,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 415, col: 1, offset: 12898},
+			pos:  position{line: 415, col: 1, offset: 12926},
 			expr: &ruleRefExpr{
-				pos:  position{line: 415, col: 8, offset: 12905},
+				pos:  position{line: 415, col: 8, offset: 12933},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 417, col: 1, offset: 12922},
+			pos:  position{line: 417, col: 1, offset: 12950},
 			expr: &choiceExpr{
-				pos: position{line: 418, col: 5, offset: 12942},
+				pos: position{line: 418, col: 5, offset: 12970},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 418, col: 5, offset: 12942},
+						pos: position{line: 418, col: 5, offset: 12970},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 418, col: 5, offset: 12942},
+							pos: position{line: 418, col: 5, offset: 12970},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 418, col: 5, offset: 12942},
+									pos:   position{line: 418, col: 5, offset: 12970},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 418, col: 15, offset: 12952},
+										pos:  position{line: 418, col: 15, offset: 12980},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 418, col: 29, offset: 12966},
+									pos:  position{line: 418, col: 29, offset: 12994},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 418, col: 32, offset: 12969},
+									pos:        position{line: 418, col: 32, offset: 12997},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 418, col: 36, offset: 12973},
+									pos:  position{line: 418, col: 36, offset: 13001},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 418, col: 39, offset: 12976},
+									pos:   position{line: 418, col: 39, offset: 13004},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 418, col: 50, offset: 12987},
+										pos:  position{line: 418, col: 50, offset: 13015},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 418, col: 55, offset: 12992},
+									pos:  position{line: 418, col: 55, offset: 13020},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 418, col: 58, offset: 12995},
+									pos:        position{line: 418, col: 58, offset: 13023},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 418, col: 62, offset: 12999},
+									pos:  position{line: 418, col: 62, offset: 13027},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 418, col: 65, offset: 13002},
+									pos:   position{line: 418, col: 65, offset: 13030},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 418, col: 76, offset: 13013},
+										pos:  position{line: 418, col: 76, offset: 13041},
 										name: "Expr",
 									},
 								},
@@ -2938,7 +2968,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 421, col: 5, offset: 13160},
+						pos:  position{line: 421, col: 5, offset: 13188},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -2946,53 +2976,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 423, col: 1, offset: 13175},
+			pos:  position{line: 423, col: 1, offset: 13203},
 			expr: &actionExpr{
-				pos: position{line: 424, col: 5, offset: 13193},
+				pos: position{line: 424, col: 5, offset: 13221},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 424, col: 5, offset: 13193},
+					pos: position{line: 424, col: 5, offset: 13221},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 424, col: 5, offset: 13193},
+							pos:   position{line: 424, col: 5, offset: 13221},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 424, col: 11, offset: 13199},
+								pos:  position{line: 424, col: 11, offset: 13227},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 425, col: 5, offset: 13218},
+							pos:   position{line: 425, col: 5, offset: 13246},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 425, col: 10, offset: 13223},
+								pos: position{line: 425, col: 10, offset: 13251},
 								expr: &actionExpr{
-									pos: position{line: 425, col: 11, offset: 13224},
+									pos: position{line: 425, col: 11, offset: 13252},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 425, col: 11, offset: 13224},
+										pos: position{line: 425, col: 11, offset: 13252},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 425, col: 11, offset: 13224},
+												pos:  position{line: 425, col: 11, offset: 13252},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 425, col: 14, offset: 13227},
+												pos:   position{line: 425, col: 14, offset: 13255},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 425, col: 17, offset: 13230},
+													pos:  position{line: 425, col: 17, offset: 13258},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 425, col: 25, offset: 13238},
+												pos:  position{line: 425, col: 25, offset: 13266},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 425, col: 28, offset: 13241},
+												pos:   position{line: 425, col: 28, offset: 13269},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 425, col: 33, offset: 13246},
+													pos:  position{line: 425, col: 33, offset: 13274},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -3007,53 +3037,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 429, col: 1, offset: 13364},
+			pos:  position{line: 429, col: 1, offset: 13392},
 			expr: &actionExpr{
-				pos: position{line: 430, col: 5, offset: 13383},
+				pos: position{line: 430, col: 5, offset: 13411},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 430, col: 5, offset: 13383},
+					pos: position{line: 430, col: 5, offset: 13411},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 430, col: 5, offset: 13383},
+							pos:   position{line: 430, col: 5, offset: 13411},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 430, col: 11, offset: 13389},
+								pos:  position{line: 430, col: 11, offset: 13417},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 431, col: 5, offset: 13413},
+							pos:   position{line: 431, col: 5, offset: 13441},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 431, col: 10, offset: 13418},
+								pos: position{line: 431, col: 10, offset: 13446},
 								expr: &actionExpr{
-									pos: position{line: 431, col: 11, offset: 13419},
+									pos: position{line: 431, col: 11, offset: 13447},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 431, col: 11, offset: 13419},
+										pos: position{line: 431, col: 11, offset: 13447},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 431, col: 11, offset: 13419},
+												pos:  position{line: 431, col: 11, offset: 13447},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 431, col: 14, offset: 13422},
+												pos:   position{line: 431, col: 14, offset: 13450},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 431, col: 17, offset: 13425},
+													pos:  position{line: 431, col: 17, offset: 13453},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 431, col: 26, offset: 13434},
+												pos:  position{line: 431, col: 26, offset: 13462},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 431, col: 29, offset: 13437},
+												pos:   position{line: 431, col: 29, offset: 13465},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 431, col: 34, offset: 13442},
+													pos:  position{line: 431, col: 34, offset: 13470},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -3068,53 +3098,53 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 435, col: 1, offset: 13565},
+			pos:  position{line: 435, col: 1, offset: 13593},
 			expr: &actionExpr{
-				pos: position{line: 436, col: 5, offset: 13589},
+				pos: position{line: 436, col: 5, offset: 13617},
 				run: (*parser).callonEqualityCompareExpr1,
 				expr: &seqExpr{
-					pos: position{line: 436, col: 5, offset: 13589},
+					pos: position{line: 436, col: 5, offset: 13617},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 436, col: 5, offset: 13589},
+							pos:   position{line: 436, col: 5, offset: 13617},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 436, col: 11, offset: 13595},
+								pos:  position{line: 436, col: 11, offset: 13623},
 								name: "RelativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 437, col: 5, offset: 13612},
+							pos:   position{line: 437, col: 5, offset: 13640},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 437, col: 10, offset: 13617},
+								pos: position{line: 437, col: 10, offset: 13645},
 								expr: &actionExpr{
-									pos: position{line: 437, col: 11, offset: 13618},
+									pos: position{line: 437, col: 11, offset: 13646},
 									run: (*parser).callonEqualityCompareExpr7,
 									expr: &seqExpr{
-										pos: position{line: 437, col: 11, offset: 13618},
+										pos: position{line: 437, col: 11, offset: 13646},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 437, col: 11, offset: 13618},
+												pos:  position{line: 437, col: 11, offset: 13646},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 437, col: 14, offset: 13621},
+												pos:   position{line: 437, col: 14, offset: 13649},
 												label: "comp",
 												expr: &ruleRefExpr{
-													pos:  position{line: 437, col: 19, offset: 13626},
+													pos:  position{line: 437, col: 19, offset: 13654},
 													name: "EqualityComparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 437, col: 38, offset: 13645},
+												pos:  position{line: 437, col: 38, offset: 13673},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 437, col: 41, offset: 13648},
+												pos:   position{line: 437, col: 41, offset: 13676},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 437, col: 46, offset: 13653},
+													pos:  position{line: 437, col: 46, offset: 13681},
 													name: "RelativeExpr",
 												},
 											},
@@ -3129,30 +3159,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 441, col: 1, offset: 13771},
+			pos:  position{line: 441, col: 1, offset: 13799},
 			expr: &actionExpr{
-				pos: position{line: 441, col: 20, offset: 13790},
+				pos: position{line: 441, col: 20, offset: 13818},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 441, col: 21, offset: 13791},
+					pos: position{line: 441, col: 21, offset: 13819},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 441, col: 21, offset: 13791},
+							pos:        position{line: 441, col: 21, offset: 13819},
 							val:        "=~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 441, col: 28, offset: 13798},
+							pos:        position{line: 441, col: 28, offset: 13826},
 							val:        "!~",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 441, col: 35, offset: 13805},
+							pos:        position{line: 441, col: 35, offset: 13833},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 441, col: 41, offset: 13811},
+							pos:        position{line: 441, col: 41, offset: 13839},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3162,19 +3192,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 443, col: 1, offset: 13849},
+			pos:  position{line: 443, col: 1, offset: 13877},
 			expr: &choiceExpr{
-				pos: position{line: 444, col: 5, offset: 13872},
+				pos: position{line: 444, col: 5, offset: 13900},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 444, col: 5, offset: 13872},
+						pos:  position{line: 444, col: 5, offset: 13900},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 445, col: 5, offset: 13893},
+						pos: position{line: 445, col: 5, offset: 13921},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 445, col: 5, offset: 13893},
+							pos:        position{line: 445, col: 5, offset: 13921},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3184,53 +3214,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 447, col: 1, offset: 13930},
+			pos:  position{line: 447, col: 1, offset: 13958},
 			expr: &actionExpr{
-				pos: position{line: 448, col: 5, offset: 13947},
+				pos: position{line: 448, col: 5, offset: 13975},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 448, col: 5, offset: 13947},
+					pos: position{line: 448, col: 5, offset: 13975},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 448, col: 5, offset: 13947},
+							pos:   position{line: 448, col: 5, offset: 13975},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 448, col: 11, offset: 13953},
+								pos:  position{line: 448, col: 11, offset: 13981},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 449, col: 5, offset: 13970},
+							pos:   position{line: 449, col: 5, offset: 13998},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 449, col: 10, offset: 13975},
+								pos: position{line: 449, col: 10, offset: 14003},
 								expr: &actionExpr{
-									pos: position{line: 449, col: 11, offset: 13976},
+									pos: position{line: 449, col: 11, offset: 14004},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 449, col: 11, offset: 13976},
+										pos: position{line: 449, col: 11, offset: 14004},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 449, col: 11, offset: 13976},
+												pos:  position{line: 449, col: 11, offset: 14004},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 449, col: 14, offset: 13979},
+												pos:   position{line: 449, col: 14, offset: 14007},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 449, col: 17, offset: 13982},
+													pos:  position{line: 449, col: 17, offset: 14010},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 449, col: 34, offset: 13999},
+												pos:  position{line: 449, col: 34, offset: 14027},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 449, col: 37, offset: 14002},
+												pos:   position{line: 449, col: 37, offset: 14030},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 449, col: 42, offset: 14007},
+													pos:  position{line: 449, col: 42, offset: 14035},
 													name: "AdditiveExpr",
 												},
 											},
@@ -3245,30 +3275,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 453, col: 1, offset: 14123},
+			pos:  position{line: 453, col: 1, offset: 14151},
 			expr: &actionExpr{
-				pos: position{line: 453, col: 20, offset: 14142},
+				pos: position{line: 453, col: 20, offset: 14170},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 453, col: 21, offset: 14143},
+					pos: position{line: 453, col: 21, offset: 14171},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 453, col: 21, offset: 14143},
+							pos:        position{line: 453, col: 21, offset: 14171},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 453, col: 28, offset: 14150},
+							pos:        position{line: 453, col: 28, offset: 14178},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 453, col: 34, offset: 14156},
+							pos:        position{line: 453, col: 34, offset: 14184},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 453, col: 41, offset: 14163},
+							pos:        position{line: 453, col: 41, offset: 14191},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -3278,53 +3308,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 455, col: 1, offset: 14200},
+			pos:  position{line: 455, col: 1, offset: 14228},
 			expr: &actionExpr{
-				pos: position{line: 456, col: 5, offset: 14217},
+				pos: position{line: 456, col: 5, offset: 14245},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 456, col: 5, offset: 14217},
+					pos: position{line: 456, col: 5, offset: 14245},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 456, col: 5, offset: 14217},
+							pos:   position{line: 456, col: 5, offset: 14245},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 456, col: 11, offset: 14223},
+								pos:  position{line: 456, col: 11, offset: 14251},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 457, col: 5, offset: 14246},
+							pos:   position{line: 457, col: 5, offset: 14274},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 457, col: 10, offset: 14251},
+								pos: position{line: 457, col: 10, offset: 14279},
 								expr: &actionExpr{
-									pos: position{line: 457, col: 11, offset: 14252},
+									pos: position{line: 457, col: 11, offset: 14280},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 457, col: 11, offset: 14252},
+										pos: position{line: 457, col: 11, offset: 14280},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 457, col: 11, offset: 14252},
+												pos:  position{line: 457, col: 11, offset: 14280},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 457, col: 14, offset: 14255},
+												pos:   position{line: 457, col: 14, offset: 14283},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 457, col: 17, offset: 14258},
+													pos:  position{line: 457, col: 17, offset: 14286},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 457, col: 34, offset: 14275},
+												pos:  position{line: 457, col: 34, offset: 14303},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 457, col: 37, offset: 14278},
+												pos:   position{line: 457, col: 37, offset: 14306},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 457, col: 42, offset: 14283},
+													pos:  position{line: 457, col: 42, offset: 14311},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -3339,20 +3369,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 461, col: 1, offset: 14405},
+			pos:  position{line: 461, col: 1, offset: 14433},
 			expr: &actionExpr{
-				pos: position{line: 461, col: 20, offset: 14424},
+				pos: position{line: 461, col: 20, offset: 14452},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 461, col: 21, offset: 14425},
+					pos: position{line: 461, col: 21, offset: 14453},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 461, col: 21, offset: 14425},
+							pos:        position{line: 461, col: 21, offset: 14453},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 461, col: 27, offset: 14431},
+							pos:        position{line: 461, col: 27, offset: 14459},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3362,53 +3392,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 463, col: 1, offset: 14468},
+			pos:  position{line: 463, col: 1, offset: 14496},
 			expr: &actionExpr{
-				pos: position{line: 464, col: 5, offset: 14491},
+				pos: position{line: 464, col: 5, offset: 14519},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 464, col: 5, offset: 14491},
+					pos: position{line: 464, col: 5, offset: 14519},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 464, col: 5, offset: 14491},
+							pos:   position{line: 464, col: 5, offset: 14519},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 464, col: 11, offset: 14497},
+								pos:  position{line: 464, col: 11, offset: 14525},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 465, col: 5, offset: 14509},
+							pos:   position{line: 465, col: 5, offset: 14537},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 465, col: 10, offset: 14514},
+								pos: position{line: 465, col: 10, offset: 14542},
 								expr: &actionExpr{
-									pos: position{line: 465, col: 11, offset: 14515},
+									pos: position{line: 465, col: 11, offset: 14543},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 465, col: 11, offset: 14515},
+										pos: position{line: 465, col: 11, offset: 14543},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 465, col: 11, offset: 14515},
+												pos:  position{line: 465, col: 11, offset: 14543},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 465, col: 14, offset: 14518},
+												pos:   position{line: 465, col: 14, offset: 14546},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 465, col: 17, offset: 14521},
+													pos:  position{line: 465, col: 17, offset: 14549},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 465, col: 40, offset: 14544},
+												pos:  position{line: 465, col: 40, offset: 14572},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 465, col: 43, offset: 14547},
+												pos:   position{line: 465, col: 43, offset: 14575},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 465, col: 48, offset: 14552},
+													pos:  position{line: 465, col: 48, offset: 14580},
 													name: "NotExpr",
 												},
 											},
@@ -3423,20 +3453,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 469, col: 1, offset: 14663},
+			pos:  position{line: 469, col: 1, offset: 14691},
 			expr: &actionExpr{
-				pos: position{line: 469, col: 26, offset: 14688},
+				pos: position{line: 469, col: 26, offset: 14716},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 469, col: 27, offset: 14689},
+					pos: position{line: 469, col: 27, offset: 14717},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 469, col: 27, offset: 14689},
+							pos:        position{line: 469, col: 27, offset: 14717},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 469, col: 33, offset: 14695},
+							pos:        position{line: 469, col: 33, offset: 14723},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -3446,30 +3476,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 471, col: 1, offset: 14732},
+			pos:  position{line: 471, col: 1, offset: 14760},
 			expr: &choiceExpr{
-				pos: position{line: 472, col: 5, offset: 14744},
+				pos: position{line: 472, col: 5, offset: 14772},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 472, col: 5, offset: 14744},
+						pos: position{line: 472, col: 5, offset: 14772},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 472, col: 5, offset: 14744},
+							pos: position{line: 472, col: 5, offset: 14772},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 472, col: 5, offset: 14744},
+									pos:        position{line: 472, col: 5, offset: 14772},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 472, col: 9, offset: 14748},
+									pos:  position{line: 472, col: 9, offset: 14776},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 472, col: 12, offset: 14751},
+									pos:   position{line: 472, col: 12, offset: 14779},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 472, col: 14, offset: 14753},
+										pos:  position{line: 472, col: 14, offset: 14781},
 										name: "NotExpr",
 									},
 								},
@@ -3477,7 +3507,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 475, col: 5, offset: 14866},
+						pos:  position{line: 475, col: 5, offset: 14894},
 						name: "CastExpr",
 					},
 				},
@@ -3485,43 +3515,43 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpr",
-			pos:  position{line: 477, col: 1, offset: 14876},
+			pos:  position{line: 477, col: 1, offset: 14904},
 			expr: &choiceExpr{
-				pos: position{line: 478, col: 5, offset: 14889},
+				pos: position{line: 478, col: 5, offset: 14917},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 478, col: 5, offset: 14889},
+						pos: position{line: 478, col: 5, offset: 14917},
 						run: (*parser).callonCastExpr2,
 						expr: &seqExpr{
-							pos: position{line: 478, col: 5, offset: 14889},
+							pos: position{line: 478, col: 5, offset: 14917},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 478, col: 5, offset: 14889},
+									pos:   position{line: 478, col: 5, offset: 14917},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 478, col: 7, offset: 14891},
+										pos:  position{line: 478, col: 7, offset: 14919},
 										name: "FuncExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 478, col: 16, offset: 14900},
+									pos:   position{line: 478, col: 16, offset: 14928},
 									label: "typ",
 									expr: &actionExpr{
-										pos: position{line: 478, col: 22, offset: 14906},
+										pos: position{line: 478, col: 22, offset: 14934},
 										run: (*parser).callonCastExpr7,
 										expr: &seqExpr{
-											pos: position{line: 478, col: 22, offset: 14906},
+											pos: position{line: 478, col: 22, offset: 14934},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 478, col: 22, offset: 14906},
+													pos:        position{line: 478, col: 22, offset: 14934},
 													val:        ":",
 													ignoreCase: false,
 												},
 												&labeledExpr{
-													pos:   position{line: 478, col: 26, offset: 14910},
+													pos:   position{line: 478, col: 26, offset: 14938},
 													label: "typ",
 													expr: &ruleRefExpr{
-														pos:  position{line: 478, col: 30, offset: 14914},
+														pos:  position{line: 478, col: 30, offset: 14942},
 														name: "PrimitiveType",
 													},
 												},
@@ -3533,7 +3563,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 481, col: 5, offset: 15044},
+						pos:  position{line: 481, col: 5, offset: 15072},
 						name: "FuncExpr",
 					},
 				},
@@ -3541,115 +3571,115 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 484, col: 1, offset: 15055},
+			pos:  position{line: 484, col: 1, offset: 15083},
 			expr: &actionExpr{
-				pos: position{line: 485, col: 5, offset: 15073},
+				pos: position{line: 485, col: 5, offset: 15101},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 485, col: 9, offset: 15077},
+					pos: position{line: 485, col: 9, offset: 15105},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 485, col: 9, offset: 15077},
+							pos:        position{line: 485, col: 9, offset: 15105},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 19, offset: 15087},
+							pos:        position{line: 485, col: 19, offset: 15115},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 29, offset: 15097},
+							pos:        position{line: 485, col: 29, offset: 15125},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 40, offset: 15108},
+							pos:        position{line: 485, col: 40, offset: 15136},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 51, offset: 15119},
+							pos:        position{line: 485, col: 51, offset: 15147},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 486, col: 9, offset: 15136},
+							pos:        position{line: 486, col: 9, offset: 15164},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 486, col: 18, offset: 15145},
+							pos:        position{line: 486, col: 18, offset: 15173},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 486, col: 28, offset: 15155},
+							pos:        position{line: 486, col: 28, offset: 15183},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 486, col: 38, offset: 15165},
+							pos:        position{line: 486, col: 38, offset: 15193},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 487, col: 9, offset: 15181},
+							pos:        position{line: 487, col: 9, offset: 15209},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 487, col: 22, offset: 15194},
+							pos:        position{line: 487, col: 22, offset: 15222},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 488, col: 9, offset: 15209},
+							pos:        position{line: 488, col: 9, offset: 15237},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 9, offset: 15227},
+							pos:        position{line: 489, col: 9, offset: 15255},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 18, offset: 15236},
+							pos:        position{line: 489, col: 18, offset: 15264},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 28, offset: 15246},
+							pos:        position{line: 489, col: 28, offset: 15274},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 39, offset: 15257},
+							pos:        position{line: 489, col: 39, offset: 15285},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 490, col: 9, offset: 15275},
+							pos:        position{line: 490, col: 9, offset: 15303},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 490, col: 16, offset: 15282},
+							pos:        position{line: 490, col: 16, offset: 15310},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 491, col: 9, offset: 15296},
+							pos:        position{line: 491, col: 9, offset: 15324},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 491, col: 18, offset: 15305},
+							pos:        position{line: 491, col: 18, offset: 15333},
 							val:        "error",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 491, col: 28, offset: 15315},
+							pos:        position{line: 491, col: 28, offset: 15343},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -3659,31 +3689,31 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 493, col: 1, offset: 15356},
+			pos:  position{line: 493, col: 1, offset: 15384},
 			expr: &choiceExpr{
-				pos: position{line: 494, col: 5, offset: 15369},
+				pos: position{line: 494, col: 5, offset: 15397},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 494, col: 5, offset: 15369},
+						pos: position{line: 494, col: 5, offset: 15397},
 						run: (*parser).callonFuncExpr2,
 						expr: &seqExpr{
-							pos: position{line: 494, col: 5, offset: 15369},
+							pos: position{line: 494, col: 5, offset: 15397},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 494, col: 5, offset: 15369},
+									pos:   position{line: 494, col: 5, offset: 15397},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 494, col: 11, offset: 15375},
+										pos:  position{line: 494, col: 11, offset: 15403},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 494, col: 20, offset: 15384},
+									pos:   position{line: 494, col: 20, offset: 15412},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 494, col: 25, offset: 15389},
+										pos: position{line: 494, col: 25, offset: 15417},
 										expr: &ruleRefExpr{
-											pos:  position{line: 494, col: 26, offset: 15390},
+											pos:  position{line: 494, col: 26, offset: 15418},
 											name: "Deref",
 										},
 									},
@@ -3692,11 +3722,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 497, col: 5, offset: 15461},
+						pos:  position{line: 497, col: 5, offset: 15489},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 498, col: 5, offset: 15475},
+						pos:  position{line: 498, col: 5, offset: 15503},
 						name: "Primary",
 					},
 				},
@@ -3704,40 +3734,40 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 500, col: 1, offset: 15484},
+			pos:  position{line: 500, col: 1, offset: 15512},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 15497},
+				pos: position{line: 501, col: 5, offset: 15525},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 5, offset: 15497},
+					pos: position{line: 501, col: 5, offset: 15525},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 501, col: 5, offset: 15497},
+							pos:   position{line: 501, col: 5, offset: 15525},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 8, offset: 15500},
+								pos:  position{line: 501, col: 8, offset: 15528},
 								name: "DeprecatedName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 23, offset: 15515},
+							pos:  position{line: 501, col: 23, offset: 15543},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 501, col: 26, offset: 15518},
+							pos:        position{line: 501, col: 26, offset: 15546},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 30, offset: 15522},
+							pos:   position{line: 501, col: 30, offset: 15550},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 35, offset: 15527},
+								pos:  position{line: 501, col: 35, offset: 15555},
 								name: "ArgumentList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 501, col: 48, offset: 15540},
+							pos:        position{line: 501, col: 48, offset: 15568},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -3747,28 +3777,28 @@ var g = &grammar{
 		},
 		{
 			name: "DeprecatedName",
-			pos:  position{line: 507, col: 1, offset: 15772},
+			pos:  position{line: 507, col: 1, offset: 15800},
 			expr: &actionExpr{
-				pos: position{line: 507, col: 18, offset: 15789},
+				pos: position{line: 507, col: 18, offset: 15817},
 				run: (*parser).callonDeprecatedName1,
 				expr: &seqExpr{
-					pos: position{line: 507, col: 18, offset: 15789},
+					pos: position{line: 507, col: 18, offset: 15817},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 507, col: 18, offset: 15789},
+							pos:  position{line: 507, col: 18, offset: 15817},
 							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 507, col: 34, offset: 15805},
+							pos: position{line: 507, col: 34, offset: 15833},
 							expr: &choiceExpr{
-								pos: position{line: 507, col: 35, offset: 15806},
+								pos: position{line: 507, col: 35, offset: 15834},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 507, col: 35, offset: 15806},
+										pos:  position{line: 507, col: 35, offset: 15834},
 										name: "IdentifierRest",
 									},
 									&litMatcher{
-										pos:        position{line: 507, col: 52, offset: 15823},
+										pos:        position{line: 507, col: 52, offset: 15851},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -3781,53 +3811,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 509, col: 1, offset: 15861},
+			pos:  position{line: 509, col: 1, offset: 15889},
 			expr: &choiceExpr{
-				pos: position{line: 510, col: 5, offset: 15878},
+				pos: position{line: 510, col: 5, offset: 15906},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 510, col: 5, offset: 15878},
+						pos: position{line: 510, col: 5, offset: 15906},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 510, col: 5, offset: 15878},
+							pos: position{line: 510, col: 5, offset: 15906},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 510, col: 5, offset: 15878},
+									pos:   position{line: 510, col: 5, offset: 15906},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 510, col: 11, offset: 15884},
+										pos:  position{line: 510, col: 11, offset: 15912},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 510, col: 16, offset: 15889},
+									pos:   position{line: 510, col: 16, offset: 15917},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 510, col: 21, offset: 15894},
+										pos: position{line: 510, col: 21, offset: 15922},
 										expr: &actionExpr{
-											pos: position{line: 510, col: 22, offset: 15895},
+											pos: position{line: 510, col: 22, offset: 15923},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 510, col: 22, offset: 15895},
+												pos: position{line: 510, col: 22, offset: 15923},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 510, col: 22, offset: 15895},
+														pos:  position{line: 510, col: 22, offset: 15923},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 510, col: 25, offset: 15898},
+														pos:        position{line: 510, col: 25, offset: 15926},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 510, col: 29, offset: 15902},
+														pos:  position{line: 510, col: 29, offset: 15930},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 510, col: 32, offset: 15905},
+														pos:   position{line: 510, col: 32, offset: 15933},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 510, col: 34, offset: 15907},
+															pos:  position{line: 510, col: 34, offset: 15935},
 															name: "Expr",
 														},
 													},
@@ -3840,10 +3870,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 513, col: 5, offset: 16019},
+						pos: position{line: 513, col: 5, offset: 16047},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 513, col: 5, offset: 16019},
+							pos:  position{line: 513, col: 5, offset: 16047},
 							name: "__",
 						},
 					},
@@ -3852,28 +3882,28 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 515, col: 1, offset: 16055},
+			pos:  position{line: 515, col: 1, offset: 16083},
 			expr: &actionExpr{
-				pos: position{line: 516, col: 5, offset: 16069},
+				pos: position{line: 516, col: 5, offset: 16097},
 				run: (*parser).callonDerefExpr1,
 				expr: &seqExpr{
-					pos: position{line: 516, col: 5, offset: 16069},
+					pos: position{line: 516, col: 5, offset: 16097},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 516, col: 5, offset: 16069},
+							pos:   position{line: 516, col: 5, offset: 16097},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 516, col: 11, offset: 16075},
+								pos:  position{line: 516, col: 11, offset: 16103},
 								name: "RootField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 516, col: 21, offset: 16085},
+							pos:   position{line: 516, col: 21, offset: 16113},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 516, col: 26, offset: 16090},
+								pos: position{line: 516, col: 26, offset: 16118},
 								expr: &ruleRefExpr{
-									pos:  position{line: 516, col: 27, offset: 16091},
+									pos:  position{line: 516, col: 27, offset: 16119},
 									name: "Deref",
 								},
 							},
@@ -3884,31 +3914,31 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 520, col: 1, offset: 16159},
+			pos:  position{line: 520, col: 1, offset: 16187},
 			expr: &choiceExpr{
-				pos: position{line: 521, col: 5, offset: 16169},
+				pos: position{line: 521, col: 5, offset: 16197},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 521, col: 5, offset: 16169},
+						pos: position{line: 521, col: 5, offset: 16197},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 521, col: 5, offset: 16169},
+							pos: position{line: 521, col: 5, offset: 16197},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 521, col: 5, offset: 16169},
+									pos:        position{line: 521, col: 5, offset: 16197},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 521, col: 9, offset: 16173},
+									pos:   position{line: 521, col: 9, offset: 16201},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 521, col: 14, offset: 16178},
+										pos:  position{line: 521, col: 14, offset: 16206},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 521, col: 19, offset: 16183},
+									pos:        position{line: 521, col: 19, offset: 16211},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -3916,29 +3946,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 522, col: 5, offset: 16232},
+						pos: position{line: 522, col: 5, offset: 16260},
 						run: (*parser).callonDeref8,
 						expr: &seqExpr{
-							pos: position{line: 522, col: 5, offset: 16232},
+							pos: position{line: 522, col: 5, offset: 16260},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 522, col: 5, offset: 16232},
+									pos:        position{line: 522, col: 5, offset: 16260},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 522, col: 9, offset: 16236},
+									pos: position{line: 522, col: 9, offset: 16264},
 									expr: &litMatcher{
-										pos:        position{line: 522, col: 11, offset: 16238},
+										pos:        position{line: 522, col: 11, offset: 16266},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 522, col: 16, offset: 16243},
+									pos:   position{line: 522, col: 16, offset: 16271},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 522, col: 19, offset: 16246},
+										pos:  position{line: 522, col: 19, offset: 16274},
 										name: "Identifier",
 									},
 								},
@@ -3950,71 +3980,71 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 524, col: 1, offset: 16297},
+			pos:  position{line: 524, col: 1, offset: 16325},
 			expr: &choiceExpr{
-				pos: position{line: 525, col: 5, offset: 16309},
+				pos: position{line: 525, col: 5, offset: 16337},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 525, col: 5, offset: 16309},
+						pos:  position{line: 525, col: 5, offset: 16337},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 526, col: 5, offset: 16327},
+						pos:  position{line: 526, col: 5, offset: 16355},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 527, col: 5, offset: 16345},
+						pos:  position{line: 527, col: 5, offset: 16373},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 528, col: 5, offset: 16363},
+						pos:  position{line: 528, col: 5, offset: 16391},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 529, col: 5, offset: 16382},
+						pos:  position{line: 529, col: 5, offset: 16410},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 530, col: 5, offset: 16399},
+						pos:  position{line: 530, col: 5, offset: 16427},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 531, col: 5, offset: 16418},
+						pos:  position{line: 531, col: 5, offset: 16446},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 532, col: 5, offset: 16437},
+						pos:  position{line: 532, col: 5, offset: 16465},
 						name: "NullLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 533, col: 5, offset: 16453},
+						pos: position{line: 533, col: 5, offset: 16481},
 						run: (*parser).callonPrimary10,
 						expr: &seqExpr{
-							pos: position{line: 533, col: 5, offset: 16453},
+							pos: position{line: 533, col: 5, offset: 16481},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 533, col: 5, offset: 16453},
+									pos:        position{line: 533, col: 5, offset: 16481},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 533, col: 9, offset: 16457},
+									pos:  position{line: 533, col: 9, offset: 16485},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 533, col: 12, offset: 16460},
+									pos:   position{line: 533, col: 12, offset: 16488},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 533, col: 17, offset: 16465},
+										pos:  position{line: 533, col: 17, offset: 16493},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 533, col: 22, offset: 16470},
+									pos:  position{line: 533, col: 22, offset: 16498},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 533, col: 25, offset: 16473},
+									pos:        position{line: 533, col: 25, offset: 16501},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -4026,16 +4056,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 535, col: 1, offset: 16499},
+			pos:  position{line: 535, col: 1, offset: 16527},
 			expr: &choiceExpr{
-				pos: position{line: 536, col: 5, offset: 16517},
+				pos: position{line: 536, col: 5, offset: 16545},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 536, col: 5, offset: 16517},
+						pos:  position{line: 536, col: 5, offset: 16545},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 536, col: 24, offset: 16536},
+						pos:  position{line: 536, col: 24, offset: 16564},
 						name: "RelativeOperator",
 					},
 				},
@@ -4043,12 +4073,12 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 538, col: 1, offset: 16554},
+			pos:  position{line: 538, col: 1, offset: 16582},
 			expr: &actionExpr{
-				pos: position{line: 538, col: 12, offset: 16565},
+				pos: position{line: 538, col: 12, offset: 16593},
 				run: (*parser).callonAndToken1,
 				expr: &litMatcher{
-					pos:        position{line: 538, col: 12, offset: 16565},
+					pos:        position{line: 538, col: 12, offset: 16593},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -4056,12 +4086,12 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 539, col: 1, offset: 16603},
+			pos:  position{line: 539, col: 1, offset: 16631},
 			expr: &actionExpr{
-				pos: position{line: 539, col: 11, offset: 16613},
+				pos: position{line: 539, col: 11, offset: 16641},
 				run: (*parser).callonOrToken1,
 				expr: &litMatcher{
-					pos:        position{line: 539, col: 11, offset: 16613},
+					pos:        position{line: 539, col: 11, offset: 16641},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -4069,12 +4099,12 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 540, col: 1, offset: 16650},
+			pos:  position{line: 540, col: 1, offset: 16678},
 			expr: &actionExpr{
-				pos: position{line: 540, col: 11, offset: 16660},
+				pos: position{line: 540, col: 11, offset: 16688},
 				run: (*parser).callonInToken1,
 				expr: &litMatcher{
-					pos:        position{line: 540, col: 11, offset: 16660},
+					pos:        position{line: 540, col: 11, offset: 16688},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -4082,12 +4112,12 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 541, col: 1, offset: 16697},
+			pos:  position{line: 541, col: 1, offset: 16725},
 			expr: &actionExpr{
-				pos: position{line: 541, col: 12, offset: 16708},
+				pos: position{line: 541, col: 12, offset: 16736},
 				run: (*parser).callonNotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 541, col: 12, offset: 16708},
+					pos:        position{line: 541, col: 12, offset: 16736},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -4095,21 +4125,21 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 543, col: 1, offset: 16747},
+			pos:  position{line: 543, col: 1, offset: 16775},
 			expr: &actionExpr{
-				pos: position{line: 543, col: 18, offset: 16764},
+				pos: position{line: 543, col: 18, offset: 16792},
 				run: (*parser).callonIdentifierName1,
 				expr: &seqExpr{
-					pos: position{line: 543, col: 18, offset: 16764},
+					pos: position{line: 543, col: 18, offset: 16792},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 543, col: 18, offset: 16764},
+							pos:  position{line: 543, col: 18, offset: 16792},
 							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 543, col: 34, offset: 16780},
+							pos: position{line: 543, col: 34, offset: 16808},
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 34, offset: 16780},
+								pos:  position{line: 543, col: 34, offset: 16808},
 								name: "IdentifierRest",
 							},
 						},
@@ -4119,9 +4149,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 545, col: 1, offset: 16828},
+			pos:  position{line: 545, col: 1, offset: 16856},
 			expr: &charClassMatcher{
-				pos:        position{line: 545, col: 19, offset: 16846},
+				pos:        position{line: 545, col: 19, offset: 16874},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -4131,16 +4161,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 546, col: 1, offset: 16857},
+			pos:  position{line: 546, col: 1, offset: 16885},
 			expr: &choiceExpr{
-				pos: position{line: 546, col: 18, offset: 16874},
+				pos: position{line: 546, col: 18, offset: 16902},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 546, col: 18, offset: 16874},
+						pos:  position{line: 546, col: 18, offset: 16902},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 546, col: 36, offset: 16892},
+						pos:        position{line: 546, col: 36, offset: 16920},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4151,21 +4181,21 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 548, col: 1, offset: 16899},
+			pos:  position{line: 548, col: 1, offset: 16927},
 			expr: &actionExpr{
-				pos: position{line: 549, col: 5, offset: 16914},
+				pos: position{line: 549, col: 5, offset: 16942},
 				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 549, col: 5, offset: 16914},
+					pos: position{line: 549, col: 5, offset: 16942},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 549, col: 5, offset: 16914},
+							pos:  position{line: 549, col: 5, offset: 16942},
 							name: "IdentifierStart",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 549, col: 21, offset: 16930},
+							pos: position{line: 549, col: 21, offset: 16958},
 							expr: &ruleRefExpr{
-								pos:  position{line: 549, col: 21, offset: 16930},
+								pos:  position{line: 549, col: 21, offset: 16958},
 								name: "IdentifierRest",
 							},
 						},
@@ -4175,54 +4205,54 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 551, col: 1, offset: 17030},
+			pos:  position{line: 551, col: 1, offset: 17058},
 			expr: &choiceExpr{
-				pos: position{line: 552, col: 5, offset: 17043},
+				pos: position{line: 552, col: 5, offset: 17071},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 552, col: 5, offset: 17043},
+						pos:  position{line: 552, col: 5, offset: 17071},
 						name: "Seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 553, col: 5, offset: 17055},
+						pos:  position{line: 553, col: 5, offset: 17083},
 						name: "Minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 554, col: 5, offset: 17067},
+						pos:  position{line: 554, col: 5, offset: 17095},
 						name: "Hours",
 					},
 					&seqExpr{
-						pos: position{line: 555, col: 5, offset: 17077},
+						pos: position{line: 555, col: 5, offset: 17105},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 555, col: 5, offset: 17077},
+								pos:  position{line: 555, col: 5, offset: 17105},
 								name: "Hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 555, col: 11, offset: 17083},
+								pos:  position{line: 555, col: 11, offset: 17111},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 555, col: 13, offset: 17085},
+								pos:        position{line: 555, col: 13, offset: 17113},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 555, col: 19, offset: 17091},
+								pos:  position{line: 555, col: 19, offset: 17119},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 555, col: 21, offset: 17093},
+								pos:  position{line: 555, col: 21, offset: 17121},
 								name: "Minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 556, col: 5, offset: 17105},
+						pos:  position{line: 556, col: 5, offset: 17133},
 						name: "Days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 557, col: 5, offset: 17114},
+						pos:  position{line: 557, col: 5, offset: 17142},
 						name: "Weeks",
 					},
 				},
@@ -4230,32 +4260,32 @@ var g = &grammar{
 		},
 		{
 			name: "SecondsToken",
-			pos:  position{line: 559, col: 1, offset: 17121},
+			pos:  position{line: 559, col: 1, offset: 17149},
 			expr: &choiceExpr{
-				pos: position{line: 560, col: 5, offset: 17138},
+				pos: position{line: 560, col: 5, offset: 17166},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 560, col: 5, offset: 17138},
+						pos:        position{line: 560, col: 5, offset: 17166},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 561, col: 5, offset: 17152},
+						pos:        position{line: 561, col: 5, offset: 17180},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 562, col: 5, offset: 17165},
+						pos:        position{line: 562, col: 5, offset: 17193},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 563, col: 5, offset: 17176},
+						pos:        position{line: 563, col: 5, offset: 17204},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 564, col: 5, offset: 17186},
+						pos:        position{line: 564, col: 5, offset: 17214},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -4264,32 +4294,32 @@ var g = &grammar{
 		},
 		{
 			name: "MinutesToken",
-			pos:  position{line: 566, col: 1, offset: 17191},
+			pos:  position{line: 566, col: 1, offset: 17219},
 			expr: &choiceExpr{
-				pos: position{line: 567, col: 5, offset: 17208},
+				pos: position{line: 567, col: 5, offset: 17236},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 567, col: 5, offset: 17208},
+						pos:        position{line: 567, col: 5, offset: 17236},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 568, col: 5, offset: 17222},
+						pos:        position{line: 568, col: 5, offset: 17250},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 569, col: 5, offset: 17235},
+						pos:        position{line: 569, col: 5, offset: 17263},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 570, col: 5, offset: 17246},
+						pos:        position{line: 570, col: 5, offset: 17274},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 571, col: 5, offset: 17256},
+						pos:        position{line: 571, col: 5, offset: 17284},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -4298,32 +4328,32 @@ var g = &grammar{
 		},
 		{
 			name: "HoursToken",
-			pos:  position{line: 573, col: 1, offset: 17261},
+			pos:  position{line: 573, col: 1, offset: 17289},
 			expr: &choiceExpr{
-				pos: position{line: 574, col: 5, offset: 17276},
+				pos: position{line: 574, col: 5, offset: 17304},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 574, col: 5, offset: 17276},
+						pos:        position{line: 574, col: 5, offset: 17304},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 575, col: 5, offset: 17288},
+						pos:        position{line: 575, col: 5, offset: 17316},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 576, col: 5, offset: 17298},
+						pos:        position{line: 576, col: 5, offset: 17326},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 577, col: 5, offset: 17307},
+						pos:        position{line: 577, col: 5, offset: 17335},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 578, col: 5, offset: 17315},
+						pos:        position{line: 578, col: 5, offset: 17343},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -4332,22 +4362,22 @@ var g = &grammar{
 		},
 		{
 			name: "DaysToken",
-			pos:  position{line: 580, col: 1, offset: 17323},
+			pos:  position{line: 580, col: 1, offset: 17351},
 			expr: &choiceExpr{
-				pos: position{line: 580, col: 13, offset: 17335},
+				pos: position{line: 580, col: 13, offset: 17363},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 580, col: 13, offset: 17335},
+						pos:        position{line: 580, col: 13, offset: 17363},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 580, col: 20, offset: 17342},
+						pos:        position{line: 580, col: 20, offset: 17370},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 580, col: 26, offset: 17348},
+						pos:        position{line: 580, col: 26, offset: 17376},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -4356,32 +4386,32 @@ var g = &grammar{
 		},
 		{
 			name: "WeeksToken",
-			pos:  position{line: 581, col: 1, offset: 17352},
+			pos:  position{line: 581, col: 1, offset: 17380},
 			expr: &choiceExpr{
-				pos: position{line: 581, col: 14, offset: 17365},
+				pos: position{line: 581, col: 14, offset: 17393},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 581, col: 14, offset: 17365},
+						pos:        position{line: 581, col: 14, offset: 17393},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 581, col: 22, offset: 17373},
+						pos:        position{line: 581, col: 22, offset: 17401},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 581, col: 29, offset: 17380},
+						pos:        position{line: 581, col: 29, offset: 17408},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 581, col: 35, offset: 17386},
+						pos:        position{line: 581, col: 35, offset: 17414},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 581, col: 40, offset: 17391},
+						pos:        position{line: 581, col: 40, offset: 17419},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -4390,39 +4420,39 @@ var g = &grammar{
 		},
 		{
 			name: "Seconds",
-			pos:  position{line: 583, col: 1, offset: 17396},
+			pos:  position{line: 583, col: 1, offset: 17424},
 			expr: &choiceExpr{
-				pos: position{line: 584, col: 5, offset: 17408},
+				pos: position{line: 584, col: 5, offset: 17436},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 584, col: 5, offset: 17408},
+						pos: position{line: 584, col: 5, offset: 17436},
 						run: (*parser).callonSeconds2,
 						expr: &litMatcher{
-							pos:        position{line: 584, col: 5, offset: 17408},
+							pos:        position{line: 584, col: 5, offset: 17436},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 585, col: 5, offset: 17494},
+						pos: position{line: 585, col: 5, offset: 17522},
 						run: (*parser).callonSeconds4,
 						expr: &seqExpr{
-							pos: position{line: 585, col: 5, offset: 17494},
+							pos: position{line: 585, col: 5, offset: 17522},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 585, col: 5, offset: 17494},
+									pos:   position{line: 585, col: 5, offset: 17522},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 585, col: 9, offset: 17498},
+										pos:  position{line: 585, col: 9, offset: 17526},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 585, col: 14, offset: 17503},
+									pos:  position{line: 585, col: 14, offset: 17531},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 585, col: 17, offset: 17506},
+									pos:  position{line: 585, col: 17, offset: 17534},
 									name: "SecondsToken",
 								},
 							},
@@ -4433,39 +4463,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minutes",
-			pos:  position{line: 587, col: 1, offset: 17595},
+			pos:  position{line: 587, col: 1, offset: 17623},
 			expr: &choiceExpr{
-				pos: position{line: 588, col: 5, offset: 17607},
+				pos: position{line: 588, col: 5, offset: 17635},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 588, col: 5, offset: 17607},
+						pos: position{line: 588, col: 5, offset: 17635},
 						run: (*parser).callonMinutes2,
 						expr: &litMatcher{
-							pos:        position{line: 588, col: 5, offset: 17607},
+							pos:        position{line: 588, col: 5, offset: 17635},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 589, col: 5, offset: 17694},
+						pos: position{line: 589, col: 5, offset: 17722},
 						run: (*parser).callonMinutes4,
 						expr: &seqExpr{
-							pos: position{line: 589, col: 5, offset: 17694},
+							pos: position{line: 589, col: 5, offset: 17722},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 589, col: 5, offset: 17694},
+									pos:   position{line: 589, col: 5, offset: 17722},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 589, col: 9, offset: 17698},
+										pos:  position{line: 589, col: 9, offset: 17726},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 589, col: 14, offset: 17703},
+									pos:  position{line: 589, col: 14, offset: 17731},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 589, col: 17, offset: 17706},
+									pos:  position{line: 589, col: 17, offset: 17734},
 									name: "MinutesToken",
 								},
 							},
@@ -4476,39 +4506,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hours",
-			pos:  position{line: 591, col: 1, offset: 17804},
+			pos:  position{line: 591, col: 1, offset: 17832},
 			expr: &choiceExpr{
-				pos: position{line: 592, col: 5, offset: 17814},
+				pos: position{line: 592, col: 5, offset: 17842},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 592, col: 5, offset: 17814},
+						pos: position{line: 592, col: 5, offset: 17842},
 						run: (*parser).callonHours2,
 						expr: &litMatcher{
-							pos:        position{line: 592, col: 5, offset: 17814},
+							pos:        position{line: 592, col: 5, offset: 17842},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 593, col: 5, offset: 17901},
+						pos: position{line: 593, col: 5, offset: 17929},
 						run: (*parser).callonHours4,
 						expr: &seqExpr{
-							pos: position{line: 593, col: 5, offset: 17901},
+							pos: position{line: 593, col: 5, offset: 17929},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 593, col: 5, offset: 17901},
+									pos:   position{line: 593, col: 5, offset: 17929},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 593, col: 9, offset: 17905},
+										pos:  position{line: 593, col: 9, offset: 17933},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 14, offset: 17910},
+									pos:  position{line: 593, col: 14, offset: 17938},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 17, offset: 17913},
+									pos:  position{line: 593, col: 17, offset: 17941},
 									name: "HoursToken",
 								},
 							},
@@ -4519,39 +4549,39 @@ var g = &grammar{
 		},
 		{
 			name: "Days",
-			pos:  position{line: 595, col: 1, offset: 18011},
+			pos:  position{line: 595, col: 1, offset: 18039},
 			expr: &choiceExpr{
-				pos: position{line: 596, col: 5, offset: 18020},
+				pos: position{line: 596, col: 5, offset: 18048},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 596, col: 5, offset: 18020},
+						pos: position{line: 596, col: 5, offset: 18048},
 						run: (*parser).callonDays2,
 						expr: &litMatcher{
-							pos:        position{line: 596, col: 5, offset: 18020},
+							pos:        position{line: 596, col: 5, offset: 18048},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 597, col: 5, offset: 18109},
+						pos: position{line: 597, col: 5, offset: 18137},
 						run: (*parser).callonDays4,
 						expr: &seqExpr{
-							pos: position{line: 597, col: 5, offset: 18109},
+							pos: position{line: 597, col: 5, offset: 18137},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 597, col: 5, offset: 18109},
+									pos:   position{line: 597, col: 5, offset: 18137},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 597, col: 9, offset: 18113},
+										pos:  position{line: 597, col: 9, offset: 18141},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 597, col: 14, offset: 18118},
+									pos:  position{line: 597, col: 14, offset: 18146},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 597, col: 17, offset: 18121},
+									pos:  position{line: 597, col: 17, offset: 18149},
 									name: "DaysToken",
 								},
 							},
@@ -4562,39 +4592,39 @@ var g = &grammar{
 		},
 		{
 			name: "Weeks",
-			pos:  position{line: 599, col: 1, offset: 18223},
+			pos:  position{line: 599, col: 1, offset: 18251},
 			expr: &choiceExpr{
-				pos: position{line: 600, col: 5, offset: 18233},
+				pos: position{line: 600, col: 5, offset: 18261},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 600, col: 5, offset: 18233},
+						pos: position{line: 600, col: 5, offset: 18261},
 						run: (*parser).callonWeeks2,
 						expr: &litMatcher{
-							pos:        position{line: 600, col: 5, offset: 18233},
+							pos:        position{line: 600, col: 5, offset: 18261},
 							val:        "week",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 601, col: 5, offset: 18325},
+						pos: position{line: 601, col: 5, offset: 18353},
 						run: (*parser).callonWeeks4,
 						expr: &seqExpr{
-							pos: position{line: 601, col: 5, offset: 18325},
+							pos: position{line: 601, col: 5, offset: 18353},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 601, col: 5, offset: 18325},
+									pos:   position{line: 601, col: 5, offset: 18353},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 601, col: 9, offset: 18329},
+										pos:  position{line: 601, col: 9, offset: 18357},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 601, col: 14, offset: 18334},
+									pos:  position{line: 601, col: 14, offset: 18362},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 601, col: 17, offset: 18337},
+									pos:  position{line: 601, col: 17, offset: 18365},
 									name: "WeeksToken",
 								},
 							},
@@ -4605,42 +4635,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 604, col: 1, offset: 18468},
+			pos:  position{line: 604, col: 1, offset: 18496},
 			expr: &actionExpr{
-				pos: position{line: 605, col: 5, offset: 18475},
+				pos: position{line: 605, col: 5, offset: 18503},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 605, col: 5, offset: 18475},
+					pos: position{line: 605, col: 5, offset: 18503},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 5, offset: 18475},
+							pos:  position{line: 605, col: 5, offset: 18503},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 605, col: 10, offset: 18480},
+							pos:        position{line: 605, col: 10, offset: 18508},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 14, offset: 18484},
+							pos:  position{line: 605, col: 14, offset: 18512},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 605, col: 19, offset: 18489},
+							pos:        position{line: 605, col: 19, offset: 18517},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 23, offset: 18493},
+							pos:  position{line: 605, col: 23, offset: 18521},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 605, col: 28, offset: 18498},
+							pos:        position{line: 605, col: 28, offset: 18526},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 32, offset: 18502},
+							pos:  position{line: 605, col: 32, offset: 18530},
 							name: "UInt",
 						},
 					},
@@ -4649,32 +4679,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 609, col: 1, offset: 18670},
+			pos:  position{line: 609, col: 1, offset: 18698},
 			expr: &choiceExpr{
-				pos: position{line: 610, col: 5, offset: 18678},
+				pos: position{line: 610, col: 5, offset: 18706},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 610, col: 5, offset: 18678},
+						pos: position{line: 610, col: 5, offset: 18706},
 						run: (*parser).callonIP62,
 						expr: &seqExpr{
-							pos: position{line: 610, col: 5, offset: 18678},
+							pos: position{line: 610, col: 5, offset: 18706},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 610, col: 5, offset: 18678},
+									pos:   position{line: 610, col: 5, offset: 18706},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 610, col: 7, offset: 18680},
+										pos: position{line: 610, col: 7, offset: 18708},
 										expr: &ruleRefExpr{
-											pos:  position{line: 610, col: 7, offset: 18680},
+											pos:  position{line: 610, col: 7, offset: 18708},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 610, col: 17, offset: 18690},
+									pos:   position{line: 610, col: 17, offset: 18718},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 610, col: 19, offset: 18692},
+										pos:  position{line: 610, col: 19, offset: 18720},
 										name: "IP6Tail",
 									},
 								},
@@ -4682,51 +4712,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 613, col: 5, offset: 18756},
+						pos: position{line: 613, col: 5, offset: 18784},
 						run: (*parser).callonIP69,
 						expr: &seqExpr{
-							pos: position{line: 613, col: 5, offset: 18756},
+							pos: position{line: 613, col: 5, offset: 18784},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 613, col: 5, offset: 18756},
+									pos:   position{line: 613, col: 5, offset: 18784},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 613, col: 7, offset: 18758},
+										pos:  position{line: 613, col: 7, offset: 18786},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 613, col: 11, offset: 18762},
+									pos:   position{line: 613, col: 11, offset: 18790},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 613, col: 13, offset: 18764},
+										pos: position{line: 613, col: 13, offset: 18792},
 										expr: &ruleRefExpr{
-											pos:  position{line: 613, col: 13, offset: 18764},
+											pos:  position{line: 613, col: 13, offset: 18792},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 613, col: 23, offset: 18774},
+									pos:        position{line: 613, col: 23, offset: 18802},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 613, col: 28, offset: 18779},
+									pos:   position{line: 613, col: 28, offset: 18807},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 613, col: 30, offset: 18781},
+										pos: position{line: 613, col: 30, offset: 18809},
 										expr: &ruleRefExpr{
-											pos:  position{line: 613, col: 30, offset: 18781},
+											pos:  position{line: 613, col: 30, offset: 18809},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 613, col: 40, offset: 18791},
+									pos:   position{line: 613, col: 40, offset: 18819},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 613, col: 42, offset: 18793},
+										pos:  position{line: 613, col: 42, offset: 18821},
 										name: "IP6Tail",
 									},
 								},
@@ -4734,32 +4764,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 616, col: 5, offset: 18892},
+						pos: position{line: 616, col: 5, offset: 18920},
 						run: (*parser).callonIP622,
 						expr: &seqExpr{
-							pos: position{line: 616, col: 5, offset: 18892},
+							pos: position{line: 616, col: 5, offset: 18920},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 616, col: 5, offset: 18892},
+									pos:        position{line: 616, col: 5, offset: 18920},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 616, col: 10, offset: 18897},
+									pos:   position{line: 616, col: 10, offset: 18925},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 616, col: 12, offset: 18899},
+										pos: position{line: 616, col: 12, offset: 18927},
 										expr: &ruleRefExpr{
-											pos:  position{line: 616, col: 12, offset: 18899},
+											pos:  position{line: 616, col: 12, offset: 18927},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 616, col: 22, offset: 18909},
+									pos:   position{line: 616, col: 22, offset: 18937},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 616, col: 24, offset: 18911},
+										pos:  position{line: 616, col: 24, offset: 18939},
 										name: "IP6Tail",
 									},
 								},
@@ -4767,32 +4797,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 619, col: 5, offset: 18982},
+						pos: position{line: 619, col: 5, offset: 19010},
 						run: (*parser).callonIP630,
 						expr: &seqExpr{
-							pos: position{line: 619, col: 5, offset: 18982},
+							pos: position{line: 619, col: 5, offset: 19010},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 619, col: 5, offset: 18982},
+									pos:   position{line: 619, col: 5, offset: 19010},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 619, col: 7, offset: 18984},
+										pos:  position{line: 619, col: 7, offset: 19012},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 619, col: 11, offset: 18988},
+									pos:   position{line: 619, col: 11, offset: 19016},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 619, col: 13, offset: 18990},
+										pos: position{line: 619, col: 13, offset: 19018},
 										expr: &ruleRefExpr{
-											pos:  position{line: 619, col: 13, offset: 18990},
+											pos:  position{line: 619, col: 13, offset: 19018},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 619, col: 23, offset: 19000},
+									pos:        position{line: 619, col: 23, offset: 19028},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -4800,10 +4830,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 622, col: 5, offset: 19068},
+						pos: position{line: 622, col: 5, offset: 19096},
 						run: (*parser).callonIP638,
 						expr: &litMatcher{
-							pos:        position{line: 622, col: 5, offset: 19068},
+							pos:        position{line: 622, col: 5, offset: 19096},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -4813,16 +4843,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 626, col: 1, offset: 19105},
+			pos:  position{line: 626, col: 1, offset: 19133},
 			expr: &choiceExpr{
-				pos: position{line: 627, col: 5, offset: 19117},
+				pos: position{line: 627, col: 5, offset: 19145},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 627, col: 5, offset: 19117},
+						pos:  position{line: 627, col: 5, offset: 19145},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 628, col: 5, offset: 19124},
+						pos:  position{line: 628, col: 5, offset: 19152},
 						name: "Hex",
 					},
 				},
@@ -4830,23 +4860,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 630, col: 1, offset: 19129},
+			pos:  position{line: 630, col: 1, offset: 19157},
 			expr: &actionExpr{
-				pos: position{line: 630, col: 12, offset: 19140},
+				pos: position{line: 630, col: 12, offset: 19168},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 630, col: 12, offset: 19140},
+					pos: position{line: 630, col: 12, offset: 19168},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 630, col: 12, offset: 19140},
+							pos:        position{line: 630, col: 12, offset: 19168},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 630, col: 16, offset: 19144},
+							pos:   position{line: 630, col: 16, offset: 19172},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 630, col: 18, offset: 19146},
+								pos:  position{line: 630, col: 18, offset: 19174},
 								name: "Hex",
 							},
 						},
@@ -4856,23 +4886,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 631, col: 1, offset: 19183},
+			pos:  position{line: 631, col: 1, offset: 19211},
 			expr: &actionExpr{
-				pos: position{line: 631, col: 12, offset: 19194},
+				pos: position{line: 631, col: 12, offset: 19222},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 631, col: 12, offset: 19194},
+					pos: position{line: 631, col: 12, offset: 19222},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 631, col: 12, offset: 19194},
+							pos:   position{line: 631, col: 12, offset: 19222},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 631, col: 14, offset: 19196},
+								pos:  position{line: 631, col: 14, offset: 19224},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 631, col: 18, offset: 19200},
+							pos:        position{line: 631, col: 18, offset: 19228},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -4882,31 +4912,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 633, col: 1, offset: 19238},
+			pos:  position{line: 633, col: 1, offset: 19266},
 			expr: &actionExpr{
-				pos: position{line: 634, col: 5, offset: 19249},
+				pos: position{line: 634, col: 5, offset: 19277},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 634, col: 5, offset: 19249},
+					pos: position{line: 634, col: 5, offset: 19277},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 634, col: 5, offset: 19249},
+							pos:   position{line: 634, col: 5, offset: 19277},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 634, col: 7, offset: 19251},
+								pos:  position{line: 634, col: 7, offset: 19279},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 634, col: 10, offset: 19254},
+							pos:        position{line: 634, col: 10, offset: 19282},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 634, col: 14, offset: 19258},
+							pos:   position{line: 634, col: 14, offset: 19286},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 634, col: 16, offset: 19260},
+								pos:  position{line: 634, col: 16, offset: 19288},
 								name: "UInt",
 							},
 						},
@@ -4916,31 +4946,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 638, col: 1, offset: 19333},
+			pos:  position{line: 638, col: 1, offset: 19361},
 			expr: &actionExpr{
-				pos: position{line: 639, col: 5, offset: 19344},
+				pos: position{line: 639, col: 5, offset: 19372},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 639, col: 5, offset: 19344},
+					pos: position{line: 639, col: 5, offset: 19372},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 639, col: 5, offset: 19344},
+							pos:   position{line: 639, col: 5, offset: 19372},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 639, col: 7, offset: 19346},
+								pos:  position{line: 639, col: 7, offset: 19374},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 639, col: 11, offset: 19350},
+							pos:        position{line: 639, col: 11, offset: 19378},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 639, col: 15, offset: 19354},
+							pos:   position{line: 639, col: 15, offset: 19382},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 639, col: 17, offset: 19356},
+								pos:  position{line: 639, col: 17, offset: 19384},
 								name: "UInt",
 							},
 						},
@@ -4950,15 +4980,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 643, col: 1, offset: 19419},
+			pos:  position{line: 643, col: 1, offset: 19447},
 			expr: &actionExpr{
-				pos: position{line: 644, col: 4, offset: 19427},
+				pos: position{line: 644, col: 4, offset: 19455},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 644, col: 4, offset: 19427},
+					pos:   position{line: 644, col: 4, offset: 19455},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 644, col: 6, offset: 19429},
+						pos:  position{line: 644, col: 6, offset: 19457},
 						name: "UIntString",
 					},
 				},
@@ -4966,16 +4996,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 646, col: 1, offset: 19469},
+			pos:  position{line: 646, col: 1, offset: 19497},
 			expr: &choiceExpr{
-				pos: position{line: 647, col: 5, offset: 19483},
+				pos: position{line: 647, col: 5, offset: 19511},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 647, col: 5, offset: 19483},
+						pos:  position{line: 647, col: 5, offset: 19511},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 648, col: 5, offset: 19498},
+						pos:  position{line: 648, col: 5, offset: 19526},
 						name: "MinusIntString",
 					},
 				},
@@ -4983,14 +5013,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 650, col: 1, offset: 19514},
+			pos:  position{line: 650, col: 1, offset: 19542},
 			expr: &actionExpr{
-				pos: position{line: 650, col: 14, offset: 19527},
+				pos: position{line: 650, col: 14, offset: 19555},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 650, col: 14, offset: 19527},
+					pos: position{line: 650, col: 14, offset: 19555},
 					expr: &charClassMatcher{
-						pos:        position{line: 650, col: 14, offset: 19527},
+						pos:        position{line: 650, col: 14, offset: 19555},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -5001,20 +5031,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 652, col: 1, offset: 19566},
+			pos:  position{line: 652, col: 1, offset: 19594},
 			expr: &actionExpr{
-				pos: position{line: 653, col: 5, offset: 19585},
+				pos: position{line: 653, col: 5, offset: 19613},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 653, col: 5, offset: 19585},
+					pos: position{line: 653, col: 5, offset: 19613},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 653, col: 5, offset: 19585},
+							pos:        position{line: 653, col: 5, offset: 19613},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 653, col: 9, offset: 19589},
+							pos:  position{line: 653, col: 9, offset: 19617},
 							name: "UIntString",
 						},
 					},
@@ -5023,28 +5053,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 655, col: 1, offset: 19632},
+			pos:  position{line: 655, col: 1, offset: 19660},
 			expr: &choiceExpr{
-				pos: position{line: 656, col: 5, offset: 19648},
+				pos: position{line: 656, col: 5, offset: 19676},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 656, col: 5, offset: 19648},
+						pos: position{line: 656, col: 5, offset: 19676},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 656, col: 5, offset: 19648},
+							pos: position{line: 656, col: 5, offset: 19676},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 656, col: 5, offset: 19648},
+									pos: position{line: 656, col: 5, offset: 19676},
 									expr: &litMatcher{
-										pos:        position{line: 656, col: 5, offset: 19648},
+										pos:        position{line: 656, col: 5, offset: 19676},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 656, col: 10, offset: 19653},
+									pos: position{line: 656, col: 10, offset: 19681},
 									expr: &charClassMatcher{
-										pos:        position{line: 656, col: 10, offset: 19653},
+										pos:        position{line: 656, col: 10, offset: 19681},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -5052,14 +5082,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 656, col: 17, offset: 19660},
+									pos:        position{line: 656, col: 17, offset: 19688},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 656, col: 21, offset: 19664},
+									pos: position{line: 656, col: 21, offset: 19692},
 									expr: &charClassMatcher{
-										pos:        position{line: 656, col: 21, offset: 19664},
+										pos:        position{line: 656, col: 21, offset: 19692},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -5067,9 +5097,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 656, col: 28, offset: 19671},
+									pos: position{line: 656, col: 28, offset: 19699},
 									expr: &ruleRefExpr{
-										pos:  position{line: 656, col: 28, offset: 19671},
+										pos:  position{line: 656, col: 28, offset: 19699},
 										name: "ExponentPart",
 									},
 								},
@@ -5077,28 +5107,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 19730},
+						pos: position{line: 659, col: 5, offset: 19758},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 19730},
+							pos: position{line: 659, col: 5, offset: 19758},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 659, col: 5, offset: 19730},
+									pos: position{line: 659, col: 5, offset: 19758},
 									expr: &litMatcher{
-										pos:        position{line: 659, col: 5, offset: 19730},
+										pos:        position{line: 659, col: 5, offset: 19758},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 659, col: 10, offset: 19735},
+									pos:        position{line: 659, col: 10, offset: 19763},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 659, col: 14, offset: 19739},
+									pos: position{line: 659, col: 14, offset: 19767},
 									expr: &charClassMatcher{
-										pos:        position{line: 659, col: 14, offset: 19739},
+										pos:        position{line: 659, col: 14, offset: 19767},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -5106,9 +5136,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 659, col: 21, offset: 19746},
+									pos: position{line: 659, col: 21, offset: 19774},
 									expr: &ruleRefExpr{
-										pos:  position{line: 659, col: 21, offset: 19746},
+										pos:  position{line: 659, col: 21, offset: 19774},
 										name: "ExponentPart",
 									},
 								},
@@ -5120,19 +5150,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 663, col: 1, offset: 19802},
+			pos:  position{line: 663, col: 1, offset: 19830},
 			expr: &seqExpr{
-				pos: position{line: 663, col: 16, offset: 19817},
+				pos: position{line: 663, col: 16, offset: 19845},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 663, col: 16, offset: 19817},
+						pos:        position{line: 663, col: 16, offset: 19845},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 663, col: 21, offset: 19822},
+						pos: position{line: 663, col: 21, offset: 19850},
 						expr: &charClassMatcher{
-							pos:        position{line: 663, col: 21, offset: 19822},
+							pos:        position{line: 663, col: 21, offset: 19850},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -5140,7 +5170,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 663, col: 27, offset: 19828},
+						pos:  position{line: 663, col: 27, offset: 19856},
 						name: "UIntString",
 					},
 				},
@@ -5148,14 +5178,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 665, col: 1, offset: 19840},
+			pos:  position{line: 665, col: 1, offset: 19868},
 			expr: &actionExpr{
-				pos: position{line: 665, col: 7, offset: 19846},
+				pos: position{line: 665, col: 7, offset: 19874},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 665, col: 7, offset: 19846},
+					pos: position{line: 665, col: 7, offset: 19874},
 					expr: &ruleRefExpr{
-						pos:  position{line: 665, col: 7, offset: 19846},
+						pos:  position{line: 665, col: 7, offset: 19874},
 						name: "HexDigit",
 					},
 				},
@@ -5163,9 +5193,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 667, col: 1, offset: 19888},
+			pos:  position{line: 667, col: 1, offset: 19916},
 			expr: &charClassMatcher{
-				pos:        position{line: 667, col: 12, offset: 19899},
+				pos:        position{line: 667, col: 12, offset: 19927},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -5174,17 +5204,17 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 669, col: 1, offset: 19912},
+			pos:  position{line: 669, col: 1, offset: 19940},
 			expr: &actionExpr{
-				pos: position{line: 670, col: 5, offset: 19924},
+				pos: position{line: 670, col: 5, offset: 19952},
 				run: (*parser).callonKeyWord1,
 				expr: &labeledExpr{
-					pos:   position{line: 670, col: 5, offset: 19924},
+					pos:   position{line: 670, col: 5, offset: 19952},
 					label: "chars",
 					expr: &oneOrMoreExpr{
-						pos: position{line: 670, col: 11, offset: 19930},
+						pos: position{line: 670, col: 11, offset: 19958},
 						expr: &ruleRefExpr{
-							pos:  position{line: 670, col: 11, offset: 19930},
+							pos:  position{line: 670, col: 11, offset: 19958},
 							name: "KeyWordPart",
 						},
 					},
@@ -5193,33 +5223,33 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordPart",
-			pos:  position{line: 672, col: 1, offset: 19977},
+			pos:  position{line: 672, col: 1, offset: 20005},
 			expr: &choiceExpr{
-				pos: position{line: 673, col: 5, offset: 19993},
+				pos: position{line: 673, col: 5, offset: 20021},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 673, col: 5, offset: 19993},
+						pos: position{line: 673, col: 5, offset: 20021},
 						run: (*parser).callonKeyWordPart2,
 						expr: &seqExpr{
-							pos: position{line: 673, col: 5, offset: 19993},
+							pos: position{line: 673, col: 5, offset: 20021},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 673, col: 5, offset: 19993},
+									pos:        position{line: 673, col: 5, offset: 20021},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 673, col: 10, offset: 19998},
+									pos:   position{line: 673, col: 10, offset: 20026},
 									label: "s",
 									expr: &choiceExpr{
-										pos: position{line: 673, col: 13, offset: 20001},
+										pos: position{line: 673, col: 13, offset: 20029},
 										alternatives: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 673, col: 13, offset: 20001},
+												pos:  position{line: 673, col: 13, offset: 20029},
 												name: "EscapeSequence",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 673, col: 30, offset: 20018},
+												pos:  position{line: 673, col: 30, offset: 20046},
 												name: "SearchEscape",
 											},
 										},
@@ -5229,18 +5259,18 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 674, col: 5, offset: 20055},
+						pos: position{line: 674, col: 5, offset: 20083},
 						run: (*parser).callonKeyWordPart9,
 						expr: &seqExpr{
-							pos: position{line: 674, col: 5, offset: 20055},
+							pos: position{line: 674, col: 5, offset: 20083},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 674, col: 5, offset: 20055},
+									pos: position{line: 674, col: 5, offset: 20083},
 									expr: &choiceExpr{
-										pos: position{line: 674, col: 7, offset: 20057},
+										pos: position{line: 674, col: 7, offset: 20085},
 										alternatives: []interface{}{
 											&charClassMatcher{
-												pos:        position{line: 674, col: 7, offset: 20057},
+												pos:        position{line: 674, col: 7, offset: 20085},
 												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;:]",
 												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';', ':'},
 												ranges:     []rune{'\x00', '\x1f'},
@@ -5248,14 +5278,14 @@ var g = &grammar{
 												inverted:   false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 674, col: 43, offset: 20093},
+												pos:  position{line: 674, col: 43, offset: 20121},
 												name: "WhiteSpace",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 674, col: 55, offset: 20105,
+									line: 674, col: 55, offset: 20133,
 								},
 							},
 						},
@@ -5265,34 +5295,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 676, col: 1, offset: 20139},
+			pos:  position{line: 676, col: 1, offset: 20167},
 			expr: &choiceExpr{
-				pos: position{line: 677, col: 5, offset: 20156},
+				pos: position{line: 677, col: 5, offset: 20184},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 677, col: 5, offset: 20156},
+						pos: position{line: 677, col: 5, offset: 20184},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 677, col: 5, offset: 20156},
+							pos: position{line: 677, col: 5, offset: 20184},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 677, col: 5, offset: 20156},
+									pos:        position{line: 677, col: 5, offset: 20184},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 677, col: 9, offset: 20160},
+									pos:   position{line: 677, col: 9, offset: 20188},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 677, col: 11, offset: 20162},
+										pos: position{line: 677, col: 11, offset: 20190},
 										expr: &ruleRefExpr{
-											pos:  position{line: 677, col: 11, offset: 20162},
+											pos:  position{line: 677, col: 11, offset: 20190},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 677, col: 29, offset: 20180},
+									pos:        position{line: 677, col: 29, offset: 20208},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5300,29 +5330,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 678, col: 5, offset: 20217},
+						pos: position{line: 678, col: 5, offset: 20245},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 678, col: 5, offset: 20217},
+							pos: position{line: 678, col: 5, offset: 20245},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 678, col: 5, offset: 20217},
+									pos:        position{line: 678, col: 5, offset: 20245},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 678, col: 9, offset: 20221},
+									pos:   position{line: 678, col: 9, offset: 20249},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 678, col: 11, offset: 20223},
+										pos: position{line: 678, col: 11, offset: 20251},
 										expr: &ruleRefExpr{
-											pos:  position{line: 678, col: 11, offset: 20223},
+											pos:  position{line: 678, col: 11, offset: 20251},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 678, col: 29, offset: 20241},
+									pos:        position{line: 678, col: 29, offset: 20269},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5334,55 +5364,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 680, col: 1, offset: 20275},
+			pos:  position{line: 680, col: 1, offset: 20303},
 			expr: &choiceExpr{
-				pos: position{line: 681, col: 5, offset: 20296},
+				pos: position{line: 681, col: 5, offset: 20324},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 681, col: 5, offset: 20296},
+						pos: position{line: 681, col: 5, offset: 20324},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 681, col: 5, offset: 20296},
+							pos: position{line: 681, col: 5, offset: 20324},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 681, col: 5, offset: 20296},
+									pos: position{line: 681, col: 5, offset: 20324},
 									expr: &choiceExpr{
-										pos: position{line: 681, col: 7, offset: 20298},
+										pos: position{line: 681, col: 7, offset: 20326},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 681, col: 7, offset: 20298},
+												pos:        position{line: 681, col: 7, offset: 20326},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 681, col: 13, offset: 20304},
+												pos:  position{line: 681, col: 13, offset: 20332},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 681, col: 26, offset: 20317,
+									line: 681, col: 26, offset: 20345,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 682, col: 5, offset: 20354},
+						pos: position{line: 682, col: 5, offset: 20382},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 682, col: 5, offset: 20354},
+							pos: position{line: 682, col: 5, offset: 20382},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 682, col: 5, offset: 20354},
+									pos:        position{line: 682, col: 5, offset: 20382},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 682, col: 10, offset: 20359},
+									pos:   position{line: 682, col: 10, offset: 20387},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 682, col: 12, offset: 20361},
+										pos:  position{line: 682, col: 12, offset: 20389},
 										name: "EscapeSequence",
 									},
 								},
@@ -5394,55 +5424,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 684, col: 1, offset: 20395},
+			pos:  position{line: 684, col: 1, offset: 20423},
 			expr: &choiceExpr{
-				pos: position{line: 685, col: 5, offset: 20416},
+				pos: position{line: 685, col: 5, offset: 20444},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 685, col: 5, offset: 20416},
+						pos: position{line: 685, col: 5, offset: 20444},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 685, col: 5, offset: 20416},
+							pos: position{line: 685, col: 5, offset: 20444},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 685, col: 5, offset: 20416},
+									pos: position{line: 685, col: 5, offset: 20444},
 									expr: &choiceExpr{
-										pos: position{line: 685, col: 7, offset: 20418},
+										pos: position{line: 685, col: 7, offset: 20446},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 685, col: 7, offset: 20418},
+												pos:        position{line: 685, col: 7, offset: 20446},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 685, col: 13, offset: 20424},
+												pos:  position{line: 685, col: 13, offset: 20452},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 685, col: 26, offset: 20437,
+									line: 685, col: 26, offset: 20465,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 686, col: 5, offset: 20474},
+						pos: position{line: 686, col: 5, offset: 20502},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 686, col: 5, offset: 20474},
+							pos: position{line: 686, col: 5, offset: 20502},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 686, col: 5, offset: 20474},
+									pos:        position{line: 686, col: 5, offset: 20502},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 686, col: 10, offset: 20479},
+									pos:   position{line: 686, col: 10, offset: 20507},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 686, col: 12, offset: 20481},
+										pos:  position{line: 686, col: 12, offset: 20509},
 										name: "EscapeSequence",
 									},
 								},
@@ -5454,38 +5484,38 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 688, col: 1, offset: 20515},
+			pos:  position{line: 688, col: 1, offset: 20543},
 			expr: &choiceExpr{
-				pos: position{line: 689, col: 5, offset: 20534},
+				pos: position{line: 689, col: 5, offset: 20562},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 689, col: 5, offset: 20534},
+						pos: position{line: 689, col: 5, offset: 20562},
 						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 689, col: 5, offset: 20534},
+							pos: position{line: 689, col: 5, offset: 20562},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 689, col: 5, offset: 20534},
+									pos:        position{line: 689, col: 5, offset: 20562},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 9, offset: 20538},
+									pos:  position{line: 689, col: 9, offset: 20566},
 									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 18, offset: 20547},
+									pos:  position{line: 689, col: 18, offset: 20575},
 									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 690, col: 5, offset: 20598},
+						pos:  position{line: 690, col: 5, offset: 20626},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 691, col: 5, offset: 20619},
+						pos:  position{line: 691, col: 5, offset: 20647},
 						name: "UnicodeEscape",
 					},
 				},
@@ -5493,75 +5523,75 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 693, col: 1, offset: 20634},
+			pos:  position{line: 693, col: 1, offset: 20662},
 			expr: &choiceExpr{
-				pos: position{line: 694, col: 5, offset: 20655},
+				pos: position{line: 694, col: 5, offset: 20683},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 694, col: 5, offset: 20655},
+						pos:        position{line: 694, col: 5, offset: 20683},
 						val:        "'",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 695, col: 5, offset: 20663},
+						pos:        position{line: 695, col: 5, offset: 20691},
 						val:        "\"",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 696, col: 5, offset: 20671},
+						pos:        position{line: 696, col: 5, offset: 20699},
 						val:        "\\",
 						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 697, col: 5, offset: 20680},
+						pos: position{line: 697, col: 5, offset: 20708},
 						run: (*parser).callonSingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 697, col: 5, offset: 20680},
+							pos:        position{line: 697, col: 5, offset: 20708},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 698, col: 5, offset: 20709},
+						pos: position{line: 698, col: 5, offset: 20737},
 						run: (*parser).callonSingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 698, col: 5, offset: 20709},
+							pos:        position{line: 698, col: 5, offset: 20737},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 699, col: 5, offset: 20738},
+						pos: position{line: 699, col: 5, offset: 20766},
 						run: (*parser).callonSingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 699, col: 5, offset: 20738},
+							pos:        position{line: 699, col: 5, offset: 20766},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 700, col: 5, offset: 20767},
+						pos: position{line: 700, col: 5, offset: 20795},
 						run: (*parser).callonSingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 700, col: 5, offset: 20767},
+							pos:        position{line: 700, col: 5, offset: 20795},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 701, col: 5, offset: 20796},
+						pos: position{line: 701, col: 5, offset: 20824},
 						run: (*parser).callonSingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 701, col: 5, offset: 20796},
+							pos:        position{line: 701, col: 5, offset: 20824},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 702, col: 5, offset: 20825},
+						pos: position{line: 702, col: 5, offset: 20853},
 						run: (*parser).callonSingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 702, col: 5, offset: 20825},
+							pos:        position{line: 702, col: 5, offset: 20853},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5571,24 +5601,24 @@ var g = &grammar{
 		},
 		{
 			name: "SearchEscape",
-			pos:  position{line: 704, col: 1, offset: 20851},
+			pos:  position{line: 704, col: 1, offset: 20879},
 			expr: &choiceExpr{
-				pos: position{line: 705, col: 5, offset: 20868},
+				pos: position{line: 705, col: 5, offset: 20896},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 705, col: 5, offset: 20868},
+						pos: position{line: 705, col: 5, offset: 20896},
 						run: (*parser).callonSearchEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 705, col: 5, offset: 20868},
+							pos:        position{line: 705, col: 5, offset: 20896},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 706, col: 5, offset: 20896},
+						pos: position{line: 706, col: 5, offset: 20924},
 						run: (*parser).callonSearchEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 706, col: 5, offset: 20896},
+							pos:        position{line: 706, col: 5, offset: 20924},
 							val:        "*",
 							ignoreCase: false,
 						},
@@ -5598,41 +5628,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 708, col: 1, offset: 20923},
+			pos:  position{line: 708, col: 1, offset: 20951},
 			expr: &choiceExpr{
-				pos: position{line: 709, col: 5, offset: 20941},
+				pos: position{line: 709, col: 5, offset: 20969},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 709, col: 5, offset: 20941},
+						pos: position{line: 709, col: 5, offset: 20969},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 709, col: 5, offset: 20941},
+							pos: position{line: 709, col: 5, offset: 20969},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 709, col: 5, offset: 20941},
+									pos:        position{line: 709, col: 5, offset: 20969},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 709, col: 9, offset: 20945},
+									pos:   position{line: 709, col: 9, offset: 20973},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 709, col: 16, offset: 20952},
+										pos: position{line: 709, col: 16, offset: 20980},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 709, col: 16, offset: 20952},
+												pos:  position{line: 709, col: 16, offset: 20980},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 709, col: 25, offset: 20961},
+												pos:  position{line: 709, col: 25, offset: 20989},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 709, col: 34, offset: 20970},
+												pos:  position{line: 709, col: 34, offset: 20998},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 709, col: 43, offset: 20979},
+												pos:  position{line: 709, col: 43, offset: 21007},
 												name: "HexDigit",
 											},
 										},
@@ -5642,63 +5672,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 712, col: 5, offset: 21042},
+						pos: position{line: 712, col: 5, offset: 21070},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 712, col: 5, offset: 21042},
+							pos: position{line: 712, col: 5, offset: 21070},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 712, col: 5, offset: 21042},
+									pos:        position{line: 712, col: 5, offset: 21070},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 712, col: 9, offset: 21046},
+									pos:        position{line: 712, col: 9, offset: 21074},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 712, col: 13, offset: 21050},
+									pos:   position{line: 712, col: 13, offset: 21078},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 712, col: 20, offset: 21057},
+										pos: position{line: 712, col: 20, offset: 21085},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 712, col: 20, offset: 21057},
+												pos:  position{line: 712, col: 20, offset: 21085},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 29, offset: 21066},
+												pos: position{line: 712, col: 29, offset: 21094},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 29, offset: 21066},
+													pos:  position{line: 712, col: 29, offset: 21094},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 39, offset: 21076},
+												pos: position{line: 712, col: 39, offset: 21104},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 39, offset: 21076},
+													pos:  position{line: 712, col: 39, offset: 21104},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 49, offset: 21086},
+												pos: position{line: 712, col: 49, offset: 21114},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 49, offset: 21086},
+													pos:  position{line: 712, col: 49, offset: 21114},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 59, offset: 21096},
+												pos: position{line: 712, col: 59, offset: 21124},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 59, offset: 21096},
+													pos:  position{line: 712, col: 59, offset: 21124},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 69, offset: 21106},
+												pos: position{line: 712, col: 69, offset: 21134},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 69, offset: 21106},
+													pos:  position{line: 712, col: 69, offset: 21134},
 													name: "HexDigit",
 												},
 											},
@@ -5706,7 +5736,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 712, col: 80, offset: 21117},
+									pos:        position{line: 712, col: 80, offset: 21145},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5718,28 +5748,28 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 716, col: 1, offset: 21171},
+			pos:  position{line: 716, col: 1, offset: 21199},
 			expr: &actionExpr{
-				pos: position{line: 717, col: 5, offset: 21182},
+				pos: position{line: 717, col: 5, offset: 21210},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 717, col: 5, offset: 21182},
+					pos: position{line: 717, col: 5, offset: 21210},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 717, col: 5, offset: 21182},
+							pos:        position{line: 717, col: 5, offset: 21210},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 717, col: 9, offset: 21186},
+							pos:   position{line: 717, col: 9, offset: 21214},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 717, col: 14, offset: 21191},
+								pos:  position{line: 717, col: 14, offset: 21219},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 717, col: 25, offset: 21202},
+							pos:        position{line: 717, col: 25, offset: 21230},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5749,24 +5779,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 719, col: 1, offset: 21228},
+			pos:  position{line: 719, col: 1, offset: 21256},
 			expr: &actionExpr{
-				pos: position{line: 720, col: 5, offset: 21243},
+				pos: position{line: 720, col: 5, offset: 21271},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 720, col: 5, offset: 21243},
+					pos: position{line: 720, col: 5, offset: 21271},
 					expr: &choiceExpr{
-						pos: position{line: 720, col: 6, offset: 21244},
+						pos: position{line: 720, col: 6, offset: 21272},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 720, col: 6, offset: 21244},
+								pos:        position{line: 720, col: 6, offset: 21272},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 720, col: 13, offset: 21251},
+								pos:        position{line: 720, col: 13, offset: 21279},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -5777,9 +5807,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 722, col: 1, offset: 21291},
+			pos:  position{line: 722, col: 1, offset: 21319},
 			expr: &charClassMatcher{
-				pos:        position{line: 723, col: 5, offset: 21307},
+				pos:        position{line: 723, col: 5, offset: 21335},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5789,42 +5819,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 725, col: 1, offset: 21322},
+			pos:  position{line: 725, col: 1, offset: 21350},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 725, col: 6, offset: 21327},
+				pos: position{line: 725, col: 6, offset: 21355},
 				expr: &ruleRefExpr{
-					pos:  position{line: 725, col: 6, offset: 21327},
+					pos:  position{line: 725, col: 6, offset: 21355},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 726, col: 1, offset: 21337},
+			pos:  position{line: 726, col: 1, offset: 21365},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 726, col: 6, offset: 21342},
+				pos: position{line: 726, col: 6, offset: 21370},
 				expr: &ruleRefExpr{
-					pos:  position{line: 726, col: 6, offset: 21342},
+					pos:  position{line: 726, col: 6, offset: 21370},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 728, col: 1, offset: 21353},
+			pos:  position{line: 728, col: 1, offset: 21381},
 			expr: &choiceExpr{
-				pos: position{line: 729, col: 5, offset: 21366},
+				pos: position{line: 729, col: 5, offset: 21394},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 729, col: 5, offset: 21366},
+						pos:  position{line: 729, col: 5, offset: 21394},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 730, col: 5, offset: 21381},
+						pos:  position{line: 730, col: 5, offset: 21409},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 731, col: 5, offset: 21400},
+						pos:  position{line: 731, col: 5, offset: 21428},
 						name: "Comment",
 					},
 				},
@@ -5832,45 +5862,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 733, col: 1, offset: 21409},
+			pos:  position{line: 733, col: 1, offset: 21437},
 			expr: &anyMatcher{
-				line: 734, col: 5, offset: 21429,
+				line: 734, col: 5, offset: 21457,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 736, col: 1, offset: 21432},
+			pos:         position{line: 736, col: 1, offset: 21460},
 			expr: &choiceExpr{
-				pos: position{line: 737, col: 5, offset: 21460},
+				pos: position{line: 737, col: 5, offset: 21488},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 737, col: 5, offset: 21460},
+						pos:        position{line: 737, col: 5, offset: 21488},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 738, col: 5, offset: 21469},
+						pos:        position{line: 738, col: 5, offset: 21497},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 739, col: 5, offset: 21478},
+						pos:        position{line: 739, col: 5, offset: 21506},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 740, col: 5, offset: 21487},
+						pos:        position{line: 740, col: 5, offset: 21515},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 741, col: 5, offset: 21495},
+						pos:        position{line: 741, col: 5, offset: 21523},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 742, col: 5, offset: 21508},
+						pos:        position{line: 742, col: 5, offset: 21536},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5879,9 +5909,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 744, col: 1, offset: 21518},
+			pos:  position{line: 744, col: 1, offset: 21546},
 			expr: &charClassMatcher{
-				pos:        position{line: 745, col: 5, offset: 21537},
+				pos:        position{line: 745, col: 5, offset: 21565},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -5891,45 +5921,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 751, col: 1, offset: 21867},
+			pos:         position{line: 751, col: 1, offset: 21895},
 			expr: &ruleRefExpr{
-				pos:  position{line: 754, col: 5, offset: 21938},
+				pos:  position{line: 754, col: 5, offset: 21966},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 756, col: 1, offset: 21957},
+			pos:  position{line: 756, col: 1, offset: 21985},
 			expr: &seqExpr{
-				pos: position{line: 757, col: 5, offset: 21978},
+				pos: position{line: 757, col: 5, offset: 22006},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 757, col: 5, offset: 21978},
+						pos:        position{line: 757, col: 5, offset: 22006},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 757, col: 10, offset: 21983},
+						pos: position{line: 757, col: 10, offset: 22011},
 						expr: &seqExpr{
-							pos: position{line: 757, col: 11, offset: 21984},
+							pos: position{line: 757, col: 11, offset: 22012},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 757, col: 11, offset: 21984},
+									pos: position{line: 757, col: 11, offset: 22012},
 									expr: &litMatcher{
-										pos:        position{line: 757, col: 12, offset: 21985},
+										pos:        position{line: 757, col: 12, offset: 22013},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 757, col: 17, offset: 21990},
+									pos:  position{line: 757, col: 17, offset: 22018},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 757, col: 35, offset: 22008},
+						pos:        position{line: 757, col: 35, offset: 22036},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -5938,29 +5968,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 759, col: 1, offset: 22014},
+			pos:  position{line: 759, col: 1, offset: 22042},
 			expr: &seqExpr{
-				pos: position{line: 760, col: 5, offset: 22036},
+				pos: position{line: 760, col: 5, offset: 22064},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 760, col: 5, offset: 22036},
+						pos:        position{line: 760, col: 5, offset: 22064},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 760, col: 10, offset: 22041},
+						pos: position{line: 760, col: 10, offset: 22069},
 						expr: &seqExpr{
-							pos: position{line: 760, col: 11, offset: 22042},
+							pos: position{line: 760, col: 11, offset: 22070},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 760, col: 11, offset: 22042},
+									pos: position{line: 760, col: 11, offset: 22070},
 									expr: &ruleRefExpr{
-										pos:  position{line: 760, col: 12, offset: 22043},
+										pos:  position{line: 760, col: 12, offset: 22071},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 760, col: 27, offset: 22058},
+									pos:  position{line: 760, col: 27, offset: 22086},
 									name: "SourceCharacter",
 								},
 							},
@@ -5971,11 +6001,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 762, col: 1, offset: 22077},
+			pos:  position{line: 762, col: 1, offset: 22105},
 			expr: &notExpr{
-				pos: position{line: 762, col: 7, offset: 22083},
+				pos: position{line: 762, col: 7, offset: 22111},
 				expr: &anyMatcher{
-					line: 762, col: 8, offset: 22084,
+					line: 762, col: 8, offset: 22112,
 				},
 			},
 		},
@@ -6382,15 +6412,15 @@ func (p *parser) callonSequentialTail1() (interface{}, error) {
 	return p.cur.onSequentialTail1(stack["p"])
 }
 
-func (c *current) onProc4(proc interface{}) (interface{}, error) {
+func (c *current) onProc3(proc interface{}) (interface{}, error) {
 	return proc, nil
 
 }
 
-func (p *parser) callonProc4() (interface{}, error) {
+func (p *parser) callonProc3() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onProc4(stack["proc"])
+	return p.cur.onProc3(stack["proc"])
 }
 
 func (c *current) onProcs1(first, rest interface{}) (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -253,10 +253,14 @@ function peg$parse(input, options) {
       peg$c51 = "|",
       peg$c52 = peg$literalExpectation("|", false),
       peg$c53 = function(p) { return p },
-      peg$c54 = function(proc) {
+      peg$c54 = "split",
+      peg$c55 = peg$literalExpectation("split", false),
+      peg$c56 = "=>",
+      peg$c57 = peg$literalExpectation("=>", false),
+      peg$c58 = function(proc) {
             return proc
           },
-      peg$c55 = function(first, rest) {
+      peg$c59 = function(first, rest) {
             let fp = {"op": "SequentialProc", "procs": first}
             if (rest) {
               return {"op": "ParallelProc", "procs": [fp, ... rest]}
@@ -264,69 +268,69 @@ function peg$parse(input, options) {
               return fp
             }
           },
-      peg$c56 = ";",
-      peg$c57 = peg$literalExpectation(";", false),
-      peg$c58 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
-      peg$c59 = function(every, keys, limit) {
+      peg$c60 = ";",
+      peg$c61 = peg$literalExpectation(";", false),
+      peg$c62 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
+      peg$c63 = function(every, keys, limit) {
             return {"op": "GroupByProc", "keys": keys, "reducers": null, "duration": every, "limit": limit}
           },
-      peg$c60 = function(every, reducers, keys, limit) {
+      peg$c64 = function(every, reducers, keys, limit) {
             let p = {"op": "GroupByProc", "keys": null, "reducers": reducers, "duration": every, "limit": limit}
             if (keys) {
               p["keys"] = keys[1]
             }
             return p
           },
-      peg$c61 = "every",
-      peg$c62 = peg$literalExpectation("every", true),
-      peg$c63 = function(dur) { return dur },
-      peg$c64 = "by",
-      peg$c65 = peg$literalExpectation("by", true),
-      peg$c66 = function(columns) { return columns },
-      peg$c67 = "with",
-      peg$c68 = peg$literalExpectation("with", false),
-      peg$c69 = "-limit",
-      peg$c70 = peg$literalExpectation("-limit", false),
-      peg$c71 = function(limit) { return limit },
-      peg$c72 = "",
-      peg$c73 = function() { return 0 },
-      peg$c74 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c75 = ",",
-      peg$c76 = peg$literalExpectation(",", false),
-      peg$c77 = function(first, expr) { return expr },
-      peg$c78 = function(first, rest) {
+      peg$c65 = "every",
+      peg$c66 = peg$literalExpectation("every", true),
+      peg$c67 = function(dur) { return dur },
+      peg$c68 = "by",
+      peg$c69 = peg$literalExpectation("by", true),
+      peg$c70 = function(columns) { return columns },
+      peg$c71 = "with",
+      peg$c72 = peg$literalExpectation("with", false),
+      peg$c73 = "-limit",
+      peg$c74 = peg$literalExpectation("-limit", false),
+      peg$c75 = function(limit) { return limit },
+      peg$c76 = "",
+      peg$c77 = function() { return 0 },
+      peg$c78 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c79 = ",",
+      peg$c80 = peg$literalExpectation(",", false),
+      peg$c81 = function(first, expr) { return expr },
+      peg$c82 = function(first, rest) {
             return [first, ... rest]
           },
-      peg$c79 = "=",
-      peg$c80 = peg$literalExpectation("=", false),
-      peg$c81 = function(lval, reducer) {
+      peg$c83 = "=",
+      peg$c84 = peg$literalExpectation("=", false),
+      peg$c85 = function(lval, reducer) {
             return {"op": "Assignment", "lhs": lval, "rhs": reducer}
           },
-      peg$c82 = function(reducer) {
+      peg$c86 = function(reducer) {
             return {"op": "Assignment", "lhs": null, "rhs": reducer}
           },
-      peg$c83 = "not",
-      peg$c84 = peg$literalExpectation("not", false),
-      peg$c85 = function(op, expr, where) {
+      peg$c87 = "not",
+      peg$c88 = peg$literalExpectation("not", false),
+      peg$c89 = function(op, expr, where) {
             let r = {"op": "Reducer", "operator": op, "expr": null, "where":where}
             if (expr) {
               r["expr"] = expr
             }
             return r
           },
-      peg$c86 = "where",
-      peg$c87 = peg$literalExpectation("where", false),
-      peg$c88 = function(first, rest) {
+      peg$c90 = "where",
+      peg$c91 = peg$literalExpectation("where", false),
+      peg$c92 = function(first, rest) {
             let result = [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c89 = "sort",
-      peg$c90 = peg$literalExpectation("sort", true),
-      peg$c91 = function(args, l) { return l },
-      peg$c92 = function(args, list) {
+      peg$c93 = "sort",
+      peg$c94 = peg$literalExpectation("sort", true),
+      peg$c95 = function(args, l) { return l },
+      peg$c96 = function(args, list) {
             let argm = args
             let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false}
             if ( "r" in argm) {
@@ -339,26 +343,26 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c93 = function(a) { return a },
-      peg$c94 = function(args) { return makeArgMap(args) },
-      peg$c95 = "-r",
-      peg$c96 = peg$literalExpectation("-r", false),
-      peg$c97 = function() { return {"name": "r", "value": null} },
-      peg$c98 = "-nulls",
-      peg$c99 = peg$literalExpectation("-nulls", false),
-      peg$c100 = "first",
-      peg$c101 = peg$literalExpectation("first", false),
-      peg$c102 = "last",
-      peg$c103 = peg$literalExpectation("last", false),
-      peg$c104 = function() { return text() },
-      peg$c105 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c106 = "top",
-      peg$c107 = peg$literalExpectation("top", true),
-      peg$c108 = function(n) { return n},
-      peg$c109 = "-flush",
-      peg$c110 = peg$literalExpectation("-flush", false),
-      peg$c111 = function(limit, flush, f) { return f },
-      peg$c112 = function(limit, flush, fields) {
+      peg$c97 = function(a) { return a },
+      peg$c98 = function(args) { return makeArgMap(args) },
+      peg$c99 = "-r",
+      peg$c100 = peg$literalExpectation("-r", false),
+      peg$c101 = function() { return {"name": "r", "value": null} },
+      peg$c102 = "-nulls",
+      peg$c103 = peg$literalExpectation("-nulls", false),
+      peg$c104 = "first",
+      peg$c105 = peg$literalExpectation("first", false),
+      peg$c106 = "last",
+      peg$c107 = peg$literalExpectation("last", false),
+      peg$c108 = function() { return text() },
+      peg$c109 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c110 = "top",
+      peg$c111 = peg$literalExpectation("top", true),
+      peg$c112 = function(n) { return n},
+      peg$c113 = "-flush",
+      peg$c114 = peg$literalExpectation("-flush", false),
+      peg$c115 = function(limit, flush, f) { return f },
+      peg$c116 = function(limit, flush, fields) {
             let proc = {"op": "TopProc", "limit": 0, "fields": null, "flush": false}
             if (limit) {
               proc["limit"] = limit
@@ -371,9 +375,9 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c113 = "cut",
-      peg$c114 = peg$literalExpectation("cut", true),
-      peg$c115 = function(args, columns) {
+      peg$c117 = "cut",
+      peg$c118 = peg$literalExpectation("cut", true),
+      peg$c119 = function(args, columns) {
             let argm = args
             let proc = {"op": "CutProc", "fields": columns, "complement": false}
             if ( "c" in argm) {
@@ -381,77 +385,77 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c116 = "-c",
-      peg$c117 = peg$literalExpectation("-c", false),
-      peg$c118 = function() { return {"name": "c", "value": null} },
-      peg$c119 = function(args) {
+      peg$c120 = "-c",
+      peg$c121 = peg$literalExpectation("-c", false),
+      peg$c122 = function() { return {"name": "c", "value": null} },
+      peg$c123 = function(args) {
             return makeArgMap(args)
           },
-      peg$c120 = "pick",
-      peg$c121 = peg$literalExpectation("pick", true),
-      peg$c122 = function(columns) {
+      peg$c124 = "pick",
+      peg$c125 = peg$literalExpectation("pick", true),
+      peg$c126 = function(columns) {
             return {"op": "PickProc", "fields": columns}
           },
-      peg$c123 = "drop",
-      peg$c124 = peg$literalExpectation("drop", true),
-      peg$c125 = function(columns) {
+      peg$c127 = "drop",
+      peg$c128 = peg$literalExpectation("drop", true),
+      peg$c129 = function(columns) {
             return {"op": "DropProc", "fields": columns}
           },
-      peg$c126 = "head",
-      peg$c127 = peg$literalExpectation("head", true),
-      peg$c128 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c129 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c130 = "tail",
-      peg$c131 = peg$literalExpectation("tail", true),
-      peg$c132 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c133 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c134 = "filter",
-      peg$c135 = peg$literalExpectation("filter", true),
-      peg$c136 = "uniq",
-      peg$c137 = peg$literalExpectation("uniq", true),
-      peg$c138 = function() {
+      peg$c130 = "head",
+      peg$c131 = peg$literalExpectation("head", true),
+      peg$c132 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c133 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c134 = "tail",
+      peg$c135 = peg$literalExpectation("tail", true),
+      peg$c136 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c137 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c138 = "filter",
+      peg$c139 = peg$literalExpectation("filter", true),
+      peg$c140 = "uniq",
+      peg$c141 = peg$literalExpectation("uniq", true),
+      peg$c142 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c139 = function() {
+      peg$c143 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c140 = "put",
-      peg$c141 = peg$literalExpectation("put", true),
-      peg$c142 = function(columns) {
+      peg$c144 = "put",
+      peg$c145 = peg$literalExpectation("put", true),
+      peg$c146 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c143 = "rename",
-      peg$c144 = peg$literalExpectation("rename", true),
-      peg$c145 = function(first, cl) { return cl },
-      peg$c146 = function(first, rest) {
+      peg$c147 = "rename",
+      peg$c148 = peg$literalExpectation("rename", true),
+      peg$c149 = function(first, cl) { return cl },
+      peg$c150 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c147 = "fuse",
-      peg$c148 = peg$literalExpectation("fuse", true),
-      peg$c149 = function() {
+      peg$c151 = "fuse",
+      peg$c152 = peg$literalExpectation("fuse", true),
+      peg$c153 = function() {
             return {"op": "FuseProc"}
           },
-      peg$c150 = "join",
-      peg$c151 = peg$literalExpectation("join", true),
-      peg$c152 = function(leftKey, rightKey, columns) {
+      peg$c154 = "join",
+      peg$c155 = peg$literalExpectation("join", true),
+      peg$c156 = function(leftKey, rightKey, columns) {
             let proc = {"op": "JoinProc", "left_key": leftKey, "right_key": rightKey, "clauses": null}
             if (columns) {
               proc["clauses"] = columns[1]
             }
             return proc
           },
-      peg$c153 = function(key, columns) {
+      peg$c157 = function(key, columns) {
             let proc = {"op": "JoinProc", "left_key": key, "right_key": key, "clauses": null}
             if (columns) {
               proc["clauses"] = columns[1]
             }
             return proc
           },
-      peg$c154 = ".",
-      peg$c155 = peg$literalExpectation(".", false),
-      peg$c156 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
-      peg$c157 = function() { return {"op": "RootRecord"} },
-      peg$c158 = function(first, rest) {
+      peg$c158 = ".",
+      peg$c159 = peg$literalExpectation(".", false),
+      peg$c160 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
+      peg$c161 = function() { return {"op": "RootRecord"} },
+      peg$c162 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -460,273 +464,273 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c159 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c160 = "?",
-      peg$c161 = peg$literalExpectation("?", false),
-      peg$c162 = ":",
-      peg$c163 = peg$literalExpectation(":", false),
-      peg$c164 = function(condition, thenClause, elseClause) {
+      peg$c163 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c164 = "?",
+      peg$c165 = peg$literalExpectation("?", false),
+      peg$c166 = ":",
+      peg$c167 = peg$literalExpectation(":", false),
+      peg$c168 = function(condition, thenClause, elseClause) {
             return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c165 = function(first, op, expr) { return [op, expr] },
-      peg$c166 = function(first, rest) {
+      peg$c169 = function(first, op, expr) { return [op, expr] },
+      peg$c170 = function(first, rest) {
               return makeBinaryExprChain(first, rest)
           },
-      peg$c167 = function(first, comp, expr) { return [comp, expr] },
-      peg$c168 = "=~",
-      peg$c169 = peg$literalExpectation("=~", false),
-      peg$c170 = "!~",
-      peg$c171 = peg$literalExpectation("!~", false),
-      peg$c172 = "!=",
-      peg$c173 = peg$literalExpectation("!=", false),
-      peg$c174 = "in",
-      peg$c175 = peg$literalExpectation("in", false),
-      peg$c176 = "<=",
-      peg$c177 = peg$literalExpectation("<=", false),
-      peg$c178 = "<",
-      peg$c179 = peg$literalExpectation("<", false),
-      peg$c180 = ">=",
-      peg$c181 = peg$literalExpectation(">=", false),
-      peg$c182 = ">",
-      peg$c183 = peg$literalExpectation(">", false),
-      peg$c184 = "+",
-      peg$c185 = peg$literalExpectation("+", false),
-      peg$c186 = "/",
-      peg$c187 = peg$literalExpectation("/", false),
-      peg$c188 = function(e) {
+      peg$c171 = function(first, comp, expr) { return [comp, expr] },
+      peg$c172 = "=~",
+      peg$c173 = peg$literalExpectation("=~", false),
+      peg$c174 = "!~",
+      peg$c175 = peg$literalExpectation("!~", false),
+      peg$c176 = "!=",
+      peg$c177 = peg$literalExpectation("!=", false),
+      peg$c178 = "in",
+      peg$c179 = peg$literalExpectation("in", false),
+      peg$c180 = "<=",
+      peg$c181 = peg$literalExpectation("<=", false),
+      peg$c182 = "<",
+      peg$c183 = peg$literalExpectation("<", false),
+      peg$c184 = ">=",
+      peg$c185 = peg$literalExpectation(">=", false),
+      peg$c186 = ">",
+      peg$c187 = peg$literalExpectation(">", false),
+      peg$c188 = "+",
+      peg$c189 = peg$literalExpectation("+", false),
+      peg$c190 = "/",
+      peg$c191 = peg$literalExpectation("/", false),
+      peg$c192 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c189 = function(e, typ) { return typ },
-      peg$c190 = function(e, typ) {
+      peg$c193 = function(e, typ) { return typ },
+      peg$c194 = function(e, typ) {
             return {"op": "CastExpr", "expr": e, "type": typ}
           },
-      peg$c191 = "bytes",
-      peg$c192 = peg$literalExpectation("bytes", false),
-      peg$c193 = "uint8",
-      peg$c194 = peg$literalExpectation("uint8", false),
-      peg$c195 = "uint16",
-      peg$c196 = peg$literalExpectation("uint16", false),
-      peg$c197 = "uint32",
-      peg$c198 = peg$literalExpectation("uint32", false),
-      peg$c199 = "uint64",
-      peg$c200 = peg$literalExpectation("uint64", false),
-      peg$c201 = "int8",
-      peg$c202 = peg$literalExpectation("int8", false),
-      peg$c203 = "int16",
-      peg$c204 = peg$literalExpectation("int16", false),
-      peg$c205 = "int32",
-      peg$c206 = peg$literalExpectation("int32", false),
-      peg$c207 = "int64",
-      peg$c208 = peg$literalExpectation("int64", false),
-      peg$c209 = "duration",
-      peg$c210 = peg$literalExpectation("duration", false),
-      peg$c211 = "time",
-      peg$c212 = peg$literalExpectation("time", false),
-      peg$c213 = "float64",
-      peg$c214 = peg$literalExpectation("float64", false),
-      peg$c215 = "bool",
-      peg$c216 = peg$literalExpectation("bool", false),
-      peg$c217 = "string",
-      peg$c218 = peg$literalExpectation("string", false),
-      peg$c219 = "bstring",
-      peg$c220 = peg$literalExpectation("bstring", false),
-      peg$c221 = "ip",
-      peg$c222 = peg$literalExpectation("ip", false),
-      peg$c223 = "net",
-      peg$c224 = peg$literalExpectation("net", false),
-      peg$c225 = "type",
-      peg$c226 = peg$literalExpectation("type", false),
-      peg$c227 = "error",
-      peg$c228 = peg$literalExpectation("error", false),
-      peg$c229 = function(first, rest) {
+      peg$c195 = "bytes",
+      peg$c196 = peg$literalExpectation("bytes", false),
+      peg$c197 = "uint8",
+      peg$c198 = peg$literalExpectation("uint8", false),
+      peg$c199 = "uint16",
+      peg$c200 = peg$literalExpectation("uint16", false),
+      peg$c201 = "uint32",
+      peg$c202 = peg$literalExpectation("uint32", false),
+      peg$c203 = "uint64",
+      peg$c204 = peg$literalExpectation("uint64", false),
+      peg$c205 = "int8",
+      peg$c206 = peg$literalExpectation("int8", false),
+      peg$c207 = "int16",
+      peg$c208 = peg$literalExpectation("int16", false),
+      peg$c209 = "int32",
+      peg$c210 = peg$literalExpectation("int32", false),
+      peg$c211 = "int64",
+      peg$c212 = peg$literalExpectation("int64", false),
+      peg$c213 = "duration",
+      peg$c214 = peg$literalExpectation("duration", false),
+      peg$c215 = "time",
+      peg$c216 = peg$literalExpectation("time", false),
+      peg$c217 = "float64",
+      peg$c218 = peg$literalExpectation("float64", false),
+      peg$c219 = "bool",
+      peg$c220 = peg$literalExpectation("bool", false),
+      peg$c221 = "string",
+      peg$c222 = peg$literalExpectation("string", false),
+      peg$c223 = "bstring",
+      peg$c224 = peg$literalExpectation("bstring", false),
+      peg$c225 = "ip",
+      peg$c226 = peg$literalExpectation("ip", false),
+      peg$c227 = "net",
+      peg$c228 = peg$literalExpectation("net", false),
+      peg$c229 = "type",
+      peg$c230 = peg$literalExpectation("type", false),
+      peg$c231 = "error",
+      peg$c232 = peg$literalExpectation("error", false),
+      peg$c233 = function(first, rest) {
             return makeBinaryExprChain(first, rest)
           },
-      peg$c230 = function(fn, args) {
+      peg$c234 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c231 = function(first, e) { return e },
-      peg$c232 = function() { return [] },
-      peg$c233 = "[",
-      peg$c234 = peg$literalExpectation("[", false),
-      peg$c235 = "]",
-      peg$c236 = peg$literalExpectation("]", false),
-      peg$c237 = function(expr) { return ["[", expr] },
-      peg$c238 = function(id) { return [".", id] },
-      peg$c239 = "and",
-      peg$c240 = peg$literalExpectation("and", true),
-      peg$c241 = "or",
-      peg$c242 = peg$literalExpectation("or", true),
-      peg$c243 = peg$literalExpectation("in", true),
-      peg$c244 = peg$literalExpectation("not", true),
-      peg$c245 = /^[A-Za-z_$]/,
-      peg$c246 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c247 = /^[0-9]/,
-      peg$c248 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c249 = function() { return {"op": "Identifier", "name": text()} },
-      peg$c250 = peg$literalExpectation("and", false),
-      peg$c251 = "seconds",
-      peg$c252 = peg$literalExpectation("seconds", false),
-      peg$c253 = "second",
-      peg$c254 = peg$literalExpectation("second", false),
-      peg$c255 = "secs",
-      peg$c256 = peg$literalExpectation("secs", false),
-      peg$c257 = "sec",
-      peg$c258 = peg$literalExpectation("sec", false),
-      peg$c259 = "s",
-      peg$c260 = peg$literalExpectation("s", false),
-      peg$c261 = "minutes",
-      peg$c262 = peg$literalExpectation("minutes", false),
-      peg$c263 = "minute",
-      peg$c264 = peg$literalExpectation("minute", false),
-      peg$c265 = "mins",
-      peg$c266 = peg$literalExpectation("mins", false),
-      peg$c267 = "min",
-      peg$c268 = peg$literalExpectation("min", false),
-      peg$c269 = "m",
-      peg$c270 = peg$literalExpectation("m", false),
-      peg$c271 = "hours",
-      peg$c272 = peg$literalExpectation("hours", false),
-      peg$c273 = "hrs",
-      peg$c274 = peg$literalExpectation("hrs", false),
-      peg$c275 = "hr",
-      peg$c276 = peg$literalExpectation("hr", false),
-      peg$c277 = "h",
-      peg$c278 = peg$literalExpectation("h", false),
-      peg$c279 = "hour",
-      peg$c280 = peg$literalExpectation("hour", false),
-      peg$c281 = "days",
-      peg$c282 = peg$literalExpectation("days", false),
-      peg$c283 = "day",
-      peg$c284 = peg$literalExpectation("day", false),
-      peg$c285 = "d",
-      peg$c286 = peg$literalExpectation("d", false),
-      peg$c287 = "weeks",
-      peg$c288 = peg$literalExpectation("weeks", false),
-      peg$c289 = "week",
-      peg$c290 = peg$literalExpectation("week", false),
-      peg$c291 = "wks",
-      peg$c292 = peg$literalExpectation("wks", false),
-      peg$c293 = "wk",
-      peg$c294 = peg$literalExpectation("wk", false),
-      peg$c295 = "w",
-      peg$c296 = peg$literalExpectation("w", false),
-      peg$c297 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c298 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c299 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c300 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c301 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c302 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c303 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c304 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c305 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c306 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c307 = function(a, b) {
+      peg$c235 = function(first, e) { return e },
+      peg$c236 = function() { return [] },
+      peg$c237 = "[",
+      peg$c238 = peg$literalExpectation("[", false),
+      peg$c239 = "]",
+      peg$c240 = peg$literalExpectation("]", false),
+      peg$c241 = function(expr) { return ["[", expr] },
+      peg$c242 = function(id) { return [".", id] },
+      peg$c243 = "and",
+      peg$c244 = peg$literalExpectation("and", true),
+      peg$c245 = "or",
+      peg$c246 = peg$literalExpectation("or", true),
+      peg$c247 = peg$literalExpectation("in", true),
+      peg$c248 = peg$literalExpectation("not", true),
+      peg$c249 = /^[A-Za-z_$]/,
+      peg$c250 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c251 = /^[0-9]/,
+      peg$c252 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c253 = function() { return {"op": "Identifier", "name": text()} },
+      peg$c254 = peg$literalExpectation("and", false),
+      peg$c255 = "seconds",
+      peg$c256 = peg$literalExpectation("seconds", false),
+      peg$c257 = "second",
+      peg$c258 = peg$literalExpectation("second", false),
+      peg$c259 = "secs",
+      peg$c260 = peg$literalExpectation("secs", false),
+      peg$c261 = "sec",
+      peg$c262 = peg$literalExpectation("sec", false),
+      peg$c263 = "s",
+      peg$c264 = peg$literalExpectation("s", false),
+      peg$c265 = "minutes",
+      peg$c266 = peg$literalExpectation("minutes", false),
+      peg$c267 = "minute",
+      peg$c268 = peg$literalExpectation("minute", false),
+      peg$c269 = "mins",
+      peg$c270 = peg$literalExpectation("mins", false),
+      peg$c271 = "min",
+      peg$c272 = peg$literalExpectation("min", false),
+      peg$c273 = "m",
+      peg$c274 = peg$literalExpectation("m", false),
+      peg$c275 = "hours",
+      peg$c276 = peg$literalExpectation("hours", false),
+      peg$c277 = "hrs",
+      peg$c278 = peg$literalExpectation("hrs", false),
+      peg$c279 = "hr",
+      peg$c280 = peg$literalExpectation("hr", false),
+      peg$c281 = "h",
+      peg$c282 = peg$literalExpectation("h", false),
+      peg$c283 = "hour",
+      peg$c284 = peg$literalExpectation("hour", false),
+      peg$c285 = "days",
+      peg$c286 = peg$literalExpectation("days", false),
+      peg$c287 = "day",
+      peg$c288 = peg$literalExpectation("day", false),
+      peg$c289 = "d",
+      peg$c290 = peg$literalExpectation("d", false),
+      peg$c291 = "weeks",
+      peg$c292 = peg$literalExpectation("weeks", false),
+      peg$c293 = "week",
+      peg$c294 = peg$literalExpectation("week", false),
+      peg$c295 = "wks",
+      peg$c296 = peg$literalExpectation("wks", false),
+      peg$c297 = "wk",
+      peg$c298 = peg$literalExpectation("wk", false),
+      peg$c299 = "w",
+      peg$c300 = peg$literalExpectation("w", false),
+      peg$c301 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c302 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c303 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c304 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c305 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c306 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c307 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c308 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c309 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c310 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c311 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c308 = "::",
-      peg$c309 = peg$literalExpectation("::", false),
-      peg$c310 = function(a, b, d, e) {
+      peg$c312 = "::",
+      peg$c313 = peg$literalExpectation("::", false),
+      peg$c314 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c311 = function(a, b) {
+      peg$c315 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c312 = function(a, b) {
+      peg$c316 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c313 = function() {
+      peg$c317 = function() {
             return "::"
           },
-      peg$c314 = function(v) { return ":" + v },
-      peg$c315 = function(v) { return v + ":" },
-      peg$c316 = function(a, m) {
+      peg$c318 = function(v) { return ":" + v },
+      peg$c319 = function(v) { return v + ":" },
+      peg$c320 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c317 = function(a, m) {
+      peg$c321 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c318 = function(s) { return parseInt(s) },
-      peg$c319 = function() {
+      peg$c322 = function(s) { return parseInt(s) },
+      peg$c323 = function() {
             return text()
           },
-      peg$c320 = "e",
-      peg$c321 = peg$literalExpectation("e", true),
-      peg$c322 = /^[+\-]/,
-      peg$c323 = peg$classExpectation(["+", "-"], false, false),
-      peg$c324 = /^[0-9a-fA-F]/,
-      peg$c325 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c326 = function(chars) { return joinChars(chars) },
-      peg$c327 = "\\",
-      peg$c328 = peg$literalExpectation("\\", false),
-      peg$c329 = /^[\0-\x1F\\(),!><="|';:]/,
-      peg$c330 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
-      peg$c331 = peg$anyExpectation(),
-      peg$c332 = "\"",
-      peg$c333 = peg$literalExpectation("\"", false),
-      peg$c334 = function(v) { return joinChars(v) },
-      peg$c335 = "'",
-      peg$c336 = peg$literalExpectation("'", false),
-      peg$c337 = "x",
-      peg$c338 = peg$literalExpectation("x", false),
-      peg$c339 = function() { return "\\" + text() },
-      peg$c340 = "b",
-      peg$c341 = peg$literalExpectation("b", false),
-      peg$c342 = function() { return "\b" },
-      peg$c343 = "f",
-      peg$c344 = peg$literalExpectation("f", false),
-      peg$c345 = function() { return "\f" },
-      peg$c346 = "n",
-      peg$c347 = peg$literalExpectation("n", false),
-      peg$c348 = function() { return "\n" },
-      peg$c349 = "r",
-      peg$c350 = peg$literalExpectation("r", false),
-      peg$c351 = function() { return "\r" },
-      peg$c352 = "t",
-      peg$c353 = peg$literalExpectation("t", false),
-      peg$c354 = function() { return "\t" },
-      peg$c355 = "v",
-      peg$c356 = peg$literalExpectation("v", false),
-      peg$c357 = function() { return "\v" },
-      peg$c358 = function() { return "=" },
-      peg$c359 = function() { return "\\*" },
-      peg$c360 = "u",
-      peg$c361 = peg$literalExpectation("u", false),
-      peg$c362 = function(chars) {
+      peg$c324 = "e",
+      peg$c325 = peg$literalExpectation("e", true),
+      peg$c326 = /^[+\-]/,
+      peg$c327 = peg$classExpectation(["+", "-"], false, false),
+      peg$c328 = /^[0-9a-fA-F]/,
+      peg$c329 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c330 = function(chars) { return joinChars(chars) },
+      peg$c331 = "\\",
+      peg$c332 = peg$literalExpectation("\\", false),
+      peg$c333 = /^[\0-\x1F\\(),!><="|';:]/,
+      peg$c334 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
+      peg$c335 = peg$anyExpectation(),
+      peg$c336 = "\"",
+      peg$c337 = peg$literalExpectation("\"", false),
+      peg$c338 = function(v) { return joinChars(v) },
+      peg$c339 = "'",
+      peg$c340 = peg$literalExpectation("'", false),
+      peg$c341 = "x",
+      peg$c342 = peg$literalExpectation("x", false),
+      peg$c343 = function() { return "\\" + text() },
+      peg$c344 = "b",
+      peg$c345 = peg$literalExpectation("b", false),
+      peg$c346 = function() { return "\b" },
+      peg$c347 = "f",
+      peg$c348 = peg$literalExpectation("f", false),
+      peg$c349 = function() { return "\f" },
+      peg$c350 = "n",
+      peg$c351 = peg$literalExpectation("n", false),
+      peg$c352 = function() { return "\n" },
+      peg$c353 = "r",
+      peg$c354 = peg$literalExpectation("r", false),
+      peg$c355 = function() { return "\r" },
+      peg$c356 = "t",
+      peg$c357 = peg$literalExpectation("t", false),
+      peg$c358 = function() { return "\t" },
+      peg$c359 = "v",
+      peg$c360 = peg$literalExpectation("v", false),
+      peg$c361 = function() { return "\v" },
+      peg$c362 = function() { return "=" },
+      peg$c363 = function() { return "\\*" },
+      peg$c364 = "u",
+      peg$c365 = peg$literalExpectation("u", false),
+      peg$c366 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c363 = "{",
-      peg$c364 = peg$literalExpectation("{", false),
-      peg$c365 = "}",
-      peg$c366 = peg$literalExpectation("}", false),
-      peg$c367 = function(body) { return body },
-      peg$c368 = /^[^\/\\]/,
-      peg$c369 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c370 = "\\/",
-      peg$c371 = peg$literalExpectation("\\/", false),
-      peg$c372 = /^[\0-\x1F\\]/,
-      peg$c373 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c374 = peg$otherExpectation("whitespace"),
-      peg$c375 = "\t",
-      peg$c376 = peg$literalExpectation("\t", false),
-      peg$c377 = "\x0B",
-      peg$c378 = peg$literalExpectation("\x0B", false),
-      peg$c379 = "\f",
-      peg$c380 = peg$literalExpectation("\f", false),
-      peg$c381 = " ",
-      peg$c382 = peg$literalExpectation(" ", false),
-      peg$c383 = "\xA0",
-      peg$c384 = peg$literalExpectation("\xA0", false),
-      peg$c385 = "\uFEFF",
-      peg$c386 = peg$literalExpectation("\uFEFF", false),
-      peg$c387 = /^[\n\r\u2028\u2029]/,
-      peg$c388 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c389 = peg$otherExpectation("comment"),
-      peg$c390 = "/*",
-      peg$c391 = peg$literalExpectation("/*", false),
-      peg$c392 = "*/",
-      peg$c393 = peg$literalExpectation("*/", false),
-      peg$c394 = "//",
-      peg$c395 = peg$literalExpectation("//", false),
+      peg$c367 = "{",
+      peg$c368 = peg$literalExpectation("{", false),
+      peg$c369 = "}",
+      peg$c370 = peg$literalExpectation("}", false),
+      peg$c371 = function(body) { return body },
+      peg$c372 = /^[^\/\\]/,
+      peg$c373 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c374 = "\\/",
+      peg$c375 = peg$literalExpectation("\\/", false),
+      peg$c376 = /^[\0-\x1F\\]/,
+      peg$c377 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c378 = peg$otherExpectation("whitespace"),
+      peg$c379 = "\t",
+      peg$c380 = peg$literalExpectation("\t", false),
+      peg$c381 = "\x0B",
+      peg$c382 = peg$literalExpectation("\x0B", false),
+      peg$c383 = "\f",
+      peg$c384 = peg$literalExpectation("\f", false),
+      peg$c385 = " ",
+      peg$c386 = peg$literalExpectation(" ", false),
+      peg$c387 = "\xA0",
+      peg$c388 = peg$literalExpectation("\xA0", false),
+      peg$c389 = "\uFEFF",
+      peg$c390 = peg$literalExpectation("\uFEFF", false),
+      peg$c391 = /^[\n\r\u2028\u2029]/,
+      peg$c392 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c393 = peg$otherExpectation("comment"),
+      peg$c394 = "/*",
+      peg$c395 = peg$literalExpectation("/*", false),
+      peg$c396 = "*/",
+      peg$c397 = peg$literalExpectation("*/", false),
+      peg$c398 = "//",
+      peg$c399 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -1999,38 +2003,68 @@ function peg$parse(input, options) {
   }
 
   function peg$parseProc() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$parseNamedProc();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseGroupByProc();
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c14;
-          peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c15); }
-        }
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parse__();
-          if (s2 !== peg$FAILED) {
-            s3 = peg$parseProcs();
-            if (s3 !== peg$FAILED) {
-              s4 = peg$parse__();
-              if (s4 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c16;
-                  peg$currPos++;
-                } else {
-                  s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c17); }
-                }
-                if (s5 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c54(s3);
-                  s0 = s1;
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 5) === peg$c54) {
+        s1 = peg$c54;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c55); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse__();
+        if (s2 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 40) {
+            s3 = peg$c14;
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c15); }
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse__();
+            if (s4 !== peg$FAILED) {
+              if (input.substr(peg$currPos, 2) === peg$c56) {
+                s5 = peg$c56;
+                peg$currPos += 2;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c57); }
+              }
+              if (s5 !== peg$FAILED) {
+                s6 = peg$parse__();
+                if (s6 !== peg$FAILED) {
+                  s7 = peg$parseProcs();
+                  if (s7 !== peg$FAILED) {
+                    s8 = peg$parse__();
+                    if (s8 !== peg$FAILED) {
+                      if (input.charCodeAt(peg$currPos) === 41) {
+                        s9 = peg$c16;
+                        peg$currPos++;
+                      } else {
+                        s9 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                      }
+                      if (s9 !== peg$FAILED) {
+                        peg$savedPos = s0;
+                        s1 = peg$c58(s7);
+                        s0 = s1;
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -2051,6 +2085,12 @@ function peg$parse(input, options) {
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseGroupByProc();
       }
     }
 
@@ -2071,7 +2111,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c55(s1, s2);
+        s1 = peg$c59(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2086,26 +2126,47 @@ function peg$parse(input, options) {
   }
 
   function peg$parseParallelTail() {
-    var s0, s1, s2, s3, s4;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 59) {
-        s2 = peg$c56;
+        s2 = peg$c60;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c57); }
+        if (peg$silentFails === 0) { peg$fail(peg$c61); }
+      }
+      if (s2 === peg$FAILED) {
+        s2 = null;
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseSequentialProcs();
+          if (input.substr(peg$currPos, 2) === peg$c56) {
+            s4 = peg$c56;
+            peg$currPos += 2;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c57); }
+          }
           if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c58(s4);
-            s0 = s1;
+            s5 = peg$parse__();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parseSequentialProcs();
+              if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c62(s6);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -2140,7 +2201,7 @@ function peg$parse(input, options) {
         s3 = peg$parseLimitArg();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c59(s1, s2, s3);
+          s1 = peg$c63(s1, s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2188,7 +2249,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c60(s1, s2, s3, s4);
+              s1 = peg$c64(s1, s2, s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2215,12 +2276,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c61) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c65) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c62); }
+      if (peg$silentFails === 0) { peg$fail(peg$c66); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2230,7 +2291,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c63(s3);
+            s1 = peg$c67(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2256,12 +2317,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c64) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c68) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c65); }
+      if (peg$silentFails === 0) { peg$fail(peg$c69); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2269,7 +2330,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c66(s3);
+          s1 = peg$c70(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2293,22 +2354,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c67) {
-        s2 = peg$c67;
+      if (input.substr(peg$currPos, 4) === peg$c71) {
+        s2 = peg$c71;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c68); }
+        if (peg$silentFails === 0) { peg$fail(peg$c72); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c69) {
-            s4 = peg$c69;
+          if (input.substr(peg$currPos, 6) === peg$c73) {
+            s4 = peg$c73;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c70); }
+            if (peg$silentFails === 0) { peg$fail(peg$c74); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -2316,7 +2377,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c71(s6);
+                s1 = peg$c75(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2344,10 +2405,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c72;
+      s1 = peg$c76;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c73();
+        s1 = peg$c77();
       }
       s0 = s1;
     }
@@ -2364,7 +2425,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c74(s1);
+        s1 = peg$c78(s1);
       }
       s0 = s1;
     }
@@ -2383,11 +2444,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c79;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2395,7 +2456,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c77(s1, s7);
+              s4 = peg$c81(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2419,11 +2480,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c79;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2431,7 +2492,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c77(s1, s7);
+                s4 = peg$c81(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2452,7 +2513,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c78(s1, s2);
+        s1 = peg$c82(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2475,11 +2536,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c79;
+          s3 = peg$c83;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c84); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -2487,7 +2548,7 @@ function peg$parse(input, options) {
             s5 = peg$parseReducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c81(s1, s5);
+              s1 = peg$c85(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2514,7 +2575,7 @@ function peg$parse(input, options) {
       s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c82(s1);
+        s1 = peg$c86(s1);
       }
       s0 = s1;
     }
@@ -2528,12 +2589,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
-    if (input.substr(peg$currPos, 3) === peg$c83) {
-      s2 = peg$c83;
+    if (input.substr(peg$currPos, 3) === peg$c87) {
+      s2 = peg$c87;
       peg$currPos += 3;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c84); }
+      if (peg$silentFails === 0) { peg$fail(peg$c88); }
     }
     if (s2 === peg$FAILED) {
       if (input.substr(peg$currPos, 3) === peg$c26) {
@@ -2587,7 +2648,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c85(s2, s6, s9);
+                      s1 = peg$c89(s2, s6, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -2635,12 +2696,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c86) {
-        s2 = peg$c86;
+      if (input.substr(peg$currPos, 5) === peg$c90) {
+        s2 = peg$c90;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c87); }
+        if (peg$silentFails === 0) { peg$fail(peg$c91); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -2681,11 +2742,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c79;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2716,11 +2777,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c79;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2748,7 +2809,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c88(s1, s2);
+        s1 = peg$c92(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2810,12 +2871,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c89) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c93) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c90); }
+      if (peg$silentFails === 0) { peg$fail(peg$c94); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -2826,7 +2887,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c91(s2, s5);
+            s4 = peg$c95(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2841,7 +2902,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c92(s2, s3);
+          s1 = peg$c96(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2870,7 +2931,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c93(s4);
+        s3 = peg$c97(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -2888,7 +2949,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c93(s4);
+          s3 = peg$c97(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -2901,7 +2962,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c94(s1);
+      s1 = peg$c98(s1);
     }
     s0 = s1;
 
@@ -2912,55 +2973,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c95) {
-      s1 = peg$c95;
+    if (input.substr(peg$currPos, 2) === peg$c99) {
+      s1 = peg$c99;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c96); }
+      if (peg$silentFails === 0) { peg$fail(peg$c100); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c97();
+      s1 = peg$c101();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c98) {
-        s1 = peg$c98;
+      if (input.substr(peg$currPos, 6) === peg$c102) {
+        s1 = peg$c102;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        if (peg$silentFails === 0) { peg$fail(peg$c103); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c100) {
-            s4 = peg$c100;
+          if (input.substr(peg$currPos, 5) === peg$c104) {
+            s4 = peg$c104;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c105); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c102) {
-              s4 = peg$c102;
+            if (input.substr(peg$currPos, 4) === peg$c106) {
+              s4 = peg$c106;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c103); }
+              if (peg$silentFails === 0) { peg$fail(peg$c107); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c104();
+            s4 = peg$c108();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c105(s3);
+            s1 = peg$c109(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2983,12 +3044,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c106) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c110) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c107); }
+      if (peg$silentFails === 0) { peg$fail(peg$c111); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -2997,7 +3058,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c108(s4);
+          s3 = peg$c112(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3014,12 +3075,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c109) {
-            s5 = peg$c109;
+          if (input.substr(peg$currPos, 6) === peg$c113) {
+            s5 = peg$c113;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3042,7 +3103,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c111(s2, s3, s6);
+              s5 = peg$c115(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3057,7 +3118,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c112(s2, s3, s4);
+            s1 = peg$c116(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3083,12 +3144,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c113) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c117) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c114); }
+      if (peg$silentFails === 0) { peg$fail(peg$c118); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseCutArgs();
@@ -3098,7 +3159,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFlexAssignments();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c115(s2, s4);
+            s1 = peg$c119(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3128,16 +3189,16 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     s3 = peg$parse_();
     if (s3 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c116) {
-        s4 = peg$c116;
+      if (input.substr(peg$currPos, 2) === peg$c120) {
+        s4 = peg$c120;
         peg$currPos += 2;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c117); }
+        if (peg$silentFails === 0) { peg$fail(peg$c121); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c118();
+        s3 = peg$c122();
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3152,16 +3213,16 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c116) {
-          s4 = peg$c116;
+        if (input.substr(peg$currPos, 2) === peg$c120) {
+          s4 = peg$c120;
           peg$currPos += 2;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c117); }
+          if (peg$silentFails === 0) { peg$fail(peg$c121); }
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c118();
+          s3 = peg$c122();
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3174,7 +3235,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c119(s1);
+      s1 = peg$c123(s1);
     }
     s0 = s1;
 
@@ -3185,12 +3246,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c120) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c124) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c121); }
+      if (peg$silentFails === 0) { peg$fail(peg$c125); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3198,7 +3259,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c122(s3);
+          s1 = peg$c126(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3220,12 +3281,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c123) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c127) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c124); }
+      if (peg$silentFails === 0) { peg$fail(peg$c128); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3233,7 +3294,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFieldExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c125(s3);
+          s1 = peg$c129(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3252,56 +3313,6 @@ function peg$parse(input, options) {
   }
 
   function peg$parseHeadProc() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c126) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c127); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseUInt();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c128(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c126) {
-        s1 = input.substr(peg$currPos, 4);
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c127); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c129();
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseTailProc() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -3351,16 +3362,66 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseTailProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c134) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c135); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseUInt();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c136(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c134) {
+        s1 = input.substr(peg$currPos, 4);
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c135); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c137();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
   function peg$parseFilterProc() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c134) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c138) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c135); }
+      if (peg$silentFails === 0) { peg$fail(peg$c139); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3390,26 +3451,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c136) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c140) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c137); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c116) {
-          s3 = peg$c116;
+        if (input.substr(peg$currPos, 2) === peg$c120) {
+          s3 = peg$c120;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c117); }
+          if (peg$silentFails === 0) { peg$fail(peg$c121); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c138();
+          s1 = peg$c142();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3425,16 +3486,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c136) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c140) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c137); }
+        if (peg$silentFails === 0) { peg$fail(peg$c141); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c139();
+        s1 = peg$c143();
       }
       s0 = s1;
     }
@@ -3446,12 +3507,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c140) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c144) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c145); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3459,7 +3520,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c142(s3);
+          s1 = peg$c146(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3481,12 +3542,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c143) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c147) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c144); }
+      if (peg$silentFails === 0) { peg$fail(peg$c148); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3498,11 +3559,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c75;
+              s7 = peg$c79;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c76); }
+              if (peg$silentFails === 0) { peg$fail(peg$c80); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -3510,7 +3571,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c145(s3, s9);
+                  s6 = peg$c149(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -3534,11 +3595,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c75;
+                s7 = peg$c79;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                if (peg$silentFails === 0) { peg$fail(peg$c80); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -3546,7 +3607,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c145(s3, s9);
+                    s6 = peg$c149(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -3567,7 +3628,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c146(s3, s4);
+            s1 = peg$c150(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3593,16 +3654,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c147) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c151) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c152); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c149();
+      s1 = peg$c153();
     }
     s0 = s1;
 
@@ -3613,12 +3674,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c151); }
+      if (peg$silentFails === 0) { peg$fail(peg$c155); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3628,11 +3689,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 61) {
-              s5 = peg$c79;
+              s5 = peg$c83;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c80); }
+              if (peg$silentFails === 0) { peg$fail(peg$c84); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
@@ -3659,7 +3720,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c152(s3, s7, s8);
+                    s1 = peg$c156(s3, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3695,12 +3756,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c151); }
+        if (peg$silentFails === 0) { peg$fail(peg$c155); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -3727,7 +3788,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c153(s3, s4);
+              s1 = peg$c157(s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3799,11 +3860,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c154;
+      s1 = peg$c158;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+      if (peg$silentFails === 0) { peg$fail(peg$c159); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -3826,7 +3887,7 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifier();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c156(s3);
+          s1 = peg$c160(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3843,11 +3904,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c154;
+        s1 = peg$c158;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c159); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
@@ -3862,7 +3923,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c157();
+          s1 = peg$c161();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3888,11 +3949,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c79;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3923,11 +3984,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c79;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -3955,7 +4016,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c162(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3980,11 +4041,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c79;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -4015,11 +4076,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c79;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -4047,7 +4108,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s1, s2);
+        s1 = peg$c162(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4070,11 +4131,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c79;
+          s3 = peg$c83;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c84); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4082,7 +4143,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c159(s1, s5);
+              s1 = peg$c163(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4125,11 +4186,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c160;
+          s3 = peg$c164;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c161); }
+          if (peg$silentFails === 0) { peg$fail(peg$c165); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4139,11 +4200,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c162;
+                  s7 = peg$c166;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c163); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c167); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -4151,7 +4212,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c164(s1, s5, s9);
+                      s1 = peg$c168(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4213,7 +4274,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c165(s1, s5, s7);
+              s4 = peg$c169(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4243,7 +4304,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c165(s1, s5, s7);
+                s4 = peg$c169(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4264,7 +4325,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c166(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4295,7 +4356,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c165(s1, s5, s7);
+              s4 = peg$c169(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4325,7 +4386,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c165(s1, s5, s7);
+                s4 = peg$c169(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4346,7 +4407,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c166(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4377,7 +4438,7 @@ function peg$parse(input, options) {
             s7 = peg$parseRelativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c167(s1, s5, s7);
+              s4 = peg$c171(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4407,7 +4468,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c167(s1, s5, s7);
+                s4 = peg$c171(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4428,7 +4489,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c166(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4446,43 +4507,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c168) {
-      s1 = peg$c168;
+    if (input.substr(peg$currPos, 2) === peg$c172) {
+      s1 = peg$c172;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c169); }
+      if (peg$silentFails === 0) { peg$fail(peg$c173); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c170) {
-        s1 = peg$c170;
+      if (input.substr(peg$currPos, 2) === peg$c174) {
+        s1 = peg$c174;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c171); }
+        if (peg$silentFails === 0) { peg$fail(peg$c175); }
       }
       if (s1 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c79;
+          s1 = peg$c83;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c84); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c172) {
-            s1 = peg$c172;
+          if (input.substr(peg$currPos, 2) === peg$c176) {
+            s1 = peg$c176;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c173); }
+            if (peg$silentFails === 0) { peg$fail(peg$c177); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -4495,16 +4556,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c174) {
-        s1 = peg$c174;
+      if (input.substr(peg$currPos, 2) === peg$c178) {
+        s1 = peg$c178;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
+        if (peg$silentFails === 0) { peg$fail(peg$c179); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c108();
       }
       s0 = s1;
     }
@@ -4529,7 +4590,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c165(s1, s5, s7);
+              s4 = peg$c169(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4559,7 +4620,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c165(s1, s5, s7);
+                s4 = peg$c169(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4580,7 +4641,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c166(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4598,43 +4659,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c176) {
-      s1 = peg$c176;
+    if (input.substr(peg$currPos, 2) === peg$c180) {
+      s1 = peg$c180;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c177); }
+      if (peg$silentFails === 0) { peg$fail(peg$c181); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c178;
+        s1 = peg$c182;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c183); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c180) {
-          s1 = peg$c180;
+        if (input.substr(peg$currPos, 2) === peg$c184) {
+          s1 = peg$c184;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c181); }
+          if (peg$silentFails === 0) { peg$fail(peg$c185); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c182;
+            s1 = peg$c186;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c183); }
+            if (peg$silentFails === 0) { peg$fail(peg$c187); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -4658,7 +4719,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c165(s1, s5, s7);
+              s4 = peg$c169(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4688,7 +4749,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c165(s1, s5, s7);
+                s4 = peg$c169(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4709,7 +4770,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c166(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4728,11 +4789,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c184;
+      s1 = peg$c188;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c185); }
+      if (peg$silentFails === 0) { peg$fail(peg$c189); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
@@ -4745,7 +4806,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -4769,7 +4830,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c165(s1, s5, s7);
+              s4 = peg$c169(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4799,7 +4860,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c165(s1, s5, s7);
+                s4 = peg$c169(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4820,7 +4881,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c166(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4847,16 +4908,16 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c186;
+        s1 = peg$c190;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c187); }
+        if (peg$silentFails === 0) { peg$fail(peg$c191); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -4880,7 +4941,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c188(s3);
+          s1 = peg$c192(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4909,17 +4970,17 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 58) {
-        s3 = peg$c162;
+        s3 = peg$c166;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c167); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parsePrimitiveType();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c189(s1, s4);
+          s3 = peg$c193(s1, s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4931,7 +4992,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c190(s1, s2);
+        s1 = peg$c194(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4952,164 +5013,164 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c191) {
-      s1 = peg$c191;
+    if (input.substr(peg$currPos, 5) === peg$c195) {
+      s1 = peg$c195;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c192); }
+      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c193) {
-        s1 = peg$c193;
+      if (input.substr(peg$currPos, 5) === peg$c197) {
+        s1 = peg$c197;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c194); }
+        if (peg$silentFails === 0) { peg$fail(peg$c198); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c195) {
-          s1 = peg$c195;
+        if (input.substr(peg$currPos, 6) === peg$c199) {
+          s1 = peg$c199;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c196); }
+          if (peg$silentFails === 0) { peg$fail(peg$c200); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c197) {
-            s1 = peg$c197;
+          if (input.substr(peg$currPos, 6) === peg$c201) {
+            s1 = peg$c201;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c198); }
+            if (peg$silentFails === 0) { peg$fail(peg$c202); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c199) {
-              s1 = peg$c199;
+            if (input.substr(peg$currPos, 6) === peg$c203) {
+              s1 = peg$c203;
               peg$currPos += 6;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c200); }
+              if (peg$silentFails === 0) { peg$fail(peg$c204); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4) === peg$c201) {
-                s1 = peg$c201;
+              if (input.substr(peg$currPos, 4) === peg$c205) {
+                s1 = peg$c205;
                 peg$currPos += 4;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c202); }
+                if (peg$silentFails === 0) { peg$fail(peg$c206); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c203) {
-                  s1 = peg$c203;
+                if (input.substr(peg$currPos, 5) === peg$c207) {
+                  s1 = peg$c207;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c204); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c208); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c205) {
-                    s1 = peg$c205;
+                  if (input.substr(peg$currPos, 5) === peg$c209) {
+                    s1 = peg$c209;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c206); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c210); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c207) {
-                      s1 = peg$c207;
+                    if (input.substr(peg$currPos, 5) === peg$c211) {
+                      s1 = peg$c211;
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c208); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c212); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 8) === peg$c209) {
-                        s1 = peg$c209;
+                      if (input.substr(peg$currPos, 8) === peg$c213) {
+                        s1 = peg$c213;
                         peg$currPos += 8;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c210); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c214); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c211) {
-                          s1 = peg$c211;
+                        if (input.substr(peg$currPos, 4) === peg$c215) {
+                          s1 = peg$c215;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c212); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c216); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 7) === peg$c213) {
-                            s1 = peg$c213;
+                          if (input.substr(peg$currPos, 7) === peg$c217) {
+                            s1 = peg$c217;
                             peg$currPos += 7;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c214); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c218); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 4) === peg$c215) {
-                              s1 = peg$c215;
+                            if (input.substr(peg$currPos, 4) === peg$c219) {
+                              s1 = peg$c219;
                               peg$currPos += 4;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c220); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 5) === peg$c191) {
-                                s1 = peg$c191;
+                              if (input.substr(peg$currPos, 5) === peg$c195) {
+                                s1 = peg$c195;
                                 peg$currPos += 5;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c192); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c196); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 6) === peg$c217) {
-                                  s1 = peg$c217;
+                                if (input.substr(peg$currPos, 6) === peg$c221) {
+                                  s1 = peg$c221;
                                   peg$currPos += 6;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c218); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c222); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 7) === peg$c219) {
-                                    s1 = peg$c219;
+                                  if (input.substr(peg$currPos, 7) === peg$c223) {
+                                    s1 = peg$c223;
                                     peg$currPos += 7;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c220); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c224); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c221) {
-                                      s1 = peg$c221;
+                                    if (input.substr(peg$currPos, 2) === peg$c225) {
+                                      s1 = peg$c225;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c222); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c226); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c223) {
-                                        s1 = peg$c223;
+                                      if (input.substr(peg$currPos, 3) === peg$c227) {
+                                        s1 = peg$c227;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c224); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c228); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c225) {
-                                          s1 = peg$c225;
+                                        if (input.substr(peg$currPos, 4) === peg$c229) {
+                                          s1 = peg$c229;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c226); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c230); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 5) === peg$c227) {
-                                            s1 = peg$c227;
+                                          if (input.substr(peg$currPos, 5) === peg$c231) {
+                                            s1 = peg$c231;
                                             peg$currPos += 5;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c228); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c232); }
                                           }
                                           if (s1 === peg$FAILED) {
                                             if (input.substr(peg$currPos, 4) === peg$c47) {
@@ -5141,7 +5202,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -5162,7 +5223,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c229(s1, s2);
+        s1 = peg$c233(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5209,7 +5270,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c230(s1, s4);
+              s1 = peg$c234(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5245,11 +5306,11 @@ function peg$parse(input, options) {
       s3 = peg$parseIdentifierRest();
       if (s3 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c154;
+          s3 = peg$c158;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c159); }
         }
       }
       while (s3 !== peg$FAILED) {
@@ -5257,17 +5318,17 @@ function peg$parse(input, options) {
         s3 = peg$parseIdentifierRest();
         if (s3 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s3 = peg$c154;
+            s3 = peg$c158;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c155); }
+            if (peg$silentFails === 0) { peg$fail(peg$c159); }
           }
         }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c108();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5292,11 +5353,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c75;
+          s5 = peg$c79;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c80); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5304,7 +5365,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c231(s1, s7);
+              s4 = peg$c235(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5328,11 +5389,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c75;
+            s5 = peg$c79;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c80); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5340,7 +5401,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c231(s1, s7);
+                s4 = peg$c235(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5361,7 +5422,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c78(s1, s2);
+        s1 = peg$c82(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5376,7 +5437,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c232();
+        s1 = peg$c236();
       }
       s0 = s1;
     }
@@ -5398,7 +5459,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c229(s1, s2);
+        s1 = peg$c233(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5417,25 +5478,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c233;
+      s1 = peg$c237;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c234); }
+      if (peg$silentFails === 0) { peg$fail(peg$c238); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseConditionalExpr();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c235;
+          s3 = peg$c239;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c236); }
+          if (peg$silentFails === 0) { peg$fail(peg$c240); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c237(s2);
+          s1 = peg$c241(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5452,21 +5513,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c154;
+        s1 = peg$c158;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c159); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c154;
+          s3 = peg$c158;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c159); }
         }
         peg$silentFails--;
         if (s3 === peg$FAILED) {
@@ -5479,7 +5540,7 @@ function peg$parse(input, options) {
           s3 = peg$parseIdentifier();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c238(s3);
+            s1 = peg$c242(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5590,16 +5651,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c239) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c243) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c240); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -5610,16 +5671,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c241) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c245) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c242); }
+      if (peg$silentFails === 0) { peg$fail(peg$c246); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -5630,16 +5691,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c174) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c178) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c243); }
+      if (peg$silentFails === 0) { peg$fail(peg$c247); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -5650,16 +5711,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c83) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c87) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c248); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -5680,7 +5741,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c108();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5697,12 +5758,12 @@ function peg$parse(input, options) {
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c245.test(input.charAt(peg$currPos))) {
+    if (peg$c249.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c250); }
     }
 
     return s0;
@@ -5713,12 +5774,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c247.test(input.charAt(peg$currPos))) {
+      if (peg$c251.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c248); }
+        if (peg$silentFails === 0) { peg$fail(peg$c252); }
       }
     }
 
@@ -5739,7 +5800,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c249();
+        s1 = peg$c253();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5767,12 +5828,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c239) {
-                s3 = peg$c239;
+              if (input.substr(peg$currPos, 3) === peg$c243) {
+                s3 = peg$c243;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c250); }
+                if (peg$silentFails === 0) { peg$fail(peg$c254); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -5817,44 +5878,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c251) {
-      s0 = peg$c251;
+    if (input.substr(peg$currPos, 7) === peg$c255) {
+      s0 = peg$c255;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c252); }
+      if (peg$silentFails === 0) { peg$fail(peg$c256); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c253) {
-        s0 = peg$c253;
+      if (input.substr(peg$currPos, 6) === peg$c257) {
+        s0 = peg$c257;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c254); }
+        if (peg$silentFails === 0) { peg$fail(peg$c258); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c255) {
-          s0 = peg$c255;
+        if (input.substr(peg$currPos, 4) === peg$c259) {
+          s0 = peg$c259;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c256); }
+          if (peg$silentFails === 0) { peg$fail(peg$c260); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c257) {
-            s0 = peg$c257;
+          if (input.substr(peg$currPos, 3) === peg$c261) {
+            s0 = peg$c261;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c258); }
+            if (peg$silentFails === 0) { peg$fail(peg$c262); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c259;
+              s0 = peg$c263;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c260); }
+              if (peg$silentFails === 0) { peg$fail(peg$c264); }
             }
           }
         }
@@ -5867,44 +5928,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c261) {
-      s0 = peg$c261;
+    if (input.substr(peg$currPos, 7) === peg$c265) {
+      s0 = peg$c265;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c262); }
+      if (peg$silentFails === 0) { peg$fail(peg$c266); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c263) {
-        s0 = peg$c263;
+      if (input.substr(peg$currPos, 6) === peg$c267) {
+        s0 = peg$c267;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c264); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c265) {
-          s0 = peg$c265;
+        if (input.substr(peg$currPos, 4) === peg$c269) {
+          s0 = peg$c269;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c266); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c267) {
-            s0 = peg$c267;
+          if (input.substr(peg$currPos, 3) === peg$c271) {
+            s0 = peg$c271;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c268); }
+            if (peg$silentFails === 0) { peg$fail(peg$c272); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c269;
+              s0 = peg$c273;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c270); }
+              if (peg$silentFails === 0) { peg$fail(peg$c274); }
             }
           }
         }
@@ -5917,44 +5978,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c271) {
-      s0 = peg$c271;
+    if (input.substr(peg$currPos, 5) === peg$c275) {
+      s0 = peg$c275;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c272); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c273) {
-        s0 = peg$c273;
+      if (input.substr(peg$currPos, 3) === peg$c277) {
+        s0 = peg$c277;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c274); }
+        if (peg$silentFails === 0) { peg$fail(peg$c278); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c275) {
-          s0 = peg$c275;
+        if (input.substr(peg$currPos, 2) === peg$c279) {
+          s0 = peg$c279;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c276); }
+          if (peg$silentFails === 0) { peg$fail(peg$c280); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c277;
+            s0 = peg$c281;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c278); }
+            if (peg$silentFails === 0) { peg$fail(peg$c282); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c279) {
-              s0 = peg$c279;
+            if (input.substr(peg$currPos, 4) === peg$c283) {
+              s0 = peg$c283;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c280); }
+              if (peg$silentFails === 0) { peg$fail(peg$c284); }
             }
           }
         }
@@ -5967,28 +6028,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c281) {
-      s0 = peg$c281;
+    if (input.substr(peg$currPos, 4) === peg$c285) {
+      s0 = peg$c285;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+      if (peg$silentFails === 0) { peg$fail(peg$c286); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c283) {
-        s0 = peg$c283;
+      if (input.substr(peg$currPos, 3) === peg$c287) {
+        s0 = peg$c287;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+        if (peg$silentFails === 0) { peg$fail(peg$c288); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c285;
+          s0 = peg$c289;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+          if (peg$silentFails === 0) { peg$fail(peg$c290); }
         }
       }
     }
@@ -5999,44 +6060,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c287) {
-      s0 = peg$c287;
+    if (input.substr(peg$currPos, 5) === peg$c291) {
+      s0 = peg$c291;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c288); }
+      if (peg$silentFails === 0) { peg$fail(peg$c292); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c289) {
-        s0 = peg$c289;
+      if (input.substr(peg$currPos, 4) === peg$c293) {
+        s0 = peg$c293;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c290); }
+        if (peg$silentFails === 0) { peg$fail(peg$c294); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c291) {
-          s0 = peg$c291;
+        if (input.substr(peg$currPos, 3) === peg$c295) {
+          s0 = peg$c295;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c292); }
+          if (peg$silentFails === 0) { peg$fail(peg$c296); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c293) {
-            s0 = peg$c293;
+          if (input.substr(peg$currPos, 2) === peg$c297) {
+            s0 = peg$c297;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c294); }
+            if (peg$silentFails === 0) { peg$fail(peg$c298); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c295;
+              s0 = peg$c299;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c296); }
+              if (peg$silentFails === 0) { peg$fail(peg$c300); }
             }
           }
         }
@@ -6050,16 +6111,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c253) {
-      s1 = peg$c253;
+    if (input.substr(peg$currPos, 6) === peg$c257) {
+      s1 = peg$c257;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c254); }
+      if (peg$silentFails === 0) { peg$fail(peg$c258); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c297();
+      s1 = peg$c301();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6071,7 +6132,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c298(s1);
+            s1 = peg$c302(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6094,16 +6155,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c263) {
-      s1 = peg$c263;
+    if (input.substr(peg$currPos, 6) === peg$c267) {
+      s1 = peg$c267;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+      if (peg$silentFails === 0) { peg$fail(peg$c268); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c299();
+      s1 = peg$c303();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6115,7 +6176,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c300(s1);
+            s1 = peg$c304(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6138,16 +6199,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c279) {
-      s1 = peg$c279;
+    if (input.substr(peg$currPos, 4) === peg$c283) {
+      s1 = peg$c283;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c284); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c301();
+      s1 = peg$c305();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6159,7 +6220,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c302(s1);
+            s1 = peg$c306(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6182,16 +6243,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c283) {
-      s1 = peg$c283;
+    if (input.substr(peg$currPos, 3) === peg$c287) {
+      s1 = peg$c287;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c284); }
+      if (peg$silentFails === 0) { peg$fail(peg$c288); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c303();
+      s1 = peg$c307();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6203,7 +6264,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c304(s1);
+            s1 = peg$c308(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6226,16 +6287,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c289) {
-      s1 = peg$c289;
+    if (input.substr(peg$currPos, 4) === peg$c293) {
+      s1 = peg$c293;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c290); }
+      if (peg$silentFails === 0) { peg$fail(peg$c294); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c305();
+      s1 = peg$c309();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6247,7 +6308,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c306(s1);
+            s1 = peg$c310(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6273,37 +6334,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c154;
+        s2 = peg$c158;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c159); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c154;
+            s4 = peg$c158;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c155); }
+            if (peg$silentFails === 0) { peg$fail(peg$c159); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c154;
+                s6 = peg$c158;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c155); }
+                if (peg$silentFails === 0) { peg$fail(peg$c159); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c104();
+                  s1 = peg$c108();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6355,7 +6416,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c307(s1, s2);
+        s1 = peg$c311(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6376,12 +6437,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c308) {
-            s3 = peg$c308;
+          if (input.substr(peg$currPos, 2) === peg$c312) {
+            s3 = peg$c312;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c309); }
+            if (peg$silentFails === 0) { peg$fail(peg$c313); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6394,7 +6455,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c310(s1, s2, s4, s5);
+                s1 = peg$c314(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6418,12 +6479,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c308) {
-          s1 = peg$c308;
+        if (input.substr(peg$currPos, 2) === peg$c312) {
+          s1 = peg$c312;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c309); }
+          if (peg$silentFails === 0) { peg$fail(peg$c313); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6436,7 +6497,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c311(s2, s3);
+              s1 = peg$c315(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6461,16 +6522,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c308) {
-                s3 = peg$c308;
+              if (input.substr(peg$currPos, 2) === peg$c312) {
+                s3 = peg$c312;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c309); }
+                if (peg$silentFails === 0) { peg$fail(peg$c313); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c312(s1, s2);
+                s1 = peg$c316(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6486,16 +6547,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c308) {
-              s1 = peg$c308;
+            if (input.substr(peg$currPos, 2) === peg$c312) {
+              s1 = peg$c312;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c309); }
+              if (peg$silentFails === 0) { peg$fail(peg$c313); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c313();
+              s1 = peg$c317();
             }
             s0 = s1;
           }
@@ -6522,17 +6583,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c162;
+      s1 = peg$c166;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c163); }
+      if (peg$silentFails === 0) { peg$fail(peg$c167); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c314(s2);
+        s1 = peg$c318(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6553,15 +6614,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c162;
+        s2 = peg$c166;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c167); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c315(s1);
+        s1 = peg$c319(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6582,17 +6643,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c186;
+        s2 = peg$c190;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c187); }
+        if (peg$silentFails === 0) { peg$fail(peg$c191); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c316(s1, s3);
+          s1 = peg$c320(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6617,17 +6678,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c186;
+        s2 = peg$c190;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c187); }
+        if (peg$silentFails === 0) { peg$fail(peg$c191); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c317(s1, s3);
+          s1 = peg$c321(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6652,7 +6713,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c318(s1);
+      s1 = peg$c322(s1);
     }
     s0 = s1;
 
@@ -6675,22 +6736,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c247.test(input.charAt(peg$currPos))) {
+    if (peg$c251.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c248); }
+      if (peg$silentFails === 0) { peg$fail(peg$c252); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c247.test(input.charAt(peg$currPos))) {
+        if (peg$c251.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c248); }
+          if (peg$silentFails === 0) { peg$fail(peg$c252); }
         }
       }
     } else {
@@ -6698,7 +6759,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -6720,7 +6781,7 @@ function peg$parse(input, options) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c108();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6750,22 +6811,22 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c247.test(input.charAt(peg$currPos))) {
+      if (peg$c251.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c248); }
+        if (peg$silentFails === 0) { peg$fail(peg$c252); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c247.test(input.charAt(peg$currPos))) {
+          if (peg$c251.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c248); }
+            if (peg$silentFails === 0) { peg$fail(peg$c252); }
           }
         }
       } else {
@@ -6773,30 +6834,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c154;
+          s3 = peg$c158;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c159); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c247.test(input.charAt(peg$currPos))) {
+          if (peg$c251.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c248); }
+            if (peg$silentFails === 0) { peg$fail(peg$c252); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c247.test(input.charAt(peg$currPos))) {
+              if (peg$c251.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c248); }
+                if (peg$silentFails === 0) { peg$fail(peg$c252); }
               }
             }
           } else {
@@ -6809,7 +6870,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c319();
+              s1 = peg$c323();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6845,30 +6906,30 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c154;
+          s2 = peg$c158;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c155); }
+          if (peg$silentFails === 0) { peg$fail(peg$c159); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c247.test(input.charAt(peg$currPos))) {
+          if (peg$c251.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c248); }
+            if (peg$silentFails === 0) { peg$fail(peg$c252); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c247.test(input.charAt(peg$currPos))) {
+              if (peg$c251.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c248); }
+                if (peg$silentFails === 0) { peg$fail(peg$c252); }
               }
             }
           } else {
@@ -6881,7 +6942,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c319();
+              s1 = peg$c323();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6908,20 +6969,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c320) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c324) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c321); }
+      if (peg$silentFails === 0) { peg$fail(peg$c325); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c322.test(input.charAt(peg$currPos))) {
+      if (peg$c326.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c323); }
+        if (peg$silentFails === 0) { peg$fail(peg$c327); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -6963,7 +7024,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -6973,12 +7034,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c324.test(input.charAt(peg$currPos))) {
+    if (peg$c328.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c329); }
     }
 
     return s0;
@@ -7000,7 +7061,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c326(s1);
+      s1 = peg$c330(s1);
     }
     s0 = s1;
 
@@ -7012,11 +7073,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c327;
+      s1 = peg$c331;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c328); }
+      if (peg$silentFails === 0) { peg$fail(peg$c332); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
@@ -7039,12 +7100,12 @@ function peg$parse(input, options) {
       s0 = peg$currPos;
       s1 = peg$currPos;
       peg$silentFails++;
-      if (peg$c329.test(input.charAt(peg$currPos))) {
+      if (peg$c333.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c330); }
+        if (peg$silentFails === 0) { peg$fail(peg$c334); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$parseWhiteSpace();
@@ -7062,11 +7123,11 @@ function peg$parse(input, options) {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c331); }
+          if (peg$silentFails === 0) { peg$fail(peg$c335); }
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c104();
+          s1 = peg$c108();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7086,11 +7147,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c332;
+      s1 = peg$c336;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c333); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -7101,15 +7162,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c332;
+          s3 = peg$c336;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c333); }
+          if (peg$silentFails === 0) { peg$fail(peg$c337); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c334(s2);
+          s1 = peg$c338(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7126,11 +7187,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c335;
+        s1 = peg$c339;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c336); }
+        if (peg$silentFails === 0) { peg$fail(peg$c340); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7141,15 +7202,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c335;
+            s3 = peg$c339;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c336); }
+            if (peg$silentFails === 0) { peg$fail(peg$c340); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c334(s2);
+            s1 = peg$c338(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7175,11 +7236,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c332;
+      s2 = peg$c336;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c333); }
+      if (peg$silentFails === 0) { peg$fail(peg$c337); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -7197,11 +7258,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c331); }
+        if (peg$silentFails === 0) { peg$fail(peg$c335); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c108();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7214,11 +7275,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c327;
+        s1 = peg$c331;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c328); }
+        if (peg$silentFails === 0) { peg$fail(peg$c332); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -7246,11 +7307,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c335;
+      s2 = peg$c339;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c336); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -7268,11 +7329,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c331); }
+        if (peg$silentFails === 0) { peg$fail(peg$c335); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104();
+        s1 = peg$c108();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7285,11 +7346,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c327;
+        s1 = peg$c331;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c328); }
+        if (peg$silentFails === 0) { peg$fail(peg$c332); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
@@ -7315,11 +7376,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c337;
+      s1 = peg$c341;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c338); }
+      if (peg$silentFails === 0) { peg$fail(peg$c342); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -7327,7 +7388,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c339();
+          s1 = peg$c343();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7355,110 +7416,110 @@ function peg$parse(input, options) {
     var s0, s1;
 
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c335;
+      s0 = peg$c339;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c336); }
+      if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c332;
+        s0 = peg$c336;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c333); }
+        if (peg$silentFails === 0) { peg$fail(peg$c337); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c327;
+          s0 = peg$c331;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c328); }
+          if (peg$silentFails === 0) { peg$fail(peg$c332); }
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c340;
+            s1 = peg$c344;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c341); }
+            if (peg$silentFails === 0) { peg$fail(peg$c345); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c342();
+            s1 = peg$c346();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c343;
+              s1 = peg$c347;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c344); }
+              if (peg$silentFails === 0) { peg$fail(peg$c348); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c345();
+              s1 = peg$c349();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c346;
+                s1 = peg$c350;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c347); }
+                if (peg$silentFails === 0) { peg$fail(peg$c351); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c348();
+                s1 = peg$c352();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c349;
+                  s1 = peg$c353;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c350); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c354); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c351();
+                  s1 = peg$c355();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c352;
+                    s1 = peg$c356;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c353); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c357); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c354();
+                    s1 = peg$c358();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c355;
+                      s1 = peg$c359;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c356); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c360); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c357();
+                      s1 = peg$c361();
                     }
                     s0 = s1;
                   }
@@ -7478,15 +7539,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c79;
+      s1 = peg$c83;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c80); }
+      if (peg$silentFails === 0) { peg$fail(peg$c84); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c358();
+      s1 = peg$c362();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7500,7 +7561,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c359();
+        s1 = peg$c363();
       }
       s0 = s1;
     }
@@ -7513,11 +7574,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c360;
+      s1 = peg$c364;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c361); }
+      if (peg$silentFails === 0) { peg$fail(peg$c365); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7549,7 +7610,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c362(s2);
+        s1 = peg$c366(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7562,19 +7623,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c360;
+        s1 = peg$c364;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c361); }
+        if (peg$silentFails === 0) { peg$fail(peg$c365); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c363;
+          s2 = peg$c367;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c364); }
+          if (peg$silentFails === 0) { peg$fail(peg$c368); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7633,15 +7694,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c365;
+              s4 = peg$c369;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c366); }
+              if (peg$silentFails === 0) { peg$fail(peg$c370); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c362(s3);
+              s1 = peg$c366(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7669,25 +7730,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c186;
+      s1 = peg$c190;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c187); }
+      if (peg$silentFails === 0) { peg$fail(peg$c191); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c186;
+          s3 = peg$c190;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c187); }
+          if (peg$silentFails === 0) { peg$fail(peg$c191); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c367(s2);
+          s1 = peg$c371(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7710,39 +7771,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c368.test(input.charAt(peg$currPos))) {
+    if (peg$c372.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c369); }
+      if (peg$silentFails === 0) { peg$fail(peg$c373); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c370) {
-        s2 = peg$c370;
+      if (input.substr(peg$currPos, 2) === peg$c374) {
+        s2 = peg$c374;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c371); }
+        if (peg$silentFails === 0) { peg$fail(peg$c375); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c368.test(input.charAt(peg$currPos))) {
+        if (peg$c372.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c369); }
+          if (peg$silentFails === 0) { peg$fail(peg$c373); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c370) {
-            s2 = peg$c370;
+          if (input.substr(peg$currPos, 2) === peg$c374) {
+            s2 = peg$c374;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c371); }
+            if (peg$silentFails === 0) { peg$fail(peg$c375); }
           }
         }
       }
@@ -7751,7 +7812,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c108();
     }
     s0 = s1;
 
@@ -7761,12 +7822,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c372.test(input.charAt(peg$currPos))) {
+    if (peg$c376.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c377); }
     }
 
     return s0;
@@ -7824,7 +7885,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c331); }
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
     }
 
     return s0;
@@ -7835,51 +7896,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c375;
+      s0 = peg$c379;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c376); }
+      if (peg$silentFails === 0) { peg$fail(peg$c380); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c377;
+        s0 = peg$c381;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c378); }
+        if (peg$silentFails === 0) { peg$fail(peg$c382); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c379;
+          s0 = peg$c383;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c380); }
+          if (peg$silentFails === 0) { peg$fail(peg$c384); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c381;
+            s0 = peg$c385;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c382); }
+            if (peg$silentFails === 0) { peg$fail(peg$c386); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c383;
+              s0 = peg$c387;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c384); }
+              if (peg$silentFails === 0) { peg$fail(peg$c388); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c385;
+                s0 = peg$c389;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c386); }
+                if (peg$silentFails === 0) { peg$fail(peg$c390); }
               }
             }
           }
@@ -7889,7 +7950,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c374); }
+      if (peg$silentFails === 0) { peg$fail(peg$c378); }
     }
 
     return s0;
@@ -7898,12 +7959,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c387.test(input.charAt(peg$currPos))) {
+    if (peg$c391.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c388); }
+      if (peg$silentFails === 0) { peg$fail(peg$c392); }
     }
 
     return s0;
@@ -7917,7 +7978,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
 
     return s0;
@@ -7927,24 +7988,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c390) {
-      s1 = peg$c390;
+    if (input.substr(peg$currPos, 2) === peg$c394) {
+      s1 = peg$c394;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c391); }
+      if (peg$silentFails === 0) { peg$fail(peg$c395); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c392) {
-        s5 = peg$c392;
+      if (input.substr(peg$currPos, 2) === peg$c396) {
+        s5 = peg$c396;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c393); }
+        if (peg$silentFails === 0) { peg$fail(peg$c397); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -7971,12 +8032,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c392) {
-          s5 = peg$c392;
+        if (input.substr(peg$currPos, 2) === peg$c396) {
+          s5 = peg$c396;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c393); }
+          if (peg$silentFails === 0) { peg$fail(peg$c397); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -8000,12 +8061,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c392) {
-          s3 = peg$c392;
+        if (input.substr(peg$currPos, 2) === peg$c396) {
+          s3 = peg$c396;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c393); }
+          if (peg$silentFails === 0) { peg$fail(peg$c397); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -8030,12 +8091,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c394) {
-      s1 = peg$c394;
+    if (input.substr(peg$currPos, 2) === peg$c398) {
+      s1 = peg$c398;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c395); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -8115,7 +8176,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c331); }
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -207,10 +207,10 @@ SequentialTail = __ "|" __ p:Proc { RETURN(p) }
 
 Proc
   = NamedProc
-  / GroupByProc
-  / "(" __ proc:Procs __ ")" {
+  / "split" __ "(" __ "=>" __ proc:Procs __ ")" {
       RETURN(proc)
     }
+  / GroupByProc
 
 Procs
   = first:SequentialProcs rest:ParallelTail* {
@@ -223,7 +223,7 @@ Procs
     }
 
 ParallelTail
-  = __ ";" __ ch:SequentialProcs { RETURN(MAP("op": "SequentialProc", "procs": ch)) }
+  = __ ";"? __ "=>" __ ch:SequentialProcs { RETURN(MAP("op": "SequentialProc", "procs": ch)) }
 
 GroupByProc
   = every:EveryDur? keys:GroupByKeys limit:LimitArg {

--- a/ztests/suite/rename/rename-share.yaml
+++ b/ztests/suite/rename/rename-share.yaml
@@ -1,5 +1,5 @@
 # tests that a rename isn't visible to other procs operating on same records.
-zql: (rename id2=id; cut id.orig_h) | sort id
+zql: split (=>rename id2=id =>cut id.orig_h) | sort id
 
 input: |
   #port=uint16


### PR DESCRIPTION
This commit changes the parallel graph syntax from parens
and semicolons to use the "split" keyword and fat arrows (=>)
as discussed in issue #1790.  The semicolon at the end
of each parallel path is optional.