### PR TITLE
fix rename bug

### DIFF
--- a/proc/rename/rename.go
+++ b/proc/rename/rename.go
@@ -87,14 +87,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 			p.typeMap[id] = typ
 		}
 		out := in.Keep()
-		if id != p.typeMap[id].ID() {
-			if out != in {
-				out.Type = p.typeMap[id]
-			} else {
-				out = zng.NewRecord(p.typeMap[id], out.Raw)
-			}
-		}
-		recs = append(recs, out)
+		recs = append(recs, zng.NewRecord(p.typeMap[id], out.Raw))
 	}
 	batch.Unref()
 	return zbuf.Array(recs), nil

--- a/proc/rename/ztests/count-by.yaml
+++ b/proc/rename/ztests/count-by.yaml
@@ -1,4 +1,4 @@
-zql: 'rename s2=s | count() by s2'
+zql: 'rename s2=s | count() by s2 | sort s2'
 
 # This test previously failed only for binary zng.
 # #0:record[s:string]

--- a/proc/rename/ztests/count-by.yaml
+++ b/proc/rename/ztests/count-by.yaml
@@ -1,0 +1,13 @@
+zql: 'rename s2=s | count() by s2'
+
+# This test previously failed only for binary zng.
+# #0:record[s:string]
+# 0:[a;]
+# 0:[b;]
+# 0:[a;]
+input: !!binary 9gEBcxAXAgRhFwIEYhcCBGH/
+
+output: |
+  #0:record[s2:string,count:uint64]
+  0:[a;2;]
+  0:[b;1;]


### PR DESCRIPTION
This commit fixes a bug in the rename processor where new records
would be created with the wrong alias type.  This will all be fixed
when we rework the zng.Record data structure and batch, but for now
we simplify the code here to always create a new zng.Record so the
proper alias pointer is created.

Fixes #2044
