### PR TITLE
Shaping functions: make '.' subject implicit

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -441,17 +441,21 @@ func isShaperFunc(name string) bool {
 }
 
 func compileShaper(zctx *resolver.Context, scope *Scope, node ast.FunctionCall) (*expr.Shaper, error) {
-	if len(node.Args) < 2 {
+	args := node.Args
+	if len(args) == 1 {
+		args = append([]ast.Expression{&ast.RootRecord{}}, args...)
+	}
+	if len(args) < 2 {
 		return nil, function.ErrTooFewArgs
 	}
-	if len(node.Args) > 2 {
+	if len(args) > 2 {
 		return nil, function.ErrTooManyArgs
 	}
-	field, err := compileExpr(zctx, scope, node.Args[0])
+	field, err := compileExpr(zctx, scope, args[0])
 	if err != nil {
 		return nil, err
 	}
-	ev, err := compileExpr(zctx, scope, node.Args[1])
+	ev, err := compileExpr(zctx, scope, args[1])
 	if err != nil {
 		return nil, err
 	}

--- a/expr/ztests/shape-cast-array-to-set.yaml
+++ b/expr/ztests/shape-cast-array-to-set.yaml
@@ -1,5 +1,5 @@
 zql: |
-  put . = cast(., {a:|[ip]|,b:|[{b:ip}]|})
+  put . = cast({a:|[ip]|,b:|[{b:ip}]|})
 
 input: |
   #0:record[a:array[string],b:array[record[b:string]]]

--- a/expr/ztests/shape-cast-arrays.yaml
+++ b/expr/ztests/shape-cast-arrays.yaml
@@ -1,5 +1,5 @@
 zql: |
-  put . = cast(., {a:[ip],b:[{b:ip}]})
+  put . = cast({a:[ip],b:[{b:ip}]})
 
 input: |
   #0:record[a:array[string],b:array[record[b:string]]]

--- a/expr/ztests/shape-cast-set-to-array.yaml
+++ b/expr/ztests/shape-cast-set-to-array.yaml
@@ -1,5 +1,5 @@
 zql: |
-  put . = cast(., {a:[ip],b:[{b:ip}]})
+  put . = cast({a:[ip],b:[{b:ip}]})
 
 input: |
   #0:record[a:set[string],b:set[record[b:string]]]

--- a/expr/ztests/shape-cast-sets.yaml
+++ b/expr/ztests/shape-cast-sets.yaml
@@ -1,5 +1,5 @@
 zql: |
-  put . = cast(., {a:|[ip]|,b:|[{b:ip}]|})
+  put . = cast({a:|[ip]|,b:|[{b:ip}]|})
 
 input: |
   #0:record[a:set[string],b:set[record[b:string]]]

--- a/expr/ztests/shape-crop-arrays-sets.yaml
+++ b/expr/ztests/shape-crop-arrays-sets.yaml
@@ -1,5 +1,5 @@
 zql: |
-  put . = crop(., {set:|[{b:string}]|,arr:[{a:string}]})
+  put . = crop({set:|[{b:string}]|,arr:[{a:string}]})
 
 input: |
   #0:record[arr:array[record[a:string,b:string]],set:set[record[a:string,b:string]]]

--- a/expr/ztests/shape-fill-arrays-sets.yaml
+++ b/expr/ztests/shape-fill-arrays-sets.yaml
@@ -1,5 +1,5 @@
 zql: |
-  put . = fill(., {arr:[{b:string,a:string}],set:|[{b:string,a:string}]|})
+  put . = fill({arr:[{b:string,a:string}],set:|[{b:string,a:string}]|})
 
 input: |
   #0:record[arr:array[record[a:string]],set:set[record[a:string]]]

--- a/expr/ztests/shape-fill.yaml
+++ b/expr/ztests/shape-fill.yaml
@@ -1,4 +1,4 @@
-zql: put . = fill(., {a:{b:{c:string}}})
+zql: put . = fill({a:{b:{c:string}}})
 
 input: |
   #0:record[s:string]

--- a/expr/ztests/shape-nested.yaml
+++ b/expr/ztests/shape-nested.yaml
@@ -1,5 +1,5 @@
 zql: |
-   cut x = shape(., {a:{a:float64,b:float64}})
+   cut x = shape({a:{a:float64,b:float64}})
 
 input: |
   {"a": {"a": 1}}

--- a/expr/ztests/shape-null-cast.yaml
+++ b/expr/ztests/shape-null-cast.yaml
@@ -1,5 +1,5 @@
 zql: |
-   put . = shape(., {a:string,b:string})
+   put . = shape({a:string,b:string})
 
 input: |
   #0:record[a:null,b:int64]

--- a/expr/ztests/shape-order-arrays-sets.yaml
+++ b/expr/ztests/shape-order-arrays-sets.yaml
@@ -1,5 +1,5 @@
 zql: |
-  put . = order(., {set:|[{b:string,a:string}]|,arr:[{b:string,a:string}]})
+  put . = order({set:|[{b:string,a:string}]|,arr:[{b:string,a:string}]})
 
 input: |
   #0:record[arr:array[record[a:string,b:string]],set:set[record[a:string,b:string]]]

--- a/expr/ztests/shape-order.yaml
+++ b/expr/ztests/shape-order.yaml
@@ -1,5 +1,5 @@
 zql: |
-   put .=order(., {id: {orig_h: string, orig_p: port=(uint16), resp_h:ip,resp_p:port=(uint16)}})
+   put .=order({id: {orig_h: string, orig_p: port=(uint16), resp_h:ip,resp_p:port=(uint16)}})
 
 input: |
    #port=uint16

--- a/expr/ztests/shape.yaml
+++ b/expr/ztests/shape.yaml
@@ -1,5 +1,5 @@
 zql: |
-   put .=shape(., {id: {orig_h: ip, orig_p: port=(uint16), vlan: uint16, resp_h:ip,resp_p:port}})
+   put .=shape({id: {orig_h: ip, orig_p: port=(uint16), vlan: uint16, resp_h:ip,resp_p:port}})
 
 input: |
    #port=uint16


### PR DESCRIPTION
In the common case of shaping the entire record as in `shape(., <sometype..>)`, allow the `.` argument to be omitted, following the pattern introduced with `is()`.