### PR TITLE
Pass type context to fuse.WriteCloser()

### DIFF
--- a/emitter/bytes.go
+++ b/emitter/bytes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
+	"github.com/brimsec/zq/zng/resolver"
 )
 
 type Bytes struct {
@@ -19,7 +20,7 @@ func (b *Bytes) Bytes() []byte {
 
 func NewBytes(opts zio.WriterOpts) (*Bytes, error) {
 	b := &Bytes{}
-	w, err := detector.LookupWriter(zio.NopCloser(&b.buf), opts)
+	w, err := detector.LookupWriter(zio.NopCloser(&b.buf), resolver.NewContext(), opts)
 	if err != nil {
 		return nil, err
 	}

--- a/emitter/file.go
+++ b/emitter/file.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/detector"
+	"github.com/brimsec/zq/zng/resolver"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -58,7 +59,7 @@ func NewFileWithSource(ctx context.Context, path iosrc.URI, opts zio.WriterOpts,
 	// On close, zbuf.WriteCloser.Close() will close and flush the
 	// downstream writer, which will flush the bufwriter here and,
 	// in turn, close its underlying writer.
-	w, err := detector.LookupWriter(wc, opts)
+	w, err := detector.LookupWriter(wc, resolver.NewContext(), opts)
 	if err != nil {
 		return nil, err
 	}

--- a/ppl/zqd/handlers_test.go
+++ b/ppl/zqd/handlers_test.go
@@ -872,7 +872,7 @@ func tzngCopy(t *testing.T, prog string, in string, outFormat string) string {
 	zctx := resolver.NewContext()
 	r := tzngio.NewReader(bytes.NewReader([]byte(in)), zctx)
 	buf := bytes.NewBuffer(nil)
-	w, err := detector.LookupWriter(zio.NopCloser(buf), zio.WriterOpts{Format: outFormat})
+	w, err := detector.LookupWriter(zio.NopCloser(buf), zctx, zio.WriterOpts{Format: outFormat})
 	require.NoError(t, err)
 	p := compiler.MustParseProc(prog)
 	err = driver.Copy(context.Background(), w, p, zctx, r, driver.Config{})

--- a/ppl/zqd/search/csv.go
+++ b/ppl/zqd/search/csv.go
@@ -6,6 +6,7 @@ import (
 	"github.com/brimsec/zq/zbuf"
 	"github.com/brimsec/zq/zio"
 	"github.com/brimsec/zq/zio/csvio"
+	"github.com/brimsec/zq/zng/resolver"
 )
 
 // CSVOutput implements the Output inteface and writes csv encoded-output
@@ -18,7 +19,7 @@ type CSVOutput struct {
 func NewCSVOutput(response http.ResponseWriter, ctrl bool) *CSVOutput {
 	return &CSVOutput{
 		response: response,
-		wc: csvio.NewWriter(zio.NopCloser(response), csvio.WriterOpts{
+		wc: csvio.NewWriter(zio.NopCloser(response), resolver.NewContext(), csvio.WriterOpts{
 			EpochDates: false,
 			Fuse:       true,
 			UTF8:       true,

--- a/proc/fuse/writer.go
+++ b/proc/fuse/writer.go
@@ -6,8 +6,8 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-func WriteCloser(wc zbuf.WriteCloser) zbuf.WriteCloser {
-	return &writeCloser{wc, NewFuser(resolver.NewContext(), MemMaxBytes)}
+func WriteCloser(wc zbuf.WriteCloser, zctx *resolver.Context) zbuf.WriteCloser {
+	return &writeCloser{wc, NewFuser(zctx, MemMaxBytes)}
 }
 
 type writeCloser struct {

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -492,7 +492,7 @@ func TestGroupbyStreamingSpill(t *testing.T) {
 		zr := tzngio.NewReader(strings.NewReader(strings.Join(data, "\n")), zctx)
 		cr := &countReader{r: zr}
 		var outbuf bytes.Buffer
-		zw, _ := detector.LookupWriter(&nopCloser{&outbuf}, zio.WriterOpts{})
+		zw, _ := detector.LookupWriter(&nopCloser{&outbuf}, zctx, zio.WriterOpts{})
 		d := &testGroupByDriver{
 			writer: zw,
 			cb: func(n int) {

--- a/zio/csvio/writer.go
+++ b/zio/csvio/writer.go
@@ -30,7 +30,7 @@ type WriterOpts struct {
 	UTF8       bool
 }
 
-func NewWriter(w io.WriteCloser, opts WriterOpts) zbuf.WriteCloser {
+func NewWriter(w io.WriteCloser, zctx *resolver.Context, opts WriterOpts) zbuf.WriteCloser {
 	format := zng.OutFormatZeekAscii
 	if opts.UTF8 {
 		format = zng.OutFormatZeek
@@ -43,7 +43,7 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) zbuf.WriteCloser {
 		format:     format,
 	}
 	if opts.Fuse {
-		return fuse.WriteCloser(zw)
+		return fuse.WriteCloser(zw, zctx)
 	}
 	return zw
 }

--- a/zio/detector/lookup.go
+++ b/zio/detector/lookup.go
@@ -32,7 +32,7 @@ func (*nullWriter) Close() error {
 	return nil
 }
 
-func LookupWriter(w io.WriteCloser, opts zio.WriterOpts) (zbuf.WriteCloser, error) {
+func LookupWriter(w io.WriteCloser, zctx *resolver.Context, opts zio.WriterOpts) (zbuf.WriteCloser, error) {
 	if opts.Format == "" {
 		opts.Format = "tzng"
 	}
@@ -58,7 +58,7 @@ func LookupWriter(w io.WriteCloser, opts zio.WriterOpts) (zbuf.WriteCloser, erro
 	case "table":
 		return tableio.NewWriter(w, opts.UTF8, opts.EpochDates), nil
 	case "csv":
-		return csvio.NewWriter(w, csvio.WriterOpts{
+		return csvio.NewWriter(w, zctx, csvio.WriterOpts{
 			EpochDates: opts.EpochDates,
 			Fuse:       opts.CSVFuse,
 			UTF8:       opts.UTF8,

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -597,7 +597,7 @@ func runzq(path, ZQL string, outputFlags []string, inputs ...string) (string, st
 	if err := flags.Parse(outputFlags); err != nil {
 		return "", "", err
 	}
-	zw, err := detector.LookupWriter(&nopCloser{&outbuf}, zflags.Options())
+	zw, err := detector.LookupWriter(&nopCloser{&outbuf}, zctx, zflags.Options())
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
Previously, the csv writer was creating its own type context. Instead,
pass in the type context newly passed to detector.LookupWriter().

close #1953 