### PR TITLE
break out compiler package into sub-packages

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -55,7 +55,7 @@ func MustParseProc(query string) ast.Proc {
 	return proc
 }
 
-// XXX These functions will all get reworked in a subsequent when
+// XXX These functions will all get reworked in a subsequent PR when
 // the semantic pass converts an AST to a flow DSL.
 
 func Optimize(zctx *resolver.Context, program ast.Proc, sortKey field.Static, sortReversed bool) (*kernel.Filter, ast.Proc) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -2,7 +2,13 @@ package compiler
 
 import (
 	"github.com/brimsec/zq/compiler/ast"
+	"github.com/brimsec/zq/compiler/kernel"
+	"github.com/brimsec/zq/compiler/semantic"
+	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/pkg/joe"
+	"github.com/brimsec/zq/proc"
+	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zql"
 	"github.com/mitchellh/mapstructure"
 )
@@ -47,4 +53,30 @@ func MustParseProc(query string) ast.Proc {
 		panic(err)
 	}
 	return proc
+}
+
+// XXX These functions will all get reworked in a subsequent when
+// the semantic pass converts an AST to a flow DSL.
+
+func Optimize(zctx *resolver.Context, program ast.Proc, sortKey field.Static, sortReversed bool) (*kernel.Filter, ast.Proc) {
+	return semantic.Optimize(zctx, program, sortKey, sortReversed)
+}
+
+func IsParallelizable(p ast.Proc, inputSortField field.Static, inputSortReversed bool) bool {
+	return semantic.IsParallelizable(p, inputSortField, inputSortReversed)
+}
+
+func Parallelize(p ast.Proc, N int, inputSortField field.Static, inputSortReversed bool) (*ast.SequentialProc, bool) {
+	return semantic.Parallelize(p, N, inputSortField, inputSortReversed)
+}
+
+func NewFilter(zctx *resolver.Context, ast ast.Expression) *kernel.Filter {
+	return kernel.NewFilter(zctx, ast)
+}
+func Compile(custom kernel.Hook, node ast.Proc, pctx *proc.Context, parents []proc.Interface) ([]proc.Interface, error) {
+	return kernel.Compile(custom, node, pctx, nil, parents)
+}
+
+func CompileAssignments(dsts []field.Static, srcs []field.Static) ([]field.Static, []expr.Evaluator) {
+	return kernel.CompileAssignments(dsts, srcs)
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -41,7 +41,7 @@ func TestCompileParents(t *testing.T) {
 		query, err := compiler.ParseProc("split (=>filter * =>filter *) | filter *")
 		require.NoError(t, err)
 
-		leaves, err := compiler.Compile(nil, query, pctx, nil, sources)
+		leaves, err := compiler.Compile(nil, query, pctx, sources)
 		require.NoError(t, err)
 
 		var sb strings.Builder
@@ -56,14 +56,14 @@ func TestCompileParents(t *testing.T) {
 
 		query.(*ast.SequentialProc).Procs = query.(*ast.SequentialProc).Procs[1:]
 
-		_, err = compiler.Compile(nil, query, pctx, nil, sources)
+		_, err = compiler.Compile(nil, query, pctx, sources)
 		require.Error(t, err)
 	})
 
 	t.Run("too many parents", func(t *testing.T) {
 		query, err := compiler.ParseProc("* | split(=>filter * =>filter *) | filter *")
 		require.NoError(t, err)
-		_, err = compiler.Compile(nil, query, pctx, nil, sources)
+		_, err = compiler.Compile(nil, query, pctx, sources)
 		require.Error(t, err)
 	})
 }
