### PR TITLE
Revert zio/csvio/ztests/type.yaml

### DIFF
--- a/zio/csvio/ztests/type.yaml
+++ b/zio/csvio/ztests/type.yaml
@@ -3,9 +3,19 @@ zql: '*'
 input: |
   #0:record[type:type]
   0:[-;]
+  0:[;]
+  0:[";]
+  0:[,;]
+  0:[-;]
+  0:[\x5c;]
 
 output-flags: -f csv
 
-output: |+
+output: |
   type
-
+  
+  
+  """"
+  ","
+  
+  \x5c


### PR DESCRIPTION
#2128 clobbered most of this test unnecessarily.