### PR TITLE
Exclude markdown link check from Slack notify to #test

### DIFF
--- a/.github/workflows/notify-master-failure.yml
+++ b/.github/workflows/notify-master-failure.yml
@@ -6,6 +6,7 @@ on:
       - master
     workflows:
       - '**'
+      - '!Markdown link check'
     types:
       - completed
 


### PR DESCRIPTION
In #2074 I modified our Actions Workflows so failure notifications for the markdown link checker would go to a separate `#docs` channel on Slack. I neglected to exclude it from the "Notify master failure" Workflow, though, so notifications were still prone to leaking out. I tested this exclusion out in a personal repo and it seems to do the trick.

There's a companion PR in the Brim repo https://github.com/brimsec/brim/pull/1431 that makes the same change, so if you're approving this one and can approve the other as well, that would be appreciated!