### PR TITLE
s3io.ReadFile

### DIFF
--- a/pkg/iosrc/s3.go
+++ b/pkg/iosrc/s3.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -36,12 +35,8 @@ func (s *s3Source) NewReader(ctx context.Context, u URI) (Reader, error) {
 }
 
 func (s *s3Source) ReadFile(ctx context.Context, u URI) ([]byte, error) {
-	r, err := NewReader(ctx, u)
-	if err != nil {
-		return nil, err
-	}
-	defer r.Close()
-	return ioutil.ReadAll(r)
+	b, err := s3io.ReadFile(ctx, u.String(), s.Client)
+	return b, wrapErr(err)
 }
 
 func (s *s3Source) WriteFile(ctx context.Context, d []byte, u URI) error {

--- a/pkg/s3io/s3io.go
+++ b/pkg/s3io/s3io.go
@@ -132,6 +132,23 @@ func (w *Writer) Close() error {
 	return w.closeWithError(nil)
 }
 
+func ReadFile(ctx context.Context, path string, client s3iface.S3API) ([]byte, error) {
+	bucket, key, err := parsePath(path)
+	if err != nil {
+		return nil, err
+	}
+	wbuf := aws.NewWriteAtBuffer(nil)
+	downloader := s3manager.NewDownloaderWithClient(client)
+	_, err = downloader.DownloadWithContext(ctx, wbuf, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return wbuf.Bytes(), nil
+}
+
 func RemoveAll(ctx context.Context, path string, client s3iface.S3API) error {
 	bucket, key, err := parsePath(path)
 	if err != nil {


### PR DESCRIPTION
Add s3io.ReadFile which uses s3manager.Downloader to download the Object. For
downloading entire files this has several advantages over s3io.NewReader:

1. s3manager.Downloader doesn't require HEAD api request to get the size of the
   entire object.

2. s3manager can use concurrency to download Objects faster.