### PR TITLE
clean up conventions for missing values

### DIFF
--- a/expr/agg.go
+++ b/expr/agg.go
@@ -45,7 +45,7 @@ func (a *Aggregator) Apply(f agg.Function, rec *zng.Record) error {
 	}
 	zv, err := a.expr.Eval(rec)
 	if err != nil {
-		if err == ErrNoSuchField {
+		if err == zng.ErrMissing {
 			err = nil
 		}
 		return err

--- a/expr/cutter.go
+++ b/expr/cutter.go
@@ -3,8 +3,9 @@ package expr
 import (
 	"errors"
 	"fmt"
-	"github.com/brimsec/zq/zcode"
 	"strings"
+
+	"github.com/brimsec/zq/zcode"
 
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/zng"
@@ -76,7 +77,7 @@ func (c *Cutter) Apply(in *zng.Record) (*zng.Record, error) {
 	if len(c.fieldRefs) == 1 && c.fieldRefs[0].IsRoot() {
 		zv, err := c.fieldExprs[0].Eval(in)
 		if err != nil {
-			if err == ErrNoSuchField {
+			if err == zng.ErrMissing {
 				return nil, nil
 			}
 			return nil, err
@@ -95,7 +96,7 @@ func (c *Cutter) Apply(in *zng.Record) (*zng.Record, error) {
 	for k, e := range c.fieldExprs {
 		zv, err := e.Eval(in)
 		if err != nil {
-			if err == ErrNoSuchField {
+			if err == zng.ErrMissing {
 				if c.droppers != nil {
 					if c.droppers[k] == nil {
 						c.droppers[k] = NewDropper(c.zctx, c.fieldRefs[k:k+1])
@@ -175,7 +176,7 @@ func (c *Cutter) Eval(rec *zng.Record) (zng.Value, error) {
 		return zng.Value{}, err
 	}
 	if out == nil {
-		return zng.Value{}, ErrNoSuchField
+		return zng.Value{}, zng.ErrMissing
 	}
 	return zng.Value{out.Type, out.Raw}, nil
 }

--- a/expr/cutter.go
+++ b/expr/cutter.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/brimsec/zq/zcode"
-
 	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/builder"
 	"github.com/brimsec/zq/zng/resolver"

--- a/expr/dot.go
+++ b/expr/dot.go
@@ -33,11 +33,11 @@ func NewDotExpr(f field.Static) Evaluator {
 func accessField(record zng.Value, field string) (zng.Value, error) {
 	recType, ok := zng.AliasedType(record.Type).(*zng.TypeRecord)
 	if !ok {
-		return zng.Value{}, ErrNoSuchField
+		return zng.Value{}, zng.ErrMissing
 	}
 	idx, ok := recType.ColumnOfField(field)
 	if !ok {
-		return zng.Value{}, ErrNoSuchField
+		return zng.Value{}, zng.ErrMissing
 	}
 	typ := recType.Columns[idx].Type
 	if record.Bytes == nil {

--- a/expr/eval.go
+++ b/expr/eval.go
@@ -15,15 +15,10 @@ import (
 	"github.com/brimsec/zq/zng/resolver"
 )
 
-var ErrNoSuchField = errors.New("field is not present")
 var ErrIncompatibleTypes = coerce.ErrIncompatibleTypes
 var ErrIndexOutOfBounds = errors.New("array index out of bounds")
 var ErrNotContainer = errors.New("cannot apply in to a non-container")
 var ErrBadCast = errors.New("bad cast")
-
-// The literature on SQL++ etc uses the concept of missing values rather than
-// "no such field".  Missing seems more apt.
-var ErrMissing = ErrNoSuchField
 
 type Evaluator interface {
 	Eval(*zng.Record) (zng.Value, error)

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -143,7 +143,7 @@ func TestPrimitives(t *testing.T) {
 	testSuccessful(t, "s", record, zstring("hello"))
 
 	// Test bad field reference
-	testError(t, "doesnexist", record, expr.ErrNoSuchField, "referencing non-existent field")
+	testError(t, "doesnexist", record, zng.ErrMissing, "referencing non-existent field")
 }
 
 func TestComplex(t *testing.T) {
@@ -659,7 +659,7 @@ func TestFieldReference(t *testing.T) {
 	testSuccessful(t, "rec.s", record, zstring("boo"))
 	testSuccessful(t, "rec.f", record, zfloat64(6.1))
 
-	testError(t, "rec.no", record, expr.ErrNoSuchField, "referencing nonexistent field")
+	testError(t, "rec.no", record, zng.ErrMissing, "referencing nonexistent field")
 }
 
 func TestConditional(t *testing.T) {

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -143,7 +143,7 @@ func TestPrimitives(t *testing.T) {
 	testSuccessful(t, "s", record, zstring("hello"))
 
 	// Test bad field reference
-	testError(t, "doesnexist", record, zng.ErrMissing, "referencing non-existent field")
+	testError(t, "doesnexist", record, zng.ErrMissing, "referencing nonexistent field")
 }
 
 func TestComplex(t *testing.T) {

--- a/expr/function/fields.go
+++ b/expr/function/fields.go
@@ -1,8 +1,6 @@
 package function
 
 import (
-	"errors"
-
 	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zson"
@@ -32,10 +30,7 @@ func (f *fields) Call(args []zng.Value) (zng.Value, error) {
 	zvSubject := args[0]
 	typ := isRecordType(zvSubject, f.types)
 	if typ == nil {
-		//XXX create a zng.Missing which is ErrMissing as zng.Value
-		// To do this, need to move ErrNoSuchField=>ErrMissing to zng.
-		// See issue #2130.
-		return zng.NewError(errors.New("missing value")), nil
+		return zng.Missing, nil
 	}
 	bytes := f.bytes[:0]
 	for _, field := range fieldNames(typ) {

--- a/expr/var.go
+++ b/expr/var.go
@@ -15,7 +15,7 @@ func NewVar(ref *zng.Value) *Var {
 func (v *Var) Eval(*zng.Record) (zng.Value, error) {
 	zv := *v.ref
 	if zv.Type == nil {
-		return zng.Value{}, ErrMissing
+		return zng.Value{}, zng.ErrMissing
 	}
 	return zv, nil
 }

--- a/expr/ztests/cut.yaml
+++ b/expr/ztests/cut.yaml
@@ -1,7 +1,7 @@
 zql: put v=cut(s,x)
 
 warnings: |
-  field is not present
+  put: a referenced field is missing
 
 input: |
   #0:record[x:int32,s:string]

--- a/proc/groupby/groupby.go
+++ b/proc/groupby/groupby.go
@@ -264,7 +264,7 @@ func (a *Aggregator) Consume(r *zng.Record) error {
 	for i, keyExpr := range a.keyExprs {
 		zv, err := keyExpr.Eval(r)
 		if err != nil {
-			if errors.Is(err, expr.ErrNoSuchField) {
+			if errors.Is(err, zng.ErrMissing) {
 				// block this input type
 				a.block[id] = struct{}{}
 				return nil

--- a/proc/join/join.go
+++ b/proc/join/join.go
@@ -72,7 +72,7 @@ func (p *Proc) Pull() (zbuf.Batch, error) {
 			// If the left key isn't present (which is not a thing
 			// in a sql join), then drop the record and return only
 			// left records that can eval the key expression.
-			if err == expr.ErrNoSuchField {
+			if err == zng.ErrMissing {
 				continue
 			}
 			return nil, err
@@ -133,7 +133,7 @@ func (p *Proc) getJoinSet(leftKey zng.Value) ([]*zng.Record, error) {
 		}
 		rightKey, err := p.getRightKey.Eval(rec)
 		if err != nil {
-			if err == expr.ErrNoSuchField {
+			if err == zng.ErrMissing {
 				p.right.Read()
 				continue
 			}
@@ -172,7 +172,7 @@ func (p *Proc) readJoinSet(joinKey zng.Value) ([]*zng.Record, error) {
 		}
 		key, err := p.getRightKey.Eval(rec)
 		if err != nil {
-			if err == expr.ErrNoSuchField {
+			if err == zng.ErrMissing {
 				p.right.Read()
 				continue
 			}

--- a/proc/put/put.go
+++ b/proc/put/put.go
@@ -69,6 +69,9 @@ func (p *Proc) maybeWarn(err error) {
 	s := err.Error()
 	_, alreadyWarned := p.warned[s]
 	if !alreadyWarned {
+		if err == zng.ErrMissing {
+			s = "put: a referenced field is missing"
+		}
 		p.pctx.Warnings <- s
 		p.warned[s] = struct{}{}
 	}

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -479,7 +479,7 @@ func (r *Reader) readTypeAlias() error {
 func (r *Reader) parseValue(rec *zng.Record, id int, b []byte) (*zng.Record, error) {
 	typ := r.zctx.Lookup(id)
 	if typ == nil {
-		return nil, zng.ErrDescriptorInvalid
+		return nil, zng.ErrTypeIDInvalid
 	}
 	sharedType := r.mapper.Map(id)
 	if sharedType == nil {

--- a/zng/error.go
+++ b/zng/error.go
@@ -7,6 +7,9 @@ import (
 	"github.com/brimsec/zq/zcode"
 )
 
+var ErrMissing = errors.New("missing")
+var Missing = NewError(ErrMissing)
+
 type TypeOfError struct{}
 
 func NewErrorf(format string, args ...interface{}) Value {

--- a/zng/error.go
+++ b/zng/error.go
@@ -7,7 +7,20 @@ import (
 	"github.com/brimsec/zq/zcode"
 )
 
-var ErrMissing = errors.New("missing")
+// ErrMissing is returned by entities that fail because a referenced field
+// was missing or because an argument to the entity had a missing value.
+// This is used at sites in the code where it is unknown whether the outcome
+// should result in a runtime exit or in continued execution with a
+// Missing value embedded in the Z results.
+var ErrMissing = errors.New(missing)
+
+const missing = "missing"
+
+// Missing is value that represents the error condition that a field
+// referenced was not present.  The Missing value can be propagated through
+// functions and expressions and each operator must clearly defined its
+// semantics with respect to the Missing value.  For example, "true AND MISSING"
+// is MISSING.
 var Missing = NewError(ErrMissing)
 
 type TypeOfError struct{}

--- a/zng/recordval.go
+++ b/zng/recordval.go
@@ -11,20 +11,17 @@ import (
 )
 
 var (
-	ErrMissingField      = errors.New("record missing a field")
-	ErrExtraField        = errors.New("record with extra field")
-	ErrNotContainer      = errors.New("expected container type, got primitive")
-	ErrNotPrimitive      = errors.New("expected primitive type, got container")
-	ErrDescriptorExists  = errors.New("zng descriptor exists")
-	ErrDescriptorInvalid = errors.New("zng descriptor out of range")
-	ErrBadValue          = errors.New("malformed zng value")
-	ErrBadFormat         = errors.New("malformed zng record")
-	ErrTypeMismatch      = errors.New("type/value mismatch")
-	ErrNoSuchField       = errors.New("no such field in zng record")
-	ErrNoSuchColumn      = errors.New("no such column in zng record")
-	ErrColumnMismatch    = errors.New("zng record mismatch between columns in type and columns in value")
-	ErrCorruptTd         = errors.New("corrupt type descriptor")
-	ErrCorruptColumns    = errors.New("wrong number of columns in zng record value")
+	ErrMissingField   = errors.New("record missing a field")
+	ErrExtraField     = errors.New("record with extra field")
+	ErrNotContainer   = errors.New("expected container type, got primitive")
+	ErrNotPrimitive   = errors.New("expected primitive type, got container")
+	ErrTypeIDExists   = errors.New("zng type ID exists")
+	ErrTypeIDInvalid  = errors.New("zng type ID out of range")
+	ErrBadValue       = errors.New("malformed zng value")
+	ErrBadFormat      = errors.New("malformed zng record")
+	ErrTypeMismatch   = errors.New("type/value mismatch")
+	ErrColumnMismatch = errors.New("zng record mismatch between columns in type and columns in value")
+	ErrCorruptColumns = errors.New("wrong number of columns in zng record value")
 )
 
 type RecordTypeError struct {
@@ -241,7 +238,7 @@ func (r *Record) Slice(column int) (zcode.Bytes, error) {
 	var zv zcode.Bytes
 	for i, it := 0, r.Raw.Iter(); i <= column; i++ {
 		if it.Done() {
-			return nil, ErrNoSuchColumn
+			return nil, ErrMissing
 		}
 		var err error
 		zv, _, err = it.Next()
@@ -265,7 +262,7 @@ func (r *Record) Value(col int) Value {
 func (r *Record) ValueByField(field string) (Value, error) {
 	col, ok := r.ColumnOfField(field)
 	if !ok {
-		return Value{}, ErrNoSuchField
+		return Value{}, ErrMissing
 	}
 	return r.Value(col), nil
 }
@@ -281,7 +278,7 @@ func (r *Record) TypeOfColumn(col int) Type {
 func (r *Record) Access(field string) (Value, error) {
 	col, ok := r.ColumnOfField(field)
 	if !ok {
-		return Value{}, ErrNoSuchField
+		return Value{}, ErrMissing
 	}
 	return r.Value(col), nil
 }

--- a/zng/value.go
+++ b/zng/value.go
@@ -188,6 +188,12 @@ func (v Value) IsError() bool {
 	return v.Type == TypeError
 }
 
+var missingAsBytes = []byte(missing)
+
+func (v Value) IsMissing() bool {
+	return v.Type == TypeError && bytes.Equal(v.Bytes, missingAsBytes)
+}
+
 func (v Value) Equal(p Value) bool {
 	return v.Type == p.Type && bytes.Equal(v.Bytes, p.Bytes)
 }

--- a/zst/column/record.go
+++ b/zst/column/record.go
@@ -115,7 +115,7 @@ func (r Record) Lookup(typ *zng.TypeRecord, fields []string) (zng.Type, Interfac
 	}
 	k, ok := typ.ColumnOfField(fields[0])
 	if !ok {
-		return nil, nil, zng.ErrNoSuchField
+		return nil, nil, zng.ErrMissing
 	}
 	t := typ.Columns[k].Type
 	if len(fields) == 1 {

--- a/zst/cutter.go
+++ b/zst/cutter.go
@@ -72,7 +72,7 @@ func NewCutAssembler(zctx *resolver.Context, fields []string, object *Object) (*
 			return nil, err
 		}
 		_, ca.columns[k], err = topcol.Lookup(schema, fields)
-		if err == zng.ErrNoSuchField || err == column.ErrNonRecordAccess {
+		if err == zng.ErrMissing || err == column.ErrNonRecordAccess {
 			continue
 		}
 		if err != nil {
@@ -85,7 +85,7 @@ func NewCutAssembler(zctx *resolver.Context, fields []string, object *Object) (*
 		cnt++
 	}
 	if cnt == 0 {
-		return nil, zng.ErrNoSuchField
+		return nil, zng.ErrMissing
 	}
 	return ca, nil
 }
@@ -96,7 +96,7 @@ func cutType(zctx *resolver.Context, typ *zng.TypeRecord, fields []string) (*zng
 	}
 	k, ok := typ.ColumnOfField(fields[0])
 	if !ok {
-		return nil, 0, zng.ErrNoSuchField
+		return nil, 0, zng.ErrMissing
 	}
 	if len(fields) == 1 {
 		col := []zng.Column{typ.Columns[k]}


### PR DESCRIPTION
This commit creates zng.ErrMissing and zng.Missing to work toward
a unified way of handling missing values (i.e., expressions that
refer to fields that don't exist).  ErrMissing is a Go error
that can be returned up the chain to signal this condition while
Missing is a value that can be returned in zng data when a
result calls for embedding a Missing value instead of ignoring
it all together.

Closes #2130 