### PR TITLE
Fix autodetect with typeconfig issue

### DIFF
--- a/ppl/zqd/handlers_test.go
+++ b/ppl/zqd/handlers_test.go
@@ -545,8 +545,8 @@ func TestPostNDJSONLogs(t *testing.T) {
 }
 
 func TestPostNDJSONLogWarning(t *testing.T) {
-	src1 := strings.NewReader(`{"ts":"1000","_path":"nosuchpath"}
-{"ts":"2000","_path":"http"}`)
+	src1 := strings.NewReader(`{"ts":"1000","_path":"http"}
+{"ts":"2000","_path":"nosuchpath"}`)
 	src2 := strings.NewReader(`{"ts":"1000","_path":"http"}
 {"ts":"1000","_path":"http","extra":"foo"}`)
 	tc := ndjsonio.TypeConfig{
@@ -574,7 +574,7 @@ func TestPostNDJSONLogWarning(t *testing.T) {
 	res, err := conn.LogPostReaders(context.Background(), sp.ID, opts, src1, src2)
 	require.NoError(t, err)
 	require.Len(t, res.Warnings, 2)
-	assert.Regexp(t, ": line 1: descriptor not found", res.Warnings[0])
+	assert.Regexp(t, ": line 2: descriptor not found", res.Warnings[0])
 	assert.Regexp(t, ": line 2: incomplete descriptor", res.Warnings[1])
 	assert.EqualValues(t, 134, res.BytesRead)
 }

--- a/ztests/suite/jsontype/autodetect-nonjson.yaml
+++ b/ztests/suite/jsontype/autodetect-nonjson.yaml
@@ -1,0 +1,20 @@
+script: zq -t -j types.json "*" in.zng
+
+
+inputs:
+  - name: in.zng
+    data: !!binary 9gEBcxAXAgRhFwIEYhcCBGH/
+  - name: types.json
+    data: |
+        {
+          "descriptors": {},
+          "rules": []
+        }
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[s:string]
+      0:[a;]
+      0:[b;]
+      0:[a;]


### PR DESCRIPTION
Try again without typeconfig if autodetect with typeconfig fails. This
fixes a bug that occurred when a typeconfig was supplied even though
the input was non-json.

close #2151 

(note that the new test isn't actually exercised here due to #2155 !! but i checked it with the fix from #2155 before putting up this PR)