### PR TITLE
fix join bug with memory management

### DIFF
--- a/proc/join/join.go
+++ b/proc/join/join.go
@@ -116,8 +116,8 @@ func (p *Proc) Done() {
 
 func (p *Proc) setJoinKey(key zng.Value) {
 	// Copy the joinkey value into the joinKeBytes buffer since
-	// we want to stash it and they zcode.Bytes points to a record
-	// that could be freed.
+	// we want to stash it and the zcode.Bytes points to a record
+	// that otherwise could be freed.
 	p.joinKey.Type = key.Type
 	p.joinKey.Bytes = append(p.joinKey.Bytes[:0], key.Bytes...)
 }


### PR DESCRIPTION
The join proc did not correctly do a zng.Record.Keep() while building
the join set array causing the underlying batch to be freed while
record references still existed.  The fix is to call keep in the right
place.  Also, the joinkey memory could also be freed while in use
so it's now copied to a buffer in the join proc struct.

This bug happened more often with a 'join' proc at the front of the 
pipeline (with no split) because the splitter proc otherwise keeps a ref on each 
batch so this bug was better hidden from the downstream consumer.
