### PR TITLE
fix scanning of zson primitives

### DIFF
--- a/zson/lexer.go
+++ b/zson/lexer.go
@@ -352,11 +352,9 @@ func (l *Lexer) peekPrimitive() (string, error) {
 	var err error
 	var off int
 	for {
-		if off+utf8.UTFMax > len(l.cursor) {
-			err = l.check(off + utf8.UTFMax)
-			if off <= len(l.cursor) || err != nil {
-				break
-			}
+		err = l.check(off + utf8.UTFMax)
+		if err != nil {
+			break
 		}
 		r, n := utf8.DecodeRune(l.cursor[off:])
 		if unicode.IsSpace(r) || r == ',' {


### PR DESCRIPTION
The logic to scan zson primitive values did not properly handle the
recent changes to read input as a stream and had presumed all of
the needed input was in the cursor.  This commit fixes peekPrimitive()
to make sure there is data up to the next whitespace, comma, or EOF
(since none of this can appear in a primitive value).

I would spend a bit more time here to do a bit more review and more 
comprehensive tests at this point, but there are other priorities so I 
created issue #2057 

Fixes #2056 