### PR TITLE
fix bug where top-level typedefs were mishandled by zng

### DIFF
--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -477,8 +477,8 @@ func (r *Reader) readTypeAlias() error {
 }
 
 func (r *Reader) parseValue(rec *zng.Record, id int, b []byte) (*zng.Record, error) {
-	typ := r.zctx.Lookup(id)
-	if typ == nil {
+	typ, err := r.zctx.LookupType(id)
+	if err != nil {
 		return nil, zng.ErrTypeIDInvalid
 	}
 	sharedType := r.mapper.Map(id)

--- a/zio/zngio/writer.go
+++ b/zio/zngio/writer.go
@@ -104,7 +104,7 @@ func (w *Writer) LastSOS() int64 {
 
 func (w *Writer) Write(r *zng.Record) error {
 	// First send any typedefs for unsent types.
-	typ := w.encoder.Lookup(r.Type)
+	typ := w.encoder.Lookup(r.Alias)
 	if typ == nil {
 		var b []byte
 		var err error
@@ -127,6 +127,9 @@ func (w *Writer) Write(r *zng.Record) error {
 	}
 	dst := w.buffer[:0]
 	id := typ.ID()
+	if typ, ok := typ.(*zng.TypeAlias); ok {
+		id = typ.AliasID()
+	}
 	if id < zng.CtrlValueEscape {
 		dst = append(dst, byte(id))
 	} else {

--- a/zio/zngio/ztests/outer-alias.yaml
+++ b/zio/zngio/ztests/outer-alias.yaml
@@ -1,5 +1,5 @@
 script: |
-  zq  - | zq -f zson -pretty=0
+  zq  - | zq -f zson -pretty=0 -
 
 inputs:
   - name: stdin

--- a/zio/zngio/ztests/outer-alias.yaml
+++ b/zio/zngio/ztests/outer-alias.yaml
@@ -1,0 +1,12 @@
+script: |
+  zq  - | zq -f zson -pretty=0
+
+inputs:
+  - name: stdin
+    data: |
+      {x:0} (=typ)
+
+outputs:
+  - name: stdout
+    data: |
+      {x:0} (=typ)


### PR DESCRIPTION
This commit fixes a bug where the zng reader and writer were
not properly handling alias encodings when the top-level
record had an aliased type.

Fixes #2187 