### PR TITLE
POC elasticsearch bulk api support

### DIFF
--- a/ppl/zqd/core.go
+++ b/ppl/zqd/core.go
@@ -181,6 +181,10 @@ func (c *Core) addAPIServerRoutes() {
 	c.authhandle("/space/{space}/log/paths", handleLogPost).Methods("POST")
 	c.authhandle("/space/{space}/pcap", handlePcapPost).Methods("POST")
 	c.authhandle("/space/{space}/pcap", handlePcapSearch).Methods("GET")
+
+	// XXX POC ES Bulk API
+	sub := c.router.PathPrefix("/space/{space}/elastic-bulk")
+	sub.Handler(c.handler(handleElasticBulk))
 }
 
 func (c *Core) addRecruiterRoutes() {


### PR DESCRIPTION
(Not for merge, just for demonstration)

With these changes, I can use the elasticsearch output configuration in fluent-bit and OSS Beats to ingest records into an archive store. I was testing with a small NDJSON file. I had an oddity with fluentbit where the 'tail' output option would try to send a string record instead of actual JSON, hence it uses the TCP input, unlike OSS Beats that watches a file.

Fluentbit:
```
$ cat fluentbit.conf
[SERVICE]
    Flush           1
    Daemon          off
    Log_Level       debug

[INPUT]
    Name        tcp
    Listen      127.0.0.1
    #Port        5170

[OUTPUT]
    Name  es
    Match *
    Host  127.0.0.1
    Port  9867
    Path  /space/sp_1oXdrkqndL0bvywoggiudCV3iBX/elastic-bulk
$ fluent-bit -c fluentbit.conf
# separate terminal:
$ cat loglines.ndjson | nc 127.0.0.1 5170
```

OSS Beats:
```
$ cat ~/tmp/filebeat.yml
filebeat.inputs:
- type: log
  enabled: true
  json:
    keys_under_root: false
  paths:
    - /Users/alfred/tmp/input
output.elasticsearch:
  hosts: ["http://127.0.0.1:9867/space/sp_1oXe7FyKutBJTa19w2jMhsbxDF5/elastic-bulk"]
$ filebeat -e -v --path.config ~/tmp/
# separate terminal:
$ cat loglines.ndjson >> ~/tmp/input
```
