### PR TITLE
don't panic when putting a non-record to root

### DIFF
--- a/proc/put/put.go
+++ b/proc/put/put.go
@@ -348,8 +348,7 @@ func (p *Proc) put(in *zng.Record) (*zng.Record, error) {
 	}
 	rule, err := p.lookupRule(in.Type, vals)
 	if err != nil {
-		p.maybeWarn(err)
-		return in, nil
+		return nil, err
 	}
 
 	bytes, err := rule.step.build(in.Raw, &p.builder, vals)

--- a/proc/put/ztests/put-to-root-error-non-record.yaml
+++ b/proc/put/ztests/put-to-root-error-non-record.yaml
@@ -3,4 +3,5 @@ zql: 'put .=a'
 input: |
   #0:record[a:int32]
   0:[1;]
+  
 errorRE: cannot put a non-record to \.

--- a/proc/put/ztests/put-to-root-error-non-record.yaml
+++ b/proc/put/ztests/put-to-root-error-non-record.yaml
@@ -1,0 +1,6 @@
+zql: 'put .=a'
+
+input: |
+  #0:record[a:int32]
+  0:[1;]
+errorRE: cannot put a non-record to \.


### PR DESCRIPTION
close #2135 

With this change, putting a non-record to `.` is a fatal error (similar to `cut` behavior). Making such errors be non-fatal is #1429.