### PR TITLE
Tolerate missing column during cut to root field

### DIFF
--- a/expr/cutter.go
+++ b/expr/cutter.go
@@ -76,6 +76,9 @@ func (c *Cutter) Apply(in *zng.Record) (*zng.Record, error) {
 	if len(c.fieldRefs) == 1 && c.fieldRefs[0].IsRoot() {
 		zv, err := c.fieldExprs[0].Eval(in)
 		if err != nil {
+			if err == ErrNoSuchField {
+				return nil, nil
+			}
 			return nil, err
 		}
 		recType, ok := zng.AliasedType(zv.Type).(*zng.TypeRecord)

--- a/expr/ztests/cut-to-root-warning.yaml
+++ b/expr/ztests/cut-to-root-warning.yaml
@@ -1,0 +1,10 @@
+zql: 'cut .=c'
+
+input: |
+  #0:record[a:record[b:int32]]
+  0:[-;]
+  0:[[-;]]
+  0:[[1;]]
+
+warnings: |
+  cut: no record found with columns c


### PR DESCRIPTION
Cutting to the root field (e.g, cut .=f) produces a fatal error when it
encounters a record missing the source column.  Ignore the record
instead to match the behavior when cutting to non-root fields.

Closes #2120.