### PR TITLE
zar: Add missing Init/Cleanup to commands

### DIFF
--- a/ppl/cmd/zar/compact/command.go
+++ b/ppl/cmd/zar/compact/command.go
@@ -39,6 +39,11 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
+
 	lk, err := lake.OpenLake(c.root, nil)
 	if err != nil {
 		return err

--- a/ppl/cmd/zar/index/drop.go
+++ b/ppl/cmd/zar/index/drop.go
@@ -51,6 +51,11 @@ func (c *DropCommand) Run(args []string) error {
 }
 
 func (c *DropCommand) run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
+
 	if len(args) == 0 {
 		return errors.New("no index definition specified")
 	}

--- a/ppl/cmd/zar/ls/command.go
+++ b/ppl/cmd/zar/ls/command.go
@@ -55,6 +55,11 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
+
 	if len(args) > 1 {
 		return errors.New("zar ls: too many arguments")
 	}

--- a/ppl/cmd/zar/rm/command.go
+++ b/ppl/cmd/zar/rm/command.go
@@ -48,6 +48,11 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
+
 	if len(args) == 0 {
 		return errors.New("zar rm: no file specified")
 	}

--- a/ppl/cmd/zar/rmdirs/command.go
+++ b/ppl/cmd/zar/rmdirs/command.go
@@ -39,6 +39,11 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) error {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
+
 	lk, err := lake.OpenLake(c.root, nil)
 	if err != nil {
 		return err

--- a/ppl/cmd/zar/stat/command.go
+++ b/ppl/cmd/zar/stat/command.go
@@ -44,6 +44,10 @@ func New(parent charm.Command, f *flag.FlagSet) (charm.Command, error) {
 }
 
 func (c *Command) Run(args []string) (err error) {
+	defer c.Cleanup()
+	if err := c.Init(); err != nil {
+		return err
+	}
 	if len(args) > 0 {
 		return errors.New("zar stat: too many arguments")
 	}


### PR DESCRIPTION
Some zar commands were missing the required Init / Cleanup calls needed for
some of the global options to work correctly (e.g. -cpuprofile, -memprofile).

Add these.