### PR TITLE
lake: Parallelize tsdir fetch

### DIFF
--- a/ppl/lake/tsdirstream.go
+++ b/ppl/lake/tsdirstream.go
@@ -1,7 +1,6 @@
 package lake
 
 import (
-	"container/heap"
 	"context"
 	"sort"
 
@@ -13,6 +12,11 @@ import (
 type tsDirStream struct {
 	ch  chan tsDirStreamResult
 	err error
+}
+
+type tsDirStreamResult struct {
+	tsDir  tsDir
+	chunks []chunk.Chunk
 }
 
 func newTsDirStream(ctx context.Context, lk *Lake, tsDirs []tsDir) *tsDirStream {
@@ -29,12 +33,15 @@ func newTsDirStream(ctx context.Context, lk *Lake, tsDirs []tsDir) *tsDirStream 
 }
 
 func (t *tsDirStream) run(ctx context.Context, lk *Lake, tsDirs []tsDir) {
-	ch := make(chan tsDirStreamResult)
-	results := &tsDirStreamResultHeap{order: lk.DataOrder}
+	// Use a channel of channels to ensure results are returned in the correct
+	// order.
+	tsDirChs := make(chan chan tsDirStreamResult, len(tsDirs))
 	g, ctx := errgroup.WithContext(ctx)
-
 	for _, tsDir := range tsDirs {
 		tsDir := tsDir
+		ch := make(chan tsDirStreamResult)
+		tsDirChs <- ch
+
 		g.Go(func() error {
 			chunks, err := tsDirChunks(ctx, tsDir, lk)
 			if err != nil {
@@ -49,72 +56,26 @@ func (t *tsDirStream) run(ctx context.Context, lk *Lake, tsDirs []tsDir) {
 		})
 	}
 
+	close(tsDirChs)
 	g.Go(func() error {
-		for len(tsDirs) > 0 {
-			result, ok := <-ch
-			if !ok {
-				return nil
-			}
-
-			heap.Push(results, result)
-			for results.Len() > 0 && results.items[0].tsDir == tsDirs[0] {
-				next := heap.Pop(results).(tsDirStreamResult)
-				tsDirs = tsDirs[1:]
-				select {
-				case t.ch <- next:
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+		for ch := range tsDirChs {
+			select {
+			case t.ch <- <-ch:
+			case <-ctx.Done():
+				return ctx.Err()
 			}
 		}
 		return nil
 	})
+
 	t.err = g.Wait()
-	close(ch)
 	close(t.ch)
 }
 
-func (t *tsDirStream) Next() (*tsDir, chunk.Chunks, error) {
+func (t *tsDirStream) next() (*tsDir, chunk.Chunks, error) {
 	result, ok := <-t.ch
 	if !ok {
 		return nil, nil, t.err
 	}
 	return &result.tsDir, result.chunks, nil
-}
-
-type tsDirStreamResult struct {
-	tsDir  tsDir
-	chunks []chunk.Chunk
-}
-
-type tsDirStreamResultHeap struct {
-	order zbuf.Order
-	items []tsDirStreamResult
-}
-
-func (t tsDirStreamResultHeap) top() tsDirStreamResult {
-	n := len(t.items)
-	return t.items[n-1]
-}
-
-func (t tsDirStreamResultHeap) Len() int { return len(t.items) }
-
-func (t tsDirStreamResultHeap) Swap(i, j int) { t.items[i], t.items[j] = t.items[j], t.items[i] }
-
-func (t tsDirStreamResultHeap) Less(i, j int) bool {
-	if t.order == zbuf.OrderAsc {
-		return t.items[i].tsDir.Ts < t.items[j].tsDir.Ts
-	}
-	return t.items[i].tsDir.Ts > t.items[j].tsDir.Ts
-}
-
-func (t *tsDirStreamResultHeap) Push(x interface{}) {
-	t.items = append(t.items, x.(tsDirStreamResult))
-}
-
-func (t *tsDirStreamResultHeap) Pop() interface{} {
-	n := len(t.items)
-	x := t.items[n-1]
-	t.items = t.items[:n-1]
-	return x
 }

--- a/ppl/lake/tsdirstream.go
+++ b/ppl/lake/tsdirstream.go
@@ -59,8 +59,15 @@ func (t *tsDirStream) run(ctx context.Context, lk *Lake, tsDirs []tsDir) {
 	close(tsDirChs)
 	g.Go(func() error {
 		for ch := range tsDirChs {
+			var result tsDirStreamResult
 			select {
-			case t.ch <- <-ch:
+			case result = <-ch:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			select {
+			case t.ch <- result:
 			case <-ctx.Done():
 				return ctx.Err()
 			}

--- a/ppl/lake/tsdirstream.go
+++ b/ppl/lake/tsdirstream.go
@@ -1,0 +1,121 @@
+package lake
+
+import (
+	"container/heap"
+	"context"
+	"sort"
+	"sync/atomic"
+
+	"github.com/brimsec/zq/ppl/lake/chunk"
+	"github.com/brimsec/zq/zbuf"
+)
+
+type tsDirStream struct {
+	ch chan tsDirStreamResult
+}
+
+func newTsDirStream(ctx context.Context, lk *Lake, tsDirs []tsDir) *tsDirStream {
+	sort.Slice(tsDirs, func(i, j int) bool {
+		if lk.DataOrder == zbuf.OrderAsc {
+			return tsDirs[i].Ts < tsDirs[j].Ts
+		}
+		return tsDirs[j].Ts < tsDirs[i].Ts
+	})
+
+	t := &tsDirStream{ch: make(chan tsDirStreamResult)}
+
+	if len(tsDirs) > 0 {
+		go t.run(ctx, lk, tsDirs)
+	} else {
+		close(t.ch)
+	}
+
+	return t
+}
+
+func (t *tsDirStream) run(ctx context.Context, lk *Lake, tsDirs []tsDir) {
+	var count int64
+	ch := make(chan tsDirStreamResult)
+	results := &tsDirStreamResultHeap{order: lk.DataOrder}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for _, tsDir := range tsDirs {
+		tsDir := tsDir
+		atomic.AddInt64(&count, 1)
+		go func() {
+			chunks, err := tsDirChunks(ctx, tsDir, lk)
+			ch <- tsDirStreamResult{tsDir: tsDir, chunks: chunks, err: err}
+			if c := atomic.AddInt64(&count, -1); c == 0 {
+				close(ch)
+			}
+		}()
+	}
+
+	for result := range ch {
+		if result.err != nil {
+			cancel()
+			// drain channel
+			for range ch {
+			}
+			t.ch <- result
+			break
+		}
+		heap.Push(results, result)
+
+		for results.Len() > 0 && results.items[0].tsDir == tsDirs[0] {
+			next := heap.Pop(results).(tsDirStreamResult)
+			tsDirs = tsDirs[1:]
+			t.ch <- next
+		}
+	}
+
+	close(t.ch)
+}
+
+func (t *tsDirStream) Next() (*tsDir, chunk.Chunks, error) {
+	result, ok := <-t.ch
+	if !ok {
+		return nil, nil, nil
+	}
+	return &result.tsDir, result.chunks, result.err
+}
+
+type tsDirStreamResult struct {
+	tsDir  tsDir
+	chunks []chunk.Chunk
+	err    error
+}
+
+type tsDirStreamResultHeap struct {
+	order zbuf.Order
+	items []tsDirStreamResult
+}
+
+func (t tsDirStreamResultHeap) top() tsDirStreamResult {
+	n := len(t.items)
+	return t.items[n-1]
+}
+
+func (t tsDirStreamResultHeap) Len() int { return len(t.items) }
+
+func (t tsDirStreamResultHeap) Swap(i, j int) { t.items[i], t.items[j] = t.items[j], t.items[i] }
+
+func (t tsDirStreamResultHeap) Less(i, j int) bool {
+	if t.order == zbuf.OrderAsc {
+		return t.items[i].tsDir.Ts < t.items[j].tsDir.Ts
+	}
+	return t.items[i].tsDir.Ts > t.items[j].tsDir.Ts
+}
+
+func (t *tsDirStreamResultHeap) Push(x interface{}) {
+	t.items = append(t.items, x.(tsDirStreamResult))
+}
+
+func (t *tsDirStreamResultHeap) Pop() interface{} {
+	n := len(t.items)
+	x := t.items[n-1]
+	t.items = t.items[:n-1]
+	return x
+}

--- a/ppl/lake/walk.go
+++ b/ppl/lake/walk.go
@@ -72,19 +72,15 @@ func tsDirVisit(ctx context.Context, lk *Lake, filterSpan nano.Span, visitor tsD
 
 	stream := newTsDirStream(ctx, lk, tsdirs)
 	for {
-		tsdir, chunks, err := stream.Next()
-		if err != nil {
+		tsdir, chunks, err := stream.next()
+		if tsdir == nil || err != nil {
 			return err
-		}
-		if tsdir == nil {
-			break
 		}
 		chunks = chunks.Overlapping(filterSpan)
 		if err := visitor(*tsdir, chunks); err != nil {
 			return err
 		}
 	}
-	return nil
 }
 
 func tsDirChunks(ctx context.Context, d tsDir, lk *Lake) (chunk.Chunks, error) {


### PR DESCRIPTION
The walk of lake stored in s3 is slowed greated in that tsDirs are fetched
sequentially. The main thread sits by idly while the metadata for all chunks in
a tsdir are retrieved over the network. Speed this process up by running the
tsdir fetches each in a separate goroutine.

Because it is important that results be returned in order, save the retrieved
tsdirs in a min/max heap, and release results from the stream when the next
min/max is received.

Closes #2017