### PR TITLE
Update flags for cluster tests

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - redis-cache-fix
+      - fix-eks-deploy
 
 jobs:
   ecr-image-push:

--- a/ppl/zqd/ztests/cluster/count.yaml
+++ b/ppl/zqd/ztests/cluster/count.yaml
@@ -2,7 +2,7 @@ tag: cluster
 
 script: |
   # Test assumes a remote zqd instance with space "files" is available at 9867
-  time zapi -s files get -workers 4 -t 'count()' 2>&1
+  time zapi -s files get -workers 4 -f tzng 'count()' 2>&1
 
 outputs:
   - name: stdout

--- a/ppl/zqd/ztests/cluster/countbytxhost.yaml
+++ b/ppl/zqd/ztests/cluster/countbytxhost.yaml
@@ -2,7 +2,7 @@ tag: cluster
 
 script: |
   # Test assumes a remote zqd instance with space "files" is available at 9867
-  zapi -s files get -workers 4 -t 'count() by tx_hosts | sort -r count | head 5' 2>&1
+  zapi -s files get -workers 4 -f tzng 'count() by tx_hosts | sort -r count | head 5' 2>&1
 
 outputs:
   - name: stdout

--- a/ppl/zqd/ztests/cluster/filter1.yaml
+++ b/ppl/zqd/ztests/cluster/filter1.yaml
@@ -2,7 +2,7 @@ tag: cluster
 
 script: |
   # Test assumes a remote zqd instance with space "files" is available at 9867
-  zapi -s files get -workers 1 -t '"FgzbkQ15TOoOENn1lb" | sort tx_hosts' 2>&1 
+  zapi -s files get -workers 1 -f tzng '"FgzbkQ15TOoOENn1lb" | sort tx_hosts' 2>&1 
 
 outputs:
   - name: stdout

--- a/ppl/zqd/ztests/cluster/filter2.yaml
+++ b/ppl/zqd/ztests/cluster/filter2.yaml
@@ -2,7 +2,7 @@ tag: cluster
 
 script: |
   # Test assumes a remote zqd instance with space "files" is available at 9867
-  zapi -s files get -workers 2 -t '"FgzbkQ15TOoOENn1lb" | sort tx_hosts' 2>&1 
+  zapi -s files get -workers 2 -f tzng '"FgzbkQ15TOoOENn1lb" | sort tx_hosts' 2>&1 
 
 outputs:
   - name: stdout

--- a/ppl/zqd/ztests/cluster/filter4.yaml
+++ b/ppl/zqd/ztests/cluster/filter4.yaml
@@ -2,7 +2,7 @@ tag: cluster
 
 script: |
   # Test assumes a remote zqd instance with space "files" is available at 9867
-  zapi -s files get -workers 4 -t '"FgzbkQ15TOoOENn1lb" | sort tx_hosts' 2>&1 
+  zapi -s files get -workers 4 -f tzng '"FgzbkQ15TOoOENn1lb" | sort tx_hosts' 2>&1 
 
 outputs:
   - name: stdout


### PR DESCRIPTION
In #2208 the -t flag was deprecated. Use -f tzng instead.