### PR TITLE
fix bug in string split() function

### DIFF
--- a/expr/function/string.go
+++ b/expr/function/string.go
@@ -278,7 +278,7 @@ func (s *split) Call(args []zng.Value) (zng.Value, error) {
 		return zng.Value{}, err
 	}
 	splits := strings.Split(str, sep)
-	b := s.bytes[0:]
+	b := s.bytes[:0]
 	for _, substr := range splits {
 		b = zcode.AppendPrimitive(b, zng.EncodeString(substr))
 	}

--- a/expr/ztests/split-multi.yaml
+++ b/expr/ztests/split-multi.yaml
@@ -1,0 +1,13 @@
+zql: cut split(s,".")
+
+input: |
+  #0:record[s:string]
+  0:[foo.bar.com;]
+  0:[foo;]
+  0:[acme.io;]
+
+output: |
+  #0:record[split:array[string]]
+  0:[[foo;bar;com;]]
+  0:[[foo;]]
+  0:[[acme;io;]]


### PR DESCRIPTION
This commit fixes a bug where the result buffer was properly
initially to an empty slice.