### PR TITLE
handle null casts properly for all Z types

### DIFF
--- a/expr/eval.go
+++ b/expr/eval.go
@@ -718,18 +718,24 @@ func NewCast(expr Evaluator, styp string) (Evaluator, error) {
 		// XXX See issue #1572.   To implement aliascast here.
 		return nil, fmt.Errorf("cast to %s not implemented", styp)
 	}
-	return &evalCast{expr, c}, nil
+	return &evalCast{expr, c, typ}, nil
 }
 
 type evalCast struct {
 	expr   Evaluator
 	caster PrimitiveCaster
+	typ    zng.Type
 }
 
 func (c *evalCast) Eval(rec *zng.Record) (zng.Value, error) {
 	zv, err := c.expr.Eval(rec)
 	if err != nil {
 		return zng.Value{}, err
+	}
+	if zv.Bytes == nil {
+		// Take care of null here so the casters don't have to
+		// worry about it.  Anything type can be a null after all.
+		return zng.Value{c.typ, nil}, nil
 	}
 	return c.caster(zv)
 }

--- a/expr/eval.go
+++ b/expr/eval.go
@@ -734,7 +734,7 @@ func (c *evalCast) Eval(rec *zng.Record) (zng.Value, error) {
 	}
 	if zv.Bytes == nil {
 		// Take care of null here so the casters don't have to
-		// worry about it.  Anything type can be a null after all.
+		// worry about it.  Any value can be null after all.
 		return zng.Value{c.typ, nil}, nil
 	}
 	return c.caster(zv)

--- a/expr/ztests/null-cast.yaml
+++ b/expr/ztests/null-cast.yaml
@@ -1,0 +1,9 @@
+zql: cut s=null:string,a=null:ip
+
+input: |
+  #0:record[x:string]
+  0:[foo;]
+
+output: |
+  #0:record[s:string,a:int32]
+  0:[-;-;]

--- a/expr/ztests/null-cast.yaml
+++ b/expr/ztests/null-cast.yaml
@@ -5,5 +5,5 @@ input: |
   0:[foo;]
 
 output: |
-  #0:record[s:string,a:int32]
+  #0:record[s:string,a:ip]
   0:[-;-;]


### PR DESCRIPTION
The cast expressions are still a work in progress, but in particular,
the various casters aren't handling null properly.  Since Z allows
any value to be null, this is very easy handed as universal check
before calling the type-specific caster.  This commit adds this logic
and a simple test to cover it.

This is related to issue #1603 and fixes #2065 
