### PR TITLE
add join/split string functions

### DIFF
--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -80,6 +80,9 @@ func New(zctx *resolver.Context, name string, narg int) (Interface, error) {
 		f = &ceil{}
 	case "floor":
 		f = &floor{}
+	case "join":
+		argmax = 2
+		f = &join{}
 	case "log":
 		f = &log{}
 	case "max":
@@ -116,6 +119,10 @@ func New(zctx *resolver.Context, name string, narg int) (Interface, error) {
 		f = &iso{}
 	case "sec":
 		f = &sec{}
+	case "split":
+		argmin = 2
+		argmax = 2
+		f = newSplit(zctx)
 	case "msec":
 		f = &msec{}
 	case "usec":

--- a/expr/function/string.go
+++ b/expr/function/string.go
@@ -297,7 +297,7 @@ func (j *join) Call(args []zng.Value) (zng.Value, error) {
 	if !ok {
 		return zng.NewErrorf("argument to join() is not an array"), nil
 	}
-	if !zng.IsStringy(zng.AliasedType(typ.Type).ID()) {
+	if !zng.IsStringy(typ.Type.ID()) {
 		return zng.NewErrorf("argument to join() is not a string array"), nil
 	}
 	var separator string

--- a/expr/function/string.go
+++ b/expr/function/string.go
@@ -7,7 +7,9 @@ import (
 	"unicode/utf8"
 
 	"github.com/brimsec/zq/expr/result"
+	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
 )
 
 // XXX these string format functions should be handlded by :string cast
@@ -244,4 +246,88 @@ func (*trim) Call(args []zng.Value) (zng.Value, error) {
 	// XXX GC
 	s := strings.TrimSpace(string(zv.Bytes))
 	return zng.Value{zng.TypeString, zng.EncodeString(s)}, nil
+}
+
+type split struct {
+	zctx  *resolver.Context
+	typ   zng.Type
+	bytes zcode.Bytes
+}
+
+func newSplit(zctx *resolver.Context) *split {
+	return &split{
+		typ: zctx.LookupTypeArray(zng.TypeString),
+	}
+}
+
+func (s *split) Call(args []zng.Value) (zng.Value, error) {
+	zs := args[0]
+	zsep := args[1]
+	if !zs.IsStringy() || !zsep.IsStringy() {
+		return badarg("split")
+	}
+	if zs.Bytes == nil || zsep.Bytes == nil {
+		return zng.Value{Type: s.typ}, nil
+	}
+	str, err := zng.DecodeString(zs.Bytes)
+	if err != nil {
+		return zng.Value{}, err
+	}
+	sep, err := zng.DecodeString(zsep.Bytes)
+	if err != nil {
+		return zng.Value{}, err
+	}
+	splits := strings.Split(str, sep)
+	b := s.bytes[0:]
+	for _, substr := range splits {
+		b = zcode.AppendPrimitive(b, zng.EncodeString(substr))
+	}
+	s.bytes = b
+	return zng.Value{s.typ, b}, nil
+}
+
+type join struct {
+	bytes   zcode.Bytes
+	builder strings.Builder
+}
+
+func (j *join) Call(args []zng.Value) (zng.Value, error) {
+	zsplits := args[0]
+	typ, ok := zng.AliasedType(zsplits.Type).(*zng.TypeArray)
+	if !ok {
+		return zng.NewErrorf("argument to join() is not an array"), nil
+	}
+	if !zng.IsStringy(zng.AliasedType(typ.Type).ID()) {
+		return zng.NewErrorf("argument to join() is not a string array"), nil
+	}
+	var separator string
+	if len(args) == 2 {
+		zsep := args[1]
+		if !zsep.IsStringy() {
+			return zng.NewErrorf("separator argument to join() is not a string"), nil
+		}
+		var err error
+		separator, err = zng.DecodeString(zsep.Bytes)
+		if err != nil {
+			return zng.Value{}, err
+		}
+	}
+	b := j.builder
+	b.Reset()
+	it := zsplits.Bytes.Iter()
+	var sep string
+	for !it.Done() {
+		bytes, _, err := it.Next()
+		if err != nil {
+			return zng.Value{}, err
+		}
+		s, err := zng.DecodeString(bytes)
+		if err != nil {
+			return zng.Value{}, err
+		}
+		b.WriteString(sep)
+		b.WriteString(s)
+		sep = separator
+	}
+	return zng.Value{zng.TypeString, zng.EncodeString(b.String())}, nil
 }

--- a/expr/ztests/join.yaml
+++ b/expr/ztests/join.yaml
@@ -1,0 +1,10 @@
+zql: |
+   cut s1=join(a1,"."),s2=join(a1,"."),s3=join(a3,"."),s4=join(a4,"."),s5=join(oo)
+
+input: |
+  #0:record[a1:array[string],a2:array[string],a3:array[string],a4:array[string],oo:array[string]]
+  0:[[foo;bar;com;][foo;]-;[;][f;.bar.com;]]
+
+output: |
+  #0:record[s1:string,s2:string,s3:string,s4:string,s5:string]
+  0:[foo.bar.com;foo.bar.com;;;f.bar.com;]

--- a/expr/ztests/split.yaml
+++ b/expr/ztests/split.yaml
@@ -1,0 +1,10 @@
+zql: |
+   cut a1=split(s1,"."),a2=split(s2,"."),a3=split(s3,"."),a4=split(s4,"."),oo=split(s1,"oo")
+
+input: |
+  #0:record[s1:string,s2:string,s3:string,s4:string]
+  0:[foo.bar.com;foo;-;;]
+
+output: |
+  #0:record[a1:array[string],a2:array[string],a3:array[string],a4:array[string],oo:array[string]]
+  0:[[foo;bar;com;][foo;]-;[;][f;.bar.com;]]


### PR DESCRIPTION
This commit adds functions for join() and split() with respect to strings.
Since Z is dynamically typed, this functions may do more down the road 
based on the types of their arguments, but for now they are just string
functions.

Closes #2089, #2090 
