### PR TITLE
zqd: Do not log /status & /metrics routes

### DIFF
--- a/ppl/zqd/core.go
+++ b/ppl/zqd/core.go
@@ -95,7 +95,7 @@ func NewCore(ctx context.Context, conf Config) (*Core, error) {
 
 	router := mux.NewRouter()
 	router.Use(requestIDMiddleware())
-	router.Use(accessLogMiddleware(conf.Logger))
+	router.Use(accessLogMiddleware(conf.Logger, "/status", "/metrics"))
 	router.Use(panicCatchMiddleware(conf.Logger))
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, indexPage)

--- a/ppl/zqd/middleware.go
+++ b/ppl/zqd/middleware.go
@@ -29,29 +29,35 @@ func requestIDMiddleware() mux.MiddlewareFunc {
 	}
 }
 
-func accessLogMiddleware(logger *zap.Logger) mux.MiddlewareFunc {
+func accessLogMiddleware(logger *zap.Logger, ignore ...string) mux.MiddlewareFunc {
+	ignoredPaths := make(map[string]struct{})
+	for _, path := range ignore {
+		ignoredPaths[path] = struct{}{}
+	}
 	logger = logger.Named("http.access")
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			logger := logger.With(zap.String("request_id", api.RequestIDFromContext(r.Context())))
-			detailedLogger := logger.With(
-				zap.String("host", r.Host),
-				zap.String("method", r.Method),
-				zap.String("proto", r.Proto),
-				zap.String("remote_addr", r.RemoteAddr),
-				zap.Int64("request_content_length", r.ContentLength),
-				zap.Stringer("url", r.URL),
-			)
-			recorder := newRecordingResponseWriter(w)
-			w = recorder
-			detailedLogger.Debug("Request started")
-			defer func(start time.Time) {
-				detailedLogger.Info("Request completed",
-					zap.Duration("elapsed", time.Since(start)),
-					zap.Int("response_content_length", recorder.contentLength),
-					zap.Int("status_code", recorder.statusCode),
+			if _, ok := ignoredPaths[r.URL.Path]; !ok {
+				logger := logger.With(zap.String("request_id", api.RequestIDFromContext(r.Context())))
+				detailedLogger := logger.With(
+					zap.String("host", r.Host),
+					zap.String("method", r.Method),
+					zap.String("proto", r.Proto),
+					zap.String("remote_addr", r.RemoteAddr),
+					zap.Int64("request_content_length", r.ContentLength),
+					zap.Stringer("url", r.URL),
 				)
-			}(time.Now())
+				recorder := newRecordingResponseWriter(w)
+				w = recorder
+				detailedLogger.Debug("Request started")
+				defer func(start time.Time) {
+					detailedLogger.Info("Request completed",
+						zap.Duration("elapsed", time.Since(start)),
+						zap.Int("response_content_length", recorder.contentLength),
+						zap.Int("status_code", recorder.statusCode),
+					)
+				}(time.Now())
+			}
 
 			next.ServeHTTP(w, r)
 		})


### PR DESCRIPTION
The status log is particularly noisy in the cloud service and does not provide
a whole lot value. Add functionality to requestLogMiddleware to ignore
specified paths.