### PR TITLE
s3io: Use s3iface.S3API over *aws.Config

### DIFF
--- a/pkg/iosrc/s3.go
+++ b/pkg/iosrc/s3.go
@@ -14,13 +14,12 @@ import (
 	"github.com/brimsec/zq/zqe"
 )
 
-var defaultS3Source = &s3Source{}
-var _ Source = defaultS3Source
-var _ ReplacerAble = defaultS3Source
+var defaultS3Source = &s3Source{Client: s3io.NewClient(nil)}
 
-func init() {
-	defaultS3Source.Client = s3io.NewClient(nil)
-}
+var (
+	_ Source       = defaultS3Source
+	_ ReplacerAble = defaultS3Source
+)
 
 type s3Source struct {
 	Client s3iface.S3API

--- a/pkg/s3io/reader.go
+++ b/pkg/s3io/reader.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
 type Reader struct {
-	client *s3.S3
+	client s3iface.S3API
 	ctx    context.Context
 	bucket string
 	key    string
@@ -21,8 +22,8 @@ type Reader struct {
 	body   io.ReadCloser
 }
 
-func NewReader(ctx context.Context, path string, cfg *aws.Config) (*Reader, error) {
-	info, err := Stat(ctx, path, cfg)
+func NewReader(ctx context.Context, path string, client s3iface.S3API) (*Reader, error) {
+	info, err := Stat(ctx, path, client)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +32,7 @@ func NewReader(ctx context.Context, path string, cfg *aws.Config) (*Reader, erro
 		return nil, err
 	}
 	return &Reader{
-		client: newClient(cfg),
+		client: client,
 		ctx:    ctx,
 		bucket: bucket,
 		key:    key,


### PR DESCRIPTION
Currently the s3io code path requires *aws.Config for all its calls and creates
a new client for each request from the passed configuration. This is not
a totally expense free operation. I recently did a cpu profile of lake walk
and saw that having AWS_SDK_LOAD_CONFIG=true results in a OpenFile syscall
everytime s3io.newClient is called; meaning we read from the file system
everytime a call to s3 is made (twice for calls that need head first).

Instead have all s3io functions accept a s3iface.S3API interface. For the
default iosrc.S3Source use the go init() hook to call s3io.NewClient once at
the start of a program.