### PR TITLE
zqd: Fix pprof routes

### DIFF
--- a/ppl/zqd/core.go
+++ b/ppl/zqd/core.go
@@ -100,11 +100,14 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, indexPage)
 	})
-	router.HandleFunc("/debug/pprof/", pprof.Index)
-	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	debug := router.PathPrefix("/debug/pprof").Subrouter()
+	debug.HandleFunc("/cmdline", pprof.Cmdline)
+	debug.HandleFunc("/profile", pprof.Profile)
+	debug.HandleFunc("/symbol", pprof.Symbol)
+	debug.HandleFunc("/trace", pprof.Trace)
+	debug.PathPrefix("/").HandlerFunc(pprof.Index)
+
 	router.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 	router.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, "ok")


### PR DESCRIPTION
The zqd pprof routes were setup in a way assuming the gorilla mux router
behaves similarly to go http.ServeMux. It does not; this resulted in the routes
not behaving as expected. For instance the router was only routing
/debug/pprof/ to pprof.Index and the other sub routes of pprof.Index (e.g.
"/block", "/goroutine", etc) were getting 404'd.

Do things the gorilla mux router way so the pprof routes work correctly.