### PR TITLE
cleanup zson floats

### DIFF
--- a/zng/float64.go
+++ b/zng/float64.go
@@ -3,6 +3,7 @@ package zng
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math"
 	"strconv"
 
@@ -76,6 +77,9 @@ func (t *TypeOfFloat64) ZSONOf(zv zcode.Bytes) string {
 	d, err := DecodeFloat64(zv)
 	if err != nil {
 		return badZng(err, t, zv)
+	}
+	if d == float64(int64(d)) {
+		return fmt.Sprintf("%d.", int64(d))
 	}
 	return strconv.FormatFloat(d, 'e', -1, 64)
 }


### PR DESCRIPTION
This commits changes the zson formatter to print float64's that
are integers as the number followed by a "." rather than using
scientific notation for everything.  This makes reading numbers
that come from javascript or csv and haven't been shaped into
integers much more ergonomic.