### PR TITLE
Put link checker on a schedule rather than on pushes to master

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,16 +1,30 @@
 name: Markdown link check
 
 on:
+  schedule:
+    - cron: '5 8 * * *'
   pull_request:
-  push:
-    branches:
-      - master
+    paths:
+      - '**.md'
 
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Extract branch name
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         config-file: .github/workflows/markdown-link-check-config.json
+    - name: Inform Slack users of link check failures
+      uses: tiloio/slack-webhook-action@v1.1.2
+      if: ${{ failure() && steps.extract_branch.outputs.branch == 'master' }}
+      with: 
+        slack_web_hook_url: ${{ secrets.SLACK_WEBHOOK_BRIMLABS_DOCS }}
+        slack_json: |
+          {
+            "username": "markdown-link-check",
+            "text": "Markdown link check failed: https://github.com/{{GITHUB_REPOSITORY}}/actions/runs/{{GITHUB_RUN_ID}}"
+          }


### PR DESCRIPTION
### Background

We run a "markdown link checker" in Actions that can flag dead hyperlinks in any of our markdown docs. It's been configured to run against all markdown files in the repo, which means that each time it runs, it may catch new bad links introduced in a particular commit as well as links in not-touched-in-that-commit markdown-in-the-repo that happen to point at sites that are dead or temporarily down. I've appreciated the periodic general coverage because I assume it's disappointing to users when they follow a link we feature prominently in our docs only to find it doesn't work. If a site fails often, it would be a motivation to try and find an alternate place to link to, or perhaps cover the subject without hyperlinking at all. But in order to do this, we'd have to know the failures are happening.

For a while now the markdown link checker has run whenever PRs merge to `master`. While this has given us information useful for the purposes described above, it's had the drawback of causing developers to respond to test failures that have nothing to do with their own changes. This has become more of an issue more recently when we set up notifications to a Slack `#test` channel to make each failure more visible.

### What's Changing

The change in this PR makes it such that the markdown link checker no longer runs on merges to `master`. Instead, it runs on a schedule each night around midnight PT. It also sends its failure notifications to a separate `#docs` channel on our Slack so they need only be seen by those who are interested in knowing about these kinds of periodic failures in random hyperlinks.

The runs on in-progress PRs remain in place, but with a tweak to have it only target [included paths](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths) that happen to be `.md` markdown files. I found the docs a little lacking in this area, so I black box tested it a bit and will share the observed behavior here so everyone knows what to expect & to serve as education if we use this functionality again in the future. Basically it seems like what defines a "path" in that PR context is whether there's ever been a `.md` file changed in the branch attached to PR. So for instance, when I created my PR based on a branch in which I changed a `.md` file, the Workflow was triggered right then, as well as each time I pushed other changes to my branch, even if those additional pushes did not change any `.md` files. Similarly, if I didn't touch any `.md` files in my branch before creating my PR, the Workflow did _not_ run when I created my PR, nor in any subsequent pushes in which I changed  non-`.md` files. But as soon as I changed & pushed a single `.md` file in my branch, it kept getting triggered on all subsequent pushes regardless. 

In conclusion, this means that developers who _do_ happen to touch `.md` files while working on their PR branches may be exposed to some failed runs of this test if other random sites we link to in the repo happen to be dead when the test runs. However, this seems like a reasonable cost to quickly catch the possible bad links the developer may have added in their own `.md` changes.

If what's being proposed gets merged here, I'll then put up a PR for a similar change in the Brim repo.

### Testing

Since this scheduled stuff only runs on `master`, I tested this all out in a personal forked repo https://github.com/philrz/zq pointing at the `#docs` channel.