### PR TITLE
change -z to -I and allow multiple files

### DIFF
--- a/zql/ztests/comments.yaml
+++ b/zql/ztests/comments.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -t -z count.zql in.tzng
+  zq -t -I count.zql in.tzng
 
 inputs:
   - name: count.zql

--- a/zql/ztests/multi-line.yaml
+++ b/zql/ztests/multi-line.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq -t -z count.zql in.tzng
+  zq -t -I count.zql in.tzng
 
 inputs:
   - name: count.zql


### PR DESCRIPTION
This commit changes the flag (-z) for running zq with the Z query in
a file.  The flag is replaced with -I (for "include") and the behavior
is a bit different: -I can be used multiple times and it is combined
with the normal Z query on the command line.  These combinations can
create some confusing syntax errors so the Z text parsed is display
when a syntax error occurs.

We also changed the "ZQL" name convention to "Z" in the command help.