### PR TITLE
make connection.Search easier to use

### DIFF
--- a/api/client/connection.go
+++ b/api/client/connection.go
@@ -17,6 +17,7 @@ import (
 	"github.com/brimsec/zq/ast"
 	"github.com/brimsec/zq/pcap/pcapio"
 	"github.com/brimsec/zq/zio/ndjsonio"
+	"github.com/brimsec/zq/zqe"
 	"github.com/go-resty/resty/v2"
 )
 
@@ -163,6 +164,18 @@ func (c *Connection) Version(ctx context.Context) (string, error) {
 	return resp.Result().(*api.VersionResponse).Version, nil
 }
 
+// ZtoAST sends a request to the server to translate a Z program into its
+// AST form.
+func (c *Connection) ZtoAST(ctx context.Context, zprog string) ([]byte, error) {
+	resp, err := c.Request(ctx).
+		SetBody(api.ASTRequest{ZQL: zprog}).
+		Post("/ast")
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body(), nil
+}
+
 // SpaceInfo retrieves information about the specified space.
 func (c *Connection) SpaceInfo(ctx context.Context, id api.SpaceID) (*api.SpaceInfo, error) {
 	path := path.Join("/space", url.PathEscape(string(id)))
@@ -205,6 +218,19 @@ func (c *Connection) SpaceList(ctx context.Context) ([]api.Space, error) {
 		SetResult(&res).
 		Get("/space")
 	return res, err
+}
+
+func (c *Connection) SpaceLookup(ctx context.Context, name string) (api.SpaceID, error) {
+	spaces, err := c.SpaceList(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, s := range spaces {
+		if s.Name == name {
+			return s.ID, nil
+		}
+	}
+	return "", zqe.ErrNotFound()
 }
 
 func (c *Connection) SpaceDelete(ctx context.Context, id api.SpaceID) (err error) {
@@ -253,10 +279,35 @@ func (c *Connection) WorkerRelease(ctx context.Context) error {
 	return err
 }
 
-// Search sends a search task to the server and returns a Search interface
+// Search sends a search request to the server and returns a ZngSearch
 // that the caller uses to stream back results via the Read method.
-func (c *Connection) Search(ctx context.Context, search api.SearchRequest, params map[string]string) (*ZngSearch, error) {
-	r, err := c.SearchRaw(ctx, search, params)
+// Example usage:
+//
+//	conn := client.NewConnectionTo("http://localhost:9867")
+//	spaceID, err := conn.SpaceLookup(ctx, "spaceName")
+//	if err != nil { return err }
+//	search, err := conn.Search(ctx, spaceID, "_path=conn | count()")
+//	if err != nil { return err }
+//	for {
+//		rec, err := search.Read()
+//		if err != nil { return err }
+//		if rec == nil {
+//			// End of results.
+//			return nil
+//		}
+//		fmt.Println(rec)
+//	}
+//
+func (c *Connection) Search(ctx context.Context, spaceID api.SpaceID, query string) (*ZngSearch, error) {
+	procBytes, err := c.ZtoAST(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	r, err := c.SearchRaw(ctx, api.SearchRequest{
+		Space: spaceID,
+		Proc:  procBytes,
+		Dir:   -1,
+	}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ppl/zqd/handlers_test.go
+++ b/ppl/zqd/handlers_test.go
@@ -60,12 +60,16 @@ func TestSearch(t *testing.T) {
 0:[conn;1521911721.255387;C8Tful1TvM3Zf5x8fl;]
 `
 	_, conn := newCore(t)
-	sp, err := conn.SpacePost(context.Background(), api.SpacePostRequest{Name: "test"})
+	ctx := context.Background()
+	_, err := conn.SpacePost(ctx, api.SpacePostRequest{Name: "test"})
 	require.NoError(t, err)
-	_, err = conn.LogPostReaders(context.Background(), sp.ID, nil, strings.NewReader(src))
+	id, err := conn.SpaceLookup(ctx, "test")
 	require.NoError(t, err)
 
-	res := searchTzng(t, conn, sp.ID, "*")
+	_, err = conn.LogPostReaders(context.Background(), id, nil, strings.NewReader(src))
+	require.NoError(t, err)
+
+	res := searchTzng(t, conn, id, "*")
 	require.Equal(t, test.Trim(src), res)
 }
 
@@ -91,9 +95,10 @@ func TestSearchNoCtrl(t *testing.T) {
 		Span:  nano.MaxSpan,
 		Dir:   -1,
 	}
-	r, err := conn.Search(context.Background(), req, map[string]string{"noctrl": "true"})
+	body, err := conn.SearchRaw(context.Background(), req, map[string]string{"noctrl": "true"})
 	require.NoError(t, err)
 	var msgs []interface{}
+	r := client.NewZngSearch(body)
 	r.SetOnCtrl(func(i interface{}) {
 		msgs = append(msgs, i)
 	})
@@ -186,7 +191,7 @@ func TestSearchError(t *testing.T) {
 			Span:  nano.MaxSpan,
 			Dir:   2,
 		}
-		_, err = conn.Search(context.Background(), req, nil)
+		_, err = conn.SearchRaw(context.Background(), req, nil)
 		require.Error(t, err)
 		errResp := err.(*client.ErrorResponse)
 		assert.Equal(t, http.StatusBadRequest, errResp.StatusCode())
@@ -199,7 +204,7 @@ func TestSearchError(t *testing.T) {
 			Span:  nano.MaxSpan,
 			Dir:   1,
 		}
-		_, err = conn.Search(context.Background(), req, nil)
+		_, err = conn.SearchRaw(context.Background(), req, nil)
 		require.Error(t, err)
 		errResp := err.(*client.ErrorResponse)
 		assert.Equal(t, http.StatusBadRequest, errResp.StatusCode())
@@ -841,8 +846,9 @@ func search(t *testing.T, conn *client.Connection, space api.SpaceID, prog strin
 		Span:  nano.MaxSpan,
 		Dir:   -1,
 	}
-	r, err := conn.Search(context.Background(), req, nil)
+	body, err := conn.SearchRaw(context.Background(), req, nil)
 	require.NoError(t, err)
+	r := client.NewZngSearch(body)
 	buf := bytes.NewBuffer(nil)
 	w := tzngio.NewWriter(zio.NopCloser(buf))
 	var msgs []interface{}
@@ -854,8 +860,12 @@ func search(t *testing.T, conn *client.Connection, space api.SpaceID, prog strin
 }
 
 func searchTzng(t *testing.T, conn *client.Connection, space api.SpaceID, prog string) string {
-	tzng, _ := search(t, conn, space, prog)
-	return tzng
+	res, err := conn.Search(context.Background(), space, prog)
+	require.NoError(t, err)
+	buf := bytes.NewBuffer(nil)
+	w := tzngio.NewWriter(zio.NopCloser(buf))
+	require.NoError(t, zbuf.Copy(w, res))
+	return buf.String()
 }
 
 func tzngCopy(t *testing.T, prog string, in string, outFormat string) string {


### PR DESCRIPTION
connection.Search is a convenience wrapper around connection.SearchRaw. This change makes it a little easier to use, and adds example usage. It roundtrips with the server to parse the search query, to be more resilient against AST changes until we add support for AST versioning.
