### PR TITLE
first step toward unifying search and expressions

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -41,7 +41,7 @@ func TestCompileParents(t *testing.T) {
 		query, err := compiler.ParseProc("split (=>filter * =>filter *) | filter *")
 		require.NoError(t, err)
 
-		leaves, err := compiler.Compile(nil, query, pctx, sources)
+		leaves, err := compiler.Compile(nil, query, pctx, nil, sources)
 		require.NoError(t, err)
 
 		var sb strings.Builder
@@ -56,14 +56,14 @@ func TestCompileParents(t *testing.T) {
 
 		query.(*ast.SequentialProc).Procs = query.(*ast.SequentialProc).Procs[1:]
 
-		_, err = compiler.Compile(nil, query, pctx, sources)
+		_, err = compiler.Compile(nil, query, pctx, nil, sources)
 		require.Error(t, err)
 	})
 
 	t.Run("too many parents", func(t *testing.T) {
 		query, err := compiler.ParseProc("* | split(=>filter * =>filter *) | filter *")
 		require.NoError(t, err)
-		_, err = compiler.Compile(nil, query, pctx, sources)
+		_, err = compiler.Compile(nil, query, pctx, nil, sources)
 		require.Error(t, err)
 	})
 }
@@ -94,7 +94,7 @@ func TestCompileMergeDone(t *testing.T) {
 
 	// Force the parallel proc to create a merge proc instead of combine.
 	p.MergeOrderField = field.New("k")
-	leaves, err := compiler.Compile(nil, query, pctx, []proc.Interface{src})
+	leaves, err := compiler.Compile(nil, query, pctx, nil, []proc.Interface{src})
 	require.NoError(t, err)
 
 	var sb strings.Builder

--- a/compiler/expr.go
+++ b/compiler/expr.go
@@ -6,12 +6,19 @@ import (
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/expr/agg"
 	"github.com/brimsec/zq/expr/function"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-// CompileExpr compiles the given Expression into an object
+// TestCompileExpr provides an exported entry point for unit tests
+// to compile expressions (e.g., as is used by expr/expr_test.go).
+func TestCompileExpr(zctx *resolver.Context, node ast.Expression) (expr.Evaluator, error) {
+	return compileExpr(zctx, nil, node)
+}
+
+// compileExpr compiles the given Expression into an object
 // that evaluates the expression against a provided Record.  It returns an
 // error if compilation fails for any reason.
 //
@@ -41,33 +48,58 @@ import (
 // TBD: string values and net.IP address do not need to be copied because they
 // are allocated by go libraries and temporary buffers are not used.  This will
 // change down the road when we implement no-allocation string and IP conversion.
-func CompileExpr(zctx *resolver.Context, node ast.Expression) (expr.Evaluator, error) {
+func compileExpr(zctx *resolver.Context, scope *Scope, node ast.Expression) (expr.Evaluator, error) {
+	if scope == nil {
+		// XXX The compiler should be a struct with all of these functions
+		// becoming recievers.  Then, zctx and scope can be member variables
+		// of the compiler.  As compiler becomes more sophisticated, we will
+		// build on this structure.  See issue #2067.
+		scope = &Scope{}
+	}
 	switch n := node.(type) {
 	case *ast.Literal:
 		return expr.NewLiteral(*n)
 	case *ast.Identifier:
-		return nil, fmt.Errorf("stray identifier in AST: %s", n.Name)
+		// If the identifier refers to a named variable in scope (like "$"),
+		// then return a Var expression referring to the pointer to the value.
+		// Note that constants may be accessed this way too by entering their
+		// names into the global (outermost) scope in the Scope entity.
+		if ref := scope.Lookup(n.Name); ref != nil {
+			return expr.NewVar(ref), nil
+		}
+		return compileExpr(zctx, scope, rootField(n.Name))
 	case *ast.RootRecord:
 		return &expr.RootRecord{}, nil
 	case *ast.UnaryExpression:
-		return compileUnary(zctx, *n)
+		return compileUnary(zctx, scope, *n)
+	case *ast.SelectExpression:
+		return nil, errors.New("select expression found outside of generator context")
 	case *ast.BinaryExpression:
-		return compileBinary(zctx, n.Operator, n.LHS, n.RHS)
+		return compileBinary(zctx, scope, n.Operator, n.LHS, n.RHS)
 	case *ast.ConditionalExpression:
-		return compileConditional(zctx, *n)
+		return compileConditional(zctx, scope, *n)
 	case *ast.FunctionCall:
-		return compileCall(zctx, *n)
+		return compileCall(zctx, scope, *n)
 	case *ast.CastExpression:
-		return compileCast(zctx, *n)
+		return compileCast(zctx, scope, *n)
 	default:
 		return nil, fmt.Errorf("invalid expression type %T", node)
 	}
 }
 
-func CompileExprs(zctx *resolver.Context, nodes []ast.Expression) ([]expr.Evaluator, error) {
+func rootField(name string) *ast.BinaryExpression {
+	return &ast.BinaryExpression{
+		Op:       "BinaryExpr",
+		Operator: ".",
+		LHS:      &ast.RootRecord{"RootRecord"},
+		RHS:      &ast.Identifier{Name: name},
+	}
+}
+
+func CompileExprs(zctx *resolver.Context, scope *Scope, nodes []ast.Expression) ([]expr.Evaluator, error) {
 	var exprs []expr.Evaluator
 	for k := range nodes {
-		e, err := CompileExpr(zctx, nodes[k])
+		e, err := compileExpr(zctx, scope, nodes[k])
 		if err != nil {
 			return nil, err
 		}
@@ -76,20 +108,23 @@ func CompileExprs(zctx *resolver.Context, nodes []ast.Expression) ([]expr.Evalua
 	return exprs, nil
 }
 
-func compileBinary(zctx *resolver.Context, op string, LHS, RHS ast.Expression) (expr.Evaluator, error) {
+func compileBinary(zctx *resolver.Context, scope *Scope, op string, LHS, RHS ast.Expression) (expr.Evaluator, error) {
 	if op == "." {
-		return compileDotExpr(zctx, LHS, RHS)
+		return compileDotExpr(zctx, scope, LHS, RHS)
 	}
-	lhs, err := CompileExpr(zctx, LHS)
+	if op == "@" {
+		return nil, errors.New("generator expression encountered outside of aggregator")
+	}
+	lhs, err := compileExpr(zctx, scope, LHS)
 	if err != nil {
 		return nil, err
 	}
-	rhs, err := CompileExpr(zctx, RHS)
+	rhs, err := compileExpr(zctx, scope, RHS)
 	if err != nil {
 		return nil, err
 	}
 	switch op {
-	case "AND", "OR":
+	case "and", "or":
 		return compileLogical(lhs, rhs, op)
 	case "in":
 		return expr.NewIn(lhs, rhs), nil
@@ -108,11 +143,91 @@ func compileBinary(zctx *resolver.Context, op string, LHS, RHS ast.Expression) (
 	}
 }
 
-func compileUnary(zctx *resolver.Context, node ast.UnaryExpression) (expr.Evaluator, error) {
+func compileGenerator(zctx *resolver.Context, scope *Scope, e ast.Expression) (expr.Generator, error) {
+	switch e := e.(type) {
+	case *ast.BinaryExpression:
+		if e.Operator != "@" {
+			return nil, fmt.Errorf("bad expression in generator: %s", e.Operator)
+		}
+		src, err := compileGenerator(zctx, scope, e.LHS)
+		if err != nil {
+			return nil, err
+		}
+		return compileMethod(zctx, scope, src, e.RHS)
+	case *ast.SelectExpression:
+		exprs, err := compileExprs(zctx, scope, e.Selectors)
+		if err != nil {
+			return nil, err
+		}
+		return expr.NewSelector(exprs), nil
+	}
+	return nil, fmt.Errorf("bad generator expression: %T", e)
+}
+
+func compileMethod(zctx *resolver.Context, scope *Scope, src expr.Generator, e ast.Expression) (expr.Generator, error) {
+	method, ok := e.(*ast.FunctionCall)
+	if !ok {
+		return nil, fmt.Errorf("bad method expression: %T", e)
+	}
+	switch method.Function {
+	case "map":
+		if len(method.Args) != 1 {
+			return nil, errors.New("map() method requires one argument")
+		}
+		mapMethod := expr.NewMapMethod(src)
+		scope.Enter()
+		defer scope.Exit()
+		scope.Bind("$", mapMethod.Ref())
+		mapExpr, err := compileExpr(zctx, scope, method.Args[0])
+		if err != nil {
+			return nil, err
+		}
+		mapMethod.Set(mapExpr)
+		return mapMethod, nil
+	case "filter":
+		if len(method.Args) != 1 {
+			return nil, errors.New("filter() method requires one argument")
+		}
+		filterMethod := expr.NewFilterMethod(src)
+		scope.Enter()
+		defer scope.Exit()
+		scope.Bind("$", filterMethod.Ref())
+		filterExpr, err := compileExpr(zctx, scope, method.Args[0])
+		if err != nil {
+			fmt.Println("ERR", err)
+			return nil, err
+		}
+		filterMethod.Set(filterExpr)
+		return filterMethod, nil
+	default:
+		return nil, fmt.Errorf("uknown method: %s", method.Function)
+	}
+}
+
+// compileMethodChain tries to compile the given function call as an aggregation
+// function operating on a generator.  If this fails with an error or (nil,nil),
+// then it doesn't have the required shape and the caller can try compiling
+// this AST node a different way.
+func compileMethodChain(zctx *resolver.Context, scope *Scope, call ast.FunctionCall) (expr.Evaluator, error) {
+	if len(call.Args) != 1 {
+		return nil, nil
+	}
+	pattern, err := agg.NewPattern(call.Function)
+	if err != nil {
+		return nil, nil
+	}
+	gen, err := compileGenerator(zctx, scope, call.Args[0])
+	if gen == nil || err != nil {
+		return nil, nil
+	}
+	return expr.NewAggExpr(zctx, pattern, gen), nil
+}
+
+func compileUnary(zctx *resolver.Context, scope *Scope, node ast.UnaryExpression) (expr.Evaluator, error) {
 	if node.Operator != "!" {
 		return nil, fmt.Errorf("unknown unary operator %s\n", node.Operator)
 	}
-	e, err := CompileExpr(zctx, node.Operand)
+	e, err := compileExpr(zctx, scope, node.Operand)
 	if err != nil {
 		return nil, err
 	}
@@ -121,45 +236,45 @@ func compileUnary(zctx *resolver.Context, node ast.UnaryExpression) (expr.Evalua
 
 func compileLogical(lhs, rhs expr.Evaluator, operator string) (expr.Evaluator, error) {
 	switch operator {
-	case "AND":
+	case "and":
 		return expr.NewLogicalAnd(lhs, rhs), nil
-	case "OR":
+	case "or":
 		return expr.NewLogicalOr(lhs, rhs), nil
 	default:
 		return nil, fmt.Errorf("unknown logical operator: %s", operator)
 	}
 }
 
-func compileConditional(zctx *resolver.Context, node ast.ConditionalExpression) (expr.Evaluator, error) {
-	predicate, err := CompileExpr(zctx, node.Condition)
+func compileConditional(zctx *resolver.Context, scope *Scope, node ast.ConditionalExpression) (expr.Evaluator, error) {
+	predicate, err := compileExpr(zctx, scope, node.Condition)
 	if err != nil {
 		return nil, err
 	}
-	thenExpr, err := CompileExpr(zctx, node.Then)
+	thenExpr, err := compileExpr(zctx, scope, node.Then)
 	if err != nil {
 		return nil, err
 	}
-	elseExpr, err := CompileExpr(zctx, node.Else)
+	elseExpr, err := compileExpr(zctx, scope, node.Else)
 	if err != nil {
 		return nil, err
 	}
 	return expr.NewConditional(predicate, thenExpr, elseExpr), nil
 }
 
-func compileDotExpr(zctx *resolver.Context, lhs, rhs ast.Expression) (expr.Evaluator, error) {
+func compileDotExpr(zctx *resolver.Context, scope *Scope, lhs, rhs ast.Expression) (expr.Evaluator, error) {
 	id, ok := rhs.(*ast.Identifier)
 	if !ok {
 		return nil, errors.New("rhs of dot expression is not an identifier")
 	}
-	record, err := CompileExpr(zctx, lhs)
+	record, err := compileExpr(zctx, scope, lhs)
 	if err != nil {
 		return nil, err
 	}
 	return expr.NewDotAccess(record, id.Name), nil
 }
 
-func compileCast(zctx *resolver.Context, node ast.CastExpression) (expr.Evaluator, error) {
-	e, err := CompileExpr(zctx, node.Expr)
+func compileCast(zctx *resolver.Context, scope *Scope, node ast.CastExpression) (expr.Evaluator, error) {
+	e, err := compileExpr(zctx, scope, node.Expr)
 	if err != nil {
 		return nil, err
 	}
@@ -185,12 +300,16 @@ func CompileLval(node ast.Expression) (field.Static, error) {
 			return nil, err
 		}
 		return append(lhs, id.Name), nil
+	case *ast.Identifier:
+		return CompileLval(rootField(node.Name))
 	}
 	return nil, errors.New("invalid expression on lhs of assignment")
 }
 
-func CompileAssignment(zctx *resolver.Context, node *ast.Assignment) (expr.Assignment, error) {
-	rhs, err := CompileExpr(zctx, node.RHS)
+var ErrInference = errors.New("assignment name could not be inferred from rhs expressioin")
+
+func CompileAssignment(zctx *resolver.Context, scope *Scope, node *ast.Assignment) (expr.Assignment, error) {
+	rhs, err := compileExpr(zctx, scope, node.RHS)
 	if err != nil {
 		return expr.Assignment{}, fmt.Errorf("rhs of assigment expression: %w", err)
 	}
@@ -204,6 +323,8 @@ func CompileAssignment(zctx *resolver.Context, node *ast.Assignment) (expr.Assig
 		switch rhs := node.RHS.(type) {
 		case *ast.RootRecord:
 			lhs = field.New(".")
+		case *ast.Identifier:
+			lhs = field.New(rhs.Name)
 		case *ast.FunctionCall:
 			lhs = field.New(rhs.Function)
 		case *ast.BinaryExpression:
@@ -214,10 +335,10 @@ func CompileAssignment(zctx *resolver.Context, node *ast.Assignment) (expr.Assig
 			// we'll just catch this as an error.
 			lhs, err = CompileLval(rhs)
 			if err != nil {
-				err = expr.ErrInference
+				err = ErrInference
 			}
 		default:
-			err = expr.ErrInference
+			err = ErrInference
 		}
 	}
 	return expr.Assignment{lhs, rhs}, err
@@ -236,7 +357,7 @@ func CompileAssignments(dsts []field.Static, srcs []field.Static) ([]field.Stati
 	return fields, resolvers
 }
 
-func compileCutter(zctx *resolver.Context, node ast.FunctionCall) (*expr.Cutter, error) {
+func compileCutter(zctx *resolver.Context, scope *Scope, node ast.FunctionCall) (*expr.Cutter, error) {
 	var lhs []field.Static
 	var rhs []expr.Evaluator
 	for _, expr := range node.Args {
@@ -248,7 +369,7 @@ func compileCutter(zctx *resolver.Context, node ast.FunctionCall) (*expr.Cutter,
 		// We should allow field assignments as function arguments.
 		// See issue #1772.
 		assignment := &ast.Assignment{LHS: expr, RHS: expr}
-		compiled, err := CompileAssignment(zctx, assignment)
+		compiled, err := CompileAssignment(zctx, scope, assignment)
 		if err != nil {
 			return nil, err
 		}
@@ -282,31 +403,32 @@ func isShaperFunc(name string) bool {
 	return shaperOps(name) != 0
 }
 
-func compileShaper(zctx *resolver.Context, node ast.FunctionCall) (*expr.Shaper, error) {
+func compileShaper(zctx *resolver.Context, scope *Scope, node ast.FunctionCall) (*expr.Shaper, error) {
 	if len(node.Args) < 2 {
 		return nil, function.ErrTooFewArgs
 	}
 	if len(node.Args) > 2 {
 		return nil, function.ErrTooManyArgs
 	}
-	field, err := CompileExpr(zctx, node.Args[0])
+	field, err := compileExpr(zctx, scope, node.Args[0])
 	if err != nil {
 		return nil, err
 	}
-	ev, err := CompileExpr(zctx, node.Args[1])
+	ev, err := compileExpr(zctx, scope, node.Args[1])
 	if err != nil {
 		return nil, err
 	}
 	return expr.NewShaper(zctx, field, ev, shaperOps(node.Function))
 }
 
-func compileCall(zctx *resolver.Context, node ast.FunctionCall) (expr.Evaluator, error) {
+func compileCall(zctx *resolver.Context, scope *Scope, node ast.FunctionCall) (expr.Evaluator, error) {
+
 	// For now, we special case cut and pick here.  We shuold generalize this
 	// as we will add many more stateful functions and also resolve this
 	// the changes to create running aggegation functions from reducers.
 	// XXX See issue #1259.
 	if node.Function == "cut" {
-		cut, err := compileCutter(zctx, node)
+		cut, err := compileCutter(zctx, scope, node)
 		if err != nil {
 			return nil, err
 		}
@@ -314,23 +436,34 @@ func compileCall(zctx *resolver.Context, node ast.FunctionCall) (expr.Evaluator,
 		return cut, nil
 	}
 	if node.Function == "pick" {
-		return compileCutter(zctx, node)
+		return compileCutter(zctx, scope, node)
 	}
 	if isShaperFunc(node.Function) {
-		return compileShaper(zctx, node)
+		return compileShaper(zctx, scope, node)
+	}
+	if e, err := compileMethodChain(zctx, scope, node); e != nil || err != nil {
+		return e, err
 	}
 	nargs := len(node.Args)
 	fn, err := function.New(zctx, node.Function, nargs)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", node.Function, err)
 	}
-	exprs := make([]expr.Evaluator, 0, nargs)
-	for _, expr := range node.Args {
-		e, err := CompileExpr(zctx, expr)
+	exprs, err := compileExprs(zctx, scope, node.Args)
+	if err != nil {
+		return nil, fmt.Errorf("%s: bad argument: %w", node.Function, err)
+	}
+	return expr.NewCall(zctx, node.Function, fn, exprs), nil
+}
+
+func compileExprs(zctx *resolver.Context, scope *Scope, in []ast.Expression) ([]expr.Evaluator, error) {
+	out := make([]expr.Evaluator, 0, len(in))
+	for _, e := range in {
+		ev, err := compileExpr(zctx, scope, e)
 		if err != nil {
 			return nil, err
 		}
-		exprs = append(exprs, e)
+		out = append(out, ev)
 	}
-	return expr.NewCall(zctx, node.Function, fn, exprs), nil
+	return out, nil
 }

--- a/compiler/parallelize.go
+++ b/compiler/parallelize.go
@@ -44,10 +44,10 @@ func ensureSequentialProc(p ast.Proc) *ast.SequentialProc {
 }
 
 // liftFilter removes the filter at the head of the flowgraph AST, if
-// one is present, and returns its ast.BooleanExpr and the modified
+// one is present, and returns its ast.Expression and the modified
 // flowgraph AST. If the flowgraph does not start with a filter, it
 // returns nil and the unmodified flowgraph.
-func liftFilter(p ast.Proc) (ast.BooleanExpr, ast.Proc) {
+func liftFilter(p ast.Proc) (ast.Expression, ast.Proc) {
 	if fp, ok := p.(*ast.FilterProc); ok {
 		return fp.Filter, passProc
 	}

--- a/compiler/proc.go
+++ b/compiler/proc.go
@@ -40,8 +40,9 @@ func isContainerProc(node ast.Proc) bool {
 	return false
 }
 
-func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, parent proc.Interface) (proc.Interface, error) {
+func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, scope *Scope, parent proc.Interface) (proc.Interface, error) {
 	if custom != nil {
+		// XXX custom should take scope
 		p, err := custom(node, pctx, parent)
 		if err != nil {
 			return nil, err
@@ -52,13 +53,13 @@ func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, parent proc.Int
 	}
 	switch v := node.(type) {
 	case *ast.GroupByProc:
-		return compileGroupBy(pctx, parent, v)
+		return compileGroupBy(pctx, scope, parent, v)
 
 	case *ast.CutProc:
 		if v.Complement {
 			return nil, errors.New("cut -c deprecated; use drop instead")
 		}
-		assignments, err := compileAssignments(v.Fields, pctx.TypeContext)
+		assignments, err := compileAssignments(v.Fields, pctx.TypeContext, scope)
 		if err != nil {
 			return nil, err
 		}
@@ -71,7 +72,7 @@ func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, parent proc.Int
 		return proc.FromFunction(pctx, parent, cutter, "cut"), nil
 
 	case *ast.PickProc:
-		assignments, err := compileAssignments(v.Fields, pctx.TypeContext)
+		assignments, err := compileAssignments(v.Fields, pctx.TypeContext, scope)
 		if err != nil {
 			return nil, err
 		}
@@ -98,7 +99,7 @@ func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, parent proc.Int
 		return proc.FromFunction(pctx, parent, dropper, "drop"), nil
 
 	case *ast.SortProc:
-		fields, err := CompileExprs(pctx.TypeContext, v.Fields)
+		fields, err := CompileExprs(pctx.TypeContext, scope, v.Fields)
 		if err != nil {
 			return nil, err
 		}
@@ -129,21 +130,21 @@ func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, parent proc.Int
 		return pass.New(parent), nil
 
 	case *ast.FilterProc:
-		f, err := compileFilter(pctx.TypeContext, v.Filter)
+		f, err := compileFilter(pctx.TypeContext, scope, v.Filter)
 		if err != nil {
 			return nil, fmt.Errorf("compiling filter: %w", err)
 		}
 		return filterproc.New(parent, f), nil
 
 	case *ast.TopProc:
-		fields, err := CompileExprs(pctx.TypeContext, v.Fields)
+		fields, err := CompileExprs(pctx.TypeContext, scope, v.Fields)
 		if err != nil {
 			return nil, fmt.Errorf("compiling top: %w", err)
 		}
 		return top.New(parent, v.Limit, fields, v.Flush), nil
 
 	case *ast.PutProc:
-		clauses, err := compileAssignments(v.Clauses, pctx.TypeContext)
+		clauses, err := compileAssignments(v.Clauses, pctx.TypeContext, scope)
 		if err != nil {
 			return nil, err
 		}
@@ -194,10 +195,10 @@ func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, parent proc.Int
 	}
 }
 
-func compileAssignments(assignments []ast.Assignment, zctx *resolver.Context) ([]expr.Assignment, error) {
+func compileAssignments(assignments []ast.Assignment, zctx *resolver.Context, scope *Scope) ([]expr.Assignment, error) {
 	keys := make([]expr.Assignment, 0, len(assignments))
 	for _, assignment := range assignments {
-		a, err := CompileAssignment(zctx, &assignment)
+		a, err := CompileAssignment(zctx, scope, &assignment)
 		if err != nil {
 			return nil, err
 		}
@@ -225,9 +226,9 @@ func enteringJoin(nodes []ast.Proc) bool {
 	return ok
 }
 
-func compileSequential(custom Hook, nodes []ast.Proc, pctx *proc.Context, parents []proc.Interface) ([]proc.Interface, error) {
+func compileSequential(custom Hook, nodes []ast.Proc, pctx *proc.Context, scope *Scope, parents []proc.Interface) ([]proc.Interface, error) {
 	node := nodes[0]
-	parents, err := Compile(custom, node, pctx, parents)
+	parents, err := Compile(custom, node, pctx, scope, parents)
 	if err != nil {
 		return nil, err
 	}
@@ -248,10 +249,10 @@ func compileSequential(custom Hook, nodes []ast.Proc, pctx *proc.Context, parent
 		}
 		parents = []proc.Interface{parent}
 	}
-	return compileSequential(custom, nodes[1:], pctx, parents)
+	return compileSequential(custom, nodes[1:], pctx, scope, parents)
 }
 
-func compileParallel(custom Hook, pp *ast.ParallelProc, c *proc.Context, parents []proc.Interface) ([]proc.Interface, error) {
+func compileParallel(custom Hook, pp *ast.ParallelProc, c *proc.Context, scope *Scope, parents []proc.Interface) ([]proc.Interface, error) {
 	n := len(pp.Procs)
 	if len(parents) == 1 {
 		// Single parent: insert a splitter and wire to each branch.
@@ -267,7 +268,7 @@ func compileParallel(custom Hook, pp *ast.ParallelProc, c *proc.Context, parents
 	}
 	var procs []proc.Interface
 	for k := 0; k < n; k++ {
-		proc, err := Compile(custom, pp.Procs[k], c, []proc.Interface{parents[k]})
+		proc, err := Compile(custom, pp.Procs[k], c, scope, []proc.Interface{parents[k]})
 		if err != nil {
 			return nil, err
 		}
@@ -279,34 +280,39 @@ func compileParallel(custom Hook, pp *ast.ParallelProc, c *proc.Context, parents
 // Compile compiles an AST into a graph of Procs, and returns
 // the leaves.  A custom compiler hook can be included and it will be tried first
 // for each node encountered during the compilation.
-func Compile(custom Hook, node ast.Proc, pctx *proc.Context, parents []proc.Interface) ([]proc.Interface, error) {
+func Compile(custom Hook, node ast.Proc, pctx *proc.Context, scope *Scope, parents []proc.Interface) ([]proc.Interface, error) {
 	if len(parents) == 0 {
 		return nil, errors.New("no parents")
+	}
+	if scope == nil {
+		// Outermost caller should pass in global scope object.  If nil,
+		// we assume no global context and allocate a fresh, empty scope.
+		scope = newScope()
 	}
 	switch node := node.(type) {
 	case *ast.SequentialProc:
 		if len(node.Procs) == 0 {
 			return nil, errors.New("sequential proc without procs")
 		}
-		return compileSequential(custom, node.Procs, pctx, parents)
+		return compileSequential(custom, node.Procs, pctx, scope, parents)
 
 	case *ast.ParallelProc:
-		return compileParallel(custom, node, pctx, parents)
+		return compileParallel(custom, node, pctx, scope, parents)
 
 	case *ast.JoinProc:
 		if len(parents) != 2 {
 			return nil, ErrJoinParents
 		}
-		assignments, err := compileAssignments(node.Clauses, pctx.TypeContext)
+		assignments, err := compileAssignments(node.Clauses, pctx.TypeContext, scope)
 		if err != nil {
 			return nil, err
 		}
 		lhs, rhs := splitAssignments(assignments)
-		leftKey, err := CompileExpr(pctx.TypeContext, node.LeftKey)
+		leftKey, err := compileExpr(pctx.TypeContext, scope, node.LeftKey)
 		if err != nil {
 			return nil, err
 		}
-		rightKey, err := CompileExpr(pctx.TypeContext, node.RightKey)
+		rightKey, err := compileExpr(pctx.TypeContext, scope, node.RightKey)
 		if err != nil {
 			return nil, err
 		}
@@ -320,7 +326,7 @@ func Compile(custom Hook, node ast.Proc, pctx *proc.Context, parents []proc.Inte
 		if len(parents) > 1 {
 			return nil, fmt.Errorf("ast type %v cannot have multiple parents", node)
 		}
-		p, err := compileProc(custom, node, pctx, parents[0])
+		p, err := compileProc(custom, node, pctx, scope, parents[0])
 		return []proc.Interface{p}, err
 	}
 }

--- a/compiler/scope.go
+++ b/compiler/scope.go
@@ -1,0 +1,52 @@
+package compiler
+
+import "github.com/brimsec/zq/zng"
+
+// A Scope is a stack of bindings that map identifiers to literals,
+// generator variables, functions etc.  Currently, we only handle iterators
+// but this will change soone as we add support for richer Z script semantics.
+type Scope struct {
+	stack []Binder
+}
+
+func newScope() *Scope {
+	return &Scope{}
+}
+
+func (s *Scope) tos() Binder {
+	return s.stack[len(s.stack)-1]
+}
+
+func (s *Scope) Enter() {
+	s.stack = append(s.stack, NewBinder())
+}
+
+func (s *Scope) Exit() {
+	s.stack = s.stack[:len(s.stack)-1]
+}
+
+func (s *Scope) Bind(name string, ref *zng.Value) {
+	s.tos().Define(name, ref)
+}
+
+func (s *Scope) Lookup(name string) *zng.Value {
+	for k := len(s.stack) - 1; k >= 0; k-- {
+		if ref, ok := s.stack[k][name]; ok {
+			return ref
+		}
+	}
+	return nil
+}
+
+//XXX for now, Binder is just a map of identifiers to a specific zng.Value
+// reference that the name refers to.  This will be generalized later to handle
+// all possible types of identifier bindings.
+type Binder map[string]*zng.Value
+
+func NewBinder() Binder {
+	return make(map[string]*zng.Value)
+}
+
+func (b Binder) Define(name string, ref *zng.Value) {
+	b[name] = ref
+}

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -74,7 +74,7 @@ func compile(ctx context.Context, program ast.Proc, zctx *resolver.Context, read
 		Logger:      cfg.Logger,
 		Warnings:    make(chan string, 5),
 	}
-	leaves, err := compiler.Compile(cfg.Custom, program, pctx, procs)
+	leaves, err := compiler.Compile(cfg.Custom, program, pctx, nil, procs)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func compileMulti(ctx context.Context, program ast.Proc, zctx *resolver.Context,
 	if len(sources) > 1 {
 		program, _ = compiler.Parallelize(program, len(sources), sortKey, sortReversed)
 	}
-	leaves, err := compiler.Compile(mcfg.Custom, program, pctx, sources)
+	leaves, err := compiler.Compile(mcfg.Custom, program, pctx, nil, sources)
 	if err != nil {
 		return nil, err
 	}

--- a/expr/agg.go
+++ b/expr/agg.go
@@ -15,10 +15,10 @@ var (
 type Aggregator struct {
 	pattern agg.Pattern
 	expr    Evaluator
-	where   Evaluator
+	where   Filter
 }
 
-func NewAggregator(op string, expr, where Evaluator) (*Aggregator, error) {
+func NewAggregator(op string, expr Evaluator, where Filter) (*Aggregator, error) {
 	pattern, err := agg.NewPattern(op)
 	if err != nil {
 		return nil, err
@@ -57,9 +57,5 @@ func (a *Aggregator) filter(rec *zng.Record) bool {
 	if a.where == nil {
 		return false
 	}
-	zv, err := a.where.Eval(rec)
-	if err != nil {
-		return true
-	}
-	return !zng.IsTrue(zv.Bytes)
+	return !a.where(rec)
 }

--- a/expr/boolean.go
+++ b/expr/boolean.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/pkg/byteconv"
-	"github.com/brimsec/zq/reglob"
 	"github.com/brimsec/zq/zng"
 )
 
@@ -27,8 +26,6 @@ type Boolean func(zng.Value) bool
 var compareBool = map[string]func(bool, bool) bool{
 	"=":  func(a, b bool) bool { return a == b },
 	"!=": func(a, b bool) bool { return a != b },
-	"=~": func(a, b bool) bool { return false },
-	"!~": func(a, b bool) bool { return false },
 	">":  func(a, b bool) bool { return a && !b },
 	">=": func(a, b bool) bool { return a || !b },
 	"<":  func(a, b bool) bool { return !a && b },
@@ -58,8 +55,6 @@ func CompareBool(op string, pattern bool) (Boolean, error) {
 var compareInt = map[string]func(int64, int64) bool{
 	"=":  func(a, b int64) bool { return a == b },
 	"!=": func(a, b int64) bool { return a != b },
-	"=~": func(a, b int64) bool { return false },
-	"!~": func(a, b int64) bool { return false },
 	">":  func(a, b int64) bool { return a > b },
 	">=": func(a, b int64) bool { return a >= b },
 	"<":  func(a, b int64) bool { return a < b },
@@ -68,8 +63,6 @@ var compareInt = map[string]func(int64, int64) bool{
 var compareFloat = map[string]func(float64, float64) bool{
 	"=":  func(a, b float64) bool { return a == b },
 	"!=": func(a, b float64) bool { return a != b },
-	"=~": func(a, b float64) bool { return false },
-	"!~": func(a, b float64) bool { return false },
 	">":  func(a, b float64) bool { return a > b },
 	">=": func(a, b float64) bool { return a >= b },
 	"<":  func(a, b float64) bool { return a < b },
@@ -137,8 +130,6 @@ func CompareContainerLen(op string, len int64) (Boolean, error) {
 var compareAddr = map[string]func(net.IP, net.IP) bool{
 	"=":  func(a, b net.IP) bool { return a.Equal(b) },
 	"!=": func(a, b net.IP) bool { return !a.Equal(b) },
-	"=~": func(a, b net.IP) bool { return false },
-	"!~": func(a, b net.IP) bool { return false },
 	">":  func(a, b net.IP) bool { return bytes.Compare(a, b) > 0 },
 	">=": func(a, b net.IP) bool { return bytes.Compare(a, b) >= 0 },
 	"<":  func(a, b net.IP) bool { return bytes.Compare(a, b) < 0 },
@@ -216,8 +207,6 @@ func CompareFloat64(op string, pattern float64) (Boolean, error) {
 var compareString = map[string]func(string, string) bool{
 	"=":  func(a, b string) bool { return a == b },
 	"!=": func(a, b string) bool { return a != b },
-	"=~": func(a, b string) bool { return false },
-	"!~": func(a, b string) bool { return false },
 	">":  func(a, b string) bool { return a > b },
 	">=": func(a, b string) bool { return a >= b },
 	"<":  func(a, b string) bool { return a < b },
@@ -251,7 +240,7 @@ func compareRegexp(op, pattern string) (Boolean, error) {
 		return nil, err
 	}
 	switch op {
-	case "=~":
+	case "=":
 		return func(v zng.Value) bool {
 			switch v.Type.ID() {
 			case zng.IdString, zng.IdBstring:
@@ -259,7 +248,7 @@ func compareRegexp(op, pattern string) (Boolean, error) {
 			}
 			return false
 		}, nil
-	case "!~":
+	case "!=":
 		return func(v zng.Value) bool {
 			switch v.Type.ID() {
 			case zng.IdString, zng.IdBstring:
@@ -293,8 +282,6 @@ func CompareUnset(op string) (Boolean, error) {
 var compareSubnet = map[string]func(*net.IPNet, *net.IPNet) bool{
 	"=":  func(a, b *net.IPNet) bool { return bytes.Equal(a.IP, b.IP) },
 	"!=": func(a, b *net.IPNet) bool { return bytes.Equal(a.IP, b.IP) },
-	"=~": func(a, b *net.IPNet) bool { return false },
-	"!~": func(a, b *net.IPNet) bool { return false },
 	"<":  func(a, b *net.IPNet) bool { return bytes.Compare(a.IP, b.IP) < 0 },
 	"<=": func(a, b *net.IPNet) bool { return bytes.Compare(a.IP, b.IP) <= 0 },
 	">":  func(a, b *net.IPNet) bool { return bytes.Compare(a.IP, b.IP) > 0 },
@@ -302,12 +289,11 @@ var compareSubnet = map[string]func(*net.IPNet, *net.IPNet) bool{
 }
 
 var matchSubnet = map[string]func(net.IP, *net.IPNet) bool{
-	"=":  func(a net.IP, b *net.IPNet) bool { return false },
-	"!=": func(a net.IP, b *net.IPNet) bool { return false },
-	"=~": func(a net.IP, b *net.IPNet) bool {
-		return b.IP.Equal(a.Mask(b.Mask))
+	"=": func(a net.IP, b *net.IPNet) bool {
+		ok := b.IP.Equal(a.Mask(b.Mask))
+		return ok
 	},
-	"!~": func(a net.IP, b *net.IPNet) bool {
+	"!=": func(a net.IP, b *net.IPNet) bool {
 		return !b.IP.Equal(a.Mask(b.Mask))
 	},
 	"<": func(a net.IP, b *net.IPNet) bool {
@@ -385,18 +371,14 @@ func Contains(compare Boolean) Boolean {
 }
 
 // Comparison returns a Predicate for comparing this value to other values.
-// The op argument is one of "=", "!=", "=~", "!~", "<", "<=", ">", ">=".
+// The op argument is one of "=", "!=", "<", "<=", ">", ">=".
 // See the comments of the various type implementations
 // of this method as some types limit the operand to equality and
 // the various types handle coercion in different ways.
 func Comparison(op string, literal ast.Literal) (Boolean, error) {
 	if literal.Type == "regexp" {
 		return compareRegexp(op, literal.Value)
-	} else if (op == "=~" || op == "!~") && literal.Type == "string" {
-		pattern := reglob.Reglob(literal.Value)
-		return compareRegexp(op, pattern)
 	}
-
 	v, err := zng.ParseLiteral(literal)
 	if err != nil {
 		return nil, err

--- a/expr/coerce/coerce.go
+++ b/expr/coerce/coerce.go
@@ -35,6 +35,15 @@ type Pair struct {
 }
 
 func (c *Pair) Equal() bool {
+	// bytes.Equal() returns true for nil compared to an empty-slice,
+	// which doesn't work for Z null comparisons, so we explicitly check
+	// for the nil condition here.
+	if c.A == nil {
+		return c.B == nil
+	}
+	if c.B == nil {
+		return c.A == nil
+	}
 	return bytes.Equal(c.A, c.B)
 }
 
@@ -59,6 +68,12 @@ func (c *Pair) Coerce(a, b zng.Value) (int, error) {
 			id = zng.IdBstring
 		}
 		return id, nil
+	}
+	if aid == zng.IdNull {
+		return bid, nil
+	}
+	if bid == zng.IdNull {
+		return aid, nil
 	}
 	return 0, ErrIncompatibleTypes
 }

--- a/expr/cut_test.go
+++ b/expr/cut_test.go
@@ -1,6 +1,7 @@
 package expr_test
 
 import (
+	"fmt"
 	"testing"
 
 	"errors"
@@ -86,7 +87,7 @@ func testNonAdjacentFields(t *testing.T, zql string) {
 	_, err := proctest.CompileTestProc(zql, proctest.NewTestContext(nil), nil)
 	require.Error(t, err, "cut with non-adjacent records did not fail")
 	ok := errors.Is(err, builder.ErrNonAdjacent)
-	require.True(t, ok, "cut with non-adjacent records failed with the wrong error")
+	require.True(t, ok, fmt.Sprintf("cut with non-adjacent records failed with the wrong error: %s", err))
 }
 
 func TestNotAdjacentErrors(t *testing.T) {

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -53,7 +53,7 @@ func compileExpr(s string) (expr.Evaluator, error) {
 		return nil, errors.New("expected Expression")
 	}
 
-	return compiler.CompileExpr(resolver.NewContext(), node)
+	return compiler.TestCompileExpr(resolver.NewContext(), node)
 }
 
 // Compile and evaluate a zql expression against a provided Record.
@@ -466,21 +466,12 @@ func TestCompareNonNumbers(t *testing.T) {
 }
 
 func TestPattern(t *testing.T) {
-	testSuccessful(t, `"abc" =~ "abc"`, nil, zbool(true))
-	testSuccessful(t, `"abc" =~ "a*"`, nil, zbool(true))
-	testSuccessful(t, `"abc" =~ "*bc"`, nil, zbool(true))
-	testSuccessful(t, `"abc" =~ "x*"`, nil, zbool(false))
-
-	testSuccessful(t, `"abc" !~ "abc"`, nil, zbool(false))
-	testSuccessful(t, `"abc" !~ "a*"`, nil, zbool(false))
-	testSuccessful(t, `"abc" !~ "*bc"`, nil, zbool(false))
-	testSuccessful(t, `"abc" !~ "x*"`, nil, zbool(true))
-
-	testSuccessful(t, "10.1.1.1 =~ 10.0.0.0/8", nil, zbool(true))
-	testSuccessful(t, "10.1.1.1 =~ 192.168.0.0/16", nil, zbool(false))
-
-	testSuccessful(t, "10.1.1.1 !~ 10.0.0.0/8", nil, zbool(false))
-	testSuccessful(t, "10.1.1.1 !~ 192.168.0.0/16", nil, zbool(true))
+	testSuccessful(t, `"abc" = "abc"`, nil, zbool(true))
+	testSuccessful(t, `"abc" != "abc"`, nil, zbool(false))
+	testSuccessful(t, "10.1.1.1 in 10.0.0.0/8", nil, zbool(true))
+	testSuccessful(t, "10.1.1.1 in 192.168.0.0/16", nil, zbool(false))
+	testSuccessful(t, "!(10.1.1.1 in 10.0.0.0/8)", nil, zbool(false))
+	testSuccessful(t, "!(10.1.1.1 in 192.168.0.0/16)", nil, zbool(true))
 }
 
 func TestIn(t *testing.T) {

--- a/expr/filter_test.go
+++ b/expr/filter_test.go
@@ -45,7 +45,9 @@ func runCasesHelper(t *testing.T, tzng string, cases []testcase, expectBufferFil
 
 			proc, err := compiler.ParseProc(c.filter)
 			require.NoError(t, err, "filter: %q", c.filter)
-			filterExpr := proc.(*ast.FilterProc).Filter
+			fproc := filterProc(proc)
+			require.NotNil(t, fproc)
+			filterExpr := fproc.Filter
 
 			filterAST := compiler.NewFilter(zctx, filterExpr)
 			f, err := filterAST.AsFilter()
@@ -84,10 +86,10 @@ func TestFilters(t *testing.T) {
 #0:record[stringset:set[bstring]]
 0:[[abc;xyz;]]`
 	runCases(t, tzng, []testcase{
-		{"abc in stringset", true},
-		{"xyz in stringset", true},
-		{"ab in stringset", false},
-		{"abcd in stringset", false},
+		{"'abc' in stringset", true},
+		{"'xyz' in stringset", true},
+		{"'ab'in stringset", false},
+		{"'abcd' in stringset", false},
 	})
 
 	// Test escaped bstrings inside a set
@@ -96,9 +98,9 @@ func TestFilters(t *testing.T) {
 0:[[a\x3bb;xyz;]]`
 	runCases(t, tzng, []testcase{
 		{"\"a;b\" in stringset", true},
-		{"a in stringset", false},
-		{"b in stringset", false},
-		{"xyz in stringset", true},
+		{"'a' in stringset", false},
+		{"'b' in stringset", false},
+		{"'xyz' in stringset", true},
 	})
 
 	// Test array membership with "in"
@@ -106,10 +108,10 @@ func TestFilters(t *testing.T) {
 #0:record[stringvec:array[bstring]]
 0:[[abc;xyz;]]`
 	runCases(t, tzng, []testcase{
-		{"abc in stringvec", true},
-		{"xyz in stringvec", true},
-		{"ab in stringvec", false},
-		{"abcd in stringvec", false},
+		{"'abc' in stringvec", true},
+		{"'xyz' in stringvec", true},
+		{"'ab' in stringvec", false},
+		{"'abcd' in stringvec", false},
 	})
 
 	// Test escaped bstrings inside an array
@@ -118,9 +120,9 @@ func TestFilters(t *testing.T) {
 0:[[a\x3bb;xyz;]]`
 	runCases(t, tzng, []testcase{
 		{"\"a;b\" in stringvec", true},
-		{"a in stringvec", false},
-		{"b in stringvec", false},
-		{"xyz in stringvec", true},
+		{"'a' in stringvec", false},
+		{"'b' in stringvec", false},
+		{"'xyz' in stringvec", true},
 	})
 
 	// Test membership in set of integers
@@ -130,7 +132,7 @@ func TestFilters(t *testing.T) {
 	runCases(t, tzng, []testcase{
 		{"2 in intset", true},
 		{"4 in intset", false},
-		{"abc in intset", false},
+		{"'abc' in intset", false},
 	})
 
 	// Test membership in array of integers
@@ -140,7 +142,7 @@ func TestFilters(t *testing.T) {
 	runCases(t, tzng, []testcase{
 		{"2 in intvec", true},
 		{"4 in intvec", false},
-		{"abc in intvec", false},
+		{"'abc' in intvec", false},
 	})
 
 	// Test membership in set of ip addresses
@@ -179,7 +181,6 @@ func TestFilters(t *testing.T) {
 		{"bogus.field = test", false},
 		{"nested.bogus = test", false},
 		{"* = test", false},
-		{"** = test", true},
 	})
 
 	// Test array of records
@@ -217,9 +218,7 @@ func TestFilters(t *testing.T) {
 		{"s=begin", false},
 		{"begin\\x01\\x02\\xffend", true},
 		{"s=begin\\x01\\x02\\xffend", true},
-		{"s=*\\x01\\x02*", false},
-		{"s=~*\\x01\\x02*", true},
-		{"s!~*\\x01\\x02*", false},
+		{"s=*\\x01\\x02*", true},
 	})
 
 	// Test unicode string comparison.  The following two records
@@ -440,15 +439,13 @@ func TestFilters(t *testing.T) {
 0:[hello;]`
 	runCases(t, tzng, []testcase{
 		{"s = hello", true},
-		{"s =~ hello", true},
-		{"s !~ hello", false},
+		{"s != hello", false},
 
 		// Also smoke test that globs work...
-		{"s = hell*", false},
-		{"s =~ hell*", true},
-		{"s =~ ell*", false},
-		{"s !~ hell*", false},
-		{"s !~ ell*", true},
+		{"s = hell*", true},
+		{"s = ell*", false},
+		{"s != hell*", false},
+		{"s != ell*", true},
 	})
 
 	// Test ip comparisons
@@ -459,10 +456,10 @@ func TestFilters(t *testing.T) {
 		{"a = 192.168.1.50", true},
 		{"a = 50.1.168.192", false},
 		{"a != 50.1.168.192", true},
-		{"a =~ 192.168.0.0/16", true},
-		{"a =~ 10.0.0.0/16", false},
-		{"a !~ 192.168.0.0/16", false},
-		{"a !~ 10.0.0.0/16", true},
+		{"a in 192.168.0.0/16", true},
+		{"a = 10.0.0.0/16", false},
+		{"a != 192.168.0.0/16", false},
+		{"a != 10.0.0.0/16", true},
 	})
 
 	// Test comparisons with an aliased type
@@ -516,12 +513,23 @@ func TestFilters(t *testing.T) {
 
 }
 
+func filterProc(p ast.Proc) *ast.FilterProc {
+	if seq, ok := p.(*ast.SequentialProc); ok {
+		p = seq.Procs[0]
+	}
+	if f, ok := p.(*ast.FilterProc); ok {
+		return f
+	}
+	return nil
+}
+
 func TestBadFilter(t *testing.T) {
 	t.Parallel()
-	proc, err := compiler.ParseProc(`s =~ \xa8*`)
+	proc, err := compiler.ParseProc(`s = \xa8*`)
 	require.NoError(t, err)
-	f := compiler.NewFilter(resolver.NewContext(), proc.(*ast.FilterProc).Filter)
+	fproc := filterProc(proc)
+	require.NotNil(t, fproc)
+	f := compiler.NewFilter(resolver.NewContext(), fproc.Filter)
 	_, err = f.AsFilter()
 	assert.Error(t, err, "Received error for bad glob")
-	assert.Contains(t, err.Error(), "invalid UTF-8", "Received good error message for invalid UTF-8 in a regexp")
 }

--- a/expr/generator.go
+++ b/expr/generator.go
@@ -1,0 +1,124 @@
+package expr
+
+import (
+	"github.com/brimsec/zq/expr/agg"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type Generator interface {
+	Init(*zng.Record)
+	Next() (zng.Value, error)
+}
+
+type MapMethod struct {
+	src    Generator
+	dollar zng.Value
+	expr   Evaluator
+	rec    *zng.Record
+}
+
+func NewMapMethod(src Generator) *MapMethod {
+	return &MapMethod{src: src}
+}
+
+func (m *MapMethod) Ref() *zng.Value {
+	return &m.dollar
+}
+
+func (m *MapMethod) Set(e Evaluator) {
+	m.expr = e
+}
+
+func (m *MapMethod) Init(rec *zng.Record) {
+	m.rec = rec
+	m.src.Init(rec)
+}
+
+func (m *MapMethod) Next() (zng.Value, error) {
+	zv, err := m.src.Next()
+	if err != nil || zv.Type == nil {
+		return zv, err
+	}
+	m.dollar = zv
+	return m.expr.Eval(m.rec)
+}
+
+type FilterMethod struct {
+	src    Generator
+	dollar zng.Value
+	expr   Evaluator
+	rec    *zng.Record
+}
+
+func NewFilterMethod(src Generator) *FilterMethod {
+	return &FilterMethod{src: src}
+}
+
+func (f *FilterMethod) Ref() *zng.Value {
+	return &f.dollar
+}
+
+func (f *FilterMethod) Set(e Evaluator) {
+	f.expr = e
+}
+
+func (f *FilterMethod) Init(rec *zng.Record) {
+	f.rec = rec
+	f.src.Init(rec)
+}
+
+func (f *FilterMethod) Next() (zng.Value, error) {
+	for {
+		zv, err := f.src.Next()
+		if err != nil || zv.Type == nil {
+			return zv, err
+		}
+		f.dollar = zv
+		b, err := f.expr.Eval(f.rec)
+		if err != nil {
+			return zng.Value{}, err
+		}
+		if zng.AliasedType(b.Type) != zng.TypeBool {
+			return zng.NewErrorf("not a boolean"), nil
+		}
+		if zng.IsTrue(b.Bytes) {
+			return zv, nil
+		}
+	}
+}
+
+type AggExpr struct {
+	zctx   *resolver.Context
+	newAgg agg.Pattern
+	src    Generator
+}
+
+func NewAggExpr(zctx *resolver.Context, pattern agg.Pattern, src Generator) *AggExpr {
+	return &AggExpr{
+		zctx:   zctx,
+		newAgg: pattern,
+		src:    src,
+	}
+}
+
+func (a *AggExpr) Eval(rec *zng.Record) (zng.Value, error) {
+	// XXX This is currently really inefficient while we prototype
+	// this machinery.  We used to have a Reset() method on aggregators
+	// and we should probably reintroduce that for use here so we
+	// don't create a new aggregator for every record. See Issue #2068.
+	f := a.newAgg()
+	a.src.Init(rec)
+	for {
+		zv, err := a.src.Next()
+		if err != nil {
+			return zng.Value{}, nil
+		}
+		if zv.Type == nil {
+			return f.Result(a.zctx)
+		}
+		if err := f.Consume(zv); err != nil {
+			return zng.Value{}, err
+		}
+	}
+}

--- a/expr/selector.go
+++ b/expr/selector.go
@@ -1,0 +1,56 @@
+package expr
+
+import (
+	"errors"
+
+	"github.com/brimsec/zq/zcode"
+	"github.com/brimsec/zq/zng"
+)
+
+type Selector struct {
+	selectors []Evaluator
+	cursor    []Evaluator
+	iter      zcode.Iter
+	iterCols  []zng.Column
+	rec       *zng.Record
+}
+
+func NewSelector(selectors []Evaluator) *Selector {
+	return &Selector{selectors: selectors}
+}
+
+func (s *Selector) Init(rec *zng.Record) {
+	s.rec = rec
+	s.cursor = s.selectors
+}
+
+func (s *Selector) Next() (zng.Value, error) {
+again:
+	if s.iter != nil && !s.iter.Done() {
+		b, _, err := s.iter.Next()
+		if err != nil {
+			return zng.Value{}, err
+		}
+		if len(s.iterCols) == 0 {
+			return zng.Value{}, errors.New("selector encountered bad record value")
+		}
+		typ := s.iterCols[0].Type
+		s.iterCols = s.iterCols[1:]
+		x := zng.Value{typ, b}
+		return x, nil
+	}
+	if len(s.cursor) == 0 {
+		return zng.Value{}, nil
+	}
+	zv, err := s.cursor[0].Eval(s.rec)
+	if err != nil {
+		return zng.Value{}, err
+	}
+	s.cursor = s.cursor[1:]
+	if typ, ok := zv.Type.(*zng.TypeRecord); ok {
+		s.iter = zv.Iter()
+		s.iterCols = typ.Columns
+		goto again
+	}
+	return zv, nil
+}

--- a/expr/var.go
+++ b/expr/var.go
@@ -1,0 +1,21 @@
+package expr
+
+import (
+	"github.com/brimsec/zq/zng"
+)
+
+type Var struct {
+	ref *zng.Value
+}
+
+func NewVar(ref *zng.Value) *Var {
+	return &Var{ref}
+}
+
+func (v *Var) Eval(*zng.Record) (zng.Value, error) {
+	zv := *v.ref
+	if zv.Type == nil {
+		return zng.Value{}, ErrMissing
+	}
+	return zv, nil
+}

--- a/expr/ztests/in-field.yaml
+++ b/expr/ztests/in-field.yaml
@@ -1,0 +1,12 @@
+zql: 2 in a
+
+input: |
+  #0:record[a:array[uint32]]
+  0:[[1;2;]]
+  0:[[1;]]
+  0:[[2;3;]]
+
+output: |
+  #0:record[a:array[uint32]]
+  0:[[1;2;]]
+  0:[[2;3;]]

--- a/expr/ztests/in-star.yaml
+++ b/expr/ztests/in-star.yaml
@@ -1,0 +1,12 @@
+zql: 2 in *
+
+input: |
+  #0:record[a:array[uint32]]
+  0:[[1;2;]]
+  0:[[1;]]
+  0:[[2;3;]]
+
+output: |
+  #0:record[a:array[uint32]]
+  0:[[1;2;]]
+  0:[[2;3;]]

--- a/ppl/lake/ztests/index-drop.yaml
+++ b/ppl/lake/ztests/index-drop.yaml
@@ -5,7 +5,7 @@ script: |
   zar index ls -R logs -stats -f zng > stats.zng
   zq -f table "drop id" stats.zng
   echo ===
-  zar index drop -R logs $(zq -f text "desc=field-_path | cut id" stats.zng) >/dev/null
+  zar index drop -R logs $(zq -f text "desc='field-_path' | cut id" stats.zng) >/dev/null
   zar index ls -R logs -stats -f zng | zq -f table "drop id" -
 
 inputs:

--- a/ppl/zqd/handlers_test.go
+++ b/ppl/zqd/handlers_test.go
@@ -50,7 +50,7 @@ func TestASTPost(t *testing.T) {
 	_, conn := newCore(t)
 	resp, err := conn.Do(context.Background(), http.MethodPost, "/ast", &api.ASTRequest{ZQL: "*"})
 	require.NoError(t, err)
-	require.Equal(t, string(resp.Body()), "{\"op\":\"FilterProc\",\"filter\":{\"op\":\"MatchAll\"}}\n")
+	require.Equal(t, string(resp.Body()), "{\"op\":\"SequentialProc\",\"procs\":[{\"op\":\"FilterProc\",\"filter\":{\"op\":\"Literal\",\"type\":\"bool\",\"value\":\"true\"}}]}\n")
 }
 
 func TestSearch(t *testing.T) {
@@ -666,7 +666,7 @@ func TestCreateArchiveSpace(t *testing.T) {
 #0:record[ts:time,s:string,v:int64]
 0:[1587508881.0613914;harefoot-raucous;137;]
 `
-	res := searchTzng(t, conn, sp.ID, "s=harefoot-raucous")
+	res := searchTzng(t, conn, sp.ID, "s=harefoot\\-raucous")
 	require.Equal(t, test.Trim(exptzng), res)
 }
 

--- a/ppl/zqd/ztests/s3/s3root.yaml
+++ b/ppl/zqd/ztests/s3/s3root.yaml
@@ -5,7 +5,7 @@ script: |
   echo ===
   zapi -h $ZQD_HOST -s testsp info | egrep -v 'data_path|id|pcap_path'
   echo ===
-  zapi -h $ZQD_HOST -s testsp get -f tzng "s=harefoot-raucous"
+  zapi -h $ZQD_HOST -s testsp get -f tzng 's="harefoot-raucous"'
 
 inputs:
   - name: babble.tzng

--- a/ppl/zqd/ztests/s3/search.yaml
+++ b/ppl/zqd/ztests/s3/search.yaml
@@ -3,7 +3,7 @@ script: |
   zapi -h $ZQD_HOST new -d s3://bucket/zartest -k archivestore -thresh 20KiB testsp
   zapi -h $ZQD_HOST -s testsp post babble.tzng >/dev/null
   echo ===
-  zapi -h $ZQD_HOST -s testsp get -f tzng "s=harefoot-raucous"
+  zapi -h $ZQD_HOST -s testsp get -f tzng 's="harefoot-raucous"'
 
 inputs:
   - name: babble.tzng

--- a/proc/proctest/utils.go
+++ b/proc/proctest/utils.go
@@ -63,7 +63,7 @@ func CompileTestProc(code string, pctx *proc.Context, parent proc.Interface) (pr
 }
 
 func CompileTestProcAST(node ast.Proc, pctx *proc.Context, parent proc.Interface) (proc.Interface, error) {
-	procs, err := compiler.Compile(nil, node, pctx, []proc.Interface{parent})
+	procs, err := compiler.Compile(nil, node, pctx, nil, []proc.Interface{parent})
 	if err != nil {
 		return nil, err
 	}

--- a/zql/docs/data-types/README.md
+++ b/zql/docs/data-types/README.md
@@ -12,13 +12,13 @@ in progress. In the meantime, here's a few tips to get started with.
 In the Zeek `ntp` log, the field `ref_id` is of Zeek's `string` type, but is often populated with a value that happens to be an IP address. When treated as a string, the attempted CIDR match in the following ZQL would be unsuccessful and no events would be counted.
 
 ```
-zq -f table 'ref_id =~ 83.162.0.0/16 | count()' ntp.log.gz
+zq -f table 'ref_id in 83.162.0.0/16 | count()' ntp.log.gz
 ```
 
 However, if we cast it to an `ip` type, now the CIDR match is successful. The `bad cast` warning on stderr tells us that some of the values for `ref_id` could _not_ be successfully cast to `ip`.
 
 ```zq-command
-zq -f table 'put ref_id=ref_id:ip | filter ref_id =~ 83.162.0.0/16 | count()' ntp.log.gz
+zq -f table 'put ref_id=ref_id:ip | filter ref_id in 83.162.0.0/16 | count()' ntp.log.gz
 ```
 
 #### Output:

--- a/zql/docs/search-syntax/README.md
+++ b/zql/docs/search-syntax/README.md
@@ -286,7 +286,7 @@ To achieve this with a field/value match, we can use [glob wildcards](#glob-wild
 
 #### Example:
 ```zq-command
-zq -f table 'certificate.subject=~*Widgits*' *.log.gz
+zq -f table 'certificate.subject=*Widgits*' *.log.gz
 ```
 
 #### Output:
@@ -304,7 +304,7 @@ x509  2018-03-24T17:15:47.493786Z FdBWBA3eODh6nHFt82 3                   C5F8CDF
 
 #### Example:
 ```zq-command
-zq -f table 'uri =~ /scripts\/waE8_BuNCEKM.(pl|sh)/' http.log.gz
+zq -f table 'uri = /scripts\/waE8_BuNCEKM.(pl|sh)/' http.log.gz
 ```
 
 #### Output:
@@ -322,7 +322,7 @@ Determining whether the value of a Zeek `addr`-type field is within a subnet als
 
 #### Example:
 ```zq-command
-zq -f table 'id.resp_h =~ 208.78.0.0/16' conn.log.gz
+zq -f table 'id.resp_h in 208.78.0.0/16' conn.log.gz
 ```
 
 #### Output:
@@ -378,12 +378,12 @@ It's possible to search across _all_ fields of the value's data type by entering
 For example, the following search matches many `ssl` and `conn` events that contain the value `10.150.0.85` in `addr`-type fields of the `id` record, such as `id.resp_h`. It also matches `notice` events where it appears in `id.resp_h` and also `dst`, a top-level field also of the `addr` type. Compare this with our [bare word](#bare-word) example where we also matched as a substring of the `string`-type field named `certificate.subject`. This highlights how bare word searches match both on typed values and their string representation, whereas a field/value match is stricter, and considers typed values only.
 
 #### Example:
-```zq-command
+```zq-command-disabled
 zq -f table '**=10.150.0.85' *.log.gz
 ```
 
 #### Output:
-```zq-output head:8
+```zq-output-disabled head:8
 _PATH TS                          UID                ID.ORIG_H    ID.ORIG_P ID.RESP_H   ID.RESP_P PROTO SERVICE DURATION ORIG_BYTES RESP_BYTES CONN_STATE LOCAL_ORIG LOCAL_RESP MISSED_BYTES HISTORY   ORIG_PKTS ORIG_IP_BYTES RESP_PKTS RESP_IP_BYTES TUNNEL_PARENTS
 conn  2018-03-24T17:15:22.18798Z  CFis4J1xm9BOgtib34 10.47.8.10   56800     10.150.0.85 443       tcp   -       1.000534 31         77         SF         -          -          0            ^dtAfDTFr 8         382           10        554           -
 conn  2018-03-24T17:15:25.527535Z CnvVUp1zg3fnDKrlFk 10.47.27.186 58665     10.150.0.85 443       tcp   -       1.000958 31         77         SF         -          -          0            ^dtAfDFTr 8         478           10        626           -
@@ -494,7 +494,7 @@ For example, suppose you've noticed that the vast majority of the sample Zeek ev
 
 #### Example:
 ```zq-command
-zq -f table 'not _path=~/conn|dns|files|ssl|x509|http|weird/' *.log.gz
+zq -f table 'not _path=/conn|dns|files|ssl|x509|http|weird/' *.log.gz
 ```
 
 #### Output:
@@ -538,11 +538,12 @@ smb_mapping 2018-03-24T17:15:25.562072Z C3kUnM2kEJZnvZmSp7 10.164.94.120 45903  
 ...
 ```
 
+XXX fix comment
 If we change the order of the terms to what's shown below, now we match almost every event we have. This is due to the left-to-right evaluation: Since the `not` comes first, it inverts the logic of _everything that comes after it_, hence giving us all stored events _other than_ `smb_mapping` events that have the value of their `share_type` field set to `DISK`.
 
 #### Example:
 ```zq-command
-zq -f table 'not share_type=DISK _path=smb_mapping' *.log.gz
+zq -f table 'not (share_type=DISK and _path=smb_mapping)' *.log.gz
 ```
 
 #### Output:

--- a/zql/expr.md
+++ b/zql/expr.md
@@ -1,0 +1,633 @@
+# expression syntax and searches
+
+> This document describes recent work on unifying the search syntax with
+> the expression syntax.  We are checking this markdown file here with a bunch
+> of thoughts and notes into master for now with the
+> goal of integrating these concepts into the mainline documentation.
+> See Issue #2021.
+
+In order to support a mixture of _ad hoc_ search and well-defined analytics,
+the zql expression syntax attempts to blend the more informal properties
+of keyword search languages with the formal properties of expression syntax
+from programming languages.
+
+For example, when searching email, you might say something like
+```
+john smith
+```
+to mean emails relating to "John Smith" but you realize you got too many
+false positives so you refined the search to
+```
+john smith acme.com
+```
+becase you know he works at acme.com.  But then you realize he also has a  
+personal gmail account, so instead you search for
+```
+"John Smith"
+```
+and that's better but still too many false positives.  Finally, you  
+refine the search to
+```
+"John Smith" (acme.com OR gmail.com)
+```
+and you find what you were looking for.
+
+Now, suppose you were searching a structured database for John Smith.  The SQL
+query might look like this:
+```
+SELECT * FROM Messages
+   WHERE LastName='Smith' AND FirstName = "John" AND
+     (Email LIKE '*.acme.com' OR Email Like '*.gmail.com')
+```
+This SQL syntax is great because it's very precise and predictable, but this
+comes at more cognitive load and more typing than the ad hoc search query.
+If you're writing an analytics query to be saved in a notebook or run from
+automation, then the cognitive load is justified but if you are searching for
+stuff on an ad hoc basis, the free form syntax is much more productive.
+
+## zql - A Hybrid Approach
+
+Log search and analytics systems came along to fill this gap.
+In this approach, you can run a keyword search and send the
+results to a
+pipeline of operators to transform the search hits to something more
+predictable.
+
+In previous approaches, the search syntax is very different from the analytics
+syntax and the syntax for expressions can be somewhat cumbersome.
+
+With zql, however, we have strived to blend together the search language
+with the expression language where you can enjoy the ease of use of ad hoc,
+search-style syntax but blend searches with precision expression syntax
+that works both within the search predicate as well as the analytics processing.
+
+For example, suppose you wanted to search certain for zeek http logs
+that had some particular string pattern in one of the http headers and an unusually
+large request size.  You might say
+```
+_path=http AND (finance OR sales) request_body_len >= 10*MiB
+```
+Here, `_path=http` is an exact-match field comparisong between the field
+`_path` and the string `"http"`, `(finance OR sales)` is a free-form
+text search for either string `"finance"` or `"sales"` and
+`request_body_len >= 10*MiB` is boolean expression predicate that matches
+any zeek http logs whose field `request_body_len` is larger than 10MiB, where
+`MiB` is a constant equal to 2^20.
+
+> NOTE: We don't yet have support for constants like MiB but this will come soon.
+
+Compare this to...
+```
+_path=http (finance OR sales) request_body_len >= 10*MiB
+```
+Here, you would expect the concatenation-implies-AND to work for the
+ terms `_path=http` and `(finance OR sales)` but this is instead interpreted
+ as a reducer called "http" then a syntax error at `request_body_len`.
+
+ > How should we handle this ambiguity?  Right now, we say you need
+ > an explicit "and" before an open paren but this could be confusing.
+ > Perhaps we could say contatenated-AND is valid only for concatenated
+ > keyword search terms?  This might be less confusing and it shouldn't be
+ > too hard to implement.
+
+## The ambiguity problem
+
+Getting this all right and balancing the informal syntax with the formal syntax
+is a bit tricky.  For example, `*` can mean glob match in a search context or
+multiplication in an expression context.  So what should this mean?
+```
+a=b*c
+```
+Does this match numeric fields for field `a` that equals field `b` times
+`c` or should it match string fields starting with `"b"` and ending with `"c"`?
+
+What about this?
+```
+a < b * c
+```
+
+Or this?
+```
+query=web.*.com
+```
+
+Currently, we're assuming `a=b*c` is a string glob match but `a = b * c`
+is `b` times `c` as the spaces make it clear that it is not a glob string.
+
+Likewise, domain names use dotted notation as do record accesses and
+numeric IP address. So, clearly, this expression
+```
+query=acme.com
+```
+means to match the field called `query` against the string value `"acme.com"`,
+but this expression is less clear
+```
+id.orig_p=id.resp_p
+```
+In the case of zeek `id` records, the intent here is to match records
+in which the originator port and responder port is the same.
+
+Finally, consider these two expressions:
+```
+_path=conn | count()
+count() where _path=conn
+```
+The intent here is that the first `_path=conn` expression is in the context
+of a search while the second is in the context of a boolean expression
+embedded in a where clause.  In the unified approach, the where clause is
+simply a boolean search expression so you can say
+```
+count() where acme.com or google.com
+```
+Consider another examples
+```
+* | put isConn=_path=conn, isSSL=_path=ssl, portsMatch=id.orig_h=id.orig_p | ...
+```
+Here, `=` means two different things (assignment and comparison).  The parse
+knows by context which is which but it can look a bit funny.  This might
+make more sense:
+```
+* | put isConn=_path==conn, isSSL=_path==ssl, portsMatch=id.orig_h==id.orig_p | ...
+```
+But now, we don't want to have to say this...
+```
+_path==conn | ...
+```
+Again, blending keyword search metaphors with programming language expressions
+necessarily creates ambiguities.
+
+## Resolving the ambiguities
+
+To settle all this and still support a nice hybrid language, we define
+a set of "shortcuts" that are valid in search expressions (but not
+in standard expressions).
+
+> Maybe we should make the shortcuts work for standard expressions too?
+> This would be more consistent and probably easier to document and understand
+> and you can always "escape out of" the shortcuts with canonical syntax.
+
+The shortcuts will use these definitions:
+```
+ID = identifier (interpreted as string literal)
+DottedID = two or more IDs joined by "." (interpreted as string literal)
+```
+
+The shortcuts are:
+
+* RHS of `<lval>=<expr>` is a string iff `<expr>` is an ID or DottedID even
+when LHS is something more complicated than a simple field expression, e.g.,
+`ip_list[3]=foo` or even `1+1=foo`, which is false (comparing 2 to string "foo"),
+which is not the same as the predicate `foo=2`.
+* RHS of `<lval>=<glob>` is a regular expression match iff `<glob>` is a glob
+style string  (i.e., not to be interpreted as multiplication)
+when LHS is something more complicated than a simple field expression, e.g.,
+`ip_list[3]=foo` or even `1+1=foo`, which is false (comparing 2 to string "foo"),
+which is not the same as the predicate `foo=2`.
+* To interpret a standalone ID or DottedID on RHS as record access instead
+of string, you simply prepend a ".", e.g., `id.orig_p=.id.resp_p`.  Of course,
+this is the same as `.id.orig_p=.id.resp_p`.
+* A RHS that is an expression does not ever interpret ID or DottedID as a string,
+e.g., in `foo=bar*baz>10`, `bar` and `baz` are field references not strings and
+`*` is multiplication not glob match because it appears in the context of a
+comparision expression.  On the other hand, for `foo=bar*baz`, the RHS would
+be a glob style match for strings beginning with `bar` and ending in `baz`.
+
+> Note: we don't quite have all these rules working yet.  "."prefix
+> disambiguation and `1+1=foo` isn't doing the right thing.  The
+> expression syntax needs one more pass of re-jiggering.  That said, we have
+> no unified (most) generic expression syntax so you can search on  
+> expression-oriented boolean predicates.
+
+> Also note: minus sign is no longer allowed as a shortcut RHS string, so
+> `acme.com-foo` is always any expression.  We could change this back if we'd like.
+
+For expression context, e.g., RHS of `put` or `cut` assignment or
+boolean-expression in `where` clause, these SAME rules apply as the
+search predicates.
+
+That said, keyword search does not appear in expression context.
+e.g.,
+```
+* | put x=foo
+```
+means assign the field foo to x.  The RHS is never a keyword search resulting
+in a boolean for matches to the word "foo".   That said, search syntax can
+appear inside of an expression with the explicit use of the `match` function,
+e.g.,
+```
+* | put foundIt=match(foo)
+```
+or from our example above...
+```
+* | put foundIt=match("John Smith" (acme.com OR gmail.com))
+```
+
+> Note: we may want to make `put x=foo==bar` treat bar as a string to be
+> consistent with the search shortcuts.  It doesn't work like this now,
+> but we could easily make this change.
+
+### `*` and `**` replaced with generators and method chaining
+
+As part of this work, the implementation of `*`, and `**` wildcard matches
+has been generalized.
+
+Querying over semi-structured data has been extensively studied in the worlds of
+XML and NOSQL databases.
+SQL++ has N1QL have
+[collection operators](https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/collectionops.html).
+
+While we were motivated by the approach in these systems, they are very
+SQL-oriented and don't match the flow-based programming model of Z.
+(It is future work to put a SQL interface onto the Z analytics engine and
+perhaps these SQL++ style idioms will come into play here.)
+
+The field wildcard search is a specific-case in the current Z implementation
+of operating over semi-structured data, e.g.,
+```
+*=foo
+```
+This is really a boolean predicate applied to each field a (short-circuit)
+OR-ed together.  This leads one to think that maybe a generator style model
+could be used here, where we select values to be "generated" then we operate
+on those values using
+[fluent-style](https://en.wikipedia.org/wiki/Fluent_interface)
+method chaining a la d3, jQuery, react, etc.
+
+For example, `select` could be used to select a sequence of records that
+would generate the field values of each record,
+```
+select(a,b)
+```
+(where `a` and `b` are expected to be records)
+then we could operate on those values with an aggregator, e.g.,
+```
+sum(select(a,b))
+```
+Of course, the fields of "." could be selected as follows,
+```
+sum(select(.))
+```
+Then a predicate applied to each generated value:
+```
+sum(select(.).map($=foo)
+```
+where `$` refers to the "current value" in the generated sequence,
+then the results could be aggreagated with an "or" function:
+```
+or(sum(select(.).map($=foo))
+```
+which is equivalent to
+```
+*=foo
+```
+
+> Note the compiled optimizes the general structure to something more
+> compact and efficient for the common cases like "match any field".
+
+The select syntax needs exploration but the idea is that it generates a
+sequence of values that can be operated upon by methods which can modify or
+filter the sequence (where `$` refers to the current value in the sequence)
+and the resulting sequence can be summarized with an aggregate function.
+
+Selecting a container generates each value in the container (for records,
+the top level fields are generated and not recursed into... I was thinking
+we could have another variant of select called `traverse` that descends
+into records and perhaps has a continuation/halt predicate to control the walk).
+
+Selecting a primitive generates that one value.  But select can take multiple
+arguments so you can select a sequence of values.
+
+> Note: currently only record selecting is implemented but these variations
+> are pretty straightforward to add.
+
+#### Syntactic Sugar
+
+Once we play around with these generator concepts, we may decide upon syntactic
+sugar for common use cases and Z patterns.
+
+We may want to build `any` and `all` boolean expressions from SQL++,
+e.g., for addr and nets you could say
+```
+any(n over nets, addr in n)
+```
+or
+```
+all(n over nets, addr in n)
+```
+This could recurse in the array of arrays case, e.g.,
+```
+A:[[1,2,3],[4,5],[3,3]]
+```
+```
+any(a over A, any(v over a, v=1))
+```
+would be true
+```
+any(a over A, all(v over a, v=3))
+```
+would also be true but
+```
+any(a over A, all(v over a, v=1))
+```
+would be false.
+
+Once we have this, we can define `a in A` to mean the above or a variation
+of above where there is flexibility in traversing the nesting as in the
+confusing `recursive` flag (it wouldn't be so confusing if there were
+precise semantics that were documented like we are trying to do here).
+
+With type values, this pattern also means we can do bare searches based on type:
+```
+any(addr is typeof(ip) within ., addr=192.168.1.1)
+```
+where we could have an abbreviation
+```
+192.168.1.1 in* .
+```
+where `in*` implies the recursive behavior from before.
+
+To make this all clear, I think what's going on here is we're identifying
+sets of things to traverse then we are traversing them with a loop variable
+and we're allowing the construct to be recursive.  This means we should
+break the pattern into two pieces: (1) an expression syntax to create / refer to
+sets of values, and (2) an any/all syntax to apply a predicate to each value
+of the set and compute a boolean AND (for all) or a boolean OR (for any) of
+each predicate.
+
+is the set of values of type ip nested within `.`  This is perhaps where the
+recursive matcher belongs.  Then the above expression can be written as
+```
+any(addr over types_of(., (ip)), addr=192.168.1.1)
+```
+> These structures are vectorizable and are predicates that can be
+> pushed down into the zst scanner when we get to columnar optimization (well
+> after launch of MVP).
+
+
+### Examples
+
+```
+put s=sum(select(.).filter($>0))
+put s=sum(select(.).filter(typeof($)={[int64]})).map(sum($))
+```
+
+`select` generates the top-level field values of a record.
+`traverse` does a dfs traversal of nested records but does not enter  
+non-record container-types (see below).
+
+But how do we differentiate this from standard aggregator?
+Right now, this compiles to-group-by.
+We can distinguish here because the arg must be a generator instead
+of a value expression and generators cannot be elements of an expression
+(e.g., you can't say `select(.)+1` you have to say `select(.).map($+1)`)
+
+and
+```
+**=foo
+```
+is the same as
+```
+or($.traverse(.).map($=foo))
+```
+
+Traversals can be recursive into array of records or array of arrays...
+```
+sum(x.y.traverse().filter(typeof($)=[int32]).traverse().filter($>100))
+```
+
+Collect can be used to put stuff into an array (or array of union)...
+```
+($g=x.y.traverse(.)).filter($=foo+$g)
+```
+
+> TBD: fix collect() reducer to handle mixed-type inputs
+
+> Note: in the implementation, the *parser* knows that something is a
+> generator chain because it starts with a keyword that creates a generator
+> as generators are not otherwise first-class values.  In the first stab at
+> this only select() and traverse() will create the initial generator.
+> Then any reducer can be applied to a generated sequence to produce a
+> first-class value/result.  In the very first stab, we'll start with select().
+
+Syntactically, we know that a generator-function happens if and only if
+we see the construct
+```
+<gen-expr> . <identifier> ( <args> )
+```
+
+> Note because the parser knows what is a generated thing, we can differentiate
+> between this and module syntax for function calls if we ever want to do that.
+
+We need to distinguish between:
+* global aggregations
+* running aggregation inside of expression
+* aggregations operating on generated sequences
+
+An array can be used as a generator, e.g., if `a` is an array...
+```
+select(a).filter($>1)
+```
+
+An array constant...
+
+```
+select([1,2,3]).filter($>=2)
+```
+or this can work...
+```
+c=collect(select({a:1,b:2,c:3}).map($+1))
+```
+
+The slice operator works on sequences like this:
+```
+[1,2,3,4].[1:2]
+```
+which gives the sequence
+```
+2,3
+```
+This can be applied to arrays as well as generators.  In the case of array,
+the result is an array (not a generator).  But you can use the array as a source
+of a generator expression so you can slice something then operate on the generated
+alements like this:
+```
+collect(select(a[2:4]).map($+1))
+```
+
+> NOTE: we might want to make array be an implied sequence if a method is
+> applied to them.  Then the system won't know that something is generated
+> until runtime but that might be okay.
+
+Or we can distinguish generator idioms from field access are that the
+generator operators are reserved keywords, e.g.,
+* select
+* map
+* filter
+* join
+
+Search syntax can be applied in expression context with the "match" keyword
+```
+... | put isGoogle=match(google.com or acme.com) | ...
+```
+
+Sub-searches can be triggered with the search keyword where the result
+of a search is a
+(it would be up to the runtime context to, for instance, apply the primary-key
+time window of the outer search to the sub-search, unless somehow overridden).
+```
+... | put queryMap=map(search(google.com or acme.com | c=count() by q=query)) | ...
+```
+The `map` aggregator creates a map value.
+
+## Misc
+
+We should have a way to get the filed names of a record as `[string]`.
+(Note: this is just the keys, not nested naming.)
+This could be `fields()`.
+
+`has()` should be a boolean operator on a record that says whether a record
+has the given name (and it can be recursive with "." or with string array
+like field.Static).  More generally, it can operate on an expression and
+return true iff the expression is not equal to `error("missing")`.
+Perhaps `missing` could be a reserved word like `null` that is the
+same as `error("missing")`.
+
+`is()` could be shorthand for a type boolean, e.g., `id.is(socket)`
+where once we have constants you could put a definition for `conn`
+in the Z:
+```
+let port = uint16
+let socket = {orig_h:ip,orig_p:port,resp_h:ip,resp_p:port}
+* | put hasSocket=id.is(socket)
+```
+
+We should have methods for all of this so we could say `.is(string)`
+or `foo.is(string)` where we node this is not module naming.
+If we ever do module naming we would might use something like `$` or `@`
+to clarify the module reference.  Maybe we can get away without having this?
+
+A sub-search can be easily integrated into the generator model by having
+a sub-search simply be a generator of records.  Woohoo!  This is sweet.
+```
+put c=collect(search(<expr>).filter(<expr>))
+```
+
+## Matrix of `<agg>(<gen>), <running-agg>(<expr>), <predicate-agg>(<gen>)`
+
+In search context, "or" collides with logical-or, but we could have a
+generic "agg" function like this...
+```
+agg(or, select(*).map($=foo))
+```
+
+In expression context, the syntax-collision here is resolved because we don't
+have and-concatentation so the parser can handle this:
+```
+... | put x = or(select(foo)) or or(select(bar)) | ...
+```
+
+Actually... if generators are syntatically distinct, then `or(<gen>)` can be
+differentiated from `or (<expr>)`.
+
+## @ operator
+
+An operator is applied to a generator using BinaryExpr with operator `@`
+(i.e,. this is what appears in the binary expression ast node).
+We could have this in the Z language but we know when a generator is on
+the left-hand side so we can overload "." and it will look cleaner.
+
+With @-notation,
+```
+or(select(.).map($=foo))
+```
+would look like this:
+```
+or(.select(*)@map($=foo))
+```
+
+## TO DO
+
+* `1+1=foo` not right yet... this should apply in expression context too so
+things are the same.
+* `cut(x).y=z` ... should `z` be a string here?  or identifier?
+* `filter true` does a search for bool(true)... maybe true/false should be treated
+special.  also, true shouldn't be an identifier unless escaped (like or etc)
+* we need to test generators inside of generators, e.g., `collect(select(.).map(collect(select($.foo))`.  This should "just work" but
+we should play with this further and see where we might want to take this.
+
+> XXX for now just return (nil, nil) if it doesn't work...
+> we should distinguish between "this is clearly a generator
+> but there's an error" and this is something else...
+> or maybe it's okay that the layer above flags the error.
+> or maybe not because it will say "unknown function" when
+> the function name might be right but the syntax here is wrong.
+> we need an isAggregator test on the name then code to do
+> either an continuous-agg or a generator-agg
+
+## Discussion points
+
+### `foo(bar)`
+
+If you want `foo AND bar` should we required the `AND` or a space?
+Or something else?
+
+### Canonical Syntax
+
+What did the compiler do?  Can look at AST but it would be nice to have
+a clear and unambiguous canonical form so we could show the user
+"this is what we think you want".  Noah had some thoughts on this based on
+a few ideas from kusto.
+
+
+### deprecating =~
+
+We got rid of `=~`, which in other systems means case insensitive equality but
+in our system was a hybrid.  It meant RE match and subnet match.  Previously,
+`s=foo*` meant a literal match of `foo*` but `foo*` meant a glob keyword search.
+
+With better glob handling, `s=foo*` should be a glob match
+and `s="foo*"` should be literal match and s=/foo.*/ should
+be regexp match.
+
+Since we took out `=~`, I made this work
+```
+addr in 192.168.0.0/16
+```
+
+Also, it seems like this should work (cidr match over an array of nets)...
+```
+addr in [192.168.1.0/24, 192.168.2.0/24, 10.1.0.0/16]
+```
+but this means is the IP address one of the elements in the array.
+The right way to do this (see below) is as follows:
+```
+or(select([192.168.1.0/24, 192.168.2.0/24, 10.1.0.0/16]).map(addr in $))
+```
+
+> Note: array expressions are not yet implemented nor is selection on
+> an array expression but this is pretty straightforward and will come soon.
+
+## Syntactic sugar
+
+For example...
+```
+ANY departure IN schedule SATISFIES departure.utc > "23:41"
+```
+Here, `departure` is essentially the loop variable that takes on each
+value in schedule and `ANY` performs a short-circuit OR of the predicate
+give by `SATISFIES`.
+
+This is really a lamba that is applied to a value then the results of
+the lamba are operated upon.  Here, the lambda is boolean-valued:
+```
+lambda(x): x > "23:41"
+```
+and the logical operator is like the current `or` aggregator that is applied
+to the sequence generated by the collection, e.g.,
+```
+vk over schedule: apply OR lambda(vk)
+```
+
+Given this, we could have low-level syntax that creates and applies lambdas
+either as an aggregator or as a map function, let's call them `agg` and `apply`.
+Then

--- a/zql/valid.zql
+++ b/zql/valid.zql
@@ -23,3 +23,5 @@ foo\x11\bar
 *abc*
 field=null
 every 3600s count() by _path
+s="harefoot-raucous"
+s=/a/b

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -286,195 +286,204 @@ function peg$parse(input, options) {
       peg$startRuleFunction  = peg$parsestart,
 
       peg$c0 = function(ast) { return ast },
-      peg$c1 = function(procs) {
-            return {"op": "SequentialProc", "procs": procs}
+      peg$c1 = function(first, rest) {
+            return {"op": "SequentialProc", "procs": [first, ... rest]}
           },
-      peg$c2 = function(s, rest) {
-            if (rest.length == 0) {
-                return s
-            } else {
-                return {"op": "SequentialProc", "procs": [s, ... rest]}
-            }
+      peg$c2 = function(op) {
+            return {"op": "SequentialProc", "procs": [op]}
           },
-      peg$c3 = function(expr) {
+      peg$c3 = "|",
+      peg$c4 = peg$literalExpectation("|", false),
+      peg$c5 = function(p) { return p },
+      peg$c6 = function(first, rest) {
+            return [first, ... rest]
+          },
+      peg$c7 = function(first) {
+            return [first]
+          },
+      peg$c8 = "=>",
+      peg$c9 = peg$literalExpectation("=>", false),
+      peg$c10 = function(ch) { return ch },
+      peg$c11 = "split",
+      peg$c12 = peg$literalExpectation("split", false),
+      peg$c13 = "(",
+      peg$c14 = peg$literalExpectation("(", false),
+      peg$c15 = ")",
+      peg$c16 = peg$literalExpectation(")", false),
+      peg$c17 = function(procArray) {
+            return {"op": "ParallelProc", "procs": procArray}
+          },
+      peg$c18 = function(a) { return a },
+      peg$c19 = function(expr) {
             return {"op": "FilterProc", "filter": expr}
           },
-      peg$c4 = function(first, rest) {
-            return makeChain(first, rest, "LogicalOr")
+      peg$c20 = ":",
+      peg$c21 = peg$literalExpectation(":", false),
+      peg$c22 = "-with",
+      peg$c23 = peg$literalExpectation("-with", false),
+      peg$c24 = ",",
+      peg$c25 = peg$literalExpectation(",", false),
+      peg$c26 = function(first, rest) {
+            return makeBinaryExprChain(first, rest)
           },
-      peg$c5 = function(t) { return t },
-      peg$c6 = function(first, rest) {
-            return makeChain(first, rest, "LogicalAnd")
+      peg$c27 = function(t) { return ["or", t] },
+      peg$c28 = function(first, expr) { return ["and", expr] },
+      peg$c29 = function(first, rest) {
+            return makeBinaryExprChain(first,rest)
           },
-      peg$c7 = function(f) { return f },
-      peg$c8 = "!",
-      peg$c9 = peg$literalExpectation("!", false),
-      peg$c10 = function(e) {
-            return {"op": "LogicalNot", "expr": e}
+      peg$c30 = "!",
+      peg$c31 = peg$literalExpectation("!", false),
+      peg$c32 = function(e) {
+            return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c11 = "-",
-      peg$c12 = peg$literalExpectation("-", false),
-      peg$c13 = function(s) { return s },
-      peg$c14 = "(",
-      peg$c15 = peg$literalExpectation("(", false),
-      peg$c16 = ")",
-      peg$c17 = peg$literalExpectation(")", false),
-      peg$c18 = function(expr) { return expr },
-      peg$c19 = "*",
-      peg$c20 = peg$literalExpectation("*", false),
-      peg$c21 = function(comp, v) {
-            return {"op": "CompareAny", "comparator": comp, "recursive": false, "value": v}
+      peg$c33 = function(expr) { return expr },
+      peg$c34 = "*",
+      peg$c35 = peg$literalExpectation("*", false),
+      peg$c36 = function(compareOp, v) {
+            return {"op": "FunctionCall", "function": "or",
+              
+            "args": [{"op": "BinaryExpr", "operator":"@",
+                       
+            "lhs":{"op": "SelectExpr", "selectors": [{"op": "RootRecord"}]},
+                       
+            "rhs":{"op": "FunctionCall", "function": "map",
+                         
+            "args": [{"op": "BinaryExpr", "operator": "=",
+                           
+            "lhs": {"op": "Identifier", "name": "$"},
+                           
+            "rhs": v}]}}]}
+          
+
+
+
+
+
           },
-      peg$c22 = "**",
-      peg$c23 = peg$literalExpectation("**", false),
-      peg$c24 = function(comp, v) {
-            return {"op": "CompareAny", "comparator": comp, "recursive": true, "value": v}
+      peg$c37 = function(f, comp, v) {
+            return {"op": "BinaryExpr", "operator":comp, "lhs":f, "rhs":v}
           },
-      peg$c25 = function(f, comp, v) {
-            return {"op": "CompareField", "comparator": comp, "field": f, "value": v}
+      peg$c38 = function(v) {
+            return {"op": "FunctionCall", "function": "or",
+              
+            "args": [{"op": "BinaryExpr", "operator":"@",
+                       
+            "lhs":{"op": "SelectExpr", "selectors": [{"op": "RootRecord"}]},
+                       
+            "rhs":{"op": "FunctionCall", "function": "map",
+                         
+            "args": [{"op": "BinaryExpr", "operator": "in",
+                           
+            "lhs": v,
+                           
+            "rhs": {"op": "Identifier", "name": "$"}}]}}]}
+          
+
+
+
+
+
           },
-      peg$c26 = "len",
-      peg$c27 = peg$literalExpectation("len", false),
-      peg$c28 = function(expr, comp, v) {
-          return {"op": "BinaryExpression", "operator": comp, "lhs": expr, "rhs": v}
-        },
-      peg$c29 = function(v) {
-            return {"op": "CompareAny", "comparator": "in", "recursive": false, "value": v}
-          },
-      peg$c30 = function(v, f) {
-            return {"op": "CompareField", "comparator": "in", "field": f, "value": v}
-          },
-      peg$c31 = function(v) {
+      peg$c39 = function(v) {
             return {"op": "Search", "text": text(), "value": v}
           },
-      peg$c32 = function(v) {
+      peg$c40 = function() {
+            return {"op": "Literal", "type": "bool", "value": "true"}
+          },
+      peg$c41 = function(v) {
+            return {"op": "Literal", "type": "string", "value": v}
+          },
+      peg$c42 = function(v) {
             let str = v;
-            if (str == "*") {
-              return {"op": "MatchAll"}
-            }
             let literal = {"op": "Literal", "type": "string", "value": v};
             if (reglob$1.IsGlobby(str)) {
               literal["type"] = "regexp";
               literal["value"] = reglob$1.Reglob(str);
             }
-            return {"op": "Search", "text": text(), "value": literal}
+            return literal
           },
-      peg$c33 = function(v) {
-            return {"op": "Literal", "type": "string", "value": v}
+      peg$c43 = function(head, tail) {
+            return joinChars(head) + joinChars(tail)
           },
-      peg$c34 = function(i) { return i },
-      peg$c35 = function(v) { return v },
-      peg$c36 = function(v) {
-            return {"op": "Literal", "type": "regexp", "value": v}
+      peg$c44 = function(s, v) { return s+v },
+      peg$c45 = function() { return text() },
+      peg$c46 = "=",
+      peg$c47 = peg$literalExpectation("=", false),
+      peg$c48 = "!=",
+      peg$c49 = peg$literalExpectation("!=", false),
+      peg$c50 = "in",
+      peg$c51 = peg$literalExpectation("in", false),
+      peg$c52 = "<=",
+      peg$c53 = peg$literalExpectation("<=", false),
+      peg$c54 = "<",
+      peg$c55 = peg$literalExpectation("<", false),
+      peg$c56 = ">=",
+      peg$c57 = peg$literalExpectation(">=", false),
+      peg$c58 = ">",
+      peg$c59 = peg$literalExpectation(">", false),
+      peg$c60 = function(first, op, expr) { return [op, expr] },
+      peg$c61 = function(first, rest) {
+              return makeBinaryExprChain(first, rest)
           },
-      peg$c37 = function(v) {
-            return {"op": "Literal", "type": "net", "value": v}
+      peg$c62 = function(e, typ) { return typ },
+      peg$c63 = function(e, typ) {
+            return {"op": "CastExpr", "expr": e, "type": typ}
           },
-      peg$c38 = function(v) {
-            return {"op": "Literal", "type": "ip", "value": v}
-          },
-      peg$c39 = function(v) {
-            return {"op": "Literal", "type": "float64", "value": v}
-          },
-      peg$c40 = function(v) {
-            return {"op": "Literal", "type": "int64", "value": v}
-          },
-      peg$c41 = "true",
-      peg$c42 = peg$literalExpectation("true", false),
-      peg$c43 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
-      peg$c44 = "false",
-      peg$c45 = peg$literalExpectation("false", false),
-      peg$c46 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
-      peg$c47 = "null",
-      peg$c48 = peg$literalExpectation("null", false),
-      peg$c49 = function() { return {"op": "Literal", "type": "null", "value": ""} },
-      peg$c50 = function(first, rest) {
-           if (rest) {
-              return [first, ... rest]
-            }
-            return [first]
-          },
-      peg$c51 = "|",
-      peg$c52 = peg$literalExpectation("|", false),
-      peg$c53 = function(p) { return p },
-      peg$c54 = "split",
-      peg$c55 = peg$literalExpectation("split", false),
-      peg$c56 = "=>",
-      peg$c57 = peg$literalExpectation("=>", false),
-      peg$c58 = function(proc) {
-            return proc
-          },
-      peg$c59 = function(first, rest) {
-            let fp = {"op": "SequentialProc", "procs": first};
-            if (rest) {
-              return {"op": "ParallelProc", "procs": [fp, ... rest]}
-            } else {
-              return fp
-            }
-          },
-      peg$c60 = ";",
-      peg$c61 = peg$literalExpectation(";", false),
-      peg$c62 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
-      peg$c63 = function(every, keys, limit) {
+      peg$c64 = function(every, keys, limit) {
             return {"op": "GroupByProc", "keys": keys, "reducers": null, "duration": every, "limit": limit}
           },
-      peg$c64 = function(every, reducers, keys, limit) {
+      peg$c65 = function(every, reducers, keys, limit) {
             let p = {"op": "GroupByProc", "keys": null, "reducers": reducers, "duration": every, "limit": limit};
             if (keys) {
               p["keys"] = keys[1];
             }
             return p
           },
-      peg$c65 = "every",
-      peg$c66 = peg$literalExpectation("every", true),
-      peg$c67 = function(dur) { return dur },
-      peg$c68 = "by",
-      peg$c69 = peg$literalExpectation("by", true),
-      peg$c70 = function(columns) { return columns },
-      peg$c71 = "with",
-      peg$c72 = peg$literalExpectation("with", false),
-      peg$c73 = "-limit",
-      peg$c74 = peg$literalExpectation("-limit", false),
-      peg$c75 = function(limit) { return limit },
-      peg$c76 = "",
-      peg$c77 = function() { return 0 },
-      peg$c78 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c79 = ",",
-      peg$c80 = peg$literalExpectation(",", false),
-      peg$c81 = function(first, expr) { return expr },
-      peg$c82 = function(first, rest) {
-            return [first, ... rest]
-          },
-      peg$c83 = "=",
-      peg$c84 = peg$literalExpectation("=", false),
-      peg$c85 = function(lval, reducer) {
+      peg$c66 = "every",
+      peg$c67 = peg$literalExpectation("every", true),
+      peg$c68 = function(dur) { return dur },
+      peg$c69 = function(columns) { return columns },
+      peg$c70 = "with",
+      peg$c71 = peg$literalExpectation("with", false),
+      peg$c72 = "-limit",
+      peg$c73 = peg$literalExpectation("-limit", false),
+      peg$c74 = function(limit) { return limit },
+      peg$c75 = "",
+      peg$c76 = function() { return 0 },
+      peg$c77 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c78 = function(first, expr) { return expr },
+      peg$c79 = function(lval, reducer) {
             return {"op": "Assignment", "lhs": lval, "rhs": reducer}
           },
-      peg$c86 = function(reducer) {
+      peg$c80 = function(reducer) {
             return {"op": "Assignment", "lhs": null, "rhs": reducer}
           },
-      peg$c87 = "not",
-      peg$c88 = peg$literalExpectation("not", false),
-      peg$c89 = function(op, expr, where) {
+      peg$c81 = ".",
+      peg$c82 = peg$literalExpectation(".", false),
+      peg$c83 = function(op, expr, where) {
             let r = {"op": "Reducer", "operator": op, "expr": null, "where":where};
             if (expr) {
               r["expr"] = expr;
             }
             return r
           },
-      peg$c90 = "where",
-      peg$c91 = peg$literalExpectation("where", false),
-      peg$c92 = function(first, rest) {
+      peg$c84 = "not",
+      peg$c85 = peg$literalExpectation("not", false),
+      peg$c86 = "match",
+      peg$c87 = peg$literalExpectation("match", false),
+      peg$c88 = "where",
+      peg$c89 = peg$literalExpectation("where", false),
+      peg$c90 = function(first, rest) {
             let result = [first];
             for(let  r of rest) {
               result.push( r[3]);
             }
             return result
           },
-      peg$c93 = "sort",
-      peg$c94 = peg$literalExpectation("sort", true),
-      peg$c95 = function(args, l) { return l },
-      peg$c96 = function(args, list) {
+      peg$c91 = "sort",
+      peg$c92 = peg$literalExpectation("sort", true),
+      peg$c93 = function(args, l) { return l },
+      peg$c94 = function(args, list) {
             let argm = args;
             let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false};
             if ( "r" in argm) {
@@ -487,26 +496,24 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c97 = function(a) { return a },
-      peg$c98 = function(args) { return makeArgMap(args) },
-      peg$c99 = "-r",
-      peg$c100 = peg$literalExpectation("-r", false),
-      peg$c101 = function() { return {"name": "r", "value": null} },
-      peg$c102 = "-nulls",
-      peg$c103 = peg$literalExpectation("-nulls", false),
-      peg$c104 = "first",
-      peg$c105 = peg$literalExpectation("first", false),
-      peg$c106 = "last",
-      peg$c107 = peg$literalExpectation("last", false),
-      peg$c108 = function() { return text() },
-      peg$c109 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c110 = "top",
-      peg$c111 = peg$literalExpectation("top", true),
-      peg$c112 = function(n) { return n},
-      peg$c113 = "-flush",
-      peg$c114 = peg$literalExpectation("-flush", false),
-      peg$c115 = function(limit, flush, f) { return f },
-      peg$c116 = function(limit, flush, fields) {
+      peg$c95 = function(args) { return makeArgMap(args) },
+      peg$c96 = "-r",
+      peg$c97 = peg$literalExpectation("-r", false),
+      peg$c98 = function() { return {"name": "r", "value": null} },
+      peg$c99 = "-nulls",
+      peg$c100 = peg$literalExpectation("-nulls", false),
+      peg$c101 = "first",
+      peg$c102 = peg$literalExpectation("first", false),
+      peg$c103 = "last",
+      peg$c104 = peg$literalExpectation("last", false),
+      peg$c105 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c106 = "top",
+      peg$c107 = peg$literalExpectation("top", true),
+      peg$c108 = function(n) { return n},
+      peg$c109 = "-flush",
+      peg$c110 = peg$literalExpectation("-flush", false),
+      peg$c111 = function(limit, flush, f) { return f },
+      peg$c112 = function(limit, flush, fields) {
             let proc = {"op": "TopProc", "limit": 0, "fields": null, "flush": false};
             if (limit) {
               proc["limit"] = limit;
@@ -519,9 +526,9 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c117 = "cut",
-      peg$c118 = peg$literalExpectation("cut", true),
-      peg$c119 = function(args, columns) {
+      peg$c113 = "cut",
+      peg$c114 = peg$literalExpectation("cut", true),
+      peg$c115 = function(args, columns) {
             let argm = args;
             let proc = {"op": "CutProc", "fields": columns, "complement": false};
             if ( "c" in argm) {
@@ -529,77 +536,76 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c120 = "-c",
-      peg$c121 = peg$literalExpectation("-c", false),
-      peg$c122 = function() { return {"name": "c", "value": null} },
-      peg$c123 = function(args) {
+      peg$c116 = "-c",
+      peg$c117 = peg$literalExpectation("-c", false),
+      peg$c118 = function() { return {"name": "c", "value": null} },
+      peg$c119 = function(args) {
             return makeArgMap(args)
           },
-      peg$c124 = "pick",
-      peg$c125 = peg$literalExpectation("pick", true),
-      peg$c126 = function(columns) {
+      peg$c120 = "pick",
+      peg$c121 = peg$literalExpectation("pick", true),
+      peg$c122 = function(columns) {
             return {"op": "PickProc", "fields": columns}
           },
-      peg$c127 = "drop",
-      peg$c128 = peg$literalExpectation("drop", true),
-      peg$c129 = function(columns) {
+      peg$c123 = "drop",
+      peg$c124 = peg$literalExpectation("drop", true),
+      peg$c125 = function(columns) {
             return {"op": "DropProc", "fields": columns}
           },
-      peg$c130 = "head",
-      peg$c131 = peg$literalExpectation("head", true),
-      peg$c132 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c133 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c134 = "tail",
-      peg$c135 = peg$literalExpectation("tail", true),
-      peg$c136 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c137 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c138 = "filter",
-      peg$c139 = peg$literalExpectation("filter", true),
-      peg$c140 = "uniq",
-      peg$c141 = peg$literalExpectation("uniq", true),
-      peg$c142 = function() {
+      peg$c126 = "head",
+      peg$c127 = peg$literalExpectation("head", true),
+      peg$c128 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c129 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c130 = "tail",
+      peg$c131 = peg$literalExpectation("tail", true),
+      peg$c132 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c133 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c134 = "filter",
+      peg$c135 = peg$literalExpectation("filter", true),
+      peg$c136 = function(op) {
+            return op
+          },
+      peg$c137 = "uniq",
+      peg$c138 = peg$literalExpectation("uniq", true),
+      peg$c139 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c143 = function() {
+      peg$c140 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c144 = "put",
-      peg$c145 = peg$literalExpectation("put", true),
-      peg$c146 = function(columns) {
+      peg$c141 = "put",
+      peg$c142 = peg$literalExpectation("put", true),
+      peg$c143 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c147 = "rename",
-      peg$c148 = peg$literalExpectation("rename", true),
-      peg$c149 = function(first, cl) { return cl },
-      peg$c150 = function(first, rest) {
+      peg$c144 = "rename",
+      peg$c145 = peg$literalExpectation("rename", true),
+      peg$c146 = function(first, cl) { return cl },
+      peg$c147 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c151 = "fuse",
-      peg$c152 = peg$literalExpectation("fuse", true),
-      peg$c153 = function() {
+      peg$c148 = "fuse",
+      peg$c149 = peg$literalExpectation("fuse", true),
+      peg$c150 = function() {
             return {"op": "FuseProc"}
           },
-      peg$c154 = "join",
-      peg$c155 = peg$literalExpectation("join", true),
-      peg$c156 = function(leftKey, rightKey, columns) {
+      peg$c151 = "join",
+      peg$c152 = peg$literalExpectation("join", true),
+      peg$c153 = function(leftKey, rightKey, columns) {
             let proc = {"op": "JoinProc", "left_key": leftKey, "right_key": rightKey, "clauses": null};
             if (columns) {
               proc["clauses"] = columns[1];
             }
             return proc
           },
-      peg$c157 = function(key, columns) {
+      peg$c154 = function(key, columns) {
             let proc = {"op": "JoinProc", "left_key": key, "right_key": key, "clauses": null};
             if (columns) {
               proc["clauses"] = columns[1];
             }
             return proc
           },
-      peg$c158 = ".",
-      peg$c159 = peg$literalExpectation(".", false),
-      peg$c160 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
-      peg$c161 = function() { return {"op": "RootRecord"} },
-      peg$c162 = function(first, rest) {
+      peg$c155 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -608,269 +614,308 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c163 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c164 = "?",
-      peg$c165 = peg$literalExpectation("?", false),
-      peg$c166 = ":",
-      peg$c167 = peg$literalExpectation(":", false),
-      peg$c168 = function(condition, thenClause, elseClause) {
+      peg$c156 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c157 = "?",
+      peg$c158 = peg$literalExpectation("?", false),
+      peg$c159 = function(condition, thenClause, elseClause) {
             return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c169 = function(first, op, expr) { return [op, expr] },
-      peg$c170 = function(first, rest) {
-              return makeBinaryExprChain(first, rest)
-          },
-      peg$c171 = function(first, comp, expr) { return [comp, expr] },
-      peg$c172 = "=~",
-      peg$c173 = peg$literalExpectation("=~", false),
-      peg$c174 = "!~",
-      peg$c175 = peg$literalExpectation("!~", false),
-      peg$c176 = "!=",
-      peg$c177 = peg$literalExpectation("!=", false),
-      peg$c178 = "in",
-      peg$c179 = peg$literalExpectation("in", false),
-      peg$c180 = "<=",
-      peg$c181 = peg$literalExpectation("<=", false),
-      peg$c182 = "<",
-      peg$c183 = peg$literalExpectation("<", false),
-      peg$c184 = ">=",
-      peg$c185 = peg$literalExpectation(">=", false),
-      peg$c186 = ">",
-      peg$c187 = peg$literalExpectation(">", false),
-      peg$c188 = "+",
-      peg$c189 = peg$literalExpectation("+", false),
-      peg$c190 = "/",
-      peg$c191 = peg$literalExpectation("/", false),
-      peg$c192 = function(e) {
+      peg$c160 = function(first, comp, expr) { return [comp, expr] },
+      peg$c161 = "+",
+      peg$c162 = peg$literalExpectation("+", false),
+      peg$c163 = "-",
+      peg$c164 = peg$literalExpectation("-", false),
+      peg$c165 = "/",
+      peg$c166 = peg$literalExpectation("/", false),
+      peg$c167 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c193 = function(e, typ) { return typ },
-      peg$c194 = function(e, typ) {
-            return {"op": "CastExpr", "expr": e, "type": typ}
+      peg$c168 = "bytes",
+      peg$c169 = peg$literalExpectation("bytes", false),
+      peg$c170 = "uint8",
+      peg$c171 = peg$literalExpectation("uint8", false),
+      peg$c172 = "uint16",
+      peg$c173 = peg$literalExpectation("uint16", false),
+      peg$c174 = "uint32",
+      peg$c175 = peg$literalExpectation("uint32", false),
+      peg$c176 = "uint64",
+      peg$c177 = peg$literalExpectation("uint64", false),
+      peg$c178 = "int8",
+      peg$c179 = peg$literalExpectation("int8", false),
+      peg$c180 = "int16",
+      peg$c181 = peg$literalExpectation("int16", false),
+      peg$c182 = "int32",
+      peg$c183 = peg$literalExpectation("int32", false),
+      peg$c184 = "int64",
+      peg$c185 = peg$literalExpectation("int64", false),
+      peg$c186 = "duration",
+      peg$c187 = peg$literalExpectation("duration", false),
+      peg$c188 = "time",
+      peg$c189 = peg$literalExpectation("time", false),
+      peg$c190 = "float64",
+      peg$c191 = peg$literalExpectation("float64", false),
+      peg$c192 = "bool",
+      peg$c193 = peg$literalExpectation("bool", false),
+      peg$c194 = "string",
+      peg$c195 = peg$literalExpectation("string", false),
+      peg$c196 = "bstring",
+      peg$c197 = peg$literalExpectation("bstring", false),
+      peg$c198 = "ip",
+      peg$c199 = peg$literalExpectation("ip", false),
+      peg$c200 = "net",
+      peg$c201 = peg$literalExpectation("net", false),
+      peg$c202 = "type",
+      peg$c203 = peg$literalExpectation("type", false),
+      peg$c204 = "error",
+      peg$c205 = peg$literalExpectation("error", false),
+      peg$c206 = "null",
+      peg$c207 = peg$literalExpectation("null", false),
+      peg$c208 = "select",
+      peg$c209 = peg$literalExpectation("select", false),
+      peg$c210 = function(args, e) { return ["@", e] },
+      peg$c211 = function(args, methods) {
+            return makeBinaryExprChain({"op":"SelectExpr", "selectors":args}, methods)
           },
-      peg$c195 = "bytes",
-      peg$c196 = peg$literalExpectation("bytes", false),
-      peg$c197 = "uint8",
-      peg$c198 = peg$literalExpectation("uint8", false),
-      peg$c199 = "uint16",
-      peg$c200 = peg$literalExpectation("uint16", false),
-      peg$c201 = "uint32",
-      peg$c202 = peg$literalExpectation("uint32", false),
-      peg$c203 = "uint64",
-      peg$c204 = peg$literalExpectation("uint64", false),
-      peg$c205 = "int8",
-      peg$c206 = peg$literalExpectation("int8", false),
-      peg$c207 = "int16",
-      peg$c208 = peg$literalExpectation("int16", false),
-      peg$c209 = "int32",
-      peg$c210 = peg$literalExpectation("int32", false),
-      peg$c211 = "int64",
-      peg$c212 = peg$literalExpectation("int64", false),
-      peg$c213 = "duration",
-      peg$c214 = peg$literalExpectation("duration", false),
-      peg$c215 = "time",
-      peg$c216 = peg$literalExpectation("time", false),
-      peg$c217 = "float64",
-      peg$c218 = peg$literalExpectation("float64", false),
-      peg$c219 = "bool",
-      peg$c220 = peg$literalExpectation("bool", false),
-      peg$c221 = "string",
-      peg$c222 = peg$literalExpectation("string", false),
-      peg$c223 = "bstring",
-      peg$c224 = peg$literalExpectation("bstring", false),
-      peg$c225 = "ip",
-      peg$c226 = peg$literalExpectation("ip", false),
-      peg$c227 = "net",
-      peg$c228 = peg$literalExpectation("net", false),
-      peg$c229 = "type",
-      peg$c230 = peg$literalExpectation("type", false),
-      peg$c231 = "error",
-      peg$c232 = peg$literalExpectation("error", false),
-      peg$c233 = function(first, rest) {
-            return makeBinaryExprChain(first, rest)
-          },
-      peg$c234 = function(fn, args) {
+      peg$c212 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c235 = function(first, e) { return e },
-      peg$c236 = function() { return [] },
-      peg$c237 = "[",
-      peg$c238 = peg$literalExpectation("[", false),
-      peg$c239 = "]",
-      peg$c240 = peg$literalExpectation("]", false),
-      peg$c241 = function(expr) { return ["[", expr] },
-      peg$c242 = function(id) { return [".", id] },
-      peg$c243 = "and",
-      peg$c244 = peg$literalExpectation("and", true),
-      peg$c245 = "or",
-      peg$c246 = peg$literalExpectation("or", true),
-      peg$c247 = peg$literalExpectation("in", true),
-      peg$c248 = peg$literalExpectation("not", true),
+      peg$c213 = function(first, e) { return e },
+      peg$c214 = function() { return [] },
+      peg$c215 = function() {
+            return {"op":"RootRecord"}
+          },
+      peg$c216 = function(field) {
+            return {"op": "BinaryExpr", "operator":".",
+                           
+            "lhs":{"op":"RootRecord"},
+                           
+            "rhs":field}
+          
+
+          },
+      peg$c217 = "[",
+      peg$c218 = peg$literalExpectation("[", false),
+      peg$c219 = "]",
+      peg$c220 = peg$literalExpectation("]", false),
+      peg$c221 = function(expr) {
+            return {"op": "BinaryExpr", "operator":"[",
+                           
+            "lhs":{"op":"RootRecord"},
+                           
+            "rhs":expr}
+          
+
+          },
+      peg$c222 = function(expr) { return ["[", expr] },
+      peg$c223 = function(id) { return [".", id] },
+      peg$c224 = function(v) {
+            return {"op": "Literal", "type": "regexp", "value": v}
+          },
+      peg$c225 = function(v) {
+            return {"op": "Literal", "type": "net", "value": v}
+          },
+      peg$c226 = function(v) {
+            return {"op": "Literal", "type": "ip", "value": v}
+          },
+      peg$c227 = function(v) {
+            return {"op": "Literal", "type": "float64", "value": v}
+          },
+      peg$c228 = function(v) {
+            return {"op": "Literal", "type": "int64", "value": v}
+          },
+      peg$c229 = "true",
+      peg$c230 = peg$literalExpectation("true", false),
+      peg$c231 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
+      peg$c232 = "false",
+      peg$c233 = peg$literalExpectation("false", false),
+      peg$c234 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
+      peg$c235 = function() { return {"op": "Literal", "type": "null", "value": ""} },
+      peg$c236 = "and",
+      peg$c237 = peg$literalExpectation("and", true),
+      peg$c238 = function() { return "and" },
+      peg$c239 = "or",
+      peg$c240 = peg$literalExpectation("or", true),
+      peg$c241 = function() { return "or" },
+      peg$c242 = peg$literalExpectation("in", true),
+      peg$c243 = function() { return "in" },
+      peg$c244 = peg$literalExpectation("not", true),
+      peg$c245 = function() { return "not" },
+      peg$c246 = "by",
+      peg$c247 = peg$literalExpectation("by", true),
+      peg$c248 = function() { return "by" },
       peg$c249 = /^[A-Za-z_$]/,
       peg$c250 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
       peg$c251 = /^[0-9]/,
       peg$c252 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c253 = function() { return {"op": "Identifier", "name": text()} },
-      peg$c254 = peg$literalExpectation("and", false),
-      peg$c255 = "seconds",
-      peg$c256 = peg$literalExpectation("seconds", false),
-      peg$c257 = "second",
-      peg$c258 = peg$literalExpectation("second", false),
-      peg$c259 = "secs",
-      peg$c260 = peg$literalExpectation("secs", false),
-      peg$c261 = "sec",
-      peg$c262 = peg$literalExpectation("sec", false),
-      peg$c263 = "s",
-      peg$c264 = peg$literalExpectation("s", false),
-      peg$c265 = "minutes",
-      peg$c266 = peg$literalExpectation("minutes", false),
-      peg$c267 = "minute",
-      peg$c268 = peg$literalExpectation("minute", false),
-      peg$c269 = "mins",
-      peg$c270 = peg$literalExpectation("mins", false),
-      peg$c271 = "min",
-      peg$c272 = peg$literalExpectation("min", false),
-      peg$c273 = "m",
-      peg$c274 = peg$literalExpectation("m", false),
-      peg$c275 = "hours",
-      peg$c276 = peg$literalExpectation("hours", false),
-      peg$c277 = "hrs",
-      peg$c278 = peg$literalExpectation("hrs", false),
-      peg$c279 = "hr",
-      peg$c280 = peg$literalExpectation("hr", false),
-      peg$c281 = "h",
-      peg$c282 = peg$literalExpectation("h", false),
-      peg$c283 = "hour",
-      peg$c284 = peg$literalExpectation("hour", false),
-      peg$c285 = "days",
-      peg$c286 = peg$literalExpectation("days", false),
-      peg$c287 = "day",
-      peg$c288 = peg$literalExpectation("day", false),
-      peg$c289 = "d",
-      peg$c290 = peg$literalExpectation("d", false),
-      peg$c291 = "weeks",
-      peg$c292 = peg$literalExpectation("weeks", false),
-      peg$c293 = "week",
-      peg$c294 = peg$literalExpectation("week", false),
-      peg$c295 = "wks",
-      peg$c296 = peg$literalExpectation("wks", false),
-      peg$c297 = "wk",
-      peg$c298 = peg$literalExpectation("wk", false),
-      peg$c299 = "w",
-      peg$c300 = peg$literalExpectation("w", false),
-      peg$c301 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c302 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c303 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c304 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c305 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c306 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c307 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c308 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c309 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c310 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c311 = function(a, b) {
+      peg$c253 = function(id) { return {"op": "Identifier", "name": id} },
+      peg$c254 = function() {  return text() },
+      peg$c255 = "$",
+      peg$c256 = peg$literalExpectation("$", false),
+      peg$c257 = "\\",
+      peg$c258 = peg$literalExpectation("\\", false),
+      peg$c259 = function(id) { return id },
+      peg$c260 = peg$literalExpectation("and", false),
+      peg$c261 = "seconds",
+      peg$c262 = peg$literalExpectation("seconds", false),
+      peg$c263 = "second",
+      peg$c264 = peg$literalExpectation("second", false),
+      peg$c265 = "secs",
+      peg$c266 = peg$literalExpectation("secs", false),
+      peg$c267 = "sec",
+      peg$c268 = peg$literalExpectation("sec", false),
+      peg$c269 = "s",
+      peg$c270 = peg$literalExpectation("s", false),
+      peg$c271 = "minutes",
+      peg$c272 = peg$literalExpectation("minutes", false),
+      peg$c273 = "minute",
+      peg$c274 = peg$literalExpectation("minute", false),
+      peg$c275 = "mins",
+      peg$c276 = peg$literalExpectation("mins", false),
+      peg$c277 = "min",
+      peg$c278 = peg$literalExpectation("min", false),
+      peg$c279 = "m",
+      peg$c280 = peg$literalExpectation("m", false),
+      peg$c281 = "hours",
+      peg$c282 = peg$literalExpectation("hours", false),
+      peg$c283 = "hrs",
+      peg$c284 = peg$literalExpectation("hrs", false),
+      peg$c285 = "hr",
+      peg$c286 = peg$literalExpectation("hr", false),
+      peg$c287 = "h",
+      peg$c288 = peg$literalExpectation("h", false),
+      peg$c289 = "hour",
+      peg$c290 = peg$literalExpectation("hour", false),
+      peg$c291 = "days",
+      peg$c292 = peg$literalExpectation("days", false),
+      peg$c293 = "day",
+      peg$c294 = peg$literalExpectation("day", false),
+      peg$c295 = "d",
+      peg$c296 = peg$literalExpectation("d", false),
+      peg$c297 = "weeks",
+      peg$c298 = peg$literalExpectation("weeks", false),
+      peg$c299 = "week",
+      peg$c300 = peg$literalExpectation("week", false),
+      peg$c301 = "wks",
+      peg$c302 = peg$literalExpectation("wks", false),
+      peg$c303 = "wk",
+      peg$c304 = peg$literalExpectation("wk", false),
+      peg$c305 = "w",
+      peg$c306 = peg$literalExpectation("w", false),
+      peg$c307 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c308 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c309 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c310 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c311 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c312 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c313 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c314 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c315 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c316 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c317 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c312 = "::",
-      peg$c313 = peg$literalExpectation("::", false),
-      peg$c314 = function(a, b, d, e) {
+      peg$c318 = "::",
+      peg$c319 = peg$literalExpectation("::", false),
+      peg$c320 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c315 = function(a, b) {
+      peg$c321 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c316 = function(a, b) {
+      peg$c322 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c317 = function() {
+      peg$c323 = function() {
             return "::"
           },
-      peg$c318 = function(v) { return ":" + v },
-      peg$c319 = function(v) { return v + ":" },
-      peg$c320 = function(a, m) {
+      peg$c324 = function(v) { return ":" + v },
+      peg$c325 = function(v) { return v + ":" },
+      peg$c326 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c321 = function(a, m) {
+      peg$c327 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c322 = function(s) { return parseInt(s) },
-      peg$c323 = function() {
+      peg$c328 = function(s) { return parseInt(s) },
+      peg$c329 = function() {
             return text()
           },
-      peg$c324 = "e",
-      peg$c325 = peg$literalExpectation("e", true),
-      peg$c326 = /^[+\-]/,
-      peg$c327 = peg$classExpectation(["+", "-"], false, false),
-      peg$c328 = /^[0-9a-fA-F]/,
-      peg$c329 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c330 = function(chars) { return joinChars(chars) },
-      peg$c331 = "\\",
-      peg$c332 = peg$literalExpectation("\\", false),
-      peg$c333 = /^[\0-\x1F\\(),!><="|';:]/,
-      peg$c334 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
-      peg$c335 = peg$anyExpectation(),
+      peg$c330 = "e",
+      peg$c331 = peg$literalExpectation("e", true),
+      peg$c332 = /^[+\-]/,
+      peg$c333 = peg$classExpectation(["+", "-"], false, false),
+      peg$c334 = /^[0-9a-fA-F]/,
+      peg$c335 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
       peg$c336 = "\"",
       peg$c337 = peg$literalExpectation("\"", false),
       peg$c338 = function(v) { return joinChars(v) },
       peg$c339 = "'",
       peg$c340 = peg$literalExpectation("'", false),
-      peg$c341 = "x",
-      peg$c342 = peg$literalExpectation("x", false),
-      peg$c343 = function() { return "\\" + text() },
-      peg$c344 = "b",
-      peg$c345 = peg$literalExpectation("b", false),
-      peg$c346 = function() { return "\b" },
-      peg$c347 = "f",
-      peg$c348 = peg$literalExpectation("f", false),
-      peg$c349 = function() { return "\f" },
-      peg$c350 = "n",
-      peg$c351 = peg$literalExpectation("n", false),
-      peg$c352 = function() { return "\n" },
-      peg$c353 = "r",
-      peg$c354 = peg$literalExpectation("r", false),
-      peg$c355 = function() { return "\r" },
-      peg$c356 = "t",
-      peg$c357 = peg$literalExpectation("t", false),
-      peg$c358 = function() { return "\t" },
-      peg$c359 = "v",
-      peg$c360 = peg$literalExpectation("v", false),
-      peg$c361 = function() { return "\v" },
-      peg$c362 = function() { return "=" },
-      peg$c363 = function() { return "\\*" },
-      peg$c364 = "u",
-      peg$c365 = peg$literalExpectation("u", false),
-      peg$c366 = function(chars) {
+      peg$c341 = peg$anyExpectation(),
+      peg$c342 = function(s) { return s },
+      peg$c343 = function(head, tail) { return head + joinChars(tail) },
+      peg$c344 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c345 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c346 = "x",
+      peg$c347 = peg$literalExpectation("x", false),
+      peg$c348 = function() { return "\\" + text() },
+      peg$c349 = function() { return "'"},
+      peg$c350 = function() { return '"'},
+      peg$c351 = function() { return "\\"},
+      peg$c352 = "b",
+      peg$c353 = peg$literalExpectation("b", false),
+      peg$c354 = function() { return "\b" },
+      peg$c355 = "f",
+      peg$c356 = peg$literalExpectation("f", false),
+      peg$c357 = function() { return "\f" },
+      peg$c358 = "n",
+      peg$c359 = peg$literalExpectation("n", false),
+      peg$c360 = function() { return "\n" },
+      peg$c361 = "r",
+      peg$c362 = peg$literalExpectation("r", false),
+      peg$c363 = function() { return "\r" },
+      peg$c364 = "t",
+      peg$c365 = peg$literalExpectation("t", false),
+      peg$c366 = function() { return "\t" },
+      peg$c367 = "v",
+      peg$c368 = peg$literalExpectation("v", false),
+      peg$c369 = function() { return "\v" },
+      peg$c370 = function() { return "=" },
+      peg$c371 = function() { return "\\*" },
+      peg$c372 = "u",
+      peg$c373 = peg$literalExpectation("u", false),
+      peg$c374 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c367 = "{",
-      peg$c368 = peg$literalExpectation("{", false),
-      peg$c369 = "}",
-      peg$c370 = peg$literalExpectation("}", false),
-      peg$c371 = function(body) { return body },
-      peg$c372 = /^[^\/\\]/,
-      peg$c373 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c374 = "\\/",
-      peg$c375 = peg$literalExpectation("\\/", false),
-      peg$c376 = /^[\0-\x1F\\]/,
-      peg$c377 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c378 = peg$otherExpectation("whitespace"),
-      peg$c379 = "\t",
-      peg$c380 = peg$literalExpectation("\t", false),
-      peg$c381 = "\x0B",
-      peg$c382 = peg$literalExpectation("\x0B", false),
-      peg$c383 = "\f",
-      peg$c384 = peg$literalExpectation("\f", false),
-      peg$c385 = " ",
-      peg$c386 = peg$literalExpectation(" ", false),
-      peg$c387 = "\xA0",
-      peg$c388 = peg$literalExpectation("\xA0", false),
-      peg$c389 = "\uFEFF",
-      peg$c390 = peg$literalExpectation("\uFEFF", false),
-      peg$c391 = /^[\n\r\u2028\u2029]/,
-      peg$c392 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c393 = peg$otherExpectation("comment"),
-      peg$c398 = "//",
-      peg$c399 = peg$literalExpectation("//", false),
+      peg$c375 = "{",
+      peg$c376 = peg$literalExpectation("{", false),
+      peg$c377 = "}",
+      peg$c378 = peg$literalExpectation("}", false),
+      peg$c379 = function(body) { return body },
+      peg$c380 = /^[^\/\\]/,
+      peg$c381 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c382 = "\\/",
+      peg$c383 = peg$literalExpectation("\\/", false),
+      peg$c384 = /^[\0-\x1F\\]/,
+      peg$c385 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c386 = peg$otherExpectation("whitespace"),
+      peg$c387 = "\t",
+      peg$c388 = peg$literalExpectation("\t", false),
+      peg$c389 = "\x0B",
+      peg$c390 = peg$literalExpectation("\x0B", false),
+      peg$c391 = "\f",
+      peg$c392 = peg$literalExpectation("\f", false),
+      peg$c393 = " ",
+      peg$c394 = peg$literalExpectation(" ", false),
+      peg$c395 = "\xA0",
+      peg$c396 = peg$literalExpectation("\xA0", false),
+      peg$c397 = "\uFEFF",
+      peg$c398 = peg$literalExpectation("\uFEFF", false),
+      peg$c399 = /^[\n\r\u2028\u2029]/,
+      peg$c400 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c401 = peg$otherExpectation("comment"),
+      peg$c406 = "//",
+      peg$c407 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -990,7 +1035,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseQuery();
+      s2 = peg$parseSequential();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
@@ -1019,78 +1064,25 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseQuery() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parseSequentialProcs();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c1(s1);
-    }
-    s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseSearch();
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
-        if (s2 !== peg$FAILED) {
-          s3 = [];
-          s4 = peg$parseSequentialTail();
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            s4 = peg$parseSequentialTail();
-          }
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c2(s1, s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseSearch() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parseSearchExpr();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c3(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseSearchExpr() {
+  function peg$parseSequential() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseSearchTerm();
+    s1 = peg$parseOperation();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseOredSearchTerm();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseOredSearchTerm();
+      s3 = peg$parseSequentialTail();
+      if (s3 !== peg$FAILED) {
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parseSequentialTail();
+        }
+      } else {
+        s2 = peg$FAILED;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c4(s1, s2);
+        s1 = peg$c1(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1100,21 +1092,36 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseOperation();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c2(s1);
+      }
+      s0 = s1;
+    }
 
     return s0;
   }
 
-  function peg$parseOredSearchTerm() {
+  function peg$parseSequentialTail() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parse_();
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseOrToken();
+      if (input.charCodeAt(peg$currPos) === 124) {
+        s2 = peg$c3;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c4); }
+      }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
+        s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseSearchTerm();
+          s4 = peg$parseOperation();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
             s1 = peg$c5(s4);
@@ -1139,17 +1146,21 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseSearchTerm() {
+  function peg$parseParallel() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseSearchFactor();
+    s1 = peg$parseSequential();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseAndedSearchTerm();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseAndedSearchTerm();
+      s3 = peg$parseParallelTail();
+      if (s3 !== peg$FAILED) {
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parseParallelTail();
+        }
+      } else {
+        s2 = peg$FAILED;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -1163,20 +1174,231 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseSequential();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c7(s1);
+      }
+      s0 = s1;
+    }
 
     return s0;
   }
 
-  function peg$parseAndedSearchTerm() {
+  function peg$parseParallelTail() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parse_();
+    s1 = peg$parse__();
+    if (s1 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c8) {
+        s2 = peg$c8;
+        peg$currPos += 2;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse__();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseSequential();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c10(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseOperation() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5) === peg$c11) {
+      s1 = peg$c11;
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c12); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c13;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c14); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            if (input.substr(peg$currPos, 2) === peg$c8) {
+              s5 = peg$c8;
+              peg$currPos += 2;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c9); }
+            }
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseParallel();
+                if (s7 !== peg$FAILED) {
+                  s8 = peg$parse__();
+                  if (s8 !== peg$FAILED) {
+                    if (input.charCodeAt(peg$currPos) === 41) {
+                      s9 = peg$c15;
+                      peg$currPos++;
+                    } else {
+                      s9 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                    }
+                    if (s9 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c17(s7);
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseOperator();
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseAggregation();
+        if (s1 !== peg$FAILED) {
+          s2 = peg$currPos;
+          peg$silentFails++;
+          s3 = peg$parseExprGuard();
+          peg$silentFails--;
+          if (s3 === peg$FAILED) {
+            s2 = void 0;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c18(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parseSearchBoolean();
+          if (s1 !== peg$FAILED) {
+            s2 = peg$currPos;
+            peg$silentFails++;
+            s3 = peg$parseAggGuard();
+            peg$silentFails--;
+            if (s3 === peg$FAILED) {
+              s2 = void 0;
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+            if (s2 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c19(s1);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseExprGuard() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      s3 = peg$parseAndToken();
+      s3 = peg$currPos;
+      peg$silentFails++;
+      if (input.substr(peg$currPos, 2) === peg$c8) {
+        s4 = peg$c8;
+        peg$currPos += 2;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      }
+      peg$silentFails--;
+      if (s4 === peg$FAILED) {
+        s3 = void 0;
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
       if (s3 !== peg$FAILED) {
-        s4 = peg$parse_();
+        s4 = peg$parseComparator();
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
           s2 = s3;
@@ -1189,18 +1411,271 @@ function peg$parse(input, options) {
         s2 = peg$FAILED;
       }
       if (s2 === peg$FAILED) {
-        s2 = null;
+        s2 = peg$parseAdditiveOperator();
+        if (s2 === peg$FAILED) {
+          s2 = peg$parseMultiplicativeOperator();
+          if (s2 === peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 58) {
+              s2 = peg$c20;
+              peg$currPos++;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c21); }
+            }
+            if (s2 === peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 40) {
+                s2 = peg$c13;
+                peg$currPos++;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c14); }
+              }
+            }
+          }
+        }
       }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseSearchFactor();
+        s1 = [s1, s2];
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAggGuard() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parse_();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseByToken();
+      if (s2 === peg$FAILED) {
+        if (input.substr(peg$currPos, 5) === peg$c22) {
+          s2 = peg$c22;
+          peg$currPos += 5;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c23); }
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseEOT();
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c7(s3);
+          s1 = [s1, s2, s3];
           s0 = s1;
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parse__();
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s2 = peg$c24;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
+        }
+        if (s2 !== peg$FAILED) {
+          s1 = [s1, s2];
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchBoolean() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSearchAnd();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseSearchOrTerm();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseSearchOrTerm();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c26(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchOrTerm() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parse_();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseOrToken();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse_();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseSearchAnd();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c27(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchAnd() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSearchFactor();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$currPos;
+        s6 = peg$parseAndToken();
+        if (s6 !== peg$FAILED) {
+          s7 = peg$parse_();
+          if (s7 !== peg$FAILED) {
+            s6 = [s6, s7];
+            s5 = s6;
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s5;
+          s5 = peg$FAILED;
+        }
+        if (s5 === peg$FAILED) {
+          s5 = null;
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseSearchFactor();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c28(s1, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$currPos;
+          s6 = peg$parseAndToken();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parse_();
+            if (s7 !== peg$FAILED) {
+              s6 = [s6, s7];
+              s5 = s6;
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+          if (s5 === peg$FAILED) {
+            s5 = null;
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseSearchFactor();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c28(s1, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c29(s1, s2);
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1235,11 +1710,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c8;
+        s2 = peg$c30;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c9); }
+        if (peg$silentFails === 0) { peg$fail(peg$c31); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -1256,10 +1731,10 @@ function peg$parse(input, options) {
       }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseSearchExpr();
+      s2 = peg$parseSearchFactor();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c10(s2);
+        s1 = peg$c32(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1270,64 +1745,40 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$currPos;
-      peg$silentFails++;
-      if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c11;
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c12); }
-      }
-      peg$silentFails--;
-      if (s2 === peg$FAILED) {
-        s1 = void 0;
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parseSearchPred();
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c13(s2);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+      s0 = peg$parseShortCut();
       if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c14;
-          peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c15); }
-        }
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parse__();
-          if (s2 !== peg$FAILED) {
-            s3 = peg$parseSearchExpr();
-            if (s3 !== peg$FAILED) {
-              s4 = peg$parse__();
-              if (s4 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c16;
-                  peg$currPos++;
-                } else {
-                  s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c17); }
-                }
-                if (s5 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c18(s3);
-                  s0 = s1;
+        s0 = peg$parseSearchExprRelative();
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 40) {
+            s1 = peg$c13;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c14); }
+          }
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parse__();
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parseSearchBoolean();
+              if (s3 !== peg$FAILED) {
+                s4 = peg$parse__();
+                if (s4 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 41) {
+                    s5 = peg$c15;
+                    peg$currPos++;
+                  } else {
+                    s5 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                  }
+                  if (s5 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c33(s3);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -1344,9 +1795,6 @@ function peg$parse(input, options) {
             peg$currPos = s0;
             s0 = peg$FAILED;
           }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
         }
       }
     }
@@ -1354,16 +1802,16 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseSearchPred() {
-    var s0, s1, s2, s3, s4, s5, s6;
+  function peg$parseShortCut() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c19;
+      s1 = peg$c34;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c20); }
+      if (peg$silentFails === 0) { peg$fail(peg$c35); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -1375,7 +1823,7 @@ function peg$parse(input, options) {
             s5 = peg$parseSearchValue();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c21(s3, s5);
+              s1 = peg$c36(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1399,13 +1847,7 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c22) {
-        s1 = peg$c22;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c23); }
-      }
+      s1 = peg$parseDerefExpr();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
@@ -1413,11 +1855,26 @@ function peg$parse(input, options) {
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
-              s5 = peg$parseSearchValue();
+              s5 = peg$parseGlobbySearchValue();
               if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c24(s3, s5);
-                s0 = s1;
+                s6 = peg$currPos;
+                peg$silentFails++;
+                s7 = peg$parseExprGuard();
+                peg$silentFails--;
+                if (s7 === peg$FAILED) {
+                  s6 = void 0;
+                } else {
+                  peg$currPos = s6;
+                  s6 = peg$FAILED;
+                }
+                if (s6 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c37(s1, s3, s5);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -1440,18 +1897,24 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parseDerefExpr();
+        s1 = peg$parseSearchValue();
         if (s1 !== peg$FAILED) {
-          s2 = peg$parse__();
+          s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parseEqualityToken();
+            s3 = peg$parseInToken();
             if (s3 !== peg$FAILED) {
-              s4 = peg$parse__();
+              s4 = peg$parse_();
               if (s4 !== peg$FAILED) {
-                s5 = peg$parseSearchValue();
+                if (input.charCodeAt(peg$currPos) === 42) {
+                  s5 = peg$c34;
+                  peg$currPos++;
+                } else {
+                  s5 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c35); }
+                }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c25(s1, s3, s5);
+                  s1 = peg$c38(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1477,46 +1940,45 @@ function peg$parse(input, options) {
           s0 = peg$currPos;
           s1 = peg$currPos;
           peg$silentFails++;
-          if (input.substr(peg$currPos, 3) === peg$c26) {
-            s2 = peg$c26;
-            peg$currPos += 3;
+          s2 = peg$currPos;
+          s3 = peg$parseSearchGuard();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parseEOT();
+            if (s4 !== peg$FAILED) {
+              s3 = [s3, s4];
+              s2 = s3;
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
           } else {
+            peg$currPos = s2;
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c27); }
           }
           peg$silentFails--;
-          if (s2 !== peg$FAILED) {
-            peg$currPos = s1;
+          if (s2 === peg$FAILED) {
             s1 = void 0;
           } else {
+            peg$currPos = s1;
             s1 = peg$FAILED;
           }
           if (s1 !== peg$FAILED) {
-            s2 = peg$parseFunction();
+            s2 = peg$parseGlobbySearchValue();
             if (s2 !== peg$FAILED) {
-              s3 = peg$parse__();
+              s3 = peg$currPos;
+              peg$silentFails++;
+              s4 = peg$parseExprGuard();
+              peg$silentFails--;
+              if (s4 === peg$FAILED) {
+                s3 = void 0;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
               if (s3 !== peg$FAILED) {
-                s4 = peg$parseEqualityToken();
-                if (s4 !== peg$FAILED) {
-                  s5 = peg$parse__();
-                  if (s5 !== peg$FAILED) {
-                    s6 = peg$parseSearchValue();
-                    if (s6 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c28(s2, s4, s6);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
+                peg$savedPos = s0;
+                s1 = peg$c39(s2);
+                s0 = s1;
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -1531,37 +1993,28 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            s1 = peg$parseSearchValue();
+            if (input.charCodeAt(peg$currPos) === 42) {
+              s1 = peg$c34;
+              peg$currPos++;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            }
             if (s1 !== peg$FAILED) {
-              s2 = peg$parse__();
+              s2 = peg$currPos;
+              peg$silentFails++;
+              s3 = peg$parseExprGuard();
+              peg$silentFails--;
+              if (s3 === peg$FAILED) {
+                s2 = void 0;
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
               if (s2 !== peg$FAILED) {
-                s3 = peg$parseInToken();
-                if (s3 !== peg$FAILED) {
-                  s4 = peg$parse__();
-                  if (s4 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 42) {
-                      s5 = peg$c19;
-                      peg$currPos++;
-                    } else {
-                      s5 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c20); }
-                    }
-                    if (s5 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c29(s1);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
+                peg$savedPos = s0;
+                s1 = peg$c40();
+                s0 = s1;
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -1569,92 +2022,6 @@ function peg$parse(input, options) {
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
-            }
-            if (s0 === peg$FAILED) {
-              s0 = peg$currPos;
-              s1 = peg$parseSearchValue();
-              if (s1 !== peg$FAILED) {
-                s2 = peg$parse__();
-                if (s2 !== peg$FAILED) {
-                  s3 = peg$parseInToken();
-                  if (s3 !== peg$FAILED) {
-                    s4 = peg$parse__();
-                    if (s4 !== peg$FAILED) {
-                      s5 = peg$parseDerefExpr();
-                      if (s5 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c30(s1, s5);
-                        s0 = s1;
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-              if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$parseSearchLiteral();
-                if (s1 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c31(s1);
-                }
-                s0 = s1;
-                if (s0 === peg$FAILED) {
-                  s0 = peg$currPos;
-                  s1 = peg$currPos;
-                  peg$silentFails++;
-                  s2 = peg$currPos;
-                  s3 = peg$parseSearchTokens();
-                  if (s3 !== peg$FAILED) {
-                    s4 = peg$parse_();
-                    if (s4 !== peg$FAILED) {
-                      s3 = [s3, s4];
-                      s2 = s3;
-                    } else {
-                      peg$currPos = s2;
-                      s2 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s2;
-                    s2 = peg$FAILED;
-                  }
-                  peg$silentFails--;
-                  if (s2 === peg$FAILED) {
-                    s1 = void 0;
-                  } else {
-                    peg$currPos = s1;
-                    s1 = peg$FAILED;
-                  }
-                  if (s1 !== peg$FAILED) {
-                    s2 = peg$parseKeyWord();
-                    if (s2 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c32(s2);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                }
-              }
             }
           }
         }
@@ -1665,19 +2032,508 @@ function peg$parse(input, options) {
   }
 
   function peg$parseSearchValue() {
-    var s0, s1, s2, s3, s4;
+    var s0, s1;
 
-    s0 = peg$parseSearchLiteral();
+    s0 = peg$parseLiteral();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$currPos;
-      peg$silentFails++;
-      s2 = peg$currPos;
-      s3 = peg$parseSearchTokens();
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parse_();
+      s1 = peg$parseKeyWord();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c41(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseGlobbySearchValue() {
+    var s0, s1;
+
+    s0 = peg$parseLiteral();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseSearchGlob();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c42(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchGlob() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$parseGlobPart();
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        s2 = peg$parseGlobPart();
+      }
+    } else {
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      if (input.charCodeAt(peg$currPos) === 42) {
+        s3 = peg$c34;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        if (input.charCodeAt(peg$currPos) === 42) {
+          s3 = peg$c34;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c43(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseGlobPart() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = peg$parseStars();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseKeyWord();
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c44(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseKeyWord();
+    }
+
+    return s0;
+  }
+
+  function peg$parseStars() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = [];
+    if (input.charCodeAt(peg$currPos) === 42) {
+      s2 = peg$c34;
+      peg$currPos++;
+    } else {
+      s2 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c35); }
+    }
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        if (input.charCodeAt(peg$currPos) === 42) {
+          s2 = peg$c34;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        }
+      }
+    } else {
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c45();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseSearchGuard() {
+    var s0;
+
+    s0 = peg$parseAndToken();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseOrToken();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseNotToken();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseInToken();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseByToken();
+          }
+        }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseComparator() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 61) {
+      s1 = peg$c46;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c48) {
+        s1 = peg$c48;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      }
+      if (s1 === peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c50) {
+          s1 = peg$c50;
+          peg$currPos += 2;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c51); }
+        }
+        if (s1 === peg$FAILED) {
+          if (input.substr(peg$currPos, 2) === peg$c52) {
+            s1 = peg$c52;
+            peg$currPos += 2;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          }
+          if (s1 === peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 60) {
+              s1 = peg$c54;
+              peg$currPos++;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            }
+            if (s1 === peg$FAILED) {
+              if (input.substr(peg$currPos, 2) === peg$c56) {
+                s1 = peg$c56;
+                peg$currPos += 2;
+              } else {
+                s1 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c57); }
+              }
+              if (s1 === peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 62) {
+                  s1 = peg$c58;
+                  peg$currPos++;
+                } else {
+                  s1 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c59); }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c45();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseSearchExprRelative() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSearchExprAdd();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseComparator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseSearchExprAdd();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c60(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
-          s3 = [s3, s4];
+          s5 = peg$parseComparator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseSearchExprAdd();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c60(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c61(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchExprAdd() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSearchExprMul();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseAdditiveOperator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseSearchExprMul();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c60(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseAdditiveOperator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseSearchExprMul();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c60(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c61(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchExprMul() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSearchExprCast();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseMultiplicativeOperator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseSearchExprCast();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c60(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseMultiplicativeOperator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseSearchExprCast();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c60(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c61(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchExprCast() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSearchExprFunc();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 58) {
+        s3 = peg$c20;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c21); }
+      }
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parsePrimitiveType();
+        if (s4 !== peg$FAILED) {
+          peg$savedPos = s2;
+          s3 = peg$c62(s1, s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -1687,18 +2543,42 @@ function peg$parse(input, options) {
         peg$currPos = s2;
         s2 = peg$FAILED;
       }
-      peg$silentFails--;
-      if (s2 === peg$FAILED) {
-        s1 = void 0;
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c63(s1, s2);
+        s0 = s1;
       } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
+        peg$currPos = s0;
+        s0 = peg$FAILED;
       }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseSearchExprFunc();
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchExprFunc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$parseMatchExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseFunction();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseKeyWord();
+        s2 = [];
+        s3 = peg$parseDeref();
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parseDeref();
+        }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c33(s2);
+          s1 = peg$c26(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1708,147 +2588,10 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-    }
-
-    return s0;
-  }
-
-  function peg$parseSearchTokens() {
-    var s0;
-
-    s0 = peg$parseAndToken();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseOrToken();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseInToken();
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseSearchLiteral() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$parseStringLiteral();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseRegexpLiteral();
-      if (s0 === peg$FAILED) {
-        s0 = peg$parseSubnetLiteral();
+        s0 = peg$parseDerefExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseAddressLiteral();
-          if (s0 === peg$FAILED) {
-            s0 = peg$parseFloatLiteral();
-            if (s0 === peg$FAILED) {
-              s0 = peg$currPos;
-              s1 = peg$parseIntegerLiteral();
-              if (s1 !== peg$FAILED) {
-                s2 = peg$currPos;
-                peg$silentFails++;
-                s3 = peg$parseKeyWord();
-                peg$silentFails--;
-                if (s3 === peg$FAILED) {
-                  s2 = void 0;
-                } else {
-                  peg$currPos = s2;
-                  s2 = peg$FAILED;
-                }
-                if (s2 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c34(s1);
-                  s0 = s1;
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-              if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$currPos;
-                peg$silentFails++;
-                s2 = peg$currPos;
-                s3 = peg$parseSearchTokens();
-                if (s3 !== peg$FAILED) {
-                  s4 = peg$parse_();
-                  if (s4 !== peg$FAILED) {
-                    s3 = [s3, s4];
-                    s2 = s3;
-                  } else {
-                    peg$currPos = s2;
-                    s2 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s2;
-                  s2 = peg$FAILED;
-                }
-                peg$silentFails--;
-                if (s2 === peg$FAILED) {
-                  s1 = void 0;
-                } else {
-                  peg$currPos = s1;
-                  s1 = peg$FAILED;
-                }
-                if (s1 !== peg$FAILED) {
-                  s2 = peg$parseBooleanLiteral();
-                  if (s2 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c35(s2);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-                if (s0 === peg$FAILED) {
-                  s0 = peg$currPos;
-                  s1 = peg$currPos;
-                  peg$silentFails++;
-                  s2 = peg$currPos;
-                  s3 = peg$parseSearchTokens();
-                  if (s3 !== peg$FAILED) {
-                    s4 = peg$parse_();
-                    if (s4 !== peg$FAILED) {
-                      s3 = [s3, s4];
-                      s2 = s3;
-                    } else {
-                      peg$currPos = s2;
-                      s2 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s2;
-                    s2 = peg$FAILED;
-                  }
-                  peg$silentFails--;
-                  if (s2 === peg$FAILED) {
-                    s1 = void 0;
-                  } else {
-                    peg$currPos = s1;
-                    s1 = peg$FAILED;
-                  }
-                  if (s1 !== peg$FAILED) {
-                    s2 = peg$parseNullLiteral();
-                    if (s2 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c35(s2);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                }
-              }
-            }
-          }
+          s0 = peg$parseLiteral();
         }
       }
     }
@@ -1856,454 +2599,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseStringLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parseQuotedString();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c33(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseRegexpLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parseRegexp();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c36(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseSubnetLiteral() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseIP6Net();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c37(s1);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseIP4Net();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c37(s1);
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseAddressLiteral() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseIP6();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c38(s1);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseIP();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c38(s1);
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseFloatLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFloatString();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c39(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseIntegerLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parseIntString();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c40(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseBooleanLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c41) {
-      s1 = peg$c41;
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c42); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c43();
-    }
-    s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c44) {
-        s1 = peg$c44;
-        peg$currPos += 5;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c45); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c46();
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseNullLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c47) {
-      s1 = peg$c47;
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c48); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c49();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseSequentialProcs() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseProc();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseSequentialTail();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseSequentialTail();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c50(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseSequentialTail() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parse__();
-    if (s1 !== peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 124) {
-        s2 = peg$c51;
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c52); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse__();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseProc();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c53(s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseProc() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
-
-    s0 = peg$parseNamedProc();
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c54) {
-        s1 = peg$c54;
-        peg$currPos += 5;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
-        if (s2 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c14;
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c15); }
-          }
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
-            if (s4 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c56) {
-                s5 = peg$c56;
-                peg$currPos += 2;
-              } else {
-                s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c57); }
-              }
-              if (s5 !== peg$FAILED) {
-                s6 = peg$parse__();
-                if (s6 !== peg$FAILED) {
-                  s7 = peg$parseProcs();
-                  if (s7 !== peg$FAILED) {
-                    s8 = peg$parse__();
-                    if (s8 !== peg$FAILED) {
-                      if (input.charCodeAt(peg$currPos) === 41) {
-                        s9 = peg$c16;
-                        peg$currPos++;
-                      } else {
-                        s9 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c17); }
-                      }
-                      if (s9 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c58(s7);
-                        s0 = s1;
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$parseGroupByProc();
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseProcs() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseSequentialProcs();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseParallelTail();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseParallelTail();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c59(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseParallelTail() {
-    var s0, s1, s2, s3, s4, s5, s6;
-
-    s0 = peg$currPos;
-    s1 = peg$parse__();
-    if (s1 !== peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 59) {
-        s2 = peg$c60;
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
-      }
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse__();
-        if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c56) {
-            s4 = peg$c56;
-            peg$currPos += 2;
-          } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c57); }
-          }
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parse__();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parseSequentialProcs();
-              if (s6 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c62(s6);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseGroupByProc() {
+  function peg$parseAggregation() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
@@ -2317,7 +2613,7 @@ function peg$parse(input, options) {
         s3 = peg$parseLimitArg();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c63(s1, s2, s3);
+          s1 = peg$c64(s1, s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2365,7 +2661,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c64(s1, s2, s3, s4);
+              s1 = peg$c65(s1, s2, s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2392,12 +2688,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c65) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c66) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c66); }
+      if (peg$silentFails === 0) { peg$fail(peg$c67); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2407,7 +2703,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c67(s3);
+            s1 = peg$c68(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2433,20 +2729,14 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c68) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
-    }
+    s1 = peg$parseByToken();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c70(s3);
+          s1 = peg$c69(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2470,22 +2760,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c71) {
-        s2 = peg$c71;
+      if (input.substr(peg$currPos, 4) === peg$c70) {
+        s2 = peg$c70;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c72); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c73) {
-            s4 = peg$c73;
+          if (input.substr(peg$currPos, 6) === peg$c72) {
+            s4 = peg$c72;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -2493,7 +2783,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c75(s6);
+                s1 = peg$c74(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2521,10 +2811,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c76;
+      s1 = peg$c75;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c77();
+        s1 = peg$c76();
       }
       s0 = s1;
     }
@@ -2541,7 +2831,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c78(s1);
+        s1 = peg$c77(s1);
       }
       s0 = s1;
     }
@@ -2560,11 +2850,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c79;
+          s5 = peg$c24;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2572,7 +2862,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c81(s1, s7);
+              s4 = peg$c78(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2596,11 +2886,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c79;
+            s5 = peg$c24;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2608,7 +2898,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c81(s1, s7);
+                s4 = peg$c78(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2629,7 +2919,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c82(s1, s2);
+        s1 = peg$c6(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2652,11 +2942,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c83;
+          s3 = peg$c46;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -2664,7 +2954,7 @@ function peg$parse(input, options) {
             s5 = peg$parseReducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c85(s1, s5);
+              s1 = peg$c79(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2691,7 +2981,7 @@ function peg$parse(input, options) {
       s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c86(s1);
+        s1 = peg$c80(s1);
       }
       s0 = s1;
     }
@@ -2700,26 +2990,37 @@ function peg$parse(input, options) {
   }
 
   function peg$parseReducer() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12;
 
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
-    if (input.substr(peg$currPos, 3) === peg$c87) {
-      s2 = peg$c87;
-      peg$currPos += 3;
-    } else {
-      s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c88); }
-    }
-    if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c26) {
-        s2 = peg$c26;
-        peg$currPos += 3;
+    s2 = peg$currPos;
+    s3 = peg$parseNotReducers();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s5 = peg$c13;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c14); }
+        }
+        if (s5 !== peg$FAILED) {
+          s3 = [s3, s4, s5];
+          s2 = s3;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
       } else {
+        peg$currPos = s2;
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c27); }
       }
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
     }
     peg$silentFails--;
     if (s2 === peg$FAILED) {
@@ -2734,11 +3035,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c14;
+            s4 = peg$c13;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c15); }
+            if (peg$silentFails === 0) { peg$fail(peg$c14); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -2751,21 +3052,56 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c16;
+                    s8 = peg$c15;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c16); }
                   }
                   if (s8 !== peg$FAILED) {
-                    s9 = peg$parseWhereClause();
-                    if (s9 === peg$FAILED) {
-                      s9 = null;
+                    s9 = peg$currPos;
+                    peg$silentFails++;
+                    s10 = peg$currPos;
+                    s11 = peg$parse__();
+                    if (s11 !== peg$FAILED) {
+                      if (input.charCodeAt(peg$currPos) === 46) {
+                        s12 = peg$c81;
+                        peg$currPos++;
+                      } else {
+                        s12 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                      }
+                      if (s12 !== peg$FAILED) {
+                        s11 = [s11, s12];
+                        s10 = s11;
+                      } else {
+                        peg$currPos = s10;
+                        s10 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s10;
+                      s10 = peg$FAILED;
+                    }
+                    peg$silentFails--;
+                    if (s10 === peg$FAILED) {
+                      s9 = void 0;
+                    } else {
+                      peg$currPos = s9;
+                      s9 = peg$FAILED;
                     }
                     if (s9 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c89(s2, s6, s9);
-                      s0 = s1;
+                      s10 = peg$parseWhereClause();
+                      if (s10 === peg$FAILED) {
+                        s10 = null;
+                      }
+                      if (s10 !== peg$FAILED) {
+                        peg$savedPos = s0;
+                        s1 = peg$c83(s2, s6, s10);
+                        s0 = s1;
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
                     } else {
                       peg$currPos = s0;
                       s0 = peg$FAILED;
@@ -2806,26 +3142,49 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseNotReducers() {
+    var s0;
+
+    if (input.substr(peg$currPos, 3) === peg$c84) {
+      s0 = peg$c84;
+      peg$currPos += 3;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c85); }
+    }
+    if (s0 === peg$FAILED) {
+      if (input.substr(peg$currPos, 5) === peg$c86) {
+        s0 = peg$c86;
+        peg$currPos += 5;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c87); }
+      }
+    }
+
+    return s0;
+  }
+
   function peg$parseWhereClause() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c90) {
-        s2 = peg$c90;
+      if (input.substr(peg$currPos, 5) === peg$c88) {
+        s2 = peg$c88;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c91); }
+        if (peg$silentFails === 0) { peg$fail(peg$c89); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseConditionalExpr();
+          s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c18(s4);
+            s1 = peg$c33(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2858,11 +3217,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c79;
+          s5 = peg$c24;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2893,11 +3252,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c79;
+            s5 = peg$c24;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2925,7 +3284,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c92(s1, s2);
+        s1 = peg$c90(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2939,7 +3298,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseNamedProc() {
+  function peg$parseOperator() {
     var s0;
 
     s0 = peg$parseSortProc();
@@ -2987,12 +3346,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c93) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c91) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      if (peg$silentFails === 0) { peg$fail(peg$c92); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -3003,7 +3362,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c95(s2, s5);
+            s4 = peg$c93(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -3018,7 +3377,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c96(s2, s3);
+          s1 = peg$c94(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3047,7 +3406,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c97(s4);
+        s3 = peg$c18(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3065,7 +3424,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c97(s4);
+          s3 = peg$c18(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3078,7 +3437,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c98(s1);
+      s1 = peg$c95(s1);
     }
     s0 = s1;
 
@@ -3089,55 +3448,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c99) {
-      s1 = peg$c99;
+    if (input.substr(peg$currPos, 2) === peg$c96) {
+      s1 = peg$c96;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+      if (peg$silentFails === 0) { peg$fail(peg$c97); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c101();
+      s1 = peg$c98();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c102) {
-        s1 = peg$c102;
+      if (input.substr(peg$currPos, 6) === peg$c99) {
+        s1 = peg$c99;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c100); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c104) {
-            s4 = peg$c104;
+          if (input.substr(peg$currPos, 5) === peg$c101) {
+            s4 = peg$c101;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c105); }
+            if (peg$silentFails === 0) { peg$fail(peg$c102); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c106) {
-              s4 = peg$c106;
+            if (input.substr(peg$currPos, 4) === peg$c103) {
+              s4 = peg$c103;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c107); }
+              if (peg$silentFails === 0) { peg$fail(peg$c104); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c108();
+            s4 = peg$c45();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c109(s3);
+            s1 = peg$c105(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3160,12 +3519,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c110) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c106) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c111); }
+      if (peg$silentFails === 0) { peg$fail(peg$c107); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -3174,7 +3533,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c112(s4);
+          s3 = peg$c108(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3191,12 +3550,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c113) {
-            s5 = peg$c113;
+          if (input.substr(peg$currPos, 6) === peg$c109) {
+            s5 = peg$c109;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c114); }
+            if (peg$silentFails === 0) { peg$fail(peg$c110); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3219,7 +3578,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c115(s2, s3, s6);
+              s5 = peg$c111(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3234,7 +3593,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c116(s2, s3, s4);
+            s1 = peg$c112(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3260,12 +3619,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c117) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c113) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c118); }
+      if (peg$silentFails === 0) { peg$fail(peg$c114); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseCutArgs();
@@ -3275,7 +3634,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFlexAssignments();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c119(s2, s4);
+            s1 = peg$c115(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3305,16 +3664,16 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     s3 = peg$parse_();
     if (s3 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c120) {
-        s4 = peg$c120;
+      if (input.substr(peg$currPos, 2) === peg$c116) {
+        s4 = peg$c116;
         peg$currPos += 2;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c122();
+        s3 = peg$c118();
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3329,16 +3688,16 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c120) {
-          s4 = peg$c120;
+        if (input.substr(peg$currPos, 2) === peg$c116) {
+          s4 = peg$c116;
           peg$currPos += 2;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c117); }
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c122();
+          s3 = peg$c118();
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3351,7 +3710,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c123(s1);
+      s1 = peg$c119(s1);
     }
     s0 = s1;
 
@@ -3362,12 +3721,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c124) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c120) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c125); }
+      if (peg$silentFails === 0) { peg$fail(peg$c121); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3375,7 +3734,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c126(s3);
+          s1 = peg$c122(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3397,12 +3756,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c127) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c123) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c128); }
+      if (peg$silentFails === 0) { peg$fail(peg$c124); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3410,7 +3769,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFieldExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c129(s3);
+          s1 = peg$c125(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3429,6 +3788,56 @@ function peg$parse(input, options) {
   }
 
   function peg$parseHeadProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c126) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c127); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseUInt();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c128(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c126) {
+        s1 = input.substr(peg$currPos, 4);
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c127); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c129();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseTailProc() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -3478,13 +3887,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseTailProc() {
+  function peg$parseFilterProc() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c134) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c134) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c135); }
@@ -3492,7 +3901,7 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseUInt();
+        s3 = peg$parseFilter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$c136(s3);
@@ -3509,56 +3918,20 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c134) {
-        s1 = input.substr(peg$currPos, 4);
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c135); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c137();
-      }
-      s0 = s1;
-    }
 
     return s0;
   }
 
-  function peg$parseFilterProc() {
-    var s0, s1, s2, s3;
+  function peg$parseFilter() {
+    var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c138) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c139); }
-    }
+    s1 = peg$parseSearchBoolean();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseSearchExpr();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c3(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
+      peg$savedPos = s0;
+      s1 = peg$c19(s1);
     }
+    s0 = s1;
 
     return s0;
   }
@@ -3567,26 +3940,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c140) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c137) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c138); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c120) {
-          s3 = peg$c120;
+        if (input.substr(peg$currPos, 2) === peg$c116) {
+          s3 = peg$c116;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c117); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c142();
+          s1 = peg$c139();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3602,16 +3975,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c140) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c137) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c141); }
+        if (peg$silentFails === 0) { peg$fail(peg$c138); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c143();
+        s1 = peg$c140();
       }
       s0 = s1;
     }
@@ -3623,12 +3996,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c144) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c141) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c145); }
+      if (peg$silentFails === 0) { peg$fail(peg$c142); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3636,7 +4009,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c146(s3);
+          s1 = peg$c143(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3658,12 +4031,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c147) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c144) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c145); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3675,11 +4048,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c79;
+              s7 = peg$c24;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c80); }
+              if (peg$silentFails === 0) { peg$fail(peg$c25); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -3687,7 +4060,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c149(s3, s9);
+                  s6 = peg$c146(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -3711,11 +4084,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c79;
+                s7 = peg$c24;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c80); }
+                if (peg$silentFails === 0) { peg$fail(peg$c25); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -3723,7 +4096,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c149(s3, s9);
+                    s6 = peg$c146(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -3744,7 +4117,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c150(s3, s4);
+            s1 = peg$c147(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3770,16 +4143,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c151) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c148) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c152); }
+      if (peg$silentFails === 0) { peg$fail(peg$c149); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c153();
+      s1 = peg$c150();
     }
     s0 = s1;
 
@@ -3790,12 +4163,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c151) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+      if (peg$silentFails === 0) { peg$fail(peg$c152); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3805,11 +4178,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 61) {
-              s5 = peg$c83;
+              s5 = peg$c46;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c84); }
+              if (peg$silentFails === 0) { peg$fail(peg$c47); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
@@ -3836,7 +4209,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c156(s3, s7, s8);
+                    s1 = peg$c153(s3, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3872,12 +4245,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c151) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c152); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -3904,7 +4277,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c157(s3, s4);
+              s1 = peg$c154(s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3934,113 +4307,30 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c14;
+        s1 = peg$c13;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c15); }
+        if (peg$silentFails === 0) { peg$fail(peg$c14); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseConditionalExpr();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s3 = peg$c16;
+            s3 = peg$c15;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c18(s2);
+            s1 = peg$c33(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
           }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseRootField() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c158;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c159); }
-    }
-    if (s1 === peg$FAILED) {
-      s1 = null;
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseBooleanLiteral();
-      if (s3 === peg$FAILED) {
-        s3 = peg$parseNullLiteral();
-      }
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseIdentifier();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c160(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c158;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c159); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$currPos;
-        peg$silentFails++;
-        s3 = peg$parseIdentifier();
-        peg$silentFails--;
-        if (s3 === peg$FAILED) {
-          s2 = void 0;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c161();
-          s0 = s1;
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -4065,11 +4355,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c79;
+          s5 = peg$c24;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -4100,11 +4390,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c79;
+            s5 = peg$c24;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -4132,7 +4422,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c162(s1, s2);
+        s1 = peg$c155(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4157,11 +4447,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c79;
+          s5 = peg$c24;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -4192,11 +4482,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c79;
+            s5 = peg$c24;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -4224,7 +4514,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c162(s1, s2);
+        s1 = peg$c155(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4247,11 +4537,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c83;
+          s3 = peg$c46;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4259,7 +4549,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c163(s1, s5);
+              s1 = peg$c156(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4302,11 +4592,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c164;
+          s3 = peg$c157;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c165); }
+          if (peg$silentFails === 0) { peg$fail(peg$c158); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4316,11 +4606,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c166;
+                  s7 = peg$c20;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c167); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c21); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -4328,7 +4618,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c168(s1, s5, s9);
+                      s1 = peg$c159(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4390,7 +4680,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c169(s1, s5, s7);
+              s4 = peg$c60(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4420,7 +4710,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c169(s1, s5, s7);
+                s4 = peg$c60(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4441,7 +4731,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4472,7 +4762,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c169(s1, s5, s7);
+              s4 = peg$c60(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4502,7 +4792,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c169(s1, s5, s7);
+                s4 = peg$c60(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4523,7 +4813,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4554,7 +4844,7 @@ function peg$parse(input, options) {
             s7 = peg$parseRelativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c171(s1, s5, s7);
+              s4 = peg$c160(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4584,7 +4874,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c171(s1, s5, s7);
+                s4 = peg$c160(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4605,7 +4895,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4623,43 +4913,25 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c172) {
-      s1 = peg$c172;
-      peg$currPos += 2;
+    if (input.charCodeAt(peg$currPos) === 61) {
+      s1 = peg$c46;
+      peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c173); }
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c174) {
-        s1 = peg$c174;
+      if (input.substr(peg$currPos, 2) === peg$c48) {
+        s1 = peg$c48;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
-      }
-      if (s1 === peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c83;
-          peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
-        }
-        if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c176) {
-            s1 = peg$c176;
-            peg$currPos += 2;
-          } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c177); }
-          }
-        }
+        if (peg$silentFails === 0) { peg$fail(peg$c49); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -4672,16 +4944,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c178) {
-        s1 = peg$c178;
+      if (input.substr(peg$currPos, 2) === peg$c50) {
+        s1 = peg$c50;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c51); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c108();
+        s1 = peg$c45();
       }
       s0 = s1;
     }
@@ -4706,7 +4978,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c169(s1, s5, s7);
+              s4 = peg$c60(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4736,7 +5008,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c169(s1, s5, s7);
+                s4 = peg$c60(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4757,7 +5029,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4775,43 +5047,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c180) {
-      s1 = peg$c180;
+    if (input.substr(peg$currPos, 2) === peg$c52) {
+      s1 = peg$c52;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c181); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c182;
+        s1 = peg$c54;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c55); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c184) {
-          s1 = peg$c184;
+        if (input.substr(peg$currPos, 2) === peg$c56) {
+          s1 = peg$c56;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c185); }
+          if (peg$silentFails === 0) { peg$fail(peg$c57); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c186;
+            s1 = peg$c58;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c187); }
+            if (peg$silentFails === 0) { peg$fail(peg$c59); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -4835,7 +5107,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c169(s1, s5, s7);
+              s4 = peg$c60(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4865,7 +5137,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c169(s1, s5, s7);
+                s4 = peg$c60(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4886,7 +5158,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4905,24 +5177,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c188;
+      s1 = peg$c161;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c189); }
+      if (peg$silentFails === 0) { peg$fail(peg$c162); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c11;
+        s1 = peg$c163;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c12); }
+        if (peg$silentFails === 0) { peg$fail(peg$c164); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -4946,7 +5218,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c169(s1, s5, s7);
+              s4 = peg$c60(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4976,7 +5248,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c169(s1, s5, s7);
+                s4 = peg$c60(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4997,7 +5269,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5016,24 +5288,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c19;
+      s1 = peg$c34;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c20); }
+      if (peg$silentFails === 0) { peg$fail(peg$c35); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c190;
+        s1 = peg$c165;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c191); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -5045,11 +5317,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c8;
+      s1 = peg$c30;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      if (peg$silentFails === 0) { peg$fail(peg$c31); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -5057,7 +5329,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c192(s3);
+          s1 = peg$c167(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5086,17 +5358,17 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 58) {
-        s3 = peg$c166;
+        s3 = peg$c20;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c167); }
+        if (peg$silentFails === 0) { peg$fail(peg$c21); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parsePrimitiveType();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c193(s1, s4);
+          s3 = peg$c62(s1, s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -5108,7 +5380,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c194(s1, s2);
+        s1 = peg$c63(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5129,172 +5401,172 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c195) {
-      s1 = peg$c195;
+    if (input.substr(peg$currPos, 5) === peg$c168) {
+      s1 = peg$c168;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c169); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c197) {
-        s1 = peg$c197;
+      if (input.substr(peg$currPos, 5) === peg$c170) {
+        s1 = peg$c170;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+        if (peg$silentFails === 0) { peg$fail(peg$c171); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c199) {
-          s1 = peg$c199;
+        if (input.substr(peg$currPos, 6) === peg$c172) {
+          s1 = peg$c172;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c200); }
+          if (peg$silentFails === 0) { peg$fail(peg$c173); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c201) {
-            s1 = peg$c201;
+          if (input.substr(peg$currPos, 6) === peg$c174) {
+            s1 = peg$c174;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c202); }
+            if (peg$silentFails === 0) { peg$fail(peg$c175); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c203) {
-              s1 = peg$c203;
+            if (input.substr(peg$currPos, 6) === peg$c176) {
+              s1 = peg$c176;
               peg$currPos += 6;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c204); }
+              if (peg$silentFails === 0) { peg$fail(peg$c177); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4) === peg$c205) {
-                s1 = peg$c205;
+              if (input.substr(peg$currPos, 4) === peg$c178) {
+                s1 = peg$c178;
                 peg$currPos += 4;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c206); }
+                if (peg$silentFails === 0) { peg$fail(peg$c179); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c207) {
-                  s1 = peg$c207;
+                if (input.substr(peg$currPos, 5) === peg$c180) {
+                  s1 = peg$c180;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c208); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c181); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c209) {
-                    s1 = peg$c209;
+                  if (input.substr(peg$currPos, 5) === peg$c182) {
+                    s1 = peg$c182;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c210); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c183); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c211) {
-                      s1 = peg$c211;
+                    if (input.substr(peg$currPos, 5) === peg$c184) {
+                      s1 = peg$c184;
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c212); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c185); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 8) === peg$c213) {
-                        s1 = peg$c213;
+                      if (input.substr(peg$currPos, 8) === peg$c186) {
+                        s1 = peg$c186;
                         peg$currPos += 8;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c214); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c187); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c215) {
-                          s1 = peg$c215;
+                        if (input.substr(peg$currPos, 4) === peg$c188) {
+                          s1 = peg$c188;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c189); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 7) === peg$c217) {
-                            s1 = peg$c217;
+                          if (input.substr(peg$currPos, 7) === peg$c190) {
+                            s1 = peg$c190;
                             peg$currPos += 7;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c218); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c191); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 4) === peg$c219) {
-                              s1 = peg$c219;
+                            if (input.substr(peg$currPos, 4) === peg$c192) {
+                              s1 = peg$c192;
                               peg$currPos += 4;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c220); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c193); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 5) === peg$c195) {
-                                s1 = peg$c195;
+                              if (input.substr(peg$currPos, 5) === peg$c168) {
+                                s1 = peg$c168;
                                 peg$currPos += 5;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c196); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c169); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 6) === peg$c221) {
-                                  s1 = peg$c221;
+                                if (input.substr(peg$currPos, 6) === peg$c194) {
+                                  s1 = peg$c194;
                                   peg$currPos += 6;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c222); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c195); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 7) === peg$c223) {
-                                    s1 = peg$c223;
+                                  if (input.substr(peg$currPos, 7) === peg$c196) {
+                                    s1 = peg$c196;
                                     peg$currPos += 7;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c224); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c197); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c225) {
-                                      s1 = peg$c225;
+                                    if (input.substr(peg$currPos, 2) === peg$c198) {
+                                      s1 = peg$c198;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c199); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c227) {
-                                        s1 = peg$c227;
+                                      if (input.substr(peg$currPos, 3) === peg$c200) {
+                                        s1 = peg$c200;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c228); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c201); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c229) {
-                                          s1 = peg$c229;
+                                        if (input.substr(peg$currPos, 4) === peg$c202) {
+                                          s1 = peg$c202;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c230); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c203); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 5) === peg$c231) {
-                                            s1 = peg$c231;
+                                          if (input.substr(peg$currPos, 5) === peg$c204) {
+                                            s1 = peg$c204;
                                             peg$currPos += 5;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c232); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c205); }
                                           }
                                           if (s1 === peg$FAILED) {
-                                            if (input.substr(peg$currPos, 4) === peg$c47) {
-                                              s1 = peg$c47;
+                                            if (input.substr(peg$currPos, 4) === peg$c206) {
+                                              s1 = peg$c206;
                                               peg$currPos += 4;
                                             } else {
                                               s1 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c48); }
+                                              if (peg$silentFails === 0) { peg$fail(peg$c207); }
                                             }
                                           }
                                         }
@@ -5318,7 +5590,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -5328,65 +5600,77 @@ function peg$parse(input, options) {
   function peg$parseFuncExpr() {
     var s0, s1, s2, s3;
 
-    s0 = peg$currPos;
-    s1 = peg$parseFunction();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseDeref();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseDeref();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c233(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
+    s0 = peg$parseSelectExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseDerefExpr();
+      s0 = peg$parseMatchExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parsePrimary();
+        s0 = peg$currPos;
+        s1 = peg$parseFunction();
+        if (s1 !== peg$FAILED) {
+          s2 = [];
+          s3 = peg$parseDeref();
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            s3 = peg$parseDeref();
+          }
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c26(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseDerefExpr();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parsePrimary();
+          }
+        }
       }
     }
 
     return s0;
   }
 
-  function peg$parseFunction() {
+  function peg$parseMatchExpr() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    s1 = peg$parseDeprecatedName();
+    if (input.substr(peg$currPos, 5) === peg$c86) {
+      s1 = peg$c86;
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c87); }
+    }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c14;
+          s3 = peg$c13;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c15); }
+          if (peg$silentFails === 0) { peg$fail(peg$c14); }
         }
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseArgumentList();
+          s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c16;
+              s5 = peg$c15;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c17); }
+              if (peg$silentFails === 0) { peg$fail(peg$c16); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c234(s1, s4);
+              s1 = peg$c33(s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5412,40 +5696,207 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseDeprecatedName() {
-    var s0, s1, s2, s3;
+  function peg$parseSelectExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
     s0 = peg$currPos;
-    s1 = peg$parseIdentifierStart();
+    if (input.substr(peg$currPos, 6) === peg$c208) {
+      s1 = peg$c208;
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c209); }
+    }
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseIdentifierRest();
-      if (s3 === peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c158;
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c13;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c159); }
+          if (peg$silentFails === 0) { peg$fail(peg$c14); }
         }
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseIdentifierRest();
-        if (s3 === peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 46) {
-            s3 = peg$c158;
-            peg$currPos++;
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseArgumentList();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c15;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                }
+                if (s7 !== peg$FAILED) {
+                  s8 = [];
+                  s9 = peg$currPos;
+                  s10 = peg$parse__();
+                  if (s10 !== peg$FAILED) {
+                    if (input.charCodeAt(peg$currPos) === 46) {
+                      s11 = peg$c81;
+                      peg$currPos++;
+                    } else {
+                      s11 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                    }
+                    if (s11 !== peg$FAILED) {
+                      s12 = peg$parse__();
+                      if (s12 !== peg$FAILED) {
+                        s13 = peg$parseFunction();
+                        if (s13 !== peg$FAILED) {
+                          peg$savedPos = s9;
+                          s10 = peg$c210(s5, s13);
+                          s9 = s10;
+                        } else {
+                          peg$currPos = s9;
+                          s9 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s9;
+                        s9 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s9;
+                      s9 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s9;
+                    s9 = peg$FAILED;
+                  }
+                  while (s9 !== peg$FAILED) {
+                    s8.push(s9);
+                    s9 = peg$currPos;
+                    s10 = peg$parse__();
+                    if (s10 !== peg$FAILED) {
+                      if (input.charCodeAt(peg$currPos) === 46) {
+                        s11 = peg$c81;
+                        peg$currPos++;
+                      } else {
+                        s11 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                      }
+                      if (s11 !== peg$FAILED) {
+                        s12 = peg$parse__();
+                        if (s12 !== peg$FAILED) {
+                          s13 = peg$parseFunction();
+                          if (s13 !== peg$FAILED) {
+                            peg$savedPos = s9;
+                            s10 = peg$c210(s5, s13);
+                            s9 = s10;
+                          } else {
+                            peg$currPos = s9;
+                            s9 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s9;
+                          s9 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s9;
+                        s9 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s9;
+                      s9 = peg$FAILED;
+                    }
+                  }
+                  if (s8 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c211(s5, s8);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c159); }
+            peg$currPos = s0;
+            s0 = peg$FAILED;
           }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
       }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseFunction() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseIdentifierName();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c108();
-        s0 = s1;
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c13;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c14); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseArgumentList();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c15;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                }
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c212(s1, s5);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -5469,11 +5920,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c79;
+          s5 = peg$c24;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5481,7 +5932,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c235(s1, s7);
+              s4 = peg$c213(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5505,11 +5956,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c79;
+            s5 = peg$c24;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5517,7 +5968,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c235(s1, s7);
+                s4 = peg$c213(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5538,7 +5989,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c82(s1, s2);
+        s1 = peg$c6(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5553,7 +6004,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c236();
+        s1 = peg$c214();
       }
       s0 = s1;
     }
@@ -5565,7 +6016,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseRootField();
+    s1 = peg$parseDotId();
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$parseDeref();
@@ -5575,7 +6026,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c233(s1, s2);
+        s1 = peg$c26(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5584,6 +6035,121 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseIdentifier();
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        s3 = peg$parseDeref();
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parseDeref();
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c26(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 46) {
+          s1 = peg$c81;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        }
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c215();
+        }
+        s0 = s1;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseDotId() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 46) {
+      s1 = peg$c81;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c82); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseIdentifier();
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c216(s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 46) {
+        s1 = peg$c81;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+      }
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 91) {
+          s2 = peg$c217;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c218); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseConditionalExpr();
+          if (s3 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 93) {
+              s4 = peg$c219;
+              peg$currPos++;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c220); }
+            }
+            if (s4 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c221(s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     }
 
     return s0;
@@ -5594,25 +6160,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c237;
+      s1 = peg$c217;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c218); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseConditionalExpr();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c239;
+          s3 = peg$c219;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          if (peg$silentFails === 0) { peg$fail(peg$c220); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c241(s2);
+          s1 = peg$c222(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5629,21 +6195,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c158;
+        s1 = peg$c81;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c159); }
+        if (peg$silentFails === 0) { peg$fail(peg$c82); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c158;
+          s3 = peg$c81;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c159); }
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
         }
         peg$silentFails--;
         if (s3 === peg$FAILED) {
@@ -5656,7 +6222,7 @@ function peg$parse(input, options) {
           s3 = peg$parseIdentifier();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c242(s3);
+            s1 = peg$c223(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5678,6 +6244,62 @@ function peg$parse(input, options) {
   function peg$parsePrimary() {
     var s0, s1, s2, s3, s4, s5;
 
+    s0 = peg$parseLiteral();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 40) {
+        s1 = peg$c13;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c14); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse__();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseConditionalExpr();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse__();
+            if (s4 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 41) {
+                s5 = peg$c15;
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c16); }
+              }
+              if (s5 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c33(s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseLiteral() {
+    var s0;
+
     s0 = peg$parseStringLiteral();
     if (s0 === peg$FAILED) {
       s0 = peg$parseRegexpLiteral();
@@ -5693,54 +6315,6 @@ function peg$parse(input, options) {
                 s0 = peg$parseBooleanLiteral();
                 if (s0 === peg$FAILED) {
                   s0 = peg$parseNullLiteral();
-                  if (s0 === peg$FAILED) {
-                    s0 = peg$currPos;
-                    if (input.charCodeAt(peg$currPos) === 40) {
-                      s1 = peg$c14;
-                      peg$currPos++;
-                    } else {
-                      s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c15); }
-                    }
-                    if (s1 !== peg$FAILED) {
-                      s2 = peg$parse__();
-                      if (s2 !== peg$FAILED) {
-                        s3 = peg$parseConditionalExpr();
-                        if (s3 !== peg$FAILED) {
-                          s4 = peg$parse__();
-                          if (s4 !== peg$FAILED) {
-                            if (input.charCodeAt(peg$currPos) === 41) {
-                              s5 = peg$c16;
-                              peg$currPos++;
-                            } else {
-                              s5 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c17); }
-                            }
-                            if (s5 !== peg$FAILED) {
-                              peg$savedPos = s0;
-                              s1 = peg$c18(s3);
-                              s0 = s1;
-                            } else {
-                              peg$currPos = s0;
-                              s0 = peg$FAILED;
-                            }
-                          } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                          }
-                        } else {
-                          peg$currPos = s0;
-                          s0 = peg$FAILED;
-                        }
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  }
                 }
               }
             }
@@ -5748,6 +6322,217 @@ function peg$parse(input, options) {
         }
       }
     }
+
+    return s0;
+  }
+
+  function peg$parseStringLiteral() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseQuotedString();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c41(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseRegexpLiteral() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseRegexp();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseKeyWordStart();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c224(s1);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSubnetLiteral() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseIP6Net();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c225(s1);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseIP4Net();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c225(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAddressLiteral() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseIP6();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c226(s1);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseIP();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c226(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseFloatLiteral() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseFloatString();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c227(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseIntegerLiteral() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseIntString();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c228(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseBooleanLiteral() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4) === peg$c229) {
+      s1 = peg$c229;
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c230); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c231();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 5) === peg$c232) {
+        s1 = peg$c232;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c233); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c234();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseNullLiteral() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4) === peg$c206) {
+      s1 = peg$c206;
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c207); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c235();
+    }
+    s0 = s1;
 
     return s0;
   }
@@ -5767,16 +6552,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c243) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c236) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c237); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c238();
     }
     s0 = s1;
 
@@ -5787,16 +6572,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c245) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c239) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c241();
     }
     s0 = s1;
 
@@ -5807,16 +6592,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c178) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c50) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c242); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c243();
     }
     s0 = s1;
 
@@ -5827,46 +6612,38 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c87) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c84) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c248); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c245();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseIdentifierName() {
-    var s0, s1, s2, s3;
+  function peg$parseByToken() {
+    var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parseIdentifierStart();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseIdentifierRest();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseIdentifierRest();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c108();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c246) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c247); }
     }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c248();
+    }
+    s0 = s1;
 
     return s0;
   }
@@ -5903,21 +6680,64 @@ function peg$parse(input, options) {
   }
 
   function peg$parseIdentifier() {
-    var s0, s1, s2, s3;
+    var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parseIdentifierStart();
+    s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseIdentifierRest();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseIdentifierRest();
+      peg$savedPos = s0;
+      s1 = peg$c253(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseIdentifierName() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$currPos;
+    peg$silentFails++;
+    s2 = peg$currPos;
+    s3 = peg$parseIdGuard();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parseEOT();
+      if (s4 !== peg$FAILED) {
+        s3 = [s3, s4];
+        s2 = s3;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
       }
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    peg$silentFails--;
+    if (s2 === peg$FAILED) {
+      s1 = void 0;
+    } else {
+      peg$currPos = s1;
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseIdentifierStart();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c253();
-        s0 = s1;
+        s3 = [];
+        s4 = peg$parseIdentifierRest();
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$parseIdentifierRest();
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c254();
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -5925,6 +6745,59 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 36) {
+        s1 = peg$c255;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c256); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c45();
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 92) {
+          s1 = peg$c257;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c258); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parseIdGuard();
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c259(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseIdGuard() {
+    var s0;
+
+    s0 = peg$parseBooleanLiteral();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseNullLiteral();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseSearchGuard();
+      }
     }
 
     return s0;
@@ -5944,12 +6817,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c243) {
-                s3 = peg$c243;
+              if (input.substr(peg$currPos, 3) === peg$c236) {
+                s3 = peg$c236;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c254); }
+                if (peg$silentFails === 0) { peg$fail(peg$c260); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -5994,44 +6867,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c255) {
-      s0 = peg$c255;
+    if (input.substr(peg$currPos, 7) === peg$c261) {
+      s0 = peg$c261;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c256); }
+      if (peg$silentFails === 0) { peg$fail(peg$c262); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c257) {
-        s0 = peg$c257;
+      if (input.substr(peg$currPos, 6) === peg$c263) {
+        s0 = peg$c263;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c258); }
+        if (peg$silentFails === 0) { peg$fail(peg$c264); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c259) {
-          s0 = peg$c259;
+        if (input.substr(peg$currPos, 4) === peg$c265) {
+          s0 = peg$c265;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c260); }
+          if (peg$silentFails === 0) { peg$fail(peg$c266); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c261) {
-            s0 = peg$c261;
+          if (input.substr(peg$currPos, 3) === peg$c267) {
+            s0 = peg$c267;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c262); }
+            if (peg$silentFails === 0) { peg$fail(peg$c268); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c263;
+              s0 = peg$c269;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c264); }
+              if (peg$silentFails === 0) { peg$fail(peg$c270); }
             }
           }
         }
@@ -6044,44 +6917,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c265) {
-      s0 = peg$c265;
+    if (input.substr(peg$currPos, 7) === peg$c271) {
+      s0 = peg$c271;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c266); }
+      if (peg$silentFails === 0) { peg$fail(peg$c272); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c267) {
-        s0 = peg$c267;
+      if (input.substr(peg$currPos, 6) === peg$c273) {
+        s0 = peg$c273;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c274); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c269) {
-          s0 = peg$c269;
+        if (input.substr(peg$currPos, 4) === peg$c275) {
+          s0 = peg$c275;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c270); }
+          if (peg$silentFails === 0) { peg$fail(peg$c276); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c271) {
-            s0 = peg$c271;
+          if (input.substr(peg$currPos, 3) === peg$c277) {
+            s0 = peg$c277;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c272); }
+            if (peg$silentFails === 0) { peg$fail(peg$c278); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c273;
+              s0 = peg$c279;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c274); }
+              if (peg$silentFails === 0) { peg$fail(peg$c280); }
             }
           }
         }
@@ -6094,44 +6967,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c275) {
-      s0 = peg$c275;
+    if (input.substr(peg$currPos, 5) === peg$c281) {
+      s0 = peg$c281;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c276); }
+      if (peg$silentFails === 0) { peg$fail(peg$c282); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c277) {
-        s0 = peg$c277;
+      if (input.substr(peg$currPos, 3) === peg$c283) {
+        s0 = peg$c283;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c278); }
+        if (peg$silentFails === 0) { peg$fail(peg$c284); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c279) {
-          s0 = peg$c279;
+        if (input.substr(peg$currPos, 2) === peg$c285) {
+          s0 = peg$c285;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c280); }
+          if (peg$silentFails === 0) { peg$fail(peg$c286); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c281;
+            s0 = peg$c287;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c282); }
+            if (peg$silentFails === 0) { peg$fail(peg$c288); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c283) {
-              s0 = peg$c283;
+            if (input.substr(peg$currPos, 4) === peg$c289) {
+              s0 = peg$c289;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c284); }
+              if (peg$silentFails === 0) { peg$fail(peg$c290); }
             }
           }
         }
@@ -6144,28 +7017,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c285) {
-      s0 = peg$c285;
+    if (input.substr(peg$currPos, 4) === peg$c291) {
+      s0 = peg$c291;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c292); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c287) {
-        s0 = peg$c287;
+      if (input.substr(peg$currPos, 3) === peg$c293) {
+        s0 = peg$c293;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+        if (peg$silentFails === 0) { peg$fail(peg$c294); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c289;
+          s0 = peg$c295;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c290); }
+          if (peg$silentFails === 0) { peg$fail(peg$c296); }
         }
       }
     }
@@ -6176,44 +7049,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c291) {
-      s0 = peg$c291;
+    if (input.substr(peg$currPos, 5) === peg$c297) {
+      s0 = peg$c297;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c292); }
+      if (peg$silentFails === 0) { peg$fail(peg$c298); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c293) {
-        s0 = peg$c293;
+      if (input.substr(peg$currPos, 4) === peg$c299) {
+        s0 = peg$c299;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c294); }
+        if (peg$silentFails === 0) { peg$fail(peg$c300); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c295) {
-          s0 = peg$c295;
+        if (input.substr(peg$currPos, 3) === peg$c301) {
+          s0 = peg$c301;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c296); }
+          if (peg$silentFails === 0) { peg$fail(peg$c302); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c297) {
-            s0 = peg$c297;
+          if (input.substr(peg$currPos, 2) === peg$c303) {
+            s0 = peg$c303;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c298); }
+            if (peg$silentFails === 0) { peg$fail(peg$c304); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c299;
+              s0 = peg$c305;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c300); }
+              if (peg$silentFails === 0) { peg$fail(peg$c306); }
             }
           }
         }
@@ -6227,16 +7100,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c257) {
-      s1 = peg$c257;
+    if (input.substr(peg$currPos, 6) === peg$c263) {
+      s1 = peg$c263;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c258); }
+      if (peg$silentFails === 0) { peg$fail(peg$c264); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c301();
+      s1 = peg$c307();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6248,7 +7121,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c302(s1);
+            s1 = peg$c308(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6271,16 +7144,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c267) {
-      s1 = peg$c267;
+    if (input.substr(peg$currPos, 6) === peg$c273) {
+      s1 = peg$c273;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c268); }
+      if (peg$silentFails === 0) { peg$fail(peg$c274); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c303();
+      s1 = peg$c309();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6292,7 +7165,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c304(s1);
+            s1 = peg$c310(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6315,16 +7188,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c283) {
-      s1 = peg$c283;
+    if (input.substr(peg$currPos, 4) === peg$c289) {
+      s1 = peg$c289;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c284); }
+      if (peg$silentFails === 0) { peg$fail(peg$c290); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c305();
+      s1 = peg$c311();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6336,7 +7209,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c306(s1);
+            s1 = peg$c312(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6359,16 +7232,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c287) {
-      s1 = peg$c287;
+    if (input.substr(peg$currPos, 3) === peg$c293) {
+      s1 = peg$c293;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c288); }
+      if (peg$silentFails === 0) { peg$fail(peg$c294); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c307();
+      s1 = peg$c313();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6380,7 +7253,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c308(s1);
+            s1 = peg$c314(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6403,16 +7276,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c293) {
-      s1 = peg$c293;
+    if (input.substr(peg$currPos, 4) === peg$c299) {
+      s1 = peg$c299;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c294); }
+      if (peg$silentFails === 0) { peg$fail(peg$c300); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c309();
+      s1 = peg$c315();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6424,7 +7297,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c310(s1);
+            s1 = peg$c316(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6450,37 +7323,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c158;
+        s2 = peg$c81;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c159); }
+        if (peg$silentFails === 0) { peg$fail(peg$c82); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c158;
+            s4 = peg$c81;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c159); }
+            if (peg$silentFails === 0) { peg$fail(peg$c82); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c158;
+                s6 = peg$c81;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c159); }
+                if (peg$silentFails === 0) { peg$fail(peg$c82); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c108();
+                  s1 = peg$c45();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6532,7 +7405,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c311(s1, s2);
+        s1 = peg$c317(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6553,12 +7426,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c312) {
-            s3 = peg$c312;
+          if (input.substr(peg$currPos, 2) === peg$c318) {
+            s3 = peg$c318;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c313); }
+            if (peg$silentFails === 0) { peg$fail(peg$c319); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6571,7 +7444,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c314(s1, s2, s4, s5);
+                s1 = peg$c320(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6595,12 +7468,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c312) {
-          s1 = peg$c312;
+        if (input.substr(peg$currPos, 2) === peg$c318) {
+          s1 = peg$c318;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c313); }
+          if (peg$silentFails === 0) { peg$fail(peg$c319); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6613,7 +7486,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c315(s2, s3);
+              s1 = peg$c321(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6638,16 +7511,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c312) {
-                s3 = peg$c312;
+              if (input.substr(peg$currPos, 2) === peg$c318) {
+                s3 = peg$c318;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c313); }
+                if (peg$silentFails === 0) { peg$fail(peg$c319); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c316(s1, s2);
+                s1 = peg$c322(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6663,16 +7536,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c312) {
-              s1 = peg$c312;
+            if (input.substr(peg$currPos, 2) === peg$c318) {
+              s1 = peg$c318;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c313); }
+              if (peg$silentFails === 0) { peg$fail(peg$c319); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c317();
+              s1 = peg$c323();
             }
             s0 = s1;
           }
@@ -6699,17 +7572,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c166;
+      s1 = peg$c20;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c167); }
+      if (peg$silentFails === 0) { peg$fail(peg$c21); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c318(s2);
+        s1 = peg$c324(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6730,15 +7603,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c166;
+        s2 = peg$c20;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c167); }
+        if (peg$silentFails === 0) { peg$fail(peg$c21); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c319(s1);
+        s1 = peg$c325(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6759,17 +7632,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c190;
+        s2 = peg$c165;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c191); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c320(s1, s3);
+          s1 = peg$c326(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6794,17 +7667,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c190;
+        s2 = peg$c165;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c191); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c321(s1, s3);
+          s1 = peg$c327(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6829,7 +7702,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c322(s1);
+      s1 = peg$c328(s1);
     }
     s0 = s1;
 
@@ -6875,7 +7748,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -6887,17 +7760,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c11;
+      s1 = peg$c163;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c12); }
+      if (peg$silentFails === 0) { peg$fail(peg$c164); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c108();
+        s1 = peg$c45();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6916,11 +7789,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c11;
+      s1 = peg$c163;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c12); }
+      if (peg$silentFails === 0) { peg$fail(peg$c164); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -6950,11 +7823,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c158;
+          s3 = peg$c81;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c159); }
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
@@ -6986,7 +7859,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c323();
+              s1 = peg$c329();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7011,22 +7884,22 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c11;
+        s1 = peg$c163;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c12); }
+        if (peg$silentFails === 0) { peg$fail(peg$c164); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c158;
+          s2 = peg$c81;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c159); }
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
@@ -7058,7 +7931,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c323();
+              s1 = peg$c329();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7085,20 +7958,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c324) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c330) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c331); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c326.test(input.charAt(peg$currPos))) {
+      if (peg$c332.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c327); }
+        if (peg$silentFails === 0) { peg$fail(peg$c333); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -7140,7 +8013,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -7150,109 +8023,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c328.test(input.charAt(peg$currPos))) {
+    if (peg$c334.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c329); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseKeyWord() {
-    var s0, s1, s2;
-
-    s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$parseKeyWordPart();
-    if (s2 !== peg$FAILED) {
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        s2 = peg$parseKeyWordPart();
-      }
-    } else {
-      s1 = peg$FAILED;
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c330(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseKeyWordPart() {
-    var s0, s1, s2;
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c331;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c332); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseEscapeSequence();
-      if (s2 === peg$FAILED) {
-        s2 = peg$parseSearchEscape();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c13(s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$currPos;
-      peg$silentFails++;
-      if (peg$c333.test(input.charAt(peg$currPos))) {
-        s2 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c334); }
-      }
-      if (s2 === peg$FAILED) {
-        s2 = peg$parseWhiteSpace();
-      }
-      peg$silentFails--;
-      if (s2 === peg$FAILED) {
-        s1 = void 0;
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-      if (s1 !== peg$FAILED) {
-        if (input.length > peg$currPos) {
-          s2 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c335); }
-        }
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c108();
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
     }
 
     return s0;
@@ -7374,11 +8150,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c335); }
+        if (peg$silentFails === 0) { peg$fail(peg$c341); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c108();
+        s1 = peg$c45();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7391,17 +8167,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c331;
+        s1 = peg$c257;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c332); }
+        if (peg$silentFails === 0) { peg$fail(peg$c258); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c13(s2);
+          s1 = peg$c342(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7411,6 +8187,106 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
+    }
+
+    return s0;
+  }
+
+  function peg$parseKeyWord() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseKeyWordStart();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseKeyWordRest();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseKeyWordRest();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c343(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseKeyWordStart() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (peg$c344.test(input.charAt(peg$currPos))) {
+      s1 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c345); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c45();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseKeyWordEsc();
+    }
+
+    return s0;
+  }
+
+  function peg$parseKeyWordRest() {
+    var s0;
+
+    s0 = peg$parseKeyWordStart();
+    if (s0 === peg$FAILED) {
+      if (peg$c251.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c252); }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseKeyWordEsc() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 92) {
+      s1 = peg$c257;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c258); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseKeywordEscape();
+      if (s2 === peg$FAILED) {
+        s2 = peg$parseEscapeSequence();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c342(s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
     return s0;
@@ -7445,11 +8321,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c335); }
+        if (peg$silentFails === 0) { peg$fail(peg$c341); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c108();
+        s1 = peg$c45();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7462,17 +8338,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c331;
+        s1 = peg$c257;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c332); }
+        if (peg$silentFails === 0) { peg$fail(peg$c258); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c13(s2);
+          s1 = peg$c342(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7492,11 +8368,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c341;
+      s1 = peg$c346;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c342); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -7504,7 +8380,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c343();
+          s1 = peg$c348();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7531,111 +8407,129 @@ function peg$parse(input, options) {
   function peg$parseSingleCharEscape() {
     var s0, s1;
 
+    s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c339;
+      s1 = peg$c339;
       peg$currPos++;
     } else {
-      s0 = peg$FAILED;
+      s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c349();
+    }
+    s0 = s1;
     if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c336;
+        s1 = peg$c336;
         peg$currPos++;
       } else {
-        s0 = peg$FAILED;
+        s1 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c337); }
       }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c350();
+      }
+      s0 = s1;
       if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c331;
+          s1 = peg$c257;
           peg$currPos++;
         } else {
-          s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c332); }
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c258); }
         }
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c351();
+        }
+        s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c344;
+            s1 = peg$c352;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c345); }
+            if (peg$silentFails === 0) { peg$fail(peg$c353); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c346();
+            s1 = peg$c354();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c347;
+              s1 = peg$c355;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c348); }
+              if (peg$silentFails === 0) { peg$fail(peg$c356); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c349();
+              s1 = peg$c357();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c350;
+                s1 = peg$c358;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c351); }
+                if (peg$silentFails === 0) { peg$fail(peg$c359); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c352();
+                s1 = peg$c360();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c353;
+                  s1 = peg$c361;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c354); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c362); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c355();
+                  s1 = peg$c363();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c356;
+                    s1 = peg$c364;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c357); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c365); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c358();
+                    s1 = peg$c366();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c359;
+                      s1 = peg$c367;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c368); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c361();
+                      s1 = peg$c369();
                     }
                     s0 = s1;
                   }
@@ -7650,36 +8544,45 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseSearchEscape() {
+  function peg$parseKeywordEscape() {
     var s0, s1;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c83;
+      s1 = peg$c46;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c84); }
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c370();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c19;
+        s1 = peg$c34;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c20); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c363();
+        s1 = peg$c371();
       }
       s0 = s1;
+      if (s0 === peg$FAILED) {
+        if (peg$c332.test(input.charAt(peg$currPos))) {
+          s0 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c333); }
+        }
+      }
     }
 
     return s0;
@@ -7690,11 +8593,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c364;
+      s1 = peg$c372;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c373); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7726,7 +8629,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c366(s2);
+        s1 = peg$c374(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7739,19 +8642,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c364;
+        s1 = peg$c372;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c365); }
+        if (peg$silentFails === 0) { peg$fail(peg$c373); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c367;
+          s2 = peg$c375;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c368); }
+          if (peg$silentFails === 0) { peg$fail(peg$c376); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7810,15 +8713,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c369;
+              s4 = peg$c377;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c370); }
+              if (peg$silentFails === 0) { peg$fail(peg$c378); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c366(s3);
+              s1 = peg$c374(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7846,25 +8749,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c190;
+      s1 = peg$c165;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c191); }
+      if (peg$silentFails === 0) { peg$fail(peg$c166); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c190;
+          s3 = peg$c165;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c191); }
+          if (peg$silentFails === 0) { peg$fail(peg$c166); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c371(s2);
+          s1 = peg$c379(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7887,39 +8790,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c372.test(input.charAt(peg$currPos))) {
+    if (peg$c380.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c381); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c374) {
-        s2 = peg$c374;
+      if (input.substr(peg$currPos, 2) === peg$c382) {
+        s2 = peg$c382;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c375); }
+        if (peg$silentFails === 0) { peg$fail(peg$c383); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c372.test(input.charAt(peg$currPos))) {
+        if (peg$c380.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c373); }
+          if (peg$silentFails === 0) { peg$fail(peg$c381); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c374) {
-            s2 = peg$c374;
+          if (input.substr(peg$currPos, 2) === peg$c382) {
+            s2 = peg$c382;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c375); }
+            if (peg$silentFails === 0) { peg$fail(peg$c383); }
           }
         }
       }
@@ -7928,7 +8831,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -7938,12 +8841,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c376.test(input.charAt(peg$currPos))) {
+    if (peg$c384.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c377); }
+      if (peg$silentFails === 0) { peg$fail(peg$c385); }
     }
 
     return s0;
@@ -8001,7 +8904,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
 
     return s0;
@@ -8012,51 +8915,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c379;
+      s0 = peg$c387;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c380); }
+      if (peg$silentFails === 0) { peg$fail(peg$c388); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c381;
+        s0 = peg$c389;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c382); }
+        if (peg$silentFails === 0) { peg$fail(peg$c390); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c383;
+          s0 = peg$c391;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c384); }
+          if (peg$silentFails === 0) { peg$fail(peg$c392); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c385;
+            s0 = peg$c393;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c386); }
+            if (peg$silentFails === 0) { peg$fail(peg$c394); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c387;
+              s0 = peg$c395;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c388); }
+              if (peg$silentFails === 0) { peg$fail(peg$c396); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c389;
+                s0 = peg$c397;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c390); }
+                if (peg$silentFails === 0) { peg$fail(peg$c398); }
               }
             }
           }
@@ -8065,7 +8968,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c378); }
+      if (peg$silentFails === 0) { peg$fail(peg$c386); }
     }
 
     return s0;
@@ -8074,12 +8977,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c391.test(input.charAt(peg$currPos))) {
+    if (peg$c399.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c392); }
+      if (peg$silentFails === 0) { peg$fail(peg$c400); }
     }
 
     return s0;
@@ -8092,7 +8995,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c393); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
 
     return s0;
@@ -8102,12 +9005,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c398) {
-      s1 = peg$c398;
+    if (input.substr(peg$currPos, 2) === peg$c406) {
+      s1 = peg$c406;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c399); }
+      if (peg$silentFails === 0) { peg$fail(peg$c407); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -8177,6 +9080,17 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseEOT() {
+    var s0;
+
+    s0 = peg$parse_();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseEOF();
+    }
+
+    return s0;
+  }
+
   function peg$parseEOF() {
     var s0, s1;
 
@@ -8187,7 +9101,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {
@@ -8203,17 +9117,6 @@ function peg$parse(input, options) {
 
 
   let reglob$1 = reglob;
-
-  function makeChain(first, rest, op) {
-    if (!rest || rest.length == 0) {
-      return first;
-    }
-    let result = first;
-    for (let term of rest) {
-      result = { op, left: result, right: term };
-    }
-    return result;
-  }
 
   function makeArgMap(args) {
     let m = {};

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -39,15 +39,15 @@ var g = &grammar{
 							label: "ast",
 							expr: &ruleRefExpr{
 								pos:  position{line: 10, col: 16, offset: 41},
-								name: "Query",
+								name: "Z",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 10, col: 22, offset: 47},
+							pos:  position{line: 10, col: 18, offset: 43},
 							name: "__",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 10, col: 25, offset: 50},
+							pos:  position{line: 10, col: 21, offset: 46},
 							name: "EOF",
 						},
 					},
@@ -55,48 +55,40 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "Query",
-			pos:  position{line: 12, col: 1, offset: 75},
+			name: "Z",
+			pos:  position{line: 16, col: 1, offset: 352},
+			expr: &ruleRefExpr{
+				pos:  position{line: 17, col: 5, offset: 432},
+				name: "Sequential",
+			},
+		},
+		{
+			name: "Sequential",
+			pos:  position{line: 19, col: 1, offset: 444},
 			expr: &choiceExpr{
-				pos: position{line: 13, col: 5, offset: 85},
+				pos: position{line: 20, col: 5, offset: 459},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 13, col: 5, offset: 85},
-						run: (*parser).callonQuery2,
-						expr: &labeledExpr{
-							pos:   position{line: 13, col: 5, offset: 85},
-							label: "procs",
-							expr: &ruleRefExpr{
-								pos:  position{line: 13, col: 11, offset: 91},
-								name: "SequentialProcs",
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 16, col: 5, offset: 200},
-						run: (*parser).callonQuery5,
+						pos: position{line: 20, col: 5, offset: 459},
+						run: (*parser).callonSequential2,
 						expr: &seqExpr{
-							pos: position{line: 16, col: 5, offset: 200},
+							pos: position{line: 20, col: 5, offset: 459},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 16, col: 5, offset: 200},
-									label: "s",
+									pos:   position{line: 20, col: 5, offset: 459},
+									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 16, col: 7, offset: 202},
-										name: "Search",
+										pos:  position{line: 20, col: 11, offset: 465},
+										name: "Operation",
 									},
 								},
-								&ruleRefExpr{
-									pos:  position{line: 16, col: 14, offset: 209},
-									name: "__",
-								},
 								&labeledExpr{
-									pos:   position{line: 16, col: 17, offset: 212},
+									pos:   position{line: 20, col: 21, offset: 475},
 									label: "rest",
-									expr: &zeroOrMoreExpr{
-										pos: position{line: 16, col: 22, offset: 217},
+									expr: &oneOrMoreExpr{
+										pos: position{line: 20, col: 26, offset: 480},
 										expr: &ruleRefExpr{
-											pos:  position{line: 16, col: 22, offset: 217},
+											pos:  position{line: 20, col: 26, offset: 480},
 											name: "SequentialTail",
 										},
 									},
@@ -104,50 +96,245 @@ var g = &grammar{
 							},
 						},
 					},
-				},
-			},
-		},
-		{
-			name: "Search",
-			pos:  position{line: 24, col: 1, offset: 465},
-			expr: &actionExpr{
-				pos: position{line: 25, col: 5, offset: 476},
-				run: (*parser).callonSearch1,
-				expr: &labeledExpr{
-					pos:   position{line: 25, col: 5, offset: 476},
-					label: "expr",
-					expr: &ruleRefExpr{
-						pos:  position{line: 25, col: 10, offset: 481},
-						name: "SearchExpr",
+					&actionExpr{
+						pos: position{line: 23, col: 5, offset: 640},
+						run: (*parser).callonSequential9,
+						expr: &labeledExpr{
+							pos:   position{line: 23, col: 5, offset: 640},
+							label: "op",
+							expr: &ruleRefExpr{
+								pos:  position{line: 23, col: 8, offset: 643},
+								name: "Operation",
+							},
+						},
 					},
 				},
 			},
 		},
 		{
-			name: "SearchExpr",
-			pos:  position{line: 29, col: 1, offset: 578},
+			name: "SequentialTail",
+			pos:  position{line: 27, col: 1, offset: 755},
 			expr: &actionExpr{
-				pos: position{line: 30, col: 5, offset: 593},
-				run: (*parser).callonSearchExpr1,
+				pos: position{line: 27, col: 18, offset: 772},
+				run: (*parser).callonSequentialTail1,
 				expr: &seqExpr{
-					pos: position{line: 30, col: 5, offset: 593},
+					pos: position{line: 27, col: 18, offset: 772},
 					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 30, col: 5, offset: 593},
-							label: "first",
-							expr: &ruleRefExpr{
-								pos:  position{line: 30, col: 11, offset: 599},
-								name: "SearchTerm",
-							},
+						&ruleRefExpr{
+							pos:  position{line: 27, col: 18, offset: 772},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 27, col: 21, offset: 775},
+							val:        "|",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 27, col: 25, offset: 779},
+							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 30, col: 22, offset: 610},
-							label: "rest",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 30, col: 27, offset: 615},
-								expr: &ruleRefExpr{
-									pos:  position{line: 30, col: 27, offset: 615},
-									name: "OredSearchTerm",
+							pos:   position{line: 27, col: 28, offset: 782},
+							label: "p",
+							expr: &ruleRefExpr{
+								pos:  position{line: 27, col: 30, offset: 784},
+								name: "Operation",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Parallel",
+			pos:  position{line: 29, col: 1, offset: 813},
+			expr: &choiceExpr{
+				pos: position{line: 30, col: 5, offset: 826},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 30, col: 5, offset: 826},
+						run: (*parser).callonParallel2,
+						expr: &seqExpr{
+							pos: position{line: 30, col: 5, offset: 826},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 30, col: 5, offset: 826},
+									label: "first",
+									expr: &ruleRefExpr{
+										pos:  position{line: 30, col: 11, offset: 832},
+										name: "Sequential",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 30, col: 22, offset: 843},
+									label: "rest",
+									expr: &oneOrMoreExpr{
+										pos: position{line: 30, col: 27, offset: 848},
+										expr: &ruleRefExpr{
+											pos:  position{line: 30, col: 27, offset: 848},
+											name: "ParallelTail",
+										},
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 33, col: 5, offset: 949},
+						run: (*parser).callonParallel9,
+						expr: &labeledExpr{
+							pos:   position{line: 33, col: 5, offset: 949},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 33, col: 11, offset: 955},
+								name: "Sequential",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ParallelTail",
+			pos:  position{line: 37, col: 1, offset: 1014},
+			expr: &actionExpr{
+				pos: position{line: 38, col: 5, offset: 1031},
+				run: (*parser).callonParallelTail1,
+				expr: &seqExpr{
+					pos: position{line: 38, col: 5, offset: 1031},
+					exprs: []interface{}{
+						&ruleRefExpr{
+							pos:  position{line: 38, col: 5, offset: 1031},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 38, col: 8, offset: 1034},
+							val:        "=>",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 38, col: 13, offset: 1039},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 38, col: 16, offset: 1042},
+							label: "ch",
+							expr: &ruleRefExpr{
+								pos:  position{line: 38, col: 19, offset: 1045},
+								name: "Sequential",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Operation",
+			pos:  position{line: 40, col: 1, offset: 1076},
+			expr: &choiceExpr{
+				pos: position{line: 41, col: 5, offset: 1090},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 41, col: 5, offset: 1090},
+						run: (*parser).callonOperation2,
+						expr: &seqExpr{
+							pos: position{line: 41, col: 5, offset: 1090},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 41, col: 5, offset: 1090},
+									val:        "split",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 41, col: 13, offset: 1098},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 41, col: 16, offset: 1101},
+									val:        "(",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 41, col: 20, offset: 1105},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 41, col: 23, offset: 1108},
+									val:        "=>",
+									ignoreCase: false,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 41, col: 28, offset: 1113},
+									name: "__",
+								},
+								&labeledExpr{
+									pos:   position{line: 41, col: 31, offset: 1116},
+									label: "procArray",
+									expr: &ruleRefExpr{
+										pos:  position{line: 41, col: 41, offset: 1126},
+										name: "Parallel",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 41, col: 50, offset: 1135},
+									name: "__",
+								},
+								&litMatcher{
+									pos:        position{line: 41, col: 53, offset: 1138},
+									val:        ")",
+									ignoreCase: false,
+								},
+							},
+						},
+					},
+					&ruleRefExpr{
+						pos:  position{line: 44, col: 5, offset: 1237},
+						name: "Operator",
+					},
+					&actionExpr{
+						pos: position{line: 45, col: 5, offset: 1250},
+						run: (*parser).callonOperation15,
+						expr: &seqExpr{
+							pos: position{line: 45, col: 5, offset: 1250},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 45, col: 5, offset: 1250},
+									label: "a",
+									expr: &ruleRefExpr{
+										pos:  position{line: 45, col: 7, offset: 1252},
+										name: "Aggregation",
+									},
+								},
+								&notExpr{
+									pos: position{line: 45, col: 19, offset: 1264},
+									expr: &ruleRefExpr{
+										pos:  position{line: 45, col: 20, offset: 1265},
+										name: "ExprGuard",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 46, col: 5, offset: 1298},
+						run: (*parser).callonOperation21,
+						expr: &seqExpr{
+							pos: position{line: 46, col: 5, offset: 1298},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 46, col: 5, offset: 1298},
+									label: "expr",
+									expr: &ruleRefExpr{
+										pos:  position{line: 46, col: 10, offset: 1303},
+										name: "SearchBoolean",
+									},
+								},
+								&notExpr{
+									pos: position{line: 46, col: 24, offset: 1317},
+									expr: &ruleRefExpr{
+										pos:  position{line: 46, col: 25, offset: 1318},
+										name: "AggGuard",
+									},
 								},
 							},
 						},
@@ -156,32 +343,167 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "OredSearchTerm",
-			pos:  position{line: 34, col: 1, offset: 694},
+			name: "ExprGuard",
+			pos:  position{line: 50, col: 1, offset: 1413},
+			expr: &seqExpr{
+				pos: position{line: 50, col: 13, offset: 1425},
+				exprs: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 50, col: 13, offset: 1425},
+						name: "__",
+					},
+					&choiceExpr{
+						pos: position{line: 50, col: 17, offset: 1429},
+						alternatives: []interface{}{
+							&seqExpr{
+								pos: position{line: 50, col: 18, offset: 1430},
+								exprs: []interface{}{
+									&notExpr{
+										pos: position{line: 50, col: 18, offset: 1430},
+										expr: &litMatcher{
+											pos:        position{line: 50, col: 19, offset: 1431},
+											val:        "=>",
+											ignoreCase: false,
+										},
+									},
+									&ruleRefExpr{
+										pos:  position{line: 50, col: 24, offset: 1436},
+										name: "Comparator",
+									},
+								},
+							},
+							&ruleRefExpr{
+								pos:  position{line: 50, col: 38, offset: 1450},
+								name: "AdditiveOperator",
+							},
+							&ruleRefExpr{
+								pos:  position{line: 50, col: 57, offset: 1469},
+								name: "MultiplicativeOperator",
+							},
+							&litMatcher{
+								pos:        position{line: 50, col: 82, offset: 1494},
+								val:        ":",
+								ignoreCase: false,
+							},
+							&litMatcher{
+								pos:        position{line: 50, col: 88, offset: 1500},
+								val:        "(",
+								ignoreCase: false,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "AggGuard",
+			pos:  position{line: 51, col: 1, offset: 1505},
+			expr: &choiceExpr{
+				pos: position{line: 51, col: 12, offset: 1516},
+				alternatives: []interface{}{
+					&seqExpr{
+						pos: position{line: 51, col: 13, offset: 1517},
+						exprs: []interface{}{
+							&ruleRefExpr{
+								pos:  position{line: 51, col: 13, offset: 1517},
+								name: "_",
+							},
+							&choiceExpr{
+								pos: position{line: 51, col: 16, offset: 1520},
+								alternatives: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 51, col: 16, offset: 1520},
+										name: "ByToken",
+									},
+									&litMatcher{
+										pos:        position{line: 51, col: 26, offset: 1530},
+										val:        "-with",
+										ignoreCase: false,
+									},
+								},
+							},
+							&ruleRefExpr{
+								pos:  position{line: 51, col: 35, offset: 1539},
+								name: "EOT",
+							},
+						},
+					},
+					&seqExpr{
+						pos: position{line: 51, col: 43, offset: 1547},
+						exprs: []interface{}{
+							&ruleRefExpr{
+								pos:  position{line: 51, col: 43, offset: 1547},
+								name: "__",
+							},
+							&litMatcher{
+								pos:        position{line: 51, col: 46, offset: 1550},
+								val:        ",",
+								ignoreCase: false,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SearchBoolean",
+			pos:  position{line: 53, col: 1, offset: 1556},
 			expr: &actionExpr{
-				pos: position{line: 34, col: 18, offset: 711},
-				run: (*parser).callonOredSearchTerm1,
+				pos: position{line: 54, col: 5, offset: 1574},
+				run: (*parser).callonSearchBoolean1,
 				expr: &seqExpr{
-					pos: position{line: 34, col: 18, offset: 711},
+					pos: position{line: 54, col: 5, offset: 1574},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 54, col: 5, offset: 1574},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 54, col: 11, offset: 1580},
+								name: "SearchAnd",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 54, col: 21, offset: 1590},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 54, col: 26, offset: 1595},
+								expr: &ruleRefExpr{
+									pos:  position{line: 54, col: 26, offset: 1595},
+									name: "SearchOrTerm",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SearchOrTerm",
+			pos:  position{line: 58, col: 1, offset: 1669},
+			expr: &actionExpr{
+				pos: position{line: 58, col: 16, offset: 1684},
+				run: (*parser).callonSearchOrTerm1,
+				expr: &seqExpr{
+					pos: position{line: 58, col: 16, offset: 1684},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 34, col: 18, offset: 711},
+							pos:  position{line: 58, col: 16, offset: 1684},
 							name: "_",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 34, col: 20, offset: 713},
+							pos:  position{line: 58, col: 18, offset: 1686},
 							name: "OrToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 34, col: 28, offset: 721},
+							pos:  position{line: 58, col: 26, offset: 1694},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 34, col: 30, offset: 723},
+							pos:   position{line: 58, col: 28, offset: 1696},
 							label: "t",
 							expr: &ruleRefExpr{
-								pos:  position{line: 34, col: 32, offset: 725},
-								name: "SearchTerm",
+								pos:  position{line: 58, col: 30, offset: 1698},
+								name: "SearchAnd",
 							},
 						},
 					},
@@ -189,72 +511,68 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "SearchTerm",
-			pos:  position{line: 36, col: 1, offset: 755},
+			name: "SearchAnd",
+			pos:  position{line: 60, col: 1, offset: 1748},
 			expr: &actionExpr{
-				pos: position{line: 37, col: 5, offset: 770},
-				run: (*parser).callonSearchTerm1,
+				pos: position{line: 61, col: 5, offset: 1762},
+				run: (*parser).callonSearchAnd1,
 				expr: &seqExpr{
-					pos: position{line: 37, col: 5, offset: 770},
+					pos: position{line: 61, col: 5, offset: 1762},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 37, col: 5, offset: 770},
+							pos:   position{line: 61, col: 5, offset: 1762},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 37, col: 11, offset: 776},
+								pos:  position{line: 61, col: 11, offset: 1768},
 								name: "SearchFactor",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 37, col: 24, offset: 789},
+							pos:   position{line: 62, col: 5, offset: 1785},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 37, col: 29, offset: 794},
-								expr: &ruleRefExpr{
-									pos:  position{line: 37, col: 29, offset: 794},
-									name: "AndedSearchTerm",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "AndedSearchTerm",
-			pos:  position{line: 41, col: 1, offset: 875},
-			expr: &actionExpr{
-				pos: position{line: 41, col: 19, offset: 893},
-				run: (*parser).callonAndedSearchTerm1,
-				expr: &seqExpr{
-					pos: position{line: 41, col: 19, offset: 893},
-					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 41, col: 19, offset: 893},
-							name: "_",
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 41, col: 21, offset: 895},
-							expr: &seqExpr{
-								pos: position{line: 41, col: 22, offset: 896},
-								exprs: []interface{}{
-									&ruleRefExpr{
-										pos:  position{line: 41, col: 22, offset: 896},
-										name: "AndToken",
+								pos: position{line: 62, col: 10, offset: 1790},
+								expr: &actionExpr{
+									pos: position{line: 62, col: 11, offset: 1791},
+									run: (*parser).callonSearchAnd7,
+									expr: &seqExpr{
+										pos: position{line: 62, col: 11, offset: 1791},
+										exprs: []interface{}{
+											&ruleRefExpr{
+												pos:  position{line: 62, col: 11, offset: 1791},
+												name: "__",
+											},
+											&zeroOrOneExpr{
+												pos: position{line: 62, col: 14, offset: 1794},
+												expr: &seqExpr{
+													pos: position{line: 62, col: 15, offset: 1795},
+													exprs: []interface{}{
+														&ruleRefExpr{
+															pos:  position{line: 62, col: 15, offset: 1795},
+															name: "AndToken",
+														},
+														&ruleRefExpr{
+															pos:  position{line: 62, col: 24, offset: 1804},
+															name: "_",
+														},
+													},
+												},
+											},
+											&ruleRefExpr{
+												pos:  position{line: 62, col: 28, offset: 1808},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 62, col: 31, offset: 1811},
+												label: "expr",
+												expr: &ruleRefExpr{
+													pos:  position{line: 62, col: 36, offset: 1816},
+													name: "SearchFactor",
+												},
+											},
+										},
 									},
-									&ruleRefExpr{
-										pos:  position{line: 41, col: 31, offset: 905},
-										name: "_",
-									},
 								},
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 41, col: 35, offset: 909},
-							label: "f",
-							expr: &ruleRefExpr{
-								pos:  position{line: 41, col: 37, offset: 911},
-								name: "SearchFactor",
 							},
 						},
 					},
@@ -263,42 +581,42 @@ var g = &grammar{
 		},
 		{
 			name: "SearchFactor",
-			pos:  position{line: 43, col: 1, offset: 943},
+			pos:  position{line: 66, col: 1, offset: 1932},
 			expr: &choiceExpr{
-				pos: position{line: 44, col: 5, offset: 960},
+				pos: position{line: 67, col: 5, offset: 1949},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 44, col: 5, offset: 960},
+						pos: position{line: 67, col: 5, offset: 1949},
 						run: (*parser).callonSearchFactor2,
 						expr: &seqExpr{
-							pos: position{line: 44, col: 5, offset: 960},
+							pos: position{line: 67, col: 5, offset: 1949},
 							exprs: []interface{}{
 								&choiceExpr{
-									pos: position{line: 44, col: 6, offset: 961},
+									pos: position{line: 67, col: 6, offset: 1950},
 									alternatives: []interface{}{
 										&seqExpr{
-											pos: position{line: 44, col: 6, offset: 961},
+											pos: position{line: 67, col: 6, offset: 1950},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 44, col: 6, offset: 961},
+													pos:  position{line: 67, col: 6, offset: 1950},
 													name: "NotToken",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 44, col: 15, offset: 970},
+													pos:  position{line: 67, col: 15, offset: 1959},
 													name: "_",
 												},
 											},
 										},
 										&seqExpr{
-											pos: position{line: 44, col: 19, offset: 974},
+											pos: position{line: 67, col: 19, offset: 1963},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 44, col: 19, offset: 974},
+													pos:        position{line: 67, col: 19, offset: 1963},
 													val:        "!",
 													ignoreCase: false,
 												},
 												&ruleRefExpr{
-													pos:  position{line: 44, col: 23, offset: 978},
+													pos:  position{line: 67, col: 23, offset: 1967},
 													name: "__",
 												},
 											},
@@ -306,70 +624,53 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 44, col: 27, offset: 982},
+									pos:   position{line: 67, col: 27, offset: 1971},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 44, col: 29, offset: 984},
-										name: "SearchExpr",
+										pos:  position{line: 67, col: 29, offset: 1973},
+										name: "SearchFactor",
 									},
 								},
 							},
 						},
 					},
-					&actionExpr{
-						pos: position{line: 47, col: 5, offset: 1079},
-						run: (*parser).callonSearchFactor13,
-						expr: &seqExpr{
-							pos: position{line: 47, col: 5, offset: 1079},
-							exprs: []interface{}{
-								&notExpr{
-									pos: position{line: 47, col: 5, offset: 1079},
-									expr: &litMatcher{
-										pos:        position{line: 47, col: 7, offset: 1081},
-										val:        "-",
-										ignoreCase: false,
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 47, col: 12, offset: 1086},
-									label: "s",
-									expr: &ruleRefExpr{
-										pos:  position{line: 47, col: 14, offset: 1088},
-										name: "SearchPred",
-									},
-								},
-							},
-						},
+					&ruleRefExpr{
+						pos:  position{line: 70, col: 5, offset: 2089},
+						name: "ShortCut",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 71, col: 5, offset: 2102},
+						name: "SearchExpr",
 					},
 					&actionExpr{
-						pos: position{line: 48, col: 5, offset: 1121},
-						run: (*parser).callonSearchFactor19,
+						pos: position{line: 72, col: 5, offset: 2117},
+						run: (*parser).callonSearchFactor15,
 						expr: &seqExpr{
-							pos: position{line: 48, col: 5, offset: 1121},
+							pos: position{line: 72, col: 5, offset: 2117},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 48, col: 5, offset: 1121},
+									pos:        position{line: 72, col: 5, offset: 2117},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 48, col: 9, offset: 1125},
+									pos:  position{line: 72, col: 9, offset: 2121},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 48, col: 12, offset: 1128},
+									pos:   position{line: 72, col: 12, offset: 2124},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 48, col: 17, offset: 1133},
-										name: "SearchExpr",
+										pos:  position{line: 72, col: 17, offset: 2129},
+										name: "SearchBoolean",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 48, col: 28, offset: 1144},
+									pos:  position{line: 72, col: 31, offset: 2143},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 48, col: 31, offset: 1147},
+									pos:        position{line: 72, col: 34, offset: 2146},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -380,43 +681,43 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "SearchPred",
-			pos:  position{line: 50, col: 1, offset: 1173},
+			name: "ShortCut",
+			pos:  position{line: 74, col: 1, offset: 2172},
 			expr: &choiceExpr{
-				pos: position{line: 51, col: 5, offset: 1188},
+				pos: position{line: 75, col: 5, offset: 2185},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 51, col: 5, offset: 1188},
-						run: (*parser).callonSearchPred2,
+						pos: position{line: 75, col: 5, offset: 2185},
+						run: (*parser).callonShortCut2,
 						expr: &seqExpr{
-							pos: position{line: 51, col: 5, offset: 1188},
+							pos: position{line: 75, col: 5, offset: 2185},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 51, col: 5, offset: 1188},
+									pos:        position{line: 75, col: 5, offset: 2185},
 									val:        "*",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 51, col: 9, offset: 1192},
+									pos:  position{line: 75, col: 9, offset: 2189},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 51, col: 12, offset: 1195},
-									label: "comp",
+									pos:   position{line: 75, col: 12, offset: 2192},
+									label: "compareOp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 51, col: 17, offset: 1200},
+										pos:  position{line: 75, col: 22, offset: 2202},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 51, col: 31, offset: 1214},
+									pos:  position{line: 75, col: 36, offset: 2216},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 51, col: 34, offset: 1217},
+									pos:   position{line: 75, col: 39, offset: 2219},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 51, col: 36, offset: 1219},
+										pos:  position{line: 75, col: 41, offset: 2221},
 										name: "SearchValue",
 									},
 								},
@@ -424,161 +725,81 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 54, col: 5, offset: 1356},
-						run: (*parser).callonSearchPred11,
+						pos: position{line: 96, col: 5, offset: 2915},
+						run: (*parser).callonShortCut11,
 						expr: &seqExpr{
-							pos: position{line: 54, col: 5, offset: 1356},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 54, col: 5, offset: 1356},
-									val:        "**",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 54, col: 10, offset: 1361},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 54, col: 13, offset: 1364},
-									label: "comp",
-									expr: &ruleRefExpr{
-										pos:  position{line: 54, col: 18, offset: 1369},
-										name: "EqualityToken",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 54, col: 32, offset: 1383},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 54, col: 35, offset: 1386},
-									label: "v",
-									expr: &ruleRefExpr{
-										pos:  position{line: 54, col: 37, offset: 1388},
-										name: "SearchValue",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 57, col: 5, offset: 1524},
-						run: (*parser).callonSearchPred20,
-						expr: &seqExpr{
-							pos: position{line: 57, col: 5, offset: 1524},
+							pos: position{line: 96, col: 5, offset: 2915},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 57, col: 5, offset: 1524},
+									pos:   position{line: 96, col: 5, offset: 2915},
 									label: "f",
 									expr: &ruleRefExpr{
-										pos:  position{line: 57, col: 7, offset: 1526},
+										pos:  position{line: 96, col: 7, offset: 2917},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 57, col: 12, offset: 1531},
+									pos:  position{line: 96, col: 12, offset: 2922},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 57, col: 15, offset: 1534},
+									pos:   position{line: 96, col: 15, offset: 2925},
 									label: "comp",
 									expr: &ruleRefExpr{
-										pos:  position{line: 57, col: 20, offset: 1539},
+										pos:  position{line: 96, col: 20, offset: 2930},
 										name: "EqualityToken",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 57, col: 34, offset: 1553},
+									pos:  position{line: 96, col: 34, offset: 2944},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 57, col: 37, offset: 1556},
+									pos:   position{line: 96, col: 37, offset: 2947},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 57, col: 39, offset: 1558},
-										name: "SearchValue",
+										pos:  position{line: 96, col: 39, offset: 2949},
+										name: "GlobbySearchValue",
+									},
+								},
+								&notExpr{
+									pos: position{line: 96, col: 57, offset: 2967},
+									expr: &ruleRefExpr{
+										pos:  position{line: 96, col: 58, offset: 2968},
+										name: "ExprGuard",
 									},
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 64, col: 5, offset: 2012},
-						run: (*parser).callonSearchPred30,
+						pos: position{line: 99, col: 5, offset: 3086},
+						run: (*parser).callonShortCut23,
 						expr: &seqExpr{
-							pos: position{line: 64, col: 5, offset: 2012},
-							exprs: []interface{}{
-								&andExpr{
-									pos: position{line: 64, col: 5, offset: 2012},
-									expr: &litMatcher{
-										pos:        position{line: 64, col: 6, offset: 2013},
-										val:        "len",
-										ignoreCase: false,
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 64, col: 12, offset: 2019},
-									label: "expr",
-									expr: &ruleRefExpr{
-										pos:  position{line: 64, col: 17, offset: 2024},
-										name: "Function",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 64, col: 26, offset: 2033},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 64, col: 29, offset: 2036},
-									label: "comp",
-									expr: &ruleRefExpr{
-										pos:  position{line: 64, col: 34, offset: 2041},
-										name: "EqualityToken",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 64, col: 48, offset: 2055},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 64, col: 51, offset: 2058},
-									label: "v",
-									expr: &ruleRefExpr{
-										pos:  position{line: 64, col: 53, offset: 2060},
-										name: "SearchValue",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 67, col: 5, offset: 2188},
-						run: (*parser).callonSearchPred42,
-						expr: &seqExpr{
-							pos: position{line: 67, col: 5, offset: 2188},
+							pos: position{line: 99, col: 5, offset: 3086},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 67, col: 5, offset: 2188},
+									pos:   position{line: 99, col: 5, offset: 3086},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 67, col: 7, offset: 2190},
+										pos:  position{line: 99, col: 7, offset: 3088},
 										name: "SearchValue",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 67, col: 19, offset: 2202},
-									name: "__",
+									pos:  position{line: 99, col: 19, offset: 3100},
+									name: "_",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 67, col: 22, offset: 2205},
+									pos:  position{line: 99, col: 21, offset: 3102},
 									name: "InToken",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 67, col: 30, offset: 2213},
-									name: "__",
+									pos:  position{line: 99, col: 29, offset: 3110},
+									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 67, col: 33, offset: 2216},
+									pos:        position{line: 99, col: 31, offset: 3112},
 									val:        "*",
 									ignoreCase: false,
 								},
@@ -586,82 +807,61 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 70, col: 5, offset: 2345},
-						run: (*parser).callonSearchPred50,
+						pos: position{line: 120, col: 5, offset: 3799},
+						run: (*parser).callonShortCut31,
 						expr: &seqExpr{
-							pos: position{line: 70, col: 5, offset: 2345},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 70, col: 5, offset: 2345},
-									label: "v",
-									expr: &ruleRefExpr{
-										pos:  position{line: 70, col: 7, offset: 2347},
-										name: "SearchValue",
-									},
-								},
-								&ruleRefExpr{
-									pos:  position{line: 70, col: 19, offset: 2359},
-									name: "__",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 70, col: 22, offset: 2362},
-									name: "InToken",
-								},
-								&ruleRefExpr{
-									pos:  position{line: 70, col: 30, offset: 2370},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 70, col: 33, offset: 2373},
-									label: "f",
-									expr: &ruleRefExpr{
-										pos:  position{line: 70, col: 35, offset: 2375},
-										name: "FieldExpr",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 73, col: 5, offset: 2504},
-						run: (*parser).callonSearchPred59,
-						expr: &labeledExpr{
-							pos:   position{line: 73, col: 5, offset: 2504},
-							label: "v",
-							expr: &ruleRefExpr{
-								pos:  position{line: 73, col: 7, offset: 2506},
-								name: "SearchLiteral",
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 76, col: 5, offset: 2625},
-						run: (*parser).callonSearchPred62,
-						expr: &seqExpr{
-							pos: position{line: 76, col: 5, offset: 2625},
+							pos: position{line: 120, col: 5, offset: 3799},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 76, col: 5, offset: 2625},
+									pos: position{line: 120, col: 5, offset: 3799},
 									expr: &seqExpr{
-										pos: position{line: 76, col: 7, offset: 2627},
+										pos: position{line: 120, col: 7, offset: 3801},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 76, col: 7, offset: 2627},
-												name: "SearchTokens",
+												pos:  position{line: 120, col: 7, offset: 3801},
+												name: "SearchGuard",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 76, col: 20, offset: 2640},
-												name: "_",
+												pos:  position{line: 120, col: 19, offset: 3813},
+												name: "EOT",
 											},
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 76, col: 24, offset: 2644},
+									pos:   position{line: 120, col: 24, offset: 3818},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 76, col: 26, offset: 2646},
-										name: "KeyWord",
+										pos:  position{line: 120, col: 26, offset: 3820},
+										name: "GlobbySearchValue",
+									},
+								},
+								&notExpr{
+									pos: position{line: 120, col: 44, offset: 3838},
+									expr: &ruleRefExpr{
+										pos:  position{line: 120, col: 45, offset: 3839},
+										name: "ExprGuard",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 123, col: 5, offset: 3954},
+						run: (*parser).callonShortCut41,
+						expr: &seqExpr{
+							pos: position{line: 123, col: 5, offset: 3954},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 123, col: 5, offset: 3954},
+									val:        "*",
+									ignoreCase: false,
+								},
+								&notExpr{
+									pos: position{line: 123, col: 9, offset: 3958},
+									expr: &ruleRefExpr{
+										pos:  position{line: 123, col: 10, offset: 3959},
+										name: "ExprGuard",
 									},
 								},
 							},
@@ -672,43 +872,83 @@ var g = &grammar{
 		},
 		{
 			name: "SearchValue",
-			pos:  position{line: 89, col: 1, offset: 3095},
+			pos:  position{line: 127, col: 1, offset: 4069},
 			expr: &choiceExpr{
-				pos: position{line: 90, col: 5, offset: 3111},
+				pos: position{line: 128, col: 5, offset: 4085},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 90, col: 5, offset: 3111},
-						name: "SearchLiteral",
+						pos:  position{line: 128, col: 5, offset: 4085},
+						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 91, col: 5, offset: 3129},
+						pos: position{line: 129, col: 5, offset: 4097},
 						run: (*parser).callonSearchValue3,
-						expr: &seqExpr{
-							pos: position{line: 91, col: 5, offset: 3129},
-							exprs: []interface{}{
-								&notExpr{
-									pos: position{line: 91, col: 5, offset: 3129},
-									expr: &seqExpr{
-										pos: position{line: 91, col: 7, offset: 3131},
-										exprs: []interface{}{
-											&ruleRefExpr{
-												pos:  position{line: 91, col: 7, offset: 3131},
-												name: "SearchTokens",
-											},
-											&ruleRefExpr{
-												pos:  position{line: 91, col: 20, offset: 3144},
-												name: "_",
-											},
-										},
-									},
+						expr: &labeledExpr{
+							pos:   position{line: 129, col: 5, offset: 4097},
+							label: "v",
+							expr: &ruleRefExpr{
+								pos:  position{line: 129, col: 7, offset: 4099},
+								name: "KeyWord",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "GlobbySearchValue",
+			pos:  position{line: 133, col: 1, offset: 4204},
+			expr: &choiceExpr{
+				pos: position{line: 134, col: 5, offset: 4226},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 134, col: 5, offset: 4226},
+						name: "Literal",
+					},
+					&actionExpr{
+						pos: position{line: 135, col: 5, offset: 4238},
+						run: (*parser).callonGlobbySearchValue3,
+						expr: &labeledExpr{
+							pos:   position{line: 135, col: 5, offset: 4238},
+							label: "v",
+							expr: &ruleRefExpr{
+								pos:  position{line: 135, col: 7, offset: 4240},
+								name: "SearchGlob",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SearchGlob",
+			pos:  position{line: 145, col: 1, offset: 4526},
+			expr: &actionExpr{
+				pos: position{line: 146, col: 5, offset: 4541},
+				run: (*parser).callonSearchGlob1,
+				expr: &seqExpr{
+					pos: position{line: 146, col: 5, offset: 4541},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 146, col: 5, offset: 4541},
+							label: "head",
+							expr: &oneOrMoreExpr{
+								pos: position{line: 146, col: 10, offset: 4546},
+								expr: &ruleRefExpr{
+									pos:  position{line: 146, col: 10, offset: 4546},
+									name: "GlobPart",
 								},
-								&labeledExpr{
-									pos:   position{line: 91, col: 23, offset: 3147},
-									label: "v",
-									expr: &ruleRefExpr{
-										pos:  position{line: 91, col: 25, offset: 3149},
-										name: "KeyWord",
-									},
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 146, col: 20, offset: 4556},
+							label: "tail",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 146, col: 25, offset: 4561},
+								expr: &litMatcher{
+									pos:        position{line: 146, col: 26, offset: 4562},
+									val:        "*",
+									ignoreCase: false,
 								},
 							},
 						},
@@ -717,139 +957,260 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "SearchTokens",
-			pos:  position{line: 95, col: 1, offset: 3254},
+			name: "GlobPart",
+			pos:  position{line: 150, col: 1, offset: 4629},
 			expr: &choiceExpr{
-				pos: position{line: 96, col: 5, offset: 3271},
+				pos: position{line: 151, col: 5, offset: 4642},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 151, col: 5, offset: 4642},
+						run: (*parser).callonGlobPart2,
+						expr: &seqExpr{
+							pos: position{line: 151, col: 5, offset: 4642},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 151, col: 5, offset: 4642},
+									label: "s",
+									expr: &ruleRefExpr{
+										pos:  position{line: 151, col: 7, offset: 4644},
+										name: "Stars",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 151, col: 13, offset: 4650},
+									label: "v",
+									expr: &ruleRefExpr{
+										pos:  position{line: 151, col: 15, offset: 4652},
+										name: "KeyWord",
+									},
+								},
+							},
+						},
+					},
+					&ruleRefExpr{
+						pos:  position{line: 152, col: 5, offset: 4702},
+						name: "KeyWord",
+					},
+				},
+			},
+		},
+		{
+			name: "Stars",
+			pos:  position{line: 154, col: 1, offset: 4711},
+			expr: &actionExpr{
+				pos: position{line: 154, col: 9, offset: 4719},
+				run: (*parser).callonStars1,
+				expr: &oneOrMoreExpr{
+					pos: position{line: 154, col: 9, offset: 4719},
+					expr: &litMatcher{
+						pos:        position{line: 154, col: 9, offset: 4719},
+						val:        "*",
+						ignoreCase: false,
+					},
+				},
+			},
+		},
+		{
+			name: "SearchGuard",
+			pos:  position{line: 156, col: 1, offset: 4756},
+			expr: &choiceExpr{
+				pos: position{line: 157, col: 5, offset: 4772},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 96, col: 5, offset: 3271},
+						pos:  position{line: 157, col: 5, offset: 4772},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 97, col: 5, offset: 3284},
+						pos:  position{line: 158, col: 5, offset: 4785},
 						name: "OrToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 98, col: 5, offset: 3296},
+						pos:  position{line: 159, col: 5, offset: 4797},
+						name: "NotToken",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 160, col: 5, offset: 4810},
 						name: "InToken",
 					},
+					&ruleRefExpr{
+						pos:  position{line: 161, col: 5, offset: 4822},
+						name: "ByToken",
+					},
 				},
 			},
 		},
 		{
-			name: "SearchLiteral",
-			pos:  position{line: 100, col: 1, offset: 3305},
-			expr: &choiceExpr{
-				pos: position{line: 101, col: 5, offset: 3323},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 101, col: 5, offset: 3323},
-						name: "StringLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 102, col: 5, offset: 3341},
-						name: "RegexpLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 103, col: 5, offset: 3359},
-						name: "SubnetLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 104, col: 5, offset: 3377},
-						name: "AddressLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 105, col: 5, offset: 3396},
-						name: "FloatLiteral",
-					},
-					&actionExpr{
-						pos: position{line: 109, col: 5, offset: 3563},
-						run: (*parser).callonSearchLiteral7,
-						expr: &seqExpr{
-							pos: position{line: 109, col: 5, offset: 3563},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 109, col: 5, offset: 3563},
-									label: "i",
-									expr: &ruleRefExpr{
-										pos:  position{line: 109, col: 7, offset: 3565},
-										name: "IntegerLiteral",
-									},
-								},
-								&notExpr{
-									pos: position{line: 109, col: 22, offset: 3580},
-									expr: &ruleRefExpr{
-										pos:  position{line: 109, col: 23, offset: 3581},
-										name: "KeyWord",
-									},
-								},
-							},
+			name: "SearchExpr",
+			pos:  position{line: 165, col: 1, offset: 4879},
+			expr: &ruleRefExpr{
+				pos:  position{line: 165, col: 14, offset: 4892},
+				name: "SearchExprRelative",
+			},
+		},
+		{
+			name: "Comparator",
+			pos:  position{line: 167, col: 1, offset: 4912},
+			expr: &actionExpr{
+				pos: position{line: 167, col: 14, offset: 4925},
+				run: (*parser).callonComparator1,
+				expr: &choiceExpr{
+					pos: position{line: 167, col: 15, offset: 4926},
+					alternatives: []interface{}{
+						&litMatcher{
+							pos:        position{line: 167, col: 15, offset: 4926},
+							val:        "=",
+							ignoreCase: false,
+						},
+						&litMatcher{
+							pos:        position{line: 167, col: 21, offset: 4932},
+							val:        "!=",
+							ignoreCase: false,
+						},
+						&litMatcher{
+							pos:        position{line: 167, col: 28, offset: 4939},
+							val:        "in",
+							ignoreCase: false,
+						},
+						&litMatcher{
+							pos:        position{line: 167, col: 35, offset: 4946},
+							val:        "<=",
+							ignoreCase: false,
+						},
+						&litMatcher{
+							pos:        position{line: 167, col: 42, offset: 4953},
+							val:        "<",
+							ignoreCase: false,
+						},
+						&litMatcher{
+							pos:        position{line: 167, col: 48, offset: 4959},
+							val:        ">=",
+							ignoreCase: false,
+						},
+						&litMatcher{
+							pos:        position{line: 167, col: 55, offset: 4966},
+							val:        ">",
+							ignoreCase: false,
 						},
 					},
-					&actionExpr{
-						pos: position{line: 111, col: 5, offset: 3612},
-						run: (*parser).callonSearchLiteral13,
-						expr: &seqExpr{
-							pos: position{line: 111, col: 5, offset: 3612},
-							exprs: []interface{}{
-								&notExpr{
-									pos: position{line: 111, col: 5, offset: 3612},
+				},
+			},
+		},
+		{
+			name: "SearchExprRelative",
+			pos:  position{line: 169, col: 1, offset: 5003},
+			expr: &actionExpr{
+				pos: position{line: 170, col: 5, offset: 5026},
+				run: (*parser).callonSearchExprRelative1,
+				expr: &seqExpr{
+					pos: position{line: 170, col: 5, offset: 5026},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 170, col: 5, offset: 5026},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 170, col: 11, offset: 5032},
+								name: "SearchExprAdd",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 171, col: 5, offset: 5050},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 171, col: 10, offset: 5055},
+								expr: &actionExpr{
+									pos: position{line: 171, col: 11, offset: 5056},
+									run: (*parser).callonSearchExprRelative7,
 									expr: &seqExpr{
-										pos: position{line: 111, col: 7, offset: 3614},
+										pos: position{line: 171, col: 11, offset: 5056},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 111, col: 7, offset: 3614},
-												name: "SearchTokens",
+												pos:  position{line: 171, col: 11, offset: 5056},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 171, col: 14, offset: 5059},
+												label: "op",
+												expr: &ruleRefExpr{
+													pos:  position{line: 171, col: 17, offset: 5062},
+													name: "Comparator",
+												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 111, col: 20, offset: 3627},
-												name: "_",
+												pos:  position{line: 171, col: 28, offset: 5073},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 171, col: 31, offset: 5076},
+												label: "expr",
+												expr: &ruleRefExpr{
+													pos:  position{line: 171, col: 36, offset: 5081},
+													name: "SearchExprAdd",
+												},
 											},
 										},
 									},
 								},
-								&labeledExpr{
-									pos:   position{line: 111, col: 23, offset: 3630},
-									label: "v",
-									expr: &ruleRefExpr{
-										pos:  position{line: 111, col: 25, offset: 3632},
-										name: "BooleanLiteral",
-									},
-								},
 							},
 						},
 					},
-					&actionExpr{
-						pos: position{line: 112, col: 5, offset: 3669},
-						run: (*parser).callonSearchLiteral21,
-						expr: &seqExpr{
-							pos: position{line: 112, col: 5, offset: 3669},
-							exprs: []interface{}{
-								&notExpr{
-									pos: position{line: 112, col: 5, offset: 3669},
+				},
+			},
+		},
+		{
+			name: "SearchExprAdd",
+			pos:  position{line: 175, col: 1, offset: 5198},
+			expr: &actionExpr{
+				pos: position{line: 176, col: 5, offset: 5216},
+				run: (*parser).callonSearchExprAdd1,
+				expr: &seqExpr{
+					pos: position{line: 176, col: 5, offset: 5216},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 176, col: 5, offset: 5216},
+							label: "first",
+							expr: &ruleRefExpr{
+								pos:  position{line: 176, col: 11, offset: 5222},
+								name: "SearchExprMul",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 177, col: 5, offset: 5240},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 177, col: 10, offset: 5245},
+								expr: &actionExpr{
+									pos: position{line: 177, col: 11, offset: 5246},
+									run: (*parser).callonSearchExprAdd7,
 									expr: &seqExpr{
-										pos: position{line: 112, col: 7, offset: 3671},
+										pos: position{line: 177, col: 11, offset: 5246},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 112, col: 7, offset: 3671},
-												name: "SearchTokens",
+												pos:  position{line: 177, col: 11, offset: 5246},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 177, col: 14, offset: 5249},
+												label: "op",
+												expr: &ruleRefExpr{
+													pos:  position{line: 177, col: 17, offset: 5252},
+													name: "AdditiveOperator",
+												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 112, col: 20, offset: 3684},
-												name: "_",
+												pos:  position{line: 177, col: 34, offset: 5269},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 177, col: 37, offset: 5272},
+												label: "expr",
+												expr: &ruleRefExpr{
+													pos:  position{line: 177, col: 42, offset: 5277},
+													name: "SearchExprMul",
+												},
 											},
 										},
 									},
 								},
-								&labeledExpr{
-									pos:   position{line: 112, col: 23, offset: 3687},
-									label: "v",
-									expr: &ruleRefExpr{
-										pos:  position{line: 112, col: 25, offset: 3689},
-										name: "NullLiteral",
-									},
-								},
 							},
 						},
 					},
@@ -857,449 +1218,207 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "StringLiteral",
-			pos:  position{line: 115, col: 1, offset: 3721},
+			name: "SearchExprMul",
+			pos:  position{line: 181, col: 1, offset: 5394},
 			expr: &actionExpr{
-				pos: position{line: 116, col: 5, offset: 3739},
-				run: (*parser).callonStringLiteral1,
-				expr: &labeledExpr{
-					pos:   position{line: 116, col: 5, offset: 3739},
-					label: "v",
-					expr: &ruleRefExpr{
-						pos:  position{line: 116, col: 7, offset: 3741},
-						name: "QuotedString",
-					},
-				},
-			},
-		},
-		{
-			name: "RegexpLiteral",
-			pos:  position{line: 120, col: 1, offset: 3851},
-			expr: &actionExpr{
-				pos: position{line: 121, col: 5, offset: 3869},
-				run: (*parser).callonRegexpLiteral1,
-				expr: &labeledExpr{
-					pos:   position{line: 121, col: 5, offset: 3869},
-					label: "v",
-					expr: &ruleRefExpr{
-						pos:  position{line: 121, col: 7, offset: 3871},
-						name: "Regexp",
-					},
-				},
-			},
-		},
-		{
-			name: "SubnetLiteral",
-			pos:  position{line: 125, col: 1, offset: 3975},
-			expr: &choiceExpr{
-				pos: position{line: 126, col: 5, offset: 3993},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 126, col: 5, offset: 3993},
-						run: (*parser).callonSubnetLiteral2,
-						expr: &seqExpr{
-							pos: position{line: 126, col: 5, offset: 3993},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 126, col: 5, offset: 3993},
-									label: "v",
-									expr: &ruleRefExpr{
-										pos:  position{line: 126, col: 7, offset: 3995},
-										name: "IP6Net",
-									},
-								},
-								&notExpr{
-									pos: position{line: 126, col: 14, offset: 4002},
-									expr: &ruleRefExpr{
-										pos:  position{line: 126, col: 15, offset: 4003},
-										name: "IdentifierRest",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 129, col: 5, offset: 4115},
-						run: (*parser).callonSubnetLiteral8,
-						expr: &labeledExpr{
-							pos:   position{line: 129, col: 5, offset: 4115},
-							label: "v",
-							expr: &ruleRefExpr{
-								pos:  position{line: 129, col: 7, offset: 4117},
-								name: "IP4Net",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "AddressLiteral",
-			pos:  position{line: 133, col: 1, offset: 4218},
-			expr: &choiceExpr{
-				pos: position{line: 134, col: 5, offset: 4237},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 134, col: 5, offset: 4237},
-						run: (*parser).callonAddressLiteral2,
-						expr: &seqExpr{
-							pos: position{line: 134, col: 5, offset: 4237},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 134, col: 5, offset: 4237},
-									label: "v",
-									expr: &ruleRefExpr{
-										pos:  position{line: 134, col: 7, offset: 4239},
-										name: "IP6",
-									},
-								},
-								&notExpr{
-									pos: position{line: 134, col: 11, offset: 4243},
-									expr: &ruleRefExpr{
-										pos:  position{line: 134, col: 12, offset: 4244},
-										name: "IdentifierRest",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 137, col: 5, offset: 4355},
-						run: (*parser).callonAddressLiteral8,
-						expr: &labeledExpr{
-							pos:   position{line: 137, col: 5, offset: 4355},
-							label: "v",
-							expr: &ruleRefExpr{
-								pos:  position{line: 137, col: 7, offset: 4357},
-								name: "IP",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "FloatLiteral",
-			pos:  position{line: 141, col: 1, offset: 4453},
-			expr: &actionExpr{
-				pos: position{line: 142, col: 5, offset: 4470},
-				run: (*parser).callonFloatLiteral1,
-				expr: &labeledExpr{
-					pos:   position{line: 142, col: 5, offset: 4470},
-					label: "v",
-					expr: &ruleRefExpr{
-						pos:  position{line: 142, col: 7, offset: 4472},
-						name: "FloatString",
-					},
-				},
-			},
-		},
-		{
-			name: "IntegerLiteral",
-			pos:  position{line: 146, col: 1, offset: 4582},
-			expr: &actionExpr{
-				pos: position{line: 147, col: 5, offset: 4601},
-				run: (*parser).callonIntegerLiteral1,
-				expr: &labeledExpr{
-					pos:   position{line: 147, col: 5, offset: 4601},
-					label: "v",
-					expr: &ruleRefExpr{
-						pos:  position{line: 147, col: 7, offset: 4603},
-						name: "IntString",
-					},
-				},
-			},
-		},
-		{
-			name: "BooleanLiteral",
-			pos:  position{line: 151, col: 1, offset: 4709},
-			expr: &choiceExpr{
-				pos: position{line: 152, col: 5, offset: 4728},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 152, col: 5, offset: 4728},
-						run: (*parser).callonBooleanLiteral2,
-						expr: &litMatcher{
-							pos:        position{line: 152, col: 5, offset: 4728},
-							val:        "true",
-							ignoreCase: false,
-						},
-					},
-					&actionExpr{
-						pos: position{line: 153, col: 5, offset: 4838},
-						run: (*parser).callonBooleanLiteral4,
-						expr: &litMatcher{
-							pos:        position{line: 153, col: 5, offset: 4838},
-							val:        "false",
-							ignoreCase: false,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "NullLiteral",
-			pos:  position{line: 155, col: 1, offset: 4946},
-			expr: &actionExpr{
-				pos: position{line: 156, col: 5, offset: 4962},
-				run: (*parser).callonNullLiteral1,
-				expr: &litMatcher{
-					pos:        position{line: 156, col: 5, offset: 4962},
-					val:        "null",
-					ignoreCase: false,
-				},
-			},
-		},
-		{
-			name: "SequentialProcs",
-			pos:  position{line: 158, col: 1, offset: 5065},
-			expr: &actionExpr{
-				pos: position{line: 159, col: 5, offset: 5085},
-				run: (*parser).callonSequentialProcs1,
+				pos: position{line: 182, col: 5, offset: 5412},
+				run: (*parser).callonSearchExprMul1,
 				expr: &seqExpr{
-					pos: position{line: 159, col: 5, offset: 5085},
+					pos: position{line: 182, col: 5, offset: 5412},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 159, col: 5, offset: 5085},
+							pos:   position{line: 182, col: 5, offset: 5412},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 159, col: 11, offset: 5091},
-								name: "Proc",
+								pos:  position{line: 182, col: 11, offset: 5418},
+								name: "SearchExprCast",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 159, col: 16, offset: 5096},
+							pos:   position{line: 183, col: 5, offset: 5437},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 159, col: 21, offset: 5101},
-								expr: &ruleRefExpr{
-									pos:  position{line: 159, col: 21, offset: 5101},
-									name: "SequentialTail",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "SequentialTail",
-			pos:  position{line: 166, col: 1, offset: 5272},
-			expr: &actionExpr{
-				pos: position{line: 166, col: 18, offset: 5289},
-				run: (*parser).callonSequentialTail1,
-				expr: &seqExpr{
-					pos: position{line: 166, col: 18, offset: 5289},
-					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 166, col: 18, offset: 5289},
-							name: "__",
-						},
-						&litMatcher{
-							pos:        position{line: 166, col: 21, offset: 5292},
-							val:        "|",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 166, col: 25, offset: 5296},
-							name: "__",
-						},
-						&labeledExpr{
-							pos:   position{line: 166, col: 28, offset: 5299},
-							label: "p",
-							expr: &ruleRefExpr{
-								pos:  position{line: 166, col: 30, offset: 5301},
-								name: "Proc",
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Proc",
-			pos:  position{line: 168, col: 1, offset: 5325},
-			expr: &choiceExpr{
-				pos: position{line: 169, col: 5, offset: 5334},
-				alternatives: []interface{}{
-					&ruleRefExpr{
-						pos:  position{line: 169, col: 5, offset: 5334},
-						name: "NamedProc",
-					},
-					&actionExpr{
-						pos: position{line: 170, col: 5, offset: 5348},
-						run: (*parser).callonProc3,
-						expr: &seqExpr{
-							pos: position{line: 170, col: 5, offset: 5348},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 170, col: 5, offset: 5348},
-									val:        "split",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 170, col: 13, offset: 5356},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 170, col: 16, offset: 5359},
-									val:        "(",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 170, col: 20, offset: 5363},
-									name: "__",
-								},
-								&litMatcher{
-									pos:        position{line: 170, col: 23, offset: 5366},
-									val:        "=>",
-									ignoreCase: false,
-								},
-								&ruleRefExpr{
-									pos:  position{line: 170, col: 28, offset: 5371},
-									name: "__",
-								},
-								&labeledExpr{
-									pos:   position{line: 170, col: 31, offset: 5374},
-									label: "proc",
-									expr: &ruleRefExpr{
-										pos:  position{line: 170, col: 36, offset: 5379},
-										name: "Procs",
+								pos: position{line: 183, col: 10, offset: 5442},
+								expr: &actionExpr{
+									pos: position{line: 183, col: 11, offset: 5443},
+									run: (*parser).callonSearchExprMul7,
+									expr: &seqExpr{
+										pos: position{line: 183, col: 11, offset: 5443},
+										exprs: []interface{}{
+											&ruleRefExpr{
+												pos:  position{line: 183, col: 11, offset: 5443},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 183, col: 14, offset: 5446},
+												label: "op",
+												expr: &ruleRefExpr{
+													pos:  position{line: 183, col: 17, offset: 5449},
+													name: "MultiplicativeOperator",
+												},
+											},
+											&ruleRefExpr{
+												pos:  position{line: 183, col: 40, offset: 5472},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 183, col: 43, offset: 5475},
+												label: "expr",
+												expr: &ruleRefExpr{
+													pos:  position{line: 183, col: 48, offset: 5480},
+													name: "SearchExprCast",
+												},
+											},
+										},
 									},
 								},
-								&ruleRefExpr{
-									pos:  position{line: 170, col: 42, offset: 5385},
-									name: "__",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SearchExprCast",
+			pos:  position{line: 187, col: 1, offset: 5598},
+			expr: &choiceExpr{
+				pos: position{line: 188, col: 5, offset: 5617},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 188, col: 5, offset: 5617},
+						run: (*parser).callonSearchExprCast2,
+						expr: &seqExpr{
+							pos: position{line: 188, col: 5, offset: 5617},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 188, col: 5, offset: 5617},
+									label: "e",
+									expr: &ruleRefExpr{
+										pos:  position{line: 188, col: 7, offset: 5619},
+										name: "SearchExprFunc",
+									},
 								},
-								&litMatcher{
-									pos:        position{line: 170, col: 45, offset: 5388},
-									val:        ")",
-									ignoreCase: false,
+								&labeledExpr{
+									pos:   position{line: 188, col: 22, offset: 5634},
+									label: "typ",
+									expr: &actionExpr{
+										pos: position{line: 188, col: 28, offset: 5640},
+										run: (*parser).callonSearchExprCast7,
+										expr: &seqExpr{
+											pos: position{line: 188, col: 28, offset: 5640},
+											exprs: []interface{}{
+												&litMatcher{
+													pos:        position{line: 188, col: 28, offset: 5640},
+													val:        ":",
+													ignoreCase: false,
+												},
+												&labeledExpr{
+													pos:   position{line: 188, col: 32, offset: 5644},
+													label: "typ",
+													expr: &ruleRefExpr{
+														pos:  position{line: 188, col: 36, offset: 5648},
+														name: "PrimitiveType",
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 173, col: 5, offset: 5427},
-						name: "GroupByProc",
+						pos:  position{line: 191, col: 5, offset: 5778},
+						name: "SearchExprFunc",
 					},
 				},
 			},
 		},
 		{
-			name: "Procs",
-			pos:  position{line: 175, col: 1, offset: 5440},
-			expr: &actionExpr{
-				pos: position{line: 176, col: 5, offset: 5450},
-				run: (*parser).callonProcs1,
-				expr: &seqExpr{
-					pos: position{line: 176, col: 5, offset: 5450},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 176, col: 5, offset: 5450},
-							label: "first",
-							expr: &ruleRefExpr{
-								pos:  position{line: 176, col: 11, offset: 5456},
-								name: "SequentialProcs",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 176, col: 27, offset: 5472},
-							label: "rest",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 176, col: 32, offset: 5477},
-								expr: &ruleRefExpr{
-									pos:  position{line: 176, col: 32, offset: 5477},
-									name: "ParallelTail",
+			name: "SearchExprFunc",
+			pos:  position{line: 193, col: 1, offset: 5794},
+			expr: &choiceExpr{
+				pos: position{line: 194, col: 5, offset: 5813},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 194, col: 5, offset: 5813},
+						name: "MatchExpr",
+					},
+					&actionExpr{
+						pos: position{line: 195, col: 5, offset: 5827},
+						run: (*parser).callonSearchExprFunc3,
+						expr: &seqExpr{
+							pos: position{line: 195, col: 5, offset: 5827},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 195, col: 5, offset: 5827},
+									label: "first",
+									expr: &ruleRefExpr{
+										pos:  position{line: 195, col: 11, offset: 5833},
+										name: "Function",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 195, col: 20, offset: 5842},
+									label: "rest",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 195, col: 25, offset: 5847},
+										expr: &ruleRefExpr{
+											pos:  position{line: 195, col: 26, offset: 5848},
+											name: "Deref",
+										},
+									},
 								},
 							},
 						},
 					},
-				},
-			},
-		},
-		{
-			name: "ParallelTail",
-			pos:  position{line: 185, col: 1, offset: 5776},
-			expr: &actionExpr{
-				pos: position{line: 186, col: 5, offset: 5793},
-				run: (*parser).callonParallelTail1,
-				expr: &seqExpr{
-					pos: position{line: 186, col: 5, offset: 5793},
-					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 186, col: 5, offset: 5793},
-							name: "__",
-						},
-						&zeroOrOneExpr{
-							pos: position{line: 186, col: 8, offset: 5796},
-							expr: &litMatcher{
-								pos:        position{line: 186, col: 8, offset: 5796},
-								val:        ";",
-								ignoreCase: false,
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 186, col: 13, offset: 5801},
-							name: "__",
-						},
-						&litMatcher{
-							pos:        position{line: 186, col: 16, offset: 5804},
-							val:        "=>",
-							ignoreCase: false,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 186, col: 21, offset: 5809},
-							name: "__",
-						},
-						&labeledExpr{
-							pos:   position{line: 186, col: 24, offset: 5812},
-							label: "ch",
-							expr: &ruleRefExpr{
-								pos:  position{line: 186, col: 27, offset: 5815},
-								name: "SequentialProcs",
-							},
-						},
+					&ruleRefExpr{
+						pos:  position{line: 198, col: 5, offset: 5920},
+						name: "DerefExpr",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 199, col: 5, offset: 5934},
+						name: "Literal",
 					},
 				},
 			},
 		},
 		{
-			name: "GroupByProc",
-			pos:  position{line: 188, col: 1, offset: 5908},
+			name: "Aggregation",
+			pos:  position{line: 203, col: 1, offset: 5969},
 			expr: &choiceExpr{
-				pos: position{line: 189, col: 5, offset: 5924},
+				pos: position{line: 204, col: 5, offset: 5985},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 189, col: 5, offset: 5924},
-						run: (*parser).callonGroupByProc2,
+						pos: position{line: 204, col: 5, offset: 5985},
+						run: (*parser).callonAggregation2,
 						expr: &seqExpr{
-							pos: position{line: 189, col: 5, offset: 5924},
+							pos: position{line: 204, col: 5, offset: 5985},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 189, col: 5, offset: 5924},
+									pos:   position{line: 204, col: 5, offset: 5985},
 									label: "every",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 189, col: 11, offset: 5930},
+										pos: position{line: 204, col: 11, offset: 5991},
 										expr: &ruleRefExpr{
-											pos:  position{line: 189, col: 11, offset: 5930},
+											pos:  position{line: 204, col: 11, offset: 5991},
 											name: "EveryDur",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 189, col: 21, offset: 5940},
+									pos:   position{line: 204, col: 21, offset: 6001},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 189, col: 26, offset: 5945},
+										pos:  position{line: 204, col: 26, offset: 6006},
 										name: "GroupByKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 189, col: 38, offset: 5957},
+									pos:   position{line: 204, col: 38, offset: 6018},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 189, col: 44, offset: 5963},
+										pos:  position{line: 204, col: 44, offset: 6024},
 										name: "LimitArg",
 									},
 								},
@@ -1307,44 +1426,44 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 192, col: 5, offset: 6112},
-						run: (*parser).callonGroupByProc11,
+						pos: position{line: 207, col: 5, offset: 6173},
+						run: (*parser).callonAggregation11,
 						expr: &seqExpr{
-							pos: position{line: 192, col: 5, offset: 6112},
+							pos: position{line: 207, col: 5, offset: 6173},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 192, col: 5, offset: 6112},
+									pos:   position{line: 207, col: 5, offset: 6173},
 									label: "every",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 192, col: 11, offset: 6118},
+										pos: position{line: 207, col: 11, offset: 6179},
 										expr: &ruleRefExpr{
-											pos:  position{line: 192, col: 11, offset: 6118},
+											pos:  position{line: 207, col: 11, offset: 6179},
 											name: "EveryDur",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 192, col: 21, offset: 6128},
+									pos:   position{line: 207, col: 21, offset: 6189},
 									label: "reducers",
 									expr: &ruleRefExpr{
-										pos:  position{line: 192, col: 30, offset: 6137},
+										pos:  position{line: 207, col: 30, offset: 6198},
 										name: "Reducers",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 192, col: 39, offset: 6146},
+									pos:   position{line: 207, col: 39, offset: 6207},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 192, col: 44, offset: 6151},
+										pos: position{line: 207, col: 44, offset: 6212},
 										expr: &seqExpr{
-											pos: position{line: 192, col: 45, offset: 6152},
+											pos: position{line: 207, col: 45, offset: 6213},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 192, col: 45, offset: 6152},
+													pos:  position{line: 207, col: 45, offset: 6213},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 192, col: 47, offset: 6154},
+													pos:  position{line: 207, col: 47, offset: 6215},
 													name: "GroupByKeys",
 												},
 											},
@@ -1352,12 +1471,12 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 192, col: 61, offset: 6168},
+									pos:   position{line: 207, col: 61, offset: 6229},
 									label: "limit",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 192, col: 67, offset: 6174},
+										pos: position{line: 207, col: 67, offset: 6235},
 										expr: &ruleRefExpr{
-											pos:  position{line: 192, col: 67, offset: 6174},
+											pos:  position{line: 207, col: 67, offset: 6235},
 											name: "LimitArg",
 										},
 									},
@@ -1370,32 +1489,32 @@ var g = &grammar{
 		},
 		{
 			name: "EveryDur",
-			pos:  position{line: 200, col: 1, offset: 6416},
+			pos:  position{line: 215, col: 1, offset: 6477},
 			expr: &actionExpr{
-				pos: position{line: 201, col: 5, offset: 6429},
+				pos: position{line: 216, col: 5, offset: 6490},
 				run: (*parser).callonEveryDur1,
 				expr: &seqExpr{
-					pos: position{line: 201, col: 5, offset: 6429},
+					pos: position{line: 216, col: 5, offset: 6490},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 201, col: 5, offset: 6429},
+							pos:        position{line: 216, col: 5, offset: 6490},
 							val:        "every",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 201, col: 14, offset: 6438},
+							pos:  position{line: 216, col: 14, offset: 6499},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 201, col: 16, offset: 6440},
+							pos:   position{line: 216, col: 16, offset: 6501},
 							label: "dur",
 							expr: &ruleRefExpr{
-								pos:  position{line: 201, col: 20, offset: 6444},
+								pos:  position{line: 216, col: 20, offset: 6505},
 								name: "Duration",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 201, col: 29, offset: 6453},
+							pos:  position{line: 216, col: 29, offset: 6514},
 							name: "_",
 						},
 					},
@@ -1404,27 +1523,26 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 203, col: 1, offset: 6476},
+			pos:  position{line: 218, col: 1, offset: 6537},
 			expr: &actionExpr{
-				pos: position{line: 204, col: 5, offset: 6492},
+				pos: position{line: 219, col: 5, offset: 6553},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 204, col: 5, offset: 6492},
+					pos: position{line: 219, col: 5, offset: 6553},
 					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 204, col: 5, offset: 6492},
-							val:        "by",
-							ignoreCase: true,
+						&ruleRefExpr{
+							pos:  position{line: 219, col: 5, offset: 6553},
+							name: "ByToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 204, col: 11, offset: 6498},
+							pos:  position{line: 219, col: 13, offset: 6561},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 204, col: 13, offset: 6500},
+							pos:   position{line: 219, col: 15, offset: 6563},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 204, col: 21, offset: 6508},
+								pos:  position{line: 219, col: 23, offset: 6571},
 								name: "FlexAssignments",
 							},
 						},
@@ -1434,43 +1552,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 206, col: 1, offset: 6549},
+			pos:  position{line: 221, col: 1, offset: 6612},
 			expr: &choiceExpr{
-				pos: position{line: 207, col: 5, offset: 6562},
+				pos: position{line: 222, col: 5, offset: 6625},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 207, col: 5, offset: 6562},
+						pos: position{line: 222, col: 5, offset: 6625},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 207, col: 5, offset: 6562},
+							pos: position{line: 222, col: 5, offset: 6625},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 207, col: 5, offset: 6562},
+									pos:  position{line: 222, col: 5, offset: 6625},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 207, col: 7, offset: 6564},
+									pos:        position{line: 222, col: 7, offset: 6627},
 									val:        "with",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 207, col: 14, offset: 6571},
+									pos:  position{line: 222, col: 14, offset: 6634},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 207, col: 16, offset: 6573},
+									pos:        position{line: 222, col: 16, offset: 6636},
 									val:        "-limit",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 207, col: 25, offset: 6582},
+									pos:  position{line: 222, col: 25, offset: 6645},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 207, col: 27, offset: 6584},
+									pos:   position{line: 222, col: 27, offset: 6647},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 207, col: 33, offset: 6590},
+										pos:  position{line: 222, col: 33, offset: 6653},
 										name: "UInt",
 									},
 								},
@@ -1478,10 +1596,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 208, col: 5, offset: 6621},
+						pos: position{line: 223, col: 5, offset: 6684},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 208, col: 5, offset: 6621},
+							pos:        position{line: 223, col: 5, offset: 6684},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -1491,22 +1609,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 213, col: 1, offset: 6881},
+			pos:  position{line: 228, col: 1, offset: 6944},
 			expr: &choiceExpr{
-				pos: position{line: 214, col: 5, offset: 6900},
+				pos: position{line: 229, col: 5, offset: 6963},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 214, col: 5, offset: 6900},
+						pos:  position{line: 229, col: 5, offset: 6963},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 215, col: 5, offset: 6915},
+						pos: position{line: 230, col: 5, offset: 6978},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 215, col: 5, offset: 6915},
+							pos:   position{line: 230, col: 5, offset: 6978},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 215, col: 10, offset: 6920},
+								pos:  position{line: 230, col: 10, offset: 6983},
 								name: "Expr",
 							},
 						},
@@ -1516,50 +1634,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 217, col: 1, offset: 7010},
+			pos:  position{line: 232, col: 1, offset: 7073},
 			expr: &actionExpr{
-				pos: position{line: 218, col: 5, offset: 7030},
+				pos: position{line: 233, col: 5, offset: 7093},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 218, col: 5, offset: 7030},
+					pos: position{line: 233, col: 5, offset: 7093},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 218, col: 5, offset: 7030},
+							pos:   position{line: 233, col: 5, offset: 7093},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 218, col: 11, offset: 7036},
+								pos:  position{line: 233, col: 11, offset: 7099},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 218, col: 26, offset: 7051},
+							pos:   position{line: 233, col: 26, offset: 7114},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 218, col: 31, offset: 7056},
+								pos: position{line: 233, col: 31, offset: 7119},
 								expr: &actionExpr{
-									pos: position{line: 218, col: 32, offset: 7057},
+									pos: position{line: 233, col: 32, offset: 7120},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 218, col: 32, offset: 7057},
+										pos: position{line: 233, col: 32, offset: 7120},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 218, col: 32, offset: 7057},
+												pos:  position{line: 233, col: 32, offset: 7120},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 218, col: 35, offset: 7060},
+												pos:        position{line: 233, col: 35, offset: 7123},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 218, col: 39, offset: 7064},
+												pos:  position{line: 233, col: 39, offset: 7127},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 218, col: 42, offset: 7067},
+												pos:   position{line: 233, col: 42, offset: 7130},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 218, col: 47, offset: 7072},
+													pos:  position{line: 233, col: 47, offset: 7135},
 													name: "FlexAssignment",
 												},
 											},
@@ -1574,42 +1692,42 @@ var g = &grammar{
 		},
 		{
 			name: "ReducerAssignment",
-			pos:  position{line: 222, col: 1, offset: 7194},
+			pos:  position{line: 237, col: 1, offset: 7257},
 			expr: &choiceExpr{
-				pos: position{line: 223, col: 5, offset: 7216},
+				pos: position{line: 238, col: 5, offset: 7279},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 223, col: 5, offset: 7216},
+						pos: position{line: 238, col: 5, offset: 7279},
 						run: (*parser).callonReducerAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 223, col: 5, offset: 7216},
+							pos: position{line: 238, col: 5, offset: 7279},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 223, col: 5, offset: 7216},
+									pos:   position{line: 238, col: 5, offset: 7279},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 223, col: 10, offset: 7221},
+										pos:  position{line: 238, col: 10, offset: 7284},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 223, col: 15, offset: 7226},
+									pos:  position{line: 238, col: 15, offset: 7289},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 223, col: 18, offset: 7229},
+									pos:        position{line: 238, col: 18, offset: 7292},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 223, col: 22, offset: 7233},
+									pos:  position{line: 238, col: 22, offset: 7296},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 223, col: 25, offset: 7236},
+									pos:   position{line: 238, col: 25, offset: 7299},
 									label: "reducer",
 									expr: &ruleRefExpr{
-										pos:  position{line: 223, col: 33, offset: 7244},
+										pos:  position{line: 238, col: 33, offset: 7307},
 										name: "Reducer",
 									},
 								},
@@ -1617,13 +1735,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 226, col: 5, offset: 7354},
+						pos: position{line: 241, col: 5, offset: 7417},
 						run: (*parser).callonReducerAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 226, col: 5, offset: 7354},
+							pos:   position{line: 241, col: 5, offset: 7417},
 							label: "reducer",
 							expr: &ruleRefExpr{
-								pos:  position{line: 226, col: 13, offset: 7362},
+								pos:  position{line: 241, col: 13, offset: 7425},
 								name: "Reducer",
 							},
 						},
@@ -1633,79 +1751,99 @@ var g = &grammar{
 		},
 		{
 			name: "Reducer",
-			pos:  position{line: 230, col: 1, offset: 7468},
+			pos:  position{line: 245, col: 1, offset: 7531},
 			expr: &actionExpr{
-				pos: position{line: 231, col: 5, offset: 7480},
+				pos: position{line: 246, col: 5, offset: 7543},
 				run: (*parser).callonReducer1,
 				expr: &seqExpr{
-					pos: position{line: 231, col: 5, offset: 7480},
+					pos: position{line: 246, col: 5, offset: 7543},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 231, col: 5, offset: 7480},
-							expr: &choiceExpr{
-								pos: position{line: 231, col: 7, offset: 7482},
-								alternatives: []interface{}{
-									&litMatcher{
-										pos:        position{line: 231, col: 7, offset: 7482},
-										val:        "not",
-										ignoreCase: false,
+							pos: position{line: 246, col: 5, offset: 7543},
+							expr: &seqExpr{
+								pos: position{line: 246, col: 7, offset: 7545},
+								exprs: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 246, col: 7, offset: 7545},
+										name: "NotReducers",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 246, col: 19, offset: 7557},
+										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 231, col: 13, offset: 7488},
-										val:        "len",
+										pos:        position{line: 246, col: 22, offset: 7560},
+										val:        "(",
 										ignoreCase: false,
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 231, col: 20, offset: 7495},
+							pos:   position{line: 246, col: 27, offset: 7565},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 231, col: 23, offset: 7498},
+								pos:  position{line: 246, col: 30, offset: 7568},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 231, col: 38, offset: 7513},
+							pos:  position{line: 246, col: 45, offset: 7583},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 231, col: 41, offset: 7516},
+							pos:        position{line: 246, col: 48, offset: 7586},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 231, col: 45, offset: 7520},
+							pos:  position{line: 246, col: 52, offset: 7590},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 231, col: 48, offset: 7523},
+							pos:   position{line: 246, col: 55, offset: 7593},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 231, col: 53, offset: 7528},
+								pos: position{line: 246, col: 60, offset: 7598},
 								expr: &ruleRefExpr{
-									pos:  position{line: 231, col: 53, offset: 7528},
+									pos:  position{line: 246, col: 60, offset: 7598},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 231, col: 60, offset: 7535},
+							pos:  position{line: 246, col: 67, offset: 7605},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 231, col: 63, offset: 7538},
+							pos:        position{line: 246, col: 70, offset: 7608},
 							val:        ")",
 							ignoreCase: false,
 						},
+						&notExpr{
+							pos: position{line: 246, col: 74, offset: 7612},
+							expr: &seqExpr{
+								pos: position{line: 246, col: 76, offset: 7614},
+								exprs: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 246, col: 76, offset: 7614},
+										name: "__",
+									},
+									&litMatcher{
+										pos:        position{line: 246, col: 79, offset: 7617},
+										val:        ".",
+										ignoreCase: false,
+									},
+								},
+							},
+						},
 						&labeledExpr{
-							pos:   position{line: 231, col: 67, offset: 7542},
+							pos:   position{line: 246, col: 84, offset: 7622},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 231, col: 73, offset: 7548},
+								pos: position{line: 246, col: 90, offset: 7628},
 								expr: &ruleRefExpr{
-									pos:  position{line: 231, col: 73, offset: 7548},
+									pos:  position{line: 246, col: 90, offset: 7628},
 									name: "WhereClause",
 								},
 							},
@@ -1715,33 +1853,52 @@ var g = &grammar{
 			},
 		},
 		{
+			name: "NotReducers",
+			pos:  position{line: 254, col: 1, offset: 7824},
+			expr: &choiceExpr{
+				pos: position{line: 255, col: 5, offset: 7840},
+				alternatives: []interface{}{
+					&litMatcher{
+						pos:        position{line: 255, col: 5, offset: 7840},
+						val:        "not",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 256, col: 5, offset: 7850},
+						val:        "match",
+						ignoreCase: false,
+					},
+				},
+			},
+		},
+		{
 			name: "WhereClause",
-			pos:  position{line: 239, col: 1, offset: 7744},
+			pos:  position{line: 258, col: 1, offset: 7859},
 			expr: &actionExpr{
-				pos: position{line: 239, col: 15, offset: 7758},
+				pos: position{line: 258, col: 15, offset: 7873},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 239, col: 15, offset: 7758},
+					pos: position{line: 258, col: 15, offset: 7873},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 239, col: 15, offset: 7758},
+							pos:  position{line: 258, col: 15, offset: 7873},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 239, col: 17, offset: 7760},
+							pos:        position{line: 258, col: 17, offset: 7875},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 239, col: 25, offset: 7768},
+							pos:  position{line: 258, col: 25, offset: 7883},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 239, col: 27, offset: 7770},
+							pos:   position{line: 258, col: 27, offset: 7885},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 239, col: 32, offset: 7775},
-								name: "Expr",
+								pos:  position{line: 258, col: 32, offset: 7890},
+								name: "SearchBoolean",
 							},
 						},
 					},
@@ -1750,44 +1907,44 @@ var g = &grammar{
 		},
 		{
 			name: "Reducers",
-			pos:  position{line: 241, col: 1, offset: 7802},
+			pos:  position{line: 260, col: 1, offset: 7926},
 			expr: &actionExpr{
-				pos: position{line: 242, col: 5, offset: 7815},
+				pos: position{line: 261, col: 5, offset: 7939},
 				run: (*parser).callonReducers1,
 				expr: &seqExpr{
-					pos: position{line: 242, col: 5, offset: 7815},
+					pos: position{line: 261, col: 5, offset: 7939},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 242, col: 5, offset: 7815},
+							pos:   position{line: 261, col: 5, offset: 7939},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 242, col: 11, offset: 7821},
+								pos:  position{line: 261, col: 11, offset: 7945},
 								name: "ReducerAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 242, col: 29, offset: 7839},
+							pos:   position{line: 261, col: 29, offset: 7963},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 242, col: 34, offset: 7844},
+								pos: position{line: 261, col: 34, offset: 7968},
 								expr: &seqExpr{
-									pos: position{line: 242, col: 35, offset: 7845},
+									pos: position{line: 261, col: 35, offset: 7969},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 242, col: 35, offset: 7845},
+											pos:  position{line: 261, col: 35, offset: 7969},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 242, col: 38, offset: 7848},
+											pos:        position{line: 261, col: 38, offset: 7972},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 242, col: 42, offset: 7852},
+											pos:  position{line: 261, col: 42, offset: 7976},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 242, col: 45, offset: 7855},
+											pos:  position{line: 261, col: 45, offset: 7979},
 											name: "ReducerAssignment",
 										},
 									},
@@ -1799,61 +1956,61 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "NamedProc",
-			pos:  position{line: 250, col: 1, offset: 8060},
+			name: "Operator",
+			pos:  position{line: 269, col: 1, offset: 8184},
 			expr: &choiceExpr{
-				pos: position{line: 251, col: 5, offset: 8074},
+				pos: position{line: 270, col: 5, offset: 8197},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 251, col: 5, offset: 8074},
+						pos:  position{line: 270, col: 5, offset: 8197},
 						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 252, col: 5, offset: 8087},
+						pos:  position{line: 271, col: 5, offset: 8210},
 						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 253, col: 5, offset: 8099},
+						pos:  position{line: 272, col: 5, offset: 8222},
 						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 254, col: 5, offset: 8111},
+						pos:  position{line: 273, col: 5, offset: 8234},
 						name: "PickProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 255, col: 5, offset: 8124},
+						pos:  position{line: 274, col: 5, offset: 8247},
 						name: "DropProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 256, col: 5, offset: 8137},
+						pos:  position{line: 275, col: 5, offset: 8260},
 						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 257, col: 5, offset: 8150},
+						pos:  position{line: 276, col: 5, offset: 8273},
 						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 258, col: 5, offset: 8163},
+						pos:  position{line: 277, col: 5, offset: 8286},
 						name: "FilterProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 259, col: 5, offset: 8178},
+						pos:  position{line: 278, col: 5, offset: 8301},
 						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 260, col: 5, offset: 8191},
+						pos:  position{line: 279, col: 5, offset: 8314},
 						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 261, col: 5, offset: 8203},
+						pos:  position{line: 280, col: 5, offset: 8326},
 						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 262, col: 5, offset: 8218},
+						pos:  position{line: 281, col: 5, offset: 8341},
 						name: "FuseProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 263, col: 5, offset: 8231},
+						pos:  position{line: 282, col: 5, offset: 8354},
 						name: "JoinProc",
 					},
 				},
@@ -1861,46 +2018,46 @@ var g = &grammar{
 		},
 		{
 			name: "SortProc",
-			pos:  position{line: 265, col: 1, offset: 8241},
+			pos:  position{line: 284, col: 1, offset: 8364},
 			expr: &actionExpr{
-				pos: position{line: 266, col: 5, offset: 8254},
+				pos: position{line: 285, col: 5, offset: 8377},
 				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 266, col: 5, offset: 8254},
+					pos: position{line: 285, col: 5, offset: 8377},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 266, col: 5, offset: 8254},
+							pos:        position{line: 285, col: 5, offset: 8377},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 266, col: 13, offset: 8262},
+							pos:   position{line: 285, col: 13, offset: 8385},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 266, col: 18, offset: 8267},
+								pos:  position{line: 285, col: 18, offset: 8390},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 266, col: 27, offset: 8276},
+							pos:   position{line: 285, col: 27, offset: 8399},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 266, col: 32, offset: 8281},
+								pos: position{line: 285, col: 32, offset: 8404},
 								expr: &actionExpr{
-									pos: position{line: 266, col: 33, offset: 8282},
+									pos: position{line: 285, col: 33, offset: 8405},
 									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 266, col: 33, offset: 8282},
+										pos: position{line: 285, col: 33, offset: 8405},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 266, col: 33, offset: 8282},
+												pos:  position{line: 285, col: 33, offset: 8405},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 266, col: 35, offset: 8284},
+												pos:   position{line: 285, col: 35, offset: 8407},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 266, col: 37, offset: 8286},
+													pos:  position{line: 285, col: 37, offset: 8409},
 													name: "Exprs",
 												},
 											},
@@ -1915,30 +2072,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 280, col: 1, offset: 8705},
+			pos:  position{line: 299, col: 1, offset: 8828},
 			expr: &actionExpr{
-				pos: position{line: 280, col: 12, offset: 8716},
+				pos: position{line: 299, col: 12, offset: 8839},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 280, col: 12, offset: 8716},
+					pos:   position{line: 299, col: 12, offset: 8839},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 280, col: 17, offset: 8721},
+						pos: position{line: 299, col: 17, offset: 8844},
 						expr: &actionExpr{
-							pos: position{line: 280, col: 18, offset: 8722},
+							pos: position{line: 299, col: 18, offset: 8845},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 280, col: 18, offset: 8722},
+								pos: position{line: 299, col: 18, offset: 8845},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 280, col: 18, offset: 8722},
+										pos:  position{line: 299, col: 18, offset: 8845},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 280, col: 20, offset: 8724},
+										pos:   position{line: 299, col: 20, offset: 8847},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 280, col: 22, offset: 8726},
+											pos:  position{line: 299, col: 22, offset: 8849},
 											name: "SortArg",
 										},
 									},
@@ -1951,50 +2108,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 282, col: 1, offset: 8782},
+			pos:  position{line: 301, col: 1, offset: 8905},
 			expr: &choiceExpr{
-				pos: position{line: 283, col: 5, offset: 8794},
+				pos: position{line: 302, col: 5, offset: 8917},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 283, col: 5, offset: 8794},
+						pos: position{line: 302, col: 5, offset: 8917},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 283, col: 5, offset: 8794},
+							pos:        position{line: 302, col: 5, offset: 8917},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 284, col: 5, offset: 8869},
+						pos: position{line: 303, col: 5, offset: 8992},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 284, col: 5, offset: 8869},
+							pos: position{line: 303, col: 5, offset: 8992},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 284, col: 5, offset: 8869},
+									pos:        position{line: 303, col: 5, offset: 8992},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 284, col: 14, offset: 8878},
+									pos:  position{line: 303, col: 14, offset: 9001},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 284, col: 16, offset: 8880},
+									pos:   position{line: 303, col: 16, offset: 9003},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 284, col: 23, offset: 8887},
+										pos: position{line: 303, col: 23, offset: 9010},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 284, col: 24, offset: 8888},
+											pos: position{line: 303, col: 24, offset: 9011},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 284, col: 24, offset: 8888},
+													pos:        position{line: 303, col: 24, offset: 9011},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 284, col: 34, offset: 8898},
+													pos:        position{line: 303, col: 34, offset: 9021},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2010,38 +2167,38 @@ var g = &grammar{
 		},
 		{
 			name: "TopProc",
-			pos:  position{line: 286, col: 1, offset: 9012},
+			pos:  position{line: 305, col: 1, offset: 9135},
 			expr: &actionExpr{
-				pos: position{line: 287, col: 5, offset: 9024},
+				pos: position{line: 306, col: 5, offset: 9147},
 				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 287, col: 5, offset: 9024},
+					pos: position{line: 306, col: 5, offset: 9147},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 287, col: 5, offset: 9024},
+							pos:        position{line: 306, col: 5, offset: 9147},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 287, col: 12, offset: 9031},
+							pos:   position{line: 306, col: 12, offset: 9154},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 287, col: 18, offset: 9037},
+								pos: position{line: 306, col: 18, offset: 9160},
 								expr: &actionExpr{
-									pos: position{line: 287, col: 19, offset: 9038},
+									pos: position{line: 306, col: 19, offset: 9161},
 									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 287, col: 19, offset: 9038},
+										pos: position{line: 306, col: 19, offset: 9161},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 287, col: 19, offset: 9038},
+												pos:  position{line: 306, col: 19, offset: 9161},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 287, col: 21, offset: 9040},
+												pos:   position{line: 306, col: 21, offset: 9163},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 287, col: 23, offset: 9042},
+													pos:  position{line: 306, col: 23, offset: 9165},
 													name: "UInt",
 												},
 											},
@@ -2051,19 +2208,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 287, col: 47, offset: 9066},
+							pos:   position{line: 306, col: 47, offset: 9189},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 287, col: 53, offset: 9072},
+								pos: position{line: 306, col: 53, offset: 9195},
 								expr: &seqExpr{
-									pos: position{line: 287, col: 54, offset: 9073},
+									pos: position{line: 306, col: 54, offset: 9196},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 287, col: 54, offset: 9073},
+											pos:  position{line: 306, col: 54, offset: 9196},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 287, col: 56, offset: 9075},
+											pos:        position{line: 306, col: 56, offset: 9198},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2072,25 +2229,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 287, col: 67, offset: 9086},
+							pos:   position{line: 306, col: 67, offset: 9209},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 287, col: 74, offset: 9093},
+								pos: position{line: 306, col: 74, offset: 9216},
 								expr: &actionExpr{
-									pos: position{line: 287, col: 75, offset: 9094},
+									pos: position{line: 306, col: 75, offset: 9217},
 									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 287, col: 75, offset: 9094},
+										pos: position{line: 306, col: 75, offset: 9217},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 287, col: 75, offset: 9094},
+												pos:  position{line: 306, col: 75, offset: 9217},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 287, col: 77, offset: 9096},
+												pos:   position{line: 306, col: 77, offset: 9219},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 287, col: 79, offset: 9098},
+													pos:  position{line: 306, col: 79, offset: 9221},
 													name: "FieldExprs",
 												},
 											},
@@ -2105,35 +2262,35 @@ var g = &grammar{
 		},
 		{
 			name: "CutProc",
-			pos:  position{line: 301, col: 1, offset: 9449},
+			pos:  position{line: 320, col: 1, offset: 9572},
 			expr: &actionExpr{
-				pos: position{line: 302, col: 5, offset: 9461},
+				pos: position{line: 321, col: 5, offset: 9584},
 				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 302, col: 5, offset: 9461},
+					pos: position{line: 321, col: 5, offset: 9584},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 302, col: 5, offset: 9461},
+							pos:        position{line: 321, col: 5, offset: 9584},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 302, col: 12, offset: 9468},
+							pos:   position{line: 321, col: 12, offset: 9591},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 302, col: 17, offset: 9473},
+								pos:  position{line: 321, col: 17, offset: 9596},
 								name: "CutArgs",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 302, col: 25, offset: 9481},
+							pos:  position{line: 321, col: 25, offset: 9604},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 302, col: 27, offset: 9483},
+							pos:   position{line: 321, col: 27, offset: 9606},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 302, col: 35, offset: 9491},
+								pos:  position{line: 321, col: 35, offset: 9614},
 								name: "FlexAssignments",
 							},
 						},
@@ -2143,27 +2300,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutArgs",
-			pos:  position{line: 311, col: 1, offset: 9760},
+			pos:  position{line: 330, col: 1, offset: 9883},
 			expr: &actionExpr{
-				pos: position{line: 312, col: 5, offset: 9772},
+				pos: position{line: 331, col: 5, offset: 9895},
 				run: (*parser).callonCutArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 312, col: 5, offset: 9772},
+					pos:   position{line: 331, col: 5, offset: 9895},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 312, col: 10, offset: 9777},
+						pos: position{line: 331, col: 10, offset: 9900},
 						expr: &actionExpr{
-							pos: position{line: 312, col: 11, offset: 9778},
+							pos: position{line: 331, col: 11, offset: 9901},
 							run: (*parser).callonCutArgs4,
 							expr: &seqExpr{
-								pos: position{line: 312, col: 11, offset: 9778},
+								pos: position{line: 331, col: 11, offset: 9901},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 312, col: 11, offset: 9778},
+										pos:  position{line: 331, col: 11, offset: 9901},
 										name: "_",
 									},
 									&litMatcher{
-										pos:        position{line: 312, col: 13, offset: 9780},
+										pos:        position{line: 331, col: 13, offset: 9903},
 										val:        "-c",
 										ignoreCase: false,
 									},
@@ -2176,27 +2333,27 @@ var g = &grammar{
 		},
 		{
 			name: "PickProc",
-			pos:  position{line: 316, col: 1, offset: 9892},
+			pos:  position{line: 335, col: 1, offset: 10015},
 			expr: &actionExpr{
-				pos: position{line: 317, col: 5, offset: 9905},
+				pos: position{line: 336, col: 5, offset: 10028},
 				run: (*parser).callonPickProc1,
 				expr: &seqExpr{
-					pos: position{line: 317, col: 5, offset: 9905},
+					pos: position{line: 336, col: 5, offset: 10028},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 317, col: 5, offset: 9905},
+							pos:        position{line: 336, col: 5, offset: 10028},
 							val:        "pick",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 317, col: 13, offset: 9913},
+							pos:  position{line: 336, col: 13, offset: 10036},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 317, col: 15, offset: 9915},
+							pos:   position{line: 336, col: 15, offset: 10038},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 317, col: 23, offset: 9923},
+								pos:  position{line: 336, col: 23, offset: 10046},
 								name: "FlexAssignments",
 							},
 						},
@@ -2206,27 +2363,27 @@ var g = &grammar{
 		},
 		{
 			name: "DropProc",
-			pos:  position{line: 321, col: 1, offset: 10026},
+			pos:  position{line: 340, col: 1, offset: 10149},
 			expr: &actionExpr{
-				pos: position{line: 322, col: 5, offset: 10039},
+				pos: position{line: 341, col: 5, offset: 10162},
 				run: (*parser).callonDropProc1,
 				expr: &seqExpr{
-					pos: position{line: 322, col: 5, offset: 10039},
+					pos: position{line: 341, col: 5, offset: 10162},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 322, col: 5, offset: 10039},
+							pos:        position{line: 341, col: 5, offset: 10162},
 							val:        "drop",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 322, col: 13, offset: 10047},
+							pos:  position{line: 341, col: 13, offset: 10170},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 322, col: 15, offset: 10049},
+							pos:   position{line: 341, col: 15, offset: 10172},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 322, col: 23, offset: 10057},
+								pos:  position{line: 341, col: 23, offset: 10180},
 								name: "FieldExprs",
 							},
 						},
@@ -2236,30 +2393,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadProc",
-			pos:  position{line: 326, col: 1, offset: 10155},
+			pos:  position{line: 345, col: 1, offset: 10278},
 			expr: &choiceExpr{
-				pos: position{line: 327, col: 5, offset: 10168},
+				pos: position{line: 346, col: 5, offset: 10291},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 327, col: 5, offset: 10168},
+						pos: position{line: 346, col: 5, offset: 10291},
 						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 327, col: 5, offset: 10168},
+							pos: position{line: 346, col: 5, offset: 10291},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 327, col: 5, offset: 10168},
+									pos:        position{line: 346, col: 5, offset: 10291},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 327, col: 13, offset: 10176},
+									pos:  position{line: 346, col: 13, offset: 10299},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 327, col: 15, offset: 10178},
+									pos:   position{line: 346, col: 15, offset: 10301},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 327, col: 21, offset: 10184},
+										pos:  position{line: 346, col: 21, offset: 10307},
 										name: "UInt",
 									},
 								},
@@ -2267,10 +2424,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 328, col: 5, offset: 10266},
+						pos: position{line: 347, col: 5, offset: 10389},
 						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 328, col: 5, offset: 10266},
+							pos:        position{line: 347, col: 5, offset: 10389},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2280,30 +2437,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailProc",
-			pos:  position{line: 330, col: 1, offset: 10344},
+			pos:  position{line: 349, col: 1, offset: 10467},
 			expr: &choiceExpr{
-				pos: position{line: 331, col: 5, offset: 10357},
+				pos: position{line: 350, col: 5, offset: 10480},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 331, col: 5, offset: 10357},
+						pos: position{line: 350, col: 5, offset: 10480},
 						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 331, col: 5, offset: 10357},
+							pos: position{line: 350, col: 5, offset: 10480},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 331, col: 5, offset: 10357},
+									pos:        position{line: 350, col: 5, offset: 10480},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 331, col: 13, offset: 10365},
+									pos:  position{line: 350, col: 13, offset: 10488},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 331, col: 15, offset: 10367},
+									pos:   position{line: 350, col: 15, offset: 10490},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 331, col: 21, offset: 10373},
+										pos:  position{line: 350, col: 21, offset: 10496},
 										name: "UInt",
 									},
 								},
@@ -2311,10 +2468,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 332, col: 5, offset: 10455},
+						pos: position{line: 351, col: 5, offset: 10578},
 						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 332, col: 5, offset: 10455},
+							pos:        position{line: 351, col: 5, offset: 10578},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2324,28 +2481,28 @@ var g = &grammar{
 		},
 		{
 			name: "FilterProc",
-			pos:  position{line: 334, col: 1, offset: 10533},
+			pos:  position{line: 353, col: 1, offset: 10656},
 			expr: &actionExpr{
-				pos: position{line: 335, col: 5, offset: 10548},
+				pos: position{line: 354, col: 5, offset: 10671},
 				run: (*parser).callonFilterProc1,
 				expr: &seqExpr{
-					pos: position{line: 335, col: 5, offset: 10548},
+					pos: position{line: 354, col: 5, offset: 10671},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 335, col: 5, offset: 10548},
+							pos:        position{line: 354, col: 5, offset: 10671},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 335, col: 15, offset: 10558},
+							pos:  position{line: 354, col: 15, offset: 10681},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 335, col: 17, offset: 10560},
-							label: "expr",
+							pos:   position{line: 354, col: 17, offset: 10683},
+							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 335, col: 22, offset: 10565},
-								name: "SearchExpr",
+								pos:  position{line: 354, col: 20, offset: 10686},
+								name: "Filter",
 							},
 						},
 					},
@@ -2353,28 +2510,44 @@ var g = &grammar{
 			},
 		},
 		{
+			name: "Filter",
+			pos:  position{line: 358, col: 1, offset: 10723},
+			expr: &actionExpr{
+				pos: position{line: 359, col: 5, offset: 10734},
+				run: (*parser).callonFilter1,
+				expr: &labeledExpr{
+					pos:   position{line: 359, col: 5, offset: 10734},
+					label: "expr",
+					expr: &ruleRefExpr{
+						pos:  position{line: 359, col: 10, offset: 10739},
+						name: "SearchBoolean",
+					},
+				},
+			},
+		},
+		{
 			name: "UniqProc",
-			pos:  position{line: 339, col: 1, offset: 10662},
+			pos:  position{line: 363, col: 1, offset: 10839},
 			expr: &choiceExpr{
-				pos: position{line: 340, col: 5, offset: 10675},
+				pos: position{line: 364, col: 5, offset: 10852},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 340, col: 5, offset: 10675},
+						pos: position{line: 364, col: 5, offset: 10852},
 						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 340, col: 5, offset: 10675},
+							pos: position{line: 364, col: 5, offset: 10852},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 340, col: 5, offset: 10675},
+									pos:        position{line: 364, col: 5, offset: 10852},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 340, col: 13, offset: 10683},
+									pos:  position{line: 364, col: 13, offset: 10860},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 340, col: 15, offset: 10685},
+									pos:        position{line: 364, col: 15, offset: 10862},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2382,10 +2555,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 343, col: 5, offset: 10776},
+						pos: position{line: 367, col: 5, offset: 10953},
 						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 343, col: 5, offset: 10776},
+							pos:        position{line: 367, col: 5, offset: 10953},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2395,27 +2568,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutProc",
-			pos:  position{line: 347, col: 1, offset: 10868},
+			pos:  position{line: 371, col: 1, offset: 11045},
 			expr: &actionExpr{
-				pos: position{line: 348, col: 5, offset: 10880},
+				pos: position{line: 372, col: 5, offset: 11057},
 				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 348, col: 5, offset: 10880},
+					pos: position{line: 372, col: 5, offset: 11057},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 348, col: 5, offset: 10880},
+							pos:        position{line: 372, col: 5, offset: 11057},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 348, col: 12, offset: 10887},
+							pos:  position{line: 372, col: 12, offset: 11064},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 348, col: 14, offset: 10889},
+							pos:   position{line: 372, col: 14, offset: 11066},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 348, col: 22, offset: 10897},
+								pos:  position{line: 372, col: 22, offset: 11074},
 								name: "FlexAssignments",
 							},
 						},
@@ -2425,59 +2598,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameProc",
-			pos:  position{line: 352, col: 1, offset: 11000},
+			pos:  position{line: 376, col: 1, offset: 11177},
 			expr: &actionExpr{
-				pos: position{line: 353, col: 5, offset: 11015},
+				pos: position{line: 377, col: 5, offset: 11192},
 				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 353, col: 5, offset: 11015},
+					pos: position{line: 377, col: 5, offset: 11192},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 353, col: 5, offset: 11015},
+							pos:        position{line: 377, col: 5, offset: 11192},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 353, col: 15, offset: 11025},
+							pos:  position{line: 377, col: 15, offset: 11202},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 353, col: 17, offset: 11027},
+							pos:   position{line: 377, col: 17, offset: 11204},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 353, col: 23, offset: 11033},
+								pos:  position{line: 377, col: 23, offset: 11210},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 353, col: 34, offset: 11044},
+							pos:   position{line: 377, col: 34, offset: 11221},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 353, col: 39, offset: 11049},
+								pos: position{line: 377, col: 39, offset: 11226},
 								expr: &actionExpr{
-									pos: position{line: 353, col: 40, offset: 11050},
+									pos: position{line: 377, col: 40, offset: 11227},
 									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 353, col: 40, offset: 11050},
+										pos: position{line: 377, col: 40, offset: 11227},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 353, col: 40, offset: 11050},
+												pos:  position{line: 377, col: 40, offset: 11227},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 353, col: 43, offset: 11053},
+												pos:        position{line: 377, col: 43, offset: 11230},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 353, col: 47, offset: 11057},
+												pos:  position{line: 377, col: 47, offset: 11234},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 353, col: 50, offset: 11060},
+												pos:   position{line: 377, col: 50, offset: 11237},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 353, col: 53, offset: 11063},
+													pos:  position{line: 377, col: 53, offset: 11240},
 													name: "Assignment",
 												},
 											},
@@ -2492,12 +2665,12 @@ var g = &grammar{
 		},
 		{
 			name: "FuseProc",
-			pos:  position{line: 357, col: 1, offset: 11233},
+			pos:  position{line: 381, col: 1, offset: 11410},
 			expr: &actionExpr{
-				pos: position{line: 358, col: 5, offset: 11246},
+				pos: position{line: 382, col: 5, offset: 11423},
 				run: (*parser).callonFuseProc1,
 				expr: &litMatcher{
-					pos:        position{line: 358, col: 5, offset: 11246},
+					pos:        position{line: 382, col: 5, offset: 11423},
 					val:        "fuse",
 					ignoreCase: true,
 				},
@@ -2505,68 +2678,68 @@ var g = &grammar{
 		},
 		{
 			name: "JoinProc",
-			pos:  position{line: 362, col: 1, offset: 11322},
+			pos:  position{line: 386, col: 1, offset: 11499},
 			expr: &choiceExpr{
-				pos: position{line: 363, col: 5, offset: 11335},
+				pos: position{line: 387, col: 5, offset: 11512},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 363, col: 5, offset: 11335},
+						pos: position{line: 387, col: 5, offset: 11512},
 						run: (*parser).callonJoinProc2,
 						expr: &seqExpr{
-							pos: position{line: 363, col: 5, offset: 11335},
+							pos: position{line: 387, col: 5, offset: 11512},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 363, col: 5, offset: 11335},
+									pos:        position{line: 387, col: 5, offset: 11512},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 363, col: 13, offset: 11343},
+									pos:  position{line: 387, col: 13, offset: 11520},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 363, col: 15, offset: 11345},
+									pos:   position{line: 387, col: 15, offset: 11522},
 									label: "leftKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 363, col: 23, offset: 11353},
+										pos:  position{line: 387, col: 23, offset: 11530},
 										name: "JoinKey",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 363, col: 31, offset: 11361},
+									pos:  position{line: 387, col: 31, offset: 11538},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 363, col: 34, offset: 11364},
+									pos:        position{line: 387, col: 34, offset: 11541},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 363, col: 38, offset: 11368},
+									pos:  position{line: 387, col: 38, offset: 11545},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 363, col: 41, offset: 11371},
+									pos:   position{line: 387, col: 41, offset: 11548},
 									label: "rightKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 363, col: 50, offset: 11380},
+										pos:  position{line: 387, col: 50, offset: 11557},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 363, col: 58, offset: 11388},
+									pos:   position{line: 387, col: 58, offset: 11565},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 363, col: 66, offset: 11396},
+										pos: position{line: 387, col: 66, offset: 11573},
 										expr: &seqExpr{
-											pos: position{line: 363, col: 67, offset: 11397},
+											pos: position{line: 387, col: 67, offset: 11574},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 363, col: 67, offset: 11397},
+													pos:  position{line: 387, col: 67, offset: 11574},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 363, col: 69, offset: 11399},
+													pos:  position{line: 387, col: 69, offset: 11576},
 													name: "FlexAssignments",
 												},
 											},
@@ -2577,42 +2750,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 370, col: 5, offset: 11657},
+						pos: position{line: 394, col: 5, offset: 11834},
 						run: (*parser).callonJoinProc18,
 						expr: &seqExpr{
-							pos: position{line: 370, col: 5, offset: 11657},
+							pos: position{line: 394, col: 5, offset: 11834},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 370, col: 5, offset: 11657},
+									pos:        position{line: 394, col: 5, offset: 11834},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 370, col: 13, offset: 11665},
+									pos:  position{line: 394, col: 13, offset: 11842},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 370, col: 15, offset: 11667},
+									pos:   position{line: 394, col: 15, offset: 11844},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 370, col: 19, offset: 11671},
+										pos:  position{line: 394, col: 19, offset: 11848},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 370, col: 27, offset: 11679},
+									pos:   position{line: 394, col: 27, offset: 11856},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 370, col: 35, offset: 11687},
+										pos: position{line: 394, col: 35, offset: 11864},
 										expr: &seqExpr{
-											pos: position{line: 370, col: 36, offset: 11688},
+											pos: position{line: 394, col: 36, offset: 11865},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 370, col: 36, offset: 11688},
+													pos:  position{line: 394, col: 36, offset: 11865},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 370, col: 38, offset: 11690},
+													pos:  position{line: 394, col: 38, offset: 11867},
 													name: "FlexAssignments",
 												},
 											},
@@ -2627,35 +2800,35 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 378, col: 1, offset: 11936},
+			pos:  position{line: 402, col: 1, offset: 12113},
 			expr: &choiceExpr{
-				pos: position{line: 379, col: 5, offset: 11948},
+				pos: position{line: 403, col: 5, offset: 12125},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 379, col: 5, offset: 11948},
+						pos:  position{line: 403, col: 5, offset: 12125},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 380, col: 5, offset: 11957},
+						pos: position{line: 404, col: 5, offset: 12134},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 380, col: 5, offset: 11957},
+							pos: position{line: 404, col: 5, offset: 12134},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 380, col: 5, offset: 11957},
+									pos:        position{line: 404, col: 5, offset: 12134},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 380, col: 9, offset: 11961},
+									pos:   position{line: 404, col: 9, offset: 12138},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 380, col: 14, offset: 11966},
+										pos:  position{line: 404, col: 14, offset: 12143},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 380, col: 19, offset: 11971},
+									pos:        position{line: 404, col: 19, offset: 12148},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -2666,132 +2839,61 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "RootField",
-			pos:  position{line: 382, col: 1, offset: 11997},
-			expr: &choiceExpr{
-				pos: position{line: 383, col: 5, offset: 12011},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 383, col: 5, offset: 12011},
-						run: (*parser).callonRootField2,
-						expr: &seqExpr{
-							pos: position{line: 383, col: 5, offset: 12011},
-							exprs: []interface{}{
-								&zeroOrOneExpr{
-									pos: position{line: 383, col: 5, offset: 12011},
-									expr: &litMatcher{
-										pos:        position{line: 383, col: 5, offset: 12011},
-										val:        ".",
-										ignoreCase: false,
-									},
-								},
-								&notExpr{
-									pos: position{line: 383, col: 10, offset: 12016},
-									expr: &choiceExpr{
-										pos: position{line: 383, col: 12, offset: 12018},
-										alternatives: []interface{}{
-											&ruleRefExpr{
-												pos:  position{line: 383, col: 12, offset: 12018},
-												name: "BooleanLiteral",
-											},
-											&ruleRefExpr{
-												pos:  position{line: 383, col: 29, offset: 12035},
-												name: "NullLiteral",
-											},
-										},
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 383, col: 42, offset: 12048},
-									label: "field",
-									expr: &ruleRefExpr{
-										pos:  position{line: 383, col: 48, offset: 12054},
-										name: "Identifier",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 384, col: 5, offset: 12207},
-						run: (*parser).callonRootField12,
-						expr: &seqExpr{
-							pos: position{line: 384, col: 5, offset: 12207},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 384, col: 5, offset: 12207},
-									val:        ".",
-									ignoreCase: false,
-								},
-								&notExpr{
-									pos: position{line: 384, col: 9, offset: 12211},
-									expr: &ruleRefExpr{
-										pos:  position{line: 384, col: 11, offset: 12213},
-										name: "Identifier",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "Lval",
-			pos:  position{line: 386, col: 1, offset: 12286},
+			pos:  position{line: 406, col: 1, offset: 12174},
 			expr: &ruleRefExpr{
-				pos:  position{line: 386, col: 8, offset: 12293},
+				pos:  position{line: 406, col: 8, offset: 12181},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 388, col: 1, offset: 12304},
+			pos:  position{line: 408, col: 1, offset: 12192},
 			expr: &ruleRefExpr{
-				pos:  position{line: 388, col: 13, offset: 12316},
+				pos:  position{line: 408, col: 13, offset: 12204},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 390, col: 1, offset: 12322},
+			pos:  position{line: 410, col: 1, offset: 12210},
 			expr: &actionExpr{
-				pos: position{line: 391, col: 5, offset: 12337},
+				pos: position{line: 411, col: 5, offset: 12225},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 391, col: 5, offset: 12337},
+					pos: position{line: 411, col: 5, offset: 12225},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 391, col: 5, offset: 12337},
+							pos:   position{line: 411, col: 5, offset: 12225},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 391, col: 11, offset: 12343},
+								pos:  position{line: 411, col: 11, offset: 12231},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 391, col: 21, offset: 12353},
+							pos:   position{line: 411, col: 21, offset: 12241},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 391, col: 26, offset: 12358},
+								pos: position{line: 411, col: 26, offset: 12246},
 								expr: &seqExpr{
-									pos: position{line: 391, col: 27, offset: 12359},
+									pos: position{line: 411, col: 27, offset: 12247},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 391, col: 27, offset: 12359},
+											pos:  position{line: 411, col: 27, offset: 12247},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 391, col: 30, offset: 12362},
+											pos:        position{line: 411, col: 30, offset: 12250},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 391, col: 34, offset: 12366},
+											pos:  position{line: 411, col: 34, offset: 12254},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 391, col: 37, offset: 12369},
+											pos:  position{line: 411, col: 37, offset: 12257},
 											name: "FieldExpr",
 										},
 									},
@@ -2804,44 +2906,44 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 401, col: 1, offset: 12568},
+			pos:  position{line: 421, col: 1, offset: 12456},
 			expr: &actionExpr{
-				pos: position{line: 402, col: 5, offset: 12578},
+				pos: position{line: 422, col: 5, offset: 12466},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 402, col: 5, offset: 12578},
+					pos: position{line: 422, col: 5, offset: 12466},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 402, col: 5, offset: 12578},
+							pos:   position{line: 422, col: 5, offset: 12466},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 402, col: 11, offset: 12584},
+								pos:  position{line: 422, col: 11, offset: 12472},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 402, col: 16, offset: 12589},
+							pos:   position{line: 422, col: 16, offset: 12477},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 402, col: 21, offset: 12594},
+								pos: position{line: 422, col: 21, offset: 12482},
 								expr: &seqExpr{
-									pos: position{line: 402, col: 22, offset: 12595},
+									pos: position{line: 422, col: 22, offset: 12483},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 402, col: 22, offset: 12595},
+											pos:  position{line: 422, col: 22, offset: 12483},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 402, col: 25, offset: 12598},
+											pos:        position{line: 422, col: 25, offset: 12486},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 402, col: 29, offset: 12602},
+											pos:  position{line: 422, col: 29, offset: 12490},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 402, col: 32, offset: 12605},
+											pos:  position{line: 422, col: 32, offset: 12493},
 											name: "Expr",
 										},
 									},
@@ -2854,39 +2956,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 412, col: 1, offset: 12799},
+			pos:  position{line: 432, col: 1, offset: 12687},
 			expr: &actionExpr{
-				pos: position{line: 413, col: 5, offset: 12814},
+				pos: position{line: 433, col: 5, offset: 12702},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 413, col: 5, offset: 12814},
+					pos: position{line: 433, col: 5, offset: 12702},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 413, col: 5, offset: 12814},
+							pos:   position{line: 433, col: 5, offset: 12702},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 413, col: 9, offset: 12818},
+								pos:  position{line: 433, col: 9, offset: 12706},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 413, col: 14, offset: 12823},
+							pos:  position{line: 433, col: 14, offset: 12711},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 413, col: 17, offset: 12826},
+							pos:        position{line: 433, col: 17, offset: 12714},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 413, col: 21, offset: 12830},
+							pos:  position{line: 433, col: 21, offset: 12718},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 413, col: 24, offset: 12833},
+							pos:   position{line: 433, col: 24, offset: 12721},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 413, col: 28, offset: 12837},
+								pos:  position{line: 433, col: 28, offset: 12725},
 								name: "Expr",
 							},
 						},
@@ -2896,71 +2998,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 415, col: 1, offset: 12926},
+			pos:  position{line: 435, col: 1, offset: 12814},
 			expr: &ruleRefExpr{
-				pos:  position{line: 415, col: 8, offset: 12933},
+				pos:  position{line: 435, col: 8, offset: 12821},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 417, col: 1, offset: 12950},
+			pos:  position{line: 437, col: 1, offset: 12838},
 			expr: &choiceExpr{
-				pos: position{line: 418, col: 5, offset: 12970},
+				pos: position{line: 438, col: 5, offset: 12858},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 418, col: 5, offset: 12970},
+						pos: position{line: 438, col: 5, offset: 12858},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 418, col: 5, offset: 12970},
+							pos: position{line: 438, col: 5, offset: 12858},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 418, col: 5, offset: 12970},
+									pos:   position{line: 438, col: 5, offset: 12858},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 418, col: 15, offset: 12980},
+										pos:  position{line: 438, col: 15, offset: 12868},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 418, col: 29, offset: 12994},
+									pos:  position{line: 438, col: 29, offset: 12882},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 418, col: 32, offset: 12997},
+									pos:        position{line: 438, col: 32, offset: 12885},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 418, col: 36, offset: 13001},
+									pos:  position{line: 438, col: 36, offset: 12889},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 418, col: 39, offset: 13004},
+									pos:   position{line: 438, col: 39, offset: 12892},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 418, col: 50, offset: 13015},
+										pos:  position{line: 438, col: 50, offset: 12903},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 418, col: 55, offset: 13020},
+									pos:  position{line: 438, col: 55, offset: 12908},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 418, col: 58, offset: 13023},
+									pos:        position{line: 438, col: 58, offset: 12911},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 418, col: 62, offset: 13027},
+									pos:  position{line: 438, col: 62, offset: 12915},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 418, col: 65, offset: 13030},
+									pos:   position{line: 438, col: 65, offset: 12918},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 418, col: 76, offset: 13041},
+										pos:  position{line: 438, col: 76, offset: 12929},
 										name: "Expr",
 									},
 								},
@@ -2968,7 +3070,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 421, col: 5, offset: 13188},
+						pos:  position{line: 441, col: 5, offset: 13076},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -2976,53 +3078,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 423, col: 1, offset: 13203},
+			pos:  position{line: 443, col: 1, offset: 13091},
 			expr: &actionExpr{
-				pos: position{line: 424, col: 5, offset: 13221},
+				pos: position{line: 444, col: 5, offset: 13109},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 424, col: 5, offset: 13221},
+					pos: position{line: 444, col: 5, offset: 13109},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 424, col: 5, offset: 13221},
+							pos:   position{line: 444, col: 5, offset: 13109},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 424, col: 11, offset: 13227},
+								pos:  position{line: 444, col: 11, offset: 13115},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 425, col: 5, offset: 13246},
+							pos:   position{line: 445, col: 5, offset: 13134},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 425, col: 10, offset: 13251},
+								pos: position{line: 445, col: 10, offset: 13139},
 								expr: &actionExpr{
-									pos: position{line: 425, col: 11, offset: 13252},
+									pos: position{line: 445, col: 11, offset: 13140},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 425, col: 11, offset: 13252},
+										pos: position{line: 445, col: 11, offset: 13140},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 425, col: 11, offset: 13252},
+												pos:  position{line: 445, col: 11, offset: 13140},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 425, col: 14, offset: 13255},
+												pos:   position{line: 445, col: 14, offset: 13143},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 425, col: 17, offset: 13258},
+													pos:  position{line: 445, col: 17, offset: 13146},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 425, col: 25, offset: 13266},
+												pos:  position{line: 445, col: 25, offset: 13154},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 425, col: 28, offset: 13269},
+												pos:   position{line: 445, col: 28, offset: 13157},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 425, col: 33, offset: 13274},
+													pos:  position{line: 445, col: 33, offset: 13162},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -3037,53 +3139,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 429, col: 1, offset: 13392},
+			pos:  position{line: 449, col: 1, offset: 13280},
 			expr: &actionExpr{
-				pos: position{line: 430, col: 5, offset: 13411},
+				pos: position{line: 450, col: 5, offset: 13299},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 430, col: 5, offset: 13411},
+					pos: position{line: 450, col: 5, offset: 13299},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 430, col: 5, offset: 13411},
+							pos:   position{line: 450, col: 5, offset: 13299},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 430, col: 11, offset: 13417},
+								pos:  position{line: 450, col: 11, offset: 13305},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 431, col: 5, offset: 13441},
+							pos:   position{line: 451, col: 5, offset: 13329},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 431, col: 10, offset: 13446},
+								pos: position{line: 451, col: 10, offset: 13334},
 								expr: &actionExpr{
-									pos: position{line: 431, col: 11, offset: 13447},
+									pos: position{line: 451, col: 11, offset: 13335},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 431, col: 11, offset: 13447},
+										pos: position{line: 451, col: 11, offset: 13335},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 431, col: 11, offset: 13447},
+												pos:  position{line: 451, col: 11, offset: 13335},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 431, col: 14, offset: 13450},
+												pos:   position{line: 451, col: 14, offset: 13338},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 431, col: 17, offset: 13453},
+													pos:  position{line: 451, col: 17, offset: 13341},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 431, col: 26, offset: 13462},
+												pos:  position{line: 451, col: 26, offset: 13350},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 431, col: 29, offset: 13465},
+												pos:   position{line: 451, col: 29, offset: 13353},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 431, col: 34, offset: 13470},
+													pos:  position{line: 451, col: 34, offset: 13358},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -3098,53 +3200,53 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 435, col: 1, offset: 13593},
+			pos:  position{line: 455, col: 1, offset: 13481},
 			expr: &actionExpr{
-				pos: position{line: 436, col: 5, offset: 13617},
+				pos: position{line: 456, col: 5, offset: 13505},
 				run: (*parser).callonEqualityCompareExpr1,
 				expr: &seqExpr{
-					pos: position{line: 436, col: 5, offset: 13617},
+					pos: position{line: 456, col: 5, offset: 13505},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 436, col: 5, offset: 13617},
+							pos:   position{line: 456, col: 5, offset: 13505},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 436, col: 11, offset: 13623},
+								pos:  position{line: 456, col: 11, offset: 13511},
 								name: "RelativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 437, col: 5, offset: 13640},
+							pos:   position{line: 457, col: 5, offset: 13528},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 437, col: 10, offset: 13645},
+								pos: position{line: 457, col: 10, offset: 13533},
 								expr: &actionExpr{
-									pos: position{line: 437, col: 11, offset: 13646},
+									pos: position{line: 457, col: 11, offset: 13534},
 									run: (*parser).callonEqualityCompareExpr7,
 									expr: &seqExpr{
-										pos: position{line: 437, col: 11, offset: 13646},
+										pos: position{line: 457, col: 11, offset: 13534},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 437, col: 11, offset: 13646},
+												pos:  position{line: 457, col: 11, offset: 13534},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 437, col: 14, offset: 13649},
+												pos:   position{line: 457, col: 14, offset: 13537},
 												label: "comp",
 												expr: &ruleRefExpr{
-													pos:  position{line: 437, col: 19, offset: 13654},
+													pos:  position{line: 457, col: 19, offset: 13542},
 													name: "EqualityComparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 437, col: 38, offset: 13673},
+												pos:  position{line: 457, col: 38, offset: 13561},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 437, col: 41, offset: 13676},
+												pos:   position{line: 457, col: 41, offset: 13564},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 437, col: 46, offset: 13681},
+													pos:  position{line: 457, col: 46, offset: 13569},
 													name: "RelativeExpr",
 												},
 											},
@@ -3159,30 +3261,20 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 441, col: 1, offset: 13799},
+			pos:  position{line: 461, col: 1, offset: 13687},
 			expr: &actionExpr{
-				pos: position{line: 441, col: 20, offset: 13818},
+				pos: position{line: 462, col: 5, offset: 13708},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 441, col: 21, offset: 13819},
+					pos: position{line: 462, col: 6, offset: 13709},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 441, col: 21, offset: 13819},
-							val:        "=~",
-							ignoreCase: false,
-						},
-						&litMatcher{
-							pos:        position{line: 441, col: 28, offset: 13826},
-							val:        "!~",
-							ignoreCase: false,
-						},
-						&litMatcher{
-							pos:        position{line: 441, col: 35, offset: 13833},
+							pos:        position{line: 462, col: 6, offset: 13709},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 441, col: 41, offset: 13839},
+							pos:        position{line: 462, col: 12, offset: 13715},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3192,19 +3284,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 443, col: 1, offset: 13877},
+			pos:  position{line: 464, col: 1, offset: 13753},
 			expr: &choiceExpr{
-				pos: position{line: 444, col: 5, offset: 13900},
+				pos: position{line: 465, col: 5, offset: 13776},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 444, col: 5, offset: 13900},
+						pos:  position{line: 465, col: 5, offset: 13776},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 445, col: 5, offset: 13921},
+						pos: position{line: 466, col: 5, offset: 13797},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 445, col: 5, offset: 13921},
+							pos:        position{line: 466, col: 5, offset: 13797},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3214,53 +3306,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 447, col: 1, offset: 13958},
+			pos:  position{line: 468, col: 1, offset: 13834},
 			expr: &actionExpr{
-				pos: position{line: 448, col: 5, offset: 13975},
+				pos: position{line: 469, col: 5, offset: 13851},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 448, col: 5, offset: 13975},
+					pos: position{line: 469, col: 5, offset: 13851},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 448, col: 5, offset: 13975},
+							pos:   position{line: 469, col: 5, offset: 13851},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 448, col: 11, offset: 13981},
+								pos:  position{line: 469, col: 11, offset: 13857},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 449, col: 5, offset: 13998},
+							pos:   position{line: 470, col: 5, offset: 13874},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 449, col: 10, offset: 14003},
+								pos: position{line: 470, col: 10, offset: 13879},
 								expr: &actionExpr{
-									pos: position{line: 449, col: 11, offset: 14004},
+									pos: position{line: 470, col: 11, offset: 13880},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 449, col: 11, offset: 14004},
+										pos: position{line: 470, col: 11, offset: 13880},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 449, col: 11, offset: 14004},
+												pos:  position{line: 470, col: 11, offset: 13880},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 449, col: 14, offset: 14007},
+												pos:   position{line: 470, col: 14, offset: 13883},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 449, col: 17, offset: 14010},
+													pos:  position{line: 470, col: 17, offset: 13886},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 449, col: 34, offset: 14027},
+												pos:  position{line: 470, col: 34, offset: 13903},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 449, col: 37, offset: 14030},
+												pos:   position{line: 470, col: 37, offset: 13906},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 449, col: 42, offset: 14035},
+													pos:  position{line: 470, col: 42, offset: 13911},
 													name: "AdditiveExpr",
 												},
 											},
@@ -3275,30 +3367,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 453, col: 1, offset: 14151},
+			pos:  position{line: 474, col: 1, offset: 14027},
 			expr: &actionExpr{
-				pos: position{line: 453, col: 20, offset: 14170},
+				pos: position{line: 474, col: 20, offset: 14046},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 453, col: 21, offset: 14171},
+					pos: position{line: 474, col: 21, offset: 14047},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 453, col: 21, offset: 14171},
+							pos:        position{line: 474, col: 21, offset: 14047},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 453, col: 28, offset: 14178},
+							pos:        position{line: 474, col: 28, offset: 14054},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 453, col: 34, offset: 14184},
+							pos:        position{line: 474, col: 34, offset: 14060},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 453, col: 41, offset: 14191},
+							pos:        position{line: 474, col: 41, offset: 14067},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -3308,53 +3400,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 455, col: 1, offset: 14228},
+			pos:  position{line: 476, col: 1, offset: 14104},
 			expr: &actionExpr{
-				pos: position{line: 456, col: 5, offset: 14245},
+				pos: position{line: 477, col: 5, offset: 14121},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 456, col: 5, offset: 14245},
+					pos: position{line: 477, col: 5, offset: 14121},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 456, col: 5, offset: 14245},
+							pos:   position{line: 477, col: 5, offset: 14121},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 456, col: 11, offset: 14251},
+								pos:  position{line: 477, col: 11, offset: 14127},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 457, col: 5, offset: 14274},
+							pos:   position{line: 478, col: 5, offset: 14150},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 457, col: 10, offset: 14279},
+								pos: position{line: 478, col: 10, offset: 14155},
 								expr: &actionExpr{
-									pos: position{line: 457, col: 11, offset: 14280},
+									pos: position{line: 478, col: 11, offset: 14156},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 457, col: 11, offset: 14280},
+										pos: position{line: 478, col: 11, offset: 14156},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 457, col: 11, offset: 14280},
+												pos:  position{line: 478, col: 11, offset: 14156},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 457, col: 14, offset: 14283},
+												pos:   position{line: 478, col: 14, offset: 14159},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 457, col: 17, offset: 14286},
+													pos:  position{line: 478, col: 17, offset: 14162},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 457, col: 34, offset: 14303},
+												pos:  position{line: 478, col: 34, offset: 14179},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 457, col: 37, offset: 14306},
+												pos:   position{line: 478, col: 37, offset: 14182},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 457, col: 42, offset: 14311},
+													pos:  position{line: 478, col: 42, offset: 14187},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -3369,20 +3461,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 461, col: 1, offset: 14433},
+			pos:  position{line: 482, col: 1, offset: 14309},
 			expr: &actionExpr{
-				pos: position{line: 461, col: 20, offset: 14452},
+				pos: position{line: 482, col: 20, offset: 14328},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 461, col: 21, offset: 14453},
+					pos: position{line: 482, col: 21, offset: 14329},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 461, col: 21, offset: 14453},
+							pos:        position{line: 482, col: 21, offset: 14329},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 461, col: 27, offset: 14459},
+							pos:        position{line: 482, col: 27, offset: 14335},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3392,53 +3484,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 463, col: 1, offset: 14496},
+			pos:  position{line: 484, col: 1, offset: 14372},
 			expr: &actionExpr{
-				pos: position{line: 464, col: 5, offset: 14519},
+				pos: position{line: 485, col: 5, offset: 14395},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 464, col: 5, offset: 14519},
+					pos: position{line: 485, col: 5, offset: 14395},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 464, col: 5, offset: 14519},
+							pos:   position{line: 485, col: 5, offset: 14395},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 464, col: 11, offset: 14525},
+								pos:  position{line: 485, col: 11, offset: 14401},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 465, col: 5, offset: 14537},
+							pos:   position{line: 486, col: 5, offset: 14413},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 465, col: 10, offset: 14542},
+								pos: position{line: 486, col: 10, offset: 14418},
 								expr: &actionExpr{
-									pos: position{line: 465, col: 11, offset: 14543},
+									pos: position{line: 486, col: 11, offset: 14419},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 465, col: 11, offset: 14543},
+										pos: position{line: 486, col: 11, offset: 14419},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 465, col: 11, offset: 14543},
+												pos:  position{line: 486, col: 11, offset: 14419},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 465, col: 14, offset: 14546},
+												pos:   position{line: 486, col: 14, offset: 14422},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 465, col: 17, offset: 14549},
+													pos:  position{line: 486, col: 17, offset: 14425},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 465, col: 40, offset: 14572},
+												pos:  position{line: 486, col: 40, offset: 14448},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 465, col: 43, offset: 14575},
+												pos:   position{line: 486, col: 43, offset: 14451},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 465, col: 48, offset: 14580},
+													pos:  position{line: 486, col: 48, offset: 14456},
 													name: "NotExpr",
 												},
 											},
@@ -3453,20 +3545,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 469, col: 1, offset: 14691},
+			pos:  position{line: 490, col: 1, offset: 14567},
 			expr: &actionExpr{
-				pos: position{line: 469, col: 26, offset: 14716},
+				pos: position{line: 490, col: 26, offset: 14592},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 469, col: 27, offset: 14717},
+					pos: position{line: 490, col: 27, offset: 14593},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 469, col: 27, offset: 14717},
+							pos:        position{line: 490, col: 27, offset: 14593},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 469, col: 33, offset: 14723},
+							pos:        position{line: 490, col: 33, offset: 14599},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -3476,30 +3568,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 471, col: 1, offset: 14760},
+			pos:  position{line: 492, col: 1, offset: 14636},
 			expr: &choiceExpr{
-				pos: position{line: 472, col: 5, offset: 14772},
+				pos: position{line: 493, col: 5, offset: 14648},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 472, col: 5, offset: 14772},
+						pos: position{line: 493, col: 5, offset: 14648},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 472, col: 5, offset: 14772},
+							pos: position{line: 493, col: 5, offset: 14648},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 472, col: 5, offset: 14772},
+									pos:        position{line: 493, col: 5, offset: 14648},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 472, col: 9, offset: 14776},
+									pos:  position{line: 493, col: 9, offset: 14652},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 472, col: 12, offset: 14779},
+									pos:   position{line: 493, col: 12, offset: 14655},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 472, col: 14, offset: 14781},
+										pos:  position{line: 493, col: 14, offset: 14657},
 										name: "NotExpr",
 									},
 								},
@@ -3507,7 +3599,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 475, col: 5, offset: 14894},
+						pos:  position{line: 496, col: 5, offset: 14770},
 						name: "CastExpr",
 					},
 				},
@@ -3515,43 +3607,43 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpr",
-			pos:  position{line: 477, col: 1, offset: 14904},
+			pos:  position{line: 498, col: 1, offset: 14780},
 			expr: &choiceExpr{
-				pos: position{line: 478, col: 5, offset: 14917},
+				pos: position{line: 499, col: 5, offset: 14793},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 478, col: 5, offset: 14917},
+						pos: position{line: 499, col: 5, offset: 14793},
 						run: (*parser).callonCastExpr2,
 						expr: &seqExpr{
-							pos: position{line: 478, col: 5, offset: 14917},
+							pos: position{line: 499, col: 5, offset: 14793},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 478, col: 5, offset: 14917},
+									pos:   position{line: 499, col: 5, offset: 14793},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 478, col: 7, offset: 14919},
+										pos:  position{line: 499, col: 7, offset: 14795},
 										name: "FuncExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 478, col: 16, offset: 14928},
+									pos:   position{line: 499, col: 16, offset: 14804},
 									label: "typ",
 									expr: &actionExpr{
-										pos: position{line: 478, col: 22, offset: 14934},
+										pos: position{line: 499, col: 22, offset: 14810},
 										run: (*parser).callonCastExpr7,
 										expr: &seqExpr{
-											pos: position{line: 478, col: 22, offset: 14934},
+											pos: position{line: 499, col: 22, offset: 14810},
 											exprs: []interface{}{
 												&litMatcher{
-													pos:        position{line: 478, col: 22, offset: 14934},
+													pos:        position{line: 499, col: 22, offset: 14810},
 													val:        ":",
 													ignoreCase: false,
 												},
 												&labeledExpr{
-													pos:   position{line: 478, col: 26, offset: 14938},
+													pos:   position{line: 499, col: 26, offset: 14814},
 													label: "typ",
 													expr: &ruleRefExpr{
-														pos:  position{line: 478, col: 30, offset: 14942},
+														pos:  position{line: 499, col: 30, offset: 14818},
 														name: "PrimitiveType",
 													},
 												},
@@ -3563,7 +3655,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 481, col: 5, offset: 15072},
+						pos:  position{line: 502, col: 5, offset: 14948},
 						name: "FuncExpr",
 					},
 				},
@@ -3571,115 +3663,115 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 484, col: 1, offset: 15083},
+			pos:  position{line: 505, col: 1, offset: 14959},
 			expr: &actionExpr{
-				pos: position{line: 485, col: 5, offset: 15101},
+				pos: position{line: 506, col: 5, offset: 14977},
 				run: (*parser).callonPrimitiveType1,
 				expr: &choiceExpr{
-					pos: position{line: 485, col: 9, offset: 15105},
+					pos: position{line: 506, col: 9, offset: 14981},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 485, col: 9, offset: 15105},
+							pos:        position{line: 506, col: 9, offset: 14981},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 19, offset: 15115},
+							pos:        position{line: 506, col: 19, offset: 14991},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 29, offset: 15125},
+							pos:        position{line: 506, col: 29, offset: 15001},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 40, offset: 15136},
+							pos:        position{line: 506, col: 40, offset: 15012},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 485, col: 51, offset: 15147},
+							pos:        position{line: 506, col: 51, offset: 15023},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 486, col: 9, offset: 15164},
+							pos:        position{line: 507, col: 9, offset: 15040},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 486, col: 18, offset: 15173},
+							pos:        position{line: 507, col: 18, offset: 15049},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 486, col: 28, offset: 15183},
+							pos:        position{line: 507, col: 28, offset: 15059},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 486, col: 38, offset: 15193},
+							pos:        position{line: 507, col: 38, offset: 15069},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 487, col: 9, offset: 15209},
+							pos:        position{line: 508, col: 9, offset: 15085},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 487, col: 22, offset: 15222},
+							pos:        position{line: 508, col: 22, offset: 15098},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 488, col: 9, offset: 15237},
+							pos:        position{line: 509, col: 9, offset: 15113},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 9, offset: 15255},
+							pos:        position{line: 510, col: 9, offset: 15131},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 18, offset: 15264},
+							pos:        position{line: 510, col: 18, offset: 15140},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 28, offset: 15274},
+							pos:        position{line: 510, col: 28, offset: 15150},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 489, col: 39, offset: 15285},
+							pos:        position{line: 510, col: 39, offset: 15161},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 490, col: 9, offset: 15303},
+							pos:        position{line: 511, col: 9, offset: 15179},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 490, col: 16, offset: 15310},
+							pos:        position{line: 511, col: 16, offset: 15186},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 491, col: 9, offset: 15324},
+							pos:        position{line: 512, col: 9, offset: 15200},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 491, col: 18, offset: 15333},
+							pos:        position{line: 512, col: 18, offset: 15209},
 							val:        "error",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 491, col: 28, offset: 15343},
+							pos:        position{line: 512, col: 28, offset: 15219},
 							val:        "null",
 							ignoreCase: false,
 						},
@@ -3689,31 +3781,39 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 493, col: 1, offset: 15384},
+			pos:  position{line: 514, col: 1, offset: 15260},
 			expr: &choiceExpr{
-				pos: position{line: 494, col: 5, offset: 15397},
+				pos: position{line: 515, col: 5, offset: 15273},
 				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 515, col: 5, offset: 15273},
+						name: "SelectExpr",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 516, col: 5, offset: 15288},
+						name: "MatchExpr",
+					},
 					&actionExpr{
-						pos: position{line: 494, col: 5, offset: 15397},
-						run: (*parser).callonFuncExpr2,
+						pos: position{line: 517, col: 5, offset: 15302},
+						run: (*parser).callonFuncExpr4,
 						expr: &seqExpr{
-							pos: position{line: 494, col: 5, offset: 15397},
+							pos: position{line: 517, col: 5, offset: 15302},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 494, col: 5, offset: 15397},
+									pos:   position{line: 517, col: 5, offset: 15302},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 494, col: 11, offset: 15403},
+										pos:  position{line: 517, col: 11, offset: 15308},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 494, col: 20, offset: 15412},
+									pos:   position{line: 517, col: 20, offset: 15317},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 494, col: 25, offset: 15417},
+										pos: position{line: 517, col: 25, offset: 15322},
 										expr: &ruleRefExpr{
-											pos:  position{line: 494, col: 26, offset: 15418},
+											pos:  position{line: 517, col: 26, offset: 15323},
 											name: "Deref",
 										},
 									},
@@ -3722,52 +3822,49 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 497, col: 5, offset: 15489},
+						pos:  position{line: 520, col: 5, offset: 15394},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 498, col: 5, offset: 15503},
+						pos:  position{line: 521, col: 5, offset: 15408},
 						name: "Primary",
 					},
 				},
 			},
 		},
 		{
-			name: "Function",
-			pos:  position{line: 500, col: 1, offset: 15512},
+			name: "MatchExpr",
+			pos:  position{line: 523, col: 1, offset: 15417},
 			expr: &actionExpr{
-				pos: position{line: 501, col: 5, offset: 15525},
-				run: (*parser).callonFunction1,
+				pos: position{line: 524, col: 5, offset: 15431},
+				run: (*parser).callonMatchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 501, col: 5, offset: 15525},
+					pos: position{line: 524, col: 5, offset: 15431},
 					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 501, col: 5, offset: 15525},
-							label: "fn",
-							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 8, offset: 15528},
-								name: "DeprecatedName",
-							},
+						&litMatcher{
+							pos:        position{line: 524, col: 5, offset: 15431},
+							val:        "match",
+							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 501, col: 23, offset: 15543},
+							pos:  position{line: 524, col: 13, offset: 15439},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 501, col: 26, offset: 15546},
+							pos:        position{line: 524, col: 16, offset: 15442},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 501, col: 30, offset: 15550},
-							label: "args",
+							pos:   position{line: 524, col: 20, offset: 15446},
+							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 501, col: 35, offset: 15555},
-								name: "ArgumentList",
+								pos:  position{line: 524, col: 25, offset: 15451},
+								name: "SearchBoolean",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 501, col: 48, offset: 15568},
+							pos:        position{line: 524, col: 39, offset: 15465},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -3776,31 +3873,82 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "DeprecatedName",
-			pos:  position{line: 507, col: 1, offset: 15800},
+			name: "SelectExpr",
+			pos:  position{line: 526, col: 1, offset: 15491},
 			expr: &actionExpr{
-				pos: position{line: 507, col: 18, offset: 15817},
-				run: (*parser).callonDeprecatedName1,
+				pos: position{line: 527, col: 5, offset: 15506},
+				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 507, col: 18, offset: 15817},
+					pos: position{line: 527, col: 5, offset: 15506},
 					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 507, col: 18, offset: 15817},
-							name: "IdentifierStart",
+						&litMatcher{
+							pos:        position{line: 527, col: 5, offset: 15506},
+							val:        "select",
+							ignoreCase: false,
 						},
-						&zeroOrMoreExpr{
-							pos: position{line: 507, col: 34, offset: 15833},
-							expr: &choiceExpr{
-								pos: position{line: 507, col: 35, offset: 15834},
-								alternatives: []interface{}{
-									&ruleRefExpr{
-										pos:  position{line: 507, col: 35, offset: 15834},
-										name: "IdentifierRest",
-									},
-									&litMatcher{
-										pos:        position{line: 507, col: 52, offset: 15851},
-										val:        ".",
-										ignoreCase: false,
+						&ruleRefExpr{
+							pos:  position{line: 527, col: 14, offset: 15515},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 527, col: 17, offset: 15518},
+							val:        "(",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 527, col: 21, offset: 15522},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 527, col: 24, offset: 15525},
+							label: "args",
+							expr: &ruleRefExpr{
+								pos:  position{line: 527, col: 29, offset: 15530},
+								name: "ArgumentList",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 527, col: 42, offset: 15543},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 527, col: 45, offset: 15546},
+							val:        ")",
+							ignoreCase: false,
+						},
+						&labeledExpr{
+							pos:   position{line: 527, col: 49, offset: 15550},
+							label: "methods",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 527, col: 57, offset: 15558},
+								expr: &actionExpr{
+									pos: position{line: 527, col: 58, offset: 15559},
+									run: (*parser).callonSelectExpr13,
+									expr: &seqExpr{
+										pos: position{line: 527, col: 58, offset: 15559},
+										exprs: []interface{}{
+											&ruleRefExpr{
+												pos:  position{line: 527, col: 58, offset: 15559},
+												name: "__",
+											},
+											&litMatcher{
+												pos:        position{line: 527, col: 61, offset: 15562},
+												val:        ".",
+												ignoreCase: false,
+											},
+											&ruleRefExpr{
+												pos:  position{line: 527, col: 65, offset: 15566},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 527, col: 68, offset: 15569},
+												label: "e",
+												expr: &ruleRefExpr{
+													pos:  position{line: 527, col: 70, offset: 15571},
+													name: "Function",
+												},
+											},
+										},
 									},
 								},
 							},
@@ -3810,54 +3958,105 @@ var g = &grammar{
 			},
 		},
 		{
+			name: "Function",
+			pos:  position{line: 531, col: 1, offset: 15737},
+			expr: &actionExpr{
+				pos: position{line: 532, col: 5, offset: 15750},
+				run: (*parser).callonFunction1,
+				expr: &seqExpr{
+					pos: position{line: 532, col: 5, offset: 15750},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 532, col: 5, offset: 15750},
+							label: "fn",
+							expr: &ruleRefExpr{
+								pos:  position{line: 532, col: 8, offset: 15753},
+								name: "IdentifierName",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 532, col: 23, offset: 15768},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 532, col: 26, offset: 15771},
+							val:        "(",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 532, col: 30, offset: 15775},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 532, col: 33, offset: 15778},
+							label: "args",
+							expr: &ruleRefExpr{
+								pos:  position{line: 532, col: 38, offset: 15783},
+								name: "ArgumentList",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 532, col: 51, offset: 15796},
+							name: "__",
+						},
+						&litMatcher{
+							pos:        position{line: 532, col: 54, offset: 15799},
+							val:        ")",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "ArgumentList",
-			pos:  position{line: 509, col: 1, offset: 15889},
+			pos:  position{line: 536, col: 1, offset: 15905},
 			expr: &choiceExpr{
-				pos: position{line: 510, col: 5, offset: 15906},
+				pos: position{line: 537, col: 5, offset: 15922},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 510, col: 5, offset: 15906},
+						pos: position{line: 537, col: 5, offset: 15922},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 510, col: 5, offset: 15906},
+							pos: position{line: 537, col: 5, offset: 15922},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 510, col: 5, offset: 15906},
+									pos:   position{line: 537, col: 5, offset: 15922},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 510, col: 11, offset: 15912},
+										pos:  position{line: 537, col: 11, offset: 15928},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 510, col: 16, offset: 15917},
+									pos:   position{line: 537, col: 16, offset: 15933},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 510, col: 21, offset: 15922},
+										pos: position{line: 537, col: 21, offset: 15938},
 										expr: &actionExpr{
-											pos: position{line: 510, col: 22, offset: 15923},
+											pos: position{line: 537, col: 22, offset: 15939},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 510, col: 22, offset: 15923},
+												pos: position{line: 537, col: 22, offset: 15939},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 510, col: 22, offset: 15923},
+														pos:  position{line: 537, col: 22, offset: 15939},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 510, col: 25, offset: 15926},
+														pos:        position{line: 537, col: 25, offset: 15942},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 510, col: 29, offset: 15930},
+														pos:  position{line: 537, col: 29, offset: 15946},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 510, col: 32, offset: 15933},
+														pos:   position{line: 537, col: 32, offset: 15949},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 510, col: 34, offset: 15935},
+															pos:  position{line: 537, col: 34, offset: 15951},
 															name: "Expr",
 														},
 													},
@@ -3870,10 +4069,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 513, col: 5, offset: 16047},
+						pos: position{line: 540, col: 5, offset: 16063},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 513, col: 5, offset: 16047},
+							pos:  position{line: 540, col: 5, offset: 16063},
 							name: "__",
 						},
 					},
@@ -3882,29 +4081,134 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 515, col: 1, offset: 16083},
-			expr: &actionExpr{
-				pos: position{line: 516, col: 5, offset: 16097},
-				run: (*parser).callonDerefExpr1,
-				expr: &seqExpr{
-					pos: position{line: 516, col: 5, offset: 16097},
-					exprs: []interface{}{
-						&labeledExpr{
-							pos:   position{line: 516, col: 5, offset: 16097},
-							label: "first",
-							expr: &ruleRefExpr{
-								pos:  position{line: 516, col: 11, offset: 16103},
-								name: "RootField",
+			pos:  position{line: 542, col: 1, offset: 16099},
+			expr: &choiceExpr{
+				pos: position{line: 543, col: 5, offset: 16113},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 543, col: 5, offset: 16113},
+						run: (*parser).callonDerefExpr2,
+						expr: &seqExpr{
+							pos: position{line: 543, col: 5, offset: 16113},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 543, col: 5, offset: 16113},
+									label: "first",
+									expr: &ruleRefExpr{
+										pos:  position{line: 543, col: 11, offset: 16119},
+										name: "DotId",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 543, col: 17, offset: 16125},
+									label: "rest",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 543, col: 22, offset: 16130},
+										expr: &ruleRefExpr{
+											pos:  position{line: 543, col: 23, offset: 16131},
+											name: "Deref",
+										},
+									},
+								},
 							},
 						},
-						&labeledExpr{
-							pos:   position{line: 516, col: 21, offset: 16113},
-							label: "rest",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 516, col: 26, offset: 16118},
-								expr: &ruleRefExpr{
-									pos:  position{line: 516, col: 27, offset: 16119},
-									name: "Deref",
+					},
+					&actionExpr{
+						pos: position{line: 546, col: 5, offset: 16202},
+						run: (*parser).callonDerefExpr9,
+						expr: &seqExpr{
+							pos: position{line: 546, col: 5, offset: 16202},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 546, col: 5, offset: 16202},
+									label: "first",
+									expr: &ruleRefExpr{
+										pos:  position{line: 546, col: 11, offset: 16208},
+										name: "Identifier",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 546, col: 22, offset: 16219},
+									label: "rest",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 546, col: 27, offset: 16224},
+										expr: &ruleRefExpr{
+											pos:  position{line: 546, col: 28, offset: 16225},
+											name: "Deref",
+										},
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 549, col: 5, offset: 16296},
+						run: (*parser).callonDerefExpr16,
+						expr: &litMatcher{
+							pos:        position{line: 549, col: 5, offset: 16296},
+							val:        ".",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "DotId",
+			pos:  position{line: 553, col: 1, offset: 16369},
+			expr: &choiceExpr{
+				pos: position{line: 554, col: 5, offset: 16379},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 554, col: 5, offset: 16379},
+						run: (*parser).callonDotId2,
+						expr: &seqExpr{
+							pos: position{line: 554, col: 5, offset: 16379},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 554, col: 5, offset: 16379},
+									val:        ".",
+									ignoreCase: false,
+								},
+								&labeledExpr{
+									pos:   position{line: 554, col: 9, offset: 16383},
+									label: "field",
+									expr: &ruleRefExpr{
+										pos:  position{line: 554, col: 15, offset: 16389},
+										name: "Identifier",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 563, col: 5, offset: 16613},
+						run: (*parser).callonDotId7,
+						expr: &seqExpr{
+							pos: position{line: 563, col: 5, offset: 16613},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 563, col: 5, offset: 16613},
+									val:        ".",
+									ignoreCase: false,
+								},
+								&litMatcher{
+									pos:        position{line: 563, col: 9, offset: 16617},
+									val:        "[",
+									ignoreCase: false,
+								},
+								&labeledExpr{
+									pos:   position{line: 563, col: 13, offset: 16621},
+									label: "expr",
+									expr: &ruleRefExpr{
+										pos:  position{line: 563, col: 18, offset: 16626},
+										name: "Expr",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 563, col: 23, offset: 16631},
+									val:        "]",
+									ignoreCase: false,
 								},
 							},
 						},
@@ -3914,31 +4218,31 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 520, col: 1, offset: 16187},
+			pos:  position{line: 573, col: 1, offset: 16844},
 			expr: &choiceExpr{
-				pos: position{line: 521, col: 5, offset: 16197},
+				pos: position{line: 574, col: 5, offset: 16854},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 521, col: 5, offset: 16197},
+						pos: position{line: 574, col: 5, offset: 16854},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 521, col: 5, offset: 16197},
+							pos: position{line: 574, col: 5, offset: 16854},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 521, col: 5, offset: 16197},
+									pos:        position{line: 574, col: 5, offset: 16854},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 521, col: 9, offset: 16201},
+									pos:   position{line: 574, col: 9, offset: 16858},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 521, col: 14, offset: 16206},
+										pos:  position{line: 574, col: 14, offset: 16863},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 521, col: 19, offset: 16211},
+									pos:        position{line: 574, col: 19, offset: 16868},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -3946,29 +4250,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 522, col: 5, offset: 16260},
+						pos: position{line: 575, col: 5, offset: 16917},
 						run: (*parser).callonDeref8,
 						expr: &seqExpr{
-							pos: position{line: 522, col: 5, offset: 16260},
+							pos: position{line: 575, col: 5, offset: 16917},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 522, col: 5, offset: 16260},
+									pos:        position{line: 575, col: 5, offset: 16917},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 522, col: 9, offset: 16264},
+									pos: position{line: 575, col: 9, offset: 16921},
 									expr: &litMatcher{
-										pos:        position{line: 522, col: 11, offset: 16266},
+										pos:        position{line: 575, col: 11, offset: 16923},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 522, col: 16, offset: 16271},
+									pos:   position{line: 575, col: 16, offset: 16928},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 522, col: 19, offset: 16274},
+										pos:  position{line: 575, col: 19, offset: 16931},
 										name: "Identifier",
 									},
 								},
@@ -3980,71 +4284,43 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 524, col: 1, offset: 16325},
+			pos:  position{line: 577, col: 1, offset: 16982},
 			expr: &choiceExpr{
-				pos: position{line: 525, col: 5, offset: 16337},
+				pos: position{line: 578, col: 5, offset: 16994},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 525, col: 5, offset: 16337},
-						name: "StringLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 526, col: 5, offset: 16355},
-						name: "RegexpLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 527, col: 5, offset: 16373},
-						name: "SubnetLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 528, col: 5, offset: 16391},
-						name: "AddressLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 529, col: 5, offset: 16410},
-						name: "FloatLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 530, col: 5, offset: 16427},
-						name: "IntegerLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 531, col: 5, offset: 16446},
-						name: "BooleanLiteral",
-					},
-					&ruleRefExpr{
-						pos:  position{line: 532, col: 5, offset: 16465},
-						name: "NullLiteral",
+						pos:  position{line: 578, col: 5, offset: 16994},
+						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 533, col: 5, offset: 16481},
-						run: (*parser).callonPrimary10,
+						pos: position{line: 579, col: 5, offset: 17006},
+						run: (*parser).callonPrimary3,
 						expr: &seqExpr{
-							pos: position{line: 533, col: 5, offset: 16481},
+							pos: position{line: 579, col: 5, offset: 17006},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 533, col: 5, offset: 16481},
+									pos:        position{line: 579, col: 5, offset: 17006},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 533, col: 9, offset: 16485},
+									pos:  position{line: 579, col: 9, offset: 17010},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 533, col: 12, offset: 16488},
+									pos:   position{line: 579, col: 12, offset: 17013},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 533, col: 17, offset: 16493},
+										pos:  position{line: 579, col: 17, offset: 17018},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 533, col: 22, offset: 16498},
+									pos:  position{line: 579, col: 22, offset: 17023},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 533, col: 25, offset: 16501},
+									pos:        position{line: 579, col: 25, offset: 17026},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -4055,92 +4331,84 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "EqualityToken",
-			pos:  position{line: 535, col: 1, offset: 16527},
+			name: "Literal",
+			pos:  position{line: 581, col: 1, offset: 17052},
 			expr: &choiceExpr{
-				pos: position{line: 536, col: 5, offset: 16545},
+				pos: position{line: 582, col: 5, offset: 17064},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 536, col: 5, offset: 16545},
-						name: "EqualityOperator",
+						pos:  position{line: 582, col: 5, offset: 17064},
+						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 536, col: 24, offset: 16564},
-						name: "RelativeOperator",
+						pos:  position{line: 583, col: 5, offset: 17082},
+						name: "RegexpLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 584, col: 5, offset: 17100},
+						name: "SubnetLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 585, col: 5, offset: 17118},
+						name: "AddressLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 586, col: 5, offset: 17137},
+						name: "FloatLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 587, col: 5, offset: 17154},
+						name: "IntegerLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 588, col: 5, offset: 17173},
+						name: "BooleanLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 589, col: 5, offset: 17192},
+						name: "NullLiteral",
 					},
 				},
 			},
 		},
 		{
-			name: "AndToken",
-			pos:  position{line: 538, col: 1, offset: 16582},
+			name: "StringLiteral",
+			pos:  position{line: 591, col: 1, offset: 17205},
 			expr: &actionExpr{
-				pos: position{line: 538, col: 12, offset: 16593},
-				run: (*parser).callonAndToken1,
-				expr: &litMatcher{
-					pos:        position{line: 538, col: 12, offset: 16593},
-					val:        "and",
-					ignoreCase: true,
+				pos: position{line: 592, col: 5, offset: 17223},
+				run: (*parser).callonStringLiteral1,
+				expr: &labeledExpr{
+					pos:   position{line: 592, col: 5, offset: 17223},
+					label: "v",
+					expr: &ruleRefExpr{
+						pos:  position{line: 592, col: 7, offset: 17225},
+						name: "QuotedString",
+					},
 				},
 			},
 		},
 		{
-			name: "OrToken",
-			pos:  position{line: 539, col: 1, offset: 16631},
+			name: "RegexpLiteral",
+			pos:  position{line: 596, col: 1, offset: 17335},
 			expr: &actionExpr{
-				pos: position{line: 539, col: 11, offset: 16641},
-				run: (*parser).callonOrToken1,
-				expr: &litMatcher{
-					pos:        position{line: 539, col: 11, offset: 16641},
-					val:        "or",
-					ignoreCase: true,
-				},
-			},
-		},
-		{
-			name: "InToken",
-			pos:  position{line: 540, col: 1, offset: 16678},
-			expr: &actionExpr{
-				pos: position{line: 540, col: 11, offset: 16688},
-				run: (*parser).callonInToken1,
-				expr: &litMatcher{
-					pos:        position{line: 540, col: 11, offset: 16688},
-					val:        "in",
-					ignoreCase: true,
-				},
-			},
-		},
-		{
-			name: "NotToken",
-			pos:  position{line: 541, col: 1, offset: 16725},
-			expr: &actionExpr{
-				pos: position{line: 541, col: 12, offset: 16736},
-				run: (*parser).callonNotToken1,
-				expr: &litMatcher{
-					pos:        position{line: 541, col: 12, offset: 16736},
-					val:        "not",
-					ignoreCase: true,
-				},
-			},
-		},
-		{
-			name: "IdentifierName",
-			pos:  position{line: 543, col: 1, offset: 16775},
-			expr: &actionExpr{
-				pos: position{line: 543, col: 18, offset: 16792},
-				run: (*parser).callonIdentifierName1,
+				pos: position{line: 597, col: 5, offset: 17353},
+				run: (*parser).callonRegexpLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 543, col: 18, offset: 16792},
+					pos: position{line: 597, col: 5, offset: 17353},
 					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 543, col: 18, offset: 16792},
-							name: "IdentifierStart",
-						},
-						&zeroOrMoreExpr{
-							pos: position{line: 543, col: 34, offset: 16808},
+						&labeledExpr{
+							pos:   position{line: 597, col: 5, offset: 17353},
+							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 34, offset: 16808},
-								name: "IdentifierRest",
+								pos:  position{line: 597, col: 7, offset: 17355},
+								name: "Regexp",
+							},
+						},
+						&notExpr{
+							pos: position{line: 597, col: 14, offset: 17362},
+							expr: &ruleRefExpr{
+								pos:  position{line: 597, col: 15, offset: 17363},
+								name: "KeyWordStart",
 							},
 						},
 					},
@@ -4148,10 +4416,254 @@ var g = &grammar{
 			},
 		},
 		{
+			name: "SubnetLiteral",
+			pos:  position{line: 601, col: 1, offset: 17473},
+			expr: &choiceExpr{
+				pos: position{line: 602, col: 5, offset: 17491},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 602, col: 5, offset: 17491},
+						run: (*parser).callonSubnetLiteral2,
+						expr: &seqExpr{
+							pos: position{line: 602, col: 5, offset: 17491},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 602, col: 5, offset: 17491},
+									label: "v",
+									expr: &ruleRefExpr{
+										pos:  position{line: 602, col: 7, offset: 17493},
+										name: "IP6Net",
+									},
+								},
+								&notExpr{
+									pos: position{line: 602, col: 14, offset: 17500},
+									expr: &ruleRefExpr{
+										pos:  position{line: 602, col: 15, offset: 17501},
+										name: "IdentifierRest",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 605, col: 5, offset: 17613},
+						run: (*parser).callonSubnetLiteral8,
+						expr: &labeledExpr{
+							pos:   position{line: 605, col: 5, offset: 17613},
+							label: "v",
+							expr: &ruleRefExpr{
+								pos:  position{line: 605, col: 7, offset: 17615},
+								name: "IP4Net",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "AddressLiteral",
+			pos:  position{line: 609, col: 1, offset: 17716},
+			expr: &choiceExpr{
+				pos: position{line: 610, col: 5, offset: 17735},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 610, col: 5, offset: 17735},
+						run: (*parser).callonAddressLiteral2,
+						expr: &seqExpr{
+							pos: position{line: 610, col: 5, offset: 17735},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 610, col: 5, offset: 17735},
+									label: "v",
+									expr: &ruleRefExpr{
+										pos:  position{line: 610, col: 7, offset: 17737},
+										name: "IP6",
+									},
+								},
+								&notExpr{
+									pos: position{line: 610, col: 11, offset: 17741},
+									expr: &ruleRefExpr{
+										pos:  position{line: 610, col: 12, offset: 17742},
+										name: "IdentifierRest",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 613, col: 5, offset: 17853},
+						run: (*parser).callonAddressLiteral8,
+						expr: &labeledExpr{
+							pos:   position{line: 613, col: 5, offset: 17853},
+							label: "v",
+							expr: &ruleRefExpr{
+								pos:  position{line: 613, col: 7, offset: 17855},
+								name: "IP",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "FloatLiteral",
+			pos:  position{line: 617, col: 1, offset: 17951},
+			expr: &actionExpr{
+				pos: position{line: 618, col: 5, offset: 17968},
+				run: (*parser).callonFloatLiteral1,
+				expr: &labeledExpr{
+					pos:   position{line: 618, col: 5, offset: 17968},
+					label: "v",
+					expr: &ruleRefExpr{
+						pos:  position{line: 618, col: 7, offset: 17970},
+						name: "FloatString",
+					},
+				},
+			},
+		},
+		{
+			name: "IntegerLiteral",
+			pos:  position{line: 622, col: 1, offset: 18080},
+			expr: &actionExpr{
+				pos: position{line: 623, col: 5, offset: 18099},
+				run: (*parser).callonIntegerLiteral1,
+				expr: &labeledExpr{
+					pos:   position{line: 623, col: 5, offset: 18099},
+					label: "v",
+					expr: &ruleRefExpr{
+						pos:  position{line: 623, col: 7, offset: 18101},
+						name: "IntString",
+					},
+				},
+			},
+		},
+		{
+			name: "BooleanLiteral",
+			pos:  position{line: 627, col: 1, offset: 18207},
+			expr: &choiceExpr{
+				pos: position{line: 628, col: 5, offset: 18226},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 628, col: 5, offset: 18226},
+						run: (*parser).callonBooleanLiteral2,
+						expr: &litMatcher{
+							pos:        position{line: 628, col: 5, offset: 18226},
+							val:        "true",
+							ignoreCase: false,
+						},
+					},
+					&actionExpr{
+						pos: position{line: 629, col: 5, offset: 18336},
+						run: (*parser).callonBooleanLiteral4,
+						expr: &litMatcher{
+							pos:        position{line: 629, col: 5, offset: 18336},
+							val:        "false",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "NullLiteral",
+			pos:  position{line: 631, col: 1, offset: 18444},
+			expr: &actionExpr{
+				pos: position{line: 632, col: 5, offset: 18460},
+				run: (*parser).callonNullLiteral1,
+				expr: &litMatcher{
+					pos:        position{line: 632, col: 5, offset: 18460},
+					val:        "null",
+					ignoreCase: false,
+				},
+			},
+		},
+		{
+			name: "EqualityToken",
+			pos:  position{line: 634, col: 1, offset: 18563},
+			expr: &choiceExpr{
+				pos: position{line: 635, col: 5, offset: 18581},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 635, col: 5, offset: 18581},
+						name: "EqualityOperator",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 635, col: 24, offset: 18600},
+						name: "RelativeOperator",
+					},
+				},
+			},
+		},
+		{
+			name: "AndToken",
+			pos:  position{line: 637, col: 1, offset: 18618},
+			expr: &actionExpr{
+				pos: position{line: 637, col: 12, offset: 18629},
+				run: (*parser).callonAndToken1,
+				expr: &litMatcher{
+					pos:        position{line: 637, col: 12, offset: 18629},
+					val:        "and",
+					ignoreCase: true,
+				},
+			},
+		},
+		{
+			name: "OrToken",
+			pos:  position{line: 638, col: 1, offset: 18658},
+			expr: &actionExpr{
+				pos: position{line: 638, col: 11, offset: 18668},
+				run: (*parser).callonOrToken1,
+				expr: &litMatcher{
+					pos:        position{line: 638, col: 11, offset: 18668},
+					val:        "or",
+					ignoreCase: true,
+				},
+			},
+		},
+		{
+			name: "InToken",
+			pos:  position{line: 639, col: 1, offset: 18695},
+			expr: &actionExpr{
+				pos: position{line: 639, col: 11, offset: 18705},
+				run: (*parser).callonInToken1,
+				expr: &litMatcher{
+					pos:        position{line: 639, col: 11, offset: 18705},
+					val:        "in",
+					ignoreCase: true,
+				},
+			},
+		},
+		{
+			name: "NotToken",
+			pos:  position{line: 640, col: 1, offset: 18732},
+			expr: &actionExpr{
+				pos: position{line: 640, col: 12, offset: 18743},
+				run: (*parser).callonNotToken1,
+				expr: &litMatcher{
+					pos:        position{line: 640, col: 12, offset: 18743},
+					val:        "not",
+					ignoreCase: true,
+				},
+			},
+		},
+		{
+			name: "ByToken",
+			pos:  position{line: 641, col: 1, offset: 18772},
+			expr: &actionExpr{
+				pos: position{line: 641, col: 11, offset: 18782},
+				run: (*parser).callonByToken1,
+				expr: &litMatcher{
+					pos:        position{line: 641, col: 11, offset: 18782},
+					val:        "by",
+					ignoreCase: true,
+				},
+			},
+		},
+		{
 			name: "IdentifierStart",
-			pos:  position{line: 545, col: 1, offset: 16856},
+			pos:  position{line: 643, col: 1, offset: 18810},
 			expr: &charClassMatcher{
-				pos:        position{line: 545, col: 19, offset: 16874},
+				pos:        position{line: 643, col: 19, offset: 18828},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -4161,16 +4673,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 546, col: 1, offset: 16885},
+			pos:  position{line: 644, col: 1, offset: 18839},
 			expr: &choiceExpr{
-				pos: position{line: 546, col: 18, offset: 16902},
+				pos: position{line: 644, col: 18, offset: 18856},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 546, col: 18, offset: 16902},
+						pos:  position{line: 644, col: 18, offset: 18856},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 546, col: 36, offset: 16920},
+						pos:        position{line: 644, col: 36, offset: 18874},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -4181,22 +4693,90 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 548, col: 1, offset: 16927},
+			pos:  position{line: 646, col: 1, offset: 18881},
 			expr: &actionExpr{
-				pos: position{line: 549, col: 5, offset: 16942},
+				pos: position{line: 647, col: 5, offset: 18896},
 				run: (*parser).callonIdentifier1,
-				expr: &seqExpr{
-					pos: position{line: 549, col: 5, offset: 16942},
-					exprs: []interface{}{
-						&ruleRefExpr{
-							pos:  position{line: 549, col: 5, offset: 16942},
-							name: "IdentifierStart",
+				expr: &labeledExpr{
+					pos:   position{line: 647, col: 5, offset: 18896},
+					label: "id",
+					expr: &ruleRefExpr{
+						pos:  position{line: 647, col: 8, offset: 18899},
+						name: "IdentifierName",
+					},
+				},
+			},
+		},
+		{
+			name: "IdentifierName",
+			pos:  position{line: 649, col: 1, offset: 18986},
+			expr: &choiceExpr{
+				pos: position{line: 650, col: 5, offset: 19005},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 650, col: 5, offset: 19005},
+						run: (*parser).callonIdentifierName2,
+						expr: &seqExpr{
+							pos: position{line: 650, col: 5, offset: 19005},
+							exprs: []interface{}{
+								&notExpr{
+									pos: position{line: 650, col: 5, offset: 19005},
+									expr: &seqExpr{
+										pos: position{line: 650, col: 7, offset: 19007},
+										exprs: []interface{}{
+											&ruleRefExpr{
+												pos:  position{line: 650, col: 7, offset: 19007},
+												name: "IdGuard",
+											},
+											&ruleRefExpr{
+												pos:  position{line: 650, col: 15, offset: 19015},
+												name: "EOT",
+											},
+										},
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 650, col: 20, offset: 19020},
+									name: "IdentifierStart",
+								},
+								&zeroOrMoreExpr{
+									pos: position{line: 650, col: 36, offset: 19036},
+									expr: &ruleRefExpr{
+										pos:  position{line: 650, col: 36, offset: 19036},
+										name: "IdentifierRest",
+									},
+								},
+							},
 						},
-						&zeroOrMoreExpr{
-							pos: position{line: 549, col: 21, offset: 16958},
-							expr: &ruleRefExpr{
-								pos:  position{line: 549, col: 21, offset: 16958},
-								name: "IdentifierRest",
+					},
+					&actionExpr{
+						pos: position{line: 651, col: 5, offset: 19088},
+						run: (*parser).callonIdentifierName11,
+						expr: &litMatcher{
+							pos:        position{line: 651, col: 5, offset: 19088},
+							val:        "$",
+							ignoreCase: false,
+						},
+					},
+					&actionExpr{
+						pos: position{line: 652, col: 5, offset: 19127},
+						run: (*parser).callonIdentifierName13,
+						expr: &seqExpr{
+							pos: position{line: 652, col: 5, offset: 19127},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 652, col: 5, offset: 19127},
+									val:        "\\",
+									ignoreCase: false,
+								},
+								&labeledExpr{
+									pos:   position{line: 652, col: 10, offset: 19132},
+									label: "id",
+									expr: &ruleRefExpr{
+										pos:  position{line: 652, col: 13, offset: 19135},
+										name: "IdGuard",
+									},
+								},
 							},
 						},
 					},
@@ -4204,55 +4784,76 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "Duration",
-			pos:  position{line: 551, col: 1, offset: 17058},
+			name: "IdGuard",
+			pos:  position{line: 654, col: 1, offset: 19163},
 			expr: &choiceExpr{
-				pos: position{line: 552, col: 5, offset: 17071},
+				pos: position{line: 655, col: 5, offset: 19175},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 552, col: 5, offset: 17071},
+						pos:  position{line: 655, col: 5, offset: 19175},
+						name: "BooleanLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 656, col: 5, offset: 19194},
+						name: "NullLiteral",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 657, col: 5, offset: 19210},
+						name: "SearchGuard",
+					},
+				},
+			},
+		},
+		{
+			name: "Duration",
+			pos:  position{line: 659, col: 1, offset: 19223},
+			expr: &choiceExpr{
+				pos: position{line: 660, col: 5, offset: 19236},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 660, col: 5, offset: 19236},
 						name: "Seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 553, col: 5, offset: 17083},
+						pos:  position{line: 661, col: 5, offset: 19248},
 						name: "Minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 554, col: 5, offset: 17095},
+						pos:  position{line: 662, col: 5, offset: 19260},
 						name: "Hours",
 					},
 					&seqExpr{
-						pos: position{line: 555, col: 5, offset: 17105},
+						pos: position{line: 663, col: 5, offset: 19270},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 555, col: 5, offset: 17105},
+								pos:  position{line: 663, col: 5, offset: 19270},
 								name: "Hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 555, col: 11, offset: 17111},
+								pos:  position{line: 663, col: 11, offset: 19276},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 555, col: 13, offset: 17113},
+								pos:        position{line: 663, col: 13, offset: 19278},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 555, col: 19, offset: 17119},
+								pos:  position{line: 663, col: 19, offset: 19284},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 555, col: 21, offset: 17121},
+								pos:  position{line: 663, col: 21, offset: 19286},
 								name: "Minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 556, col: 5, offset: 17133},
+						pos:  position{line: 664, col: 5, offset: 19298},
 						name: "Days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 557, col: 5, offset: 17142},
+						pos:  position{line: 665, col: 5, offset: 19307},
 						name: "Weeks",
 					},
 				},
@@ -4260,32 +4861,32 @@ var g = &grammar{
 		},
 		{
 			name: "SecondsToken",
-			pos:  position{line: 559, col: 1, offset: 17149},
+			pos:  position{line: 667, col: 1, offset: 19314},
 			expr: &choiceExpr{
-				pos: position{line: 560, col: 5, offset: 17166},
+				pos: position{line: 668, col: 5, offset: 19331},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 560, col: 5, offset: 17166},
+						pos:        position{line: 668, col: 5, offset: 19331},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 561, col: 5, offset: 17180},
+						pos:        position{line: 669, col: 5, offset: 19345},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 562, col: 5, offset: 17193},
+						pos:        position{line: 670, col: 5, offset: 19358},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 563, col: 5, offset: 17204},
+						pos:        position{line: 671, col: 5, offset: 19369},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 564, col: 5, offset: 17214},
+						pos:        position{line: 672, col: 5, offset: 19379},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -4294,32 +4895,32 @@ var g = &grammar{
 		},
 		{
 			name: "MinutesToken",
-			pos:  position{line: 566, col: 1, offset: 17219},
+			pos:  position{line: 674, col: 1, offset: 19384},
 			expr: &choiceExpr{
-				pos: position{line: 567, col: 5, offset: 17236},
+				pos: position{line: 675, col: 5, offset: 19401},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 567, col: 5, offset: 17236},
+						pos:        position{line: 675, col: 5, offset: 19401},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 568, col: 5, offset: 17250},
+						pos:        position{line: 676, col: 5, offset: 19415},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 569, col: 5, offset: 17263},
+						pos:        position{line: 677, col: 5, offset: 19428},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 570, col: 5, offset: 17274},
+						pos:        position{line: 678, col: 5, offset: 19439},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 571, col: 5, offset: 17284},
+						pos:        position{line: 679, col: 5, offset: 19449},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -4328,32 +4929,32 @@ var g = &grammar{
 		},
 		{
 			name: "HoursToken",
-			pos:  position{line: 573, col: 1, offset: 17289},
+			pos:  position{line: 681, col: 1, offset: 19454},
 			expr: &choiceExpr{
-				pos: position{line: 574, col: 5, offset: 17304},
+				pos: position{line: 682, col: 5, offset: 19469},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 574, col: 5, offset: 17304},
+						pos:        position{line: 682, col: 5, offset: 19469},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 575, col: 5, offset: 17316},
+						pos:        position{line: 683, col: 5, offset: 19481},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 576, col: 5, offset: 17326},
+						pos:        position{line: 684, col: 5, offset: 19491},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 577, col: 5, offset: 17335},
+						pos:        position{line: 685, col: 5, offset: 19500},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 578, col: 5, offset: 17343},
+						pos:        position{line: 686, col: 5, offset: 19508},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -4362,22 +4963,22 @@ var g = &grammar{
 		},
 		{
 			name: "DaysToken",
-			pos:  position{line: 580, col: 1, offset: 17351},
+			pos:  position{line: 688, col: 1, offset: 19516},
 			expr: &choiceExpr{
-				pos: position{line: 580, col: 13, offset: 17363},
+				pos: position{line: 688, col: 13, offset: 19528},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 580, col: 13, offset: 17363},
+						pos:        position{line: 688, col: 13, offset: 19528},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 580, col: 20, offset: 17370},
+						pos:        position{line: 688, col: 20, offset: 19535},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 580, col: 26, offset: 17376},
+						pos:        position{line: 688, col: 26, offset: 19541},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -4386,32 +4987,32 @@ var g = &grammar{
 		},
 		{
 			name: "WeeksToken",
-			pos:  position{line: 581, col: 1, offset: 17380},
+			pos:  position{line: 689, col: 1, offset: 19545},
 			expr: &choiceExpr{
-				pos: position{line: 581, col: 14, offset: 17393},
+				pos: position{line: 689, col: 14, offset: 19558},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 581, col: 14, offset: 17393},
+						pos:        position{line: 689, col: 14, offset: 19558},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 581, col: 22, offset: 17401},
+						pos:        position{line: 689, col: 22, offset: 19566},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 581, col: 29, offset: 17408},
+						pos:        position{line: 689, col: 29, offset: 19573},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 581, col: 35, offset: 17414},
+						pos:        position{line: 689, col: 35, offset: 19579},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 581, col: 40, offset: 17419},
+						pos:        position{line: 689, col: 40, offset: 19584},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -4420,39 +5021,39 @@ var g = &grammar{
 		},
 		{
 			name: "Seconds",
-			pos:  position{line: 583, col: 1, offset: 17424},
+			pos:  position{line: 691, col: 1, offset: 19589},
 			expr: &choiceExpr{
-				pos: position{line: 584, col: 5, offset: 17436},
+				pos: position{line: 692, col: 5, offset: 19601},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 584, col: 5, offset: 17436},
+						pos: position{line: 692, col: 5, offset: 19601},
 						run: (*parser).callonSeconds2,
 						expr: &litMatcher{
-							pos:        position{line: 584, col: 5, offset: 17436},
+							pos:        position{line: 692, col: 5, offset: 19601},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 585, col: 5, offset: 17522},
+						pos: position{line: 693, col: 5, offset: 19687},
 						run: (*parser).callonSeconds4,
 						expr: &seqExpr{
-							pos: position{line: 585, col: 5, offset: 17522},
+							pos: position{line: 693, col: 5, offset: 19687},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 585, col: 5, offset: 17522},
+									pos:   position{line: 693, col: 5, offset: 19687},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 585, col: 9, offset: 17526},
+										pos:  position{line: 693, col: 9, offset: 19691},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 585, col: 14, offset: 17531},
+									pos:  position{line: 693, col: 14, offset: 19696},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 585, col: 17, offset: 17534},
+									pos:  position{line: 693, col: 17, offset: 19699},
 									name: "SecondsToken",
 								},
 							},
@@ -4463,39 +5064,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minutes",
-			pos:  position{line: 587, col: 1, offset: 17623},
+			pos:  position{line: 695, col: 1, offset: 19788},
 			expr: &choiceExpr{
-				pos: position{line: 588, col: 5, offset: 17635},
+				pos: position{line: 696, col: 5, offset: 19800},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 588, col: 5, offset: 17635},
+						pos: position{line: 696, col: 5, offset: 19800},
 						run: (*parser).callonMinutes2,
 						expr: &litMatcher{
-							pos:        position{line: 588, col: 5, offset: 17635},
+							pos:        position{line: 696, col: 5, offset: 19800},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 589, col: 5, offset: 17722},
+						pos: position{line: 697, col: 5, offset: 19887},
 						run: (*parser).callonMinutes4,
 						expr: &seqExpr{
-							pos: position{line: 589, col: 5, offset: 17722},
+							pos: position{line: 697, col: 5, offset: 19887},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 589, col: 5, offset: 17722},
+									pos:   position{line: 697, col: 5, offset: 19887},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 589, col: 9, offset: 17726},
+										pos:  position{line: 697, col: 9, offset: 19891},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 589, col: 14, offset: 17731},
+									pos:  position{line: 697, col: 14, offset: 19896},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 589, col: 17, offset: 17734},
+									pos:  position{line: 697, col: 17, offset: 19899},
 									name: "MinutesToken",
 								},
 							},
@@ -4506,39 +5107,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hours",
-			pos:  position{line: 591, col: 1, offset: 17832},
+			pos:  position{line: 699, col: 1, offset: 19997},
 			expr: &choiceExpr{
-				pos: position{line: 592, col: 5, offset: 17842},
+				pos: position{line: 700, col: 5, offset: 20007},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 592, col: 5, offset: 17842},
+						pos: position{line: 700, col: 5, offset: 20007},
 						run: (*parser).callonHours2,
 						expr: &litMatcher{
-							pos:        position{line: 592, col: 5, offset: 17842},
+							pos:        position{line: 700, col: 5, offset: 20007},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 593, col: 5, offset: 17929},
+						pos: position{line: 701, col: 5, offset: 20094},
 						run: (*parser).callonHours4,
 						expr: &seqExpr{
-							pos: position{line: 593, col: 5, offset: 17929},
+							pos: position{line: 701, col: 5, offset: 20094},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 593, col: 5, offset: 17929},
+									pos:   position{line: 701, col: 5, offset: 20094},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 593, col: 9, offset: 17933},
+										pos:  position{line: 701, col: 9, offset: 20098},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 14, offset: 17938},
+									pos:  position{line: 701, col: 14, offset: 20103},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 17, offset: 17941},
+									pos:  position{line: 701, col: 17, offset: 20106},
 									name: "HoursToken",
 								},
 							},
@@ -4549,39 +5150,39 @@ var g = &grammar{
 		},
 		{
 			name: "Days",
-			pos:  position{line: 595, col: 1, offset: 18039},
+			pos:  position{line: 703, col: 1, offset: 20204},
 			expr: &choiceExpr{
-				pos: position{line: 596, col: 5, offset: 18048},
+				pos: position{line: 704, col: 5, offset: 20213},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 596, col: 5, offset: 18048},
+						pos: position{line: 704, col: 5, offset: 20213},
 						run: (*parser).callonDays2,
 						expr: &litMatcher{
-							pos:        position{line: 596, col: 5, offset: 18048},
+							pos:        position{line: 704, col: 5, offset: 20213},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 597, col: 5, offset: 18137},
+						pos: position{line: 705, col: 5, offset: 20302},
 						run: (*parser).callonDays4,
 						expr: &seqExpr{
-							pos: position{line: 597, col: 5, offset: 18137},
+							pos: position{line: 705, col: 5, offset: 20302},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 597, col: 5, offset: 18137},
+									pos:   position{line: 705, col: 5, offset: 20302},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 597, col: 9, offset: 18141},
+										pos:  position{line: 705, col: 9, offset: 20306},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 597, col: 14, offset: 18146},
+									pos:  position{line: 705, col: 14, offset: 20311},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 597, col: 17, offset: 18149},
+									pos:  position{line: 705, col: 17, offset: 20314},
 									name: "DaysToken",
 								},
 							},
@@ -4592,39 +5193,39 @@ var g = &grammar{
 		},
 		{
 			name: "Weeks",
-			pos:  position{line: 599, col: 1, offset: 18251},
+			pos:  position{line: 707, col: 1, offset: 20416},
 			expr: &choiceExpr{
-				pos: position{line: 600, col: 5, offset: 18261},
+				pos: position{line: 708, col: 5, offset: 20426},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 600, col: 5, offset: 18261},
+						pos: position{line: 708, col: 5, offset: 20426},
 						run: (*parser).callonWeeks2,
 						expr: &litMatcher{
-							pos:        position{line: 600, col: 5, offset: 18261},
+							pos:        position{line: 708, col: 5, offset: 20426},
 							val:        "week",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 601, col: 5, offset: 18353},
+						pos: position{line: 709, col: 5, offset: 20518},
 						run: (*parser).callonWeeks4,
 						expr: &seqExpr{
-							pos: position{line: 601, col: 5, offset: 18353},
+							pos: position{line: 709, col: 5, offset: 20518},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 601, col: 5, offset: 18353},
+									pos:   position{line: 709, col: 5, offset: 20518},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 601, col: 9, offset: 18357},
+										pos:  position{line: 709, col: 9, offset: 20522},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 601, col: 14, offset: 18362},
+									pos:  position{line: 709, col: 14, offset: 20527},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 601, col: 17, offset: 18365},
+									pos:  position{line: 709, col: 17, offset: 20530},
 									name: "WeeksToken",
 								},
 							},
@@ -4635,42 +5236,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 604, col: 1, offset: 18496},
+			pos:  position{line: 712, col: 1, offset: 20661},
 			expr: &actionExpr{
-				pos: position{line: 605, col: 5, offset: 18503},
+				pos: position{line: 713, col: 5, offset: 20668},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 605, col: 5, offset: 18503},
+					pos: position{line: 713, col: 5, offset: 20668},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 5, offset: 18503},
+							pos:  position{line: 713, col: 5, offset: 20668},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 605, col: 10, offset: 18508},
+							pos:        position{line: 713, col: 10, offset: 20673},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 14, offset: 18512},
+							pos:  position{line: 713, col: 14, offset: 20677},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 605, col: 19, offset: 18517},
+							pos:        position{line: 713, col: 19, offset: 20682},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 23, offset: 18521},
+							pos:  position{line: 713, col: 23, offset: 20686},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 605, col: 28, offset: 18526},
+							pos:        position{line: 713, col: 28, offset: 20691},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 32, offset: 18530},
+							pos:  position{line: 713, col: 32, offset: 20695},
 							name: "UInt",
 						},
 					},
@@ -4679,32 +5280,32 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 609, col: 1, offset: 18698},
+			pos:  position{line: 717, col: 1, offset: 20863},
 			expr: &choiceExpr{
-				pos: position{line: 610, col: 5, offset: 18706},
+				pos: position{line: 718, col: 5, offset: 20871},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 610, col: 5, offset: 18706},
+						pos: position{line: 718, col: 5, offset: 20871},
 						run: (*parser).callonIP62,
 						expr: &seqExpr{
-							pos: position{line: 610, col: 5, offset: 18706},
+							pos: position{line: 718, col: 5, offset: 20871},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 610, col: 5, offset: 18706},
+									pos:   position{line: 718, col: 5, offset: 20871},
 									label: "a",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 610, col: 7, offset: 18708},
+										pos: position{line: 718, col: 7, offset: 20873},
 										expr: &ruleRefExpr{
-											pos:  position{line: 610, col: 7, offset: 18708},
+											pos:  position{line: 718, col: 7, offset: 20873},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 610, col: 17, offset: 18718},
+									pos:   position{line: 718, col: 17, offset: 20883},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 610, col: 19, offset: 18720},
+										pos:  position{line: 718, col: 19, offset: 20885},
 										name: "IP6Tail",
 									},
 								},
@@ -4712,51 +5313,51 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 613, col: 5, offset: 18784},
+						pos: position{line: 721, col: 5, offset: 20949},
 						run: (*parser).callonIP69,
 						expr: &seqExpr{
-							pos: position{line: 613, col: 5, offset: 18784},
+							pos: position{line: 721, col: 5, offset: 20949},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 613, col: 5, offset: 18784},
+									pos:   position{line: 721, col: 5, offset: 20949},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 613, col: 7, offset: 18786},
+										pos:  position{line: 721, col: 7, offset: 20951},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 613, col: 11, offset: 18790},
+									pos:   position{line: 721, col: 11, offset: 20955},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 613, col: 13, offset: 18792},
+										pos: position{line: 721, col: 13, offset: 20957},
 										expr: &ruleRefExpr{
-											pos:  position{line: 613, col: 13, offset: 18792},
+											pos:  position{line: 721, col: 13, offset: 20957},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 613, col: 23, offset: 18802},
+									pos:        position{line: 721, col: 23, offset: 20967},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 613, col: 28, offset: 18807},
+									pos:   position{line: 721, col: 28, offset: 20972},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 613, col: 30, offset: 18809},
+										pos: position{line: 721, col: 30, offset: 20974},
 										expr: &ruleRefExpr{
-											pos:  position{line: 613, col: 30, offset: 18809},
+											pos:  position{line: 721, col: 30, offset: 20974},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 613, col: 40, offset: 18819},
+									pos:   position{line: 721, col: 40, offset: 20984},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 613, col: 42, offset: 18821},
+										pos:  position{line: 721, col: 42, offset: 20986},
 										name: "IP6Tail",
 									},
 								},
@@ -4764,32 +5365,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 616, col: 5, offset: 18920},
+						pos: position{line: 724, col: 5, offset: 21085},
 						run: (*parser).callonIP622,
 						expr: &seqExpr{
-							pos: position{line: 616, col: 5, offset: 18920},
+							pos: position{line: 724, col: 5, offset: 21085},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 616, col: 5, offset: 18920},
+									pos:        position{line: 724, col: 5, offset: 21085},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 616, col: 10, offset: 18925},
+									pos:   position{line: 724, col: 10, offset: 21090},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 616, col: 12, offset: 18927},
+										pos: position{line: 724, col: 12, offset: 21092},
 										expr: &ruleRefExpr{
-											pos:  position{line: 616, col: 12, offset: 18927},
+											pos:  position{line: 724, col: 12, offset: 21092},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 616, col: 22, offset: 18937},
+									pos:   position{line: 724, col: 22, offset: 21102},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 616, col: 24, offset: 18939},
+										pos:  position{line: 724, col: 24, offset: 21104},
 										name: "IP6Tail",
 									},
 								},
@@ -4797,32 +5398,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 619, col: 5, offset: 19010},
+						pos: position{line: 727, col: 5, offset: 21175},
 						run: (*parser).callonIP630,
 						expr: &seqExpr{
-							pos: position{line: 619, col: 5, offset: 19010},
+							pos: position{line: 727, col: 5, offset: 21175},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 619, col: 5, offset: 19010},
+									pos:   position{line: 727, col: 5, offset: 21175},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 619, col: 7, offset: 19012},
+										pos:  position{line: 727, col: 7, offset: 21177},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 619, col: 11, offset: 19016},
+									pos:   position{line: 727, col: 11, offset: 21181},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 619, col: 13, offset: 19018},
+										pos: position{line: 727, col: 13, offset: 21183},
 										expr: &ruleRefExpr{
-											pos:  position{line: 619, col: 13, offset: 19018},
+											pos:  position{line: 727, col: 13, offset: 21183},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 619, col: 23, offset: 19028},
+									pos:        position{line: 727, col: 23, offset: 21193},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -4830,10 +5431,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 622, col: 5, offset: 19096},
+						pos: position{line: 730, col: 5, offset: 21261},
 						run: (*parser).callonIP638,
 						expr: &litMatcher{
-							pos:        position{line: 622, col: 5, offset: 19096},
+							pos:        position{line: 730, col: 5, offset: 21261},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -4843,16 +5444,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 626, col: 1, offset: 19133},
+			pos:  position{line: 734, col: 1, offset: 21298},
 			expr: &choiceExpr{
-				pos: position{line: 627, col: 5, offset: 19145},
+				pos: position{line: 735, col: 5, offset: 21310},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 627, col: 5, offset: 19145},
+						pos:  position{line: 735, col: 5, offset: 21310},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 628, col: 5, offset: 19152},
+						pos:  position{line: 736, col: 5, offset: 21317},
 						name: "Hex",
 					},
 				},
@@ -4860,23 +5461,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 630, col: 1, offset: 19157},
+			pos:  position{line: 738, col: 1, offset: 21322},
 			expr: &actionExpr{
-				pos: position{line: 630, col: 12, offset: 19168},
+				pos: position{line: 738, col: 12, offset: 21333},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 630, col: 12, offset: 19168},
+					pos: position{line: 738, col: 12, offset: 21333},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 630, col: 12, offset: 19168},
+							pos:        position{line: 738, col: 12, offset: 21333},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 630, col: 16, offset: 19172},
+							pos:   position{line: 738, col: 16, offset: 21337},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 630, col: 18, offset: 19174},
+								pos:  position{line: 738, col: 18, offset: 21339},
 								name: "Hex",
 							},
 						},
@@ -4886,23 +5487,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 631, col: 1, offset: 19211},
+			pos:  position{line: 739, col: 1, offset: 21376},
 			expr: &actionExpr{
-				pos: position{line: 631, col: 12, offset: 19222},
+				pos: position{line: 739, col: 12, offset: 21387},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 631, col: 12, offset: 19222},
+					pos: position{line: 739, col: 12, offset: 21387},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 631, col: 12, offset: 19222},
+							pos:   position{line: 739, col: 12, offset: 21387},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 631, col: 14, offset: 19224},
+								pos:  position{line: 739, col: 14, offset: 21389},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 631, col: 18, offset: 19228},
+							pos:        position{line: 739, col: 18, offset: 21393},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -4912,31 +5513,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 633, col: 1, offset: 19266},
+			pos:  position{line: 741, col: 1, offset: 21431},
 			expr: &actionExpr{
-				pos: position{line: 634, col: 5, offset: 19277},
+				pos: position{line: 742, col: 5, offset: 21442},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 634, col: 5, offset: 19277},
+					pos: position{line: 742, col: 5, offset: 21442},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 634, col: 5, offset: 19277},
+							pos:   position{line: 742, col: 5, offset: 21442},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 634, col: 7, offset: 19279},
+								pos:  position{line: 742, col: 7, offset: 21444},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 634, col: 10, offset: 19282},
+							pos:        position{line: 742, col: 10, offset: 21447},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 634, col: 14, offset: 19286},
+							pos:   position{line: 742, col: 14, offset: 21451},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 634, col: 16, offset: 19288},
+								pos:  position{line: 742, col: 16, offset: 21453},
 								name: "UInt",
 							},
 						},
@@ -4946,31 +5547,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 638, col: 1, offset: 19361},
+			pos:  position{line: 746, col: 1, offset: 21526},
 			expr: &actionExpr{
-				pos: position{line: 639, col: 5, offset: 19372},
+				pos: position{line: 747, col: 5, offset: 21537},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 639, col: 5, offset: 19372},
+					pos: position{line: 747, col: 5, offset: 21537},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 639, col: 5, offset: 19372},
+							pos:   position{line: 747, col: 5, offset: 21537},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 639, col: 7, offset: 19374},
+								pos:  position{line: 747, col: 7, offset: 21539},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 639, col: 11, offset: 19378},
+							pos:        position{line: 747, col: 11, offset: 21543},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 639, col: 15, offset: 19382},
+							pos:   position{line: 747, col: 15, offset: 21547},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 639, col: 17, offset: 19384},
+								pos:  position{line: 747, col: 17, offset: 21549},
 								name: "UInt",
 							},
 						},
@@ -4980,15 +5581,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 643, col: 1, offset: 19447},
+			pos:  position{line: 751, col: 1, offset: 21612},
 			expr: &actionExpr{
-				pos: position{line: 644, col: 4, offset: 19455},
+				pos: position{line: 752, col: 4, offset: 21620},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 644, col: 4, offset: 19455},
+					pos:   position{line: 752, col: 4, offset: 21620},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 644, col: 6, offset: 19457},
+						pos:  position{line: 752, col: 6, offset: 21622},
 						name: "UIntString",
 					},
 				},
@@ -4996,16 +5597,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 646, col: 1, offset: 19497},
+			pos:  position{line: 754, col: 1, offset: 21662},
 			expr: &choiceExpr{
-				pos: position{line: 647, col: 5, offset: 19511},
+				pos: position{line: 755, col: 5, offset: 21676},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 647, col: 5, offset: 19511},
+						pos:  position{line: 755, col: 5, offset: 21676},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 648, col: 5, offset: 19526},
+						pos:  position{line: 756, col: 5, offset: 21691},
 						name: "MinusIntString",
 					},
 				},
@@ -5013,14 +5614,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 650, col: 1, offset: 19542},
+			pos:  position{line: 758, col: 1, offset: 21707},
 			expr: &actionExpr{
-				pos: position{line: 650, col: 14, offset: 19555},
+				pos: position{line: 758, col: 14, offset: 21720},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 650, col: 14, offset: 19555},
+					pos: position{line: 758, col: 14, offset: 21720},
 					expr: &charClassMatcher{
-						pos:        position{line: 650, col: 14, offset: 19555},
+						pos:        position{line: 758, col: 14, offset: 21720},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -5031,20 +5632,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 652, col: 1, offset: 19594},
+			pos:  position{line: 760, col: 1, offset: 21759},
 			expr: &actionExpr{
-				pos: position{line: 653, col: 5, offset: 19613},
+				pos: position{line: 761, col: 5, offset: 21778},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 653, col: 5, offset: 19613},
+					pos: position{line: 761, col: 5, offset: 21778},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 653, col: 5, offset: 19613},
+							pos:        position{line: 761, col: 5, offset: 21778},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 653, col: 9, offset: 19617},
+							pos:  position{line: 761, col: 9, offset: 21782},
 							name: "UIntString",
 						},
 					},
@@ -5053,28 +5654,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 655, col: 1, offset: 19660},
+			pos:  position{line: 763, col: 1, offset: 21825},
 			expr: &choiceExpr{
-				pos: position{line: 656, col: 5, offset: 19676},
+				pos: position{line: 764, col: 5, offset: 21841},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 656, col: 5, offset: 19676},
+						pos: position{line: 764, col: 5, offset: 21841},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 656, col: 5, offset: 19676},
+							pos: position{line: 764, col: 5, offset: 21841},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 656, col: 5, offset: 19676},
+									pos: position{line: 764, col: 5, offset: 21841},
 									expr: &litMatcher{
-										pos:        position{line: 656, col: 5, offset: 19676},
+										pos:        position{line: 764, col: 5, offset: 21841},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 656, col: 10, offset: 19681},
+									pos: position{line: 764, col: 10, offset: 21846},
 									expr: &charClassMatcher{
-										pos:        position{line: 656, col: 10, offset: 19681},
+										pos:        position{line: 764, col: 10, offset: 21846},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -5082,14 +5683,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 656, col: 17, offset: 19688},
+									pos:        position{line: 764, col: 17, offset: 21853},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 656, col: 21, offset: 19692},
+									pos: position{line: 764, col: 21, offset: 21857},
 									expr: &charClassMatcher{
-										pos:        position{line: 656, col: 21, offset: 19692},
+										pos:        position{line: 764, col: 21, offset: 21857},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -5097,9 +5698,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 656, col: 28, offset: 19699},
+									pos: position{line: 764, col: 28, offset: 21864},
 									expr: &ruleRefExpr{
-										pos:  position{line: 656, col: 28, offset: 19699},
+										pos:  position{line: 764, col: 28, offset: 21864},
 										name: "ExponentPart",
 									},
 								},
@@ -5107,28 +5708,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 19758},
+						pos: position{line: 767, col: 5, offset: 21923},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 19758},
+							pos: position{line: 767, col: 5, offset: 21923},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 659, col: 5, offset: 19758},
+									pos: position{line: 767, col: 5, offset: 21923},
 									expr: &litMatcher{
-										pos:        position{line: 659, col: 5, offset: 19758},
+										pos:        position{line: 767, col: 5, offset: 21923},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 659, col: 10, offset: 19763},
+									pos:        position{line: 767, col: 10, offset: 21928},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 659, col: 14, offset: 19767},
+									pos: position{line: 767, col: 14, offset: 21932},
 									expr: &charClassMatcher{
-										pos:        position{line: 659, col: 14, offset: 19767},
+										pos:        position{line: 767, col: 14, offset: 21932},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -5136,9 +5737,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 659, col: 21, offset: 19774},
+									pos: position{line: 767, col: 21, offset: 21939},
 									expr: &ruleRefExpr{
-										pos:  position{line: 659, col: 21, offset: 19774},
+										pos:  position{line: 767, col: 21, offset: 21939},
 										name: "ExponentPart",
 									},
 								},
@@ -5150,19 +5751,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 663, col: 1, offset: 19830},
+			pos:  position{line: 771, col: 1, offset: 21995},
 			expr: &seqExpr{
-				pos: position{line: 663, col: 16, offset: 19845},
+				pos: position{line: 771, col: 16, offset: 22010},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 663, col: 16, offset: 19845},
+						pos:        position{line: 771, col: 16, offset: 22010},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 663, col: 21, offset: 19850},
+						pos: position{line: 771, col: 21, offset: 22015},
 						expr: &charClassMatcher{
-							pos:        position{line: 663, col: 21, offset: 19850},
+							pos:        position{line: 771, col: 21, offset: 22015},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -5170,7 +5771,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 663, col: 27, offset: 19856},
+						pos:  position{line: 771, col: 27, offset: 22021},
 						name: "UIntString",
 					},
 				},
@@ -5178,14 +5779,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 665, col: 1, offset: 19868},
+			pos:  position{line: 773, col: 1, offset: 22033},
 			expr: &actionExpr{
-				pos: position{line: 665, col: 7, offset: 19874},
+				pos: position{line: 773, col: 7, offset: 22039},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 665, col: 7, offset: 19874},
+					pos: position{line: 773, col: 7, offset: 22039},
 					expr: &ruleRefExpr{
-						pos:  position{line: 665, col: 7, offset: 19874},
+						pos:  position{line: 773, col: 7, offset: 22039},
 						name: "HexDigit",
 					},
 				},
@@ -5193,9 +5794,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 667, col: 1, offset: 19916},
+			pos:  position{line: 775, col: 1, offset: 22081},
 			expr: &charClassMatcher{
-				pos:        position{line: 667, col: 12, offset: 19927},
+				pos:        position{line: 775, col: 12, offset: 22092},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -5203,126 +5804,35 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "KeyWord",
-			pos:  position{line: 669, col: 1, offset: 19940},
-			expr: &actionExpr{
-				pos: position{line: 670, col: 5, offset: 19952},
-				run: (*parser).callonKeyWord1,
-				expr: &labeledExpr{
-					pos:   position{line: 670, col: 5, offset: 19952},
-					label: "chars",
-					expr: &oneOrMoreExpr{
-						pos: position{line: 670, col: 11, offset: 19958},
-						expr: &ruleRefExpr{
-							pos:  position{line: 670, col: 11, offset: 19958},
-							name: "KeyWordPart",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "KeyWordPart",
-			pos:  position{line: 672, col: 1, offset: 20005},
-			expr: &choiceExpr{
-				pos: position{line: 673, col: 5, offset: 20021},
-				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 673, col: 5, offset: 20021},
-						run: (*parser).callonKeyWordPart2,
-						expr: &seqExpr{
-							pos: position{line: 673, col: 5, offset: 20021},
-							exprs: []interface{}{
-								&litMatcher{
-									pos:        position{line: 673, col: 5, offset: 20021},
-									val:        "\\",
-									ignoreCase: false,
-								},
-								&labeledExpr{
-									pos:   position{line: 673, col: 10, offset: 20026},
-									label: "s",
-									expr: &choiceExpr{
-										pos: position{line: 673, col: 13, offset: 20029},
-										alternatives: []interface{}{
-											&ruleRefExpr{
-												pos:  position{line: 673, col: 13, offset: 20029},
-												name: "EscapeSequence",
-											},
-											&ruleRefExpr{
-												pos:  position{line: 673, col: 30, offset: 20046},
-												name: "SearchEscape",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 674, col: 5, offset: 20083},
-						run: (*parser).callonKeyWordPart9,
-						expr: &seqExpr{
-							pos: position{line: 674, col: 5, offset: 20083},
-							exprs: []interface{}{
-								&notExpr{
-									pos: position{line: 674, col: 5, offset: 20083},
-									expr: &choiceExpr{
-										pos: position{line: 674, col: 7, offset: 20085},
-										alternatives: []interface{}{
-											&charClassMatcher{
-												pos:        position{line: 674, col: 7, offset: 20085},
-												val:        "[\\x00-\\x1F\\x5C(),!><=\\x22|\\x27;:]",
-												chars:      []rune{'\\', '(', ')', ',', '!', '>', '<', '=', '"', '|', '\'', ';', ':'},
-												ranges:     []rune{'\x00', '\x1f'},
-												ignoreCase: false,
-												inverted:   false,
-											},
-											&ruleRefExpr{
-												pos:  position{line: 674, col: 43, offset: 20121},
-												name: "WhiteSpace",
-											},
-										},
-									},
-								},
-								&anyMatcher{
-									line: 674, col: 55, offset: 20133,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "QuotedString",
-			pos:  position{line: 676, col: 1, offset: 20167},
+			pos:  position{line: 778, col: 1, offset: 22106},
 			expr: &choiceExpr{
-				pos: position{line: 677, col: 5, offset: 20184},
+				pos: position{line: 779, col: 5, offset: 22123},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 677, col: 5, offset: 20184},
+						pos: position{line: 779, col: 5, offset: 22123},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 677, col: 5, offset: 20184},
+							pos: position{line: 779, col: 5, offset: 22123},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 677, col: 5, offset: 20184},
+									pos:        position{line: 779, col: 5, offset: 22123},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 677, col: 9, offset: 20188},
+									pos:   position{line: 779, col: 9, offset: 22127},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 677, col: 11, offset: 20190},
+										pos: position{line: 779, col: 11, offset: 22129},
 										expr: &ruleRefExpr{
-											pos:  position{line: 677, col: 11, offset: 20190},
+											pos:  position{line: 779, col: 11, offset: 22129},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 677, col: 29, offset: 20208},
+									pos:        position{line: 779, col: 29, offset: 22147},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -5330,29 +5840,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 678, col: 5, offset: 20245},
+						pos: position{line: 780, col: 5, offset: 22184},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 678, col: 5, offset: 20245},
+							pos: position{line: 780, col: 5, offset: 22184},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 678, col: 5, offset: 20245},
+									pos:        position{line: 780, col: 5, offset: 22184},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 678, col: 9, offset: 20249},
+									pos:   position{line: 780, col: 9, offset: 22188},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 678, col: 11, offset: 20251},
+										pos: position{line: 780, col: 11, offset: 22190},
 										expr: &ruleRefExpr{
-											pos:  position{line: 678, col: 11, offset: 20251},
+											pos:  position{line: 780, col: 11, offset: 22190},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 678, col: 29, offset: 20269},
+									pos:        position{line: 780, col: 29, offset: 22208},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -5364,55 +5874,167 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 680, col: 1, offset: 20303},
+			pos:  position{line: 782, col: 1, offset: 22242},
 			expr: &choiceExpr{
-				pos: position{line: 681, col: 5, offset: 20324},
+				pos: position{line: 783, col: 5, offset: 22263},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 681, col: 5, offset: 20324},
+						pos: position{line: 783, col: 5, offset: 22263},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 681, col: 5, offset: 20324},
+							pos: position{line: 783, col: 5, offset: 22263},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 681, col: 5, offset: 20324},
+									pos: position{line: 783, col: 5, offset: 22263},
 									expr: &choiceExpr{
-										pos: position{line: 681, col: 7, offset: 20326},
+										pos: position{line: 783, col: 7, offset: 22265},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 681, col: 7, offset: 20326},
+												pos:        position{line: 783, col: 7, offset: 22265},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 681, col: 13, offset: 20332},
+												pos:  position{line: 783, col: 13, offset: 22271},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 681, col: 26, offset: 20345,
+									line: 783, col: 26, offset: 22284,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 682, col: 5, offset: 20382},
+						pos: position{line: 784, col: 5, offset: 22321},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 682, col: 5, offset: 20382},
+							pos: position{line: 784, col: 5, offset: 22321},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 682, col: 5, offset: 20382},
+									pos:        position{line: 784, col: 5, offset: 22321},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 682, col: 10, offset: 20387},
+									pos:   position{line: 784, col: 10, offset: 22326},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 682, col: 12, offset: 20389},
+										pos:  position{line: 784, col: 12, offset: 22328},
+										name: "EscapeSequence",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "KeyWord",
+			pos:  position{line: 786, col: 1, offset: 22362},
+			expr: &actionExpr{
+				pos: position{line: 787, col: 5, offset: 22374},
+				run: (*parser).callonKeyWord1,
+				expr: &seqExpr{
+					pos: position{line: 787, col: 5, offset: 22374},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 787, col: 5, offset: 22374},
+							label: "head",
+							expr: &ruleRefExpr{
+								pos:  position{line: 787, col: 10, offset: 22379},
+								name: "KeyWordStart",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 787, col: 23, offset: 22392},
+							label: "tail",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 787, col: 28, offset: 22397},
+								expr: &ruleRefExpr{
+									pos:  position{line: 787, col: 28, offset: 22397},
+									name: "KeyWordRest",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "KeyWordStart",
+			pos:  position{line: 789, col: 1, offset: 22459},
+			expr: &choiceExpr{
+				pos: position{line: 790, col: 5, offset: 22476},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 790, col: 5, offset: 22476},
+						run: (*parser).callonKeyWordStart2,
+						expr: &charClassMatcher{
+							pos:        position{line: 790, col: 5, offset: 22476},
+							val:        "[a-zA-Z_.:/%#@~]",
+							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
+							ranges:     []rune{'a', 'z', 'A', 'Z'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+					},
+					&ruleRefExpr{
+						pos:  position{line: 791, col: 5, offset: 22528},
+						name: "KeyWordEsc",
+					},
+				},
+			},
+		},
+		{
+			name: "KeyWordRest",
+			pos:  position{line: 793, col: 1, offset: 22540},
+			expr: &choiceExpr{
+				pos: position{line: 794, col: 5, offset: 22556},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 794, col: 5, offset: 22556},
+						name: "KeyWordStart",
+					},
+					&charClassMatcher{
+						pos:        position{line: 795, col: 5, offset: 22573},
+						val:        "[0-9]",
+						ranges:     []rune{'0', '9'},
+						ignoreCase: false,
+						inverted:   false,
+					},
+				},
+			},
+		},
+		{
+			name: "KeyWordEsc",
+			pos:  position{line: 797, col: 1, offset: 22580},
+			expr: &actionExpr{
+				pos: position{line: 797, col: 14, offset: 22593},
+				run: (*parser).callonKeyWordEsc1,
+				expr: &seqExpr{
+					pos: position{line: 797, col: 14, offset: 22593},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 797, col: 14, offset: 22593},
+							val:        "\\",
+							ignoreCase: false,
+						},
+						&labeledExpr{
+							pos:   position{line: 797, col: 19, offset: 22598},
+							label: "s",
+							expr: &choiceExpr{
+								pos: position{line: 797, col: 22, offset: 22601},
+								alternatives: []interface{}{
+									&ruleRefExpr{
+										pos:  position{line: 797, col: 22, offset: 22601},
+										name: "KeywordEscape",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 797, col: 38, offset: 22617},
 										name: "EscapeSequence",
 									},
 								},
@@ -5424,55 +6046,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 684, col: 1, offset: 20423},
+			pos:  position{line: 799, col: 1, offset: 22653},
 			expr: &choiceExpr{
-				pos: position{line: 685, col: 5, offset: 20444},
+				pos: position{line: 800, col: 5, offset: 22674},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 685, col: 5, offset: 20444},
+						pos: position{line: 800, col: 5, offset: 22674},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 685, col: 5, offset: 20444},
+							pos: position{line: 800, col: 5, offset: 22674},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 685, col: 5, offset: 20444},
+									pos: position{line: 800, col: 5, offset: 22674},
 									expr: &choiceExpr{
-										pos: position{line: 685, col: 7, offset: 20446},
+										pos: position{line: 800, col: 7, offset: 22676},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 685, col: 7, offset: 20446},
+												pos:        position{line: 800, col: 7, offset: 22676},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 685, col: 13, offset: 20452},
+												pos:  position{line: 800, col: 13, offset: 22682},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 685, col: 26, offset: 20465,
+									line: 800, col: 26, offset: 22695,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 686, col: 5, offset: 20502},
+						pos: position{line: 801, col: 5, offset: 22732},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 686, col: 5, offset: 20502},
+							pos: position{line: 801, col: 5, offset: 22732},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 686, col: 5, offset: 20502},
+									pos:        position{line: 801, col: 5, offset: 22732},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 686, col: 10, offset: 20507},
+									pos:   position{line: 801, col: 10, offset: 22737},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 686, col: 12, offset: 20509},
+										pos:  position{line: 801, col: 12, offset: 22739},
 										name: "EscapeSequence",
 									},
 								},
@@ -5484,38 +6106,38 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 688, col: 1, offset: 20543},
+			pos:  position{line: 803, col: 1, offset: 22773},
 			expr: &choiceExpr{
-				pos: position{line: 689, col: 5, offset: 20562},
+				pos: position{line: 804, col: 5, offset: 22792},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 689, col: 5, offset: 20562},
+						pos: position{line: 804, col: 5, offset: 22792},
 						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 689, col: 5, offset: 20562},
+							pos: position{line: 804, col: 5, offset: 22792},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 689, col: 5, offset: 20562},
+									pos:        position{line: 804, col: 5, offset: 22792},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 9, offset: 20566},
+									pos:  position{line: 804, col: 9, offset: 22796},
 									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 689, col: 18, offset: 20575},
+									pos:  position{line: 804, col: 18, offset: 22805},
 									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 690, col: 5, offset: 20626},
+						pos:  position{line: 805, col: 5, offset: 22856},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 691, col: 5, offset: 20647},
+						pos:  position{line: 806, col: 5, offset: 22877},
 						name: "UnicodeEscape",
 					},
 				},
@@ -5523,75 +6145,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 693, col: 1, offset: 20662},
+			pos:  position{line: 808, col: 1, offset: 22892},
 			expr: &choiceExpr{
-				pos: position{line: 694, col: 5, offset: 20683},
+				pos: position{line: 809, col: 5, offset: 22913},
 				alternatives: []interface{}{
-					&litMatcher{
-						pos:        position{line: 694, col: 5, offset: 20683},
-						val:        "'",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 695, col: 5, offset: 20691},
-						val:        "\"",
-						ignoreCase: false,
-					},
-					&litMatcher{
-						pos:        position{line: 696, col: 5, offset: 20699},
-						val:        "\\",
-						ignoreCase: false,
+					&actionExpr{
+						pos: position{line: 809, col: 5, offset: 22913},
+						run: (*parser).callonSingleCharEscape2,
+						expr: &litMatcher{
+							pos:        position{line: 809, col: 5, offset: 22913},
+							val:        "'",
+							ignoreCase: false,
+						},
 					},
 					&actionExpr{
-						pos: position{line: 697, col: 5, offset: 20708},
-						run: (*parser).callonSingleCharEscape5,
+						pos: position{line: 810, col: 5, offset: 22940},
+						run: (*parser).callonSingleCharEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 697, col: 5, offset: 20708},
+							pos:        position{line: 810, col: 5, offset: 22940},
+							val:        "\"",
+							ignoreCase: false,
+						},
+					},
+					&actionExpr{
+						pos: position{line: 811, col: 5, offset: 22967},
+						run: (*parser).callonSingleCharEscape6,
+						expr: &litMatcher{
+							pos:        position{line: 811, col: 5, offset: 22967},
+							val:        "\\",
+							ignoreCase: false,
+						},
+					},
+					&actionExpr{
+						pos: position{line: 812, col: 5, offset: 22996},
+						run: (*parser).callonSingleCharEscape8,
+						expr: &litMatcher{
+							pos:        position{line: 812, col: 5, offset: 22996},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 698, col: 5, offset: 20737},
-						run: (*parser).callonSingleCharEscape7,
+						pos: position{line: 813, col: 5, offset: 23025},
+						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 698, col: 5, offset: 20737},
+							pos:        position{line: 813, col: 5, offset: 23025},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 699, col: 5, offset: 20766},
-						run: (*parser).callonSingleCharEscape9,
+						pos: position{line: 814, col: 5, offset: 23054},
+						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 699, col: 5, offset: 20766},
+							pos:        position{line: 814, col: 5, offset: 23054},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 700, col: 5, offset: 20795},
-						run: (*parser).callonSingleCharEscape11,
+						pos: position{line: 815, col: 5, offset: 23083},
+						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 700, col: 5, offset: 20795},
+							pos:        position{line: 815, col: 5, offset: 23083},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 701, col: 5, offset: 20824},
-						run: (*parser).callonSingleCharEscape13,
+						pos: position{line: 816, col: 5, offset: 23112},
+						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 701, col: 5, offset: 20824},
+							pos:        position{line: 816, col: 5, offset: 23112},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 702, col: 5, offset: 20853},
-						run: (*parser).callonSingleCharEscape15,
+						pos: position{line: 817, col: 5, offset: 23141},
+						run: (*parser).callonSingleCharEscape18,
 						expr: &litMatcher{
-							pos:        position{line: 702, col: 5, offset: 20853},
+							pos:        position{line: 817, col: 5, offset: 23141},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -5600,69 +6234,76 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "SearchEscape",
-			pos:  position{line: 704, col: 1, offset: 20879},
+			name: "KeywordEscape",
+			pos:  position{line: 819, col: 1, offset: 23167},
 			expr: &choiceExpr{
-				pos: position{line: 705, col: 5, offset: 20896},
+				pos: position{line: 820, col: 5, offset: 23185},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 705, col: 5, offset: 20896},
-						run: (*parser).callonSearchEscape2,
+						pos: position{line: 820, col: 5, offset: 23185},
+						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 705, col: 5, offset: 20896},
+							pos:        position{line: 820, col: 5, offset: 23185},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 706, col: 5, offset: 20924},
-						run: (*parser).callonSearchEscape4,
+						pos: position{line: 821, col: 5, offset: 23213},
+						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 706, col: 5, offset: 20924},
+							pos:        position{line: 821, col: 5, offset: 23213},
 							val:        "*",
 							ignoreCase: false,
 						},
+					},
+					&charClassMatcher{
+						pos:        position{line: 822, col: 5, offset: 23243},
+						val:        "[+-]",
+						chars:      []rune{'+', '-'},
+						ignoreCase: false,
+						inverted:   false,
 					},
 				},
 			},
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 708, col: 1, offset: 20951},
+			pos:  position{line: 824, col: 1, offset: 23249},
 			expr: &choiceExpr{
-				pos: position{line: 709, col: 5, offset: 20969},
+				pos: position{line: 825, col: 5, offset: 23267},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 709, col: 5, offset: 20969},
+						pos: position{line: 825, col: 5, offset: 23267},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 709, col: 5, offset: 20969},
+							pos: position{line: 825, col: 5, offset: 23267},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 709, col: 5, offset: 20969},
+									pos:        position{line: 825, col: 5, offset: 23267},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 709, col: 9, offset: 20973},
+									pos:   position{line: 825, col: 9, offset: 23271},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 709, col: 16, offset: 20980},
+										pos: position{line: 825, col: 16, offset: 23278},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 709, col: 16, offset: 20980},
+												pos:  position{line: 825, col: 16, offset: 23278},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 709, col: 25, offset: 20989},
+												pos:  position{line: 825, col: 25, offset: 23287},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 709, col: 34, offset: 20998},
+												pos:  position{line: 825, col: 34, offset: 23296},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 709, col: 43, offset: 21007},
+												pos:  position{line: 825, col: 43, offset: 23305},
 												name: "HexDigit",
 											},
 										},
@@ -5672,63 +6313,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 712, col: 5, offset: 21070},
+						pos: position{line: 828, col: 5, offset: 23368},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 712, col: 5, offset: 21070},
+							pos: position{line: 828, col: 5, offset: 23368},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 712, col: 5, offset: 21070},
+									pos:        position{line: 828, col: 5, offset: 23368},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 712, col: 9, offset: 21074},
+									pos:        position{line: 828, col: 9, offset: 23372},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 712, col: 13, offset: 21078},
+									pos:   position{line: 828, col: 13, offset: 23376},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 712, col: 20, offset: 21085},
+										pos: position{line: 828, col: 20, offset: 23383},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 712, col: 20, offset: 21085},
+												pos:  position{line: 828, col: 20, offset: 23383},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 29, offset: 21094},
+												pos: position{line: 828, col: 29, offset: 23392},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 29, offset: 21094},
+													pos:  position{line: 828, col: 29, offset: 23392},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 39, offset: 21104},
+												pos: position{line: 828, col: 39, offset: 23402},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 39, offset: 21104},
+													pos:  position{line: 828, col: 39, offset: 23402},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 49, offset: 21114},
+												pos: position{line: 828, col: 49, offset: 23412},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 49, offset: 21114},
+													pos:  position{line: 828, col: 49, offset: 23412},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 59, offset: 21124},
+												pos: position{line: 828, col: 59, offset: 23422},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 59, offset: 21124},
+													pos:  position{line: 828, col: 59, offset: 23422},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 712, col: 69, offset: 21134},
+												pos: position{line: 828, col: 69, offset: 23432},
 												expr: &ruleRefExpr{
-													pos:  position{line: 712, col: 69, offset: 21134},
+													pos:  position{line: 828, col: 69, offset: 23432},
 													name: "HexDigit",
 												},
 											},
@@ -5736,7 +6377,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 712, col: 80, offset: 21145},
+									pos:        position{line: 828, col: 80, offset: 23443},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5748,28 +6389,28 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 716, col: 1, offset: 21199},
+			pos:  position{line: 832, col: 1, offset: 23497},
 			expr: &actionExpr{
-				pos: position{line: 717, col: 5, offset: 21210},
+				pos: position{line: 833, col: 5, offset: 23508},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 717, col: 5, offset: 21210},
+					pos: position{line: 833, col: 5, offset: 23508},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 717, col: 5, offset: 21210},
+							pos:        position{line: 833, col: 5, offset: 23508},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 717, col: 9, offset: 21214},
+							pos:   position{line: 833, col: 9, offset: 23512},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 717, col: 14, offset: 21219},
+								pos:  position{line: 833, col: 14, offset: 23517},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 717, col: 25, offset: 21230},
+							pos:        position{line: 833, col: 25, offset: 23528},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -5779,24 +6420,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 719, col: 1, offset: 21256},
+			pos:  position{line: 835, col: 1, offset: 23554},
 			expr: &actionExpr{
-				pos: position{line: 720, col: 5, offset: 21271},
+				pos: position{line: 836, col: 5, offset: 23569},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 720, col: 5, offset: 21271},
+					pos: position{line: 836, col: 5, offset: 23569},
 					expr: &choiceExpr{
-						pos: position{line: 720, col: 6, offset: 21272},
+						pos: position{line: 836, col: 6, offset: 23570},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 720, col: 6, offset: 21272},
+								pos:        position{line: 836, col: 6, offset: 23570},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 720, col: 13, offset: 21279},
+								pos:        position{line: 836, col: 13, offset: 23577},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -5807,9 +6448,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 722, col: 1, offset: 21319},
+			pos:  position{line: 838, col: 1, offset: 23617},
 			expr: &charClassMatcher{
-				pos:        position{line: 723, col: 5, offset: 21335},
+				pos:        position{line: 839, col: 5, offset: 23633},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -5819,42 +6460,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 725, col: 1, offset: 21350},
+			pos:  position{line: 841, col: 1, offset: 23648},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 725, col: 6, offset: 21355},
+				pos: position{line: 841, col: 6, offset: 23653},
 				expr: &ruleRefExpr{
-					pos:  position{line: 725, col: 6, offset: 21355},
+					pos:  position{line: 841, col: 6, offset: 23653},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 726, col: 1, offset: 21365},
+			pos:  position{line: 842, col: 1, offset: 23663},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 726, col: 6, offset: 21370},
+				pos: position{line: 842, col: 6, offset: 23668},
 				expr: &ruleRefExpr{
-					pos:  position{line: 726, col: 6, offset: 21370},
+					pos:  position{line: 842, col: 6, offset: 23668},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 728, col: 1, offset: 21381},
+			pos:  position{line: 844, col: 1, offset: 23679},
 			expr: &choiceExpr{
-				pos: position{line: 729, col: 5, offset: 21394},
+				pos: position{line: 845, col: 5, offset: 23692},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 729, col: 5, offset: 21394},
+						pos:  position{line: 845, col: 5, offset: 23692},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 730, col: 5, offset: 21409},
+						pos:  position{line: 846, col: 5, offset: 23707},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 731, col: 5, offset: 21428},
+						pos:  position{line: 847, col: 5, offset: 23726},
 						name: "Comment",
 					},
 				},
@@ -5862,45 +6503,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 733, col: 1, offset: 21437},
+			pos:  position{line: 849, col: 1, offset: 23735},
 			expr: &anyMatcher{
-				line: 734, col: 5, offset: 21457,
+				line: 850, col: 5, offset: 23755,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 736, col: 1, offset: 21460},
+			pos:         position{line: 852, col: 1, offset: 23758},
 			expr: &choiceExpr{
-				pos: position{line: 737, col: 5, offset: 21488},
+				pos: position{line: 853, col: 5, offset: 23786},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 737, col: 5, offset: 21488},
+						pos:        position{line: 853, col: 5, offset: 23786},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 738, col: 5, offset: 21497},
+						pos:        position{line: 854, col: 5, offset: 23795},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 739, col: 5, offset: 21506},
+						pos:        position{line: 855, col: 5, offset: 23804},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 740, col: 5, offset: 21515},
+						pos:        position{line: 856, col: 5, offset: 23813},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 741, col: 5, offset: 21523},
+						pos:        position{line: 857, col: 5, offset: 23821},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 742, col: 5, offset: 21536},
+						pos:        position{line: 858, col: 5, offset: 23834},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -5909,9 +6550,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 744, col: 1, offset: 21546},
+			pos:  position{line: 860, col: 1, offset: 23844},
 			expr: &charClassMatcher{
-				pos:        position{line: 745, col: 5, offset: 21565},
+				pos:        position{line: 861, col: 5, offset: 23863},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -5921,45 +6562,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 751, col: 1, offset: 21895},
+			pos:         position{line: 867, col: 1, offset: 24193},
 			expr: &ruleRefExpr{
-				pos:  position{line: 754, col: 5, offset: 21966},
+				pos:  position{line: 870, col: 5, offset: 24264},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 756, col: 1, offset: 21985},
+			pos:  position{line: 872, col: 1, offset: 24283},
 			expr: &seqExpr{
-				pos: position{line: 757, col: 5, offset: 22006},
+				pos: position{line: 873, col: 5, offset: 24304},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 757, col: 5, offset: 22006},
+						pos:        position{line: 873, col: 5, offset: 24304},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 757, col: 10, offset: 22011},
+						pos: position{line: 873, col: 10, offset: 24309},
 						expr: &seqExpr{
-							pos: position{line: 757, col: 11, offset: 22012},
+							pos: position{line: 873, col: 11, offset: 24310},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 757, col: 11, offset: 22012},
+									pos: position{line: 873, col: 11, offset: 24310},
 									expr: &litMatcher{
-										pos:        position{line: 757, col: 12, offset: 22013},
+										pos:        position{line: 873, col: 12, offset: 24311},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 757, col: 17, offset: 22018},
+									pos:  position{line: 873, col: 17, offset: 24316},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 757, col: 35, offset: 22036},
+						pos:        position{line: 873, col: 35, offset: 24334},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -5968,29 +6609,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 759, col: 1, offset: 22042},
+			pos:  position{line: 875, col: 1, offset: 24340},
 			expr: &seqExpr{
-				pos: position{line: 760, col: 5, offset: 22064},
+				pos: position{line: 876, col: 5, offset: 24362},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 760, col: 5, offset: 22064},
+						pos:        position{line: 876, col: 5, offset: 24362},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 760, col: 10, offset: 22069},
+						pos: position{line: 876, col: 10, offset: 24367},
 						expr: &seqExpr{
-							pos: position{line: 760, col: 11, offset: 22070},
+							pos: position{line: 876, col: 11, offset: 24368},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 760, col: 11, offset: 22070},
+									pos: position{line: 876, col: 11, offset: 24368},
 									expr: &ruleRefExpr{
-										pos:  position{line: 760, col: 12, offset: 22071},
+										pos:  position{line: 876, col: 12, offset: 24369},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 760, col: 27, offset: 22086},
+									pos:  position{line: 876, col: 27, offset: 24384},
 									name: "SourceCharacter",
 								},
 							},
@@ -6000,12 +6641,29 @@ var g = &grammar{
 			},
 		},
 		{
+			name: "EOT",
+			pos:  position{line: 878, col: 1, offset: 24403},
+			expr: &choiceExpr{
+				pos: position{line: 878, col: 7, offset: 24409},
+				alternatives: []interface{}{
+					&ruleRefExpr{
+						pos:  position{line: 878, col: 7, offset: 24409},
+						name: "_",
+					},
+					&ruleRefExpr{
+						pos:  position{line: 878, col: 11, offset: 24413},
+						name: "EOF",
+					},
+				},
+			},
+		},
+		{
 			name: "EOF",
-			pos:  position{line: 762, col: 1, offset: 22105},
+			pos:  position{line: 879, col: 1, offset: 24417},
 			expr: &notExpr{
-				pos: position{line: 762, col: 7, offset: 22111},
+				pos: position{line: 879, col: 7, offset: 24423},
 				expr: &anyMatcher{
-					line: 762, col: 8, offset: 22112,
+					line: 879, col: 8, offset: 24424,
 				},
 			},
 		},
@@ -6022,87 +6680,146 @@ func (p *parser) callonstart1() (interface{}, error) {
 	return p.cur.onstart1(stack["ast"])
 }
 
-func (c *current) onQuery2(procs interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "SequentialProc", "procs": procs}, nil
+func (c *current) onSequential2(first, rest interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "SequentialProc", "procs": append([]interface{}{first}, (rest.([]interface{}))...)}, nil
 
 }
 
-func (p *parser) callonQuery2() (interface{}, error) {
+func (p *parser) callonSequential2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onQuery2(stack["procs"])
+	return p.cur.onSequential2(stack["first"], stack["rest"])
 }
 
-func (c *current) onQuery5(s, rest interface{}) (interface{}, error) {
-	if len(rest.([]interface{})) == 0 {
-		return s, nil
-	} else {
-		return map[string]interface{}{"op": "SequentialProc", "procs": append([]interface{}{s}, (rest.([]interface{}))...)}, nil
-	}
+func (c *current) onSequential9(op interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "SequentialProc", "procs": []interface{}{op}}, nil
 
 }
 
-func (p *parser) callonQuery5() (interface{}, error) {
+func (p *parser) callonSequential9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onQuery5(stack["s"], stack["rest"])
+	return p.cur.onSequential9(stack["op"])
 }
 
-func (c *current) onSearch1(expr interface{}) (interface{}, error) {
+func (c *current) onSequentialTail1(p interface{}) (interface{}, error) {
+	return p, nil
+}
+
+func (p *parser) callonSequentialTail1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSequentialTail1(stack["p"])
+}
+
+func (c *current) onParallel2(first, rest interface{}) (interface{}, error) {
+	return append([]interface{}{first}, (rest.([]interface{}))...), nil
+
+}
+
+func (p *parser) callonParallel2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onParallel2(stack["first"], stack["rest"])
+}
+
+func (c *current) onParallel9(first interface{}) (interface{}, error) {
+	return []interface{}{first}, nil
+
+}
+
+func (p *parser) callonParallel9() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onParallel9(stack["first"])
+}
+
+func (c *current) onParallelTail1(ch interface{}) (interface{}, error) {
+	return ch, nil
+}
+
+func (p *parser) callonParallelTail1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onParallelTail1(stack["ch"])
+}
+
+func (c *current) onOperation2(procArray interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "ParallelProc", "procs": procArray}, nil
+
+}
+
+func (p *parser) callonOperation2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onOperation2(stack["procArray"])
+}
+
+func (c *current) onOperation15(a interface{}) (interface{}, error) {
+	return a, nil
+}
+
+func (p *parser) callonOperation15() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onOperation15(stack["a"])
+}
+
+func (c *current) onOperation21(expr interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "FilterProc", "filter": expr}, nil
 
 }
 
-func (p *parser) callonSearch1() (interface{}, error) {
+func (p *parser) callonOperation21() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSearch1(stack["expr"])
+	return p.cur.onOperation21(stack["expr"])
 }
 
-func (c *current) onSearchExpr1(first, rest interface{}) (interface{}, error) {
-	return makeChain(first, rest, "LogicalOr"), nil
+func (c *current) onSearchBoolean1(first, rest interface{}) (interface{}, error) {
+	return makeBinaryExprChain(first, rest), nil
 
 }
 
-func (p *parser) callonSearchExpr1() (interface{}, error) {
+func (p *parser) callonSearchBoolean1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSearchExpr1(stack["first"], stack["rest"])
+	return p.cur.onSearchBoolean1(stack["first"], stack["rest"])
 }
 
-func (c *current) onOredSearchTerm1(t interface{}) (interface{}, error) {
-	return t, nil
+func (c *current) onSearchOrTerm1(t interface{}) (interface{}, error) {
+	return []interface{}{"or", t}, nil
 }
 
-func (p *parser) callonOredSearchTerm1() (interface{}, error) {
+func (p *parser) callonSearchOrTerm1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onOredSearchTerm1(stack["t"])
+	return p.cur.onSearchOrTerm1(stack["t"])
 }
 
-func (c *current) onSearchTerm1(first, rest interface{}) (interface{}, error) {
-	return makeChain(first, rest, "LogicalAnd"), nil
-
+func (c *current) onSearchAnd7(expr interface{}) (interface{}, error) {
+	return []interface{}{"and", expr}, nil
 }
 
-func (p *parser) callonSearchTerm1() (interface{}, error) {
+func (p *parser) callonSearchAnd7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSearchTerm1(stack["first"], stack["rest"])
+	return p.cur.onSearchAnd7(stack["expr"])
 }
 
-func (c *current) onAndedSearchTerm1(f interface{}) (interface{}, error) {
-	return f, nil
+func (c *current) onSearchAnd1(first, rest interface{}) (interface{}, error) {
+	return makeBinaryExprChain(first, rest), nil
+
 }
 
-func (p *parser) callonAndedSearchTerm1() (interface{}, error) {
+func (p *parser) callonSearchAnd1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onAndedSearchTerm1(stack["f"])
+	return p.cur.onSearchAnd1(stack["first"], stack["rest"])
 }
 
 func (c *current) onSearchFactor2(e interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "LogicalNot", "expr": e}, nil
+	return map[string]interface{}{"op": "UnaryExpr", "operator": "!", "operand": e}, nil
 
 }
 
@@ -6112,121 +6829,93 @@ func (p *parser) callonSearchFactor2() (interface{}, error) {
 	return p.cur.onSearchFactor2(stack["e"])
 }
 
-func (c *current) onSearchFactor13(s interface{}) (interface{}, error) {
-	return s, nil
-}
-
-func (p *parser) callonSearchFactor13() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSearchFactor13(stack["s"])
-}
-
-func (c *current) onSearchFactor19(expr interface{}) (interface{}, error) {
+func (c *current) onSearchFactor15(expr interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonSearchFactor19() (interface{}, error) {
+func (p *parser) callonSearchFactor15() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSearchFactor19(stack["expr"])
+	return p.cur.onSearchFactor15(stack["expr"])
 }
 
-func (c *current) onSearchPred2(comp, v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "CompareAny", "comparator": comp, "recursive": false, "value": v}, nil
+func (c *current) onShortCut2(compareOp, v interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "FunctionCall", "function": "or",
+
+		"args": []interface{}{map[string]interface{}{"op": "BinaryExpr", "operator": "@",
+
+			"lhs": map[string]interface{}{"op": "SelectExpr", "selectors": []interface{}{map[string]interface{}{"op": "RootRecord"}}},
+
+			"rhs": map[string]interface{}{"op": "FunctionCall", "function": "map",
+
+				"args": []interface{}{map[string]interface{}{"op": "BinaryExpr", "operator": "=",
+
+					"lhs": map[string]interface{}{"op": "Identifier", "name": "$"},
+
+					"rhs": v}}}}}}, nil
 
 }
 
-func (p *parser) callonSearchPred2() (interface{}, error) {
+func (p *parser) callonShortCut2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSearchPred2(stack["comp"], stack["v"])
+	return p.cur.onShortCut2(stack["compareOp"], stack["v"])
 }
 
-func (c *current) onSearchPred11(comp, v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "CompareAny", "comparator": comp, "recursive": true, "value": v}, nil
+func (c *current) onShortCut11(f, comp, v interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "BinaryExpr", "operator": comp, "lhs": f, "rhs": v}, nil
 
 }
 
-func (p *parser) callonSearchPred11() (interface{}, error) {
+func (p *parser) callonShortCut11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSearchPred11(stack["comp"], stack["v"])
+	return p.cur.onShortCut11(stack["f"], stack["comp"], stack["v"])
 }
 
-func (c *current) onSearchPred20(f, comp, v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "CompareField", "comparator": comp, "field": f, "value": v}, nil
+func (c *current) onShortCut23(v interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "FunctionCall", "function": "or",
+
+		"args": []interface{}{map[string]interface{}{"op": "BinaryExpr", "operator": "@",
+
+			"lhs": map[string]interface{}{"op": "SelectExpr", "selectors": []interface{}{map[string]interface{}{"op": "RootRecord"}}},
+
+			"rhs": map[string]interface{}{"op": "FunctionCall", "function": "map",
+
+				"args": []interface{}{map[string]interface{}{"op": "BinaryExpr", "operator": "in",
+
+					"lhs": v,
+
+					"rhs": map[string]interface{}{"op": "Identifier", "name": "$"}}}}}}}, nil
 
 }
 
-func (p *parser) callonSearchPred20() (interface{}, error) {
+func (p *parser) callonShortCut23() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSearchPred20(stack["f"], stack["comp"], stack["v"])
+	return p.cur.onShortCut23(stack["v"])
 }
 
-func (c *current) onSearchPred30(expr, comp, v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "BinaryExpression", "operator": comp, "lhs": expr, "rhs": v}, nil
-
-}
-
-func (p *parser) callonSearchPred30() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSearchPred30(stack["expr"], stack["comp"], stack["v"])
-}
-
-func (c *current) onSearchPred42(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "CompareAny", "comparator": "in", "recursive": false, "value": v}, nil
-
-}
-
-func (p *parser) callonSearchPred42() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSearchPred42(stack["v"])
-}
-
-func (c *current) onSearchPred50(v, f interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "CompareField", "comparator": "in", "field": f, "value": v}, nil
-
-}
-
-func (p *parser) callonSearchPred50() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSearchPred50(stack["v"], stack["f"])
-}
-
-func (c *current) onSearchPred59(v interface{}) (interface{}, error) {
+func (c *current) onShortCut31(v interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "Search", "text": string(c.text), "value": v}, nil
 
 }
 
-func (p *parser) callonSearchPred59() (interface{}, error) {
+func (p *parser) callonShortCut31() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSearchPred59(stack["v"])
+	return p.cur.onShortCut31(stack["v"])
 }
 
-func (c *current) onSearchPred62(v interface{}) (interface{}, error) {
-	var str = v.(string)
-	if str == "*" {
-		return map[string]interface{}{"op": "MatchAll"}, nil
-	}
-	var literal = map[string]interface{}{"op": "Literal", "type": "string", "value": v}
-	if reglob.IsGlobby(str) {
-		literal["type"] = "regexp"
-		literal["value"] = reglob.Reglob(str)
-	}
-	return map[string]interface{}{"op": "Search", "text": string(c.text), "value": literal}, nil
+func (c *current) onShortCut41() (interface{}, error) {
+	return map[string]interface{}{"op": "Literal", "type": "bool", "value": "true"}, nil
 
 }
 
-func (p *parser) callonSearchPred62() (interface{}, error) {
+func (p *parser) callonShortCut41() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSearchPred62(stack["v"])
+	return p.cur.onShortCut41()
 }
 
 func (c *current) onSearchValue3(v interface{}) (interface{}, error) {
@@ -6240,227 +6929,171 @@ func (p *parser) callonSearchValue3() (interface{}, error) {
 	return p.cur.onSearchValue3(stack["v"])
 }
 
-func (c *current) onSearchLiteral7(i interface{}) (interface{}, error) {
-	return i, nil
-}
-
-func (p *parser) callonSearchLiteral7() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSearchLiteral7(stack["i"])
-}
-
-func (c *current) onSearchLiteral13(v interface{}) (interface{}, error) {
-	return v, nil
-}
-
-func (p *parser) callonSearchLiteral13() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSearchLiteral13(stack["v"])
-}
-
-func (c *current) onSearchLiteral21(v interface{}) (interface{}, error) {
-	return v, nil
-}
-
-func (p *parser) callonSearchLiteral21() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSearchLiteral21(stack["v"])
-}
-
-func (c *current) onStringLiteral1(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "string", "value": v}, nil
-
-}
-
-func (p *parser) callonStringLiteral1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onStringLiteral1(stack["v"])
-}
-
-func (c *current) onRegexpLiteral1(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "regexp", "value": v}, nil
-
-}
-
-func (p *parser) callonRegexpLiteral1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRegexpLiteral1(stack["v"])
-}
-
-func (c *current) onSubnetLiteral2(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "net", "value": v}, nil
-
-}
-
-func (p *parser) callonSubnetLiteral2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSubnetLiteral2(stack["v"])
-}
-
-func (c *current) onSubnetLiteral8(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "net", "value": v}, nil
-
-}
-
-func (p *parser) callonSubnetLiteral8() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSubnetLiteral8(stack["v"])
-}
-
-func (c *current) onAddressLiteral2(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "ip", "value": v}, nil
-
-}
-
-func (p *parser) callonAddressLiteral2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onAddressLiteral2(stack["v"])
-}
-
-func (c *current) onAddressLiteral8(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "ip", "value": v}, nil
-
-}
-
-func (p *parser) callonAddressLiteral8() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onAddressLiteral8(stack["v"])
-}
-
-func (c *current) onFloatLiteral1(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "float64", "value": v}, nil
-
-}
-
-func (p *parser) callonFloatLiteral1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onFloatLiteral1(stack["v"])
-}
-
-func (c *current) onIntegerLiteral1(v interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "int64", "value": v}, nil
-
-}
-
-func (p *parser) callonIntegerLiteral1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onIntegerLiteral1(stack["v"])
-}
-
-func (c *current) onBooleanLiteral2() (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "bool", "value": "true"}, nil
-}
-
-func (p *parser) callonBooleanLiteral2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onBooleanLiteral2()
-}
-
-func (c *current) onBooleanLiteral4() (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "bool", "value": "false"}, nil
-}
-
-func (p *parser) callonBooleanLiteral4() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onBooleanLiteral4()
-}
-
-func (c *current) onNullLiteral1() (interface{}, error) {
-	return map[string]interface{}{"op": "Literal", "type": "null", "value": ""}, nil
-}
-
-func (p *parser) callonNullLiteral1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onNullLiteral1()
-}
-
-func (c *current) onSequentialProcs1(first, rest interface{}) (interface{}, error) {
-	if rest != nil {
-		return append([]interface{}{first}, (rest.([]interface{}))...), nil
+func (c *current) onGlobbySearchValue3(v interface{}) (interface{}, error) {
+	var str = v.(string)
+	var literal = map[string]interface{}{"op": "Literal", "type": "string", "value": v}
+	if reglob.IsGlobby(str) {
+		literal["type"] = "regexp"
+		literal["value"] = reglob.Reglob(str)
 	}
-	return []interface{}{first}, nil
+	return literal, nil
 
 }
 
-func (p *parser) callonSequentialProcs1() (interface{}, error) {
+func (p *parser) callonGlobbySearchValue3() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSequentialProcs1(stack["first"], stack["rest"])
+	return p.cur.onGlobbySearchValue3(stack["v"])
 }
 
-func (c *current) onSequentialTail1(p interface{}) (interface{}, error) {
-	return p, nil
+func (c *current) onSearchGlob1(head, tail interface{}) (interface{}, error) {
+	return joinChars(head) + joinChars(tail), nil
+
 }
 
-func (p *parser) callonSequentialTail1() (interface{}, error) {
+func (p *parser) callonSearchGlob1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSequentialTail1(stack["p"])
+	return p.cur.onSearchGlob1(stack["head"], stack["tail"])
 }
 
-func (c *current) onProc3(proc interface{}) (interface{}, error) {
-	return proc, nil
-
+func (c *current) onGlobPart2(s, v interface{}) (interface{}, error) {
+	return s.(string) + v.(string), nil
 }
 
-func (p *parser) callonProc3() (interface{}, error) {
+func (p *parser) callonGlobPart2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onProc3(stack["proc"])
+	return p.cur.onGlobPart2(stack["s"], stack["v"])
 }
 
-func (c *current) onProcs1(first, rest interface{}) (interface{}, error) {
-	var fp = map[string]interface{}{"op": "SequentialProc", "procs": first}
-	if rest != nil {
-		return map[string]interface{}{"op": "ParallelProc", "procs": append([]interface{}{fp}, (rest.([]interface{}))...)}, nil
-	} else {
-		return fp, nil
-	}
-
+func (c *current) onStars1() (interface{}, error) {
+	return string(c.text), nil
 }
 
-func (p *parser) callonProcs1() (interface{}, error) {
+func (p *parser) callonStars1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onProcs1(stack["first"], stack["rest"])
+	return p.cur.onStars1()
 }
 
-func (c *current) onParallelTail1(ch interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "SequentialProc", "procs": ch}, nil
+func (c *current) onComparator1() (interface{}, error) {
+	return string(c.text), nil
 }
 
-func (p *parser) callonParallelTail1() (interface{}, error) {
+func (p *parser) callonComparator1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onParallelTail1(stack["ch"])
+	return p.cur.onComparator1()
 }
 
-func (c *current) onGroupByProc2(every, keys, limit interface{}) (interface{}, error) {
+func (c *current) onSearchExprRelative7(op, expr interface{}) (interface{}, error) {
+	return []interface{}{op, expr}, nil
+}
+
+func (p *parser) callonSearchExprRelative7() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSearchExprRelative7(stack["op"], stack["expr"])
+}
+
+func (c *current) onSearchExprRelative1(first, rest interface{}) (interface{}, error) {
+	return makeBinaryExprChain(first, rest), nil
+
+}
+
+func (p *parser) callonSearchExprRelative1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSearchExprRelative1(stack["first"], stack["rest"])
+}
+
+func (c *current) onSearchExprAdd7(op, expr interface{}) (interface{}, error) {
+	return []interface{}{op, expr}, nil
+}
+
+func (p *parser) callonSearchExprAdd7() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSearchExprAdd7(stack["op"], stack["expr"])
+}
+
+func (c *current) onSearchExprAdd1(first, rest interface{}) (interface{}, error) {
+	return makeBinaryExprChain(first, rest), nil
+
+}
+
+func (p *parser) callonSearchExprAdd1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSearchExprAdd1(stack["first"], stack["rest"])
+}
+
+func (c *current) onSearchExprMul7(op, expr interface{}) (interface{}, error) {
+	return []interface{}{op, expr}, nil
+}
+
+func (p *parser) callonSearchExprMul7() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSearchExprMul7(stack["op"], stack["expr"])
+}
+
+func (c *current) onSearchExprMul1(first, rest interface{}) (interface{}, error) {
+	return makeBinaryExprChain(first, rest), nil
+
+}
+
+func (p *parser) callonSearchExprMul1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSearchExprMul1(stack["first"], stack["rest"])
+}
+
+func (c *current) onSearchExprCast7(typ interface{}) (interface{}, error) {
+	return typ, nil
+}
+
+func (p *parser) callonSearchExprCast7() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSearchExprCast7(stack["typ"])
+}
+
+func (c *current) onSearchExprCast2(e, typ interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "CastExpr", "expr": e, "type": typ}, nil
+
+}
+
+func (p *parser) callonSearchExprCast2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSearchExprCast2(stack["e"], stack["typ"])
+}
+
+func (c *current) onSearchExprFunc3(first, rest interface{}) (interface{}, error) {
+	return makeBinaryExprChain(first, rest), nil
+
+}
+
+func (p *parser) callonSearchExprFunc3() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSearchExprFunc3(stack["first"], stack["rest"])
+}
+
+func (c *current) onAggregation2(every, keys, limit interface{}) (interface{}, error) {
 	return map[string]interface{}{"op": "GroupByProc", "keys": keys, "reducers": nil, "duration": every, "limit": limit}, nil
 
 }
 
-func (p *parser) callonGroupByProc2() (interface{}, error) {
+func (p *parser) callonAggregation2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onGroupByProc2(stack["every"], stack["keys"], stack["limit"])
+	return p.cur.onAggregation2(stack["every"], stack["keys"], stack["limit"])
 }
 
-func (c *current) onGroupByProc11(every, reducers, keys, limit interface{}) (interface{}, error) {
+func (c *current) onAggregation11(every, reducers, keys, limit interface{}) (interface{}, error) {
 	var p = map[string]interface{}{"op": "GroupByProc", "keys": nil, "reducers": reducers, "duration": every, "limit": limit}
 	if keys != nil {
 		p["keys"] = keys.([]interface{})[1]
@@ -6469,10 +7102,10 @@ func (c *current) onGroupByProc11(every, reducers, keys, limit interface{}) (int
 
 }
 
-func (p *parser) callonGroupByProc11() (interface{}, error) {
+func (p *parser) callonAggregation11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onGroupByProc11(stack["every"], stack["reducers"], stack["keys"], stack["limit"])
+	return p.cur.onAggregation11(stack["every"], stack["reducers"], stack["keys"], stack["limit"])
 }
 
 func (c *current) onEveryDur1(dur interface{}) (interface{}, error) {
@@ -6829,15 +7462,26 @@ func (p *parser) callonTailProc8() (interface{}, error) {
 	return p.cur.onTailProc8()
 }
 
-func (c *current) onFilterProc1(expr interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "FilterProc", "filter": expr}, nil
+func (c *current) onFilterProc1(op interface{}) (interface{}, error) {
+	return op, nil
 
 }
 
 func (p *parser) callonFilterProc1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFilterProc1(stack["expr"])
+	return p.cur.onFilterProc1(stack["op"])
+}
+
+func (c *current) onFilter1(expr interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "FilterProc", "filter": expr}, nil
+
+}
+
+func (p *parser) callonFilter1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onFilter1(stack["expr"])
 }
 
 func (c *current) onUniqProc2() (interface{}, error) {
@@ -6943,26 +7587,6 @@ func (p *parser) callonJoinKey3() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onJoinKey3(stack["expr"])
-}
-
-func (c *current) onRootField2(field interface{}) (interface{}, error) {
-	return map[string]interface{}{"op": "BinaryExpr", "operator": ".", "lhs": map[string]interface{}{"op": "RootRecord"}, "rhs": field}, nil
-}
-
-func (p *parser) callonRootField2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRootField2(stack["field"])
-}
-
-func (c *current) onRootField12() (interface{}, error) {
-	return map[string]interface{}{"op": "RootRecord"}, nil
-}
-
-func (p *parser) callonRootField12() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onRootField12()
 }
 
 func (c *current) onFieldExprs1(first, rest interface{}) (interface{}, error) {
@@ -7238,15 +7862,46 @@ func (p *parser) callonPrimitiveType1() (interface{}, error) {
 	return p.cur.onPrimitiveType1()
 }
 
-func (c *current) onFuncExpr2(first, rest interface{}) (interface{}, error) {
+func (c *current) onFuncExpr4(first, rest interface{}) (interface{}, error) {
 	return makeBinaryExprChain(first, rest), nil
 
 }
 
-func (p *parser) callonFuncExpr2() (interface{}, error) {
+func (p *parser) callonFuncExpr4() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFuncExpr2(stack["first"], stack["rest"])
+	return p.cur.onFuncExpr4(stack["first"], stack["rest"])
+}
+
+func (c *current) onMatchExpr1(expr interface{}) (interface{}, error) {
+	return expr, nil
+}
+
+func (p *parser) callonMatchExpr1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onMatchExpr1(stack["expr"])
+}
+
+func (c *current) onSelectExpr13(e interface{}) (interface{}, error) {
+	return []interface{}{"@", e}, nil
+}
+
+func (p *parser) callonSelectExpr13() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSelectExpr13(stack["e"])
+}
+
+func (c *current) onSelectExpr1(args, methods interface{}) (interface{}, error) {
+	return makeBinaryExprChain(map[string]interface{}{"op": "SelectExpr", "selectors": args}, methods), nil
+
+}
+
+func (p *parser) callonSelectExpr1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSelectExpr1(stack["args"], stack["methods"])
 }
 
 func (c *current) onFunction1(fn, args interface{}) (interface{}, error) {
@@ -7258,16 +7913,6 @@ func (p *parser) callonFunction1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFunction1(stack["fn"], stack["args"])
-}
-
-func (c *current) onDeprecatedName1() (interface{}, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) callonDeprecatedName1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onDeprecatedName1()
 }
 
 func (c *current) onArgumentList8(e interface{}) (interface{}, error) {
@@ -7301,15 +7946,67 @@ func (p *parser) callonArgumentList15() (interface{}, error) {
 	return p.cur.onArgumentList15()
 }
 
-func (c *current) onDerefExpr1(first, rest interface{}) (interface{}, error) {
+func (c *current) onDerefExpr2(first, rest interface{}) (interface{}, error) {
 	return makeBinaryExprChain(first, rest), nil
 
 }
 
-func (p *parser) callonDerefExpr1() (interface{}, error) {
+func (p *parser) callonDerefExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onDerefExpr1(stack["first"], stack["rest"])
+	return p.cur.onDerefExpr2(stack["first"], stack["rest"])
+}
+
+func (c *current) onDerefExpr9(first, rest interface{}) (interface{}, error) {
+	return makeBinaryExprChain(first, rest), nil
+
+}
+
+func (p *parser) callonDerefExpr9() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onDerefExpr9(stack["first"], stack["rest"])
+}
+
+func (c *current) onDerefExpr16() (interface{}, error) {
+	return map[string]interface{}{"op": "RootRecord"}, nil
+
+}
+
+func (p *parser) callonDerefExpr16() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onDerefExpr16()
+}
+
+func (c *current) onDotId2(field interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "BinaryExpr", "operator": ".",
+
+		"lhs": map[string]interface{}{"op": "RootRecord"},
+
+		"rhs": field}, nil
+
+}
+
+func (p *parser) callonDotId2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onDotId2(stack["field"])
+}
+
+func (c *current) onDotId7(expr interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "BinaryExpr", "operator": "[",
+
+		"lhs": map[string]interface{}{"op": "RootRecord"},
+
+		"rhs": expr}, nil
+
+}
+
+func (p *parser) callonDotId7() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onDotId7(stack["expr"])
 }
 
 func (c *current) onDeref2(expr interface{}) (interface{}, error) {
@@ -7332,18 +8029,136 @@ func (p *parser) callonDeref8() (interface{}, error) {
 	return p.cur.onDeref8(stack["id"])
 }
 
-func (c *current) onPrimary10(expr interface{}) (interface{}, error) {
+func (c *current) onPrimary3(expr interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonPrimary10() (interface{}, error) {
+func (p *parser) callonPrimary3() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onPrimary10(stack["expr"])
+	return p.cur.onPrimary3(stack["expr"])
+}
+
+func (c *current) onStringLiteral1(v interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Literal", "type": "string", "value": v}, nil
+
+}
+
+func (p *parser) callonStringLiteral1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onStringLiteral1(stack["v"])
+}
+
+func (c *current) onRegexpLiteral1(v interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Literal", "type": "regexp", "value": v}, nil
+
+}
+
+func (p *parser) callonRegexpLiteral1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onRegexpLiteral1(stack["v"])
+}
+
+func (c *current) onSubnetLiteral2(v interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Literal", "type": "net", "value": v}, nil
+
+}
+
+func (p *parser) callonSubnetLiteral2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSubnetLiteral2(stack["v"])
+}
+
+func (c *current) onSubnetLiteral8(v interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Literal", "type": "net", "value": v}, nil
+
+}
+
+func (p *parser) callonSubnetLiteral8() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSubnetLiteral8(stack["v"])
+}
+
+func (c *current) onAddressLiteral2(v interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Literal", "type": "ip", "value": v}, nil
+
+}
+
+func (p *parser) callonAddressLiteral2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onAddressLiteral2(stack["v"])
+}
+
+func (c *current) onAddressLiteral8(v interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Literal", "type": "ip", "value": v}, nil
+
+}
+
+func (p *parser) callonAddressLiteral8() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onAddressLiteral8(stack["v"])
+}
+
+func (c *current) onFloatLiteral1(v interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Literal", "type": "float64", "value": v}, nil
+
+}
+
+func (p *parser) callonFloatLiteral1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onFloatLiteral1(stack["v"])
+}
+
+func (c *current) onIntegerLiteral1(v interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Literal", "type": "int64", "value": v}, nil
+
+}
+
+func (p *parser) callonIntegerLiteral1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onIntegerLiteral1(stack["v"])
+}
+
+func (c *current) onBooleanLiteral2() (interface{}, error) {
+	return map[string]interface{}{"op": "Literal", "type": "bool", "value": "true"}, nil
+}
+
+func (p *parser) callonBooleanLiteral2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onBooleanLiteral2()
+}
+
+func (c *current) onBooleanLiteral4() (interface{}, error) {
+	return map[string]interface{}{"op": "Literal", "type": "bool", "value": "false"}, nil
+}
+
+func (p *parser) callonBooleanLiteral4() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onBooleanLiteral4()
+}
+
+func (c *current) onNullLiteral1() (interface{}, error) {
+	return map[string]interface{}{"op": "Literal", "type": "null", "value": ""}, nil
+}
+
+func (p *parser) callonNullLiteral1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onNullLiteral1()
 }
 
 func (c *current) onAndToken1() (interface{}, error) {
-	return string(c.text), nil
+	return "and", nil
 }
 
 func (p *parser) callonAndToken1() (interface{}, error) {
@@ -7353,7 +8168,7 @@ func (p *parser) callonAndToken1() (interface{}, error) {
 }
 
 func (c *current) onOrToken1() (interface{}, error) {
-	return string(c.text), nil
+	return "or", nil
 }
 
 func (p *parser) callonOrToken1() (interface{}, error) {
@@ -7363,7 +8178,7 @@ func (p *parser) callonOrToken1() (interface{}, error) {
 }
 
 func (c *current) onInToken1() (interface{}, error) {
-	return string(c.text), nil
+	return "in", nil
 }
 
 func (p *parser) callonInToken1() (interface{}, error) {
@@ -7373,7 +8188,7 @@ func (p *parser) callonInToken1() (interface{}, error) {
 }
 
 func (c *current) onNotToken1() (interface{}, error) {
-	return string(c.text), nil
+	return "not", nil
 }
 
 func (p *parser) callonNotToken1() (interface{}, error) {
@@ -7382,24 +8197,54 @@ func (p *parser) callonNotToken1() (interface{}, error) {
 	return p.cur.onNotToken1()
 }
 
-func (c *current) onIdentifierName1() (interface{}, error) {
-	return string(c.text), nil
+func (c *current) onByToken1() (interface{}, error) {
+	return "by", nil
 }
 
-func (p *parser) callonIdentifierName1() (interface{}, error) {
+func (p *parser) callonByToken1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onIdentifierName1()
+	return p.cur.onByToken1()
 }
 
-func (c *current) onIdentifier1() (interface{}, error) {
-	return map[string]interface{}{"op": "Identifier", "name": string(c.text)}, nil
+func (c *current) onIdentifier1(id interface{}) (interface{}, error) {
+	return map[string]interface{}{"op": "Identifier", "name": id}, nil
 }
 
 func (p *parser) callonIdentifier1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onIdentifier1()
+	return p.cur.onIdentifier1(stack["id"])
+}
+
+func (c *current) onIdentifierName2() (interface{}, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonIdentifierName2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onIdentifierName2()
+}
+
+func (c *current) onIdentifierName11() (interface{}, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonIdentifierName11() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onIdentifierName11()
+}
+
+func (c *current) onIdentifierName13(id interface{}) (interface{}, error) {
+	return id, nil
+}
+
+func (p *parser) callonIdentifierName13() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onIdentifierName13(stack["id"])
 }
 
 func (c *current) onSeconds2() (interface{}, error) {
@@ -7671,36 +8516,6 @@ func (p *parser) callonHex1() (interface{}, error) {
 	return p.cur.onHex1()
 }
 
-func (c *current) onKeyWord1(chars interface{}) (interface{}, error) {
-	return joinChars(chars), nil
-}
-
-func (p *parser) callonKeyWord1() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onKeyWord1(stack["chars"])
-}
-
-func (c *current) onKeyWordPart2(s interface{}) (interface{}, error) {
-	return s, nil
-}
-
-func (p *parser) callonKeyWordPart2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onKeyWordPart2(stack["s"])
-}
-
-func (c *current) onKeyWordPart9() (interface{}, error) {
-	return string(c.text), nil
-}
-
-func (p *parser) callonKeyWordPart9() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onKeyWordPart9()
-}
-
 func (c *current) onQuotedString2(v interface{}) (interface{}, error) {
 	return joinChars(v), nil
 }
@@ -7741,6 +8556,36 @@ func (p *parser) callonDoubleQuotedChar9() (interface{}, error) {
 	return p.cur.onDoubleQuotedChar9(stack["s"])
 }
 
+func (c *current) onKeyWord1(head, tail interface{}) (interface{}, error) {
+	return head.(string) + joinChars(tail), nil
+}
+
+func (p *parser) callonKeyWord1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onKeyWord1(stack["head"], stack["tail"])
+}
+
+func (c *current) onKeyWordStart2() (interface{}, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonKeyWordStart2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onKeyWordStart2()
+}
+
+func (c *current) onKeyWordEsc1(s interface{}) (interface{}, error) {
+	return s, nil
+}
+
+func (p *parser) callonKeyWordEsc1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onKeyWordEsc1(stack["s"])
+}
+
 func (c *current) onSingleQuotedChar2() (interface{}, error) {
 	return string(c.text), nil
 }
@@ -7771,84 +8616,114 @@ func (p *parser) callonEscapeSequence2() (interface{}, error) {
 	return p.cur.onEscapeSequence2()
 }
 
-func (c *current) onSingleCharEscape5() (interface{}, error) {
+func (c *current) onSingleCharEscape2() (interface{}, error) {
+	return "'", nil
+}
+
+func (p *parser) callonSingleCharEscape2() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSingleCharEscape2()
+}
+
+func (c *current) onSingleCharEscape4() (interface{}, error) {
+	return '"', nil
+}
+
+func (p *parser) callonSingleCharEscape4() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSingleCharEscape4()
+}
+
+func (c *current) onSingleCharEscape6() (interface{}, error) {
+	return "\\", nil
+}
+
+func (p *parser) callonSingleCharEscape6() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onSingleCharEscape6()
+}
+
+func (c *current) onSingleCharEscape8() (interface{}, error) {
 	return "\b", nil
 }
 
-func (p *parser) callonSingleCharEscape5() (interface{}, error) {
+func (p *parser) callonSingleCharEscape8() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleCharEscape5()
+	return p.cur.onSingleCharEscape8()
 }
 
-func (c *current) onSingleCharEscape7() (interface{}, error) {
+func (c *current) onSingleCharEscape10() (interface{}, error) {
 	return "\f", nil
 }
 
-func (p *parser) callonSingleCharEscape7() (interface{}, error) {
+func (p *parser) callonSingleCharEscape10() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleCharEscape7()
+	return p.cur.onSingleCharEscape10()
 }
 
-func (c *current) onSingleCharEscape9() (interface{}, error) {
+func (c *current) onSingleCharEscape12() (interface{}, error) {
 	return "\n", nil
 }
 
-func (p *parser) callonSingleCharEscape9() (interface{}, error) {
+func (p *parser) callonSingleCharEscape12() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleCharEscape9()
+	return p.cur.onSingleCharEscape12()
 }
 
-func (c *current) onSingleCharEscape11() (interface{}, error) {
+func (c *current) onSingleCharEscape14() (interface{}, error) {
 	return "\r", nil
 }
 
-func (p *parser) callonSingleCharEscape11() (interface{}, error) {
+func (p *parser) callonSingleCharEscape14() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleCharEscape11()
+	return p.cur.onSingleCharEscape14()
 }
 
-func (c *current) onSingleCharEscape13() (interface{}, error) {
+func (c *current) onSingleCharEscape16() (interface{}, error) {
 	return "\t", nil
 }
 
-func (p *parser) callonSingleCharEscape13() (interface{}, error) {
+func (p *parser) callonSingleCharEscape16() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleCharEscape13()
+	return p.cur.onSingleCharEscape16()
 }
 
-func (c *current) onSingleCharEscape15() (interface{}, error) {
+func (c *current) onSingleCharEscape18() (interface{}, error) {
 	return "\v", nil
 }
 
-func (p *parser) callonSingleCharEscape15() (interface{}, error) {
+func (p *parser) callonSingleCharEscape18() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleCharEscape15()
+	return p.cur.onSingleCharEscape18()
 }
 
-func (c *current) onSearchEscape2() (interface{}, error) {
+func (c *current) onKeywordEscape2() (interface{}, error) {
 	return "=", nil
 }
 
-func (p *parser) callonSearchEscape2() (interface{}, error) {
+func (p *parser) callonKeywordEscape2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSearchEscape2()
+	return p.cur.onKeywordEscape2()
 }
 
-func (c *current) onSearchEscape4() (interface{}, error) {
+func (c *current) onKeywordEscape4() (interface{}, error) {
 	return "\\*", nil
 }
 
-func (p *parser) callonSearchEscape4() (interface{}, error) {
+func (p *parser) callonKeywordEscape4() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSearchEscape4()
+	return p.cur.onKeywordEscape4()
 }
 
 func (c *current) onUnicodeEscape2(chars interface{}) (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -142,195 +142,204 @@ function peg$parse(input, options) {
       peg$startRuleFunction  = peg$parsestart,
 
       peg$c0 = function(ast) { return ast },
-      peg$c1 = function(procs) {
-            return {"op": "SequentialProc", "procs": procs}
+      peg$c1 = function(first, rest) {
+            return {"op": "SequentialProc", "procs": [first, ... rest]}
           },
-      peg$c2 = function(s, rest) {
-            if (rest.length == 0) {
-                return s
-            } else {
-                return {"op": "SequentialProc", "procs": [s, ... rest]}
-            }
+      peg$c2 = function(op) {
+            return {"op": "SequentialProc", "procs": [op]}
           },
-      peg$c3 = function(expr) {
+      peg$c3 = "|",
+      peg$c4 = peg$literalExpectation("|", false),
+      peg$c5 = function(p) { return p },
+      peg$c6 = function(first, rest) {
+            return [first, ... rest]
+          },
+      peg$c7 = function(first) {
+            return [first]
+          },
+      peg$c8 = "=>",
+      peg$c9 = peg$literalExpectation("=>", false),
+      peg$c10 = function(ch) { return ch },
+      peg$c11 = "split",
+      peg$c12 = peg$literalExpectation("split", false),
+      peg$c13 = "(",
+      peg$c14 = peg$literalExpectation("(", false),
+      peg$c15 = ")",
+      peg$c16 = peg$literalExpectation(")", false),
+      peg$c17 = function(procArray) {
+            return {"op": "ParallelProc", "procs": procArray}
+          },
+      peg$c18 = function(a) { return a },
+      peg$c19 = function(expr) {
             return {"op": "FilterProc", "filter": expr}
           },
-      peg$c4 = function(first, rest) {
-            return makeChain(first, rest, "LogicalOr")
+      peg$c20 = ":",
+      peg$c21 = peg$literalExpectation(":", false),
+      peg$c22 = "-with",
+      peg$c23 = peg$literalExpectation("-with", false),
+      peg$c24 = ",",
+      peg$c25 = peg$literalExpectation(",", false),
+      peg$c26 = function(first, rest) {
+            return makeBinaryExprChain(first, rest)
           },
-      peg$c5 = function(t) { return t },
-      peg$c6 = function(first, rest) {
-            return makeChain(first, rest, "LogicalAnd")
+      peg$c27 = function(t) { return ["or", t] },
+      peg$c28 = function(first, expr) { return ["and", expr] },
+      peg$c29 = function(first, rest) {
+            return makeBinaryExprChain(first,rest)
           },
-      peg$c7 = function(f) { return f },
-      peg$c8 = "!",
-      peg$c9 = peg$literalExpectation("!", false),
-      peg$c10 = function(e) {
-            return {"op": "LogicalNot", "expr": e}
+      peg$c30 = "!",
+      peg$c31 = peg$literalExpectation("!", false),
+      peg$c32 = function(e) {
+            return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c11 = "-",
-      peg$c12 = peg$literalExpectation("-", false),
-      peg$c13 = function(s) { return s },
-      peg$c14 = "(",
-      peg$c15 = peg$literalExpectation("(", false),
-      peg$c16 = ")",
-      peg$c17 = peg$literalExpectation(")", false),
-      peg$c18 = function(expr) { return expr },
-      peg$c19 = "*",
-      peg$c20 = peg$literalExpectation("*", false),
-      peg$c21 = function(comp, v) {
-            return {"op": "CompareAny", "comparator": comp, "recursive": false, "value": v}
+      peg$c33 = function(expr) { return expr },
+      peg$c34 = "*",
+      peg$c35 = peg$literalExpectation("*", false),
+      peg$c36 = function(compareOp, v) {
+            return {"op": "FunctionCall", "function": "or",
+              
+            "args": [{"op": "BinaryExpr", "operator":"@",
+                       
+            "lhs":{"op": "SelectExpr", "selectors": [{"op": "RootRecord"}]},
+                       
+            "rhs":{"op": "FunctionCall", "function": "map",
+                         
+            "args": [{"op": "BinaryExpr", "operator": "=",
+                           
+            "lhs": {"op": "Identifier", "name": "$"},
+                           
+            "rhs": v}]}}]}
+          
+
+
+
+
+
           },
-      peg$c22 = "**",
-      peg$c23 = peg$literalExpectation("**", false),
-      peg$c24 = function(comp, v) {
-            return {"op": "CompareAny", "comparator": comp, "recursive": true, "value": v}
+      peg$c37 = function(f, comp, v) {
+            return {"op": "BinaryExpr", "operator":comp, "lhs":f, "rhs":v}
           },
-      peg$c25 = function(f, comp, v) {
-            return {"op": "CompareField", "comparator": comp, "field": f, "value": v}
+      peg$c38 = function(v) {
+            return {"op": "FunctionCall", "function": "or",
+              
+            "args": [{"op": "BinaryExpr", "operator":"@",
+                       
+            "lhs":{"op": "SelectExpr", "selectors": [{"op": "RootRecord"}]},
+                       
+            "rhs":{"op": "FunctionCall", "function": "map",
+                         
+            "args": [{"op": "BinaryExpr", "operator": "in",
+                           
+            "lhs": v,
+                           
+            "rhs": {"op": "Identifier", "name": "$"}}]}}]}
+          
+
+
+
+
+
           },
-      peg$c26 = "len",
-      peg$c27 = peg$literalExpectation("len", false),
-      peg$c28 = function(expr, comp, v) {
-          return {"op": "BinaryExpression", "operator": comp, "lhs": expr, "rhs": v}
-        },
-      peg$c29 = function(v) {
-            return {"op": "CompareAny", "comparator": "in", "recursive": false, "value": v}
-          },
-      peg$c30 = function(v, f) {
-            return {"op": "CompareField", "comparator": "in", "field": f, "value": v}
-          },
-      peg$c31 = function(v) {
+      peg$c39 = function(v) {
             return {"op": "Search", "text": text(), "value": v}
           },
-      peg$c32 = function(v) {
+      peg$c40 = function() {
+            return {"op": "Literal", "type": "bool", "value": "true"}
+          },
+      peg$c41 = function(v) {
+            return {"op": "Literal", "type": "string", "value": v}
+          },
+      peg$c42 = function(v) {
             let str = v
-            if (str == "*") {
-              return {"op": "MatchAll"}
-            }
             let literal = {"op": "Literal", "type": "string", "value": v}
             if (reglob.IsGlobby(str)) {
               literal["type"] = "regexp"
               literal["value"] = reglob.Reglob(str)
             }
-            return {"op": "Search", "text": text(), "value": literal}
+            return literal
           },
-      peg$c33 = function(v) {
-            return {"op": "Literal", "type": "string", "value": v}
+      peg$c43 = function(head, tail) {
+            return joinChars(head) + joinChars(tail)
           },
-      peg$c34 = function(i) { return i },
-      peg$c35 = function(v) { return v },
-      peg$c36 = function(v) {
-            return {"op": "Literal", "type": "regexp", "value": v}
+      peg$c44 = function(s, v) { return s+v },
+      peg$c45 = function() { return text() },
+      peg$c46 = "=",
+      peg$c47 = peg$literalExpectation("=", false),
+      peg$c48 = "!=",
+      peg$c49 = peg$literalExpectation("!=", false),
+      peg$c50 = "in",
+      peg$c51 = peg$literalExpectation("in", false),
+      peg$c52 = "<=",
+      peg$c53 = peg$literalExpectation("<=", false),
+      peg$c54 = "<",
+      peg$c55 = peg$literalExpectation("<", false),
+      peg$c56 = ">=",
+      peg$c57 = peg$literalExpectation(">=", false),
+      peg$c58 = ">",
+      peg$c59 = peg$literalExpectation(">", false),
+      peg$c60 = function(first, op, expr) { return [op, expr] },
+      peg$c61 = function(first, rest) {
+              return makeBinaryExprChain(first, rest)
           },
-      peg$c37 = function(v) {
-            return {"op": "Literal", "type": "net", "value": v}
+      peg$c62 = function(e, typ) { return typ },
+      peg$c63 = function(e, typ) {
+            return {"op": "CastExpr", "expr": e, "type": typ}
           },
-      peg$c38 = function(v) {
-            return {"op": "Literal", "type": "ip", "value": v}
-          },
-      peg$c39 = function(v) {
-            return {"op": "Literal", "type": "float64", "value": v}
-          },
-      peg$c40 = function(v) {
-            return {"op": "Literal", "type": "int64", "value": v}
-          },
-      peg$c41 = "true",
-      peg$c42 = peg$literalExpectation("true", false),
-      peg$c43 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
-      peg$c44 = "false",
-      peg$c45 = peg$literalExpectation("false", false),
-      peg$c46 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
-      peg$c47 = "null",
-      peg$c48 = peg$literalExpectation("null", false),
-      peg$c49 = function() { return {"op": "Literal", "type": "null", "value": ""} },
-      peg$c50 = function(first, rest) {
-           if (rest) {
-              return [first, ... rest]
-            }
-            return [first]
-          },
-      peg$c51 = "|",
-      peg$c52 = peg$literalExpectation("|", false),
-      peg$c53 = function(p) { return p },
-      peg$c54 = "split",
-      peg$c55 = peg$literalExpectation("split", false),
-      peg$c56 = "=>",
-      peg$c57 = peg$literalExpectation("=>", false),
-      peg$c58 = function(proc) {
-            return proc
-          },
-      peg$c59 = function(first, rest) {
-            let fp = {"op": "SequentialProc", "procs": first}
-            if (rest) {
-              return {"op": "ParallelProc", "procs": [fp, ... rest]}
-            } else {
-              return fp
-            }
-          },
-      peg$c60 = ";",
-      peg$c61 = peg$literalExpectation(";", false),
-      peg$c62 = function(ch) { return {"op": "SequentialProc", "procs": ch} },
-      peg$c63 = function(every, keys, limit) {
+      peg$c64 = function(every, keys, limit) {
             return {"op": "GroupByProc", "keys": keys, "reducers": null, "duration": every, "limit": limit}
           },
-      peg$c64 = function(every, reducers, keys, limit) {
+      peg$c65 = function(every, reducers, keys, limit) {
             let p = {"op": "GroupByProc", "keys": null, "reducers": reducers, "duration": every, "limit": limit}
             if (keys) {
               p["keys"] = keys[1]
             }
             return p
           },
-      peg$c65 = "every",
-      peg$c66 = peg$literalExpectation("every", true),
-      peg$c67 = function(dur) { return dur },
-      peg$c68 = "by",
-      peg$c69 = peg$literalExpectation("by", true),
-      peg$c70 = function(columns) { return columns },
-      peg$c71 = "with",
-      peg$c72 = peg$literalExpectation("with", false),
-      peg$c73 = "-limit",
-      peg$c74 = peg$literalExpectation("-limit", false),
-      peg$c75 = function(limit) { return limit },
-      peg$c76 = "",
-      peg$c77 = function() { return 0 },
-      peg$c78 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c79 = ",",
-      peg$c80 = peg$literalExpectation(",", false),
-      peg$c81 = function(first, expr) { return expr },
-      peg$c82 = function(first, rest) {
-            return [first, ... rest]
-          },
-      peg$c83 = "=",
-      peg$c84 = peg$literalExpectation("=", false),
-      peg$c85 = function(lval, reducer) {
+      peg$c66 = "every",
+      peg$c67 = peg$literalExpectation("every", true),
+      peg$c68 = function(dur) { return dur },
+      peg$c69 = function(columns) { return columns },
+      peg$c70 = "with",
+      peg$c71 = peg$literalExpectation("with", false),
+      peg$c72 = "-limit",
+      peg$c73 = peg$literalExpectation("-limit", false),
+      peg$c74 = function(limit) { return limit },
+      peg$c75 = "",
+      peg$c76 = function() { return 0 },
+      peg$c77 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c78 = function(first, expr) { return expr },
+      peg$c79 = function(lval, reducer) {
             return {"op": "Assignment", "lhs": lval, "rhs": reducer}
           },
-      peg$c86 = function(reducer) {
+      peg$c80 = function(reducer) {
             return {"op": "Assignment", "lhs": null, "rhs": reducer}
           },
-      peg$c87 = "not",
-      peg$c88 = peg$literalExpectation("not", false),
-      peg$c89 = function(op, expr, where) {
+      peg$c81 = ".",
+      peg$c82 = peg$literalExpectation(".", false),
+      peg$c83 = function(op, expr, where) {
             let r = {"op": "Reducer", "operator": op, "expr": null, "where":where}
             if (expr) {
               r["expr"] = expr
             }
             return r
           },
-      peg$c90 = "where",
-      peg$c91 = peg$literalExpectation("where", false),
-      peg$c92 = function(first, rest) {
+      peg$c84 = "not",
+      peg$c85 = peg$literalExpectation("not", false),
+      peg$c86 = "match",
+      peg$c87 = peg$literalExpectation("match", false),
+      peg$c88 = "where",
+      peg$c89 = peg$literalExpectation("where", false),
+      peg$c90 = function(first, rest) {
             let result = [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c93 = "sort",
-      peg$c94 = peg$literalExpectation("sort", true),
-      peg$c95 = function(args, l) { return l },
-      peg$c96 = function(args, list) {
+      peg$c91 = "sort",
+      peg$c92 = peg$literalExpectation("sort", true),
+      peg$c93 = function(args, l) { return l },
+      peg$c94 = function(args, list) {
             let argm = args
             let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false}
             if ( "r" in argm) {
@@ -343,26 +352,24 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c97 = function(a) { return a },
-      peg$c98 = function(args) { return makeArgMap(args) },
-      peg$c99 = "-r",
-      peg$c100 = peg$literalExpectation("-r", false),
-      peg$c101 = function() { return {"name": "r", "value": null} },
-      peg$c102 = "-nulls",
-      peg$c103 = peg$literalExpectation("-nulls", false),
-      peg$c104 = "first",
-      peg$c105 = peg$literalExpectation("first", false),
-      peg$c106 = "last",
-      peg$c107 = peg$literalExpectation("last", false),
-      peg$c108 = function() { return text() },
-      peg$c109 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c110 = "top",
-      peg$c111 = peg$literalExpectation("top", true),
-      peg$c112 = function(n) { return n},
-      peg$c113 = "-flush",
-      peg$c114 = peg$literalExpectation("-flush", false),
-      peg$c115 = function(limit, flush, f) { return f },
-      peg$c116 = function(limit, flush, fields) {
+      peg$c95 = function(args) { return makeArgMap(args) },
+      peg$c96 = "-r",
+      peg$c97 = peg$literalExpectation("-r", false),
+      peg$c98 = function() { return {"name": "r", "value": null} },
+      peg$c99 = "-nulls",
+      peg$c100 = peg$literalExpectation("-nulls", false),
+      peg$c101 = "first",
+      peg$c102 = peg$literalExpectation("first", false),
+      peg$c103 = "last",
+      peg$c104 = peg$literalExpectation("last", false),
+      peg$c105 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c106 = "top",
+      peg$c107 = peg$literalExpectation("top", true),
+      peg$c108 = function(n) { return n},
+      peg$c109 = "-flush",
+      peg$c110 = peg$literalExpectation("-flush", false),
+      peg$c111 = function(limit, flush, f) { return f },
+      peg$c112 = function(limit, flush, fields) {
             let proc = {"op": "TopProc", "limit": 0, "fields": null, "flush": false}
             if (limit) {
               proc["limit"] = limit
@@ -375,9 +382,9 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c117 = "cut",
-      peg$c118 = peg$literalExpectation("cut", true),
-      peg$c119 = function(args, columns) {
+      peg$c113 = "cut",
+      peg$c114 = peg$literalExpectation("cut", true),
+      peg$c115 = function(args, columns) {
             let argm = args
             let proc = {"op": "CutProc", "fields": columns, "complement": false}
             if ( "c" in argm) {
@@ -385,77 +392,76 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c120 = "-c",
-      peg$c121 = peg$literalExpectation("-c", false),
-      peg$c122 = function() { return {"name": "c", "value": null} },
-      peg$c123 = function(args) {
+      peg$c116 = "-c",
+      peg$c117 = peg$literalExpectation("-c", false),
+      peg$c118 = function() { return {"name": "c", "value": null} },
+      peg$c119 = function(args) {
             return makeArgMap(args)
           },
-      peg$c124 = "pick",
-      peg$c125 = peg$literalExpectation("pick", true),
-      peg$c126 = function(columns) {
+      peg$c120 = "pick",
+      peg$c121 = peg$literalExpectation("pick", true),
+      peg$c122 = function(columns) {
             return {"op": "PickProc", "fields": columns}
           },
-      peg$c127 = "drop",
-      peg$c128 = peg$literalExpectation("drop", true),
-      peg$c129 = function(columns) {
+      peg$c123 = "drop",
+      peg$c124 = peg$literalExpectation("drop", true),
+      peg$c125 = function(columns) {
             return {"op": "DropProc", "fields": columns}
           },
-      peg$c130 = "head",
-      peg$c131 = peg$literalExpectation("head", true),
-      peg$c132 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c133 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c134 = "tail",
-      peg$c135 = peg$literalExpectation("tail", true),
-      peg$c136 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c137 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c138 = "filter",
-      peg$c139 = peg$literalExpectation("filter", true),
-      peg$c140 = "uniq",
-      peg$c141 = peg$literalExpectation("uniq", true),
-      peg$c142 = function() {
+      peg$c126 = "head",
+      peg$c127 = peg$literalExpectation("head", true),
+      peg$c128 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c129 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c130 = "tail",
+      peg$c131 = peg$literalExpectation("tail", true),
+      peg$c132 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c133 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c134 = "filter",
+      peg$c135 = peg$literalExpectation("filter", true),
+      peg$c136 = function(op) {
+            return op
+          },
+      peg$c137 = "uniq",
+      peg$c138 = peg$literalExpectation("uniq", true),
+      peg$c139 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c143 = function() {
+      peg$c140 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c144 = "put",
-      peg$c145 = peg$literalExpectation("put", true),
-      peg$c146 = function(columns) {
+      peg$c141 = "put",
+      peg$c142 = peg$literalExpectation("put", true),
+      peg$c143 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c147 = "rename",
-      peg$c148 = peg$literalExpectation("rename", true),
-      peg$c149 = function(first, cl) { return cl },
-      peg$c150 = function(first, rest) {
+      peg$c144 = "rename",
+      peg$c145 = peg$literalExpectation("rename", true),
+      peg$c146 = function(first, cl) { return cl },
+      peg$c147 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c151 = "fuse",
-      peg$c152 = peg$literalExpectation("fuse", true),
-      peg$c153 = function() {
+      peg$c148 = "fuse",
+      peg$c149 = peg$literalExpectation("fuse", true),
+      peg$c150 = function() {
             return {"op": "FuseProc"}
           },
-      peg$c154 = "join",
-      peg$c155 = peg$literalExpectation("join", true),
-      peg$c156 = function(leftKey, rightKey, columns) {
+      peg$c151 = "join",
+      peg$c152 = peg$literalExpectation("join", true),
+      peg$c153 = function(leftKey, rightKey, columns) {
             let proc = {"op": "JoinProc", "left_key": leftKey, "right_key": rightKey, "clauses": null}
             if (columns) {
               proc["clauses"] = columns[1]
             }
             return proc
           },
-      peg$c157 = function(key, columns) {
+      peg$c154 = function(key, columns) {
             let proc = {"op": "JoinProc", "left_key": key, "right_key": key, "clauses": null}
             if (columns) {
               proc["clauses"] = columns[1]
             }
             return proc
           },
-      peg$c158 = ".",
-      peg$c159 = peg$literalExpectation(".", false),
-      peg$c160 = function(field) { return {"op": "BinaryExpr", "operator":".", "lhs":{"op":"RootRecord"}, "rhs": field} },
-      peg$c161 = function() { return {"op": "RootRecord"} },
-      peg$c162 = function(first, rest) {
+      peg$c155 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -464,273 +470,312 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c163 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c164 = "?",
-      peg$c165 = peg$literalExpectation("?", false),
-      peg$c166 = ":",
-      peg$c167 = peg$literalExpectation(":", false),
-      peg$c168 = function(condition, thenClause, elseClause) {
+      peg$c156 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c157 = "?",
+      peg$c158 = peg$literalExpectation("?", false),
+      peg$c159 = function(condition, thenClause, elseClause) {
             return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c169 = function(first, op, expr) { return [op, expr] },
-      peg$c170 = function(first, rest) {
-              return makeBinaryExprChain(first, rest)
-          },
-      peg$c171 = function(first, comp, expr) { return [comp, expr] },
-      peg$c172 = "=~",
-      peg$c173 = peg$literalExpectation("=~", false),
-      peg$c174 = "!~",
-      peg$c175 = peg$literalExpectation("!~", false),
-      peg$c176 = "!=",
-      peg$c177 = peg$literalExpectation("!=", false),
-      peg$c178 = "in",
-      peg$c179 = peg$literalExpectation("in", false),
-      peg$c180 = "<=",
-      peg$c181 = peg$literalExpectation("<=", false),
-      peg$c182 = "<",
-      peg$c183 = peg$literalExpectation("<", false),
-      peg$c184 = ">=",
-      peg$c185 = peg$literalExpectation(">=", false),
-      peg$c186 = ">",
-      peg$c187 = peg$literalExpectation(">", false),
-      peg$c188 = "+",
-      peg$c189 = peg$literalExpectation("+", false),
-      peg$c190 = "/",
-      peg$c191 = peg$literalExpectation("/", false),
-      peg$c192 = function(e) {
+      peg$c160 = function(first, comp, expr) { return [comp, expr] },
+      peg$c161 = "+",
+      peg$c162 = peg$literalExpectation("+", false),
+      peg$c163 = "-",
+      peg$c164 = peg$literalExpectation("-", false),
+      peg$c165 = "/",
+      peg$c166 = peg$literalExpectation("/", false),
+      peg$c167 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c193 = function(e, typ) { return typ },
-      peg$c194 = function(e, typ) {
-            return {"op": "CastExpr", "expr": e, "type": typ}
+      peg$c168 = "bytes",
+      peg$c169 = peg$literalExpectation("bytes", false),
+      peg$c170 = "uint8",
+      peg$c171 = peg$literalExpectation("uint8", false),
+      peg$c172 = "uint16",
+      peg$c173 = peg$literalExpectation("uint16", false),
+      peg$c174 = "uint32",
+      peg$c175 = peg$literalExpectation("uint32", false),
+      peg$c176 = "uint64",
+      peg$c177 = peg$literalExpectation("uint64", false),
+      peg$c178 = "int8",
+      peg$c179 = peg$literalExpectation("int8", false),
+      peg$c180 = "int16",
+      peg$c181 = peg$literalExpectation("int16", false),
+      peg$c182 = "int32",
+      peg$c183 = peg$literalExpectation("int32", false),
+      peg$c184 = "int64",
+      peg$c185 = peg$literalExpectation("int64", false),
+      peg$c186 = "duration",
+      peg$c187 = peg$literalExpectation("duration", false),
+      peg$c188 = "time",
+      peg$c189 = peg$literalExpectation("time", false),
+      peg$c190 = "float64",
+      peg$c191 = peg$literalExpectation("float64", false),
+      peg$c192 = "bool",
+      peg$c193 = peg$literalExpectation("bool", false),
+      peg$c194 = "string",
+      peg$c195 = peg$literalExpectation("string", false),
+      peg$c196 = "bstring",
+      peg$c197 = peg$literalExpectation("bstring", false),
+      peg$c198 = "ip",
+      peg$c199 = peg$literalExpectation("ip", false),
+      peg$c200 = "net",
+      peg$c201 = peg$literalExpectation("net", false),
+      peg$c202 = "type",
+      peg$c203 = peg$literalExpectation("type", false),
+      peg$c204 = "error",
+      peg$c205 = peg$literalExpectation("error", false),
+      peg$c206 = "null",
+      peg$c207 = peg$literalExpectation("null", false),
+      peg$c208 = "select",
+      peg$c209 = peg$literalExpectation("select", false),
+      peg$c210 = function(args, e) { return ["@", e] },
+      peg$c211 = function(args, methods) {
+            return makeBinaryExprChain({"op":"SelectExpr", "selectors":args}, methods)
           },
-      peg$c195 = "bytes",
-      peg$c196 = peg$literalExpectation("bytes", false),
-      peg$c197 = "uint8",
-      peg$c198 = peg$literalExpectation("uint8", false),
-      peg$c199 = "uint16",
-      peg$c200 = peg$literalExpectation("uint16", false),
-      peg$c201 = "uint32",
-      peg$c202 = peg$literalExpectation("uint32", false),
-      peg$c203 = "uint64",
-      peg$c204 = peg$literalExpectation("uint64", false),
-      peg$c205 = "int8",
-      peg$c206 = peg$literalExpectation("int8", false),
-      peg$c207 = "int16",
-      peg$c208 = peg$literalExpectation("int16", false),
-      peg$c209 = "int32",
-      peg$c210 = peg$literalExpectation("int32", false),
-      peg$c211 = "int64",
-      peg$c212 = peg$literalExpectation("int64", false),
-      peg$c213 = "duration",
-      peg$c214 = peg$literalExpectation("duration", false),
-      peg$c215 = "time",
-      peg$c216 = peg$literalExpectation("time", false),
-      peg$c217 = "float64",
-      peg$c218 = peg$literalExpectation("float64", false),
-      peg$c219 = "bool",
-      peg$c220 = peg$literalExpectation("bool", false),
-      peg$c221 = "string",
-      peg$c222 = peg$literalExpectation("string", false),
-      peg$c223 = "bstring",
-      peg$c224 = peg$literalExpectation("bstring", false),
-      peg$c225 = "ip",
-      peg$c226 = peg$literalExpectation("ip", false),
-      peg$c227 = "net",
-      peg$c228 = peg$literalExpectation("net", false),
-      peg$c229 = "type",
-      peg$c230 = peg$literalExpectation("type", false),
-      peg$c231 = "error",
-      peg$c232 = peg$literalExpectation("error", false),
-      peg$c233 = function(first, rest) {
-            return makeBinaryExprChain(first, rest)
-          },
-      peg$c234 = function(fn, args) {
+      peg$c212 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c235 = function(first, e) { return e },
-      peg$c236 = function() { return [] },
-      peg$c237 = "[",
-      peg$c238 = peg$literalExpectation("[", false),
-      peg$c239 = "]",
-      peg$c240 = peg$literalExpectation("]", false),
-      peg$c241 = function(expr) { return ["[", expr] },
-      peg$c242 = function(id) { return [".", id] },
-      peg$c243 = "and",
-      peg$c244 = peg$literalExpectation("and", true),
-      peg$c245 = "or",
-      peg$c246 = peg$literalExpectation("or", true),
-      peg$c247 = peg$literalExpectation("in", true),
-      peg$c248 = peg$literalExpectation("not", true),
+      peg$c213 = function(first, e) { return e },
+      peg$c214 = function() { return [] },
+      peg$c215 = function() {
+            return {"op":"RootRecord"}
+          },
+      peg$c216 = function(field) {
+            return {"op": "BinaryExpr", "operator":".",
+                           
+            "lhs":{"op":"RootRecord"},
+                           
+            "rhs":field}
+          
+
+          },
+      peg$c217 = "[",
+      peg$c218 = peg$literalExpectation("[", false),
+      peg$c219 = "]",
+      peg$c220 = peg$literalExpectation("]", false),
+      peg$c221 = function(expr) {
+            return {"op": "BinaryExpr", "operator":"[",
+                           
+            "lhs":{"op":"RootRecord"},
+                           
+            "rhs":expr}
+          
+
+          },
+      peg$c222 = function(expr) { return ["[", expr] },
+      peg$c223 = function(id) { return [".", id] },
+      peg$c224 = function(v) {
+            return {"op": "Literal", "type": "regexp", "value": v}
+          },
+      peg$c225 = function(v) {
+            return {"op": "Literal", "type": "net", "value": v}
+          },
+      peg$c226 = function(v) {
+            return {"op": "Literal", "type": "ip", "value": v}
+          },
+      peg$c227 = function(v) {
+            return {"op": "Literal", "type": "float64", "value": v}
+          },
+      peg$c228 = function(v) {
+            return {"op": "Literal", "type": "int64", "value": v}
+          },
+      peg$c229 = "true",
+      peg$c230 = peg$literalExpectation("true", false),
+      peg$c231 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
+      peg$c232 = "false",
+      peg$c233 = peg$literalExpectation("false", false),
+      peg$c234 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
+      peg$c235 = function() { return {"op": "Literal", "type": "null", "value": ""} },
+      peg$c236 = "and",
+      peg$c237 = peg$literalExpectation("and", true),
+      peg$c238 = function() { return "and" },
+      peg$c239 = "or",
+      peg$c240 = peg$literalExpectation("or", true),
+      peg$c241 = function() { return "or" },
+      peg$c242 = peg$literalExpectation("in", true),
+      peg$c243 = function() { return "in" },
+      peg$c244 = peg$literalExpectation("not", true),
+      peg$c245 = function() { return "not" },
+      peg$c246 = "by",
+      peg$c247 = peg$literalExpectation("by", true),
+      peg$c248 = function() { return "by" },
       peg$c249 = /^[A-Za-z_$]/,
       peg$c250 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
       peg$c251 = /^[0-9]/,
       peg$c252 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c253 = function() { return {"op": "Identifier", "name": text()} },
-      peg$c254 = peg$literalExpectation("and", false),
-      peg$c255 = "seconds",
-      peg$c256 = peg$literalExpectation("seconds", false),
-      peg$c257 = "second",
-      peg$c258 = peg$literalExpectation("second", false),
-      peg$c259 = "secs",
-      peg$c260 = peg$literalExpectation("secs", false),
-      peg$c261 = "sec",
-      peg$c262 = peg$literalExpectation("sec", false),
-      peg$c263 = "s",
-      peg$c264 = peg$literalExpectation("s", false),
-      peg$c265 = "minutes",
-      peg$c266 = peg$literalExpectation("minutes", false),
-      peg$c267 = "minute",
-      peg$c268 = peg$literalExpectation("minute", false),
-      peg$c269 = "mins",
-      peg$c270 = peg$literalExpectation("mins", false),
-      peg$c271 = "min",
-      peg$c272 = peg$literalExpectation("min", false),
-      peg$c273 = "m",
-      peg$c274 = peg$literalExpectation("m", false),
-      peg$c275 = "hours",
-      peg$c276 = peg$literalExpectation("hours", false),
-      peg$c277 = "hrs",
-      peg$c278 = peg$literalExpectation("hrs", false),
-      peg$c279 = "hr",
-      peg$c280 = peg$literalExpectation("hr", false),
-      peg$c281 = "h",
-      peg$c282 = peg$literalExpectation("h", false),
-      peg$c283 = "hour",
-      peg$c284 = peg$literalExpectation("hour", false),
-      peg$c285 = "days",
-      peg$c286 = peg$literalExpectation("days", false),
-      peg$c287 = "day",
-      peg$c288 = peg$literalExpectation("day", false),
-      peg$c289 = "d",
-      peg$c290 = peg$literalExpectation("d", false),
-      peg$c291 = "weeks",
-      peg$c292 = peg$literalExpectation("weeks", false),
-      peg$c293 = "week",
-      peg$c294 = peg$literalExpectation("week", false),
-      peg$c295 = "wks",
-      peg$c296 = peg$literalExpectation("wks", false),
-      peg$c297 = "wk",
-      peg$c298 = peg$literalExpectation("wk", false),
-      peg$c299 = "w",
-      peg$c300 = peg$literalExpectation("w", false),
-      peg$c301 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c302 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c303 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c304 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c305 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c306 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c307 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c308 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c309 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c310 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c311 = function(a, b) {
+      peg$c253 = function(id) { return {"op": "Identifier", "name": id} },
+      peg$c254 = function() {  return text() },
+      peg$c255 = "$",
+      peg$c256 = peg$literalExpectation("$", false),
+      peg$c257 = "\\",
+      peg$c258 = peg$literalExpectation("\\", false),
+      peg$c259 = function(id) { return id },
+      peg$c260 = peg$literalExpectation("and", false),
+      peg$c261 = "seconds",
+      peg$c262 = peg$literalExpectation("seconds", false),
+      peg$c263 = "second",
+      peg$c264 = peg$literalExpectation("second", false),
+      peg$c265 = "secs",
+      peg$c266 = peg$literalExpectation("secs", false),
+      peg$c267 = "sec",
+      peg$c268 = peg$literalExpectation("sec", false),
+      peg$c269 = "s",
+      peg$c270 = peg$literalExpectation("s", false),
+      peg$c271 = "minutes",
+      peg$c272 = peg$literalExpectation("minutes", false),
+      peg$c273 = "minute",
+      peg$c274 = peg$literalExpectation("minute", false),
+      peg$c275 = "mins",
+      peg$c276 = peg$literalExpectation("mins", false),
+      peg$c277 = "min",
+      peg$c278 = peg$literalExpectation("min", false),
+      peg$c279 = "m",
+      peg$c280 = peg$literalExpectation("m", false),
+      peg$c281 = "hours",
+      peg$c282 = peg$literalExpectation("hours", false),
+      peg$c283 = "hrs",
+      peg$c284 = peg$literalExpectation("hrs", false),
+      peg$c285 = "hr",
+      peg$c286 = peg$literalExpectation("hr", false),
+      peg$c287 = "h",
+      peg$c288 = peg$literalExpectation("h", false),
+      peg$c289 = "hour",
+      peg$c290 = peg$literalExpectation("hour", false),
+      peg$c291 = "days",
+      peg$c292 = peg$literalExpectation("days", false),
+      peg$c293 = "day",
+      peg$c294 = peg$literalExpectation("day", false),
+      peg$c295 = "d",
+      peg$c296 = peg$literalExpectation("d", false),
+      peg$c297 = "weeks",
+      peg$c298 = peg$literalExpectation("weeks", false),
+      peg$c299 = "week",
+      peg$c300 = peg$literalExpectation("week", false),
+      peg$c301 = "wks",
+      peg$c302 = peg$literalExpectation("wks", false),
+      peg$c303 = "wk",
+      peg$c304 = peg$literalExpectation("wk", false),
+      peg$c305 = "w",
+      peg$c306 = peg$literalExpectation("w", false),
+      peg$c307 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c308 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c309 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c310 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c311 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c312 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c313 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c314 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c315 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c316 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c317 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c312 = "::",
-      peg$c313 = peg$literalExpectation("::", false),
-      peg$c314 = function(a, b, d, e) {
+      peg$c318 = "::",
+      peg$c319 = peg$literalExpectation("::", false),
+      peg$c320 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c315 = function(a, b) {
+      peg$c321 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c316 = function(a, b) {
+      peg$c322 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c317 = function() {
+      peg$c323 = function() {
             return "::"
           },
-      peg$c318 = function(v) { return ":" + v },
-      peg$c319 = function(v) { return v + ":" },
-      peg$c320 = function(a, m) {
+      peg$c324 = function(v) { return ":" + v },
+      peg$c325 = function(v) { return v + ":" },
+      peg$c326 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c321 = function(a, m) {
+      peg$c327 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c322 = function(s) { return parseInt(s) },
-      peg$c323 = function() {
+      peg$c328 = function(s) { return parseInt(s) },
+      peg$c329 = function() {
             return text()
           },
-      peg$c324 = "e",
-      peg$c325 = peg$literalExpectation("e", true),
-      peg$c326 = /^[+\-]/,
-      peg$c327 = peg$classExpectation(["+", "-"], false, false),
-      peg$c328 = /^[0-9a-fA-F]/,
-      peg$c329 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c330 = function(chars) { return joinChars(chars) },
-      peg$c331 = "\\",
-      peg$c332 = peg$literalExpectation("\\", false),
-      peg$c333 = /^[\0-\x1F\\(),!><="|';:]/,
-      peg$c334 = peg$classExpectation([["\0", "\x1F"], "\\", "(", ")", ",", "!", ">", "<", "=", "\"", "|", "'", ";", ":"], false, false),
-      peg$c335 = peg$anyExpectation(),
+      peg$c330 = "e",
+      peg$c331 = peg$literalExpectation("e", true),
+      peg$c332 = /^[+\-]/,
+      peg$c333 = peg$classExpectation(["+", "-"], false, false),
+      peg$c334 = /^[0-9a-fA-F]/,
+      peg$c335 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
       peg$c336 = "\"",
       peg$c337 = peg$literalExpectation("\"", false),
       peg$c338 = function(v) { return joinChars(v) },
       peg$c339 = "'",
       peg$c340 = peg$literalExpectation("'", false),
-      peg$c341 = "x",
-      peg$c342 = peg$literalExpectation("x", false),
-      peg$c343 = function() { return "\\" + text() },
-      peg$c344 = "b",
-      peg$c345 = peg$literalExpectation("b", false),
-      peg$c346 = function() { return "\b" },
-      peg$c347 = "f",
-      peg$c348 = peg$literalExpectation("f", false),
-      peg$c349 = function() { return "\f" },
-      peg$c350 = "n",
-      peg$c351 = peg$literalExpectation("n", false),
-      peg$c352 = function() { return "\n" },
-      peg$c353 = "r",
-      peg$c354 = peg$literalExpectation("r", false),
-      peg$c355 = function() { return "\r" },
-      peg$c356 = "t",
-      peg$c357 = peg$literalExpectation("t", false),
-      peg$c358 = function() { return "\t" },
-      peg$c359 = "v",
-      peg$c360 = peg$literalExpectation("v", false),
-      peg$c361 = function() { return "\v" },
-      peg$c362 = function() { return "=" },
-      peg$c363 = function() { return "\\*" },
-      peg$c364 = "u",
-      peg$c365 = peg$literalExpectation("u", false),
-      peg$c366 = function(chars) {
+      peg$c341 = peg$anyExpectation(),
+      peg$c342 = function(s) { return s },
+      peg$c343 = function(head, tail) { return head + joinChars(tail) },
+      peg$c344 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c345 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c346 = "x",
+      peg$c347 = peg$literalExpectation("x", false),
+      peg$c348 = function() { return "\\" + text() },
+      peg$c349 = function() { return "'"},
+      peg$c350 = function() { return '"'},
+      peg$c351 = function() { return "\\"},
+      peg$c352 = "b",
+      peg$c353 = peg$literalExpectation("b", false),
+      peg$c354 = function() { return "\b" },
+      peg$c355 = "f",
+      peg$c356 = peg$literalExpectation("f", false),
+      peg$c357 = function() { return "\f" },
+      peg$c358 = "n",
+      peg$c359 = peg$literalExpectation("n", false),
+      peg$c360 = function() { return "\n" },
+      peg$c361 = "r",
+      peg$c362 = peg$literalExpectation("r", false),
+      peg$c363 = function() { return "\r" },
+      peg$c364 = "t",
+      peg$c365 = peg$literalExpectation("t", false),
+      peg$c366 = function() { return "\t" },
+      peg$c367 = "v",
+      peg$c368 = peg$literalExpectation("v", false),
+      peg$c369 = function() { return "\v" },
+      peg$c370 = function() { return "=" },
+      peg$c371 = function() { return "\\*" },
+      peg$c372 = "u",
+      peg$c373 = peg$literalExpectation("u", false),
+      peg$c374 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c367 = "{",
-      peg$c368 = peg$literalExpectation("{", false),
-      peg$c369 = "}",
-      peg$c370 = peg$literalExpectation("}", false),
-      peg$c371 = function(body) { return body },
-      peg$c372 = /^[^\/\\]/,
-      peg$c373 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c374 = "\\/",
-      peg$c375 = peg$literalExpectation("\\/", false),
-      peg$c376 = /^[\0-\x1F\\]/,
-      peg$c377 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c378 = peg$otherExpectation("whitespace"),
-      peg$c379 = "\t",
-      peg$c380 = peg$literalExpectation("\t", false),
-      peg$c381 = "\x0B",
-      peg$c382 = peg$literalExpectation("\x0B", false),
-      peg$c383 = "\f",
-      peg$c384 = peg$literalExpectation("\f", false),
-      peg$c385 = " ",
-      peg$c386 = peg$literalExpectation(" ", false),
-      peg$c387 = "\xA0",
-      peg$c388 = peg$literalExpectation("\xA0", false),
-      peg$c389 = "\uFEFF",
-      peg$c390 = peg$literalExpectation("\uFEFF", false),
-      peg$c391 = /^[\n\r\u2028\u2029]/,
-      peg$c392 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c393 = peg$otherExpectation("comment"),
-      peg$c394 = "/*",
-      peg$c395 = peg$literalExpectation("/*", false),
-      peg$c396 = "*/",
-      peg$c397 = peg$literalExpectation("*/", false),
-      peg$c398 = "//",
-      peg$c399 = peg$literalExpectation("//", false),
+      peg$c375 = "{",
+      peg$c376 = peg$literalExpectation("{", false),
+      peg$c377 = "}",
+      peg$c378 = peg$literalExpectation("}", false),
+      peg$c379 = function(body) { return body },
+      peg$c380 = /^[^\/\\]/,
+      peg$c381 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c382 = "\\/",
+      peg$c383 = peg$literalExpectation("\\/", false),
+      peg$c384 = /^[\0-\x1F\\]/,
+      peg$c385 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c386 = peg$otherExpectation("whitespace"),
+      peg$c387 = "\t",
+      peg$c388 = peg$literalExpectation("\t", false),
+      peg$c389 = "\x0B",
+      peg$c390 = peg$literalExpectation("\x0B", false),
+      peg$c391 = "\f",
+      peg$c392 = peg$literalExpectation("\f", false),
+      peg$c393 = " ",
+      peg$c394 = peg$literalExpectation(" ", false),
+      peg$c395 = "\xA0",
+      peg$c396 = peg$literalExpectation("\xA0", false),
+      peg$c397 = "\uFEFF",
+      peg$c398 = peg$literalExpectation("\uFEFF", false),
+      peg$c399 = /^[\n\r\u2028\u2029]/,
+      peg$c400 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c401 = peg$otherExpectation("comment"),
+      peg$c402 = "/*",
+      peg$c403 = peg$literalExpectation("/*", false),
+      peg$c404 = "*/",
+      peg$c405 = peg$literalExpectation("*/", false),
+      peg$c406 = "//",
+      peg$c407 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -874,7 +919,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseQuery();
+      s2 = peg$parseSequential();
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
@@ -903,78 +948,25 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseQuery() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parseSequentialProcs();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c1(s1);
-    }
-    s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseSearch();
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
-        if (s2 !== peg$FAILED) {
-          s3 = [];
-          s4 = peg$parseSequentialTail();
-          while (s4 !== peg$FAILED) {
-            s3.push(s4);
-            s4 = peg$parseSequentialTail();
-          }
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c2(s1, s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseSearch() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parseSearchExpr();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c3(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseSearchExpr() {
+  function peg$parseSequential() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseSearchTerm();
+    s1 = peg$parseOperation();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseOredSearchTerm();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseOredSearchTerm();
+      s3 = peg$parseSequentialTail();
+      if (s3 !== peg$FAILED) {
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parseSequentialTail();
+        }
+      } else {
+        s2 = peg$FAILED;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c4(s1, s2);
+        s1 = peg$c1(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -984,21 +976,36 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseOperation();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c2(s1);
+      }
+      s0 = s1;
+    }
 
     return s0;
   }
 
-  function peg$parseOredSearchTerm() {
+  function peg$parseSequentialTail() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parse_();
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseOrToken();
+      if (input.charCodeAt(peg$currPos) === 124) {
+        s2 = peg$c3;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c4); }
+      }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parse_();
+        s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseSearchTerm();
+          s4 = peg$parseOperation();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
             s1 = peg$c5(s4);
@@ -1023,17 +1030,21 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseSearchTerm() {
+  function peg$parseParallel() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseSearchFactor();
+    s1 = peg$parseSequential();
     if (s1 !== peg$FAILED) {
       s2 = [];
-      s3 = peg$parseAndedSearchTerm();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseAndedSearchTerm();
+      s3 = peg$parseParallelTail();
+      if (s3 !== peg$FAILED) {
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parseParallelTail();
+        }
+      } else {
+        s2 = peg$FAILED;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -1047,20 +1058,231 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseSequential();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c7(s1);
+      }
+      s0 = s1;
+    }
 
     return s0;
   }
 
-  function peg$parseAndedSearchTerm() {
+  function peg$parseParallelTail() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    s1 = peg$parse_();
+    s1 = peg$parse__();
+    if (s1 !== peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c8) {
+        s2 = peg$c8;
+        peg$currPos += 2;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse__();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseSequential();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c10(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseOperation() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5) === peg$c11) {
+      s1 = peg$c11;
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c12); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c13;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c14); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            if (input.substr(peg$currPos, 2) === peg$c8) {
+              s5 = peg$c8;
+              peg$currPos += 2;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c9); }
+            }
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseParallel();
+                if (s7 !== peg$FAILED) {
+                  s8 = peg$parse__();
+                  if (s8 !== peg$FAILED) {
+                    if (input.charCodeAt(peg$currPos) === 41) {
+                      s9 = peg$c15;
+                      peg$currPos++;
+                    } else {
+                      s9 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                    }
+                    if (s9 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c17(s7);
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseOperator();
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseAggregation();
+        if (s1 !== peg$FAILED) {
+          s2 = peg$currPos;
+          peg$silentFails++;
+          s3 = peg$parseExprGuard();
+          peg$silentFails--;
+          if (s3 === peg$FAILED) {
+            s2 = void 0;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c18(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parseSearchBoolean();
+          if (s1 !== peg$FAILED) {
+            s2 = peg$currPos;
+            peg$silentFails++;
+            s3 = peg$parseAggGuard();
+            peg$silentFails--;
+            if (s3 === peg$FAILED) {
+              s2 = void 0;
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+            if (s2 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c19(s1);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseExprGuard() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parse__();
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
-      s3 = peg$parseAndToken();
+      s3 = peg$currPos;
+      peg$silentFails++;
+      if (input.substr(peg$currPos, 2) === peg$c8) {
+        s4 = peg$c8;
+        peg$currPos += 2;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      }
+      peg$silentFails--;
+      if (s4 === peg$FAILED) {
+        s3 = void 0;
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
       if (s3 !== peg$FAILED) {
-        s4 = peg$parse_();
+        s4 = peg$parseComparator();
         if (s4 !== peg$FAILED) {
           s3 = [s3, s4];
           s2 = s3;
@@ -1073,18 +1295,271 @@ function peg$parse(input, options) {
         s2 = peg$FAILED;
       }
       if (s2 === peg$FAILED) {
-        s2 = null;
+        s2 = peg$parseAdditiveOperator();
+        if (s2 === peg$FAILED) {
+          s2 = peg$parseMultiplicativeOperator();
+          if (s2 === peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 58) {
+              s2 = peg$c20;
+              peg$currPos++;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c21); }
+            }
+            if (s2 === peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 40) {
+                s2 = peg$c13;
+                peg$currPos++;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c14); }
+              }
+            }
+          }
+        }
       }
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseSearchFactor();
+        s1 = [s1, s2];
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAggGuard() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parse_();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseByToken();
+      if (s2 === peg$FAILED) {
+        if (input.substr(peg$currPos, 5) === peg$c22) {
+          s2 = peg$c22;
+          peg$currPos += 5;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c23); }
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseEOT();
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c7(s3);
+          s1 = [s1, s2, s3];
           s0 = s1;
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parse__();
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s2 = peg$c24;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
+        }
+        if (s2 !== peg$FAILED) {
+          s1 = [s1, s2];
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchBoolean() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSearchAnd();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseSearchOrTerm();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseSearchOrTerm();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c26(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchOrTerm() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parse_();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseOrToken();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parse_();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parseSearchAnd();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c27(s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchAnd() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSearchFactor();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$currPos;
+        s6 = peg$parseAndToken();
+        if (s6 !== peg$FAILED) {
+          s7 = peg$parse_();
+          if (s7 !== peg$FAILED) {
+            s6 = [s6, s7];
+            s5 = s6;
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s5;
+          s5 = peg$FAILED;
+        }
+        if (s5 === peg$FAILED) {
+          s5 = null;
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseSearchFactor();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c28(s1, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$currPos;
+          s6 = peg$parseAndToken();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parse_();
+            if (s7 !== peg$FAILED) {
+              s6 = [s6, s7];
+              s5 = s6;
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+          if (s5 === peg$FAILED) {
+            s5 = null;
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseSearchFactor();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c28(s1, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c29(s1, s2);
+        s0 = s1;
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1119,11 +1594,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c8;
+        s2 = peg$c30;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c9); }
+        if (peg$silentFails === 0) { peg$fail(peg$c31); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -1140,10 +1615,10 @@ function peg$parse(input, options) {
       }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseSearchExpr();
+      s2 = peg$parseSearchFactor();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c10(s2);
+        s1 = peg$c32(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1154,64 +1629,40 @@ function peg$parse(input, options) {
       s0 = peg$FAILED;
     }
     if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$currPos;
-      peg$silentFails++;
-      if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c11;
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c12); }
-      }
-      peg$silentFails--;
-      if (s2 === peg$FAILED) {
-        s1 = void 0;
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parseSearchPred();
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c13(s2);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+      s0 = peg$parseShortCut();
       if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c14;
-          peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c15); }
-        }
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parse__();
-          if (s2 !== peg$FAILED) {
-            s3 = peg$parseSearchExpr();
-            if (s3 !== peg$FAILED) {
-              s4 = peg$parse__();
-              if (s4 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 41) {
-                  s5 = peg$c16;
-                  peg$currPos++;
-                } else {
-                  s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c17); }
-                }
-                if (s5 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c18(s3);
-                  s0 = s1;
+        s0 = peg$parseSearchExprRelative();
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 40) {
+            s1 = peg$c13;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c14); }
+          }
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parse__();
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parseSearchBoolean();
+              if (s3 !== peg$FAILED) {
+                s4 = peg$parse__();
+                if (s4 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 41) {
+                    s5 = peg$c15;
+                    peg$currPos++;
+                  } else {
+                    s5 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                  }
+                  if (s5 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c33(s3);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
@@ -1228,9 +1679,6 @@ function peg$parse(input, options) {
             peg$currPos = s0;
             s0 = peg$FAILED;
           }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
         }
       }
     }
@@ -1238,16 +1686,16 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseSearchPred() {
-    var s0, s1, s2, s3, s4, s5, s6;
+  function peg$parseShortCut() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c19;
+      s1 = peg$c34;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c20); }
+      if (peg$silentFails === 0) { peg$fail(peg$c35); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -1259,7 +1707,7 @@ function peg$parse(input, options) {
             s5 = peg$parseSearchValue();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c21(s3, s5);
+              s1 = peg$c36(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1283,13 +1731,7 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c22) {
-        s1 = peg$c22;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c23); }
-      }
+      s1 = peg$parseDerefExpr();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
@@ -1297,11 +1739,26 @@ function peg$parse(input, options) {
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
-              s5 = peg$parseSearchValue();
+              s5 = peg$parseGlobbySearchValue();
               if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c24(s3, s5);
-                s0 = s1;
+                s6 = peg$currPos;
+                peg$silentFails++;
+                s7 = peg$parseExprGuard();
+                peg$silentFails--;
+                if (s7 === peg$FAILED) {
+                  s6 = void 0;
+                } else {
+                  peg$currPos = s6;
+                  s6 = peg$FAILED;
+                }
+                if (s6 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c37(s1, s3, s5);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -1324,18 +1781,24 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parseDerefExpr();
+        s1 = peg$parseSearchValue();
         if (s1 !== peg$FAILED) {
-          s2 = peg$parse__();
+          s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parseEqualityToken();
+            s3 = peg$parseInToken();
             if (s3 !== peg$FAILED) {
-              s4 = peg$parse__();
+              s4 = peg$parse_();
               if (s4 !== peg$FAILED) {
-                s5 = peg$parseSearchValue();
+                if (input.charCodeAt(peg$currPos) === 42) {
+                  s5 = peg$c34;
+                  peg$currPos++;
+                } else {
+                  s5 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c35); }
+                }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c25(s1, s3, s5);
+                  s1 = peg$c38(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1361,46 +1824,45 @@ function peg$parse(input, options) {
           s0 = peg$currPos;
           s1 = peg$currPos;
           peg$silentFails++;
-          if (input.substr(peg$currPos, 3) === peg$c26) {
-            s2 = peg$c26;
-            peg$currPos += 3;
+          s2 = peg$currPos;
+          s3 = peg$parseSearchGuard();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parseEOT();
+            if (s4 !== peg$FAILED) {
+              s3 = [s3, s4];
+              s2 = s3;
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
           } else {
+            peg$currPos = s2;
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c27); }
           }
           peg$silentFails--;
-          if (s2 !== peg$FAILED) {
-            peg$currPos = s1;
+          if (s2 === peg$FAILED) {
             s1 = void 0;
           } else {
+            peg$currPos = s1;
             s1 = peg$FAILED;
           }
           if (s1 !== peg$FAILED) {
-            s2 = peg$parseFunction();
+            s2 = peg$parseGlobbySearchValue();
             if (s2 !== peg$FAILED) {
-              s3 = peg$parse__();
+              s3 = peg$currPos;
+              peg$silentFails++;
+              s4 = peg$parseExprGuard();
+              peg$silentFails--;
+              if (s4 === peg$FAILED) {
+                s3 = void 0;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
               if (s3 !== peg$FAILED) {
-                s4 = peg$parseEqualityToken();
-                if (s4 !== peg$FAILED) {
-                  s5 = peg$parse__();
-                  if (s5 !== peg$FAILED) {
-                    s6 = peg$parseSearchValue();
-                    if (s6 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c28(s2, s4, s6);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
+                peg$savedPos = s0;
+                s1 = peg$c39(s2);
+                s0 = s1;
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -1415,37 +1877,28 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            s1 = peg$parseSearchValue();
+            if (input.charCodeAt(peg$currPos) === 42) {
+              s1 = peg$c34;
+              peg$currPos++;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c35); }
+            }
             if (s1 !== peg$FAILED) {
-              s2 = peg$parse__();
+              s2 = peg$currPos;
+              peg$silentFails++;
+              s3 = peg$parseExprGuard();
+              peg$silentFails--;
+              if (s3 === peg$FAILED) {
+                s2 = void 0;
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
               if (s2 !== peg$FAILED) {
-                s3 = peg$parseInToken();
-                if (s3 !== peg$FAILED) {
-                  s4 = peg$parse__();
-                  if (s4 !== peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 42) {
-                      s5 = peg$c19;
-                      peg$currPos++;
-                    } else {
-                      s5 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c20); }
-                    }
-                    if (s5 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c29(s1);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
+                peg$savedPos = s0;
+                s1 = peg$c40();
+                s0 = s1;
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -1453,92 +1906,6 @@ function peg$parse(input, options) {
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
-            }
-            if (s0 === peg$FAILED) {
-              s0 = peg$currPos;
-              s1 = peg$parseSearchValue();
-              if (s1 !== peg$FAILED) {
-                s2 = peg$parse__();
-                if (s2 !== peg$FAILED) {
-                  s3 = peg$parseInToken();
-                  if (s3 !== peg$FAILED) {
-                    s4 = peg$parse__();
-                    if (s4 !== peg$FAILED) {
-                      s5 = peg$parseDerefExpr();
-                      if (s5 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c30(s1, s5);
-                        s0 = s1;
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-              if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$parseSearchLiteral();
-                if (s1 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c31(s1);
-                }
-                s0 = s1;
-                if (s0 === peg$FAILED) {
-                  s0 = peg$currPos;
-                  s1 = peg$currPos;
-                  peg$silentFails++;
-                  s2 = peg$currPos;
-                  s3 = peg$parseSearchTokens();
-                  if (s3 !== peg$FAILED) {
-                    s4 = peg$parse_();
-                    if (s4 !== peg$FAILED) {
-                      s3 = [s3, s4];
-                      s2 = s3;
-                    } else {
-                      peg$currPos = s2;
-                      s2 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s2;
-                    s2 = peg$FAILED;
-                  }
-                  peg$silentFails--;
-                  if (s2 === peg$FAILED) {
-                    s1 = void 0;
-                  } else {
-                    peg$currPos = s1;
-                    s1 = peg$FAILED;
-                  }
-                  if (s1 !== peg$FAILED) {
-                    s2 = peg$parseKeyWord();
-                    if (s2 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c32(s2);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                }
-              }
             }
           }
         }
@@ -1549,19 +1916,508 @@ function peg$parse(input, options) {
   }
 
   function peg$parseSearchValue() {
-    var s0, s1, s2, s3, s4;
+    var s0, s1;
 
-    s0 = peg$parseSearchLiteral();
+    s0 = peg$parseLiteral();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$currPos;
-      peg$silentFails++;
-      s2 = peg$currPos;
-      s3 = peg$parseSearchTokens();
-      if (s3 !== peg$FAILED) {
-        s4 = peg$parse_();
+      s1 = peg$parseKeyWord();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c41(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseGlobbySearchValue() {
+    var s0, s1;
+
+    s0 = peg$parseLiteral();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseSearchGlob();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c42(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchGlob() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$parseGlobPart();
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        s2 = peg$parseGlobPart();
+      }
+    } else {
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      if (input.charCodeAt(peg$currPos) === 42) {
+        s3 = peg$c34;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        if (input.charCodeAt(peg$currPos) === 42) {
+          s3 = peg$c34;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c43(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseGlobPart() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = peg$parseStars();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseKeyWord();
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c44(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseKeyWord();
+    }
+
+    return s0;
+  }
+
+  function peg$parseStars() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = [];
+    if (input.charCodeAt(peg$currPos) === 42) {
+      s2 = peg$c34;
+      peg$currPos++;
+    } else {
+      s2 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c35); }
+    }
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        if (input.charCodeAt(peg$currPos) === 42) {
+          s2 = peg$c34;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c35); }
+        }
+      }
+    } else {
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c45();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseSearchGuard() {
+    var s0;
+
+    s0 = peg$parseAndToken();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseOrToken();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseNotToken();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseInToken();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseByToken();
+          }
+        }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseComparator() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 61) {
+      s1 = peg$c46;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
+    }
+    if (s1 === peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c48) {
+        s1 = peg$c48;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c49); }
+      }
+      if (s1 === peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c50) {
+          s1 = peg$c50;
+          peg$currPos += 2;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c51); }
+        }
+        if (s1 === peg$FAILED) {
+          if (input.substr(peg$currPos, 2) === peg$c52) {
+            s1 = peg$c52;
+            peg$currPos += 2;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+          }
+          if (s1 === peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 60) {
+              s1 = peg$c54;
+              peg$currPos++;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            }
+            if (s1 === peg$FAILED) {
+              if (input.substr(peg$currPos, 2) === peg$c56) {
+                s1 = peg$c56;
+                peg$currPos += 2;
+              } else {
+                s1 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c57); }
+              }
+              if (s1 === peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 62) {
+                  s1 = peg$c58;
+                  peg$currPos++;
+                } else {
+                  s1 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c59); }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c45();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseSearchExprRelative() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSearchExprAdd();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseComparator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseSearchExprAdd();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c60(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
-          s3 = [s3, s4];
+          s5 = peg$parseComparator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseSearchExprAdd();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c60(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c61(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchExprAdd() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSearchExprMul();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseAdditiveOperator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseSearchExprMul();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c60(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseAdditiveOperator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseSearchExprMul();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c60(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c61(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchExprMul() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSearchExprCast();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseMultiplicativeOperator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse__();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseSearchExprCast();
+            if (s7 !== peg$FAILED) {
+              peg$savedPos = s3;
+              s4 = peg$c60(s1, s5, s7);
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse__();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseMultiplicativeOperator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse__();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseSearchExprCast();
+              if (s7 !== peg$FAILED) {
+                peg$savedPos = s3;
+                s4 = peg$c60(s1, s5, s7);
+                s3 = s4;
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c61(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchExprCast() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSearchExprFunc();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 58) {
+        s3 = peg$c20;
+        peg$currPos++;
+      } else {
+        s3 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c21); }
+      }
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parsePrimitiveType();
+        if (s4 !== peg$FAILED) {
+          peg$savedPos = s2;
+          s3 = peg$c62(s1, s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -1571,18 +2427,42 @@ function peg$parse(input, options) {
         peg$currPos = s2;
         s2 = peg$FAILED;
       }
-      peg$silentFails--;
-      if (s2 === peg$FAILED) {
-        s1 = void 0;
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c63(s1, s2);
+        s0 = s1;
       } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
+        peg$currPos = s0;
+        s0 = peg$FAILED;
       }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseSearchExprFunc();
+    }
+
+    return s0;
+  }
+
+  function peg$parseSearchExprFunc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$parseMatchExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseFunction();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseKeyWord();
+        s2 = [];
+        s3 = peg$parseDeref();
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parseDeref();
+        }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c33(s2);
+          s1 = peg$c26(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1592,147 +2472,10 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-    }
-
-    return s0;
-  }
-
-  function peg$parseSearchTokens() {
-    var s0;
-
-    s0 = peg$parseAndToken();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseOrToken();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseInToken();
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseSearchLiteral() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$parseStringLiteral();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseRegexpLiteral();
-      if (s0 === peg$FAILED) {
-        s0 = peg$parseSubnetLiteral();
+        s0 = peg$parseDerefExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseAddressLiteral();
-          if (s0 === peg$FAILED) {
-            s0 = peg$parseFloatLiteral();
-            if (s0 === peg$FAILED) {
-              s0 = peg$currPos;
-              s1 = peg$parseIntegerLiteral();
-              if (s1 !== peg$FAILED) {
-                s2 = peg$currPos;
-                peg$silentFails++;
-                s3 = peg$parseKeyWord();
-                peg$silentFails--;
-                if (s3 === peg$FAILED) {
-                  s2 = void 0;
-                } else {
-                  peg$currPos = s2;
-                  s2 = peg$FAILED;
-                }
-                if (s2 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c34(s1);
-                  s0 = s1;
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-              if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$currPos;
-                peg$silentFails++;
-                s2 = peg$currPos;
-                s3 = peg$parseSearchTokens();
-                if (s3 !== peg$FAILED) {
-                  s4 = peg$parse_();
-                  if (s4 !== peg$FAILED) {
-                    s3 = [s3, s4];
-                    s2 = s3;
-                  } else {
-                    peg$currPos = s2;
-                    s2 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s2;
-                  s2 = peg$FAILED;
-                }
-                peg$silentFails--;
-                if (s2 === peg$FAILED) {
-                  s1 = void 0;
-                } else {
-                  peg$currPos = s1;
-                  s1 = peg$FAILED;
-                }
-                if (s1 !== peg$FAILED) {
-                  s2 = peg$parseBooleanLiteral();
-                  if (s2 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c35(s2);
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-                if (s0 === peg$FAILED) {
-                  s0 = peg$currPos;
-                  s1 = peg$currPos;
-                  peg$silentFails++;
-                  s2 = peg$currPos;
-                  s3 = peg$parseSearchTokens();
-                  if (s3 !== peg$FAILED) {
-                    s4 = peg$parse_();
-                    if (s4 !== peg$FAILED) {
-                      s3 = [s3, s4];
-                      s2 = s3;
-                    } else {
-                      peg$currPos = s2;
-                      s2 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s2;
-                    s2 = peg$FAILED;
-                  }
-                  peg$silentFails--;
-                  if (s2 === peg$FAILED) {
-                    s1 = void 0;
-                  } else {
-                    peg$currPos = s1;
-                    s1 = peg$FAILED;
-                  }
-                  if (s1 !== peg$FAILED) {
-                    s2 = peg$parseNullLiteral();
-                    if (s2 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c35(s2);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                }
-              }
-            }
-          }
+          s0 = peg$parseLiteral();
         }
       }
     }
@@ -1740,454 +2483,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseStringLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parseQuotedString();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c33(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseRegexpLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parseRegexp();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c36(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseSubnetLiteral() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseIP6Net();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c37(s1);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseIP4Net();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c37(s1);
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseAddressLiteral() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseIP6();
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseIdentifierRest();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c38(s1);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseIP();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c38(s1);
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseFloatLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parseFloatString();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c39(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseIntegerLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    s1 = peg$parseIntString();
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c40(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseBooleanLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c41) {
-      s1 = peg$c41;
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c42); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c43();
-    }
-    s0 = s1;
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c44) {
-        s1 = peg$c44;
-        peg$currPos += 5;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c45); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c46();
-      }
-      s0 = s1;
-    }
-
-    return s0;
-  }
-
-  function peg$parseNullLiteral() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c47) {
-      s1 = peg$c47;
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c48); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c49();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseSequentialProcs() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseProc();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseSequentialTail();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseSequentialTail();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c50(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseSequentialTail() {
-    var s0, s1, s2, s3, s4;
-
-    s0 = peg$currPos;
-    s1 = peg$parse__();
-    if (s1 !== peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 124) {
-        s2 = peg$c51;
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c52); }
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse__();
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseProc();
-          if (s4 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c53(s4);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseProc() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
-
-    s0 = peg$parseNamedProc();
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c54) {
-        s1 = peg$c54;
-        peg$currPos += 5;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c55); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parse__();
-        if (s2 !== peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 40) {
-            s3 = peg$c14;
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c15); }
-          }
-          if (s3 !== peg$FAILED) {
-            s4 = peg$parse__();
-            if (s4 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c56) {
-                s5 = peg$c56;
-                peg$currPos += 2;
-              } else {
-                s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c57); }
-              }
-              if (s5 !== peg$FAILED) {
-                s6 = peg$parse__();
-                if (s6 !== peg$FAILED) {
-                  s7 = peg$parseProcs();
-                  if (s7 !== peg$FAILED) {
-                    s8 = peg$parse__();
-                    if (s8 !== peg$FAILED) {
-                      if (input.charCodeAt(peg$currPos) === 41) {
-                        s9 = peg$c16;
-                        peg$currPos++;
-                      } else {
-                        s9 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c17); }
-                      }
-                      if (s9 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c58(s7);
-                        s0 = s1;
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$parseGroupByProc();
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseProcs() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    s1 = peg$parseSequentialProcs();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseParallelTail();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseParallelTail();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c59(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseParallelTail() {
-    var s0, s1, s2, s3, s4, s5, s6;
-
-    s0 = peg$currPos;
-    s1 = peg$parse__();
-    if (s1 !== peg$FAILED) {
-      if (input.charCodeAt(peg$currPos) === 59) {
-        s2 = peg$c60;
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c61); }
-      }
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parse__();
-        if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c56) {
-            s4 = peg$c56;
-            peg$currPos += 2;
-          } else {
-            s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c57); }
-          }
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parse__();
-            if (s5 !== peg$FAILED) {
-              s6 = peg$parseSequentialProcs();
-              if (s6 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c62(s6);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseGroupByProc() {
+  function peg$parseAggregation() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
@@ -2201,7 +2497,7 @@ function peg$parse(input, options) {
         s3 = peg$parseLimitArg();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c63(s1, s2, s3);
+          s1 = peg$c64(s1, s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2249,7 +2545,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c64(s1, s2, s3, s4);
+              s1 = peg$c65(s1, s2, s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2276,12 +2572,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c65) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c66) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c66); }
+      if (peg$silentFails === 0) { peg$fail(peg$c67); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -2291,7 +2587,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c67(s3);
+            s1 = peg$c68(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2317,20 +2613,14 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c68) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
-    }
+    s1 = peg$parseByToken();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c70(s3);
+          s1 = peg$c69(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2354,22 +2644,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c71) {
-        s2 = peg$c71;
+      if (input.substr(peg$currPos, 4) === peg$c70) {
+        s2 = peg$c70;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c72); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c73) {
-            s4 = peg$c73;
+          if (input.substr(peg$currPos, 6) === peg$c72) {
+            s4 = peg$c72;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c74); }
+            if (peg$silentFails === 0) { peg$fail(peg$c73); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -2377,7 +2667,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c75(s6);
+                s1 = peg$c74(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -2405,10 +2695,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c76;
+      s1 = peg$c75;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c77();
+        s1 = peg$c76();
       }
       s0 = s1;
     }
@@ -2425,7 +2715,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c78(s1);
+        s1 = peg$c77(s1);
       }
       s0 = s1;
     }
@@ -2444,11 +2734,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c79;
+          s5 = peg$c24;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2456,7 +2746,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c81(s1, s7);
+              s4 = peg$c78(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -2480,11 +2770,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c79;
+            s5 = peg$c24;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2492,7 +2782,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c81(s1, s7);
+                s4 = peg$c78(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -2513,7 +2803,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c82(s1, s2);
+        s1 = peg$c6(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2536,11 +2826,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c83;
+          s3 = peg$c46;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -2548,7 +2838,7 @@ function peg$parse(input, options) {
             s5 = peg$parseReducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c85(s1, s5);
+              s1 = peg$c79(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2575,7 +2865,7 @@ function peg$parse(input, options) {
       s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c86(s1);
+        s1 = peg$c80(s1);
       }
       s0 = s1;
     }
@@ -2584,26 +2874,37 @@ function peg$parse(input, options) {
   }
 
   function peg$parseReducer() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12;
 
     s0 = peg$currPos;
     s1 = peg$currPos;
     peg$silentFails++;
-    if (input.substr(peg$currPos, 3) === peg$c87) {
-      s2 = peg$c87;
-      peg$currPos += 3;
-    } else {
-      s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c88); }
-    }
-    if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c26) {
-        s2 = peg$c26;
-        peg$currPos += 3;
+    s2 = peg$currPos;
+    s3 = peg$parseNotReducers();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse__();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s5 = peg$c13;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c14); }
+        }
+        if (s5 !== peg$FAILED) {
+          s3 = [s3, s4, s5];
+          s2 = s3;
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
       } else {
+        peg$currPos = s2;
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c27); }
       }
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
     }
     peg$silentFails--;
     if (s2 === peg$FAILED) {
@@ -2618,11 +2919,11 @@ function peg$parse(input, options) {
         s3 = peg$parse__();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
-            s4 = peg$c14;
+            s4 = peg$c13;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c15); }
+            if (peg$silentFails === 0) { peg$fail(peg$c14); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse__();
@@ -2635,21 +2936,56 @@ function peg$parse(input, options) {
                 s7 = peg$parse__();
                 if (s7 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s8 = peg$c16;
+                    s8 = peg$c15;
                     peg$currPos++;
                   } else {
                     s8 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c17); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c16); }
                   }
                   if (s8 !== peg$FAILED) {
-                    s9 = peg$parseWhereClause();
-                    if (s9 === peg$FAILED) {
-                      s9 = null;
+                    s9 = peg$currPos;
+                    peg$silentFails++;
+                    s10 = peg$currPos;
+                    s11 = peg$parse__();
+                    if (s11 !== peg$FAILED) {
+                      if (input.charCodeAt(peg$currPos) === 46) {
+                        s12 = peg$c81;
+                        peg$currPos++;
+                      } else {
+                        s12 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                      }
+                      if (s12 !== peg$FAILED) {
+                        s11 = [s11, s12];
+                        s10 = s11;
+                      } else {
+                        peg$currPos = s10;
+                        s10 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s10;
+                      s10 = peg$FAILED;
+                    }
+                    peg$silentFails--;
+                    if (s10 === peg$FAILED) {
+                      s9 = void 0;
+                    } else {
+                      peg$currPos = s9;
+                      s9 = peg$FAILED;
                     }
                     if (s9 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c89(s2, s6, s9);
-                      s0 = s1;
+                      s10 = peg$parseWhereClause();
+                      if (s10 === peg$FAILED) {
+                        s10 = null;
+                      }
+                      if (s10 !== peg$FAILED) {
+                        peg$savedPos = s0;
+                        s1 = peg$c83(s2, s6, s10);
+                        s0 = s1;
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
                     } else {
                       peg$currPos = s0;
                       s0 = peg$FAILED;
@@ -2690,26 +3026,49 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseNotReducers() {
+    var s0;
+
+    if (input.substr(peg$currPos, 3) === peg$c84) {
+      s0 = peg$c84;
+      peg$currPos += 3;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c85); }
+    }
+    if (s0 === peg$FAILED) {
+      if (input.substr(peg$currPos, 5) === peg$c86) {
+        s0 = peg$c86;
+        peg$currPos += 5;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c87); }
+      }
+    }
+
+    return s0;
+  }
+
   function peg$parseWhereClause() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c90) {
-        s2 = peg$c90;
+      if (input.substr(peg$currPos, 5) === peg$c88) {
+        s2 = peg$c88;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c91); }
+        if (peg$silentFails === 0) { peg$fail(peg$c89); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseConditionalExpr();
+          s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c18(s4);
+            s1 = peg$c33(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2742,11 +3101,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c79;
+          s5 = peg$c24;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -2777,11 +3136,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c79;
+            s5 = peg$c24;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -2809,7 +3168,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c92(s1, s2);
+        s1 = peg$c90(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2823,7 +3182,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseNamedProc() {
+  function peg$parseOperator() {
     var s0;
 
     s0 = peg$parseSortProc();
@@ -2871,12 +3230,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c93) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c91) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      if (peg$silentFails === 0) { peg$fail(peg$c92); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -2887,7 +3246,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c95(s2, s5);
+            s4 = peg$c93(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -2902,7 +3261,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c96(s2, s3);
+          s1 = peg$c94(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2931,7 +3290,7 @@ function peg$parse(input, options) {
       s4 = peg$parseSortArg();
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c97(s4);
+        s3 = peg$c18(s4);
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -2949,7 +3308,7 @@ function peg$parse(input, options) {
         s4 = peg$parseSortArg();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c97(s4);
+          s3 = peg$c18(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -2962,7 +3321,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c98(s1);
+      s1 = peg$c95(s1);
     }
     s0 = s1;
 
@@ -2973,55 +3332,55 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c99) {
-      s1 = peg$c99;
+    if (input.substr(peg$currPos, 2) === peg$c96) {
+      s1 = peg$c96;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+      if (peg$silentFails === 0) { peg$fail(peg$c97); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c101();
+      s1 = peg$c98();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c102) {
-        s1 = peg$c102;
+      if (input.substr(peg$currPos, 6) === peg$c99) {
+        s1 = peg$c99;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c100); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c104) {
-            s4 = peg$c104;
+          if (input.substr(peg$currPos, 5) === peg$c101) {
+            s4 = peg$c101;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c105); }
+            if (peg$silentFails === 0) { peg$fail(peg$c102); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c106) {
-              s4 = peg$c106;
+            if (input.substr(peg$currPos, 4) === peg$c103) {
+              s4 = peg$c103;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c107); }
+              if (peg$silentFails === 0) { peg$fail(peg$c104); }
             }
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c108();
+            s4 = peg$c45();
           }
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c109(s3);
+            s1 = peg$c105(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3044,12 +3403,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c110) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c106) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c111); }
+      if (peg$silentFails === 0) { peg$fail(peg$c107); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -3058,7 +3417,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c112(s4);
+          s3 = peg$c108(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3075,12 +3434,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c113) {
-            s5 = peg$c113;
+          if (input.substr(peg$currPos, 6) === peg$c109) {
+            s5 = peg$c109;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c114); }
+            if (peg$silentFails === 0) { peg$fail(peg$c110); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -3103,7 +3462,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c115(s2, s3, s6);
+              s5 = peg$c111(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -3118,7 +3477,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c116(s2, s3, s4);
+            s1 = peg$c112(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3144,12 +3503,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c117) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c113) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c118); }
+      if (peg$silentFails === 0) { peg$fail(peg$c114); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseCutArgs();
@@ -3159,7 +3518,7 @@ function peg$parse(input, options) {
           s4 = peg$parseFlexAssignments();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c119(s2, s4);
+            s1 = peg$c115(s2, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3189,16 +3548,16 @@ function peg$parse(input, options) {
     s2 = peg$currPos;
     s3 = peg$parse_();
     if (s3 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c120) {
-        s4 = peg$c120;
+      if (input.substr(peg$currPos, 2) === peg$c116) {
+        s4 = peg$c116;
         peg$currPos += 2;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s2;
-        s3 = peg$c122();
+        s3 = peg$c118();
         s2 = s3;
       } else {
         peg$currPos = s2;
@@ -3213,16 +3572,16 @@ function peg$parse(input, options) {
       s2 = peg$currPos;
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c120) {
-          s4 = peg$c120;
+        if (input.substr(peg$currPos, 2) === peg$c116) {
+          s4 = peg$c116;
           peg$currPos += 2;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c117); }
         }
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c122();
+          s3 = peg$c118();
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -3235,7 +3594,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c123(s1);
+      s1 = peg$c119(s1);
     }
     s0 = s1;
 
@@ -3246,12 +3605,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c124) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c120) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c125); }
+      if (peg$silentFails === 0) { peg$fail(peg$c121); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3259,7 +3618,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c126(s3);
+          s1 = peg$c122(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3281,12 +3640,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c127) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c123) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c128); }
+      if (peg$silentFails === 0) { peg$fail(peg$c124); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3294,7 +3653,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFieldExprs();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c129(s3);
+          s1 = peg$c125(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3313,6 +3672,56 @@ function peg$parse(input, options) {
   }
 
   function peg$parseHeadProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c126) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c127); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseUInt();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c128(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c126) {
+        s1 = input.substr(peg$currPos, 4);
+        peg$currPos += 4;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c127); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c129();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseTailProc() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -3362,13 +3771,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseTailProc() {
+  function peg$parseFilterProc() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c134) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c134) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c135); }
@@ -3376,7 +3785,7 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseUInt();
+        s3 = peg$parseFilter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$c136(s3);
@@ -3393,56 +3802,20 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c134) {
-        s1 = input.substr(peg$currPos, 4);
-        peg$currPos += 4;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c135); }
-      }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c137();
-      }
-      s0 = s1;
-    }
 
     return s0;
   }
 
-  function peg$parseFilterProc() {
-    var s0, s1, s2, s3;
+  function peg$parseFilter() {
+    var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c138) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c139); }
-    }
+    s1 = peg$parseSearchBoolean();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseSearchExpr();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c3(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
+      peg$savedPos = s0;
+      s1 = peg$c19(s1);
     }
+    s0 = s1;
 
     return s0;
   }
@@ -3451,26 +3824,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c140) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c137) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c138); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c120) {
-          s3 = peg$c120;
+        if (input.substr(peg$currPos, 2) === peg$c116) {
+          s3 = peg$c116;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c121); }
+          if (peg$silentFails === 0) { peg$fail(peg$c117); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c142();
+          s1 = peg$c139();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3486,16 +3859,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c140) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c137) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c141); }
+        if (peg$silentFails === 0) { peg$fail(peg$c138); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c143();
+        s1 = peg$c140();
       }
       s0 = s1;
     }
@@ -3507,12 +3880,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c144) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c141) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c145); }
+      if (peg$silentFails === 0) { peg$fail(peg$c142); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3520,7 +3893,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c146(s3);
+          s1 = peg$c143(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3542,12 +3915,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c147) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c144) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c145); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3559,11 +3932,11 @@ function peg$parse(input, options) {
           s6 = peg$parse__();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s7 = peg$c79;
+              s7 = peg$c24;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c80); }
+              if (peg$silentFails === 0) { peg$fail(peg$c25); }
             }
             if (s7 !== peg$FAILED) {
               s8 = peg$parse__();
@@ -3571,7 +3944,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c149(s3, s9);
+                  s6 = peg$c146(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -3595,11 +3968,11 @@ function peg$parse(input, options) {
             s6 = peg$parse__();
             if (s6 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 44) {
-                s7 = peg$c79;
+                s7 = peg$c24;
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c80); }
+                if (peg$silentFails === 0) { peg$fail(peg$c25); }
               }
               if (s7 !== peg$FAILED) {
                 s8 = peg$parse__();
@@ -3607,7 +3980,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c149(s3, s9);
+                    s6 = peg$c146(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -3628,7 +4001,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c150(s3, s4);
+            s1 = peg$c147(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3654,16 +4027,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c151) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c148) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c152); }
+      if (peg$silentFails === 0) { peg$fail(peg$c149); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c153();
+      s1 = peg$c150();
     }
     s0 = s1;
 
@@ -3674,12 +4047,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c151) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+      if (peg$silentFails === 0) { peg$fail(peg$c152); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3689,11 +4062,11 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 61) {
-              s5 = peg$c83;
+              s5 = peg$c46;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c84); }
+              if (peg$silentFails === 0) { peg$fail(peg$c47); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
@@ -3720,7 +4093,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c156(s3, s7, s8);
+                    s1 = peg$c153(s3, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3756,12 +4129,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c154) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c151) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c152); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -3788,7 +4161,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c157(s3, s4);
+              s1 = peg$c154(s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3818,113 +4191,30 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c14;
+        s1 = peg$c13;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c15); }
+        if (peg$silentFails === 0) { peg$fail(peg$c14); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseConditionalExpr();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 41) {
-            s3 = peg$c16;
+            s3 = peg$c15;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c17); }
+            if (peg$silentFails === 0) { peg$fail(peg$c16); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c18(s2);
+            s1 = peg$c33(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
           }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseRootField() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c158;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c159); }
-    }
-    if (s1 === peg$FAILED) {
-      s1 = null;
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseBooleanLiteral();
-      if (s3 === peg$FAILED) {
-        s3 = peg$parseNullLiteral();
-      }
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseIdentifier();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c160(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c158;
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c159); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$currPos;
-        peg$silentFails++;
-        s3 = peg$parseIdentifier();
-        peg$silentFails--;
-        if (s3 === peg$FAILED) {
-          s2 = void 0;
-        } else {
-          peg$currPos = s2;
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c161();
-          s0 = s1;
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -3949,11 +4239,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c79;
+          s5 = peg$c24;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -3984,11 +4274,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c79;
+            s5 = peg$c24;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -4016,7 +4306,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c162(s1, s2);
+        s1 = peg$c155(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4041,11 +4331,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c79;
+          s5 = peg$c24;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -4076,11 +4366,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c79;
+            s5 = peg$c24;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -4108,7 +4398,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c162(s1, s2);
+        s1 = peg$c155(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4131,11 +4421,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c83;
+          s3 = peg$c46;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
+          if (peg$silentFails === 0) { peg$fail(peg$c47); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4143,7 +4433,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c163(s1, s5);
+              s1 = peg$c156(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4186,11 +4476,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c164;
+          s3 = peg$c157;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c165); }
+          if (peg$silentFails === 0) { peg$fail(peg$c158); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -4200,11 +4490,11 @@ function peg$parse(input, options) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 58) {
-                  s7 = peg$c166;
+                  s7 = peg$c20;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c167); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c21); }
                 }
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
@@ -4212,7 +4502,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c168(s1, s5, s9);
+                      s1 = peg$c159(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4274,7 +4564,7 @@ function peg$parse(input, options) {
             s7 = peg$parseLogicalAndExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c169(s1, s5, s7);
+              s4 = peg$c60(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4304,7 +4594,7 @@ function peg$parse(input, options) {
               s7 = peg$parseLogicalAndExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c169(s1, s5, s7);
+                s4 = peg$c60(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4325,7 +4615,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4356,7 +4646,7 @@ function peg$parse(input, options) {
             s7 = peg$parseEqualityCompareExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c169(s1, s5, s7);
+              s4 = peg$c60(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4386,7 +4676,7 @@ function peg$parse(input, options) {
               s7 = peg$parseEqualityCompareExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c169(s1, s5, s7);
+                s4 = peg$c60(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4407,7 +4697,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4438,7 +4728,7 @@ function peg$parse(input, options) {
             s7 = peg$parseRelativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c171(s1, s5, s7);
+              s4 = peg$c160(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4468,7 +4758,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c171(s1, s5, s7);
+                s4 = peg$c160(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4489,7 +4779,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4507,43 +4797,25 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c172) {
-      s1 = peg$c172;
-      peg$currPos += 2;
+    if (input.charCodeAt(peg$currPos) === 61) {
+      s1 = peg$c46;
+      peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c173); }
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c174) {
-        s1 = peg$c174;
+      if (input.substr(peg$currPos, 2) === peg$c48) {
+        s1 = peg$c48;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c175); }
-      }
-      if (s1 === peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 61) {
-          s1 = peg$c83;
-          peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
-        }
-        if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c176) {
-            s1 = peg$c176;
-            peg$currPos += 2;
-          } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c177); }
-          }
-        }
+        if (peg$silentFails === 0) { peg$fail(peg$c49); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -4556,16 +4828,16 @@ function peg$parse(input, options) {
     s0 = peg$parseEqualityOperator();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c178) {
-        s1 = peg$c178;
+      if (input.substr(peg$currPos, 2) === peg$c50) {
+        s1 = peg$c50;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c51); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c108();
+        s1 = peg$c45();
       }
       s0 = s1;
     }
@@ -4590,7 +4862,7 @@ function peg$parse(input, options) {
             s7 = peg$parseAdditiveExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c169(s1, s5, s7);
+              s4 = peg$c60(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4620,7 +4892,7 @@ function peg$parse(input, options) {
               s7 = peg$parseAdditiveExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c169(s1, s5, s7);
+                s4 = peg$c60(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4641,7 +4913,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4659,43 +4931,43 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c180) {
-      s1 = peg$c180;
+    if (input.substr(peg$currPos, 2) === peg$c52) {
+      s1 = peg$c52;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c181); }
+      if (peg$silentFails === 0) { peg$fail(peg$c53); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s1 = peg$c182;
+        s1 = peg$c54;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c55); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c184) {
-          s1 = peg$c184;
+        if (input.substr(peg$currPos, 2) === peg$c56) {
+          s1 = peg$c56;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c185); }
+          if (peg$silentFails === 0) { peg$fail(peg$c57); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 62) {
-            s1 = peg$c186;
+            s1 = peg$c58;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c187); }
+            if (peg$silentFails === 0) { peg$fail(peg$c59); }
           }
         }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -4719,7 +4991,7 @@ function peg$parse(input, options) {
             s7 = peg$parseMultiplicativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c169(s1, s5, s7);
+              s4 = peg$c60(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4749,7 +5021,7 @@ function peg$parse(input, options) {
               s7 = peg$parseMultiplicativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c169(s1, s5, s7);
+                s4 = peg$c60(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4770,7 +5042,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4789,24 +5061,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c188;
+      s1 = peg$c161;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c189); }
+      if (peg$silentFails === 0) { peg$fail(peg$c162); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c11;
+        s1 = peg$c163;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c12); }
+        if (peg$silentFails === 0) { peg$fail(peg$c164); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -4830,7 +5102,7 @@ function peg$parse(input, options) {
             s7 = peg$parseNotExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c169(s1, s5, s7);
+              s4 = peg$c60(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -4860,7 +5132,7 @@ function peg$parse(input, options) {
               s7 = peg$parseNotExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c169(s1, s5, s7);
+                s4 = peg$c60(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -4881,7 +5153,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4900,24 +5172,24 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c19;
+      s1 = peg$c34;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c20); }
+      if (peg$silentFails === 0) { peg$fail(peg$c35); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c190;
+        s1 = peg$c165;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c191); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -4929,11 +5201,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c8;
+      s1 = peg$c30;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c9); }
+      if (peg$silentFails === 0) { peg$fail(peg$c31); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -4941,7 +5213,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c192(s3);
+          s1 = peg$c167(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4970,17 +5242,17 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 58) {
-        s3 = peg$c166;
+        s3 = peg$c20;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c167); }
+        if (peg$silentFails === 0) { peg$fail(peg$c21); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parsePrimitiveType();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c193(s1, s4);
+          s3 = peg$c62(s1, s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4992,7 +5264,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c194(s1, s2);
+        s1 = peg$c63(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5013,172 +5285,172 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c195) {
-      s1 = peg$c195;
+    if (input.substr(peg$currPos, 5) === peg$c168) {
+      s1 = peg$c168;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c196); }
+      if (peg$silentFails === 0) { peg$fail(peg$c169); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c197) {
-        s1 = peg$c197;
+      if (input.substr(peg$currPos, 5) === peg$c170) {
+        s1 = peg$c170;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c198); }
+        if (peg$silentFails === 0) { peg$fail(peg$c171); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c199) {
-          s1 = peg$c199;
+        if (input.substr(peg$currPos, 6) === peg$c172) {
+          s1 = peg$c172;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c200); }
+          if (peg$silentFails === 0) { peg$fail(peg$c173); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c201) {
-            s1 = peg$c201;
+          if (input.substr(peg$currPos, 6) === peg$c174) {
+            s1 = peg$c174;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c202); }
+            if (peg$silentFails === 0) { peg$fail(peg$c175); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 6) === peg$c203) {
-              s1 = peg$c203;
+            if (input.substr(peg$currPos, 6) === peg$c176) {
+              s1 = peg$c176;
               peg$currPos += 6;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c204); }
+              if (peg$silentFails === 0) { peg$fail(peg$c177); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 4) === peg$c205) {
-                s1 = peg$c205;
+              if (input.substr(peg$currPos, 4) === peg$c178) {
+                s1 = peg$c178;
                 peg$currPos += 4;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c206); }
+                if (peg$silentFails === 0) { peg$fail(peg$c179); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c207) {
-                  s1 = peg$c207;
+                if (input.substr(peg$currPos, 5) === peg$c180) {
+                  s1 = peg$c180;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c208); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c181); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c209) {
-                    s1 = peg$c209;
+                  if (input.substr(peg$currPos, 5) === peg$c182) {
+                    s1 = peg$c182;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c210); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c183); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 5) === peg$c211) {
-                      s1 = peg$c211;
+                    if (input.substr(peg$currPos, 5) === peg$c184) {
+                      s1 = peg$c184;
                       peg$currPos += 5;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c212); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c185); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 8) === peg$c213) {
-                        s1 = peg$c213;
+                      if (input.substr(peg$currPos, 8) === peg$c186) {
+                        s1 = peg$c186;
                         peg$currPos += 8;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c214); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c187); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 4) === peg$c215) {
-                          s1 = peg$c215;
+                        if (input.substr(peg$currPos, 4) === peg$c188) {
+                          s1 = peg$c188;
                           peg$currPos += 4;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c216); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c189); }
                         }
                         if (s1 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 7) === peg$c217) {
-                            s1 = peg$c217;
+                          if (input.substr(peg$currPos, 7) === peg$c190) {
+                            s1 = peg$c190;
                             peg$currPos += 7;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c218); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c191); }
                           }
                           if (s1 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 4) === peg$c219) {
-                              s1 = peg$c219;
+                            if (input.substr(peg$currPos, 4) === peg$c192) {
+                              s1 = peg$c192;
                               peg$currPos += 4;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c220); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c193); }
                             }
                             if (s1 === peg$FAILED) {
-                              if (input.substr(peg$currPos, 5) === peg$c195) {
-                                s1 = peg$c195;
+                              if (input.substr(peg$currPos, 5) === peg$c168) {
+                                s1 = peg$c168;
                                 peg$currPos += 5;
                               } else {
                                 s1 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c196); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c169); }
                               }
                               if (s1 === peg$FAILED) {
-                                if (input.substr(peg$currPos, 6) === peg$c221) {
-                                  s1 = peg$c221;
+                                if (input.substr(peg$currPos, 6) === peg$c194) {
+                                  s1 = peg$c194;
                                   peg$currPos += 6;
                                 } else {
                                   s1 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c222); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c195); }
                                 }
                                 if (s1 === peg$FAILED) {
-                                  if (input.substr(peg$currPos, 7) === peg$c223) {
-                                    s1 = peg$c223;
+                                  if (input.substr(peg$currPos, 7) === peg$c196) {
+                                    s1 = peg$c196;
                                     peg$currPos += 7;
                                   } else {
                                     s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c224); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c197); }
                                   }
                                   if (s1 === peg$FAILED) {
-                                    if (input.substr(peg$currPos, 2) === peg$c225) {
-                                      s1 = peg$c225;
+                                    if (input.substr(peg$currPos, 2) === peg$c198) {
+                                      s1 = peg$c198;
                                       peg$currPos += 2;
                                     } else {
                                       s1 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c226); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c199); }
                                     }
                                     if (s1 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 3) === peg$c227) {
-                                        s1 = peg$c227;
+                                      if (input.substr(peg$currPos, 3) === peg$c200) {
+                                        s1 = peg$c200;
                                         peg$currPos += 3;
                                       } else {
                                         s1 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c228); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c201); }
                                       }
                                       if (s1 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 4) === peg$c229) {
-                                          s1 = peg$c229;
+                                        if (input.substr(peg$currPos, 4) === peg$c202) {
+                                          s1 = peg$c202;
                                           peg$currPos += 4;
                                         } else {
                                           s1 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c230); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c203); }
                                         }
                                         if (s1 === peg$FAILED) {
-                                          if (input.substr(peg$currPos, 5) === peg$c231) {
-                                            s1 = peg$c231;
+                                          if (input.substr(peg$currPos, 5) === peg$c204) {
+                                            s1 = peg$c204;
                                             peg$currPos += 5;
                                           } else {
                                             s1 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c232); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c205); }
                                           }
                                           if (s1 === peg$FAILED) {
-                                            if (input.substr(peg$currPos, 4) === peg$c47) {
-                                              s1 = peg$c47;
+                                            if (input.substr(peg$currPos, 4) === peg$c206) {
+                                              s1 = peg$c206;
                                               peg$currPos += 4;
                                             } else {
                                               s1 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c48); }
+                                              if (peg$silentFails === 0) { peg$fail(peg$c207); }
                                             }
                                           }
                                         }
@@ -5202,7 +5474,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -5212,65 +5484,77 @@ function peg$parse(input, options) {
   function peg$parseFuncExpr() {
     var s0, s1, s2, s3;
 
-    s0 = peg$currPos;
-    s1 = peg$parseFunction();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseDeref();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseDeref();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c233(s1, s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
+    s0 = peg$parseSelectExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseDerefExpr();
+      s0 = peg$parseMatchExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parsePrimary();
+        s0 = peg$currPos;
+        s1 = peg$parseFunction();
+        if (s1 !== peg$FAILED) {
+          s2 = [];
+          s3 = peg$parseDeref();
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            s3 = peg$parseDeref();
+          }
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c26(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseDerefExpr();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parsePrimary();
+          }
+        }
       }
     }
 
     return s0;
   }
 
-  function peg$parseFunction() {
+  function peg$parseMatchExpr() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    s1 = peg$parseDeprecatedName();
+    if (input.substr(peg$currPos, 5) === peg$c86) {
+      s1 = peg$c86;
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c87); }
+    }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c14;
+          s3 = peg$c13;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c15); }
+          if (peg$silentFails === 0) { peg$fail(peg$c14); }
         }
         if (s3 !== peg$FAILED) {
-          s4 = peg$parseArgumentList();
+          s4 = peg$parseSearchBoolean();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c16;
+              s5 = peg$c15;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c17); }
+              if (peg$silentFails === 0) { peg$fail(peg$c16); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c234(s1, s4);
+              s1 = peg$c33(s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5296,40 +5580,207 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseDeprecatedName() {
-    var s0, s1, s2, s3;
+  function peg$parseSelectExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
     s0 = peg$currPos;
-    s1 = peg$parseIdentifierStart();
+    if (input.substr(peg$currPos, 6) === peg$c208) {
+      s1 = peg$c208;
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c209); }
+    }
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseIdentifierRest();
-      if (s3 === peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c158;
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c13;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c159); }
+          if (peg$silentFails === 0) { peg$fail(peg$c14); }
         }
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseIdentifierRest();
-        if (s3 === peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 46) {
-            s3 = peg$c158;
-            peg$currPos++;
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseArgumentList();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c15;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                }
+                if (s7 !== peg$FAILED) {
+                  s8 = [];
+                  s9 = peg$currPos;
+                  s10 = peg$parse__();
+                  if (s10 !== peg$FAILED) {
+                    if (input.charCodeAt(peg$currPos) === 46) {
+                      s11 = peg$c81;
+                      peg$currPos++;
+                    } else {
+                      s11 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                    }
+                    if (s11 !== peg$FAILED) {
+                      s12 = peg$parse__();
+                      if (s12 !== peg$FAILED) {
+                        s13 = peg$parseFunction();
+                        if (s13 !== peg$FAILED) {
+                          peg$savedPos = s9;
+                          s10 = peg$c210(s5, s13);
+                          s9 = s10;
+                        } else {
+                          peg$currPos = s9;
+                          s9 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s9;
+                        s9 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s9;
+                      s9 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s9;
+                    s9 = peg$FAILED;
+                  }
+                  while (s9 !== peg$FAILED) {
+                    s8.push(s9);
+                    s9 = peg$currPos;
+                    s10 = peg$parse__();
+                    if (s10 !== peg$FAILED) {
+                      if (input.charCodeAt(peg$currPos) === 46) {
+                        s11 = peg$c81;
+                        peg$currPos++;
+                      } else {
+                        s11 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                      }
+                      if (s11 !== peg$FAILED) {
+                        s12 = peg$parse__();
+                        if (s12 !== peg$FAILED) {
+                          s13 = peg$parseFunction();
+                          if (s13 !== peg$FAILED) {
+                            peg$savedPos = s9;
+                            s10 = peg$c210(s5, s13);
+                            s9 = s10;
+                          } else {
+                            peg$currPos = s9;
+                            s9 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s9;
+                          s9 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s9;
+                        s9 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s9;
+                      s9 = peg$FAILED;
+                    }
+                  }
+                  if (s8 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c211(s5, s8);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c159); }
+            peg$currPos = s0;
+            s0 = peg$FAILED;
           }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
         }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
       }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseFunction() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseIdentifierName();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c108();
-        s0 = s1;
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c13;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c14); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse__();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseArgumentList();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse__();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c15;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c16); }
+                }
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c212(s1, s5);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -5353,11 +5804,11 @@ function peg$parse(input, options) {
       s4 = peg$parse__();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c79;
+          s5 = peg$c24;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c80); }
+          if (peg$silentFails === 0) { peg$fail(peg$c25); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse__();
@@ -5365,7 +5816,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c235(s1, s7);
+              s4 = peg$c213(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5389,11 +5840,11 @@ function peg$parse(input, options) {
         s4 = peg$parse__();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c79;
+            s5 = peg$c24;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c25); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse__();
@@ -5401,7 +5852,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c235(s1, s7);
+                s4 = peg$c213(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5422,7 +5873,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c82(s1, s2);
+        s1 = peg$c6(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5437,7 +5888,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c236();
+        s1 = peg$c214();
       }
       s0 = s1;
     }
@@ -5449,7 +5900,7 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    s1 = peg$parseRootField();
+    s1 = peg$parseDotId();
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$parseDeref();
@@ -5459,7 +5910,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c233(s1, s2);
+        s1 = peg$c26(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5468,6 +5919,121 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseIdentifier();
+      if (s1 !== peg$FAILED) {
+        s2 = [];
+        s3 = peg$parseDeref();
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parseDeref();
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c26(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 46) {
+          s1 = peg$c81;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        }
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c215();
+        }
+        s0 = s1;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseDotId() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 46) {
+      s1 = peg$c81;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c82); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseIdentifier();
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c216(s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 46) {
+        s1 = peg$c81;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+      }
+      if (s1 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 91) {
+          s2 = peg$c217;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c218); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseConditionalExpr();
+          if (s3 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 93) {
+              s4 = peg$c219;
+              peg$currPos++;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c220); }
+            }
+            if (s4 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c221(s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     }
 
     return s0;
@@ -5478,25 +6044,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c237;
+      s1 = peg$c217;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+      if (peg$silentFails === 0) { peg$fail(peg$c218); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseConditionalExpr();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 93) {
-          s3 = peg$c239;
+          s3 = peg$c219;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c240); }
+          if (peg$silentFails === 0) { peg$fail(peg$c220); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c241(s2);
+          s1 = peg$c222(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5513,21 +6079,21 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c158;
+        s1 = peg$c81;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c159); }
+        if (peg$silentFails === 0) { peg$fail(peg$c82); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c158;
+          s3 = peg$c81;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c159); }
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
         }
         peg$silentFails--;
         if (s3 === peg$FAILED) {
@@ -5540,7 +6106,7 @@ function peg$parse(input, options) {
           s3 = peg$parseIdentifier();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c242(s3);
+            s1 = peg$c223(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5562,6 +6128,62 @@ function peg$parse(input, options) {
   function peg$parsePrimary() {
     var s0, s1, s2, s3, s4, s5;
 
+    s0 = peg$parseLiteral();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 40) {
+        s1 = peg$c13;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c14); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse__();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseConditionalExpr();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse__();
+            if (s4 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 41) {
+                s5 = peg$c15;
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c16); }
+              }
+              if (s5 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c33(s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseLiteral() {
+    var s0;
+
     s0 = peg$parseStringLiteral();
     if (s0 === peg$FAILED) {
       s0 = peg$parseRegexpLiteral();
@@ -5577,54 +6199,6 @@ function peg$parse(input, options) {
                 s0 = peg$parseBooleanLiteral();
                 if (s0 === peg$FAILED) {
                   s0 = peg$parseNullLiteral();
-                  if (s0 === peg$FAILED) {
-                    s0 = peg$currPos;
-                    if (input.charCodeAt(peg$currPos) === 40) {
-                      s1 = peg$c14;
-                      peg$currPos++;
-                    } else {
-                      s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c15); }
-                    }
-                    if (s1 !== peg$FAILED) {
-                      s2 = peg$parse__();
-                      if (s2 !== peg$FAILED) {
-                        s3 = peg$parseConditionalExpr();
-                        if (s3 !== peg$FAILED) {
-                          s4 = peg$parse__();
-                          if (s4 !== peg$FAILED) {
-                            if (input.charCodeAt(peg$currPos) === 41) {
-                              s5 = peg$c16;
-                              peg$currPos++;
-                            } else {
-                              s5 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c17); }
-                            }
-                            if (s5 !== peg$FAILED) {
-                              peg$savedPos = s0;
-                              s1 = peg$c18(s3);
-                              s0 = s1;
-                            } else {
-                              peg$currPos = s0;
-                              s0 = peg$FAILED;
-                            }
-                          } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                          }
-                        } else {
-                          peg$currPos = s0;
-                          s0 = peg$FAILED;
-                        }
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  }
                 }
               }
             }
@@ -5632,6 +6206,217 @@ function peg$parse(input, options) {
         }
       }
     }
+
+    return s0;
+  }
+
+  function peg$parseStringLiteral() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseQuotedString();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c41(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseRegexpLiteral() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseRegexp();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseKeyWordStart();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c224(s1);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseSubnetLiteral() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseIP6Net();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c225(s1);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseIP4Net();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c225(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseAddressLiteral() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseIP6();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseIdentifierRest();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c226(s1);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseIP();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c226(s1);
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseFloatLiteral() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseFloatString();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c227(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseIntegerLiteral() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseIntString();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c228(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseBooleanLiteral() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4) === peg$c229) {
+      s1 = peg$c229;
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c230); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c231();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 5) === peg$c232) {
+        s1 = peg$c232;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c233); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c234();
+      }
+      s0 = s1;
+    }
+
+    return s0;
+  }
+
+  function peg$parseNullLiteral() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4) === peg$c206) {
+      s1 = peg$c206;
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c207); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c235();
+    }
+    s0 = s1;
 
     return s0;
   }
@@ -5651,16 +6436,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c243) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c236) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c244); }
+      if (peg$silentFails === 0) { peg$fail(peg$c237); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c238();
     }
     s0 = s1;
 
@@ -5671,16 +6456,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c245) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c239) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c246); }
+      if (peg$silentFails === 0) { peg$fail(peg$c240); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c241();
     }
     s0 = s1;
 
@@ -5691,16 +6476,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c178) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c50) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c247); }
+      if (peg$silentFails === 0) { peg$fail(peg$c242); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c243();
     }
     s0 = s1;
 
@@ -5711,46 +6496,38 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c87) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c84) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c248); }
+      if (peg$silentFails === 0) { peg$fail(peg$c244); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c245();
     }
     s0 = s1;
 
     return s0;
   }
 
-  function peg$parseIdentifierName() {
-    var s0, s1, s2, s3;
+  function peg$parseByToken() {
+    var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parseIdentifierStart();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseIdentifierRest();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseIdentifierRest();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c108();
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c246) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
     } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c247); }
     }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c248();
+    }
+    s0 = s1;
 
     return s0;
   }
@@ -5787,21 +6564,64 @@ function peg$parse(input, options) {
   }
 
   function peg$parseIdentifier() {
-    var s0, s1, s2, s3;
+    var s0, s1;
 
     s0 = peg$currPos;
-    s1 = peg$parseIdentifierStart();
+    s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$parseIdentifierRest();
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$parseIdentifierRest();
+      peg$savedPos = s0;
+      s1 = peg$c253(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseIdentifierName() {
+    var s0, s1, s2, s3, s4;
+
+    s0 = peg$currPos;
+    s1 = peg$currPos;
+    peg$silentFails++;
+    s2 = peg$currPos;
+    s3 = peg$parseIdGuard();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parseEOT();
+      if (s4 !== peg$FAILED) {
+        s3 = [s3, s4];
+        s2 = s3;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
       }
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    peg$silentFails--;
+    if (s2 === peg$FAILED) {
+      s1 = void 0;
+    } else {
+      peg$currPos = s1;
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseIdentifierStart();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c253();
-        s0 = s1;
+        s3 = [];
+        s4 = peg$parseIdentifierRest();
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$parseIdentifierRest();
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c254();
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -5809,6 +6629,59 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 36) {
+        s1 = peg$c255;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c256); }
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c45();
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 92) {
+          s1 = peg$c257;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c258); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parseIdGuard();
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c259(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseIdGuard() {
+    var s0;
+
+    s0 = peg$parseBooleanLiteral();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseNullLiteral();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseSearchGuard();
+      }
     }
 
     return s0;
@@ -5828,12 +6701,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c243) {
-                s3 = peg$c243;
+              if (input.substr(peg$currPos, 3) === peg$c236) {
+                s3 = peg$c236;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c254); }
+                if (peg$silentFails === 0) { peg$fail(peg$c260); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -5878,44 +6751,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c255) {
-      s0 = peg$c255;
+    if (input.substr(peg$currPos, 7) === peg$c261) {
+      s0 = peg$c261;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c256); }
+      if (peg$silentFails === 0) { peg$fail(peg$c262); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c257) {
-        s0 = peg$c257;
+      if (input.substr(peg$currPos, 6) === peg$c263) {
+        s0 = peg$c263;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c258); }
+        if (peg$silentFails === 0) { peg$fail(peg$c264); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c259) {
-          s0 = peg$c259;
+        if (input.substr(peg$currPos, 4) === peg$c265) {
+          s0 = peg$c265;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c260); }
+          if (peg$silentFails === 0) { peg$fail(peg$c266); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c261) {
-            s0 = peg$c261;
+          if (input.substr(peg$currPos, 3) === peg$c267) {
+            s0 = peg$c267;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c262); }
+            if (peg$silentFails === 0) { peg$fail(peg$c268); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c263;
+              s0 = peg$c269;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c264); }
+              if (peg$silentFails === 0) { peg$fail(peg$c270); }
             }
           }
         }
@@ -5928,44 +6801,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c265) {
-      s0 = peg$c265;
+    if (input.substr(peg$currPos, 7) === peg$c271) {
+      s0 = peg$c271;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c266); }
+      if (peg$silentFails === 0) { peg$fail(peg$c272); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c267) {
-        s0 = peg$c267;
+      if (input.substr(peg$currPos, 6) === peg$c273) {
+        s0 = peg$c273;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c274); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c269) {
-          s0 = peg$c269;
+        if (input.substr(peg$currPos, 4) === peg$c275) {
+          s0 = peg$c275;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c270); }
+          if (peg$silentFails === 0) { peg$fail(peg$c276); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c271) {
-            s0 = peg$c271;
+          if (input.substr(peg$currPos, 3) === peg$c277) {
+            s0 = peg$c277;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c272); }
+            if (peg$silentFails === 0) { peg$fail(peg$c278); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c273;
+              s0 = peg$c279;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c274); }
+              if (peg$silentFails === 0) { peg$fail(peg$c280); }
             }
           }
         }
@@ -5978,44 +6851,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c275) {
-      s0 = peg$c275;
+    if (input.substr(peg$currPos, 5) === peg$c281) {
+      s0 = peg$c281;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c276); }
+      if (peg$silentFails === 0) { peg$fail(peg$c282); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c277) {
-        s0 = peg$c277;
+      if (input.substr(peg$currPos, 3) === peg$c283) {
+        s0 = peg$c283;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c278); }
+        if (peg$silentFails === 0) { peg$fail(peg$c284); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c279) {
-          s0 = peg$c279;
+        if (input.substr(peg$currPos, 2) === peg$c285) {
+          s0 = peg$c285;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c280); }
+          if (peg$silentFails === 0) { peg$fail(peg$c286); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c281;
+            s0 = peg$c287;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c282); }
+            if (peg$silentFails === 0) { peg$fail(peg$c288); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c283) {
-              s0 = peg$c283;
+            if (input.substr(peg$currPos, 4) === peg$c289) {
+              s0 = peg$c289;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c284); }
+              if (peg$silentFails === 0) { peg$fail(peg$c290); }
             }
           }
         }
@@ -6028,28 +6901,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c285) {
-      s0 = peg$c285;
+    if (input.substr(peg$currPos, 4) === peg$c291) {
+      s0 = peg$c291;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c292); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c287) {
-        s0 = peg$c287;
+      if (input.substr(peg$currPos, 3) === peg$c293) {
+        s0 = peg$c293;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+        if (peg$silentFails === 0) { peg$fail(peg$c294); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c289;
+          s0 = peg$c295;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c290); }
+          if (peg$silentFails === 0) { peg$fail(peg$c296); }
         }
       }
     }
@@ -6060,44 +6933,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c291) {
-      s0 = peg$c291;
+    if (input.substr(peg$currPos, 5) === peg$c297) {
+      s0 = peg$c297;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c292); }
+      if (peg$silentFails === 0) { peg$fail(peg$c298); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c293) {
-        s0 = peg$c293;
+      if (input.substr(peg$currPos, 4) === peg$c299) {
+        s0 = peg$c299;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c294); }
+        if (peg$silentFails === 0) { peg$fail(peg$c300); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c295) {
-          s0 = peg$c295;
+        if (input.substr(peg$currPos, 3) === peg$c301) {
+          s0 = peg$c301;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c296); }
+          if (peg$silentFails === 0) { peg$fail(peg$c302); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c297) {
-            s0 = peg$c297;
+          if (input.substr(peg$currPos, 2) === peg$c303) {
+            s0 = peg$c303;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c298); }
+            if (peg$silentFails === 0) { peg$fail(peg$c304); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c299;
+              s0 = peg$c305;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c300); }
+              if (peg$silentFails === 0) { peg$fail(peg$c306); }
             }
           }
         }
@@ -6111,16 +6984,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c257) {
-      s1 = peg$c257;
+    if (input.substr(peg$currPos, 6) === peg$c263) {
+      s1 = peg$c263;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c258); }
+      if (peg$silentFails === 0) { peg$fail(peg$c264); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c301();
+      s1 = peg$c307();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6132,7 +7005,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c302(s1);
+            s1 = peg$c308(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6155,16 +7028,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c267) {
-      s1 = peg$c267;
+    if (input.substr(peg$currPos, 6) === peg$c273) {
+      s1 = peg$c273;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c268); }
+      if (peg$silentFails === 0) { peg$fail(peg$c274); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c303();
+      s1 = peg$c309();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6176,7 +7049,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c304(s1);
+            s1 = peg$c310(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6199,16 +7072,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c283) {
-      s1 = peg$c283;
+    if (input.substr(peg$currPos, 4) === peg$c289) {
+      s1 = peg$c289;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c284); }
+      if (peg$silentFails === 0) { peg$fail(peg$c290); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c305();
+      s1 = peg$c311();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6220,7 +7093,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c306(s1);
+            s1 = peg$c312(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6243,16 +7116,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c287) {
-      s1 = peg$c287;
+    if (input.substr(peg$currPos, 3) === peg$c293) {
+      s1 = peg$c293;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c288); }
+      if (peg$silentFails === 0) { peg$fail(peg$c294); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c307();
+      s1 = peg$c313();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6264,7 +7137,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c308(s1);
+            s1 = peg$c314(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6287,16 +7160,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c293) {
-      s1 = peg$c293;
+    if (input.substr(peg$currPos, 4) === peg$c299) {
+      s1 = peg$c299;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c294); }
+      if (peg$silentFails === 0) { peg$fail(peg$c300); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c309();
+      s1 = peg$c315();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6308,7 +7181,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c310(s1);
+            s1 = peg$c316(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6334,37 +7207,37 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c158;
+        s2 = peg$c81;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c159); }
+        if (peg$silentFails === 0) { peg$fail(peg$c82); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c158;
+            s4 = peg$c81;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c159); }
+            if (peg$silentFails === 0) { peg$fail(peg$c82); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c158;
+                s6 = peg$c81;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c159); }
+                if (peg$silentFails === 0) { peg$fail(peg$c82); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c108();
+                  s1 = peg$c45();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6416,7 +7289,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c311(s1, s2);
+        s1 = peg$c317(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6437,12 +7310,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c312) {
-            s3 = peg$c312;
+          if (input.substr(peg$currPos, 2) === peg$c318) {
+            s3 = peg$c318;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c313); }
+            if (peg$silentFails === 0) { peg$fail(peg$c319); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -6455,7 +7328,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c314(s1, s2, s4, s5);
+                s1 = peg$c320(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6479,12 +7352,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c312) {
-          s1 = peg$c312;
+        if (input.substr(peg$currPos, 2) === peg$c318) {
+          s1 = peg$c318;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c313); }
+          if (peg$silentFails === 0) { peg$fail(peg$c319); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -6497,7 +7370,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c315(s2, s3);
+              s1 = peg$c321(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6522,16 +7395,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c312) {
-                s3 = peg$c312;
+              if (input.substr(peg$currPos, 2) === peg$c318) {
+                s3 = peg$c318;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c313); }
+                if (peg$silentFails === 0) { peg$fail(peg$c319); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c316(s1, s2);
+                s1 = peg$c322(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6547,16 +7420,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c312) {
-              s1 = peg$c312;
+            if (input.substr(peg$currPos, 2) === peg$c318) {
+              s1 = peg$c318;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c313); }
+              if (peg$silentFails === 0) { peg$fail(peg$c319); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c317();
+              s1 = peg$c323();
             }
             s0 = s1;
           }
@@ -6583,17 +7456,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c166;
+      s1 = peg$c20;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c167); }
+      if (peg$silentFails === 0) { peg$fail(peg$c21); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c318(s2);
+        s1 = peg$c324(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6614,15 +7487,15 @@ function peg$parse(input, options) {
     s1 = peg$parseHex();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 58) {
-        s2 = peg$c166;
+        s2 = peg$c20;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c167); }
+        if (peg$silentFails === 0) { peg$fail(peg$c21); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c319(s1);
+        s1 = peg$c325(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6643,17 +7516,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c190;
+        s2 = peg$c165;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c191); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c320(s1, s3);
+          s1 = peg$c326(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6678,17 +7551,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c190;
+        s2 = peg$c165;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c191); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c321(s1, s3);
+          s1 = peg$c327(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6713,7 +7586,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c322(s1);
+      s1 = peg$c328(s1);
     }
     s0 = s1;
 
@@ -6759,7 +7632,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -6771,17 +7644,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c11;
+      s1 = peg$c163;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c12); }
+      if (peg$silentFails === 0) { peg$fail(peg$c164); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c108();
+        s1 = peg$c45();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6800,11 +7673,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c11;
+      s1 = peg$c163;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c12); }
+      if (peg$silentFails === 0) { peg$fail(peg$c164); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -6834,11 +7707,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c158;
+          s3 = peg$c81;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c159); }
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
@@ -6870,7 +7743,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c323();
+              s1 = peg$c329();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6895,22 +7768,22 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c11;
+        s1 = peg$c163;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c12); }
+        if (peg$silentFails === 0) { peg$fail(peg$c164); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c158;
+          s2 = peg$c81;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c159); }
+          if (peg$silentFails === 0) { peg$fail(peg$c82); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
@@ -6942,7 +7815,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c323();
+              s1 = peg$c329();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6969,20 +7842,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c324) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c330) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c325); }
+      if (peg$silentFails === 0) { peg$fail(peg$c331); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c326.test(input.charAt(peg$currPos))) {
+      if (peg$c332.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c327); }
+        if (peg$silentFails === 0) { peg$fail(peg$c333); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -7024,7 +7897,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -7034,109 +7907,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c328.test(input.charAt(peg$currPos))) {
+    if (peg$c334.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c329); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseKeyWord() {
-    var s0, s1, s2;
-
-    s0 = peg$currPos;
-    s1 = [];
-    s2 = peg$parseKeyWordPart();
-    if (s2 !== peg$FAILED) {
-      while (s2 !== peg$FAILED) {
-        s1.push(s2);
-        s2 = peg$parseKeyWordPart();
-      }
-    } else {
-      s1 = peg$FAILED;
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c330(s1);
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseKeyWordPart() {
-    var s0, s1, s2;
-
-    s0 = peg$currPos;
-    if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c331;
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c332); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parseEscapeSequence();
-      if (s2 === peg$FAILED) {
-        s2 = peg$parseSearchEscape();
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c13(s2);
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$currPos;
-      peg$silentFails++;
-      if (peg$c333.test(input.charAt(peg$currPos))) {
-        s2 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c334); }
-      }
-      if (s2 === peg$FAILED) {
-        s2 = peg$parseWhiteSpace();
-      }
-      peg$silentFails--;
-      if (s2 === peg$FAILED) {
-        s1 = void 0;
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-      if (s1 !== peg$FAILED) {
-        if (input.length > peg$currPos) {
-          s2 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c335); }
-        }
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c108();
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
+      if (peg$silentFails === 0) { peg$fail(peg$c335); }
     }
 
     return s0;
@@ -7258,11 +8034,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c335); }
+        if (peg$silentFails === 0) { peg$fail(peg$c341); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c108();
+        s1 = peg$c45();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7275,17 +8051,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c331;
+        s1 = peg$c257;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c332); }
+        if (peg$silentFails === 0) { peg$fail(peg$c258); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c13(s2);
+          s1 = peg$c342(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7295,6 +8071,106 @@ function peg$parse(input, options) {
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
+    }
+
+    return s0;
+  }
+
+  function peg$parseKeyWord() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    s1 = peg$parseKeyWordStart();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseKeyWordRest();
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$parseKeyWordRest();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c343(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseKeyWordStart() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (peg$c344.test(input.charAt(peg$currPos))) {
+      s1 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c345); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c45();
+    }
+    s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseKeyWordEsc();
+    }
+
+    return s0;
+  }
+
+  function peg$parseKeyWordRest() {
+    var s0;
+
+    s0 = peg$parseKeyWordStart();
+    if (s0 === peg$FAILED) {
+      if (peg$c251.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c252); }
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseKeyWordEsc() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 92) {
+      s1 = peg$c257;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c258); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseKeywordEscape();
+      if (s2 === peg$FAILED) {
+        s2 = peg$parseEscapeSequence();
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c342(s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
     return s0;
@@ -7329,11 +8205,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c335); }
+        if (peg$silentFails === 0) { peg$fail(peg$c341); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c108();
+        s1 = peg$c45();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7346,17 +8222,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c331;
+        s1 = peg$c257;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c332); }
+        if (peg$silentFails === 0) { peg$fail(peg$c258); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c13(s2);
+          s1 = peg$c342(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7376,11 +8252,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c341;
+      s1 = peg$c346;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c342); }
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -7388,7 +8264,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c343();
+          s1 = peg$c348();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7415,111 +8291,129 @@ function peg$parse(input, options) {
   function peg$parseSingleCharEscape() {
     var s0, s1;
 
+    s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s0 = peg$c339;
+      s1 = peg$c339;
       peg$currPos++;
     } else {
-      s0 = peg$FAILED;
+      s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c340); }
     }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c349();
+    }
+    s0 = s1;
     if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s0 = peg$c336;
+        s1 = peg$c336;
         peg$currPos++;
       } else {
-        s0 = peg$FAILED;
+        s1 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c337); }
       }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c350();
+      }
+      s0 = s1;
       if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s0 = peg$c331;
+          s1 = peg$c257;
           peg$currPos++;
         } else {
-          s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c332); }
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c258); }
         }
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c351();
+        }
+        s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c344;
+            s1 = peg$c352;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c345); }
+            if (peg$silentFails === 0) { peg$fail(peg$c353); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c346();
+            s1 = peg$c354();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c347;
+              s1 = peg$c355;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c348); }
+              if (peg$silentFails === 0) { peg$fail(peg$c356); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c349();
+              s1 = peg$c357();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c350;
+                s1 = peg$c358;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c351); }
+                if (peg$silentFails === 0) { peg$fail(peg$c359); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c352();
+                s1 = peg$c360();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c353;
+                  s1 = peg$c361;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c354); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c362); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c355();
+                  s1 = peg$c363();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c356;
+                    s1 = peg$c364;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c357); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c365); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c358();
+                    s1 = peg$c366();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c359;
+                      s1 = peg$c367;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c360); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c368); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c361();
+                      s1 = peg$c369();
                     }
                     s0 = s1;
                   }
@@ -7534,36 +8428,45 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseSearchEscape() {
+  function peg$parseKeywordEscape() {
     var s0, s1;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 61) {
-      s1 = peg$c83;
+      s1 = peg$c46;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c84); }
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c370();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 42) {
-        s1 = peg$c19;
+        s1 = peg$c34;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c20); }
+        if (peg$silentFails === 0) { peg$fail(peg$c35); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c363();
+        s1 = peg$c371();
       }
       s0 = s1;
+      if (s0 === peg$FAILED) {
+        if (peg$c332.test(input.charAt(peg$currPos))) {
+          s0 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c333); }
+        }
+      }
     }
 
     return s0;
@@ -7574,11 +8477,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c364;
+      s1 = peg$c372;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c365); }
+      if (peg$silentFails === 0) { peg$fail(peg$c373); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7610,7 +8513,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c366(s2);
+        s1 = peg$c374(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7623,19 +8526,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c364;
+        s1 = peg$c372;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c365); }
+        if (peg$silentFails === 0) { peg$fail(peg$c373); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c367;
+          s2 = peg$c375;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c368); }
+          if (peg$silentFails === 0) { peg$fail(peg$c376); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -7694,15 +8597,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c369;
+              s4 = peg$c377;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c370); }
+              if (peg$silentFails === 0) { peg$fail(peg$c378); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c366(s3);
+              s1 = peg$c374(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7730,25 +8633,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c190;
+      s1 = peg$c165;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c191); }
+      if (peg$silentFails === 0) { peg$fail(peg$c166); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c190;
+          s3 = peg$c165;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c191); }
+          if (peg$silentFails === 0) { peg$fail(peg$c166); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c371(s2);
+          s1 = peg$c379(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7771,39 +8674,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c372.test(input.charAt(peg$currPos))) {
+    if (peg$c380.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c373); }
+      if (peg$silentFails === 0) { peg$fail(peg$c381); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c374) {
-        s2 = peg$c374;
+      if (input.substr(peg$currPos, 2) === peg$c382) {
+        s2 = peg$c382;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c375); }
+        if (peg$silentFails === 0) { peg$fail(peg$c383); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c372.test(input.charAt(peg$currPos))) {
+        if (peg$c380.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c373); }
+          if (peg$silentFails === 0) { peg$fail(peg$c381); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c374) {
-            s2 = peg$c374;
+          if (input.substr(peg$currPos, 2) === peg$c382) {
+            s2 = peg$c382;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c375); }
+            if (peg$silentFails === 0) { peg$fail(peg$c383); }
           }
         }
       }
@@ -7812,7 +8715,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c45();
     }
     s0 = s1;
 
@@ -7822,12 +8725,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c376.test(input.charAt(peg$currPos))) {
+    if (peg$c384.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c377); }
+      if (peg$silentFails === 0) { peg$fail(peg$c385); }
     }
 
     return s0;
@@ -7885,7 +8788,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
 
     return s0;
@@ -7896,51 +8799,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c379;
+      s0 = peg$c387;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c380); }
+      if (peg$silentFails === 0) { peg$fail(peg$c388); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c381;
+        s0 = peg$c389;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c382); }
+        if (peg$silentFails === 0) { peg$fail(peg$c390); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c383;
+          s0 = peg$c391;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c384); }
+          if (peg$silentFails === 0) { peg$fail(peg$c392); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c385;
+            s0 = peg$c393;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c386); }
+            if (peg$silentFails === 0) { peg$fail(peg$c394); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c387;
+              s0 = peg$c395;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c388); }
+              if (peg$silentFails === 0) { peg$fail(peg$c396); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c389;
+                s0 = peg$c397;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c390); }
+                if (peg$silentFails === 0) { peg$fail(peg$c398); }
               }
             }
           }
@@ -7950,7 +8853,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c378); }
+      if (peg$silentFails === 0) { peg$fail(peg$c386); }
     }
 
     return s0;
@@ -7959,12 +8862,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c391.test(input.charAt(peg$currPos))) {
+    if (peg$c399.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c392); }
+      if (peg$silentFails === 0) { peg$fail(peg$c400); }
     }
 
     return s0;
@@ -7978,7 +8881,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c393); }
+      if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
 
     return s0;
@@ -7988,24 +8891,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c394) {
-      s1 = peg$c394;
+    if (input.substr(peg$currPos, 2) === peg$c402) {
+      s1 = peg$c402;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c395); }
+      if (peg$silentFails === 0) { peg$fail(peg$c403); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c396) {
-        s5 = peg$c396;
+      if (input.substr(peg$currPos, 2) === peg$c404) {
+        s5 = peg$c404;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c397); }
+        if (peg$silentFails === 0) { peg$fail(peg$c405); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -8032,12 +8935,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c396) {
-          s5 = peg$c396;
+        if (input.substr(peg$currPos, 2) === peg$c404) {
+          s5 = peg$c404;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c397); }
+          if (peg$silentFails === 0) { peg$fail(peg$c405); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -8061,12 +8964,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c396) {
-          s3 = peg$c396;
+        if (input.substr(peg$currPos, 2) === peg$c404) {
+          s3 = peg$c404;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c397); }
+          if (peg$silentFails === 0) { peg$fail(peg$c405); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -8091,12 +8994,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c398) {
-      s1 = peg$c398;
+    if (input.substr(peg$currPos, 2) === peg$c406) {
+      s1 = peg$c406;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c399); }
+      if (peg$silentFails === 0) { peg$fail(peg$c407); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -8166,6 +9069,17 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseEOT() {
+    var s0;
+
+    s0 = peg$parse_();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseEOF();
+    }
+
+    return s0;
+  }
+
   function peg$parseEOF() {
     var s0, s1;
 
@@ -8176,7 +9090,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c335); }
+      if (peg$silentFails === 0) { peg$fail(peg$c341); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -47,185 +47,176 @@
 #define PRINT(...) console.log(__VAR_ARGS__)
 #endif
 
-start = __ ast:Query __ EOF { RETURN(ast) }
+start = __ ast:Z __ EOF { RETURN(ast) }
 
-Query
-  = procs:SequentialProcs {
-      RETURN(MAP("op": "SequentialProc", "procs": procs))
+// A Z script can be either a single operation or a chain of operations.
+// For a single operation, we do not need to wrap operator in a SequentialProc,
+// but we do for everything but FilterProc because the zq runtime is fragile
+// to this difference right now.  See issue #1809.
+Z // = !(Operator / Aggregation / "(") op:Operation &EOF { RETURN(op) }
+  = Sequential
+
+Sequential
+  = first:Operation rest:SequentialTail+ {
+      RETURN(MAP("op": "SequentialProc", "procs": PREPEND(first, rest)))
     }
-  / s:Search __ rest:SequentialTail* {
-      if (ARRAY_LEN(rest) == 0) {
-          RETURN(s)
-      } else {
-          RETURN(MAP("op": "SequentialProc", "procs": PREPEND(s, rest)))
-      }
+  / op:Operation {
+      RETURN(MAP("op": "SequentialProc", "procs": ARRAY(op)))
     }
 
-Search
-  = expr:SearchExpr {
+SequentialTail = __ "|" __ p:Operation { RETURN(p) }
+
+Parallel
+  = first:Sequential rest:ParallelTail+ {
+      RETURN(PREPEND(first, rest))
+    }
+  / first:Sequential {
+      RETURN(ARRAY(first))
+    }
+
+ParallelTail
+  = __ "=>" __ ch:Sequential { RETURN(ch) }
+
+Operation
+  = "split" __ "(" __ "=>" __ procArray:Parallel __ ")" {
+      RETURN(MAP("op": "ParallelProc", "procs": procArray))
+    }
+  / Operator
+  / a:Aggregation !ExprGuard  { RETURN(a) }
+  / expr:SearchBoolean !AggGuard {
       RETURN(MAP("op": "FilterProc", "filter": expr))
     }
 
-SearchExpr
-  = first:SearchTerm rest:OredSearchTerm* {
-      RETURN(makeChain(first, rest, "LogicalOr"))
+ExprGuard = __ ((!"=>" Comparator) / AdditiveOperator / MultiplicativeOperator / ":" / "(")
+AggGuard = (_ (ByToken / "-with") EOT) / (__ ",")
+
+SearchBoolean
+  = first:SearchAnd rest:SearchOrTerm* {
+      RETURN(makeBinaryExprChain(first, rest))
     }
 
-OredSearchTerm = _ OrToken _ t:SearchTerm { RETURN(t) }
+SearchOrTerm = _ OrToken _ t:SearchAnd { RETURN(ARRAY("or", t)) }
 
-SearchTerm
-  = first:SearchFactor rest:AndedSearchTerm* {
-      RETURN(makeChain(first, rest, "LogicalAnd"))
+SearchAnd
+  = first:SearchFactor
+    rest:(__ (AndToken _)? __ expr:SearchFactor{ RETURN(ARRAY("and", expr)) })* {
+      RETURN(makeBinaryExprChain(first,rest))
     }
-
-AndedSearchTerm = _ (AndToken _)? f:SearchFactor { RETURN(f) }
 
 SearchFactor
-  = (NotToken _ / "!" __) e:SearchExpr {
-      RETURN(MAP("op": "LogicalNot", "expr": e))
+  = (NotToken _ / "!" __) e:SearchFactor {
+      RETURN(MAP("op": "UnaryExpr", "operator": "!", "operand": e))
     }
-  / !("-") s:SearchPred { RETURN(s) }
-  / "(" __ expr:SearchExpr __ ")" { RETURN(expr) }
+  / ShortCut
+  / SearchExpr
+  / "(" __ expr:SearchBoolean __ ")" { RETURN(expr) }
 
-SearchPred
-  = "*" __ comp:EqualityToken __ v:SearchValue {
-      RETURN(MAP("op": "CompareAny", "comparator": comp, "recursive": false, "value": v))
+ShortCut
+  = "*" __ compareOp:EqualityToken __ v:SearchValue {
+      RETURN(MAP("op": "FunctionCall", "function": "or",
+        "args": ARRAY(MAP("op": "BinaryExpr", "operator":"@",
+                 "lhs":MAP("op": "SelectExpr", "selectors": ARRAY(MAP("op": "RootRecord"))),
+                 "rhs":MAP("op": "FunctionCall", "function": "map",
+                   "args": ARRAY(MAP("op": "BinaryExpr", "operator": "=",
+                     "lhs": MAP("op": "Identifier", "name": "$"),
+                     "rhs": v)))))))
     }
-  / "**" __ comp:EqualityToken __ v:SearchValue {
-      RETURN(MAP("op": "CompareAny", "comparator": comp, "recursive": true, "value": v))
+  / f:Lval __ comp:EqualityToken __ v:GlobbySearchValue !ExprGuard {
+      RETURN(MAP("op": "BinaryExpr", "operator":comp, "lhs":f, "rhs":v))
     }
-  / f:Lval __ comp:EqualityToken __ v:SearchValue {
-      RETURN(MAP("op": "CompareField", "comparator": comp, "field": f, "value": v))
+  / v:SearchValue _ InToken _ "*" {
+      RETURN(MAP("op": "FunctionCall", "function": "or",
+        "args": ARRAY(MAP("op": "BinaryExpr", "operator":"@",
+                 "lhs":MAP("op": "SelectExpr", "selectors": ARRAY(MAP("op": "RootRecord"))),
+                 "rhs":MAP("op": "FunctionCall", "function": "map",
+                   "args": ARRAY(MAP("op": "BinaryExpr", "operator": "in",
+                     "lhs": v,
+                     "rhs": MAP("op": "Identifier", "name": "$"))))))))
     }
-  // XXX this is here for now to let "len(array)" be matched now that we have
-  // made reducer names generic (which will be far easier to add to and maintain),
-  // and a better fix awaits the language tweaks coming in issue #1371.  At that
-  // point this peg rule will be subsumed by a unified search/expression syntax.
-  / &"len" expr:Function __ comp:EqualityToken __ v:SearchValue {
-    RETURN(MAP("op": "BinaryExpression", "operator": comp, "lhs": expr, "rhs": v))
-  }
-  / v:SearchValue __ InToken __ "*" {
-      RETURN(MAP("op": "CompareAny", "comparator": "in", "recursive": false, "value": v))
-    }
-  / v:SearchValue __ InToken __ f:FieldExpr {
-      RETURN(MAP("op": "CompareField", "comparator": "in", "field": f, "value": v))
-    }
-  / v:SearchLiteral {
+  / !(SearchGuard EOT) v:GlobbySearchValue !ExprGuard {
       RETURN(MAP("op": "Search", "text": TEXT, "value": v))
     }
-  / !(SearchTokens _ ) v:KeyWord {
+  / "*" !ExprGuard {
+      RETURN(MAP("op": "Literal", "type": "bool", "value": "true"))
+    }
+
+SearchValue
+  = Literal
+  / v:KeyWord {
+      RETURN(MAP("op": "Literal", "type": "string", "value": v))
+    }
+
+GlobbySearchValue
+  = Literal
+  / v:SearchGlob {
       VAR(str) = ASSERT_STRING(v)
-      if (str == "*") {
-        RETURN(MAP("op": "MatchAll"))
-      }
       VAR(literal) = MAP("op": "Literal", "type": "string", "value": v)
       if (reglob.IsGlobby(str)) {
         literal["type"] = "regexp"
         literal["value"] = reglob.Reglob(str)
       }
-      RETURN(MAP("op": "Search", "text": TEXT, "value": literal))
+      RETURN(literal)
     }
 
-SearchValue
-  = SearchLiteral
-  / !(SearchTokens _) v:KeyWord {
-      RETURN(MAP("op": "Literal", "type": "string", "value": v))
+SearchGlob
+  = head:GlobPart+ tail:("*")* {
+      RETURN(joinChars(head) + joinChars(tail))
     }
 
-SearchTokens
+GlobPart
+  = s:Stars v:KeyWord { RETURN(ASSERT_STRING(s)+ASSERT_STRING(v)) }
+  / KeyWord
+
+Stars = "*"+ { RETURN(TEXT) }
+
+SearchGuard
   = AndToken
   / OrToken
+  / NotToken
   / InToken
+  / ByToken
 
-SearchLiteral
-  = StringLiteral
-  / RegexpLiteral
-  / SubnetLiteral
-  / AddressLiteral
-  / FloatLiteral
+/// === Search-embedded Expression Context ===
 
-  // Careful not to use IntegerLiteral unconditionally or it will consume
-  // the beginning of something like 1234abcd which is a valid search word
-  / i:IntegerLiteral !KeyWord { RETURN(i) }
+SearchExpr = SearchExprRelative
 
-  / !(SearchTokens _) v:BooleanLiteral { RETURN(v) }
-  / !(SearchTokens _) v:NullLiteral { RETURN(v) }
+Comparator = ("=" / "!=" / "in" / "<=" / "<" / ">=" / ">") { RETURN(TEXT) }
 
-
-StringLiteral
-  = v:QuotedString {
-      RETURN(MAP("op": "Literal", "type": "string", "value": v))
+SearchExprRelative
+  = first:SearchExprAdd
+    rest:(__ op:Comparator __ expr:SearchExprAdd{ RETURN(ARRAY(op, expr)) })* {
+        RETURN(makeBinaryExprChain(first, rest))
     }
 
-RegexpLiteral
-  = v:Regexp {
-      RETURN(MAP("op": "Literal", "type": "regexp", "value": v))
+SearchExprAdd
+  = first:SearchExprMul
+    rest:(__ op:AdditiveOperator __ expr:SearchExprMul{ RETURN(ARRAY(op, expr)) })* {
+        RETURN(makeBinaryExprChain(first, rest))
     }
 
-SubnetLiteral
-  = v:IP6Net !IdentifierRest {
-      RETURN(MAP("op": "Literal", "type": "net", "value": v))
-    }
-  / v:IP4Net {
-      RETURN(MAP("op": "Literal", "type": "net", "value": v))
+SearchExprMul
+  = first:SearchExprCast
+    rest:(__ op:MultiplicativeOperator __ expr:SearchExprCast{ RETURN(ARRAY(op, expr)) })* {
+        RETURN(makeBinaryExprChain(first, rest))
     }
 
-AddressLiteral
-  = v:IP6 !IdentifierRest {
-      RETURN(MAP("op": "Literal", "type": "ip", "value": v))
+SearchExprCast
+  = e:SearchExprFunc typ:( ":" typ:PrimitiveType { RETURN(typ) }) {
+      RETURN(MAP("op": "CastExpr", "expr": e, "type": typ))
     }
-  / v:IP {
-      RETURN(MAP("op": "Literal", "type": "ip", "value": v))
+  / SearchExprFunc
+
+SearchExprFunc
+  = MatchExpr
+  / first:Function rest:(Deref)*  {
+      RETURN(makeBinaryExprChain(first, rest))
     }
+  / DerefExpr
+  / Literal
 
-FloatLiteral
-  = v:FloatString {
-      RETURN(MAP("op": "Literal", "type": "float64", "value": v))
-    }
+/// === Aggregations ===
 
-IntegerLiteral
-  = v:IntString {
-      RETURN(MAP("op": "Literal", "type": "int64", "value": v))
-    }
-
-BooleanLiteral
-  = "true"           { RETURN(MAP("op": "Literal", "type": "bool", "value": "true")) }
-  / "false"          { RETURN(MAP("op": "Literal", "type": "bool", "value": "false")) }
-
-NullLiteral
-  = "null"           { RETURN(MAP("op": "Literal", "type": "null", "value": "")) }
-
-SequentialProcs
-  = first:Proc rest:SequentialTail* {
-     if ISNOTNULL(rest) {
-        RETURN(PREPEND(first, rest))
-      }
-      RETURN(ARRAY(first))
-    }
-
-SequentialTail = __ "|" __ p:Proc { RETURN(p) }
-
-Proc
-  = NamedProc
-  / "split" __ "(" __ "=>" __ proc:Procs __ ")" {
-      RETURN(proc)
-    }
-  / GroupByProc
-
-Procs
-  = first:SequentialProcs rest:ParallelTail* {
-      VAR(fp) = MAP("op": "SequentialProc", "procs": first)
-      if ISNOTNULL(rest) {
-        RETURN(MAP("op": "ParallelProc", "procs": PREPEND(fp, rest)))
-      } else {
-        RETURN(fp)
-      }
-    }
-
-ParallelTail
-  = __ ";"? __ "=>" __ ch:SequentialProcs { RETURN(MAP("op": "SequentialProc", "procs": ch)) }
-
-GroupByProc
+Aggregation
   = every:EveryDur? keys:GroupByKeys limit:LimitArg {
       RETURN(MAP("op": "GroupByProc", "keys": keys, "reducers": NULL, "duration": every, "limit": limit))
     }
@@ -241,7 +232,7 @@ EveryDur
   = "every"i _ dur:Duration _ { RETURN(dur) }
 
 GroupByKeys
-  = "by"i _ columns:FlexAssignments { RETURN(columns) }
+  = ByToken _ columns:FlexAssignments { RETURN(columns) }
 
 LimitArg
   = _ "with" _ "-limit" _ limit:UInt { RETURN(limit) }
@@ -268,7 +259,7 @@ ReducerAssignment
     }
 
 Reducer
-  = !("not"/"len") op:IdentifierName __ "(" __ expr:Expr?  __ ")" where:WhereClause? {
+  = !(NotReducers __ "(") op:IdentifierName __ "(" __ expr:Expr?  __ ")" !(__ ".") where:WhereClause? {
       VAR(r) = MAP("op": "Reducer", "operator": op, "expr": NULL, "where":where)
       if ISNOTNULL(expr) {
         r["expr"] = expr
@@ -276,7 +267,11 @@ Reducer
       RETURN(r)
     }
 
-WhereClause = _ "where" _ expr:Expr { RETURN(expr) }
+NotReducers
+  = "not"
+  / "match"
+
+WhereClause = _ "where" _ expr:SearchBoolean { RETURN(expr) }
 
 Reducers
   = first:ReducerAssignment rest:(__ "," __ ReducerAssignment)* {
@@ -287,7 +282,7 @@ Reducers
       RETURN(result)
     }
 
-NamedProc
+Operator
   = SortProc
   / TopProc
   / CutProc
@@ -372,7 +367,12 @@ TailProc
   / "tail"i { RETURN(MAP("op": "TailProc", "count": 1)) }
 
 FilterProc
-  = "filter"i _ expr:SearchExpr {
+  = "filter"i _ op:Filter {
+      RETURN(op)
+    }
+
+Filter
+  = expr:SearchBoolean {
       RETURN(MAP("op": "FilterProc", "filter": expr))
     }
 
@@ -418,10 +418,6 @@ JoinProc
 JoinKey
   = Lval
   / "(" expr:Expr ")" { RETURN(expr) }
-
-RootField
-  = "."? !(BooleanLiteral / NullLiteral) field:Identifier { RETURN(MAP("op": "BinaryExpr", "operator":".", "lhs":MAP("op":"RootRecord"), "rhs": field)) }
-  / "." !(Identifier)  { RETURN(MAP("op": "RootRecord")) }
 
 Lval = DerefExpr
 
@@ -478,7 +474,8 @@ EqualityCompareExpr
         RETURN(makeBinaryExprChain(first, rest))
     }
 
-EqualityOperator = ("=~" / "!~" / "=" / "!=") { RETURN(TEXT) }
+EqualityOperator
+  = ("=" / "!=") { RETURN(TEXT) }
 
 EqualityComparator
   = EqualityOperator
@@ -531,20 +528,26 @@ PrimitiveType
       / "type" / "error" / "null" ) { RETURN(TEXT) }
 
 FuncExpr
-  = first:Function rest:(Deref)* {
+  = SelectExpr
+  / MatchExpr
+  / first:Function rest:(Deref)* {
       RETURN(makeBinaryExprChain(first, rest))
     }
   / DerefExpr
   / Primary
 
-Function
-  = fn:DeprecatedName __ "(" args:ArgumentList ")" {
-      RETURN(MAP("op": "FunctionCall", "function": fn, "args": args))
+MatchExpr
+  = "match" __ "(" expr:SearchBoolean ")" { RETURN(expr) }
+
+SelectExpr
+  = "select" __ "(" __ args:ArgumentList __ ")" methods:(__ "." __ e:Function { RETURN(ARRAY("@", e)) })* {
+      RETURN(makeBinaryExprChain(MAP("op":"SelectExpr", "selectors":args), methods))
     }
 
-//XXX change Function names to IdentifierName once we completely
-// get rid of deprecated package-style function name errors.
-DeprecatedName = IdentifierStart (IdentifierRest / ".")* { RETURN(TEXT) }
+Function
+  = fn:IdentifierName __ "(" __ args:ArgumentList __ ")" {
+      RETURN(MAP("op": "FunctionCall", "function": fn, "args": args))
+    }
 
 ArgumentList
   = first:Expr rest:(__ "," __ e:Expr { RETURN(e) })* {
@@ -553,8 +556,26 @@ ArgumentList
   / __ { RETURN(ARRAY()) }
 
 DerefExpr
-  = first:RootField rest:(Deref)* {
+  = first:DotId rest:(Deref)* {
       RETURN(makeBinaryExprChain(first, rest))
+    }
+  / first:Identifier rest:(Deref)* {
+      RETURN(makeBinaryExprChain(first, rest))
+    }
+  / "." {
+      RETURN(MAP("op":"RootRecord"))
+    }
+
+DotId
+  = "." field:Identifier {
+      RETURN(MAP("op": "BinaryExpr", "operator":".",
+                     "lhs":MAP("op":"RootRecord"),
+                     "rhs":field))
+    }
+  / "." "[" expr:Expr "]" {
+      RETURN(MAP("op": "BinaryExpr", "operator":"[",
+                     "lhs":MAP("op":"RootRecord"),
+                     "rhs":expr))
     }
 
 Deref
@@ -562,6 +583,10 @@ Deref
   / "." !(".") id:Identifier { RETURN(ARRAY(".", id)) }
 
 Primary
+  = Literal
+  / "(" __ expr:Expr __ ")" { RETURN(expr) }
+
+Literal
   = StringLiteral
   / RegexpLiteral
   / SubnetLiteral
@@ -570,23 +595,74 @@ Primary
   / IntegerLiteral
   / BooleanLiteral
   / NullLiteral
-  / "(" __ expr:Expr __ ")" { RETURN(expr) }
+
+StringLiteral
+  = v:QuotedString {
+      RETURN(MAP("op": "Literal", "type": "string", "value": v))
+    }
+
+RegexpLiteral
+  = v:Regexp !KeyWordStart {
+      RETURN(MAP("op": "Literal", "type": "regexp", "value": v))
+    }
+
+SubnetLiteral
+  = v:IP6Net !IdentifierRest {
+      RETURN(MAP("op": "Literal", "type": "net", "value": v))
+    }
+  / v:IP4Net {
+      RETURN(MAP("op": "Literal", "type": "net", "value": v))
+    }
+
+AddressLiteral
+  = v:IP6 !IdentifierRest {
+      RETURN(MAP("op": "Literal", "type": "ip", "value": v))
+    }
+  / v:IP {
+      RETURN(MAP("op": "Literal", "type": "ip", "value": v))
+    }
+
+FloatLiteral
+  = v:FloatString {
+      RETURN(MAP("op": "Literal", "type": "float64", "value": v))
+    }
+
+IntegerLiteral
+  = v:IntString {
+      RETURN(MAP("op": "Literal", "type": "int64", "value": v))
+    }
+
+BooleanLiteral
+  = "true"           { RETURN(MAP("op": "Literal", "type": "bool", "value": "true")) }
+  / "false"          { RETURN(MAP("op": "Literal", "type": "bool", "value": "false")) }
+
+NullLiteral
+  = "null"           { RETURN(MAP("op": "Literal", "type": "null", "value": "")) }
 
 EqualityToken
   = EqualityOperator / RelativeOperator
 
-AndToken = "and"i { RETURN(TEXT) }
-OrToken = "or"i { RETURN(TEXT) }
-InToken = "in"i { RETURN(TEXT) }
-NotToken = "not"i { RETURN(TEXT) }
-
-IdentifierName = IdentifierStart IdentifierRest* { RETURN(TEXT) }
+AndToken = "and"i { RETURN("and") }
+OrToken = "or"i { RETURN("or") }
+InToken = "in"i { RETURN("in") }
+NotToken = "not"i { RETURN("not") }
+ByToken = "by"i { RETURN("by") }
 
 IdentifierStart = [A-Za-z_$]
 IdentifierRest = IdentifierStart / [0-9]
 
 Identifier
-  = IdentifierStart IdentifierRest* { RETURN(MAP("op": "Identifier", "name": TEXT)) }
+  = id:IdentifierName { RETURN(MAP("op": "Identifier", "name": id)) }
+
+IdentifierName
+  = !(IdGuard EOT) IdentifierStart IdentifierRest* {  RETURN(TEXT) }
+  / "$" { RETURN(TEXT) }
+  / "\\" id:IdGuard { RETURN(id) }
+
+IdGuard
+  = BooleanLiteral
+  / NullLiteral
+  / SearchGuard
 
 Duration
   = Seconds
@@ -706,12 +782,6 @@ Hex = HexDigit+ { RETURN(TEXT) }
 
 HexDigit = [0-9a-fA-F]
 
-KeyWord
-  = chars:KeyWordPart+ { RETURN(joinChars(chars)) }
-
-KeyWordPart
-  = "\\" s:(EscapeSequence / SearchEscape)  { RETURN(s) }
-  / !([\x00-\x1F\x5C(),!><=DQUOTE|SQUOTE;:] / WhiteSpace) . { RETURN(TEXT) }
 
 QuotedString
   = '"' v:DoubleQuotedChar* '"' { RETURN(joinChars(v)) }
@@ -720,6 +790,19 @@ QuotedString
 DoubleQuotedChar
   = !('"' / EscapedChar) . { RETURN(TEXT) }
   / "\\" s:EscapeSequence { RETURN(s) }
+
+KeyWord
+  = head:KeyWordStart tail:KeyWordRest* { RETURN(ASSERT_STRING(head) + joinChars(tail)) }
+
+KeyWordStart
+  = [a-zA-Z_.:/%#@~] { RETURN(TEXT) }
+  / KeyWordEsc
+
+KeyWordRest
+  = KeyWordStart
+  / [0-9]
+
+KeyWordEsc = "\\" s:(KeywordEscape / EscapeSequence)  { RETURN(s) }
 
 SingleQuotedChar
   = !("'" / EscapedChar) . { RETURN(TEXT) }
@@ -731,9 +814,9 @@ EscapeSequence
   / UnicodeEscape
 
 SingleCharEscape
-  = "'"
-  / '"'
-  / "\\"
+  = "'" { RETURN("'")}
+  / '"' { RETURN('"')}
+  / "\\" { RETURN("\\")}
   / "b" { RETURN("\b") }
   / "f" { RETURN("\f") }
   / "n" { RETURN("\n") }
@@ -741,9 +824,10 @@ SingleCharEscape
   / "t" { RETURN("\t") }
   / "v" { RETURN("\v") }
 
-SearchEscape
+KeywordEscape
   = "=" { RETURN("=") }
   / "*" { RETURN("\\*") }
+  / [+-]
 
 UnicodeEscape
   = "u" chars:(HexDigit HexDigit HexDigit HexDigit) {
@@ -799,4 +883,5 @@ MultiLineComment
 SingleLineComment
   = "//" (!LineTerminator SourceCharacter)*
 
+EOT = _ / EOF
 EOF = !.

--- a/zql/zql_test.go
+++ b/zql/zql_test.go
@@ -123,15 +123,22 @@ func parseString(in string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if seq, ok := tree.(*ast.SequentialProc); ok {
+		tree = seq.Procs[0]
+	}
 	filt, ok := tree.(*ast.FilterProc)
 	if !ok {
 		return "", fmt.Errorf("Expected FilterProc got %T", tree)
 	}
-	comp, ok := filt.Filter.(*ast.CompareField)
+	comp, ok := filt.Filter.(*ast.BinaryExpression)
 	if !ok {
-		return "", fmt.Errorf("Expected CompareField got %T", filt.Filter)
+		return "", fmt.Errorf("Expected BinaryExpression got %T", filt.Filter)
 	}
-	return comp.Value.Value, nil
+	literal, ok := comp.RHS.(*ast.Literal)
+	if !ok {
+		return "", fmt.Errorf("Expected Literal got %T", filt.Filter)
+	}
+	return literal.Value, nil
 }
 
 // Test handling of unicode escapes in the parser

--- a/zql/ztests/expr-pred.yaml
+++ b/zql/ztests/expr-pred.yaml
@@ -1,0 +1,12 @@
+zql: 'a+b>=2'
+
+input: |
+  #0:record[a:int32,b:int32]
+  0:[1;2;]
+  0:[-1;2;]
+  0:[1;1;]
+
+output: |
+  #0:record[a:int32,b:int32]
+  0:[1;2;]
+  0:[1;1;]

--- a/zql/ztests/glob-mul.yaml
+++ b/zql/ztests/glob-mul.yaml
@@ -1,0 +1,20 @@
+script: |
+  zq -t "s=a*b" in.tzng
+  echo ===
+  zq -t "s=a*b+1" in.tzng
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[s:string]
+      0:[axb;]
+      #1:record[s:int32,a:int32,b:int32]
+      1:[7;2;3;]
+      1:[8;2;3;]
+outputs:
+  - name: stdout
+    data: |
+      #0:record[s:string]
+      0:[axb;]
+      ===
+      #0:record[s:int32,a:int32,b:int32]
+      0:[7;2;3;]

--- a/zql/ztests/match-expr.yaml
+++ b/zql/ztests/match-expr.yaml
@@ -1,0 +1,12 @@
+zql: 'c=a+b'
+
+input: |
+  #0:record[a:int32,b:int32,c:int32]
+  0:[1;2;3;]
+  0:[-1;2;1;]
+  0:[1;1;0;]
+
+output: |
+  #0:record[a:int32,b:int32,c:int32]
+  0:[1;2;3;]
+  0:[-1;2;1;]

--- a/zql/ztests/proc-search.yaml
+++ b/zql/ztests/proc-search.yaml
@@ -1,0 +1,12 @@
+zql: '* | bar'
+
+input: |
+  #0:record[s1:string,s2:string]
+  0:[foo;bar;]
+  0:[foo;-;]
+  0:[-;bar;]
+
+output: |
+  #0:record[s1:string,s2:string]
+  0:[foo;bar;]
+  0:[-;bar;]

--- a/zql/ztests/select-map.yaml
+++ b/zql/ztests/select-map.yaml
@@ -1,0 +1,13 @@
+zql: cut out=collect(select(.).map($*a))
+
+input: |
+  #0:record[a:int32,b:int32,c:int32]
+  0:[1;2;3;]
+  0:[2;3;4;]
+  0:[3;4;5;]
+
+output: |
+  #0:record[out:array[int32]]
+  0:[[1;2;3;]]
+  0:[[4;6;8;]]
+  0:[[9;12;15;]]

--- a/zql/ztests/select-multi.yaml
+++ b/zql/ztests/select-multi.yaml
@@ -1,0 +1,11 @@
+zql: cut u1=union(select(r1)),u2=union(select(r1,r2))
+
+input: |
+  #0:record[r1:record[a:int32,b:int32],r2:record[a:int32,b:int32]]
+  0:[[1;2;][3;4;]]
+  0:[[3;4;][5;6;]]
+
+output: |
+  #0:record[u1:set[int32],u2:set[int32]]
+  0:[[1;2;][1;2;3;4;]]
+  0:[[3;4;][3;4;5;6;]]

--- a/zql/ztests/select-sum.yaml
+++ b/zql/ztests/select-sum.yaml
@@ -1,0 +1,13 @@
+zql: put s1=sum(select(.)), s2=sum(select(.).filter($>=3))
+
+input: |
+  #0:record[a:int32,b:int32,c:int32]
+  0:[1;2;3;]
+  0:[2;3;4;]
+  0:[3;4;5;]
+
+output: |
+  #0:record[a:int32,b:int32,c:int32,s1:int64,s2:int64]
+  0:[1;2;3;6;3;]
+  0:[2;3;4;9;7;]
+  0:[3;4;5;12;12;]

--- a/zql/ztests/where-expr.yaml
+++ b/zql/ztests/where-expr.yaml
@@ -1,0 +1,21 @@
+script: |
+  zq -t "_path=conn | count()" in.tzng
+  echo ===
+  zq -t "count() where _path=conn" in.tzng
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[_path:string]
+      0:[conn;]
+      0:[dns;]
+      0:[conn;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[count:uint64]
+      0:[2;]
+      ===
+      #0:record[count:uint64]
+      0:[2;]

--- a/zql/ztests/where-search.yaml
+++ b/zql/ztests/where-search.yaml
@@ -1,0 +1,24 @@
+script: |
+  zq -t "count() where foo" in.tzng
+  echo ===
+  zq -t "foo | count()" in.tzng
+
+inputs:
+  - name: in.tzng
+    data: |
+      #0:record[_path:string]
+      0:[conn;]
+      0:[foo;]
+      0:[conn;]
+      #1:record[a:array[string]]
+      1:[[foo;bar;]]
+      1:[[bar;]]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[count:uint64]
+      0:[2;]
+      ===
+      #0:record[count:uint64]
+      0:[2;]


### PR DESCRIPTION
This commit makes changes toward unifying search and expressions.
There is still much to be done, but this is a first step forward.
As part of this, we introduced a generator pattern as the low-level
construct for iterator wildcard field comparisons (e.g., "*=foo").
The first cut uses a "select" function to select and generate
sequences of values.  The syntax is a proposal to server as a
starting point for discussion.

We also eliminated "**" for now and the "=~" in favor of "in" for
CIDR matches.

There is now a scope abstraction in the compiler which sets us
up for named constants, variables, etc. as well as handling the
"$" reference for generated values.

Any aggregator can now be applied to a generated sequence.

Generated sequences can be modified or filtered with methods.
Currently there is support for just map() and filter().

The grammar has been refactored quite a bit in making this changes
and should be easier to extend and maintain.  There is one more big
move we want to make in unifying the standard-expression and
search-expression syntaxes.

In the runtime, the filter predicates are now all optimizations
of binary expressions and ahve been moved to package expr.

The where clause in group-by is now a search expression.

The match() function can be used in expression context to escape
the expression syntax into the search syntax.  Match() is boolean
valued.

The ast.BinaryExpr nodes now use lower case "and" and "or" for
the binary operator field.  This makes everything consistent now
and fixes a bug where case mismatch could occur in certain
situations.

The notes in zql/expr.md are rough and should be eventally
replaced with user docs and/or a design doc.