### PR TITLE
Parallelize chunk metadata fetch

### DIFF
--- a/ppl/lake/chunk/chunk.go
+++ b/ppl/lake/chunk/chunk.go
@@ -175,6 +175,18 @@ func (c Chunk) Remove(ctx context.Context) error {
 	return nil
 }
 
+type Chunks []Chunk
+
+func (cs Chunks) Overlapping(span nano.Span) Chunks {
+	chunks := make(Chunks, 0, len(cs))
+	for _, chunk := range cs {
+		if span.Overlaps(chunk.Span()) {
+			chunks = append(chunks, chunk)
+		}
+	}
+	return chunks
+}
+
 func Less(order zbuf.Order, a, b Chunk) bool {
 	if order == zbuf.OrderDesc {
 		a, b = b, a


### PR DESCRIPTION
Fetching the chunk metadata (particularly when the data hasn't been catched)
can be time consuming when doing a walk operation on a ts dir. Speed things up
by using a separate go routine to fetch each chunk's metadata in a ts dir.

Part of #2017