### PR TITLE
Windows zq: propery route - path to stdin

### DIFF
--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 
 	"github.com/brimsec/zq/cli/auto"
+	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/azngio"
@@ -87,7 +88,7 @@ func (f *Flags) Open(zctx *resolver.Context, paths []string, stopOnErr bool) ([]
 	var warned bool
 	for _, path := range paths {
 		if path == "-" {
-			path = detector.StdinPath
+			path = iosrc.Stdin
 		}
 		file, err := detector.OpenFile(zctx, path, f.ReaderOpts)
 		if err != nil {

--- a/cmd/microindex/convert/command.go
+++ b/cmd/microindex/convert/command.go
@@ -8,6 +8,7 @@ import (
 	"github.com/brimsec/zq/cmd/microindex/root"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/microindex"
+	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
@@ -70,7 +71,7 @@ func (c *Command) Run(args []string) error {
 	}
 	path := args[0]
 	if path == "-" {
-		path = detector.StdinPath
+		path = iosrc.Stdin
 	}
 	zctx := resolver.NewContext()
 	file, err := detector.OpenFile(zctx, path, c.inputFlags.Options())

--- a/cmd/microindex/create/command.go
+++ b/cmd/microindex/create/command.go
@@ -9,6 +9,7 @@ import (
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/microindex"
+	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio/detector"
 	"github.com/brimsec/zq/zng/resolver"
@@ -72,7 +73,7 @@ func (c *Command) Run(args []string) error {
 	}
 	path := args[0]
 	if path == "-" {
-		path = detector.StdinPath
+		path = iosrc.Stdin
 	}
 	zctx := resolver.NewContext()
 	file, err := detector.OpenFile(zctx, path, c.inputFlags.Options())

--- a/pkg/iosrc/uri.go
+++ b/pkg/iosrc/uri.go
@@ -9,9 +9,9 @@ import (
 type URI url.URL
 
 const (
-	stdin  = "stdio:///stdin"
-	stdout = "stdio:///stdout"
-	stderr = "stdio:///stderr"
+	Stdin  = "stdio:///stdin"
+	Stdout = "stdio:///stdout"
+	Stderr = "stdio:///stderr"
 )
 
 // ParseURI parses the path using `url.Parse`. If the provided uri does not

--- a/zio/detector/file.go
+++ b/zio/detector/file.go
@@ -18,8 +18,6 @@ import (
 	"github.com/xitongsys/parquet-go/source"
 )
 
-const StdinPath = "/dev/stdin"
-
 // OpenFile creates and returns zbuf.File for the indicated "path",
 // which can be a local file path, a local directory path, or an S3
 // URL. If the path is neither of these or can't otherwise be opened,


### PR DESCRIPTION
The current logic in zq was translating the stdin path arg '-' in a zq command
to /dev/stdin. While this works in unix environments this does not work for
windows. Instead translate '-' to the iosrc.Stdin representation
'stdio://stdin' so the path is properly routed to stdin in windows.

Closes #2000