### PR TITLE
fix bug where random data looked like non-record zng value

### DIFF
--- a/zio/detector/ztests/fake-zng.yaml
+++ b/zio/detector/ztests/fake-zng.yaml
@@ -1,0 +1,10 @@
+script: zq -f tzng -
+
+inputs:
+  - name: stdin
+    data: !!binary |
+      AAAAHGZ0eXBtcDQyAAAAAWlzb21tcDQxbXA0MgAA
+
+outputs:
+  - name: stderr
+    regexp: .*non-record, top-level zng values are not supported

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -482,7 +482,7 @@ func (r *Reader) parseValue(rec *zng.Record, id int, b []byte) (*zng.Record, err
 		return nil, zng.ErrTypeIDInvalid
 	}
 	if _, ok := zng.AliasedType(typ).(*zng.TypeRecord); !ok {
-		// An "id" of a top-level zng value not conformign with a
+		// An "id" of a top-level zng value not conforming with a
 		// record type is valid zng data but not supported by zq.
 		// This can also happen when trying to parse random non-zng
 		// data by the auto-dector.

--- a/zio/zngio/reader.go
+++ b/zio/zngio/reader.go
@@ -481,6 +481,14 @@ func (r *Reader) parseValue(rec *zng.Record, id int, b []byte) (*zng.Record, err
 	if err != nil {
 		return nil, zng.ErrTypeIDInvalid
 	}
+	if _, ok := zng.AliasedType(typ).(*zng.TypeRecord); !ok {
+		// An "id" of a top-level zng value not conformign with a
+		// record type is valid zng data but not supported by zq.
+		// This can also happen when trying to parse random non-zng
+		// data by the auto-dector.
+		return nil, errors.New("non-record, top-level zng values are not supported")
+	}
+
 	sharedType := r.mapper.Map(id)
 	if sharedType == nil {
 		var err error


### PR DESCRIPTION
This commit fixes a bug where bad data that happens to parse
as zng caused a panic when the type ID of the zng value was
was not a record type.  The fix is to check the that top-level
values are records and return an error if they don't, which
otherwise allows the auto-detector to complete its task
and report an error.

Fixes #2205