### PR TITLE
fix bug translating primitive-type aliases between type contexts

### DIFF
--- a/zng/resolver/context.go
+++ b/zng/resolver/context.go
@@ -727,10 +727,6 @@ func (c *Context) parseElement(typ zng.Type, in string) (string, zng.Element, er
 }
 
 func (c *Context) TranslateType(ext zng.Type) (zng.Type, error) {
-	id := ext.ID()
-	if id < zng.IdTypeDef {
-		return ext, nil
-	}
 	switch ext := ext.(type) {
 	case *zng.TypeRecord:
 		return c.TranslateTypeRecord(ext)
@@ -759,8 +755,8 @@ func (c *Context) TranslateType(ext zng.Type) (zng.Type, error) {
 		}
 		return c.LookupTypeAlias(ext.Name, local)
 	default:
-		//XXX
-		panic(fmt.Sprintf("zng cannot translate type: %s", ext))
+		// primitive type
+		return ext, nil
 	}
 }
 

--- a/zng/resolver/ztests/mixed-primitive-alias.yaml
+++ b/zng/resolver/ztests/mixed-primitive-alias.yaml
@@ -1,0 +1,28 @@
+script: |
+  zq -t c.log a.zng
+
+inputs:
+  - name: c.log
+    data: |
+      #separator \x09
+      #set_separator	,
+      #empty_field	(empty)
+      #unset_field	-
+      #path	conn
+      #fields	orig_p
+      #types	port
+      80
+# #port=uint16
+# #0:record[src_port:port]
+# 0:[81;]
+  - name: a.zng
+    data: !!binary /ARwb3J0AfYBCHNyY19wb3J0FxgCBFH/
+
+outputs:
+  - name: stdout
+    data: |
+      #port=uint16
+      #0:record[src_port:port]
+      0:[81;]
+      #1:record[_path:string,orig_p:port]
+      1:[conn;80;]


### PR DESCRIPTION
This commit fixes a bug where an alias for a primitive type was not
being translated into the target context and the alien alias type
instead made its way into the context.  This manifested with the
tzng writer emitting multiple alias typedefs for the same type,
then the tzng reader would complain.

Fixes #2042