@@ -94,7 +94,7 @@ func TestCompileMergeDone(t *testing.T) {
 
 	// Force the parallel proc to create a merge proc instead of combine.
 	p.MergeOrderField = field.New("k")
-	leaves, err := compiler.Compile(nil, query, pctx, nil, []proc.Interface{src})
+	leaves, err := compiler.Compile(nil, query, pctx, []proc.Interface{src})
 	require.NoError(t, err)
 
 	var sb strings.Builder

--- a/compiler/kernel/bufferfilter.go
+++ b/compiler/kernel/bufferfilter.go
@@ -1,4 +1,4 @@
-package compiler
+package kernel
 
 import (
 	"github.com/brimsec/zq/compiler/ast"

--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -1,4 +1,4 @@
-package compiler
+package kernel
 
 import (
 	"errors"

--- a/compiler/kernel/filter.go
+++ b/compiler/kernel/filter.go
@@ -1,4 +1,4 @@
-package compiler
+package kernel
 
 import (
 	"fmt"

--- a/compiler/kernel/groupby.go
+++ b/compiler/kernel/groupby.go
@@ -1,4 +1,4 @@
-package compiler
+package kernel
 
 import (
 	"errors"

--- a/compiler/kernel/proc.go
+++ b/compiler/kernel/proc.go
@@ -184,7 +184,7 @@ func compileProc(custom Hook, node ast.Proc, pctx *proc.Context, scope *Scope, p
 		return fuse.New(pctx, parent)
 
 	case *ast.FunctionCall:
-		return nil, errors.New("internal bug: semantic analyzer should have converted functioni in proc context to filter or group-by")
+		return nil, errors.New("internal error: semantic analyzer should have converted function in proc context to filter or group-by")
 
 	case *ast.JoinProc:
 		return nil, ErrJoinParents

--- a/compiler/kernel/scope.go
+++ b/compiler/kernel/scope.go
@@ -1,4 +1,4 @@
-package compiler
+package kernel
 
 import "github.com/brimsec/zq/zng"
 

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -7,10 +7,9 @@ import (
 	"time"
 
 	"github.com/brimsec/zq/compiler"
-	"github.com/brimsec/zq/compiler/kernel"
-
 	// XXX replace this with flow DSL
 	"github.com/brimsec/zq/compiler/ast"
+	"github.com/brimsec/zq/compiler/kernel"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/ppl/zqd/worker"

--- a/driver/compile.go
+++ b/driver/compile.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/brimsec/zq/compiler"
+	"github.com/brimsec/zq/compiler/kernel"
+
 	// XXX replace this with flow DSL
 	"github.com/brimsec/zq/compiler/ast"
 	"github.com/brimsec/zq/field"
@@ -20,7 +22,7 @@ import (
 
 // XXX ReaderSortKey should be a field.Static.  Issue #1467.
 type Config struct {
-	Custom            compiler.Hook
+	Custom            kernel.Hook
 	Logger            *zap.Logger
 	ReaderSortKey     string
 	ReaderSortReverse bool
@@ -75,7 +77,7 @@ func compile(ctx context.Context, program ast.Proc, zctx *resolver.Context, read
 		Logger:      cfg.Logger,
 		Warnings:    make(chan string, 5),
 	}
-	leaves, err := compiler.Compile(cfg.Custom, program, pctx, nil, procs)
+	leaves, err := compiler.Compile(cfg.Custom, program, pctx, procs)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +85,7 @@ func compile(ctx context.Context, program ast.Proc, zctx *resolver.Context, read
 }
 
 type MultiConfig struct {
-	Custom      compiler.Hook
+	Custom      kernel.Hook
 	Distributed bool // true if remote request specified worker count
 	Order       zbuf.Order
 	Logger      *zap.Logger
@@ -123,7 +125,7 @@ func compileMulti(ctx context.Context, program ast.Proc, zctx *resolver.Context,
 	if len(sources) > 1 {
 		program, _ = compiler.Parallelize(program, len(sources), sortKey, sortReversed)
 	}
-	leaves, err := compiler.Compile(mcfg.Custom, program, pctx, nil, sources)
+	leaves, err := compiler.Compile(mcfg.Custom, program, pctx, sources)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/multisource.go
+++ b/driver/multisource.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/brimsec/zq/api"
-	"github.com/brimsec/zq/compiler"
+	"github.com/brimsec/zq/compiler/kernel"
 	"github.com/brimsec/zq/field"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zbuf"
@@ -44,6 +44,6 @@ type ScannerCloser interface {
 }
 
 type SourceFilter struct {
-	Filter *compiler.Filter
+	Filter *kernel.Filter
 	Span   nano.Span
 }

--- a/driver/parallel.go
+++ b/driver/parallel.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/api/client"
-	"github.com/brimsec/zq/compiler"
+	"github.com/brimsec/zq/compiler/kernel"
 	"github.com/brimsec/zq/ppl/zqd/recruiter"
 	"github.com/brimsec/zq/proc"
 	"github.com/brimsec/zq/zbuf"
@@ -208,7 +208,7 @@ func (pg *parallelGroup) run() {
 	close(pg.sourceChan)
 }
 
-func createParallelGroup(pctx *proc.Context, filter *compiler.Filter, msrc MultiSource, mcfg MultiConfig) ([]proc.Interface, *parallelGroup, error) {
+func createParallelGroup(pctx *proc.Context, filter *kernel.Filter, msrc MultiSource, mcfg MultiConfig) ([]proc.Interface, *parallelGroup, error) {
 	pg := &parallelGroup{
 		filter: SourceFilter{
 			Filter: filter,

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/compiler/ast"
+	"github.com/brimsec/zq/compiler/kernel"
 	"github.com/brimsec/zq/expr"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zio/tzngio"
@@ -53,7 +54,7 @@ func compileExpr(s string) (expr.Evaluator, error) {
 		return nil, errors.New("expected Expression")
 	}
 
-	return compiler.TestCompileExpr(resolver.NewContext(), node)
+	return kernel.TestCompileExpr(resolver.NewContext(), node)
 }
 
 // Compile and evaluate a zql expression against a provided Record.

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/compiler"
 	"github.com/brimsec/zq/compiler/ast"
+	"github.com/brimsec/zq/compiler/semantic"
 	"github.com/brimsec/zq/driver"
 	"github.com/brimsec/zq/pkg/test"
 	"github.com/brimsec/zq/proc/groupby"
@@ -376,7 +377,7 @@ func TestGroupbyUnit(t *testing.T) {
 
 			astProc, err := compileGroupBy(zql)
 			assert.NoError(t, err)
-			compiler.SemanticTransform(astProc)
+			semantic.Transform(astProc)
 			astProc.InputSortDir = dir
 			tctx := proctest.NewTestContext(resolver)
 			src := proctest.NewTestSource(inBatches)

--- a/proc/proctest/utils.go
+++ b/proc/proctest/utils.go
@@ -63,7 +63,7 @@ func CompileTestProc(code string, pctx *proc.Context, parent proc.Interface) (pr
 }
 
 func CompileTestProcAST(node ast.Proc, pctx *proc.Context, parent proc.Interface) (proc.Interface, error) {
-	procs, err := compiler.Compile(nil, node, pctx, nil, []proc.Interface{parent})
+	procs, err := compiler.Compile(nil, node, pctx, []proc.Interface{parent})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit refactors the compiler package so that it is now
comprised of semantic analysis (compiler/semantic) and runtime
generation of the semantic output to the Z runtime kernel
represenation (aka the proc.Interface).

No new code or logic is introduced here.  A subsequent PR will use
this refactoring to create a new flowgraph-based DSL that will
server as the intermediate form between the parser's AST and
the Z kernel runtime flowgraph.