### PR TITLE
add ast output formatter and "summarize" keyword

### DIFF
--- a/cmd/ast/ast.go
+++ b/cmd/ast/ast.go
@@ -69,7 +69,7 @@ func New(f *flag.FlagSet) (charm.Command, error) {
 	f.BoolVar(&c.optimize, "O", true, "run semantic optimizer on ast version")
 	f.BoolVar(&c.debug, "D", false, "display ast version as lisp-y debugger output")
 	f.BoolVar(&c.canon, "C", false, "display canonical version")
-	f.Var(&c.includes, "I", "source file containing Z query text (may be used multiple times)")
+	f.Var(&c.includes, "I", "source file containing Z query text (may be repeated)")
 	return c, nil
 }
 

--- a/zfmt/canon.go
+++ b/zfmt/canon.go
@@ -1,0 +1,386 @@
+package zfmt
+
+import (
+	"time"
+
+	"github.com/brimsec/zq/compiler/ast"
+	"github.com/brimsec/zq/zng"
+)
+
+func Canonical(p ast.Proc) string {
+	c := &canon{formatter: formatter{tab: 2}, head: true, first: true}
+	c.proc(p)
+	c.flush()
+	return c.String()
+}
+
+type canon struct {
+	formatter
+	head  bool
+	first bool
+}
+
+func (c *canon) open(args ...interface{}) {
+	c.formatter.open(args...)
+}
+
+func (c *canon) close() {
+	c.formatter.close()
+}
+
+func (c *canon) assignments(assignments []ast.Assignment) {
+	first := true
+	for _, a := range assignments {
+		if !first {
+			c.write(",")
+		}
+		first = false
+		if a.LHS != nil {
+			c.expr(a.LHS, false)
+			c.write("=")
+		}
+		c.expr(a.RHS, false)
+	}
+}
+
+func (c *canon) exprs(exprs []ast.Expression) {
+	first := true
+	for _, e := range exprs {
+		if first {
+			first = false
+		} else {
+			c.write(", ")
+		}
+		c.expr(e, false)
+	}
+}
+
+func (c *canon) expr(e ast.Expression, paren bool) {
+	switch e := e.(type) {
+	case nil:
+		c.write("null")
+	case *ast.Reducer:
+		c.write("%s(", e.Operator)
+		if e.Expr != nil {
+			c.expr(e.Expr, false)
+		}
+		c.write(")")
+		if e.Where != nil {
+			c.write(" where ")
+			c.expr(e.Where, false)
+		}
+	case *ast.Empty:
+		c.write("(empty)")
+	case *ast.Literal:
+		c.literal(*e)
+	case *ast.Identifier:
+		// If the identifier refers to a named variable in scope (like "$"),
+		// then return a Var expression referring to the pointer to the value.
+		// Note that constants may be accessed this way too by entering their
+		// names into the global (outermost) scope in the Scope entity.
+		c.write(e.Name)
+	case *ast.RootRecord:
+		c.write(".")
+	case *ast.UnaryExpression:
+		c.space()
+		c.write(e.Operator)
+		c.expr(e.Operand, true)
+	case *ast.SelectExpression:
+		c.write("TBD:select")
+	case *ast.BinaryExpression:
+		c.binary(e)
+	case *ast.ConditionalExpression:
+		c.write("(")
+		c.expr(e.Condition, true)
+		c.write(") ? ")
+		c.expr(e.Then, false)
+		c.write(" : ")
+		c.expr(e.Else, false)
+	case *ast.FunctionCall:
+		c.write("%s(", e.Function)
+		c.exprs(e.Args)
+		c.write(")")
+	case *ast.CastExpression:
+		c.expr(e.Expr, false)
+		c.open(":%s", e.Type)
+	case *ast.Search:
+		c.write("match(")
+		c.literal(e.Value)
+		c.write(")")
+	default:
+		c.open("(unknown expr %T)", e)
+		c.close()
+		c.ret()
+	}
+}
+
+func (c *canon) binary(e *ast.BinaryExpression) {
+	switch e.Operator {
+	case ".":
+		c.dot(e)
+	case "@":
+		c.write(" BUG:@")
+	case "[":
+		c.expr(e.LHS, false)
+		c.write("[")
+		c.expr(e.RHS, false)
+		c.write("]")
+	case "in", "and":
+		c.expr(e.LHS, false)
+		c.write(" %s ", e.Operator)
+		c.expr(e.RHS, false)
+	case "or":
+		c.expr(e.LHS, true)
+		c.write(" %s ", e.Operator)
+		c.expr(e.RHS, true)
+	default:
+		// do need parens calc
+		c.expr(e.LHS, true)
+		c.write("%s", e.Operator)
+		c.expr(e.RHS, true)
+	}
+}
+
+func (c *canon) dot(e *ast.BinaryExpression) {
+	id, ok := e.RHS.(*ast.Identifier)
+	if !ok {
+		c.write("AST bug: dot operator")
+		return
+	}
+	switch e := e.LHS.(type) {
+	case *ast.RootRecord:
+		c.write(id.Name)
+	case *ast.BinaryExpression:
+		if e.Operator != "." {
+			c.write("AST bug: dot operator")
+		}
+		c.dot(e)
+		c.write(".%s", id.Name)
+	default:
+		c.write("AST bug: dot operator")
+	}
+}
+
+func (c *canon) next() {
+	if c.first {
+		c.first = false
+	} else {
+		c.write("\n")
+	}
+	c.needRet = false
+	c.writeTab()
+	if c.head {
+		c.head = false
+	} else {
+		c.write("| ")
+	}
+}
+
+func (c *canon) proc(p ast.Proc) {
+	switch p := p.(type) {
+	case *ast.SequentialProc:
+		for _, p := range p.Procs {
+			c.proc(p)
+		}
+	case *ast.ParallelProc:
+		c.next()
+		c.open("split (")
+		for _, p := range p.Procs {
+			c.ret()
+			c.write("=>")
+			c.open()
+			c.head = true
+			c.proc(p)
+			c.close()
+		}
+		c.close()
+		c.ret()
+		c.flush()
+		c.write(")")
+	case *ast.ConstProc:
+		c.write("const %s=", p.Name)
+		c.expr(p.Expr, false)
+	case *ast.TypeProc:
+		c.write("type %s=", p.Name)
+		c.typ(p.Type)
+	case *ast.GroupByProc:
+		c.next()
+		c.open("summarize")
+		if secs := p.Duration.Seconds; secs != 0 {
+			c.write(" every %s", time.Duration(1_000_000_000*secs))
+		}
+		if p.ConsumePart {
+			c.write(" partials-in")
+		}
+		if p.EmitPart {
+			c.write(" partials-out")
+		}
+		c.ret()
+		c.open()
+		c.assignments(p.Reducers)
+		if p.Keys != nil {
+			c.write(" by ")
+			c.assignments(p.Keys)
+		}
+		if p.Limit != 0 {
+			c.write(" -with limit %d", p.Limit)
+		}
+		c.close()
+		c.close()
+	case *ast.CutProc:
+		c.next()
+		c.write("cut ")
+		c.assignments(p.Fields)
+	case *ast.PickProc:
+		c.next()
+		c.open("pick ")
+		c.assignments(p.Fields)
+	case *ast.DropProc:
+		c.next()
+		c.write("drop ")
+		c.exprs(p.Fields)
+	case *ast.SortProc:
+		c.next()
+		c.write("sort")
+		if p.SortDir < 0 {
+			c.write(" -r")
+		}
+		if p.NullsFirst {
+			c.write(" -nulls first")
+		}
+		c.space()
+		c.exprs(p.Fields)
+	case *ast.HeadProc:
+		c.next()
+		c.write("head %d", p.Count)
+	case *ast.TailProc:
+		c.next()
+		c.write("tail %d", p.Count)
+	case *ast.UniqProc:
+		c.next()
+		c.write("uniq")
+		if p.Cflag {
+			c.write(" -c")
+		}
+	case *ast.PassProc:
+		c.next()
+		c.write("pass")
+	case *ast.FilterProc:
+		c.next()
+		c.open("filter ")
+		c.expr(p.Filter, false)
+		c.close()
+	case *ast.TopProc:
+		c.next()
+		c.write("top limit=%d flush=%t ", p.Limit, p.Flush)
+		c.exprs(p.Fields)
+	case *ast.PutProc:
+		c.next()
+		c.write("put ")
+		c.assignments(p.Clauses)
+	case *ast.RenameProc:
+		c.next()
+		c.write("rename")
+		c.assignments(p.Fields)
+	case *ast.FuseProc:
+		c.next()
+		c.write("fuse")
+	case *ast.FunctionCall:
+		c.next()
+		c.write("%s(", p.Function)
+		c.exprs(p.Args)
+		c.write(")")
+	case *ast.JoinProc:
+		c.next()
+		c.open("join on ")
+		c.expr(p.LeftKey, false)
+		c.write("=")
+		c.expr(p.RightKey, false)
+		c.ret()
+		c.open("join-cut ")
+		c.assignments(p.Clauses)
+		c.close()
+		c.close()
+	//case *ast.SqlExpression:
+	//	//XXX TBD
+	//	c.open("sql")
+	//	c.close()
+	default:
+		c.open("unknown proc: %T", p)
+		c.close()
+	}
+}
+
+//XXX this needs to change when we use the zson values from the ast
+func (c *canon) literal(e ast.Literal) {
+	switch e.Type {
+	case "string", "bstring", "error":
+		c.write("\"%s\"", e.Value)
+	case "regexp":
+		c.write("/%s/", e.Value)
+	default:
+		//XXX need decorators for non-implied
+		c.write("%s", e.Value)
+
+	}
+}
+
+func (c *canon) typ(t ast.Type) {
+	switch t := t.(type) {
+	case *ast.TypePrimitive:
+		c.write(t.Name)
+	case *ast.TypeRecord:
+		c.write("{")
+		c.typeFields(t.Fields)
+		c.write("}")
+	case *ast.TypeArray:
+		c.write("[")
+		c.typ(t.Type)
+		c.write("]")
+	case *ast.TypeSet:
+		c.write("|[")
+		c.typ(t.Type)
+		c.write("]|")
+	case *ast.TypeUnion:
+		c.write("(")
+		c.types(t.Types)
+		c.write(")")
+	case *ast.TypeEnum:
+		//XXX need to figure out Z syntax for enum literal which may
+		// be different than zson, requiring some ast adjustments.
+		c.write("TBD:ENUM")
+	case *ast.TypeMap:
+		c.write("|{")
+		c.typ(t.KeyType)
+		c.write(",")
+		c.typ(t.ValType)
+		c.write("}|")
+	case *ast.TypeNull:
+		c.write("null")
+	case *ast.TypeDef:
+		c.write("%s=(", t.Name)
+		c.typ(t.Type)
+		c.write(")")
+	case *ast.TypeName:
+		c.write(t.Name)
+	}
+}
+
+func (c *canon) typeFields(fields []ast.TypeField) {
+	for k, f := range fields {
+		if k != 0 {
+			c.write(",")
+		}
+		c.write("%s:", zng.QuotedName(f.Name))
+		c.typ(f.Type)
+	}
+}
+
+func (c *canon) types(types []ast.Type) {
+	for k, t := range types {
+		if k != 0 {
+			c.write(",")
+		}
+		c.typ(t)
+	}
+}

--- a/zfmt/canon.go
+++ b/zfmt/canon.go
@@ -29,12 +29,10 @@ func (c *canon) close() {
 }
 
 func (c *canon) assignments(assignments []ast.Assignment) {
-	first := true
-	for _, a := range assignments {
-		if !first {
+	for k, a := range assignments {
+		if k > 0 {
 			c.write(",")
 		}
-		first = false
 		if a.LHS != nil {
 			c.expr(a.LHS, false)
 			c.write("=")
@@ -44,11 +42,8 @@ func (c *canon) assignments(assignments []ast.Assignment) {
 }
 
 func (c *canon) exprs(exprs []ast.Expression) {
-	first := true
-	for _, e := range exprs {
-		if first {
-			first = false
-		} else {
+	for k, e := range exprs {
+		if k > 0 {
 			c.write(", ")
 		}
 		c.expr(e, false)

--- a/zfmt/debug.go
+++ b/zfmt/debug.go
@@ -1,0 +1,248 @@
+package zfmt
+
+import (
+	"fmt"
+
+	"github.com/brimsec/zq/compiler/ast"
+)
+
+func Debug(p ast.Proc) string {
+	d := &debug{formatter{tab: 2}}
+	d.proc(p)
+	d.flush()
+	return d.String()
+}
+
+type debug struct {
+	formatter
+}
+
+func (d *debug) open(args ...interface{}) {
+	d.write("(")
+	d.formatter.open(args...)
+}
+
+func (d *debug) close() {
+	d.cont(")")
+	d.formatter.close()
+}
+
+func (d *debug) assignments(assignments []ast.Assignment) {
+	first := true
+	for _, a := range assignments {
+		if !first {
+			d.ret()
+		} else {
+			first = false
+		}
+		d.open("= ")
+		d.expr(a.LHS)
+		d.write(" ")
+		d.expr(a.RHS)
+		d.close()
+	}
+}
+
+func (d *debug) exprs(exprs []ast.Expression) {
+	first := true
+	for _, e := range exprs {
+		if first {
+			first = false
+		} else {
+			d.space()
+		}
+		d.expr(e)
+	}
+}
+
+func (d *debug) expr(e ast.Expression) {
+	switch e := e.(type) {
+	case nil:
+		d.write("(nil)")
+	case *ast.Reducer:
+		d.open(e.Operator)
+		d.expr(e.Expr)
+		if e.Where != nil {
+			d.open("where ")
+			d.expr(e.Where)
+			d.close()
+		}
+		d.close()
+	case *ast.Empty:
+		d.write("(empty)")
+	case *ast.Literal:
+		d.open("literal ")
+		d.write(e.Type)
+		d.write(" ")
+		d.write(e.Value)
+		d.close()
+	case *ast.Identifier:
+		// If the identifier refers to a named variable in scope (like "$"),
+		// then return a Var expression referring to the pointer to the value.
+		// Note that constants may be accessed this way too by entering their
+		// names into the global (outermost) scope in the Scope entity.
+		d.open("id ")
+		d.write(e.Name)
+		d.close()
+	case *ast.RootRecord:
+		d.write(".")
+	case *ast.UnaryExpression:
+		d.open(e.Operator)
+		d.write(" ")
+		d.expr(e.Operand)
+		d.close()
+	case *ast.SelectExpression:
+		d.write("(select)")
+	case *ast.BinaryExpression:
+		d.open(e.Operator)
+		d.space()
+		d.expr(e.LHS)
+		d.space()
+		d.expr(e.RHS)
+		d.close()
+	case *ast.ConditionalExpression:
+		d.open("cond ")
+		d.expr(e.Condition)
+		d.space()
+		d.expr(e.Then)
+		d.space()
+		d.expr(e.Else)
+		d.close()
+	case *ast.FunctionCall:
+		d.open(e.Function)
+		d.space()
+		d.exprs(e.Args)
+		d.close()
+	case *ast.CastExpression:
+		d.open("cast %s ", e.Type)
+		d.expr(e.Expr)
+		d.close()
+	case *ast.Search:
+		d.open("search")
+		d.write(" text %s", e.Text)
+		d.ret()
+		d.write(" val %s %s", e.Value.Type, e.Value.Value)
+		d.close()
+	default:
+		d.open("(unknown expr %T)", e)
+		d.close()
+		d.ret()
+	}
+}
+
+func (d *debug) procs(procs []ast.Proc) {
+	for _, p := range procs {
+		d.proc(p)
+		d.ret()
+	}
+}
+
+func (d *debug) proc(p ast.Proc) {
+	switch p := p.(type) {
+	case *ast.SequentialProc:
+		d.open("seq")
+		d.ret()
+		d.procs(p.Procs)
+		d.close()
+	case *ast.ParallelProc:
+		d.open("par")
+		d.ret()
+		d.procs(p.Procs)
+		d.close()
+	case *ast.GroupByProc:
+		d.open("groupby dur=%d dir=%d limit=%d", p.Duration, p.InputSortDir, p.Limit)
+		if p.ConsumePart {
+			d.write(" partials-in")
+		}
+		if p.EmitPart {
+			d.write(" partials-out")
+		}
+		d.ret()
+		d.open("keys")
+		d.assignments(p.Keys)
+		d.close()
+		d.ret()
+		d.open("aggs")
+		d.assignments(p.Reducers)
+		d.close()
+		d.close()
+	case *ast.CutProc:
+		d.open("cut")
+		d.ret()
+		d.assignments(p.Fields)
+		d.close()
+	case *ast.PickProc:
+		d.open("pick")
+		d.ret()
+		d.assignments(p.Fields)
+		d.close()
+	case *ast.DropProc:
+		d.open("drop")
+		d.ret()
+		d.exprs(p.Fields)
+		d.close()
+	case *ast.SortProc:
+		d.open(fmt.Sprintf("sort dir=%d nf=%t ", p.SortDir, p.NullsFirst))
+		d.ret()
+		d.exprs(p.Fields)
+		d.close()
+	case *ast.HeadProc:
+		d.open("head %d", p.Count)
+		d.close()
+	case *ast.TailProc:
+		d.open("tail %d", p.Count)
+		d.close()
+	case *ast.UniqProc:
+		d.open("uniq")
+		if p.Cflag {
+			d.write(" -c")
+		}
+		d.close()
+	case *ast.PassProc:
+		d.open("pass")
+	case *ast.FilterProc:
+		d.open("filter ")
+		d.expr(p.Filter)
+		d.close()
+	case *ast.TopProc:
+		d.open("top limit=%d flush=%t ", p.Limit, p.Flush)
+		d.ret()
+		d.exprs(p.Fields)
+		d.close()
+	case *ast.PutProc:
+		d.open("put")
+		d.ret()
+		d.assignments(p.Clauses)
+		d.close()
+	case *ast.RenameProc:
+		d.open("rename")
+		d.ret()
+		d.assignments(p.Fields)
+		d.close()
+	case *ast.FuseProc:
+		d.open("fuse")
+		d.close()
+	case *ast.FunctionCall:
+		d.open(p.Function)
+		d.space()
+		d.exprs(p.Args)
+		d.close()
+	case *ast.JoinProc:
+		d.open("join on ")
+		d.expr(p.LeftKey)
+		d.write(" = ")
+		d.expr(p.RightKey)
+		d.ret()
+		d.open("join-cut ")
+		d.assignments(p.Clauses)
+		d.close()
+		d.close()
+	//case *ast.SqlExpression:
+	//	//XXX TBD
+	//	d.open("sql")
+	//	d.close()
+	default:
+		d.open("unknown proc: %T", p)
+		d.close()
+	}
+}

--- a/zfmt/format.go
+++ b/zfmt/format.go
@@ -1,0 +1,69 @@
+package zfmt
+
+import (
+	"fmt"
+	"strings"
+)
+
+type formatter struct {
+	strings.Builder
+	indent  int
+	tab     int
+	needTab bool
+	needRet bool
+}
+
+func (f *formatter) flush() {
+	if f.needRet {
+		f.WriteByte('\n')
+		f.needRet = false
+	}
+}
+
+func (f *formatter) writeTab() {
+	f.flush()
+	for k := 0; k < f.indent; k++ {
+		f.WriteByte(' ')
+	}
+	f.needTab = false
+}
+
+func (f *formatter) write(args ...interface{}) {
+	f.flush()
+	if f.needTab {
+		f.writeTab()
+	}
+	var s string
+	if len(args) == 1 {
+		s = args[0].(string)
+	} else if len(args) > 1 {
+		format := args[0].(string)
+		s = fmt.Sprintf(format, args[1:]...)
+	}
+	f.WriteString(s)
+}
+
+func (f *formatter) cont(args ...interface{}) {
+	format := args[0].(string)
+	f.WriteString(fmt.Sprintf(format, args[1:]...))
+}
+
+func (f *formatter) open(args ...interface{}) {
+	if len(args) > 0 {
+		f.write(args...)
+	}
+	f.indent += f.tab
+}
+
+func (f *formatter) close() {
+	f.indent -= f.tab
+}
+
+func (f *formatter) ret() {
+	f.needTab = true
+	f.needRet = true
+}
+
+func (f *formatter) space() {
+	f.write(" ")
+}

--- a/zfmt/ztests/parallel.yaml
+++ b/zfmt/ztests/parallel.yaml
@@ -1,0 +1,19 @@
+script: |
+  ast -C 'foo | split (=> count() by x=.["@foo"] => sum(x) => put a=b*c ) | cut cake | sort -r x'
+
+outputs:
+  - name: stdout
+    data: |
+      filter match("foo")
+      | split (
+        =>
+          summarize
+              count() by x=.["@foo"]
+        =>
+          summarize
+              sum(x)
+        =>
+          put a=b*c
+      )
+      | cut cake
+      | sort -r x

--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -472,47 +472,50 @@ function peg$parse(input, options) {
             }
             return p
           },
-      peg$c84 = "every",
-      peg$c85 = peg$literalExpectation("every", true),
-      peg$c86 = function(dur) { return dur },
-      peg$c87 = function(columns) { return columns },
-      peg$c88 = "with",
-      peg$c89 = peg$literalExpectation("with", false),
-      peg$c90 = "-limit",
-      peg$c91 = peg$literalExpectation("-limit", false),
-      peg$c92 = function(limit) { return limit },
-      peg$c93 = "",
-      peg$c94 = function() { return 0 },
-      peg$c95 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c96 = function(first, expr) { return expr },
-      peg$c97 = function(lval, reducer) {
+      peg$c84 = "summarize",
+      peg$c85 = peg$literalExpectation("summarize", false),
+      peg$c86 = "",
+      peg$c87 = "every",
+      peg$c88 = peg$literalExpectation("every", true),
+      peg$c89 = function(dur) { return dur },
+      peg$c90 = function() { return null },
+      peg$c91 = function(columns) { return columns },
+      peg$c92 = "with",
+      peg$c93 = peg$literalExpectation("with", false),
+      peg$c94 = "-limit",
+      peg$c95 = peg$literalExpectation("-limit", false),
+      peg$c96 = function(limit) { return limit },
+      peg$c97 = function() { return 0 },
+      peg$c98 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c99 = function(first, expr) { return expr },
+      peg$c100 = function(lval, reducer) {
             return {"op": "Assignment", "lhs": lval, "rhs": reducer}
           },
-      peg$c98 = function(reducer) {
+      peg$c101 = function(reducer) {
             return {"op": "Assignment", "lhs": null, "rhs": reducer}
           },
-      peg$c99 = ".",
-      peg$c100 = peg$literalExpectation(".", false),
-      peg$c101 = function(op, expr, where) {
+      peg$c102 = ".",
+      peg$c103 = peg$literalExpectation(".", false),
+      peg$c104 = function(op, expr, where) {
             let r = {"op": "Reducer", "operator": op, "expr": null, "where":where};
             if (expr) {
               r["expr"] = expr;
             }
             return r
           },
-      peg$c102 = "where",
-      peg$c103 = peg$literalExpectation("where", false),
-      peg$c104 = function(first, rest) {
+      peg$c105 = "where",
+      peg$c106 = peg$literalExpectation("where", false),
+      peg$c107 = function(first, rest) {
             let result = [first];
             for(let  r of rest) {
               result.push( r[3]);
             }
             return result
           },
-      peg$c105 = "sort",
-      peg$c106 = peg$literalExpectation("sort", true),
-      peg$c107 = function(args, l) { return l },
-      peg$c108 = function(args, list) {
+      peg$c108 = "sort",
+      peg$c109 = peg$literalExpectation("sort", true),
+      peg$c110 = function(args, l) { return l },
+      peg$c111 = function(args, list) {
             let argm = args;
             let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false};
             if ( "r" in argm) {
@@ -525,24 +528,24 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c109 = function(args) { return makeArgMap(args) },
-      peg$c110 = "-r",
-      peg$c111 = peg$literalExpectation("-r", false),
-      peg$c112 = function() { return {"name": "r", "value": null} },
-      peg$c113 = "-nulls",
-      peg$c114 = peg$literalExpectation("-nulls", false),
-      peg$c115 = "first",
-      peg$c116 = peg$literalExpectation("first", false),
-      peg$c117 = "last",
-      peg$c118 = peg$literalExpectation("last", false),
-      peg$c119 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c120 = "top",
-      peg$c121 = peg$literalExpectation("top", true),
-      peg$c122 = function(n) { return n},
-      peg$c123 = "-flush",
-      peg$c124 = peg$literalExpectation("-flush", false),
-      peg$c125 = function(limit, flush, f) { return f },
-      peg$c126 = function(limit, flush, fields) {
+      peg$c112 = function(args) { return makeArgMap(args) },
+      peg$c113 = "-r",
+      peg$c114 = peg$literalExpectation("-r", false),
+      peg$c115 = function() { return {"name": "r", "value": null} },
+      peg$c116 = "-nulls",
+      peg$c117 = peg$literalExpectation("-nulls", false),
+      peg$c118 = "first",
+      peg$c119 = peg$literalExpectation("first", false),
+      peg$c120 = "last",
+      peg$c121 = peg$literalExpectation("last", false),
+      peg$c122 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c123 = "top",
+      peg$c124 = peg$literalExpectation("top", true),
+      peg$c125 = function(n) { return n},
+      peg$c126 = "-flush",
+      peg$c127 = peg$literalExpectation("-flush", false),
+      peg$c128 = function(limit, flush, f) { return f },
+      peg$c129 = function(limit, flush, fields) {
             let proc = {"op": "TopProc", "limit": 0, "fields": null, "flush": false};
             if (limit) {
               proc["limit"] = limit;
@@ -555,82 +558,82 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c127 = "cut",
-      peg$c128 = peg$literalExpectation("cut", true),
-      peg$c129 = function(columns) {
+      peg$c130 = "cut",
+      peg$c131 = peg$literalExpectation("cut", true),
+      peg$c132 = function(columns) {
             return {"op": "CutProc", "fields": columns}
           },
-      peg$c130 = "pick",
-      peg$c131 = peg$literalExpectation("pick", true),
-      peg$c132 = function(columns) {
+      peg$c133 = "pick",
+      peg$c134 = peg$literalExpectation("pick", true),
+      peg$c135 = function(columns) {
             return {"op": "PickProc", "fields": columns}
           },
-      peg$c133 = "drop",
-      peg$c134 = peg$literalExpectation("drop", true),
-      peg$c135 = function(columns) {
+      peg$c136 = "drop",
+      peg$c137 = peg$literalExpectation("drop", true),
+      peg$c138 = function(columns) {
             return {"op": "DropProc", "fields": columns}
           },
-      peg$c136 = "head",
-      peg$c137 = peg$literalExpectation("head", true),
-      peg$c138 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c139 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c140 = "tail",
-      peg$c141 = peg$literalExpectation("tail", true),
-      peg$c142 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c143 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c144 = "filter",
-      peg$c145 = peg$literalExpectation("filter", true),
-      peg$c146 = function(op) {
+      peg$c139 = "head",
+      peg$c140 = peg$literalExpectation("head", true),
+      peg$c141 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c142 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c143 = "tail",
+      peg$c144 = peg$literalExpectation("tail", true),
+      peg$c145 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c146 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c147 = "filter",
+      peg$c148 = peg$literalExpectation("filter", true),
+      peg$c149 = function(op) {
             return op
           },
-      peg$c147 = "uniq",
-      peg$c148 = peg$literalExpectation("uniq", true),
-      peg$c149 = "-c",
-      peg$c150 = peg$literalExpectation("-c", false),
-      peg$c151 = function() {
+      peg$c150 = "uniq",
+      peg$c151 = peg$literalExpectation("uniq", true),
+      peg$c152 = "-c",
+      peg$c153 = peg$literalExpectation("-c", false),
+      peg$c154 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c152 = function() {
+      peg$c155 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c153 = "put",
-      peg$c154 = peg$literalExpectation("put", true),
-      peg$c155 = function(columns) {
+      peg$c156 = "put",
+      peg$c157 = peg$literalExpectation("put", true),
+      peg$c158 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c156 = "rename",
-      peg$c157 = peg$literalExpectation("rename", true),
-      peg$c158 = function(first, cl) { return cl },
-      peg$c159 = function(first, rest) {
+      peg$c159 = "rename",
+      peg$c160 = peg$literalExpectation("rename", true),
+      peg$c161 = function(first, cl) { return cl },
+      peg$c162 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c160 = "fuse",
-      peg$c161 = peg$literalExpectation("fuse", true),
-      peg$c162 = function() {
+      peg$c163 = "fuse",
+      peg$c164 = peg$literalExpectation("fuse", true),
+      peg$c165 = function() {
             return {"op": "FuseProc"}
           },
-      peg$c163 = "join",
-      peg$c164 = peg$literalExpectation("join", true),
-      peg$c165 = function(leftKey, rightKey, columns) {
+      peg$c166 = "join",
+      peg$c167 = peg$literalExpectation("join", true),
+      peg$c168 = function(leftKey, rightKey, columns) {
             let proc = {"op": "JoinProc", "left_key": leftKey, "right_key": rightKey, "clauses": null};
             if (columns) {
               proc["clauses"] = columns[1];
             }
             return proc
           },
-      peg$c166 = function(key, columns) {
+      peg$c169 = function(key, columns) {
             let proc = {"op": "JoinProc", "left_key": key, "right_key": key, "clauses": null};
             if (columns) {
               proc["clauses"] = columns[1];
             }
             return proc
           },
-      peg$c167 = "taste",
-      peg$c168 = peg$literalExpectation("taste", true),
-      peg$c169 = function(e) {
+      peg$c170 = "taste",
+      peg$c171 = peg$literalExpectation("taste", true),
+      peg$c172 = function(e) {
             return {"op": "GroupByProc",
               
-            "keys":[{"op": "Assignment",
+            "keys": [{"op": "Assignment",
                          
             "lhs": {"op": "Identifier", "name": "shape"},
                          
@@ -649,13 +652,13 @@ function peg$parse(input, options) {
             "expr": e,
                                                
             "where": null}}],
-               
+              
             "duration": null, "limit": 0}
           
           },
-      peg$c170 = function(lval) { return lval},
-      peg$c171 = function() { return {"op":"RootRecord"} },
-      peg$c172 = function(first, rest) {
+      peg$c173 = function(lval) { return lval},
+      peg$c174 = function() { return {"op":"RootRecord"} },
+      peg$c175 = function(first, rest) {
             let result = [first];
 
             for(let  r of rest) {
@@ -664,41 +667,41 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c173 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c174 = "?",
-      peg$c175 = peg$literalExpectation("?", false),
-      peg$c176 = function(condition, thenClause, elseClause) {
+      peg$c176 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c177 = "?",
+      peg$c178 = peg$literalExpectation("?", false),
+      peg$c179 = function(condition, thenClause, elseClause) {
             return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c177 = function(first, comp, expr) { return [comp, expr] },
-      peg$c178 = "+",
-      peg$c179 = peg$literalExpectation("+", false),
-      peg$c180 = "-",
-      peg$c181 = peg$literalExpectation("-", false),
-      peg$c182 = "/",
-      peg$c183 = peg$literalExpectation("/", false),
-      peg$c184 = function(e) {
+      peg$c180 = function(first, comp, expr) { return [comp, expr] },
+      peg$c181 = "+",
+      peg$c182 = peg$literalExpectation("+", false),
+      peg$c183 = "-",
+      peg$c184 = peg$literalExpectation("-", false),
+      peg$c185 = "/",
+      peg$c186 = peg$literalExpectation("/", false),
+      peg$c187 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c185 = "not",
-      peg$c186 = peg$literalExpectation("not", false),
-      peg$c187 = "match",
-      peg$c188 = peg$literalExpectation("match", false),
-      peg$c189 = "select",
-      peg$c190 = peg$literalExpectation("select", false),
-      peg$c191 = function(args, e) { return ["@", e] },
-      peg$c192 = function(args, methods) {
+      peg$c188 = "not",
+      peg$c189 = peg$literalExpectation("not", false),
+      peg$c190 = "match",
+      peg$c191 = peg$literalExpectation("match", false),
+      peg$c192 = "select",
+      peg$c193 = peg$literalExpectation("select", false),
+      peg$c194 = function(args, e) { return ["@", e] },
+      peg$c195 = function(args, methods) {
             return makeBinaryExprChain({"op":"SelectExpr", "selectors":args}, methods)
           },
-      peg$c193 = function(fn, args) {
+      peg$c196 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c194 = function(first, e) { return e },
-      peg$c195 = function() { return [] },
-      peg$c196 = function() {
+      peg$c197 = function(first, e) { return e },
+      peg$c198 = function() { return [] },
+      peg$c199 = function() {
             return {"op":"RootRecord"}
           },
-      peg$c197 = function(field) {
+      peg$c200 = function(field) {
             return {"op": "BinaryExpr", "operator":".",
                            
             "lhs":{"op":"RootRecord"},
@@ -707,11 +710,11 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c198 = "[",
-      peg$c199 = peg$literalExpectation("[", false),
-      peg$c200 = "]",
-      peg$c201 = peg$literalExpectation("]", false),
-      peg$c202 = function(expr) {
+      peg$c201 = "[",
+      peg$c202 = peg$literalExpectation("[", false),
+      peg$c203 = "]",
+      peg$c204 = peg$literalExpectation("]", false),
+      peg$c205 = function(expr) {
             return {"op": "BinaryExpr", "operator":"[",
                            
             "lhs":{"op":"RootRecord"},
@@ -720,319 +723,319 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c203 = function(from, to) {
+      peg$c206 = function(from, to) {
             return ["[", {"op": "BinaryExpr", "operator":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c204 = function(to) {
+      peg$c207 = function(to) {
             return ["[", {"op": "BinaryExpr", "operator":":",
                                   
             "lhs":{"op":"Empty"}, "rhs":to}]
           
           },
-      peg$c205 = function(from) {
+      peg$c208 = function(from) {
             return ["[", {"op": "BinaryExpr", "operator":":",
                                   
             "lhs":from, "rhs":{"op":"Empty"}}]
           
           },
-      peg$c206 = function(expr) { return ["[", expr] },
-      peg$c207 = function(id) { return [".", id] },
-      peg$c208 = function(v) {
+      peg$c209 = function(expr) { return ["[", expr] },
+      peg$c210 = function(id) { return [".", id] },
+      peg$c211 = function(v) {
             return {"op": "Literal", "type": "regexp", "value": v}
           },
-      peg$c209 = function(v) {
+      peg$c212 = function(v) {
             return {"op": "Literal", "type": "net", "value": v}
           },
-      peg$c210 = function(v) {
+      peg$c213 = function(v) {
             return {"op": "Literal", "type": "ip", "value": v}
           },
-      peg$c211 = function(v) {
+      peg$c214 = function(v) {
             return {"op": "Literal", "type": "float64", "value": v}
           },
-      peg$c212 = function(v) {
+      peg$c215 = function(v) {
             return {"op": "Literal", "type": "int64", "value": v}
           },
-      peg$c213 = "true",
-      peg$c214 = peg$literalExpectation("true", false),
-      peg$c215 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
-      peg$c216 = "false",
-      peg$c217 = peg$literalExpectation("false", false),
-      peg$c218 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
-      peg$c219 = "null",
-      peg$c220 = peg$literalExpectation("null", false),
-      peg$c221 = function() { return {"op": "Literal", "type": "null", "value": ""} },
-      peg$c222 = function(typ) {
+      peg$c216 = "true",
+      peg$c217 = peg$literalExpectation("true", false),
+      peg$c218 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
+      peg$c219 = "false",
+      peg$c220 = peg$literalExpectation("false", false),
+      peg$c221 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
+      peg$c222 = "null",
+      peg$c223 = peg$literalExpectation("null", false),
+      peg$c224 = function() { return {"op": "Literal", "type": "null", "value": ""} },
+      peg$c225 = function(typ) {
             return {"op": "TypeExpr", "type": typ}
           },
-      peg$c223 = function(typ) { return typ},
-      peg$c224 = function(typ) { return typ },
-      peg$c225 = function() {
+      peg$c226 = function(typ) { return typ},
+      peg$c227 = function(typ) { return typ },
+      peg$c228 = function() {
             return {"op": "TypeNull"}
           },
-      peg$c226 = function(name, typ) {
+      peg$c229 = function(name, typ) {
             return {"op": "TypeDef", "name": name, "type": typ}
         },
-      peg$c227 = function(name) {
+      peg$c230 = function(name) {
             return {"op": "TypeName", "name": name}
           },
-      peg$c228 = function(u) { return u },
-      peg$c229 = function(types) {
+      peg$c231 = function(u) { return u },
+      peg$c232 = function(types) {
             return {"op": "TypeUnion", "types": types}
           },
-      peg$c230 = function(first, rest) {
+      peg$c233 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c231 = "{",
-      peg$c232 = peg$literalExpectation("{", false),
-      peg$c233 = "}",
-      peg$c234 = peg$literalExpectation("}", false),
-      peg$c235 = function(fields) {
+      peg$c234 = "{",
+      peg$c235 = peg$literalExpectation("{", false),
+      peg$c236 = "}",
+      peg$c237 = peg$literalExpectation("}", false),
+      peg$c238 = function(fields) {
             return {"op":"TypeRecord", "fields":fields}
           },
-      peg$c236 = function(typ) {
+      peg$c239 = function(typ) {
             return {"op":"TypeArray", "type":typ}
           },
-      peg$c237 = "|[",
-      peg$c238 = peg$literalExpectation("|[", false),
-      peg$c239 = "]|",
-      peg$c240 = peg$literalExpectation("]|", false),
-      peg$c241 = function(typ) {
+      peg$c240 = "|[",
+      peg$c241 = peg$literalExpectation("|[", false),
+      peg$c242 = "]|",
+      peg$c243 = peg$literalExpectation("]|", false),
+      peg$c244 = function(typ) {
             return {"op":"TypeSet", "type":typ}
           },
-      peg$c242 = "|{",
-      peg$c243 = peg$literalExpectation("|{", false),
-      peg$c244 = "}|",
-      peg$c245 = peg$literalExpectation("}|", false),
-      peg$c246 = function(keyType, valType) {
+      peg$c245 = "|{",
+      peg$c246 = peg$literalExpectation("|{", false),
+      peg$c247 = "}|",
+      peg$c248 = peg$literalExpectation("}|", false),
+      peg$c249 = function(keyType, valType) {
             return {"op":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c247 = "uint8",
-      peg$c248 = peg$literalExpectation("uint8", false),
-      peg$c249 = "uint16",
-      peg$c250 = peg$literalExpectation("uint16", false),
-      peg$c251 = "uint32",
-      peg$c252 = peg$literalExpectation("uint32", false),
-      peg$c253 = "uint64",
-      peg$c254 = peg$literalExpectation("uint64", false),
-      peg$c255 = "int8",
-      peg$c256 = peg$literalExpectation("int8", false),
-      peg$c257 = "int16",
-      peg$c258 = peg$literalExpectation("int16", false),
-      peg$c259 = "int32",
-      peg$c260 = peg$literalExpectation("int32", false),
-      peg$c261 = "int64",
-      peg$c262 = peg$literalExpectation("int64", false),
-      peg$c263 = "float64",
-      peg$c264 = peg$literalExpectation("float64", false),
-      peg$c265 = "bool",
-      peg$c266 = peg$literalExpectation("bool", false),
-      peg$c267 = "string",
-      peg$c268 = peg$literalExpectation("string", false),
-      peg$c269 = function() {
+      peg$c250 = "uint8",
+      peg$c251 = peg$literalExpectation("uint8", false),
+      peg$c252 = "uint16",
+      peg$c253 = peg$literalExpectation("uint16", false),
+      peg$c254 = "uint32",
+      peg$c255 = peg$literalExpectation("uint32", false),
+      peg$c256 = "uint64",
+      peg$c257 = peg$literalExpectation("uint64", false),
+      peg$c258 = "int8",
+      peg$c259 = peg$literalExpectation("int8", false),
+      peg$c260 = "int16",
+      peg$c261 = peg$literalExpectation("int16", false),
+      peg$c262 = "int32",
+      peg$c263 = peg$literalExpectation("int32", false),
+      peg$c264 = "int64",
+      peg$c265 = peg$literalExpectation("int64", false),
+      peg$c266 = "float64",
+      peg$c267 = peg$literalExpectation("float64", false),
+      peg$c268 = "bool",
+      peg$c269 = peg$literalExpectation("bool", false),
+      peg$c270 = "string",
+      peg$c271 = peg$literalExpectation("string", false),
+      peg$c272 = function() {
                 return {"op": "TypePrimitive", "name": text()}
               },
-      peg$c270 = "duration",
-      peg$c271 = peg$literalExpectation("duration", false),
-      peg$c272 = "time",
-      peg$c273 = peg$literalExpectation("time", false),
-      peg$c274 = "bytes",
-      peg$c275 = peg$literalExpectation("bytes", false),
-      peg$c276 = "bstring",
-      peg$c277 = peg$literalExpectation("bstring", false),
-      peg$c278 = "ip",
-      peg$c279 = peg$literalExpectation("ip", false),
-      peg$c280 = "net",
-      peg$c281 = peg$literalExpectation("net", false),
-      peg$c282 = "error",
-      peg$c283 = peg$literalExpectation("error", false),
-      peg$c284 = function(name, typ) {
+      peg$c273 = "duration",
+      peg$c274 = peg$literalExpectation("duration", false),
+      peg$c275 = "time",
+      peg$c276 = peg$literalExpectation("time", false),
+      peg$c277 = "bytes",
+      peg$c278 = peg$literalExpectation("bytes", false),
+      peg$c279 = "bstring",
+      peg$c280 = peg$literalExpectation("bstring", false),
+      peg$c281 = "ip",
+      peg$c282 = peg$literalExpectation("ip", false),
+      peg$c283 = "net",
+      peg$c284 = peg$literalExpectation("net", false),
+      peg$c285 = "error",
+      peg$c286 = peg$literalExpectation("error", false),
+      peg$c287 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c285 = "and",
-      peg$c286 = peg$literalExpectation("and", true),
-      peg$c287 = function() { return "and" },
-      peg$c288 = "or",
-      peg$c289 = peg$literalExpectation("or", true),
-      peg$c290 = function() { return "or" },
-      peg$c291 = peg$literalExpectation("in", true),
-      peg$c292 = function() { return "in" },
-      peg$c293 = peg$literalExpectation("not", true),
-      peg$c294 = function() { return "not" },
-      peg$c295 = "by",
-      peg$c296 = peg$literalExpectation("by", true),
-      peg$c297 = function() { return "by" },
-      peg$c298 = /^[A-Za-z_$]/,
-      peg$c299 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c300 = /^[0-9]/,
-      peg$c301 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c302 = function(id) { return {"op": "Identifier", "name": id} },
-      peg$c303 = function() {  return text() },
-      peg$c304 = "$",
-      peg$c305 = peg$literalExpectation("$", false),
-      peg$c306 = "\\",
-      peg$c307 = peg$literalExpectation("\\", false),
-      peg$c308 = function(id) { return id },
-      peg$c309 = peg$literalExpectation("and", false),
-      peg$c310 = "seconds",
-      peg$c311 = peg$literalExpectation("seconds", false),
-      peg$c312 = "second",
-      peg$c313 = peg$literalExpectation("second", false),
-      peg$c314 = "secs",
-      peg$c315 = peg$literalExpectation("secs", false),
-      peg$c316 = "sec",
-      peg$c317 = peg$literalExpectation("sec", false),
-      peg$c318 = "s",
-      peg$c319 = peg$literalExpectation("s", false),
-      peg$c320 = "minutes",
-      peg$c321 = peg$literalExpectation("minutes", false),
-      peg$c322 = "minute",
-      peg$c323 = peg$literalExpectation("minute", false),
-      peg$c324 = "mins",
-      peg$c325 = peg$literalExpectation("mins", false),
-      peg$c326 = "min",
-      peg$c327 = peg$literalExpectation("min", false),
-      peg$c328 = "m",
-      peg$c329 = peg$literalExpectation("m", false),
-      peg$c330 = "hours",
-      peg$c331 = peg$literalExpectation("hours", false),
-      peg$c332 = "hrs",
-      peg$c333 = peg$literalExpectation("hrs", false),
-      peg$c334 = "hr",
-      peg$c335 = peg$literalExpectation("hr", false),
-      peg$c336 = "h",
-      peg$c337 = peg$literalExpectation("h", false),
-      peg$c338 = "hour",
-      peg$c339 = peg$literalExpectation("hour", false),
-      peg$c340 = "days",
-      peg$c341 = peg$literalExpectation("days", false),
-      peg$c342 = "day",
-      peg$c343 = peg$literalExpectation("day", false),
-      peg$c344 = "d",
-      peg$c345 = peg$literalExpectation("d", false),
-      peg$c346 = "weeks",
-      peg$c347 = peg$literalExpectation("weeks", false),
-      peg$c348 = "week",
-      peg$c349 = peg$literalExpectation("week", false),
-      peg$c350 = "wks",
-      peg$c351 = peg$literalExpectation("wks", false),
-      peg$c352 = "wk",
-      peg$c353 = peg$literalExpectation("wk", false),
-      peg$c354 = "w",
-      peg$c355 = peg$literalExpectation("w", false),
-      peg$c356 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c357 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c358 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c359 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c360 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c361 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c362 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c363 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c364 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c365 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c366 = function(a, b) {
+      peg$c288 = "and",
+      peg$c289 = peg$literalExpectation("and", true),
+      peg$c290 = function() { return "and" },
+      peg$c291 = "or",
+      peg$c292 = peg$literalExpectation("or", true),
+      peg$c293 = function() { return "or" },
+      peg$c294 = peg$literalExpectation("in", true),
+      peg$c295 = function() { return "in" },
+      peg$c296 = peg$literalExpectation("not", true),
+      peg$c297 = function() { return "not" },
+      peg$c298 = "by",
+      peg$c299 = peg$literalExpectation("by", true),
+      peg$c300 = function() { return "by" },
+      peg$c301 = /^[A-Za-z_$]/,
+      peg$c302 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c303 = /^[0-9]/,
+      peg$c304 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c305 = function(id) { return {"op": "Identifier", "name": id} },
+      peg$c306 = function() {  return text() },
+      peg$c307 = "$",
+      peg$c308 = peg$literalExpectation("$", false),
+      peg$c309 = "\\",
+      peg$c310 = peg$literalExpectation("\\", false),
+      peg$c311 = function(id) { return id },
+      peg$c312 = peg$literalExpectation("and", false),
+      peg$c313 = "seconds",
+      peg$c314 = peg$literalExpectation("seconds", false),
+      peg$c315 = "second",
+      peg$c316 = peg$literalExpectation("second", false),
+      peg$c317 = "secs",
+      peg$c318 = peg$literalExpectation("secs", false),
+      peg$c319 = "sec",
+      peg$c320 = peg$literalExpectation("sec", false),
+      peg$c321 = "s",
+      peg$c322 = peg$literalExpectation("s", false),
+      peg$c323 = "minutes",
+      peg$c324 = peg$literalExpectation("minutes", false),
+      peg$c325 = "minute",
+      peg$c326 = peg$literalExpectation("minute", false),
+      peg$c327 = "mins",
+      peg$c328 = peg$literalExpectation("mins", false),
+      peg$c329 = "min",
+      peg$c330 = peg$literalExpectation("min", false),
+      peg$c331 = "m",
+      peg$c332 = peg$literalExpectation("m", false),
+      peg$c333 = "hours",
+      peg$c334 = peg$literalExpectation("hours", false),
+      peg$c335 = "hrs",
+      peg$c336 = peg$literalExpectation("hrs", false),
+      peg$c337 = "hr",
+      peg$c338 = peg$literalExpectation("hr", false),
+      peg$c339 = "h",
+      peg$c340 = peg$literalExpectation("h", false),
+      peg$c341 = "hour",
+      peg$c342 = peg$literalExpectation("hour", false),
+      peg$c343 = "days",
+      peg$c344 = peg$literalExpectation("days", false),
+      peg$c345 = "day",
+      peg$c346 = peg$literalExpectation("day", false),
+      peg$c347 = "d",
+      peg$c348 = peg$literalExpectation("d", false),
+      peg$c349 = "weeks",
+      peg$c350 = peg$literalExpectation("weeks", false),
+      peg$c351 = "week",
+      peg$c352 = peg$literalExpectation("week", false),
+      peg$c353 = "wks",
+      peg$c354 = peg$literalExpectation("wks", false),
+      peg$c355 = "wk",
+      peg$c356 = peg$literalExpectation("wk", false),
+      peg$c357 = "w",
+      peg$c358 = peg$literalExpectation("w", false),
+      peg$c359 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c360 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c361 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c362 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c363 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c364 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c365 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c366 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c367 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c368 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c369 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c367 = "::",
-      peg$c368 = peg$literalExpectation("::", false),
-      peg$c369 = function(a, b, d, e) {
+      peg$c370 = "::",
+      peg$c371 = peg$literalExpectation("::", false),
+      peg$c372 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c370 = function(a, b) {
+      peg$c373 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c371 = function(a, b) {
+      peg$c374 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c372 = function() {
+      peg$c375 = function() {
             return "::"
           },
-      peg$c373 = function(v) { return ":" + v },
-      peg$c374 = function(v) { return v + ":" },
-      peg$c375 = function(a, m) {
+      peg$c376 = function(v) { return ":" + v },
+      peg$c377 = function(v) { return v + ":" },
+      peg$c378 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c376 = function(a, m) {
+      peg$c379 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c377 = function(s) { return parseInt(s) },
-      peg$c378 = function() {
+      peg$c380 = function(s) { return parseInt(s) },
+      peg$c381 = function() {
             return text()
           },
-      peg$c379 = "e",
-      peg$c380 = peg$literalExpectation("e", true),
-      peg$c381 = /^[+\-]/,
-      peg$c382 = peg$classExpectation(["+", "-"], false, false),
-      peg$c383 = /^[0-9a-fA-F]/,
-      peg$c384 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c385 = "\"",
-      peg$c386 = peg$literalExpectation("\"", false),
-      peg$c387 = function(v) { return joinChars(v) },
-      peg$c388 = "'",
-      peg$c389 = peg$literalExpectation("'", false),
-      peg$c390 = peg$anyExpectation(),
-      peg$c391 = function(s) { return s },
-      peg$c392 = function(head, tail) { return head + joinChars(tail) },
-      peg$c393 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c394 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c395 = "x",
-      peg$c396 = peg$literalExpectation("x", false),
-      peg$c397 = function() { return "\\" + text() },
-      peg$c398 = function() { return "'"},
-      peg$c399 = function() { return '"'},
-      peg$c400 = function() { return "\\"},
-      peg$c401 = "b",
-      peg$c402 = peg$literalExpectation("b", false),
-      peg$c403 = function() { return "\b" },
-      peg$c404 = "f",
-      peg$c405 = peg$literalExpectation("f", false),
-      peg$c406 = function() { return "\f" },
-      peg$c407 = "n",
-      peg$c408 = peg$literalExpectation("n", false),
-      peg$c409 = function() { return "\n" },
-      peg$c410 = "r",
-      peg$c411 = peg$literalExpectation("r", false),
-      peg$c412 = function() { return "\r" },
-      peg$c413 = "t",
-      peg$c414 = peg$literalExpectation("t", false),
-      peg$c415 = function() { return "\t" },
-      peg$c416 = "v",
-      peg$c417 = peg$literalExpectation("v", false),
-      peg$c418 = function() { return "\v" },
-      peg$c419 = function() { return "=" },
-      peg$c420 = function() { return "\\*" },
-      peg$c421 = "u",
-      peg$c422 = peg$literalExpectation("u", false),
-      peg$c423 = function(chars) {
+      peg$c382 = "e",
+      peg$c383 = peg$literalExpectation("e", true),
+      peg$c384 = /^[+\-]/,
+      peg$c385 = peg$classExpectation(["+", "-"], false, false),
+      peg$c386 = /^[0-9a-fA-F]/,
+      peg$c387 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c388 = "\"",
+      peg$c389 = peg$literalExpectation("\"", false),
+      peg$c390 = function(v) { return joinChars(v) },
+      peg$c391 = "'",
+      peg$c392 = peg$literalExpectation("'", false),
+      peg$c393 = peg$anyExpectation(),
+      peg$c394 = function(s) { return s },
+      peg$c395 = function(head, tail) { return head + joinChars(tail) },
+      peg$c396 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c397 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c398 = "x",
+      peg$c399 = peg$literalExpectation("x", false),
+      peg$c400 = function() { return "\\" + text() },
+      peg$c401 = function() { return "'"},
+      peg$c402 = function() { return '"'},
+      peg$c403 = function() { return "\\"},
+      peg$c404 = "b",
+      peg$c405 = peg$literalExpectation("b", false),
+      peg$c406 = function() { return "\b" },
+      peg$c407 = "f",
+      peg$c408 = peg$literalExpectation("f", false),
+      peg$c409 = function() { return "\f" },
+      peg$c410 = "n",
+      peg$c411 = peg$literalExpectation("n", false),
+      peg$c412 = function() { return "\n" },
+      peg$c413 = "r",
+      peg$c414 = peg$literalExpectation("r", false),
+      peg$c415 = function() { return "\r" },
+      peg$c416 = "t",
+      peg$c417 = peg$literalExpectation("t", false),
+      peg$c418 = function() { return "\t" },
+      peg$c419 = "v",
+      peg$c420 = peg$literalExpectation("v", false),
+      peg$c421 = function() { return "\v" },
+      peg$c422 = function() { return "=" },
+      peg$c423 = function() { return "\\*" },
+      peg$c424 = "u",
+      peg$c425 = peg$literalExpectation("u", false),
+      peg$c426 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c424 = function(body) { return body },
-      peg$c425 = /^[^\/\\]/,
-      peg$c426 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c427 = "\\/",
-      peg$c428 = peg$literalExpectation("\\/", false),
-      peg$c429 = /^[\0-\x1F\\]/,
-      peg$c430 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c431 = peg$otherExpectation("whitespace"),
-      peg$c432 = "\t",
-      peg$c433 = peg$literalExpectation("\t", false),
-      peg$c434 = "\x0B",
-      peg$c435 = peg$literalExpectation("\x0B", false),
-      peg$c436 = "\f",
-      peg$c437 = peg$literalExpectation("\f", false),
-      peg$c438 = " ",
-      peg$c439 = peg$literalExpectation(" ", false),
-      peg$c440 = "\xA0",
-      peg$c441 = peg$literalExpectation("\xA0", false),
-      peg$c442 = "\uFEFF",
-      peg$c443 = peg$literalExpectation("\uFEFF", false),
-      peg$c444 = /^[\n\r\u2028\u2029]/,
-      peg$c445 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c446 = peg$otherExpectation("comment"),
-      peg$c451 = "//",
-      peg$c452 = peg$literalExpectation("//", false),
+      peg$c427 = function(body) { return body },
+      peg$c428 = /^[^\/\\]/,
+      peg$c429 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c430 = "\\/",
+      peg$c431 = peg$literalExpectation("\\/", false),
+      peg$c432 = /^[\0-\x1F\\]/,
+      peg$c433 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c434 = peg$otherExpectation("whitespace"),
+      peg$c435 = "\t",
+      peg$c436 = peg$literalExpectation("\t", false),
+      peg$c437 = "\x0B",
+      peg$c438 = peg$literalExpectation("\x0B", false),
+      peg$c439 = "\f",
+      peg$c440 = peg$literalExpectation("\f", false),
+      peg$c441 = " ",
+      peg$c442 = peg$literalExpectation(" ", false),
+      peg$c443 = "\xA0",
+      peg$c444 = peg$literalExpectation("\xA0", false),
+      peg$c445 = "\uFEFF",
+      peg$c446 = peg$literalExpectation("\uFEFF", false),
+      peg$c447 = /^[\n\r\u2028\u2029]/,
+      peg$c448 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c449 = peg$otherExpectation("comment"),
+      peg$c454 = "//",
+      peg$c455 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -3284,21 +3287,24 @@ function peg$parse(input, options) {
   }
 
   function peg$parseAggregation() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    s1 = peg$parseEveryDur();
-    if (s1 === peg$FAILED) {
-      s1 = null;
-    }
+    s1 = peg$parseSummarize();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseGroupByKeys();
+      s2 = peg$parseEveryDur();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseLimitArg();
+        s3 = peg$parseGroupByKeys();
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c82(s1, s2, s3);
-          s0 = s1;
+          s4 = peg$parseLimitArg();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c82(s2, s3, s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -3313,37 +3319,40 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseEveryDur();
-      if (s1 === peg$FAILED) {
-        s1 = null;
-      }
+      s1 = peg$parseSummarize();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseReducers();
+        s2 = peg$parseEveryDur();
         if (s2 !== peg$FAILED) {
-          s3 = peg$currPos;
-          s4 = peg$parse_();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseGroupByKeys();
-            if (s5 !== peg$FAILED) {
-              s4 = [s4, s5];
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-          if (s3 === peg$FAILED) {
-            s3 = null;
-          }
+          s3 = peg$parseReducers();
           if (s3 !== peg$FAILED) {
-            s4 = peg$parseLimitArg();
+            s4 = peg$currPos;
+            s5 = peg$parse_();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parseGroupByKeys();
+              if (s6 !== peg$FAILED) {
+                s5 = [s5, s6];
+                s4 = s5;
+              } else {
+                peg$currPos = s4;
+                s4 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$FAILED;
+            }
+            if (s4 === peg$FAILED) {
+              s4 = null;
+            }
             if (s4 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c83(s1, s2, s3, s4);
-              s0 = s1;
+              s5 = peg$parseLimitArg();
+              if (s5 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c83(s2, s3, s4, s5);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -3365,16 +3374,47 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseSummarize() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 9) === peg$c84) {
+      s1 = peg$c84;
+      peg$currPos += 9;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c85); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s1 = [s1, s2];
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$c86;
+    }
+
+    return s0;
+  }
+
   function peg$parseEveryDur() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c84) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c87) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c85); }
+      if (peg$silentFails === 0) { peg$fail(peg$c88); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3384,7 +3424,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c86(s3);
+            s1 = peg$c89(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3402,6 +3442,15 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$c86;
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c90();
+      }
+      s0 = s1;
+    }
 
     return s0;
   }
@@ -3417,7 +3466,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c87(s3);
+          s1 = peg$c91(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3441,22 +3490,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c88) {
-        s2 = peg$c88;
+      if (input.substr(peg$currPos, 4) === peg$c92) {
+        s2 = peg$c92;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c89); }
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c90) {
-            s4 = peg$c90;
+          if (input.substr(peg$currPos, 6) === peg$c94) {
+            s4 = peg$c94;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c91); }
+            if (peg$silentFails === 0) { peg$fail(peg$c95); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -3464,7 +3513,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c92(s6);
+                s1 = peg$c96(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3492,10 +3541,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c93;
+      s1 = peg$c86;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c94();
+        s1 = peg$c97();
       }
       s0 = s1;
     }
@@ -3512,7 +3561,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c95(s1);
+        s1 = peg$c98(s1);
       }
       s0 = s1;
     }
@@ -3543,7 +3592,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c96(s1, s7);
+              s4 = peg$c99(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3579,7 +3628,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c96(s1, s7);
+                s4 = peg$c99(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3635,7 +3684,7 @@ function peg$parse(input, options) {
             s5 = peg$parseReducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c97(s1, s5);
+              s1 = peg$c100(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3662,7 +3711,7 @@ function peg$parse(input, options) {
       s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c98(s1);
+        s1 = peg$c101(s1);
       }
       s0 = s1;
     }
@@ -3720,11 +3769,11 @@ function peg$parse(input, options) {
                     s11 = peg$parse__();
                     if (s11 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 46) {
-                        s12 = peg$c99;
+                        s12 = peg$c102;
                         peg$currPos++;
                       } else {
                         s12 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c103); }
                       }
                       if (s12 !== peg$FAILED) {
                         s11 = [s11, s12];
@@ -3751,7 +3800,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c101(s2, s6, s10);
+                        s1 = peg$c104(s2, s6, s10);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3817,12 +3866,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c102) {
-        s2 = peg$c102;
+      if (input.substr(peg$currPos, 5) === peg$c105) {
+        s2 = peg$c105;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3930,7 +3979,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c107(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3995,12 +4044,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c105) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c108) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c106); }
+      if (peg$silentFails === 0) { peg$fail(peg$c109); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -4011,7 +4060,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c107(s2, s5);
+            s4 = peg$c110(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -4026,7 +4075,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c108(s2, s3);
+          s1 = peg$c111(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4086,7 +4135,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c109(s1);
+      s1 = peg$c112(s1);
     }
     s0 = s1;
 
@@ -4097,45 +4146,45 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c110) {
-      s1 = peg$c110;
+    if (input.substr(peg$currPos, 2) === peg$c113) {
+      s1 = peg$c113;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c111); }
+      if (peg$silentFails === 0) { peg$fail(peg$c114); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c112();
+      s1 = peg$c115();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c113) {
-        s1 = peg$c113;
+      if (input.substr(peg$currPos, 6) === peg$c116) {
+        s1 = peg$c116;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c114); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c115) {
-            s4 = peg$c115;
+          if (input.substr(peg$currPos, 5) === peg$c118) {
+            s4 = peg$c118;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c116); }
+            if (peg$silentFails === 0) { peg$fail(peg$c119); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c117) {
-              s4 = peg$c117;
+            if (input.substr(peg$currPos, 4) === peg$c120) {
+              s4 = peg$c120;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c118); }
+              if (peg$silentFails === 0) { peg$fail(peg$c121); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -4145,7 +4194,7 @@ function peg$parse(input, options) {
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c119(s3);
+            s1 = peg$c122(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4168,12 +4217,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c120) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c123) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c121); }
+      if (peg$silentFails === 0) { peg$fail(peg$c124); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4182,7 +4231,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c122(s4);
+          s3 = peg$c125(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4199,12 +4248,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c123) {
-            s5 = peg$c123;
+          if (input.substr(peg$currPos, 6) === peg$c126) {
+            s5 = peg$c126;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c124); }
+            if (peg$silentFails === 0) { peg$fail(peg$c127); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -4227,7 +4276,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c125(s2, s3, s6);
+              s5 = peg$c128(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -4242,7 +4291,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c126(s2, s3, s4);
+            s1 = peg$c129(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4268,44 +4317,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c127) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c130) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c128); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseFlexAssignments();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c129(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsePickProc() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c130) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c131); }
@@ -4334,7 +4348,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseDropProc() {
+  function peg$parsePickProc() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -4348,10 +4362,45 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseFieldExprs();
+        s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$c135(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseDropProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c136) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c137); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseFieldExprs();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c138(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4373,12 +4422,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c136) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c137); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4386,7 +4435,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c138(s3);
+          s1 = peg$c141(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4402,16 +4451,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c136) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c137); }
+        if (peg$silentFails === 0) { peg$fail(peg$c140); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c139();
+        s1 = peg$c142();
       }
       s0 = s1;
     }
@@ -4423,12 +4472,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c140) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c143) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c144); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4436,7 +4485,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c142(s3);
+          s1 = peg$c145(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4452,16 +4501,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c140) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c143) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c141); }
+        if (peg$silentFails === 0) { peg$fail(peg$c144); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c143();
+        s1 = peg$c146();
       }
       s0 = s1;
     }
@@ -4473,12 +4522,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c144) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c147) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c145); }
+      if (peg$silentFails === 0) { peg$fail(peg$c148); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4486,7 +4535,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFilter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c146(s3);
+          s1 = peg$c149(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4522,26 +4571,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c147) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c151); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c149) {
-          s3 = peg$c149;
+        if (input.substr(peg$currPos, 2) === peg$c152) {
+          s3 = peg$c152;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c150); }
+          if (peg$silentFails === 0) { peg$fail(peg$c153); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c151();
+          s1 = peg$c154();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4557,16 +4606,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c147) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c148); }
+        if (peg$silentFails === 0) { peg$fail(peg$c151); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c152();
+        s1 = peg$c155();
       }
       s0 = s1;
     }
@@ -4578,12 +4627,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c153) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c156) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c154); }
+      if (peg$silentFails === 0) { peg$fail(peg$c157); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4591,7 +4640,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c155(s3);
+          s1 = peg$c158(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4613,12 +4662,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c156) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c159) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+      if (peg$silentFails === 0) { peg$fail(peg$c160); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4642,7 +4691,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c158(s3, s9);
+                  s6 = peg$c161(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -4678,7 +4727,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c158(s3, s9);
+                    s6 = peg$c161(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -4699,7 +4748,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c159(s3, s4);
+            s1 = peg$c162(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4725,12 +4774,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c160) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c163) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c161); }
+      if (peg$silentFails === 0) { peg$fail(peg$c164); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4765,7 +4814,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c162();
+        s1 = peg$c165();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4783,12 +4832,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c163) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c166) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c164); }
+      if (peg$silentFails === 0) { peg$fail(peg$c167); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4829,7 +4878,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c165(s3, s7, s8);
+                    s1 = peg$c168(s3, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4865,12 +4914,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c163) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c166) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c164); }
+        if (peg$silentFails === 0) { peg$fail(peg$c167); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4897,7 +4946,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c166(s3, s4);
+              s1 = peg$c169(s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4968,18 +5017,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c167) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c170) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c168); }
+      if (peg$silentFails === 0) { peg$fail(peg$c171); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseTasteExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c169(s2);
+        s1 = peg$c172(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5002,7 +5051,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s2);
+        s1 = peg$c173(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5014,10 +5063,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c93;
+      s1 = peg$c86;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c171();
+        s1 = peg$c174();
       }
       s0 = s1;
     }
@@ -5103,7 +5152,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c172(s1, s2);
+        s1 = peg$c175(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5195,7 +5244,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c172(s1, s2);
+        s1 = peg$c175(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5230,7 +5279,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c173(s1, s5);
+              s1 = peg$c176(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5273,11 +5322,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c174;
+          s3 = peg$c177;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c175); }
+          if (peg$silentFails === 0) { peg$fail(peg$c178); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -5299,7 +5348,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c176(s1, s5, s9);
+                      s1 = peg$c179(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -5525,7 +5574,7 @@ function peg$parse(input, options) {
             s7 = peg$parseRelativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c177(s1, s5, s7);
+              s4 = peg$c180(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5555,7 +5604,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c177(s1, s5, s7);
+                s4 = peg$c180(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5858,19 +5907,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c178;
+      s1 = peg$c181;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c179); }
+      if (peg$silentFails === 0) { peg$fail(peg$c182); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c180;
+        s1 = peg$c183;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c181); }
+        if (peg$silentFails === 0) { peg$fail(peg$c184); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -5977,11 +6026,11 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c182;
+        s1 = peg$c185;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c186); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -6010,7 +6059,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c184(s3);
+          s1 = peg$c187(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6161,28 +6210,28 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c185) {
-      s0 = peg$c185;
+    if (input.substr(peg$currPos, 3) === peg$c188) {
+      s0 = peg$c188;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c186); }
+      if (peg$silentFails === 0) { peg$fail(peg$c189); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c187) {
-        s0 = peg$c187;
+      if (input.substr(peg$currPos, 5) === peg$c190) {
+        s0 = peg$c190;
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c188); }
+        if (peg$silentFails === 0) { peg$fail(peg$c191); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c189) {
-          s0 = peg$c189;
+        if (input.substr(peg$currPos, 6) === peg$c192) {
+          s0 = peg$c192;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c190); }
+          if (peg$silentFails === 0) { peg$fail(peg$c193); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -6203,12 +6252,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c187) {
-      s1 = peg$c187;
+    if (input.substr(peg$currPos, 5) === peg$c190) {
+      s1 = peg$c190;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c188); }
+      if (peg$silentFails === 0) { peg$fail(peg$c191); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -6262,12 +6311,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c189) {
-      s1 = peg$c189;
+    if (input.substr(peg$currPos, 6) === peg$c192) {
+      s1 = peg$c192;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c190); }
+      if (peg$silentFails === 0) { peg$fail(peg$c193); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -6299,11 +6348,11 @@ function peg$parse(input, options) {
                   s10 = peg$parse__();
                   if (s10 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 46) {
-                      s11 = peg$c99;
+                      s11 = peg$c102;
                       peg$currPos++;
                     } else {
                       s11 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c103); }
                     }
                     if (s11 !== peg$FAILED) {
                       s12 = peg$parse__();
@@ -6311,7 +6360,7 @@ function peg$parse(input, options) {
                         s13 = peg$parseFunction();
                         if (s13 !== peg$FAILED) {
                           peg$savedPos = s9;
-                          s10 = peg$c191(s5, s13);
+                          s10 = peg$c194(s5, s13);
                           s9 = s10;
                         } else {
                           peg$currPos = s9;
@@ -6335,11 +6384,11 @@ function peg$parse(input, options) {
                     s10 = peg$parse__();
                     if (s10 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 46) {
-                        s11 = peg$c99;
+                        s11 = peg$c102;
                         peg$currPos++;
                       } else {
                         s11 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c103); }
                       }
                       if (s11 !== peg$FAILED) {
                         s12 = peg$parse__();
@@ -6347,7 +6396,7 @@ function peg$parse(input, options) {
                           s13 = peg$parseFunction();
                           if (s13 !== peg$FAILED) {
                             peg$savedPos = s9;
-                            s10 = peg$c191(s5, s13);
+                            s10 = peg$c194(s5, s13);
                             s9 = s10;
                           } else {
                             peg$currPos = s9;
@@ -6368,7 +6417,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c192(s5, s8);
+                    s1 = peg$c195(s5, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6448,7 +6497,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c193(s2, s6);
+                    s1 = peg$c196(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6509,7 +6558,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c194(s1, s7);
+              s4 = peg$c197(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6545,7 +6594,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c194(s1, s7);
+                s4 = peg$c197(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6581,7 +6630,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c195();
+        s1 = peg$c198();
       }
       s0 = s1;
     }
@@ -6638,15 +6687,15 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s1 = peg$c99;
+          s1 = peg$c102;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c100); }
+          if (peg$silentFails === 0) { peg$fail(peg$c103); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c196();
+          s1 = peg$c199();
         }
         s0 = s1;
       }
@@ -6660,17 +6709,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c99;
+      s1 = peg$c102;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+      if (peg$silentFails === 0) { peg$fail(peg$c103); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c197(s2);
+        s1 = peg$c200(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6683,33 +6732,33 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c99;
+        s1 = peg$c102;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c100); }
+        if (peg$silentFails === 0) { peg$fail(peg$c103); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c198;
+          s2 = peg$c201;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c199); }
+          if (peg$silentFails === 0) { peg$fail(peg$c202); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parseConditionalExpr();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c200;
+              s4 = peg$c203;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c201); }
+              if (peg$silentFails === 0) { peg$fail(peg$c204); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c202(s3);
+              s1 = peg$c205(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6737,11 +6786,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c198;
+      s1 = peg$c201;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c199); }
+      if (peg$silentFails === 0) { peg$fail(peg$c202); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseAdditiveExpr();
@@ -6761,15 +6810,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c200;
+                  s7 = peg$c203;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c201); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c204); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c203(s2, s6);
+                  s1 = peg$c206(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6802,11 +6851,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c198;
+        s1 = peg$c201;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c199); }
+        if (peg$silentFails === 0) { peg$fail(peg$c202); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -6824,15 +6873,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c200;
+                  s6 = peg$c203;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c201); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c204); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c204(s5);
+                  s1 = peg$c207(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6861,11 +6910,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c198;
+          s1 = peg$c201;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c199); }
+          if (peg$silentFails === 0) { peg$fail(peg$c202); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseAdditiveExpr();
@@ -6883,15 +6932,15 @@ function peg$parse(input, options) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c200;
+                    s6 = peg$c203;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c201); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c204); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c205(s2);
+                    s1 = peg$c208(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6920,25 +6969,25 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c198;
+            s1 = peg$c201;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c199); }
+            if (peg$silentFails === 0) { peg$fail(peg$c202); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c200;
+                s3 = peg$c203;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c201); }
+                if (peg$silentFails === 0) { peg$fail(peg$c204); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c206(s2);
+                s1 = peg$c209(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6955,21 +7004,21 @@ function peg$parse(input, options) {
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 46) {
-              s1 = peg$c99;
+              s1 = peg$c102;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c100); }
+              if (peg$silentFails === 0) { peg$fail(peg$c103); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$currPos;
               peg$silentFails++;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s3 = peg$c99;
+                s3 = peg$c102;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                if (peg$silentFails === 0) { peg$fail(peg$c103); }
               }
               peg$silentFails--;
               if (s3 === peg$FAILED) {
@@ -6982,7 +7031,7 @@ function peg$parse(input, options) {
                 s3 = peg$parseIdentifier();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c207(s3);
+                  s1 = peg$c210(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7124,7 +7173,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c208(s1);
+        s1 = peg$c211(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7156,7 +7205,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c209(s1);
+        s1 = peg$c212(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7171,7 +7220,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c209(s1);
+        s1 = peg$c212(s1);
       }
       s0 = s1;
     }
@@ -7197,7 +7246,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c210(s1);
+        s1 = peg$c213(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7212,7 +7261,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c210(s1);
+        s1 = peg$c213(s1);
       }
       s0 = s1;
     }
@@ -7227,7 +7276,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c211(s1);
+      s1 = peg$c214(s1);
     }
     s0 = s1;
 
@@ -7241,7 +7290,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c212(s1);
+      s1 = peg$c215(s1);
     }
     s0 = s1;
 
@@ -7252,30 +7301,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c213) {
-      s1 = peg$c213;
+    if (input.substr(peg$currPos, 4) === peg$c216) {
+      s1 = peg$c216;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c214); }
+      if (peg$silentFails === 0) { peg$fail(peg$c217); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c215();
+      s1 = peg$c218();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c216) {
-        s1 = peg$c216;
+      if (input.substr(peg$currPos, 5) === peg$c219) {
+        s1 = peg$c219;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c217); }
+        if (peg$silentFails === 0) { peg$fail(peg$c220); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c218();
+        s1 = peg$c221();
       }
       s0 = s1;
     }
@@ -7287,16 +7336,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c219) {
-      s1 = peg$c219;
+    if (input.substr(peg$currPos, 4) === peg$c222) {
+      s1 = peg$c222;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c220); }
+      if (peg$silentFails === 0) { peg$fail(peg$c223); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c221();
+      s1 = peg$c224();
     }
     s0 = s1;
 
@@ -7310,7 +7359,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeExternal();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c222(s1);
+      s1 = peg$c225(s1);
     }
     s0 = s1;
 
@@ -7365,7 +7414,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c223(s5);
+                  s1 = peg$c226(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7430,7 +7479,7 @@ function peg$parse(input, options) {
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c224(s5);
+                    s1 = peg$c227(s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7478,7 +7527,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c224(s1);
+              s1 = peg$c227(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7510,16 +7559,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c219) {
-      s1 = peg$c219;
+    if (input.substr(peg$currPos, 4) === peg$c222) {
+      s1 = peg$c222;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c220); }
+      if (peg$silentFails === 0) { peg$fail(peg$c223); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c225();
+      s1 = peg$c228();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7563,7 +7612,7 @@ function peg$parse(input, options) {
                         }
                         if (s9 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c226(s1, s7);
+                          s1 = peg$c229(s1, s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7606,7 +7655,7 @@ function peg$parse(input, options) {
           s1 = peg$parseIdentifierName();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c227(s1);
+            s1 = peg$c230(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -7632,7 +7681,7 @@ function peg$parse(input, options) {
                   }
                   if (s4 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c228(s3);
+                    s1 = peg$c231(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7665,7 +7714,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c229(s1);
+      s1 = peg$c232(s1);
     }
     s0 = s1;
 
@@ -7690,7 +7739,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c230(s1, s2);
+        s1 = peg$c233(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7723,7 +7772,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c224(s4);
+            s1 = peg$c227(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7750,11 +7799,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c231;
+      s1 = peg$c234;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c232); }
+      if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7764,15 +7813,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c233;
+              s5 = peg$c236;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c234); }
+              if (peg$silentFails === 0) { peg$fail(peg$c237); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c235(s3);
+              s1 = peg$c238(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7797,11 +7846,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c198;
+        s1 = peg$c201;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c199); }
+        if (peg$silentFails === 0) { peg$fail(peg$c202); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7811,15 +7860,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c200;
+                s5 = peg$c203;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c201); }
+                if (peg$silentFails === 0) { peg$fail(peg$c204); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c236(s3);
+                s1 = peg$c239(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7843,12 +7892,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c237) {
-          s1 = peg$c237;
+        if (input.substr(peg$currPos, 2) === peg$c240) {
+          s1 = peg$c240;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c238); }
+          if (peg$silentFails === 0) { peg$fail(peg$c241); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -7857,16 +7906,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c239) {
-                  s5 = peg$c239;
+                if (input.substr(peg$currPos, 2) === peg$c242) {
+                  s5 = peg$c242;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c240); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c243); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c241(s3);
+                  s1 = peg$c244(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7890,12 +7939,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c242) {
-            s1 = peg$c242;
+          if (input.substr(peg$currPos, 2) === peg$c245) {
+            s1 = peg$c245;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c243); }
+            if (peg$silentFails === 0) { peg$fail(peg$c246); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -7918,16 +7967,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c244) {
-                            s9 = peg$c244;
+                          if (input.substr(peg$currPos, 2) === peg$c247) {
+                            s9 = peg$c247;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c245); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c248); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c246(s3, s7);
+                            s1 = peg$c249(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7987,92 +8036,92 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c247) {
-      s1 = peg$c247;
+    if (input.substr(peg$currPos, 5) === peg$c250) {
+      s1 = peg$c250;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c248); }
+      if (peg$silentFails === 0) { peg$fail(peg$c251); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c249) {
-        s1 = peg$c249;
+      if (input.substr(peg$currPos, 6) === peg$c252) {
+        s1 = peg$c252;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c250); }
+        if (peg$silentFails === 0) { peg$fail(peg$c253); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c251) {
-          s1 = peg$c251;
+        if (input.substr(peg$currPos, 6) === peg$c254) {
+          s1 = peg$c254;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c252); }
+          if (peg$silentFails === 0) { peg$fail(peg$c255); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c253) {
-            s1 = peg$c253;
+          if (input.substr(peg$currPos, 6) === peg$c256) {
+            s1 = peg$c256;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c254); }
+            if (peg$silentFails === 0) { peg$fail(peg$c257); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c255) {
-              s1 = peg$c255;
+            if (input.substr(peg$currPos, 4) === peg$c258) {
+              s1 = peg$c258;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c256); }
+              if (peg$silentFails === 0) { peg$fail(peg$c259); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c257) {
-                s1 = peg$c257;
+              if (input.substr(peg$currPos, 5) === peg$c260) {
+                s1 = peg$c260;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c258); }
+                if (peg$silentFails === 0) { peg$fail(peg$c261); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c259) {
-                  s1 = peg$c259;
+                if (input.substr(peg$currPos, 5) === peg$c262) {
+                  s1 = peg$c262;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c260); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c263); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c261) {
-                    s1 = peg$c261;
+                  if (input.substr(peg$currPos, 5) === peg$c264) {
+                    s1 = peg$c264;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c262); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c265); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c263) {
-                      s1 = peg$c263;
+                    if (input.substr(peg$currPos, 7) === peg$c266) {
+                      s1 = peg$c266;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c267); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c265) {
-                        s1 = peg$c265;
+                      if (input.substr(peg$currPos, 4) === peg$c268) {
+                        s1 = peg$c268;
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c269); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 6) === peg$c267) {
-                          s1 = peg$c267;
+                        if (input.substr(peg$currPos, 6) === peg$c270) {
+                          s1 = peg$c270;
                           peg$currPos += 6;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c268); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c271); }
                         }
                       }
                     }
@@ -8086,7 +8135,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c269();
+      s1 = peg$c272();
     }
     s0 = s1;
 
@@ -8097,52 +8146,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c270) {
-      s1 = peg$c270;
+    if (input.substr(peg$currPos, 8) === peg$c273) {
+      s1 = peg$c273;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c271); }
+      if (peg$silentFails === 0) { peg$fail(peg$c274); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c272) {
-        s1 = peg$c272;
+      if (input.substr(peg$currPos, 4) === peg$c275) {
+        s1 = peg$c275;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c273); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c274) {
-          s1 = peg$c274;
+        if (input.substr(peg$currPos, 5) === peg$c277) {
+          s1 = peg$c277;
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c275); }
+          if (peg$silentFails === 0) { peg$fail(peg$c278); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7) === peg$c276) {
-            s1 = peg$c276;
+          if (input.substr(peg$currPos, 7) === peg$c279) {
+            s1 = peg$c279;
             peg$currPos += 7;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c277); }
+            if (peg$silentFails === 0) { peg$fail(peg$c280); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c278) {
-              s1 = peg$c278;
+            if (input.substr(peg$currPos, 2) === peg$c281) {
+              s1 = peg$c281;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c279); }
+              if (peg$silentFails === 0) { peg$fail(peg$c282); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c280) {
-                s1 = peg$c280;
+              if (input.substr(peg$currPos, 3) === peg$c283) {
+                s1 = peg$c283;
                 peg$currPos += 3;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c281); }
+                if (peg$silentFails === 0) { peg$fail(peg$c284); }
               }
               if (s1 === peg$FAILED) {
                 if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -8153,12 +8202,12 @@ function peg$parse(input, options) {
                   if (peg$silentFails === 0) { peg$fail(peg$c11); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c282) {
-                    s1 = peg$c282;
+                  if (input.substr(peg$currPos, 5) === peg$c285) {
+                    s1 = peg$c285;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c283); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c286); }
                   }
                 }
               }
@@ -8169,7 +8218,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c269();
+      s1 = peg$c272();
     }
     s0 = s1;
 
@@ -8190,7 +8239,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c230(s1, s2);
+        s1 = peg$c233(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8223,7 +8272,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c224(s4);
+            s1 = peg$c227(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8266,7 +8315,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c284(s1, s5);
+              s1 = peg$c287(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8307,16 +8356,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c285) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c288) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c289); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c287();
+      s1 = peg$c290();
     }
     s0 = s1;
 
@@ -8327,16 +8376,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c288) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c291) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c289); }
+      if (peg$silentFails === 0) { peg$fail(peg$c292); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c290();
+      s1 = peg$c293();
     }
     s0 = s1;
 
@@ -8352,11 +8401,11 @@ function peg$parse(input, options) {
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c291); }
+      if (peg$silentFails === 0) { peg$fail(peg$c294); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c292();
+      s1 = peg$c295();
     }
     s0 = s1;
 
@@ -8367,29 +8416,9 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c185) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c188) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c293); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c294();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseByToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c295) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c296); }
@@ -8403,15 +8432,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseByToken() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c298) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c299); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c300();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c298.test(input.charAt(peg$currPos))) {
+    if (peg$c301.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c299); }
+      if (peg$silentFails === 0) { peg$fail(peg$c302); }
     }
 
     return s0;
@@ -8422,12 +8471,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c300.test(input.charAt(peg$currPos))) {
+      if (peg$c303.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c301); }
+        if (peg$silentFails === 0) { peg$fail(peg$c304); }
       }
     }
 
@@ -8441,7 +8490,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c302(s1);
+      s1 = peg$c305(s1);
     }
     s0 = s1;
 
@@ -8496,7 +8545,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c303();
+          s1 = peg$c306();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8513,11 +8562,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c304;
+        s1 = peg$c307;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c305); }
+        if (peg$silentFails === 0) { peg$fail(peg$c308); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -8527,17 +8576,17 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c306;
+          s1 = peg$c309;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c307); }
+          if (peg$silentFails === 0) { peg$fail(peg$c310); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIdGuard();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c308(s2);
+            s1 = peg$c311(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8599,12 +8648,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c285) {
-                s3 = peg$c285;
+              if (input.substr(peg$currPos, 3) === peg$c288) {
+                s3 = peg$c288;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c309); }
+                if (peg$silentFails === 0) { peg$fail(peg$c312); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -8649,44 +8698,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c310) {
-      s0 = peg$c310;
+    if (input.substr(peg$currPos, 7) === peg$c313) {
+      s0 = peg$c313;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c311); }
+      if (peg$silentFails === 0) { peg$fail(peg$c314); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c312) {
-        s0 = peg$c312;
+      if (input.substr(peg$currPos, 6) === peg$c315) {
+        s0 = peg$c315;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c313); }
+        if (peg$silentFails === 0) { peg$fail(peg$c316); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c314) {
-          s0 = peg$c314;
+        if (input.substr(peg$currPos, 4) === peg$c317) {
+          s0 = peg$c317;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c315); }
+          if (peg$silentFails === 0) { peg$fail(peg$c318); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c316) {
-            s0 = peg$c316;
+          if (input.substr(peg$currPos, 3) === peg$c319) {
+            s0 = peg$c319;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c317); }
+            if (peg$silentFails === 0) { peg$fail(peg$c320); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c318;
+              s0 = peg$c321;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c319); }
+              if (peg$silentFails === 0) { peg$fail(peg$c322); }
             }
           }
         }
@@ -8699,44 +8748,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c320) {
-      s0 = peg$c320;
+    if (input.substr(peg$currPos, 7) === peg$c323) {
+      s0 = peg$c323;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c321); }
+      if (peg$silentFails === 0) { peg$fail(peg$c324); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c322) {
-        s0 = peg$c322;
+      if (input.substr(peg$currPos, 6) === peg$c325) {
+        s0 = peg$c325;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c323); }
+        if (peg$silentFails === 0) { peg$fail(peg$c326); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c324) {
-          s0 = peg$c324;
+        if (input.substr(peg$currPos, 4) === peg$c327) {
+          s0 = peg$c327;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c325); }
+          if (peg$silentFails === 0) { peg$fail(peg$c328); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c326) {
-            s0 = peg$c326;
+          if (input.substr(peg$currPos, 3) === peg$c329) {
+            s0 = peg$c329;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c327); }
+            if (peg$silentFails === 0) { peg$fail(peg$c330); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c328;
+              s0 = peg$c331;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c329); }
+              if (peg$silentFails === 0) { peg$fail(peg$c332); }
             }
           }
         }
@@ -8749,44 +8798,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c330) {
-      s0 = peg$c330;
+    if (input.substr(peg$currPos, 5) === peg$c333) {
+      s0 = peg$c333;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c331); }
+      if (peg$silentFails === 0) { peg$fail(peg$c334); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c332) {
-        s0 = peg$c332;
+      if (input.substr(peg$currPos, 3) === peg$c335) {
+        s0 = peg$c335;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c333); }
+        if (peg$silentFails === 0) { peg$fail(peg$c336); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c334) {
-          s0 = peg$c334;
+        if (input.substr(peg$currPos, 2) === peg$c337) {
+          s0 = peg$c337;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c335); }
+          if (peg$silentFails === 0) { peg$fail(peg$c338); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c336;
+            s0 = peg$c339;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c337); }
+            if (peg$silentFails === 0) { peg$fail(peg$c340); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c338) {
-              s0 = peg$c338;
+            if (input.substr(peg$currPos, 4) === peg$c341) {
+              s0 = peg$c341;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c339); }
+              if (peg$silentFails === 0) { peg$fail(peg$c342); }
             }
           }
         }
@@ -8799,28 +8848,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c340) {
-      s0 = peg$c340;
+    if (input.substr(peg$currPos, 4) === peg$c343) {
+      s0 = peg$c343;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
+      if (peg$silentFails === 0) { peg$fail(peg$c344); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c342) {
-        s0 = peg$c342;
+      if (input.substr(peg$currPos, 3) === peg$c345) {
+        s0 = peg$c345;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c343); }
+        if (peg$silentFails === 0) { peg$fail(peg$c346); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c344;
+          s0 = peg$c347;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c345); }
+          if (peg$silentFails === 0) { peg$fail(peg$c348); }
         }
       }
     }
@@ -8831,44 +8880,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c346) {
-      s0 = peg$c346;
+    if (input.substr(peg$currPos, 5) === peg$c349) {
+      s0 = peg$c349;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c350); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c348) {
-        s0 = peg$c348;
+      if (input.substr(peg$currPos, 4) === peg$c351) {
+        s0 = peg$c351;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c349); }
+        if (peg$silentFails === 0) { peg$fail(peg$c352); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c350) {
-          s0 = peg$c350;
+        if (input.substr(peg$currPos, 3) === peg$c353) {
+          s0 = peg$c353;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c351); }
+          if (peg$silentFails === 0) { peg$fail(peg$c354); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c352) {
-            s0 = peg$c352;
+          if (input.substr(peg$currPos, 2) === peg$c355) {
+            s0 = peg$c355;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c353); }
+            if (peg$silentFails === 0) { peg$fail(peg$c356); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c354;
+              s0 = peg$c357;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c355); }
+              if (peg$silentFails === 0) { peg$fail(peg$c358); }
             }
           }
         }
@@ -8882,16 +8931,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c312) {
-      s1 = peg$c312;
+    if (input.substr(peg$currPos, 6) === peg$c315) {
+      s1 = peg$c315;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c313); }
+      if (peg$silentFails === 0) { peg$fail(peg$c316); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c356();
+      s1 = peg$c359();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -8903,7 +8952,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c357(s1);
+            s1 = peg$c360(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8926,16 +8975,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c322) {
-      s1 = peg$c322;
+    if (input.substr(peg$currPos, 6) === peg$c325) {
+      s1 = peg$c325;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c323); }
+      if (peg$silentFails === 0) { peg$fail(peg$c326); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c358();
+      s1 = peg$c361();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -8947,7 +8996,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c359(s1);
+            s1 = peg$c362(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8970,16 +9019,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c338) {
-      s1 = peg$c338;
+    if (input.substr(peg$currPos, 4) === peg$c341) {
+      s1 = peg$c341;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c339); }
+      if (peg$silentFails === 0) { peg$fail(peg$c342); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c360();
+      s1 = peg$c363();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -8991,7 +9040,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c361(s1);
+            s1 = peg$c364(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9014,16 +9063,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c342) {
-      s1 = peg$c342;
+    if (input.substr(peg$currPos, 3) === peg$c345) {
+      s1 = peg$c345;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c346); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c365();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -9035,7 +9084,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c363(s1);
+            s1 = peg$c366(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9058,16 +9107,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c348) {
-      s1 = peg$c348;
+    if (input.substr(peg$currPos, 4) === peg$c351) {
+      s1 = peg$c351;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c349); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c364();
+      s1 = peg$c367();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -9079,7 +9128,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c365(s1);
+            s1 = peg$c368(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9105,31 +9154,31 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c99;
+        s2 = peg$c102;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c100); }
+        if (peg$silentFails === 0) { peg$fail(peg$c103); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c99;
+            s4 = peg$c102;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c100); }
+            if (peg$silentFails === 0) { peg$fail(peg$c103); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c99;
+                s6 = peg$c102;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                if (peg$silentFails === 0) { peg$fail(peg$c103); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
@@ -9269,7 +9318,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c366(s1, s2);
+        s1 = peg$c369(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9290,12 +9339,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c367) {
-            s3 = peg$c367;
+          if (input.substr(peg$currPos, 2) === peg$c370) {
+            s3 = peg$c370;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c368); }
+            if (peg$silentFails === 0) { peg$fail(peg$c371); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -9308,7 +9357,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c369(s1, s2, s4, s5);
+                s1 = peg$c372(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9332,12 +9381,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c367) {
-          s1 = peg$c367;
+        if (input.substr(peg$currPos, 2) === peg$c370) {
+          s1 = peg$c370;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c368); }
+          if (peg$silentFails === 0) { peg$fail(peg$c371); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -9350,7 +9399,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c370(s2, s3);
+              s1 = peg$c373(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9375,16 +9424,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c367) {
-                s3 = peg$c367;
+              if (input.substr(peg$currPos, 2) === peg$c370) {
+                s3 = peg$c370;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c368); }
+                if (peg$silentFails === 0) { peg$fail(peg$c371); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c371(s1, s2);
+                s1 = peg$c374(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9400,16 +9449,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c367) {
-              s1 = peg$c367;
+            if (input.substr(peg$currPos, 2) === peg$c370) {
+              s1 = peg$c370;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c368); }
+              if (peg$silentFails === 0) { peg$fail(peg$c371); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c372();
+              s1 = peg$c375();
             }
             s0 = s1;
           }
@@ -9446,7 +9495,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c373(s2);
+        s1 = peg$c376(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9475,7 +9524,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c374(s1);
+        s1 = peg$c377(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9496,17 +9545,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c182;
+        s2 = peg$c185;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c186); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c375(s1, s3);
+          s1 = peg$c378(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9531,17 +9580,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c182;
+        s2 = peg$c185;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c186); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c376(s1, s3);
+          s1 = peg$c379(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9566,7 +9615,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c377(s1);
+      s1 = peg$c380(s1);
     }
     s0 = s1;
 
@@ -9589,22 +9638,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c300.test(input.charAt(peg$currPos))) {
+    if (peg$c303.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c301); }
+      if (peg$silentFails === 0) { peg$fail(peg$c304); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c300.test(input.charAt(peg$currPos))) {
+        if (peg$c303.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c301); }
+          if (peg$silentFails === 0) { peg$fail(peg$c304); }
         }
       }
     } else {
@@ -9624,11 +9673,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c180;
+      s1 = peg$c183;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c181); }
+      if (peg$silentFails === 0) { peg$fail(peg$c184); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -9653,33 +9702,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c180;
+      s1 = peg$c183;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c181); }
+      if (peg$silentFails === 0) { peg$fail(peg$c184); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c300.test(input.charAt(peg$currPos))) {
+      if (peg$c303.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c301); }
+        if (peg$silentFails === 0) { peg$fail(peg$c304); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c300.test(input.charAt(peg$currPos))) {
+          if (peg$c303.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c301); }
+            if (peg$silentFails === 0) { peg$fail(peg$c304); }
           }
         }
       } else {
@@ -9687,30 +9736,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c99;
+          s3 = peg$c102;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c100); }
+          if (peg$silentFails === 0) { peg$fail(peg$c103); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c300.test(input.charAt(peg$currPos))) {
+          if (peg$c303.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c301); }
+            if (peg$silentFails === 0) { peg$fail(peg$c304); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c300.test(input.charAt(peg$currPos))) {
+              if (peg$c303.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c301); }
+                if (peg$silentFails === 0) { peg$fail(peg$c304); }
               }
             }
           } else {
@@ -9723,7 +9772,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c378();
+              s1 = peg$c381();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9748,41 +9797,41 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c180;
+        s1 = peg$c183;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c181); }
+        if (peg$silentFails === 0) { peg$fail(peg$c184); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c99;
+          s2 = peg$c102;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c100); }
+          if (peg$silentFails === 0) { peg$fail(peg$c103); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c300.test(input.charAt(peg$currPos))) {
+          if (peg$c303.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c301); }
+            if (peg$silentFails === 0) { peg$fail(peg$c304); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c300.test(input.charAt(peg$currPos))) {
+              if (peg$c303.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c301); }
+                if (peg$silentFails === 0) { peg$fail(peg$c304); }
               }
             }
           } else {
@@ -9795,7 +9844,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c378();
+              s1 = peg$c381();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9822,20 +9871,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c379) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c382) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c380); }
+      if (peg$silentFails === 0) { peg$fail(peg$c383); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c381.test(input.charAt(peg$currPos))) {
+      if (peg$c384.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c382); }
+        if (peg$silentFails === 0) { peg$fail(peg$c385); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -9887,12 +9936,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c383.test(input.charAt(peg$currPos))) {
+    if (peg$c386.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c384); }
+      if (peg$silentFails === 0) { peg$fail(peg$c387); }
     }
 
     return s0;
@@ -9903,11 +9952,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c385;
+      s1 = peg$c388;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c386); }
+      if (peg$silentFails === 0) { peg$fail(peg$c389); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -9918,15 +9967,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c385;
+          s3 = peg$c388;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c386); }
+          if (peg$silentFails === 0) { peg$fail(peg$c389); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c387(s2);
+          s1 = peg$c390(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9943,11 +9992,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c388;
+        s1 = peg$c391;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c389); }
+        if (peg$silentFails === 0) { peg$fail(peg$c392); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -9958,15 +10007,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c388;
+            s3 = peg$c391;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c389); }
+            if (peg$silentFails === 0) { peg$fail(peg$c392); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c387(s2);
+            s1 = peg$c390(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9992,11 +10041,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c385;
+      s2 = peg$c388;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c386); }
+      if (peg$silentFails === 0) { peg$fail(peg$c389); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -10014,7 +10063,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c390); }
+        if (peg$silentFails === 0) { peg$fail(peg$c393); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -10031,17 +10080,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c306;
+        s1 = peg$c309;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c307); }
+        if (peg$silentFails === 0) { peg$fail(peg$c310); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c391(s2);
+          s1 = peg$c394(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10070,7 +10119,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c392(s1, s2);
+        s1 = peg$c395(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10088,12 +10137,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c393.test(input.charAt(peg$currPos))) {
+    if (peg$c396.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c394); }
+      if (peg$silentFails === 0) { peg$fail(peg$c397); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -10112,12 +10161,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c300.test(input.charAt(peg$currPos))) {
+      if (peg$c303.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c301); }
+        if (peg$silentFails === 0) { peg$fail(peg$c304); }
       }
     }
 
@@ -10129,11 +10178,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c306;
+      s1 = peg$c309;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c307); }
+      if (peg$silentFails === 0) { peg$fail(peg$c310); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -10142,7 +10191,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c391(s2);
+        s1 = peg$c394(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10163,11 +10212,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c388;
+      s2 = peg$c391;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+      if (peg$silentFails === 0) { peg$fail(peg$c392); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -10185,7 +10234,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c390); }
+        if (peg$silentFails === 0) { peg$fail(peg$c393); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -10202,17 +10251,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c306;
+        s1 = peg$c309;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c307); }
+        if (peg$silentFails === 0) { peg$fail(peg$c310); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c391(s2);
+          s1 = peg$c394(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10232,11 +10281,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c395;
+      s1 = peg$c398;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c396); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -10244,7 +10293,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c397();
+          s1 = peg$c400();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10273,127 +10322,127 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s1 = peg$c388;
+      s1 = peg$c391;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+      if (peg$silentFails === 0) { peg$fail(peg$c392); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c398();
+      s1 = peg$c401();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c385;
+        s1 = peg$c388;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c386); }
+        if (peg$silentFails === 0) { peg$fail(peg$c389); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c399();
+        s1 = peg$c402();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c306;
+          s1 = peg$c309;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c307); }
+          if (peg$silentFails === 0) { peg$fail(peg$c310); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c400();
+          s1 = peg$c403();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c401;
+            s1 = peg$c404;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c402); }
+            if (peg$silentFails === 0) { peg$fail(peg$c405); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c403();
+            s1 = peg$c406();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c404;
+              s1 = peg$c407;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c405); }
+              if (peg$silentFails === 0) { peg$fail(peg$c408); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c406();
+              s1 = peg$c409();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c407;
+                s1 = peg$c410;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c408); }
+                if (peg$silentFails === 0) { peg$fail(peg$c411); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c409();
+                s1 = peg$c412();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c410;
+                  s1 = peg$c413;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c411); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c414); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c412();
+                  s1 = peg$c415();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c413;
+                    s1 = peg$c416;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c414); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c417); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c415();
+                    s1 = peg$c418();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c416;
+                      s1 = peg$c419;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c417); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c420); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c418();
+                      s1 = peg$c421();
                     }
                     s0 = s1;
                   }
@@ -10421,7 +10470,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c419();
+      s1 = peg$c422();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -10435,16 +10484,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c420();
+        s1 = peg$c423();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c381.test(input.charAt(peg$currPos))) {
+        if (peg$c384.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c382); }
+          if (peg$silentFails === 0) { peg$fail(peg$c385); }
         }
       }
     }
@@ -10457,11 +10506,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c421;
+      s1 = peg$c424;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c422); }
+      if (peg$silentFails === 0) { peg$fail(peg$c425); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -10493,7 +10542,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c423(s2);
+        s1 = peg$c426(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10506,19 +10555,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c421;
+        s1 = peg$c424;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c422); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c231;
+          s2 = peg$c234;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c232); }
+          if (peg$silentFails === 0) { peg$fail(peg$c235); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -10577,15 +10626,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c233;
+              s4 = peg$c236;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c234); }
+              if (peg$silentFails === 0) { peg$fail(peg$c237); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c423(s3);
+              s1 = peg$c426(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10613,25 +10662,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c182;
+      s1 = peg$c185;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c182;
+          s3 = peg$c185;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c183); }
+          if (peg$silentFails === 0) { peg$fail(peg$c186); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c424(s2);
+          s1 = peg$c427(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10654,39 +10703,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c425.test(input.charAt(peg$currPos))) {
+    if (peg$c428.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+      if (peg$silentFails === 0) { peg$fail(peg$c429); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c427) {
-        s2 = peg$c427;
+      if (input.substr(peg$currPos, 2) === peg$c430) {
+        s2 = peg$c430;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c428); }
+        if (peg$silentFails === 0) { peg$fail(peg$c431); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c425.test(input.charAt(peg$currPos))) {
+        if (peg$c428.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c426); }
+          if (peg$silentFails === 0) { peg$fail(peg$c429); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c427) {
-            s2 = peg$c427;
+          if (input.substr(peg$currPos, 2) === peg$c430) {
+            s2 = peg$c430;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c428); }
+            if (peg$silentFails === 0) { peg$fail(peg$c431); }
           }
         }
       }
@@ -10705,12 +10754,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c429.test(input.charAt(peg$currPos))) {
+    if (peg$c432.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c430); }
+      if (peg$silentFails === 0) { peg$fail(peg$c433); }
     }
 
     return s0;
@@ -10768,7 +10817,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
 
     return s0;
@@ -10779,51 +10828,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c432;
+      s0 = peg$c435;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c433); }
+      if (peg$silentFails === 0) { peg$fail(peg$c436); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c434;
+        s0 = peg$c437;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c435); }
+        if (peg$silentFails === 0) { peg$fail(peg$c438); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c436;
+          s0 = peg$c439;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c437); }
+          if (peg$silentFails === 0) { peg$fail(peg$c440); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c438;
+            s0 = peg$c441;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c439); }
+            if (peg$silentFails === 0) { peg$fail(peg$c442); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c440;
+              s0 = peg$c443;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c441); }
+              if (peg$silentFails === 0) { peg$fail(peg$c444); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c442;
+                s0 = peg$c445;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c443); }
+                if (peg$silentFails === 0) { peg$fail(peg$c446); }
               }
             }
           }
@@ -10832,7 +10881,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c431); }
+      if (peg$silentFails === 0) { peg$fail(peg$c434); }
     }
 
     return s0;
@@ -10841,12 +10890,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c444.test(input.charAt(peg$currPos))) {
+    if (peg$c447.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c445); }
+      if (peg$silentFails === 0) { peg$fail(peg$c448); }
     }
 
     return s0;
@@ -10859,7 +10908,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c446); }
+      if (peg$silentFails === 0) { peg$fail(peg$c449); }
     }
 
     return s0;
@@ -10869,12 +10918,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c451) {
-      s1 = peg$c451;
+    if (input.substr(peg$currPos, 2) === peg$c454) {
+      s1 = peg$c454;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c452); }
+      if (peg$silentFails === 0) { peg$fail(peg$c455); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10992,7 +11041,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -1871,30 +1871,31 @@ var g = &grammar{
 						expr: &seqExpr{
 							pos: position{line: 250, col: 5, offset: 7340},
 							exprs: []interface{}{
+								&ruleRefExpr{
+									pos:  position{line: 250, col: 5, offset: 7340},
+									name: "Summarize",
+								},
 								&labeledExpr{
-									pos:   position{line: 250, col: 5, offset: 7340},
+									pos:   position{line: 250, col: 15, offset: 7350},
 									label: "every",
-									expr: &zeroOrOneExpr{
-										pos: position{line: 250, col: 11, offset: 7346},
-										expr: &ruleRefExpr{
-											pos:  position{line: 250, col: 11, offset: 7346},
-											name: "EveryDur",
-										},
+									expr: &ruleRefExpr{
+										pos:  position{line: 250, col: 21, offset: 7356},
+										name: "EveryDur",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 250, col: 21, offset: 7356},
+									pos:   position{line: 250, col: 30, offset: 7365},
 									label: "keys",
 									expr: &ruleRefExpr{
-										pos:  position{line: 250, col: 26, offset: 7361},
+										pos:  position{line: 250, col: 35, offset: 7370},
 										name: "GroupByKeys",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 250, col: 38, offset: 7373},
+									pos:   position{line: 250, col: 47, offset: 7382},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 250, col: 44, offset: 7379},
+										pos:  position{line: 250, col: 53, offset: 7388},
 										name: "LimitArg",
 									},
 								},
@@ -1902,44 +1903,45 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 253, col: 5, offset: 7528},
+						pos: position{line: 253, col: 5, offset: 7537},
 						run: (*parser).callonAggregation11,
 						expr: &seqExpr{
-							pos: position{line: 253, col: 5, offset: 7528},
+							pos: position{line: 253, col: 5, offset: 7537},
 							exprs: []interface{}{
+								&ruleRefExpr{
+									pos:  position{line: 253, col: 5, offset: 7537},
+									name: "Summarize",
+								},
 								&labeledExpr{
-									pos:   position{line: 253, col: 5, offset: 7528},
+									pos:   position{line: 253, col: 15, offset: 7547},
 									label: "every",
-									expr: &zeroOrOneExpr{
-										pos: position{line: 253, col: 11, offset: 7534},
-										expr: &ruleRefExpr{
-											pos:  position{line: 253, col: 11, offset: 7534},
-											name: "EveryDur",
-										},
+									expr: &ruleRefExpr{
+										pos:  position{line: 253, col: 21, offset: 7553},
+										name: "EveryDur",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 253, col: 21, offset: 7544},
+									pos:   position{line: 253, col: 30, offset: 7562},
 									label: "reducers",
 									expr: &ruleRefExpr{
-										pos:  position{line: 253, col: 30, offset: 7553},
+										pos:  position{line: 253, col: 39, offset: 7571},
 										name: "Reducers",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 253, col: 39, offset: 7562},
+									pos:   position{line: 253, col: 48, offset: 7580},
 									label: "keys",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 253, col: 44, offset: 7567},
+										pos: position{line: 253, col: 53, offset: 7585},
 										expr: &seqExpr{
-											pos: position{line: 253, col: 45, offset: 7568},
+											pos: position{line: 253, col: 54, offset: 7586},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 253, col: 45, offset: 7568},
+													pos:  position{line: 253, col: 54, offset: 7586},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 253, col: 47, offset: 7570},
+													pos:  position{line: 253, col: 56, offset: 7588},
 													name: "GroupByKeys",
 												},
 											},
@@ -1947,10 +1949,10 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 253, col: 61, offset: 7584},
+									pos:   position{line: 253, col: 70, offset: 7602},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 253, col: 67, offset: 7590},
+										pos:  position{line: 253, col: 76, offset: 7608},
 										name: "LimitArg",
 									},
 								},
@@ -1961,34 +1963,76 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "EveryDur",
-			pos:  position{line: 261, col: 1, offset: 7831},
-			expr: &actionExpr{
-				pos: position{line: 262, col: 5, offset: 7844},
-				run: (*parser).callonEveryDur1,
-				expr: &seqExpr{
-					pos: position{line: 262, col: 5, offset: 7844},
-					exprs: []interface{}{
-						&litMatcher{
-							pos:        position{line: 262, col: 5, offset: 7844},
-							val:        "every",
-							ignoreCase: true,
-						},
-						&ruleRefExpr{
-							pos:  position{line: 262, col: 14, offset: 7853},
-							name: "_",
-						},
-						&labeledExpr{
-							pos:   position{line: 262, col: 16, offset: 7855},
-							label: "dur",
-							expr: &ruleRefExpr{
-								pos:  position{line: 262, col: 20, offset: 7859},
-								name: "Duration",
+			name: "Summarize",
+			pos:  position{line: 261, col: 1, offset: 7849},
+			expr: &choiceExpr{
+				pos: position{line: 261, col: 13, offset: 7861},
+				alternatives: []interface{}{
+					&seqExpr{
+						pos: position{line: 261, col: 13, offset: 7861},
+						exprs: []interface{}{
+							&litMatcher{
+								pos:        position{line: 261, col: 13, offset: 7861},
+								val:        "summarize",
+								ignoreCase: false,
+							},
+							&ruleRefExpr{
+								pos:  position{line: 261, col: 25, offset: 7873},
+								name: "_",
 							},
 						},
-						&ruleRefExpr{
-							pos:  position{line: 262, col: 29, offset: 7868},
-							name: "_",
+					},
+					&litMatcher{
+						pos:        position{line: 261, col: 29, offset: 7877},
+						val:        "",
+						ignoreCase: false,
+					},
+				},
+			},
+		},
+		{
+			name: "EveryDur",
+			pos:  position{line: 263, col: 1, offset: 7881},
+			expr: &choiceExpr{
+				pos: position{line: 264, col: 5, offset: 7894},
+				alternatives: []interface{}{
+					&actionExpr{
+						pos: position{line: 264, col: 5, offset: 7894},
+						run: (*parser).callonEveryDur2,
+						expr: &seqExpr{
+							pos: position{line: 264, col: 5, offset: 7894},
+							exprs: []interface{}{
+								&litMatcher{
+									pos:        position{line: 264, col: 5, offset: 7894},
+									val:        "every",
+									ignoreCase: true,
+								},
+								&ruleRefExpr{
+									pos:  position{line: 264, col: 14, offset: 7903},
+									name: "_",
+								},
+								&labeledExpr{
+									pos:   position{line: 264, col: 16, offset: 7905},
+									label: "dur",
+									expr: &ruleRefExpr{
+										pos:  position{line: 264, col: 20, offset: 7909},
+										name: "Duration",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 264, col: 29, offset: 7918},
+									name: "_",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 265, col: 5, offset: 7944},
+						run: (*parser).callonEveryDur9,
+						expr: &litMatcher{
+							pos:        position{line: 265, col: 5, offset: 7944},
+							val:        "",
+							ignoreCase: false,
 						},
 					},
 				},
@@ -1996,26 +2040,26 @@ var g = &grammar{
 		},
 		{
 			name: "GroupByKeys",
-			pos:  position{line: 264, col: 1, offset: 7891},
+			pos:  position{line: 267, col: 1, offset: 7969},
 			expr: &actionExpr{
-				pos: position{line: 265, col: 5, offset: 7907},
+				pos: position{line: 268, col: 5, offset: 7985},
 				run: (*parser).callonGroupByKeys1,
 				expr: &seqExpr{
-					pos: position{line: 265, col: 5, offset: 7907},
+					pos: position{line: 268, col: 5, offset: 7985},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 265, col: 5, offset: 7907},
+							pos:  position{line: 268, col: 5, offset: 7985},
 							name: "ByToken",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 265, col: 13, offset: 7915},
+							pos:  position{line: 268, col: 13, offset: 7993},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 265, col: 15, offset: 7917},
+							pos:   position{line: 268, col: 15, offset: 7995},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 265, col: 23, offset: 7925},
+								pos:  position{line: 268, col: 23, offset: 8003},
 								name: "FlexAssignments",
 							},
 						},
@@ -2025,43 +2069,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitArg",
-			pos:  position{line: 267, col: 1, offset: 7966},
+			pos:  position{line: 270, col: 1, offset: 8044},
 			expr: &choiceExpr{
-				pos: position{line: 268, col: 5, offset: 7979},
+				pos: position{line: 271, col: 5, offset: 8057},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 268, col: 5, offset: 7979},
+						pos: position{line: 271, col: 5, offset: 8057},
 						run: (*parser).callonLimitArg2,
 						expr: &seqExpr{
-							pos: position{line: 268, col: 5, offset: 7979},
+							pos: position{line: 271, col: 5, offset: 8057},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 268, col: 5, offset: 7979},
+									pos:  position{line: 271, col: 5, offset: 8057},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 268, col: 7, offset: 7981},
+									pos:        position{line: 271, col: 7, offset: 8059},
 									val:        "with",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 268, col: 14, offset: 7988},
+									pos:  position{line: 271, col: 14, offset: 8066},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 268, col: 16, offset: 7990},
+									pos:        position{line: 271, col: 16, offset: 8068},
 									val:        "-limit",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 268, col: 25, offset: 7999},
+									pos:  position{line: 271, col: 25, offset: 8077},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 268, col: 27, offset: 8001},
+									pos:   position{line: 271, col: 27, offset: 8079},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 268, col: 33, offset: 8007},
+										pos:  position{line: 271, col: 33, offset: 8085},
 										name: "UInt",
 									},
 								},
@@ -2069,10 +2113,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 269, col: 5, offset: 8038},
+						pos: position{line: 272, col: 5, offset: 8116},
 						run: (*parser).callonLimitArg11,
 						expr: &litMatcher{
-							pos:        position{line: 269, col: 5, offset: 8038},
+							pos:        position{line: 272, col: 5, offset: 8116},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -2082,22 +2126,22 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignment",
-			pos:  position{line: 274, col: 1, offset: 8298},
+			pos:  position{line: 277, col: 1, offset: 8376},
 			expr: &choiceExpr{
-				pos: position{line: 275, col: 5, offset: 8317},
+				pos: position{line: 278, col: 5, offset: 8395},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 275, col: 5, offset: 8317},
+						pos:  position{line: 278, col: 5, offset: 8395},
 						name: "Assignment",
 					},
 					&actionExpr{
-						pos: position{line: 276, col: 5, offset: 8332},
+						pos: position{line: 279, col: 5, offset: 8410},
 						run: (*parser).callonFlexAssignment3,
 						expr: &labeledExpr{
-							pos:   position{line: 276, col: 5, offset: 8332},
+							pos:   position{line: 279, col: 5, offset: 8410},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 10, offset: 8337},
+								pos:  position{line: 279, col: 10, offset: 8415},
 								name: "Expr",
 							},
 						},
@@ -2107,50 +2151,50 @@ var g = &grammar{
 		},
 		{
 			name: "FlexAssignments",
-			pos:  position{line: 278, col: 1, offset: 8427},
+			pos:  position{line: 281, col: 1, offset: 8505},
 			expr: &actionExpr{
-				pos: position{line: 279, col: 5, offset: 8447},
+				pos: position{line: 282, col: 5, offset: 8525},
 				run: (*parser).callonFlexAssignments1,
 				expr: &seqExpr{
-					pos: position{line: 279, col: 5, offset: 8447},
+					pos: position{line: 282, col: 5, offset: 8525},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 279, col: 5, offset: 8447},
+							pos:   position{line: 282, col: 5, offset: 8525},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 11, offset: 8453},
+								pos:  position{line: 282, col: 11, offset: 8531},
 								name: "FlexAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 279, col: 26, offset: 8468},
+							pos:   position{line: 282, col: 26, offset: 8546},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 279, col: 31, offset: 8473},
+								pos: position{line: 282, col: 31, offset: 8551},
 								expr: &actionExpr{
-									pos: position{line: 279, col: 32, offset: 8474},
+									pos: position{line: 282, col: 32, offset: 8552},
 									run: (*parser).callonFlexAssignments7,
 									expr: &seqExpr{
-										pos: position{line: 279, col: 32, offset: 8474},
+										pos: position{line: 282, col: 32, offset: 8552},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 279, col: 32, offset: 8474},
+												pos:  position{line: 282, col: 32, offset: 8552},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 279, col: 35, offset: 8477},
+												pos:        position{line: 282, col: 35, offset: 8555},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 279, col: 39, offset: 8481},
+												pos:  position{line: 282, col: 39, offset: 8559},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 279, col: 42, offset: 8484},
+												pos:   position{line: 282, col: 42, offset: 8562},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 279, col: 47, offset: 8489},
+													pos:  position{line: 282, col: 47, offset: 8567},
 													name: "FlexAssignment",
 												},
 											},
@@ -2165,42 +2209,42 @@ var g = &grammar{
 		},
 		{
 			name: "ReducerAssignment",
-			pos:  position{line: 283, col: 1, offset: 8611},
+			pos:  position{line: 286, col: 1, offset: 8689},
 			expr: &choiceExpr{
-				pos: position{line: 284, col: 5, offset: 8633},
+				pos: position{line: 287, col: 5, offset: 8711},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 284, col: 5, offset: 8633},
+						pos: position{line: 287, col: 5, offset: 8711},
 						run: (*parser).callonReducerAssignment2,
 						expr: &seqExpr{
-							pos: position{line: 284, col: 5, offset: 8633},
+							pos: position{line: 287, col: 5, offset: 8711},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 284, col: 5, offset: 8633},
+									pos:   position{line: 287, col: 5, offset: 8711},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 284, col: 10, offset: 8638},
+										pos:  position{line: 287, col: 10, offset: 8716},
 										name: "Lval",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 284, col: 15, offset: 8643},
+									pos:  position{line: 287, col: 15, offset: 8721},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 284, col: 18, offset: 8646},
+									pos:        position{line: 287, col: 18, offset: 8724},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 284, col: 22, offset: 8650},
+									pos:  position{line: 287, col: 22, offset: 8728},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 284, col: 25, offset: 8653},
+									pos:   position{line: 287, col: 25, offset: 8731},
 									label: "reducer",
 									expr: &ruleRefExpr{
-										pos:  position{line: 284, col: 33, offset: 8661},
+										pos:  position{line: 287, col: 33, offset: 8739},
 										name: "Reducer",
 									},
 								},
@@ -2208,13 +2252,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 287, col: 5, offset: 8771},
+						pos: position{line: 290, col: 5, offset: 8849},
 						run: (*parser).callonReducerAssignment11,
 						expr: &labeledExpr{
-							pos:   position{line: 287, col: 5, offset: 8771},
+							pos:   position{line: 290, col: 5, offset: 8849},
 							label: "reducer",
 							expr: &ruleRefExpr{
-								pos:  position{line: 287, col: 13, offset: 8779},
+								pos:  position{line: 290, col: 13, offset: 8857},
 								name: "Reducer",
 							},
 						},
@@ -2224,72 +2268,72 @@ var g = &grammar{
 		},
 		{
 			name: "Reducer",
-			pos:  position{line: 291, col: 1, offset: 8885},
+			pos:  position{line: 294, col: 1, offset: 8963},
 			expr: &actionExpr{
-				pos: position{line: 292, col: 5, offset: 8897},
+				pos: position{line: 295, col: 5, offset: 8975},
 				run: (*parser).callonReducer1,
 				expr: &seqExpr{
-					pos: position{line: 292, col: 5, offset: 8897},
+					pos: position{line: 295, col: 5, offset: 8975},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 292, col: 5, offset: 8897},
+							pos: position{line: 295, col: 5, offset: 8975},
 							expr: &ruleRefExpr{
-								pos:  position{line: 292, col: 6, offset: 8898},
+								pos:  position{line: 295, col: 6, offset: 8976},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 292, col: 16, offset: 8908},
+							pos:   position{line: 295, col: 16, offset: 8986},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 292, col: 19, offset: 8911},
+								pos:  position{line: 295, col: 19, offset: 8989},
 								name: "ReducerName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 292, col: 31, offset: 8923},
+							pos:  position{line: 295, col: 31, offset: 9001},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 292, col: 34, offset: 8926},
+							pos:        position{line: 295, col: 34, offset: 9004},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 292, col: 38, offset: 8930},
+							pos:  position{line: 295, col: 38, offset: 9008},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 292, col: 41, offset: 8933},
+							pos:   position{line: 295, col: 41, offset: 9011},
 							label: "expr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 292, col: 46, offset: 8938},
+								pos: position{line: 295, col: 46, offset: 9016},
 								expr: &ruleRefExpr{
-									pos:  position{line: 292, col: 46, offset: 8938},
+									pos:  position{line: 295, col: 46, offset: 9016},
 									name: "Expr",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 292, col: 53, offset: 8945},
+							pos:  position{line: 295, col: 53, offset: 9023},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 292, col: 56, offset: 8948},
+							pos:        position{line: 295, col: 56, offset: 9026},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&notExpr{
-							pos: position{line: 292, col: 60, offset: 8952},
+							pos: position{line: 295, col: 60, offset: 9030},
 							expr: &seqExpr{
-								pos: position{line: 292, col: 62, offset: 8954},
+								pos: position{line: 295, col: 62, offset: 9032},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 292, col: 62, offset: 8954},
+										pos:  position{line: 295, col: 62, offset: 9032},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 292, col: 65, offset: 8957},
+										pos:        position{line: 295, col: 65, offset: 9035},
 										val:        ".",
 										ignoreCase: false,
 									},
@@ -2297,12 +2341,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 292, col: 70, offset: 8962},
+							pos:   position{line: 295, col: 70, offset: 9040},
 							label: "where",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 292, col: 76, offset: 8968},
+								pos: position{line: 295, col: 76, offset: 9046},
 								expr: &ruleRefExpr{
-									pos:  position{line: 292, col: 76, offset: 8968},
+									pos:  position{line: 295, col: 76, offset: 9046},
 									name: "WhereClause",
 								},
 							},
@@ -2313,20 +2357,20 @@ var g = &grammar{
 		},
 		{
 			name: "ReducerName",
-			pos:  position{line: 300, col: 1, offset: 9164},
+			pos:  position{line: 303, col: 1, offset: 9242},
 			expr: &choiceExpr{
-				pos: position{line: 301, col: 5, offset: 9180},
+				pos: position{line: 304, col: 5, offset: 9258},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 301, col: 5, offset: 9180},
+						pos:  position{line: 304, col: 5, offset: 9258},
 						name: "IdentifierName",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 302, col: 5, offset: 9199},
+						pos:  position{line: 305, col: 5, offset: 9277},
 						name: "AndToken",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 5, offset: 9212},
+						pos:  position{line: 306, col: 5, offset: 9290},
 						name: "OrToken",
 					},
 				},
@@ -2334,31 +2378,31 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 305, col: 1, offset: 9221},
+			pos:  position{line: 308, col: 1, offset: 9299},
 			expr: &actionExpr{
-				pos: position{line: 305, col: 15, offset: 9235},
+				pos: position{line: 308, col: 15, offset: 9313},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 305, col: 15, offset: 9235},
+					pos: position{line: 308, col: 15, offset: 9313},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 305, col: 15, offset: 9235},
+							pos:  position{line: 308, col: 15, offset: 9313},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 305, col: 17, offset: 9237},
+							pos:        position{line: 308, col: 17, offset: 9315},
 							val:        "where",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 305, col: 25, offset: 9245},
+							pos:  position{line: 308, col: 25, offset: 9323},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 305, col: 27, offset: 9247},
+							pos:   position{line: 308, col: 27, offset: 9325},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 305, col: 32, offset: 9252},
+								pos:  position{line: 308, col: 32, offset: 9330},
 								name: "SearchBoolean",
 							},
 						},
@@ -2368,44 +2412,44 @@ var g = &grammar{
 		},
 		{
 			name: "Reducers",
-			pos:  position{line: 307, col: 1, offset: 9288},
+			pos:  position{line: 310, col: 1, offset: 9366},
 			expr: &actionExpr{
-				pos: position{line: 308, col: 5, offset: 9301},
+				pos: position{line: 311, col: 5, offset: 9379},
 				run: (*parser).callonReducers1,
 				expr: &seqExpr{
-					pos: position{line: 308, col: 5, offset: 9301},
+					pos: position{line: 311, col: 5, offset: 9379},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 308, col: 5, offset: 9301},
+							pos:   position{line: 311, col: 5, offset: 9379},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 308, col: 11, offset: 9307},
+								pos:  position{line: 311, col: 11, offset: 9385},
 								name: "ReducerAssignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 308, col: 29, offset: 9325},
+							pos:   position{line: 311, col: 29, offset: 9403},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 308, col: 34, offset: 9330},
+								pos: position{line: 311, col: 34, offset: 9408},
 								expr: &seqExpr{
-									pos: position{line: 308, col: 35, offset: 9331},
+									pos: position{line: 311, col: 35, offset: 9409},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 308, col: 35, offset: 9331},
+											pos:  position{line: 311, col: 35, offset: 9409},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 308, col: 38, offset: 9334},
+											pos:        position{line: 311, col: 38, offset: 9412},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 308, col: 42, offset: 9338},
+											pos:  position{line: 311, col: 42, offset: 9416},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 308, col: 45, offset: 9341},
+											pos:  position{line: 311, col: 45, offset: 9419},
 											name: "ReducerAssignment",
 										},
 									},
@@ -2418,64 +2462,64 @@ var g = &grammar{
 		},
 		{
 			name: "Operator",
-			pos:  position{line: 316, col: 1, offset: 9546},
+			pos:  position{line: 319, col: 1, offset: 9624},
 			expr: &choiceExpr{
-				pos: position{line: 317, col: 5, offset: 9559},
+				pos: position{line: 320, col: 5, offset: 9637},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 5, offset: 9559},
+						pos:  position{line: 320, col: 5, offset: 9637},
 						name: "SortProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 318, col: 5, offset: 9572},
+						pos:  position{line: 321, col: 5, offset: 9650},
 						name: "TopProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 319, col: 5, offset: 9584},
+						pos:  position{line: 322, col: 5, offset: 9662},
 						name: "CutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 5, offset: 9596},
+						pos:  position{line: 323, col: 5, offset: 9674},
 						name: "PickProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 321, col: 5, offset: 9609},
+						pos:  position{line: 324, col: 5, offset: 9687},
 						name: "DropProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 322, col: 5, offset: 9622},
+						pos:  position{line: 325, col: 5, offset: 9700},
 						name: "HeadProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 323, col: 5, offset: 9635},
+						pos:  position{line: 326, col: 5, offset: 9713},
 						name: "TailProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 324, col: 5, offset: 9648},
+						pos:  position{line: 327, col: 5, offset: 9726},
 						name: "FilterProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 325, col: 5, offset: 9663},
+						pos:  position{line: 328, col: 5, offset: 9741},
 						name: "UniqProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 326, col: 5, offset: 9676},
+						pos:  position{line: 329, col: 5, offset: 9754},
 						name: "PutProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 327, col: 5, offset: 9688},
+						pos:  position{line: 330, col: 5, offset: 9766},
 						name: "RenameProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 328, col: 5, offset: 9703},
+						pos:  position{line: 331, col: 5, offset: 9781},
 						name: "FuseProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 329, col: 5, offset: 9716},
+						pos:  position{line: 332, col: 5, offset: 9794},
 						name: "JoinProc",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 330, col: 5, offset: 9729},
+						pos:  position{line: 333, col: 5, offset: 9807},
 						name: "TasteProc",
 					},
 				},
@@ -2483,46 +2527,46 @@ var g = &grammar{
 		},
 		{
 			name: "SortProc",
-			pos:  position{line: 332, col: 1, offset: 9740},
+			pos:  position{line: 335, col: 1, offset: 9818},
 			expr: &actionExpr{
-				pos: position{line: 333, col: 5, offset: 9753},
+				pos: position{line: 336, col: 5, offset: 9831},
 				run: (*parser).callonSortProc1,
 				expr: &seqExpr{
-					pos: position{line: 333, col: 5, offset: 9753},
+					pos: position{line: 336, col: 5, offset: 9831},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 333, col: 5, offset: 9753},
+							pos:        position{line: 336, col: 5, offset: 9831},
 							val:        "sort",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 333, col: 13, offset: 9761},
+							pos:   position{line: 336, col: 13, offset: 9839},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 333, col: 18, offset: 9766},
+								pos:  position{line: 336, col: 18, offset: 9844},
 								name: "SortArgs",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 333, col: 27, offset: 9775},
+							pos:   position{line: 336, col: 27, offset: 9853},
 							label: "list",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 333, col: 32, offset: 9780},
+								pos: position{line: 336, col: 32, offset: 9858},
 								expr: &actionExpr{
-									pos: position{line: 333, col: 33, offset: 9781},
+									pos: position{line: 336, col: 33, offset: 9859},
 									run: (*parser).callonSortProc8,
 									expr: &seqExpr{
-										pos: position{line: 333, col: 33, offset: 9781},
+										pos: position{line: 336, col: 33, offset: 9859},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 333, col: 33, offset: 9781},
+												pos:  position{line: 336, col: 33, offset: 9859},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 333, col: 35, offset: 9783},
+												pos:   position{line: 336, col: 35, offset: 9861},
 												label: "l",
 												expr: &ruleRefExpr{
-													pos:  position{line: 333, col: 37, offset: 9785},
+													pos:  position{line: 336, col: 37, offset: 9863},
 													name: "Exprs",
 												},
 											},
@@ -2537,30 +2581,30 @@ var g = &grammar{
 		},
 		{
 			name: "SortArgs",
-			pos:  position{line: 347, col: 1, offset: 10204},
+			pos:  position{line: 350, col: 1, offset: 10282},
 			expr: &actionExpr{
-				pos: position{line: 347, col: 12, offset: 10215},
+				pos: position{line: 350, col: 12, offset: 10293},
 				run: (*parser).callonSortArgs1,
 				expr: &labeledExpr{
-					pos:   position{line: 347, col: 12, offset: 10215},
+					pos:   position{line: 350, col: 12, offset: 10293},
 					label: "args",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 347, col: 17, offset: 10220},
+						pos: position{line: 350, col: 17, offset: 10298},
 						expr: &actionExpr{
-							pos: position{line: 347, col: 18, offset: 10221},
+							pos: position{line: 350, col: 18, offset: 10299},
 							run: (*parser).callonSortArgs4,
 							expr: &seqExpr{
-								pos: position{line: 347, col: 18, offset: 10221},
+								pos: position{line: 350, col: 18, offset: 10299},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 347, col: 18, offset: 10221},
+										pos:  position{line: 350, col: 18, offset: 10299},
 										name: "_",
 									},
 									&labeledExpr{
-										pos:   position{line: 347, col: 20, offset: 10223},
+										pos:   position{line: 350, col: 20, offset: 10301},
 										label: "a",
 										expr: &ruleRefExpr{
-											pos:  position{line: 347, col: 22, offset: 10225},
+											pos:  position{line: 350, col: 22, offset: 10303},
 											name: "SortArg",
 										},
 									},
@@ -2573,50 +2617,50 @@ var g = &grammar{
 		},
 		{
 			name: "SortArg",
-			pos:  position{line: 349, col: 1, offset: 10281},
+			pos:  position{line: 352, col: 1, offset: 10359},
 			expr: &choiceExpr{
-				pos: position{line: 350, col: 5, offset: 10293},
+				pos: position{line: 353, col: 5, offset: 10371},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 350, col: 5, offset: 10293},
+						pos: position{line: 353, col: 5, offset: 10371},
 						run: (*parser).callonSortArg2,
 						expr: &litMatcher{
-							pos:        position{line: 350, col: 5, offset: 10293},
+							pos:        position{line: 353, col: 5, offset: 10371},
 							val:        "-r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 351, col: 5, offset: 10368},
+						pos: position{line: 354, col: 5, offset: 10446},
 						run: (*parser).callonSortArg4,
 						expr: &seqExpr{
-							pos: position{line: 351, col: 5, offset: 10368},
+							pos: position{line: 354, col: 5, offset: 10446},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 351, col: 5, offset: 10368},
+									pos:        position{line: 354, col: 5, offset: 10446},
 									val:        "-nulls",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 351, col: 14, offset: 10377},
+									pos:  position{line: 354, col: 14, offset: 10455},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 351, col: 16, offset: 10379},
+									pos:   position{line: 354, col: 16, offset: 10457},
 									label: "where",
 									expr: &actionExpr{
-										pos: position{line: 351, col: 23, offset: 10386},
+										pos: position{line: 354, col: 23, offset: 10464},
 										run: (*parser).callonSortArg9,
 										expr: &choiceExpr{
-											pos: position{line: 351, col: 24, offset: 10387},
+											pos: position{line: 354, col: 24, offset: 10465},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 351, col: 24, offset: 10387},
+													pos:        position{line: 354, col: 24, offset: 10465},
 													val:        "first",
 													ignoreCase: false,
 												},
 												&litMatcher{
-													pos:        position{line: 351, col: 34, offset: 10397},
+													pos:        position{line: 354, col: 34, offset: 10475},
 													val:        "last",
 													ignoreCase: false,
 												},
@@ -2632,38 +2676,38 @@ var g = &grammar{
 		},
 		{
 			name: "TopProc",
-			pos:  position{line: 353, col: 1, offset: 10511},
+			pos:  position{line: 356, col: 1, offset: 10589},
 			expr: &actionExpr{
-				pos: position{line: 354, col: 5, offset: 10523},
+				pos: position{line: 357, col: 5, offset: 10601},
 				run: (*parser).callonTopProc1,
 				expr: &seqExpr{
-					pos: position{line: 354, col: 5, offset: 10523},
+					pos: position{line: 357, col: 5, offset: 10601},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 354, col: 5, offset: 10523},
+							pos:        position{line: 357, col: 5, offset: 10601},
 							val:        "top",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 12, offset: 10530},
+							pos:   position{line: 357, col: 12, offset: 10608},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 354, col: 18, offset: 10536},
+								pos: position{line: 357, col: 18, offset: 10614},
 								expr: &actionExpr{
-									pos: position{line: 354, col: 19, offset: 10537},
+									pos: position{line: 357, col: 19, offset: 10615},
 									run: (*parser).callonTopProc6,
 									expr: &seqExpr{
-										pos: position{line: 354, col: 19, offset: 10537},
+										pos: position{line: 357, col: 19, offset: 10615},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 354, col: 19, offset: 10537},
+												pos:  position{line: 357, col: 19, offset: 10615},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 354, col: 21, offset: 10539},
+												pos:   position{line: 357, col: 21, offset: 10617},
 												label: "n",
 												expr: &ruleRefExpr{
-													pos:  position{line: 354, col: 23, offset: 10541},
+													pos:  position{line: 357, col: 23, offset: 10619},
 													name: "UInt",
 												},
 											},
@@ -2673,19 +2717,19 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 47, offset: 10565},
+							pos:   position{line: 357, col: 47, offset: 10643},
 							label: "flush",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 354, col: 53, offset: 10571},
+								pos: position{line: 357, col: 53, offset: 10649},
 								expr: &seqExpr{
-									pos: position{line: 354, col: 54, offset: 10572},
+									pos: position{line: 357, col: 54, offset: 10650},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 354, col: 54, offset: 10572},
+											pos:  position{line: 357, col: 54, offset: 10650},
 											name: "_",
 										},
 										&litMatcher{
-											pos:        position{line: 354, col: 56, offset: 10574},
+											pos:        position{line: 357, col: 56, offset: 10652},
 											val:        "-flush",
 											ignoreCase: false,
 										},
@@ -2694,25 +2738,25 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 354, col: 67, offset: 10585},
+							pos:   position{line: 357, col: 67, offset: 10663},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 354, col: 74, offset: 10592},
+								pos: position{line: 357, col: 74, offset: 10670},
 								expr: &actionExpr{
-									pos: position{line: 354, col: 75, offset: 10593},
+									pos: position{line: 357, col: 75, offset: 10671},
 									run: (*parser).callonTopProc18,
 									expr: &seqExpr{
-										pos: position{line: 354, col: 75, offset: 10593},
+										pos: position{line: 357, col: 75, offset: 10671},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 354, col: 75, offset: 10593},
+												pos:  position{line: 357, col: 75, offset: 10671},
 												name: "_",
 											},
 											&labeledExpr{
-												pos:   position{line: 354, col: 77, offset: 10595},
+												pos:   position{line: 357, col: 77, offset: 10673},
 												label: "f",
 												expr: &ruleRefExpr{
-													pos:  position{line: 354, col: 79, offset: 10597},
+													pos:  position{line: 357, col: 79, offset: 10675},
 													name: "FieldExprs",
 												},
 											},
@@ -2727,27 +2771,27 @@ var g = &grammar{
 		},
 		{
 			name: "CutProc",
-			pos:  position{line: 368, col: 1, offset: 10948},
+			pos:  position{line: 371, col: 1, offset: 11026},
 			expr: &actionExpr{
-				pos: position{line: 369, col: 5, offset: 10960},
+				pos: position{line: 372, col: 5, offset: 11038},
 				run: (*parser).callonCutProc1,
 				expr: &seqExpr{
-					pos: position{line: 369, col: 5, offset: 10960},
+					pos: position{line: 372, col: 5, offset: 11038},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 369, col: 5, offset: 10960},
+							pos:        position{line: 372, col: 5, offset: 11038},
 							val:        "cut",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 369, col: 12, offset: 10967},
+							pos:  position{line: 372, col: 12, offset: 11045},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 369, col: 14, offset: 10969},
+							pos:   position{line: 372, col: 14, offset: 11047},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 369, col: 22, offset: 10977},
+								pos:  position{line: 372, col: 22, offset: 11055},
 								name: "FlexAssignments",
 							},
 						},
@@ -2757,27 +2801,27 @@ var g = &grammar{
 		},
 		{
 			name: "PickProc",
-			pos:  position{line: 373, col: 1, offset: 11079},
+			pos:  position{line: 376, col: 1, offset: 11157},
 			expr: &actionExpr{
-				pos: position{line: 374, col: 5, offset: 11092},
+				pos: position{line: 377, col: 5, offset: 11170},
 				run: (*parser).callonPickProc1,
 				expr: &seqExpr{
-					pos: position{line: 374, col: 5, offset: 11092},
+					pos: position{line: 377, col: 5, offset: 11170},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 374, col: 5, offset: 11092},
+							pos:        position{line: 377, col: 5, offset: 11170},
 							val:        "pick",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 374, col: 13, offset: 11100},
+							pos:  position{line: 377, col: 13, offset: 11178},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 374, col: 15, offset: 11102},
+							pos:   position{line: 377, col: 15, offset: 11180},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 374, col: 23, offset: 11110},
+								pos:  position{line: 377, col: 23, offset: 11188},
 								name: "FlexAssignments",
 							},
 						},
@@ -2787,27 +2831,27 @@ var g = &grammar{
 		},
 		{
 			name: "DropProc",
-			pos:  position{line: 378, col: 1, offset: 11213},
+			pos:  position{line: 381, col: 1, offset: 11291},
 			expr: &actionExpr{
-				pos: position{line: 379, col: 5, offset: 11226},
+				pos: position{line: 382, col: 5, offset: 11304},
 				run: (*parser).callonDropProc1,
 				expr: &seqExpr{
-					pos: position{line: 379, col: 5, offset: 11226},
+					pos: position{line: 382, col: 5, offset: 11304},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 379, col: 5, offset: 11226},
+							pos:        position{line: 382, col: 5, offset: 11304},
 							val:        "drop",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 379, col: 13, offset: 11234},
+							pos:  position{line: 382, col: 13, offset: 11312},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 379, col: 15, offset: 11236},
+							pos:   position{line: 382, col: 15, offset: 11314},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 379, col: 23, offset: 11244},
+								pos:  position{line: 382, col: 23, offset: 11322},
 								name: "FieldExprs",
 							},
 						},
@@ -2817,30 +2861,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadProc",
-			pos:  position{line: 383, col: 1, offset: 11342},
+			pos:  position{line: 386, col: 1, offset: 11420},
 			expr: &choiceExpr{
-				pos: position{line: 384, col: 5, offset: 11355},
+				pos: position{line: 387, col: 5, offset: 11433},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 384, col: 5, offset: 11355},
+						pos: position{line: 387, col: 5, offset: 11433},
 						run: (*parser).callonHeadProc2,
 						expr: &seqExpr{
-							pos: position{line: 384, col: 5, offset: 11355},
+							pos: position{line: 387, col: 5, offset: 11433},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 384, col: 5, offset: 11355},
+									pos:        position{line: 387, col: 5, offset: 11433},
 									val:        "head",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 384, col: 13, offset: 11363},
+									pos:  position{line: 387, col: 13, offset: 11441},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 384, col: 15, offset: 11365},
+									pos:   position{line: 387, col: 15, offset: 11443},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 384, col: 21, offset: 11371},
+										pos:  position{line: 387, col: 21, offset: 11449},
 										name: "UInt",
 									},
 								},
@@ -2848,10 +2892,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 385, col: 5, offset: 11453},
+						pos: position{line: 388, col: 5, offset: 11531},
 						run: (*parser).callonHeadProc8,
 						expr: &litMatcher{
-							pos:        position{line: 385, col: 5, offset: 11453},
+							pos:        position{line: 388, col: 5, offset: 11531},
 							val:        "head",
 							ignoreCase: true,
 						},
@@ -2861,30 +2905,30 @@ var g = &grammar{
 		},
 		{
 			name: "TailProc",
-			pos:  position{line: 387, col: 1, offset: 11531},
+			pos:  position{line: 390, col: 1, offset: 11609},
 			expr: &choiceExpr{
-				pos: position{line: 388, col: 5, offset: 11544},
+				pos: position{line: 391, col: 5, offset: 11622},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 388, col: 5, offset: 11544},
+						pos: position{line: 391, col: 5, offset: 11622},
 						run: (*parser).callonTailProc2,
 						expr: &seqExpr{
-							pos: position{line: 388, col: 5, offset: 11544},
+							pos: position{line: 391, col: 5, offset: 11622},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 388, col: 5, offset: 11544},
+									pos:        position{line: 391, col: 5, offset: 11622},
 									val:        "tail",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 388, col: 13, offset: 11552},
+									pos:  position{line: 391, col: 13, offset: 11630},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 388, col: 15, offset: 11554},
+									pos:   position{line: 391, col: 15, offset: 11632},
 									label: "count",
 									expr: &ruleRefExpr{
-										pos:  position{line: 388, col: 21, offset: 11560},
+										pos:  position{line: 391, col: 21, offset: 11638},
 										name: "UInt",
 									},
 								},
@@ -2892,10 +2936,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 389, col: 5, offset: 11642},
+						pos: position{line: 392, col: 5, offset: 11720},
 						run: (*parser).callonTailProc8,
 						expr: &litMatcher{
-							pos:        position{line: 389, col: 5, offset: 11642},
+							pos:        position{line: 392, col: 5, offset: 11720},
 							val:        "tail",
 							ignoreCase: true,
 						},
@@ -2905,27 +2949,27 @@ var g = &grammar{
 		},
 		{
 			name: "FilterProc",
-			pos:  position{line: 391, col: 1, offset: 11720},
+			pos:  position{line: 394, col: 1, offset: 11798},
 			expr: &actionExpr{
-				pos: position{line: 392, col: 5, offset: 11735},
+				pos: position{line: 395, col: 5, offset: 11813},
 				run: (*parser).callonFilterProc1,
 				expr: &seqExpr{
-					pos: position{line: 392, col: 5, offset: 11735},
+					pos: position{line: 395, col: 5, offset: 11813},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 392, col: 5, offset: 11735},
+							pos:        position{line: 395, col: 5, offset: 11813},
 							val:        "filter",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 392, col: 15, offset: 11745},
+							pos:  position{line: 395, col: 15, offset: 11823},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 392, col: 17, offset: 11747},
+							pos:   position{line: 395, col: 17, offset: 11825},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 392, col: 20, offset: 11750},
+								pos:  position{line: 395, col: 20, offset: 11828},
 								name: "Filter",
 							},
 						},
@@ -2935,15 +2979,15 @@ var g = &grammar{
 		},
 		{
 			name: "Filter",
-			pos:  position{line: 396, col: 1, offset: 11787},
+			pos:  position{line: 399, col: 1, offset: 11865},
 			expr: &actionExpr{
-				pos: position{line: 397, col: 5, offset: 11798},
+				pos: position{line: 400, col: 5, offset: 11876},
 				run: (*parser).callonFilter1,
 				expr: &labeledExpr{
-					pos:   position{line: 397, col: 5, offset: 11798},
+					pos:   position{line: 400, col: 5, offset: 11876},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 397, col: 10, offset: 11803},
+						pos:  position{line: 400, col: 10, offset: 11881},
 						name: "SearchBoolean",
 					},
 				},
@@ -2951,27 +2995,27 @@ var g = &grammar{
 		},
 		{
 			name: "UniqProc",
-			pos:  position{line: 401, col: 1, offset: 11903},
+			pos:  position{line: 404, col: 1, offset: 11981},
 			expr: &choiceExpr{
-				pos: position{line: 402, col: 5, offset: 11916},
+				pos: position{line: 405, col: 5, offset: 11994},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 402, col: 5, offset: 11916},
+						pos: position{line: 405, col: 5, offset: 11994},
 						run: (*parser).callonUniqProc2,
 						expr: &seqExpr{
-							pos: position{line: 402, col: 5, offset: 11916},
+							pos: position{line: 405, col: 5, offset: 11994},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 402, col: 5, offset: 11916},
+									pos:        position{line: 405, col: 5, offset: 11994},
 									val:        "uniq",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 402, col: 13, offset: 11924},
+									pos:  position{line: 405, col: 13, offset: 12002},
 									name: "_",
 								},
 								&litMatcher{
-									pos:        position{line: 402, col: 15, offset: 11926},
+									pos:        position{line: 405, col: 15, offset: 12004},
 									val:        "-c",
 									ignoreCase: false,
 								},
@@ -2979,10 +3023,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 405, col: 5, offset: 12017},
+						pos: position{line: 408, col: 5, offset: 12095},
 						run: (*parser).callonUniqProc7,
 						expr: &litMatcher{
-							pos:        position{line: 405, col: 5, offset: 12017},
+							pos:        position{line: 408, col: 5, offset: 12095},
 							val:        "uniq",
 							ignoreCase: true,
 						},
@@ -2992,27 +3036,27 @@ var g = &grammar{
 		},
 		{
 			name: "PutProc",
-			pos:  position{line: 409, col: 1, offset: 12109},
+			pos:  position{line: 412, col: 1, offset: 12187},
 			expr: &actionExpr{
-				pos: position{line: 410, col: 5, offset: 12121},
+				pos: position{line: 413, col: 5, offset: 12199},
 				run: (*parser).callonPutProc1,
 				expr: &seqExpr{
-					pos: position{line: 410, col: 5, offset: 12121},
+					pos: position{line: 413, col: 5, offset: 12199},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 410, col: 5, offset: 12121},
+							pos:        position{line: 413, col: 5, offset: 12199},
 							val:        "put",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 410, col: 12, offset: 12128},
+							pos:  position{line: 413, col: 12, offset: 12206},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 410, col: 14, offset: 12130},
+							pos:   position{line: 413, col: 14, offset: 12208},
 							label: "columns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 410, col: 22, offset: 12138},
+								pos:  position{line: 413, col: 22, offset: 12216},
 								name: "FlexAssignments",
 							},
 						},
@@ -3022,59 +3066,59 @@ var g = &grammar{
 		},
 		{
 			name: "RenameProc",
-			pos:  position{line: 414, col: 1, offset: 12241},
+			pos:  position{line: 417, col: 1, offset: 12319},
 			expr: &actionExpr{
-				pos: position{line: 415, col: 5, offset: 12256},
+				pos: position{line: 418, col: 5, offset: 12334},
 				run: (*parser).callonRenameProc1,
 				expr: &seqExpr{
-					pos: position{line: 415, col: 5, offset: 12256},
+					pos: position{line: 418, col: 5, offset: 12334},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 415, col: 5, offset: 12256},
+							pos:        position{line: 418, col: 5, offset: 12334},
 							val:        "rename",
 							ignoreCase: true,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 415, col: 15, offset: 12266},
+							pos:  position{line: 418, col: 15, offset: 12344},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 415, col: 17, offset: 12268},
+							pos:   position{line: 418, col: 17, offset: 12346},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 415, col: 23, offset: 12274},
+								pos:  position{line: 418, col: 23, offset: 12352},
 								name: "Assignment",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 415, col: 34, offset: 12285},
+							pos:   position{line: 418, col: 34, offset: 12363},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 415, col: 39, offset: 12290},
+								pos: position{line: 418, col: 39, offset: 12368},
 								expr: &actionExpr{
-									pos: position{line: 415, col: 40, offset: 12291},
+									pos: position{line: 418, col: 40, offset: 12369},
 									run: (*parser).callonRenameProc9,
 									expr: &seqExpr{
-										pos: position{line: 415, col: 40, offset: 12291},
+										pos: position{line: 418, col: 40, offset: 12369},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 415, col: 40, offset: 12291},
+												pos:  position{line: 418, col: 40, offset: 12369},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 415, col: 43, offset: 12294},
+												pos:        position{line: 418, col: 43, offset: 12372},
 												val:        ",",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 415, col: 47, offset: 12298},
+												pos:  position{line: 418, col: 47, offset: 12376},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 415, col: 50, offset: 12301},
+												pos:   position{line: 418, col: 50, offset: 12379},
 												label: "cl",
 												expr: &ruleRefExpr{
-													pos:  position{line: 415, col: 53, offset: 12304},
+													pos:  position{line: 418, col: 53, offset: 12382},
 													name: "Assignment",
 												},
 											},
@@ -3089,29 +3133,29 @@ var g = &grammar{
 		},
 		{
 			name: "FuseProc",
-			pos:  position{line: 423, col: 1, offset: 12715},
+			pos:  position{line: 426, col: 1, offset: 12793},
 			expr: &actionExpr{
-				pos: position{line: 424, col: 5, offset: 12728},
+				pos: position{line: 427, col: 5, offset: 12806},
 				run: (*parser).callonFuseProc1,
 				expr: &seqExpr{
-					pos: position{line: 424, col: 5, offset: 12728},
+					pos: position{line: 427, col: 5, offset: 12806},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 424, col: 5, offset: 12728},
+							pos:        position{line: 427, col: 5, offset: 12806},
 							val:        "fuse",
 							ignoreCase: true,
 						},
 						&notExpr{
-							pos: position{line: 424, col: 13, offset: 12736},
+							pos: position{line: 427, col: 13, offset: 12814},
 							expr: &seqExpr{
-								pos: position{line: 424, col: 15, offset: 12738},
+								pos: position{line: 427, col: 15, offset: 12816},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 424, col: 15, offset: 12738},
+										pos:  position{line: 427, col: 15, offset: 12816},
 										name: "__",
 									},
 									&litMatcher{
-										pos:        position{line: 424, col: 18, offset: 12741},
+										pos:        position{line: 427, col: 18, offset: 12819},
 										val:        "(",
 										ignoreCase: false,
 									},
@@ -3124,68 +3168,68 @@ var g = &grammar{
 		},
 		{
 			name: "JoinProc",
-			pos:  position{line: 428, col: 1, offset: 12814},
+			pos:  position{line: 431, col: 1, offset: 12892},
 			expr: &choiceExpr{
-				pos: position{line: 429, col: 5, offset: 12827},
+				pos: position{line: 432, col: 5, offset: 12905},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 429, col: 5, offset: 12827},
+						pos: position{line: 432, col: 5, offset: 12905},
 						run: (*parser).callonJoinProc2,
 						expr: &seqExpr{
-							pos: position{line: 429, col: 5, offset: 12827},
+							pos: position{line: 432, col: 5, offset: 12905},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 429, col: 5, offset: 12827},
+									pos:        position{line: 432, col: 5, offset: 12905},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 429, col: 13, offset: 12835},
+									pos:  position{line: 432, col: 13, offset: 12913},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 429, col: 15, offset: 12837},
+									pos:   position{line: 432, col: 15, offset: 12915},
 									label: "leftKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 429, col: 23, offset: 12845},
+										pos:  position{line: 432, col: 23, offset: 12923},
 										name: "JoinKey",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 429, col: 31, offset: 12853},
+									pos:  position{line: 432, col: 31, offset: 12931},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 429, col: 34, offset: 12856},
+									pos:        position{line: 432, col: 34, offset: 12934},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 429, col: 38, offset: 12860},
+									pos:  position{line: 432, col: 38, offset: 12938},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 429, col: 41, offset: 12863},
+									pos:   position{line: 432, col: 41, offset: 12941},
 									label: "rightKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 429, col: 50, offset: 12872},
+										pos:  position{line: 432, col: 50, offset: 12950},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 429, col: 58, offset: 12880},
+									pos:   position{line: 432, col: 58, offset: 12958},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 429, col: 66, offset: 12888},
+										pos: position{line: 432, col: 66, offset: 12966},
 										expr: &seqExpr{
-											pos: position{line: 429, col: 67, offset: 12889},
+											pos: position{line: 432, col: 67, offset: 12967},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 429, col: 67, offset: 12889},
+													pos:  position{line: 432, col: 67, offset: 12967},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 429, col: 69, offset: 12891},
+													pos:  position{line: 432, col: 69, offset: 12969},
 													name: "FlexAssignments",
 												},
 											},
@@ -3196,42 +3240,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 436, col: 5, offset: 13149},
+						pos: position{line: 439, col: 5, offset: 13227},
 						run: (*parser).callonJoinProc18,
 						expr: &seqExpr{
-							pos: position{line: 436, col: 5, offset: 13149},
+							pos: position{line: 439, col: 5, offset: 13227},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 436, col: 5, offset: 13149},
+									pos:        position{line: 439, col: 5, offset: 13227},
 									val:        "join",
 									ignoreCase: true,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 436, col: 13, offset: 13157},
+									pos:  position{line: 439, col: 13, offset: 13235},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 436, col: 15, offset: 13159},
+									pos:   position{line: 439, col: 15, offset: 13237},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 436, col: 19, offset: 13163},
+										pos:  position{line: 439, col: 19, offset: 13241},
 										name: "JoinKey",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 436, col: 27, offset: 13171},
+									pos:   position{line: 439, col: 27, offset: 13249},
 									label: "columns",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 436, col: 35, offset: 13179},
+										pos: position{line: 439, col: 35, offset: 13257},
 										expr: &seqExpr{
-											pos: position{line: 436, col: 36, offset: 13180},
+											pos: position{line: 439, col: 36, offset: 13258},
 											exprs: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 436, col: 36, offset: 13180},
+													pos:  position{line: 439, col: 36, offset: 13258},
 													name: "_",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 436, col: 38, offset: 13182},
+													pos:  position{line: 439, col: 38, offset: 13260},
 													name: "FlexAssignments",
 												},
 											},
@@ -3246,35 +3290,35 @@ var g = &grammar{
 		},
 		{
 			name: "JoinKey",
-			pos:  position{line: 444, col: 1, offset: 13428},
+			pos:  position{line: 447, col: 1, offset: 13506},
 			expr: &choiceExpr{
-				pos: position{line: 445, col: 5, offset: 13440},
+				pos: position{line: 448, col: 5, offset: 13518},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 445, col: 5, offset: 13440},
+						pos:  position{line: 448, col: 5, offset: 13518},
 						name: "Lval",
 					},
 					&actionExpr{
-						pos: position{line: 446, col: 5, offset: 13449},
+						pos: position{line: 449, col: 5, offset: 13527},
 						run: (*parser).callonJoinKey3,
 						expr: &seqExpr{
-							pos: position{line: 446, col: 5, offset: 13449},
+							pos: position{line: 449, col: 5, offset: 13527},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 446, col: 5, offset: 13449},
+									pos:        position{line: 449, col: 5, offset: 13527},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 446, col: 9, offset: 13453},
+									pos:   position{line: 449, col: 9, offset: 13531},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 446, col: 14, offset: 13458},
+										pos:  position{line: 449, col: 14, offset: 13536},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 446, col: 19, offset: 13463},
+									pos:        position{line: 449, col: 19, offset: 13541},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -3286,23 +3330,23 @@ var g = &grammar{
 		},
 		{
 			name: "TasteProc",
-			pos:  position{line: 448, col: 1, offset: 13489},
+			pos:  position{line: 451, col: 1, offset: 13567},
 			expr: &actionExpr{
-				pos: position{line: 449, col: 5, offset: 13503},
+				pos: position{line: 452, col: 5, offset: 13581},
 				run: (*parser).callonTasteProc1,
 				expr: &seqExpr{
-					pos: position{line: 449, col: 5, offset: 13503},
+					pos: position{line: 452, col: 5, offset: 13581},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 449, col: 5, offset: 13503},
+							pos:        position{line: 452, col: 5, offset: 13581},
 							val:        "taste",
 							ignoreCase: true,
 						},
 						&labeledExpr{
-							pos:   position{line: 449, col: 14, offset: 13512},
+							pos:   position{line: 452, col: 14, offset: 13590},
 							label: "e",
 							expr: &ruleRefExpr{
-								pos:  position{line: 449, col: 16, offset: 13514},
+								pos:  position{line: 452, col: 16, offset: 13592},
 								name: "TasteExpr",
 							},
 						},
@@ -3312,25 +3356,25 @@ var g = &grammar{
 		},
 		{
 			name: "TasteExpr",
-			pos:  position{line: 476, col: 1, offset: 14448},
+			pos:  position{line: 479, col: 1, offset: 14526},
 			expr: &choiceExpr{
-				pos: position{line: 477, col: 5, offset: 14462},
+				pos: position{line: 480, col: 5, offset: 14540},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 477, col: 5, offset: 14462},
+						pos: position{line: 480, col: 5, offset: 14540},
 						run: (*parser).callonTasteExpr2,
 						expr: &seqExpr{
-							pos: position{line: 477, col: 5, offset: 14462},
+							pos: position{line: 480, col: 5, offset: 14540},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 477, col: 5, offset: 14462},
+									pos:  position{line: 480, col: 5, offset: 14540},
 									name: "_",
 								},
 								&labeledExpr{
-									pos:   position{line: 477, col: 7, offset: 14464},
+									pos:   position{line: 480, col: 7, offset: 14542},
 									label: "lval",
 									expr: &ruleRefExpr{
-										pos:  position{line: 477, col: 12, offset: 14469},
+										pos:  position{line: 480, col: 12, offset: 14547},
 										name: "Lval",
 									},
 								},
@@ -3338,10 +3382,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 478, col: 5, offset: 14498},
+						pos: position{line: 481, col: 5, offset: 14576},
 						run: (*parser).callonTasteExpr7,
 						expr: &litMatcher{
-							pos:        position{line: 478, col: 5, offset: 14498},
+							pos:        position{line: 481, col: 5, offset: 14576},
 							val:        "",
 							ignoreCase: false,
 						},
@@ -3351,60 +3395,60 @@ var g = &grammar{
 		},
 		{
 			name: "Lval",
-			pos:  position{line: 480, col: 1, offset: 14560},
+			pos:  position{line: 483, col: 1, offset: 14638},
 			expr: &ruleRefExpr{
-				pos:  position{line: 480, col: 8, offset: 14567},
+				pos:  position{line: 483, col: 8, offset: 14645},
 				name: "DerefExpr",
 			},
 		},
 		{
 			name: "FieldExpr",
-			pos:  position{line: 482, col: 1, offset: 14578},
+			pos:  position{line: 485, col: 1, offset: 14656},
 			expr: &ruleRefExpr{
-				pos:  position{line: 482, col: 13, offset: 14590},
+				pos:  position{line: 485, col: 13, offset: 14668},
 				name: "Lval",
 			},
 		},
 		{
 			name: "FieldExprs",
-			pos:  position{line: 484, col: 1, offset: 14596},
+			pos:  position{line: 487, col: 1, offset: 14674},
 			expr: &actionExpr{
-				pos: position{line: 485, col: 5, offset: 14611},
+				pos: position{line: 488, col: 5, offset: 14689},
 				run: (*parser).callonFieldExprs1,
 				expr: &seqExpr{
-					pos: position{line: 485, col: 5, offset: 14611},
+					pos: position{line: 488, col: 5, offset: 14689},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 485, col: 5, offset: 14611},
+							pos:   position{line: 488, col: 5, offset: 14689},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 485, col: 11, offset: 14617},
+								pos:  position{line: 488, col: 11, offset: 14695},
 								name: "FieldExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 485, col: 21, offset: 14627},
+							pos:   position{line: 488, col: 21, offset: 14705},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 485, col: 26, offset: 14632},
+								pos: position{line: 488, col: 26, offset: 14710},
 								expr: &seqExpr{
-									pos: position{line: 485, col: 27, offset: 14633},
+									pos: position{line: 488, col: 27, offset: 14711},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 485, col: 27, offset: 14633},
+											pos:  position{line: 488, col: 27, offset: 14711},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 485, col: 30, offset: 14636},
+											pos:        position{line: 488, col: 30, offset: 14714},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 485, col: 34, offset: 14640},
+											pos:  position{line: 488, col: 34, offset: 14718},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 485, col: 37, offset: 14643},
+											pos:  position{line: 488, col: 37, offset: 14721},
 											name: "FieldExpr",
 										},
 									},
@@ -3417,44 +3461,44 @@ var g = &grammar{
 		},
 		{
 			name: "Exprs",
-			pos:  position{line: 495, col: 1, offset: 14842},
+			pos:  position{line: 498, col: 1, offset: 14920},
 			expr: &actionExpr{
-				pos: position{line: 496, col: 5, offset: 14852},
+				pos: position{line: 499, col: 5, offset: 14930},
 				run: (*parser).callonExprs1,
 				expr: &seqExpr{
-					pos: position{line: 496, col: 5, offset: 14852},
+					pos: position{line: 499, col: 5, offset: 14930},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 496, col: 5, offset: 14852},
+							pos:   position{line: 499, col: 5, offset: 14930},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 496, col: 11, offset: 14858},
+								pos:  position{line: 499, col: 11, offset: 14936},
 								name: "Expr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 496, col: 16, offset: 14863},
+							pos:   position{line: 499, col: 16, offset: 14941},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 496, col: 21, offset: 14868},
+								pos: position{line: 499, col: 21, offset: 14946},
 								expr: &seqExpr{
-									pos: position{line: 496, col: 22, offset: 14869},
+									pos: position{line: 499, col: 22, offset: 14947},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 496, col: 22, offset: 14869},
+											pos:  position{line: 499, col: 22, offset: 14947},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 496, col: 25, offset: 14872},
+											pos:        position{line: 499, col: 25, offset: 14950},
 											val:        ",",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 496, col: 29, offset: 14876},
+											pos:  position{line: 499, col: 29, offset: 14954},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 496, col: 32, offset: 14879},
+											pos:  position{line: 499, col: 32, offset: 14957},
 											name: "Expr",
 										},
 									},
@@ -3467,39 +3511,39 @@ var g = &grammar{
 		},
 		{
 			name: "Assignment",
-			pos:  position{line: 506, col: 1, offset: 15073},
+			pos:  position{line: 509, col: 1, offset: 15151},
 			expr: &actionExpr{
-				pos: position{line: 507, col: 5, offset: 15088},
+				pos: position{line: 510, col: 5, offset: 15166},
 				run: (*parser).callonAssignment1,
 				expr: &seqExpr{
-					pos: position{line: 507, col: 5, offset: 15088},
+					pos: position{line: 510, col: 5, offset: 15166},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 507, col: 5, offset: 15088},
+							pos:   position{line: 510, col: 5, offset: 15166},
 							label: "lhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 507, col: 9, offset: 15092},
+								pos:  position{line: 510, col: 9, offset: 15170},
 								name: "Lval",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 507, col: 14, offset: 15097},
+							pos:  position{line: 510, col: 14, offset: 15175},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 507, col: 17, offset: 15100},
+							pos:        position{line: 510, col: 17, offset: 15178},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 507, col: 21, offset: 15104},
+							pos:  position{line: 510, col: 21, offset: 15182},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 507, col: 24, offset: 15107},
+							pos:   position{line: 510, col: 24, offset: 15185},
 							label: "rhs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 507, col: 28, offset: 15111},
+								pos:  position{line: 510, col: 28, offset: 15189},
 								name: "Expr",
 							},
 						},
@@ -3509,71 +3553,71 @@ var g = &grammar{
 		},
 		{
 			name: "Expr",
-			pos:  position{line: 509, col: 1, offset: 15200},
+			pos:  position{line: 512, col: 1, offset: 15278},
 			expr: &ruleRefExpr{
-				pos:  position{line: 509, col: 8, offset: 15207},
+				pos:  position{line: 512, col: 8, offset: 15285},
 				name: "ConditionalExpr",
 			},
 		},
 		{
 			name: "ConditionalExpr",
-			pos:  position{line: 511, col: 1, offset: 15224},
+			pos:  position{line: 514, col: 1, offset: 15302},
 			expr: &choiceExpr{
-				pos: position{line: 512, col: 5, offset: 15244},
+				pos: position{line: 515, col: 5, offset: 15322},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 512, col: 5, offset: 15244},
+						pos: position{line: 515, col: 5, offset: 15322},
 						run: (*parser).callonConditionalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 512, col: 5, offset: 15244},
+							pos: position{line: 515, col: 5, offset: 15322},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 512, col: 5, offset: 15244},
+									pos:   position{line: 515, col: 5, offset: 15322},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 512, col: 15, offset: 15254},
+										pos:  position{line: 515, col: 15, offset: 15332},
 										name: "LogicalOrExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 512, col: 29, offset: 15268},
+									pos:  position{line: 515, col: 29, offset: 15346},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 512, col: 32, offset: 15271},
+									pos:        position{line: 515, col: 32, offset: 15349},
 									val:        "?",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 512, col: 36, offset: 15275},
+									pos:  position{line: 515, col: 36, offset: 15353},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 512, col: 39, offset: 15278},
+									pos:   position{line: 515, col: 39, offset: 15356},
 									label: "thenClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 512, col: 50, offset: 15289},
+										pos:  position{line: 515, col: 50, offset: 15367},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 512, col: 55, offset: 15294},
+									pos:  position{line: 515, col: 55, offset: 15372},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 512, col: 58, offset: 15297},
+									pos:        position{line: 515, col: 58, offset: 15375},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 512, col: 62, offset: 15301},
+									pos:  position{line: 515, col: 62, offset: 15379},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 512, col: 65, offset: 15304},
+									pos:   position{line: 515, col: 65, offset: 15382},
 									label: "elseClause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 512, col: 76, offset: 15315},
+										pos:  position{line: 515, col: 76, offset: 15393},
 										name: "Expr",
 									},
 								},
@@ -3581,7 +3625,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 515, col: 5, offset: 15462},
+						pos:  position{line: 518, col: 5, offset: 15540},
 						name: "LogicalOrExpr",
 					},
 				},
@@ -3589,53 +3633,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalOrExpr",
-			pos:  position{line: 517, col: 1, offset: 15477},
+			pos:  position{line: 520, col: 1, offset: 15555},
 			expr: &actionExpr{
-				pos: position{line: 518, col: 5, offset: 15495},
+				pos: position{line: 521, col: 5, offset: 15573},
 				run: (*parser).callonLogicalOrExpr1,
 				expr: &seqExpr{
-					pos: position{line: 518, col: 5, offset: 15495},
+					pos: position{line: 521, col: 5, offset: 15573},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 518, col: 5, offset: 15495},
+							pos:   position{line: 521, col: 5, offset: 15573},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 518, col: 11, offset: 15501},
+								pos:  position{line: 521, col: 11, offset: 15579},
 								name: "LogicalAndExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 519, col: 5, offset: 15520},
+							pos:   position{line: 522, col: 5, offset: 15598},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 519, col: 10, offset: 15525},
+								pos: position{line: 522, col: 10, offset: 15603},
 								expr: &actionExpr{
-									pos: position{line: 519, col: 11, offset: 15526},
+									pos: position{line: 522, col: 11, offset: 15604},
 									run: (*parser).callonLogicalOrExpr7,
 									expr: &seqExpr{
-										pos: position{line: 519, col: 11, offset: 15526},
+										pos: position{line: 522, col: 11, offset: 15604},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 519, col: 11, offset: 15526},
+												pos:  position{line: 522, col: 11, offset: 15604},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 519, col: 14, offset: 15529},
+												pos:   position{line: 522, col: 14, offset: 15607},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 519, col: 17, offset: 15532},
+													pos:  position{line: 522, col: 17, offset: 15610},
 													name: "OrToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 519, col: 25, offset: 15540},
+												pos:  position{line: 522, col: 25, offset: 15618},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 519, col: 28, offset: 15543},
+												pos:   position{line: 522, col: 28, offset: 15621},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 519, col: 33, offset: 15548},
+													pos:  position{line: 522, col: 33, offset: 15626},
 													name: "LogicalAndExpr",
 												},
 											},
@@ -3650,53 +3694,53 @@ var g = &grammar{
 		},
 		{
 			name: "LogicalAndExpr",
-			pos:  position{line: 523, col: 1, offset: 15666},
+			pos:  position{line: 526, col: 1, offset: 15744},
 			expr: &actionExpr{
-				pos: position{line: 524, col: 5, offset: 15685},
+				pos: position{line: 527, col: 5, offset: 15763},
 				run: (*parser).callonLogicalAndExpr1,
 				expr: &seqExpr{
-					pos: position{line: 524, col: 5, offset: 15685},
+					pos: position{line: 527, col: 5, offset: 15763},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 524, col: 5, offset: 15685},
+							pos:   position{line: 527, col: 5, offset: 15763},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 524, col: 11, offset: 15691},
+								pos:  position{line: 527, col: 11, offset: 15769},
 								name: "EqualityCompareExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 525, col: 5, offset: 15715},
+							pos:   position{line: 528, col: 5, offset: 15793},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 525, col: 10, offset: 15720},
+								pos: position{line: 528, col: 10, offset: 15798},
 								expr: &actionExpr{
-									pos: position{line: 525, col: 11, offset: 15721},
+									pos: position{line: 528, col: 11, offset: 15799},
 									run: (*parser).callonLogicalAndExpr7,
 									expr: &seqExpr{
-										pos: position{line: 525, col: 11, offset: 15721},
+										pos: position{line: 528, col: 11, offset: 15799},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 525, col: 11, offset: 15721},
+												pos:  position{line: 528, col: 11, offset: 15799},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 525, col: 14, offset: 15724},
+												pos:   position{line: 528, col: 14, offset: 15802},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 525, col: 17, offset: 15727},
+													pos:  position{line: 528, col: 17, offset: 15805},
 													name: "AndToken",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 525, col: 26, offset: 15736},
+												pos:  position{line: 528, col: 26, offset: 15814},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 525, col: 29, offset: 15739},
+												pos:   position{line: 528, col: 29, offset: 15817},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 525, col: 34, offset: 15744},
+													pos:  position{line: 528, col: 34, offset: 15822},
 													name: "EqualityCompareExpr",
 												},
 											},
@@ -3711,53 +3755,53 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityCompareExpr",
-			pos:  position{line: 529, col: 1, offset: 15867},
+			pos:  position{line: 532, col: 1, offset: 15945},
 			expr: &actionExpr{
-				pos: position{line: 530, col: 5, offset: 15891},
+				pos: position{line: 533, col: 5, offset: 15969},
 				run: (*parser).callonEqualityCompareExpr1,
 				expr: &seqExpr{
-					pos: position{line: 530, col: 5, offset: 15891},
+					pos: position{line: 533, col: 5, offset: 15969},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 530, col: 5, offset: 15891},
+							pos:   position{line: 533, col: 5, offset: 15969},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 530, col: 11, offset: 15897},
+								pos:  position{line: 533, col: 11, offset: 15975},
 								name: "RelativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 531, col: 5, offset: 15914},
+							pos:   position{line: 534, col: 5, offset: 15992},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 531, col: 10, offset: 15919},
+								pos: position{line: 534, col: 10, offset: 15997},
 								expr: &actionExpr{
-									pos: position{line: 531, col: 11, offset: 15920},
+									pos: position{line: 534, col: 11, offset: 15998},
 									run: (*parser).callonEqualityCompareExpr7,
 									expr: &seqExpr{
-										pos: position{line: 531, col: 11, offset: 15920},
+										pos: position{line: 534, col: 11, offset: 15998},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 531, col: 11, offset: 15920},
+												pos:  position{line: 534, col: 11, offset: 15998},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 531, col: 14, offset: 15923},
+												pos:   position{line: 534, col: 14, offset: 16001},
 												label: "comp",
 												expr: &ruleRefExpr{
-													pos:  position{line: 531, col: 19, offset: 15928},
+													pos:  position{line: 534, col: 19, offset: 16006},
 													name: "EqualityComparator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 531, col: 38, offset: 15947},
+												pos:  position{line: 534, col: 38, offset: 16025},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 531, col: 41, offset: 15950},
+												pos:   position{line: 534, col: 41, offset: 16028},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 531, col: 46, offset: 15955},
+													pos:  position{line: 534, col: 46, offset: 16033},
 													name: "RelativeExpr",
 												},
 											},
@@ -3772,20 +3816,20 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 535, col: 1, offset: 16073},
+			pos:  position{line: 538, col: 1, offset: 16151},
 			expr: &actionExpr{
-				pos: position{line: 536, col: 5, offset: 16094},
+				pos: position{line: 539, col: 5, offset: 16172},
 				run: (*parser).callonEqualityOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 536, col: 6, offset: 16095},
+					pos: position{line: 539, col: 6, offset: 16173},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 536, col: 6, offset: 16095},
+							pos:        position{line: 539, col: 6, offset: 16173},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 536, col: 12, offset: 16101},
+							pos:        position{line: 539, col: 12, offset: 16179},
 							val:        "!=",
 							ignoreCase: false,
 						},
@@ -3795,19 +3839,19 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityComparator",
-			pos:  position{line: 538, col: 1, offset: 16139},
+			pos:  position{line: 541, col: 1, offset: 16217},
 			expr: &choiceExpr{
-				pos: position{line: 539, col: 5, offset: 16162},
+				pos: position{line: 542, col: 5, offset: 16240},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 539, col: 5, offset: 16162},
+						pos:  position{line: 542, col: 5, offset: 16240},
 						name: "EqualityOperator",
 					},
 					&actionExpr{
-						pos: position{line: 540, col: 5, offset: 16183},
+						pos: position{line: 543, col: 5, offset: 16261},
 						run: (*parser).callonEqualityComparator3,
 						expr: &litMatcher{
-							pos:        position{line: 540, col: 5, offset: 16183},
+							pos:        position{line: 543, col: 5, offset: 16261},
 							val:        "in",
 							ignoreCase: false,
 						},
@@ -3817,53 +3861,53 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeExpr",
-			pos:  position{line: 542, col: 1, offset: 16220},
+			pos:  position{line: 545, col: 1, offset: 16298},
 			expr: &actionExpr{
-				pos: position{line: 543, col: 5, offset: 16237},
+				pos: position{line: 546, col: 5, offset: 16315},
 				run: (*parser).callonRelativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 543, col: 5, offset: 16237},
+					pos: position{line: 546, col: 5, offset: 16315},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 543, col: 5, offset: 16237},
+							pos:   position{line: 546, col: 5, offset: 16315},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 543, col: 11, offset: 16243},
+								pos:  position{line: 546, col: 11, offset: 16321},
 								name: "AdditiveExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 544, col: 5, offset: 16260},
+							pos:   position{line: 547, col: 5, offset: 16338},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 544, col: 10, offset: 16265},
+								pos: position{line: 547, col: 10, offset: 16343},
 								expr: &actionExpr{
-									pos: position{line: 544, col: 11, offset: 16266},
+									pos: position{line: 547, col: 11, offset: 16344},
 									run: (*parser).callonRelativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 544, col: 11, offset: 16266},
+										pos: position{line: 547, col: 11, offset: 16344},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 544, col: 11, offset: 16266},
+												pos:  position{line: 547, col: 11, offset: 16344},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 544, col: 14, offset: 16269},
+												pos:   position{line: 547, col: 14, offset: 16347},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 544, col: 17, offset: 16272},
+													pos:  position{line: 547, col: 17, offset: 16350},
 													name: "RelativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 544, col: 34, offset: 16289},
+												pos:  position{line: 547, col: 34, offset: 16367},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 544, col: 37, offset: 16292},
+												pos:   position{line: 547, col: 37, offset: 16370},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 544, col: 42, offset: 16297},
+													pos:  position{line: 547, col: 42, offset: 16375},
 													name: "AdditiveExpr",
 												},
 											},
@@ -3878,30 +3922,30 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeOperator",
-			pos:  position{line: 548, col: 1, offset: 16413},
+			pos:  position{line: 551, col: 1, offset: 16491},
 			expr: &actionExpr{
-				pos: position{line: 548, col: 20, offset: 16432},
+				pos: position{line: 551, col: 20, offset: 16510},
 				run: (*parser).callonRelativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 548, col: 21, offset: 16433},
+					pos: position{line: 551, col: 21, offset: 16511},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 548, col: 21, offset: 16433},
+							pos:        position{line: 551, col: 21, offset: 16511},
 							val:        "<=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 548, col: 28, offset: 16440},
+							pos:        position{line: 551, col: 28, offset: 16518},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 548, col: 34, offset: 16446},
+							pos:        position{line: 551, col: 34, offset: 16524},
 							val:        ">=",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 548, col: 41, offset: 16453},
+							pos:        position{line: 551, col: 41, offset: 16531},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -3911,53 +3955,53 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveExpr",
-			pos:  position{line: 550, col: 1, offset: 16490},
+			pos:  position{line: 553, col: 1, offset: 16568},
 			expr: &actionExpr{
-				pos: position{line: 551, col: 5, offset: 16507},
+				pos: position{line: 554, col: 5, offset: 16585},
 				run: (*parser).callonAdditiveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 551, col: 5, offset: 16507},
+					pos: position{line: 554, col: 5, offset: 16585},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 551, col: 5, offset: 16507},
+							pos:   position{line: 554, col: 5, offset: 16585},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 551, col: 11, offset: 16513},
+								pos:  position{line: 554, col: 11, offset: 16591},
 								name: "MultiplicativeExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 552, col: 5, offset: 16536},
+							pos:   position{line: 555, col: 5, offset: 16614},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 552, col: 10, offset: 16541},
+								pos: position{line: 555, col: 10, offset: 16619},
 								expr: &actionExpr{
-									pos: position{line: 552, col: 11, offset: 16542},
+									pos: position{line: 555, col: 11, offset: 16620},
 									run: (*parser).callonAdditiveExpr7,
 									expr: &seqExpr{
-										pos: position{line: 552, col: 11, offset: 16542},
+										pos: position{line: 555, col: 11, offset: 16620},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 552, col: 11, offset: 16542},
+												pos:  position{line: 555, col: 11, offset: 16620},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 552, col: 14, offset: 16545},
+												pos:   position{line: 555, col: 14, offset: 16623},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 552, col: 17, offset: 16548},
+													pos:  position{line: 555, col: 17, offset: 16626},
 													name: "AdditiveOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 552, col: 34, offset: 16565},
+												pos:  position{line: 555, col: 34, offset: 16643},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 552, col: 37, offset: 16568},
+												pos:   position{line: 555, col: 37, offset: 16646},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 552, col: 42, offset: 16573},
+													pos:  position{line: 555, col: 42, offset: 16651},
 													name: "MultiplicativeExpr",
 												},
 											},
@@ -3972,20 +4016,20 @@ var g = &grammar{
 		},
 		{
 			name: "AdditiveOperator",
-			pos:  position{line: 556, col: 1, offset: 16695},
+			pos:  position{line: 559, col: 1, offset: 16773},
 			expr: &actionExpr{
-				pos: position{line: 556, col: 20, offset: 16714},
+				pos: position{line: 559, col: 20, offset: 16792},
 				run: (*parser).callonAdditiveOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 556, col: 21, offset: 16715},
+					pos: position{line: 559, col: 21, offset: 16793},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 556, col: 21, offset: 16715},
+							pos:        position{line: 559, col: 21, offset: 16793},
 							val:        "+",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 556, col: 27, offset: 16721},
+							pos:        position{line: 559, col: 27, offset: 16799},
 							val:        "-",
 							ignoreCase: false,
 						},
@@ -3995,53 +4039,53 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeExpr",
-			pos:  position{line: 558, col: 1, offset: 16758},
+			pos:  position{line: 561, col: 1, offset: 16836},
 			expr: &actionExpr{
-				pos: position{line: 559, col: 5, offset: 16781},
+				pos: position{line: 562, col: 5, offset: 16859},
 				run: (*parser).callonMultiplicativeExpr1,
 				expr: &seqExpr{
-					pos: position{line: 559, col: 5, offset: 16781},
+					pos: position{line: 562, col: 5, offset: 16859},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 559, col: 5, offset: 16781},
+							pos:   position{line: 562, col: 5, offset: 16859},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 559, col: 11, offset: 16787},
+								pos:  position{line: 562, col: 11, offset: 16865},
 								name: "NotExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 560, col: 5, offset: 16799},
+							pos:   position{line: 563, col: 5, offset: 16877},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 560, col: 10, offset: 16804},
+								pos: position{line: 563, col: 10, offset: 16882},
 								expr: &actionExpr{
-									pos: position{line: 560, col: 11, offset: 16805},
+									pos: position{line: 563, col: 11, offset: 16883},
 									run: (*parser).callonMultiplicativeExpr7,
 									expr: &seqExpr{
-										pos: position{line: 560, col: 11, offset: 16805},
+										pos: position{line: 563, col: 11, offset: 16883},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 560, col: 11, offset: 16805},
+												pos:  position{line: 563, col: 11, offset: 16883},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 560, col: 14, offset: 16808},
+												pos:   position{line: 563, col: 14, offset: 16886},
 												label: "op",
 												expr: &ruleRefExpr{
-													pos:  position{line: 560, col: 17, offset: 16811},
+													pos:  position{line: 563, col: 17, offset: 16889},
 													name: "MultiplicativeOperator",
 												},
 											},
 											&ruleRefExpr{
-												pos:  position{line: 560, col: 40, offset: 16834},
+												pos:  position{line: 563, col: 40, offset: 16912},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 560, col: 43, offset: 16837},
+												pos:   position{line: 563, col: 43, offset: 16915},
 												label: "expr",
 												expr: &ruleRefExpr{
-													pos:  position{line: 560, col: 48, offset: 16842},
+													pos:  position{line: 563, col: 48, offset: 16920},
 													name: "NotExpr",
 												},
 											},
@@ -4056,20 +4100,20 @@ var g = &grammar{
 		},
 		{
 			name: "MultiplicativeOperator",
-			pos:  position{line: 564, col: 1, offset: 16953},
+			pos:  position{line: 567, col: 1, offset: 17031},
 			expr: &actionExpr{
-				pos: position{line: 564, col: 26, offset: 16978},
+				pos: position{line: 567, col: 26, offset: 17056},
 				run: (*parser).callonMultiplicativeOperator1,
 				expr: &choiceExpr{
-					pos: position{line: 564, col: 27, offset: 16979},
+					pos: position{line: 567, col: 27, offset: 17057},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 564, col: 27, offset: 16979},
+							pos:        position{line: 567, col: 27, offset: 17057},
 							val:        "*",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 564, col: 33, offset: 16985},
+							pos:        position{line: 567, col: 33, offset: 17063},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -4079,30 +4123,30 @@ var g = &grammar{
 		},
 		{
 			name: "NotExpr",
-			pos:  position{line: 566, col: 1, offset: 17022},
+			pos:  position{line: 569, col: 1, offset: 17100},
 			expr: &choiceExpr{
-				pos: position{line: 567, col: 5, offset: 17034},
+				pos: position{line: 570, col: 5, offset: 17112},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 567, col: 5, offset: 17034},
+						pos: position{line: 570, col: 5, offset: 17112},
 						run: (*parser).callonNotExpr2,
 						expr: &seqExpr{
-							pos: position{line: 567, col: 5, offset: 17034},
+							pos: position{line: 570, col: 5, offset: 17112},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 567, col: 5, offset: 17034},
+									pos:        position{line: 570, col: 5, offset: 17112},
 									val:        "!",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 567, col: 9, offset: 17038},
+									pos:  position{line: 570, col: 9, offset: 17116},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 567, col: 12, offset: 17041},
+									pos:   position{line: 570, col: 12, offset: 17119},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 567, col: 14, offset: 17043},
+										pos:  position{line: 570, col: 14, offset: 17121},
 										name: "NotExpr",
 									},
 								},
@@ -4110,7 +4154,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 570, col: 5, offset: 17156},
+						pos:  position{line: 573, col: 5, offset: 17234},
 						name: "CastExpr",
 					},
 				},
@@ -4118,42 +4162,42 @@ var g = &grammar{
 		},
 		{
 			name: "CastExpr",
-			pos:  position{line: 572, col: 1, offset: 17166},
+			pos:  position{line: 575, col: 1, offset: 17244},
 			expr: &choiceExpr{
-				pos: position{line: 573, col: 5, offset: 17179},
+				pos: position{line: 576, col: 5, offset: 17257},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 573, col: 5, offset: 17179},
+						pos: position{line: 576, col: 5, offset: 17257},
 						run: (*parser).callonCastExpr2,
 						expr: &seqExpr{
-							pos: position{line: 573, col: 5, offset: 17179},
+							pos: position{line: 576, col: 5, offset: 17257},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 573, col: 5, offset: 17179},
+									pos:   position{line: 576, col: 5, offset: 17257},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 573, col: 7, offset: 17181},
+										pos:  position{line: 576, col: 7, offset: 17259},
 										name: "FuncExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 573, col: 16, offset: 17190},
+									pos:  position{line: 576, col: 16, offset: 17268},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 573, col: 19, offset: 17193},
+									pos:        position{line: 576, col: 19, offset: 17271},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 573, col: 23, offset: 17197},
+									pos:  position{line: 576, col: 23, offset: 17275},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 573, col: 26, offset: 17200},
+									pos:   position{line: 576, col: 26, offset: 17278},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 573, col: 30, offset: 17204},
+										pos:  position{line: 576, col: 30, offset: 17282},
 										name: "CastType",
 									},
 								},
@@ -4161,7 +4205,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 576, col: 5, offset: 17308},
+						pos:  position{line: 579, col: 5, offset: 17386},
 						name: "FuncExpr",
 					},
 				},
@@ -4169,43 +4213,43 @@ var g = &grammar{
 		},
 		{
 			name: "FuncExpr",
-			pos:  position{line: 578, col: 1, offset: 17318},
+			pos:  position{line: 581, col: 1, offset: 17396},
 			expr: &choiceExpr{
-				pos: position{line: 579, col: 5, offset: 17331},
+				pos: position{line: 582, col: 5, offset: 17409},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 579, col: 5, offset: 17331},
+						pos:  position{line: 582, col: 5, offset: 17409},
 						name: "SelectExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 580, col: 5, offset: 17346},
+						pos:  position{line: 583, col: 5, offset: 17424},
 						name: "MatchExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 581, col: 5, offset: 17360},
+						pos:  position{line: 584, col: 5, offset: 17438},
 						name: "TypeLiteral",
 					},
 					&actionExpr{
-						pos: position{line: 582, col: 5, offset: 17376},
+						pos: position{line: 585, col: 5, offset: 17454},
 						run: (*parser).callonFuncExpr5,
 						expr: &seqExpr{
-							pos: position{line: 582, col: 5, offset: 17376},
+							pos: position{line: 585, col: 5, offset: 17454},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 582, col: 5, offset: 17376},
+									pos:   position{line: 585, col: 5, offset: 17454},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 582, col: 11, offset: 17382},
+										pos:  position{line: 585, col: 11, offset: 17460},
 										name: "Function",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 582, col: 20, offset: 17391},
+									pos:   position{line: 585, col: 20, offset: 17469},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 582, col: 25, offset: 17396},
+										pos: position{line: 585, col: 25, offset: 17474},
 										expr: &ruleRefExpr{
-											pos:  position{line: 582, col: 26, offset: 17397},
+											pos:  position{line: 585, col: 26, offset: 17475},
 											name: "Deref",
 										},
 									},
@@ -4214,11 +4258,11 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 585, col: 5, offset: 17468},
+						pos:  position{line: 588, col: 5, offset: 17546},
 						name: "DerefExpr",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 586, col: 5, offset: 17482},
+						pos:  position{line: 589, col: 5, offset: 17560},
 						name: "Primary",
 					},
 				},
@@ -4226,20 +4270,20 @@ var g = &grammar{
 		},
 		{
 			name: "FuncGuard",
-			pos:  position{line: 588, col: 1, offset: 17491},
+			pos:  position{line: 591, col: 1, offset: 17569},
 			expr: &seqExpr{
-				pos: position{line: 588, col: 13, offset: 17503},
+				pos: position{line: 591, col: 13, offset: 17581},
 				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 588, col: 13, offset: 17503},
+						pos:  position{line: 591, col: 13, offset: 17581},
 						name: "NotFuncs",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 588, col: 22, offset: 17512},
+						pos:  position{line: 591, col: 22, offset: 17590},
 						name: "__",
 					},
 					&litMatcher{
-						pos:        position{line: 588, col: 25, offset: 17515},
+						pos:        position{line: 591, col: 25, offset: 17593},
 						val:        "(",
 						ignoreCase: false,
 					},
@@ -4248,27 +4292,27 @@ var g = &grammar{
 		},
 		{
 			name: "NotFuncs",
-			pos:  position{line: 590, col: 1, offset: 17520},
+			pos:  position{line: 593, col: 1, offset: 17598},
 			expr: &choiceExpr{
-				pos: position{line: 591, col: 5, offset: 17533},
+				pos: position{line: 594, col: 5, offset: 17611},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 591, col: 5, offset: 17533},
+						pos:        position{line: 594, col: 5, offset: 17611},
 						val:        "not",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 592, col: 5, offset: 17543},
+						pos:        position{line: 595, col: 5, offset: 17621},
 						val:        "match",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 593, col: 5, offset: 17555},
+						pos:        position{line: 596, col: 5, offset: 17633},
 						val:        "select",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 594, col: 5, offset: 17568},
+						pos:        position{line: 597, col: 5, offset: 17646},
 						val:        "type",
 						ignoreCase: false,
 					},
@@ -4277,37 +4321,37 @@ var g = &grammar{
 		},
 		{
 			name: "MatchExpr",
-			pos:  position{line: 596, col: 1, offset: 17576},
+			pos:  position{line: 599, col: 1, offset: 17654},
 			expr: &actionExpr{
-				pos: position{line: 597, col: 5, offset: 17590},
+				pos: position{line: 600, col: 5, offset: 17668},
 				run: (*parser).callonMatchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 597, col: 5, offset: 17590},
+					pos: position{line: 600, col: 5, offset: 17668},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 597, col: 5, offset: 17590},
+							pos:        position{line: 600, col: 5, offset: 17668},
 							val:        "match",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 597, col: 13, offset: 17598},
+							pos:  position{line: 600, col: 13, offset: 17676},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 597, col: 16, offset: 17601},
+							pos:        position{line: 600, col: 16, offset: 17679},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 597, col: 20, offset: 17605},
+							pos:   position{line: 600, col: 20, offset: 17683},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 597, col: 25, offset: 17610},
+								pos:  position{line: 600, col: 25, offset: 17688},
 								name: "SearchBoolean",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 597, col: 39, offset: 17624},
+							pos:        position{line: 600, col: 39, offset: 17702},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4317,77 +4361,77 @@ var g = &grammar{
 		},
 		{
 			name: "SelectExpr",
-			pos:  position{line: 599, col: 1, offset: 17650},
+			pos:  position{line: 602, col: 1, offset: 17728},
 			expr: &actionExpr{
-				pos: position{line: 600, col: 5, offset: 17665},
+				pos: position{line: 603, col: 5, offset: 17743},
 				run: (*parser).callonSelectExpr1,
 				expr: &seqExpr{
-					pos: position{line: 600, col: 5, offset: 17665},
+					pos: position{line: 603, col: 5, offset: 17743},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 600, col: 5, offset: 17665},
+							pos:        position{line: 603, col: 5, offset: 17743},
 							val:        "select",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 600, col: 14, offset: 17674},
+							pos:  position{line: 603, col: 14, offset: 17752},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 600, col: 17, offset: 17677},
+							pos:        position{line: 603, col: 17, offset: 17755},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 600, col: 21, offset: 17681},
+							pos:  position{line: 603, col: 21, offset: 17759},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 600, col: 24, offset: 17684},
+							pos:   position{line: 603, col: 24, offset: 17762},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 600, col: 29, offset: 17689},
+								pos:  position{line: 603, col: 29, offset: 17767},
 								name: "ArgumentList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 600, col: 42, offset: 17702},
+							pos:  position{line: 603, col: 42, offset: 17780},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 600, col: 45, offset: 17705},
+							pos:        position{line: 603, col: 45, offset: 17783},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 600, col: 49, offset: 17709},
+							pos:   position{line: 603, col: 49, offset: 17787},
 							label: "methods",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 600, col: 57, offset: 17717},
+								pos: position{line: 603, col: 57, offset: 17795},
 								expr: &actionExpr{
-									pos: position{line: 600, col: 58, offset: 17718},
+									pos: position{line: 603, col: 58, offset: 17796},
 									run: (*parser).callonSelectExpr13,
 									expr: &seqExpr{
-										pos: position{line: 600, col: 58, offset: 17718},
+										pos: position{line: 603, col: 58, offset: 17796},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 600, col: 58, offset: 17718},
+												pos:  position{line: 603, col: 58, offset: 17796},
 												name: "__",
 											},
 											&litMatcher{
-												pos:        position{line: 600, col: 61, offset: 17721},
+												pos:        position{line: 603, col: 61, offset: 17799},
 												val:        ".",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 600, col: 65, offset: 17725},
+												pos:  position{line: 603, col: 65, offset: 17803},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 600, col: 68, offset: 17728},
+												pos:   position{line: 603, col: 68, offset: 17806},
 												label: "e",
 												expr: &ruleRefExpr{
-													pos:  position{line: 600, col: 70, offset: 17730},
+													pos:  position{line: 603, col: 70, offset: 17808},
 													name: "Function",
 												},
 											},
@@ -4402,55 +4446,55 @@ var g = &grammar{
 		},
 		{
 			name: "Function",
-			pos:  position{line: 604, col: 1, offset: 17896},
+			pos:  position{line: 607, col: 1, offset: 17974},
 			expr: &actionExpr{
-				pos: position{line: 605, col: 5, offset: 17909},
+				pos: position{line: 608, col: 5, offset: 17987},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 605, col: 5, offset: 17909},
+					pos: position{line: 608, col: 5, offset: 17987},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 605, col: 5, offset: 17909},
+							pos: position{line: 608, col: 5, offset: 17987},
 							expr: &ruleRefExpr{
-								pos:  position{line: 605, col: 6, offset: 17910},
+								pos:  position{line: 608, col: 6, offset: 17988},
 								name: "FuncGuard",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 605, col: 16, offset: 17920},
+							pos:   position{line: 608, col: 16, offset: 17998},
 							label: "fn",
 							expr: &ruleRefExpr{
-								pos:  position{line: 605, col: 19, offset: 17923},
+								pos:  position{line: 608, col: 19, offset: 18001},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 34, offset: 17938},
+							pos:  position{line: 608, col: 34, offset: 18016},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 605, col: 37, offset: 17941},
+							pos:        position{line: 608, col: 37, offset: 18019},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 41, offset: 17945},
+							pos:  position{line: 608, col: 41, offset: 18023},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 605, col: 44, offset: 17948},
+							pos:   position{line: 608, col: 44, offset: 18026},
 							label: "args",
 							expr: &ruleRefExpr{
-								pos:  position{line: 605, col: 49, offset: 17953},
+								pos:  position{line: 608, col: 49, offset: 18031},
 								name: "ArgumentList",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 605, col: 62, offset: 17966},
+							pos:  position{line: 608, col: 62, offset: 18044},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 605, col: 65, offset: 17969},
+							pos:        position{line: 608, col: 65, offset: 18047},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -4460,53 +4504,53 @@ var g = &grammar{
 		},
 		{
 			name: "ArgumentList",
-			pos:  position{line: 609, col: 1, offset: 18075},
+			pos:  position{line: 612, col: 1, offset: 18153},
 			expr: &choiceExpr{
-				pos: position{line: 610, col: 5, offset: 18092},
+				pos: position{line: 613, col: 5, offset: 18170},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 610, col: 5, offset: 18092},
+						pos: position{line: 613, col: 5, offset: 18170},
 						run: (*parser).callonArgumentList2,
 						expr: &seqExpr{
-							pos: position{line: 610, col: 5, offset: 18092},
+							pos: position{line: 613, col: 5, offset: 18170},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 610, col: 5, offset: 18092},
+									pos:   position{line: 613, col: 5, offset: 18170},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 610, col: 11, offset: 18098},
+										pos:  position{line: 613, col: 11, offset: 18176},
 										name: "Expr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 610, col: 16, offset: 18103},
+									pos:   position{line: 613, col: 16, offset: 18181},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 610, col: 21, offset: 18108},
+										pos: position{line: 613, col: 21, offset: 18186},
 										expr: &actionExpr{
-											pos: position{line: 610, col: 22, offset: 18109},
+											pos: position{line: 613, col: 22, offset: 18187},
 											run: (*parser).callonArgumentList8,
 											expr: &seqExpr{
-												pos: position{line: 610, col: 22, offset: 18109},
+												pos: position{line: 613, col: 22, offset: 18187},
 												exprs: []interface{}{
 													&ruleRefExpr{
-														pos:  position{line: 610, col: 22, offset: 18109},
+														pos:  position{line: 613, col: 22, offset: 18187},
 														name: "__",
 													},
 													&litMatcher{
-														pos:        position{line: 610, col: 25, offset: 18112},
+														pos:        position{line: 613, col: 25, offset: 18190},
 														val:        ",",
 														ignoreCase: false,
 													},
 													&ruleRefExpr{
-														pos:  position{line: 610, col: 29, offset: 18116},
+														pos:  position{line: 613, col: 29, offset: 18194},
 														name: "__",
 													},
 													&labeledExpr{
-														pos:   position{line: 610, col: 32, offset: 18119},
+														pos:   position{line: 613, col: 32, offset: 18197},
 														label: "e",
 														expr: &ruleRefExpr{
-															pos:  position{line: 610, col: 34, offset: 18121},
+															pos:  position{line: 613, col: 34, offset: 18199},
 															name: "Expr",
 														},
 													},
@@ -4519,10 +4563,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 613, col: 5, offset: 18233},
+						pos: position{line: 616, col: 5, offset: 18311},
 						run: (*parser).callonArgumentList15,
 						expr: &ruleRefExpr{
-							pos:  position{line: 613, col: 5, offset: 18233},
+							pos:  position{line: 616, col: 5, offset: 18311},
 							name: "__",
 						},
 					},
@@ -4531,31 +4575,31 @@ var g = &grammar{
 		},
 		{
 			name: "DerefExpr",
-			pos:  position{line: 615, col: 1, offset: 18269},
+			pos:  position{line: 618, col: 1, offset: 18347},
 			expr: &choiceExpr{
-				pos: position{line: 616, col: 5, offset: 18283},
+				pos: position{line: 619, col: 5, offset: 18361},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 616, col: 5, offset: 18283},
+						pos: position{line: 619, col: 5, offset: 18361},
 						run: (*parser).callonDerefExpr2,
 						expr: &seqExpr{
-							pos: position{line: 616, col: 5, offset: 18283},
+							pos: position{line: 619, col: 5, offset: 18361},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 616, col: 5, offset: 18283},
+									pos:   position{line: 619, col: 5, offset: 18361},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 616, col: 11, offset: 18289},
+										pos:  position{line: 619, col: 11, offset: 18367},
 										name: "DotId",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 616, col: 17, offset: 18295},
+									pos:   position{line: 619, col: 17, offset: 18373},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 616, col: 22, offset: 18300},
+										pos: position{line: 619, col: 22, offset: 18378},
 										expr: &ruleRefExpr{
-											pos:  position{line: 616, col: 23, offset: 18301},
+											pos:  position{line: 619, col: 23, offset: 18379},
 											name: "Deref",
 										},
 									},
@@ -4564,26 +4608,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 619, col: 5, offset: 18372},
+						pos: position{line: 622, col: 5, offset: 18450},
 						run: (*parser).callonDerefExpr9,
 						expr: &seqExpr{
-							pos: position{line: 619, col: 5, offset: 18372},
+							pos: position{line: 622, col: 5, offset: 18450},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 619, col: 5, offset: 18372},
+									pos:   position{line: 622, col: 5, offset: 18450},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 619, col: 11, offset: 18378},
+										pos:  position{line: 622, col: 11, offset: 18456},
 										name: "Identifier",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 619, col: 22, offset: 18389},
+									pos:   position{line: 622, col: 22, offset: 18467},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 619, col: 27, offset: 18394},
+										pos: position{line: 622, col: 27, offset: 18472},
 										expr: &ruleRefExpr{
-											pos:  position{line: 619, col: 28, offset: 18395},
+											pos:  position{line: 622, col: 28, offset: 18473},
 											name: "Deref",
 										},
 									},
@@ -4592,10 +4636,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 622, col: 5, offset: 18466},
+						pos: position{line: 625, col: 5, offset: 18544},
 						run: (*parser).callonDerefExpr16,
 						expr: &litMatcher{
-							pos:        position{line: 622, col: 5, offset: 18466},
+							pos:        position{line: 625, col: 5, offset: 18544},
 							val:        ".",
 							ignoreCase: false,
 						},
@@ -4605,26 +4649,26 @@ var g = &grammar{
 		},
 		{
 			name: "DotId",
-			pos:  position{line: 626, col: 1, offset: 18539},
+			pos:  position{line: 629, col: 1, offset: 18617},
 			expr: &choiceExpr{
-				pos: position{line: 627, col: 5, offset: 18549},
+				pos: position{line: 630, col: 5, offset: 18627},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 627, col: 5, offset: 18549},
+						pos: position{line: 630, col: 5, offset: 18627},
 						run: (*parser).callonDotId2,
 						expr: &seqExpr{
-							pos: position{line: 627, col: 5, offset: 18549},
+							pos: position{line: 630, col: 5, offset: 18627},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 627, col: 5, offset: 18549},
+									pos:        position{line: 630, col: 5, offset: 18627},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 627, col: 9, offset: 18553},
+									pos:   position{line: 630, col: 9, offset: 18631},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 627, col: 15, offset: 18559},
+										pos:  position{line: 630, col: 15, offset: 18637},
 										name: "Identifier",
 									},
 								},
@@ -4632,31 +4676,31 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 636, col: 5, offset: 18783},
+						pos: position{line: 639, col: 5, offset: 18861},
 						run: (*parser).callonDotId7,
 						expr: &seqExpr{
-							pos: position{line: 636, col: 5, offset: 18783},
+							pos: position{line: 639, col: 5, offset: 18861},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 636, col: 5, offset: 18783},
+									pos:        position{line: 639, col: 5, offset: 18861},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 636, col: 9, offset: 18787},
+									pos:        position{line: 639, col: 9, offset: 18865},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 636, col: 13, offset: 18791},
+									pos:   position{line: 639, col: 13, offset: 18869},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 636, col: 18, offset: 18796},
+										pos:  position{line: 639, col: 18, offset: 18874},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 636, col: 23, offset: 18801},
+									pos:        position{line: 639, col: 23, offset: 18879},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4668,52 +4712,52 @@ var g = &grammar{
 		},
 		{
 			name: "Deref",
-			pos:  position{line: 646, col: 1, offset: 19014},
+			pos:  position{line: 649, col: 1, offset: 19092},
 			expr: &choiceExpr{
-				pos: position{line: 647, col: 5, offset: 19024},
+				pos: position{line: 650, col: 5, offset: 19102},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 647, col: 5, offset: 19024},
+						pos: position{line: 650, col: 5, offset: 19102},
 						run: (*parser).callonDeref2,
 						expr: &seqExpr{
-							pos: position{line: 647, col: 5, offset: 19024},
+							pos: position{line: 650, col: 5, offset: 19102},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 647, col: 5, offset: 19024},
+									pos:        position{line: 650, col: 5, offset: 19102},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 647, col: 9, offset: 19028},
+									pos:   position{line: 650, col: 9, offset: 19106},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 647, col: 14, offset: 19033},
+										pos:  position{line: 650, col: 14, offset: 19111},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 647, col: 27, offset: 19046},
+									pos:  position{line: 650, col: 27, offset: 19124},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 647, col: 30, offset: 19049},
+									pos:        position{line: 650, col: 30, offset: 19127},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 647, col: 34, offset: 19053},
+									pos:  position{line: 650, col: 34, offset: 19131},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 647, col: 37, offset: 19056},
+									pos:   position{line: 650, col: 37, offset: 19134},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 647, col: 40, offset: 19059},
+										pos:  position{line: 650, col: 40, offset: 19137},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 647, col: 53, offset: 19072},
+									pos:        position{line: 650, col: 53, offset: 19150},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4721,39 +4765,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 653, col: 5, offset: 19247},
+						pos: position{line: 656, col: 5, offset: 19325},
 						run: (*parser).callonDeref13,
 						expr: &seqExpr{
-							pos: position{line: 653, col: 5, offset: 19247},
+							pos: position{line: 656, col: 5, offset: 19325},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 653, col: 5, offset: 19247},
+									pos:        position{line: 656, col: 5, offset: 19325},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 653, col: 9, offset: 19251},
+									pos:  position{line: 656, col: 9, offset: 19329},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 653, col: 12, offset: 19254},
+									pos:        position{line: 656, col: 12, offset: 19332},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 653, col: 16, offset: 19258},
+									pos:  position{line: 656, col: 16, offset: 19336},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 653, col: 19, offset: 19261},
+									pos:   position{line: 656, col: 19, offset: 19339},
 									label: "to",
 									expr: &ruleRefExpr{
-										pos:  position{line: 653, col: 22, offset: 19264},
+										pos:  position{line: 656, col: 22, offset: 19342},
 										name: "AdditiveExpr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 653, col: 35, offset: 19277},
+									pos:        position{line: 656, col: 35, offset: 19355},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4761,39 +4805,39 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 659, col: 5, offset: 19484},
+						pos: position{line: 662, col: 5, offset: 19562},
 						run: (*parser).callonDeref22,
 						expr: &seqExpr{
-							pos: position{line: 659, col: 5, offset: 19484},
+							pos: position{line: 662, col: 5, offset: 19562},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 659, col: 5, offset: 19484},
+									pos:        position{line: 662, col: 5, offset: 19562},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 659, col: 9, offset: 19488},
+									pos:   position{line: 662, col: 9, offset: 19566},
 									label: "from",
 									expr: &ruleRefExpr{
-										pos:  position{line: 659, col: 14, offset: 19493},
+										pos:  position{line: 662, col: 14, offset: 19571},
 										name: "AdditiveExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 659, col: 27, offset: 19506},
+									pos:  position{line: 662, col: 27, offset: 19584},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 659, col: 30, offset: 19509},
+									pos:        position{line: 662, col: 30, offset: 19587},
 									val:        ":",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 659, col: 34, offset: 19513},
+									pos:  position{line: 662, col: 34, offset: 19591},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 659, col: 37, offset: 19516},
+									pos:        position{line: 662, col: 37, offset: 19594},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4801,26 +4845,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 665, col: 5, offset: 19725},
+						pos: position{line: 668, col: 5, offset: 19803},
 						run: (*parser).callonDeref31,
 						expr: &seqExpr{
-							pos: position{line: 665, col: 5, offset: 19725},
+							pos: position{line: 668, col: 5, offset: 19803},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 665, col: 5, offset: 19725},
+									pos:        position{line: 668, col: 5, offset: 19803},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 665, col: 9, offset: 19729},
+									pos:   position{line: 668, col: 9, offset: 19807},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 665, col: 14, offset: 19734},
+										pos:  position{line: 668, col: 14, offset: 19812},
 										name: "Expr",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 665, col: 19, offset: 19739},
+									pos:        position{line: 668, col: 19, offset: 19817},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -4828,29 +4872,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 666, col: 5, offset: 19788},
+						pos: position{line: 669, col: 5, offset: 19866},
 						run: (*parser).callonDeref37,
 						expr: &seqExpr{
-							pos: position{line: 666, col: 5, offset: 19788},
+							pos: position{line: 669, col: 5, offset: 19866},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 666, col: 5, offset: 19788},
+									pos:        position{line: 669, col: 5, offset: 19866},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&notExpr{
-									pos: position{line: 666, col: 9, offset: 19792},
+									pos: position{line: 669, col: 9, offset: 19870},
 									expr: &litMatcher{
-										pos:        position{line: 666, col: 11, offset: 19794},
+										pos:        position{line: 669, col: 11, offset: 19872},
 										val:        ".",
 										ignoreCase: false,
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 666, col: 16, offset: 19799},
+									pos:   position{line: 669, col: 16, offset: 19877},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 666, col: 19, offset: 19802},
+										pos:  position{line: 669, col: 19, offset: 19880},
 										name: "Identifier",
 									},
 								},
@@ -4862,43 +4906,43 @@ var g = &grammar{
 		},
 		{
 			name: "Primary",
-			pos:  position{line: 668, col: 1, offset: 19853},
+			pos:  position{line: 671, col: 1, offset: 19931},
 			expr: &choiceExpr{
-				pos: position{line: 669, col: 5, offset: 19865},
+				pos: position{line: 672, col: 5, offset: 19943},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 669, col: 5, offset: 19865},
+						pos:  position{line: 672, col: 5, offset: 19943},
 						name: "Literal",
 					},
 					&actionExpr{
-						pos: position{line: 670, col: 5, offset: 19877},
+						pos: position{line: 673, col: 5, offset: 19955},
 						run: (*parser).callonPrimary3,
 						expr: &seqExpr{
-							pos: position{line: 670, col: 5, offset: 19877},
+							pos: position{line: 673, col: 5, offset: 19955},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 670, col: 5, offset: 19877},
+									pos:        position{line: 673, col: 5, offset: 19955},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 670, col: 9, offset: 19881},
+									pos:  position{line: 673, col: 9, offset: 19959},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 670, col: 12, offset: 19884},
+									pos:   position{line: 673, col: 12, offset: 19962},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 670, col: 17, offset: 19889},
+										pos:  position{line: 673, col: 17, offset: 19967},
 										name: "Expr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 670, col: 22, offset: 19894},
+									pos:  position{line: 673, col: 22, offset: 19972},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 670, col: 25, offset: 19897},
+									pos:        position{line: 673, col: 25, offset: 19975},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -4910,44 +4954,44 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 672, col: 1, offset: 19923},
+			pos:  position{line: 675, col: 1, offset: 20001},
 			expr: &choiceExpr{
-				pos: position{line: 673, col: 5, offset: 19935},
+				pos: position{line: 676, col: 5, offset: 20013},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 673, col: 5, offset: 19935},
+						pos:  position{line: 676, col: 5, offset: 20013},
 						name: "TypeLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 674, col: 5, offset: 19951},
+						pos:  position{line: 677, col: 5, offset: 20029},
 						name: "StringLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 675, col: 5, offset: 19969},
+						pos:  position{line: 678, col: 5, offset: 20047},
 						name: "RegexpLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 676, col: 5, offset: 19987},
+						pos:  position{line: 679, col: 5, offset: 20065},
 						name: "SubnetLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 677, col: 5, offset: 20005},
+						pos:  position{line: 680, col: 5, offset: 20083},
 						name: "AddressLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 678, col: 5, offset: 20024},
+						pos:  position{line: 681, col: 5, offset: 20102},
 						name: "FloatLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 679, col: 5, offset: 20041},
+						pos:  position{line: 682, col: 5, offset: 20119},
 						name: "IntegerLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 680, col: 5, offset: 20060},
+						pos:  position{line: 683, col: 5, offset: 20138},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 681, col: 5, offset: 20079},
+						pos:  position{line: 684, col: 5, offset: 20157},
 						name: "NullLiteral",
 					},
 				},
@@ -4955,15 +4999,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringLiteral",
-			pos:  position{line: 683, col: 1, offset: 20092},
+			pos:  position{line: 686, col: 1, offset: 20170},
 			expr: &actionExpr{
-				pos: position{line: 684, col: 5, offset: 20110},
+				pos: position{line: 687, col: 5, offset: 20188},
 				run: (*parser).callonStringLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 684, col: 5, offset: 20110},
+					pos:   position{line: 687, col: 5, offset: 20188},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 684, col: 7, offset: 20112},
+						pos:  position{line: 687, col: 7, offset: 20190},
 						name: "QuotedString",
 					},
 				},
@@ -4971,25 +5015,25 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpLiteral",
-			pos:  position{line: 688, col: 1, offset: 20222},
+			pos:  position{line: 691, col: 1, offset: 20300},
 			expr: &actionExpr{
-				pos: position{line: 689, col: 5, offset: 20240},
+				pos: position{line: 692, col: 5, offset: 20318},
 				run: (*parser).callonRegexpLiteral1,
 				expr: &seqExpr{
-					pos: position{line: 689, col: 5, offset: 20240},
+					pos: position{line: 692, col: 5, offset: 20318},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 689, col: 5, offset: 20240},
+							pos:   position{line: 692, col: 5, offset: 20318},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 689, col: 7, offset: 20242},
+								pos:  position{line: 692, col: 7, offset: 20320},
 								name: "Regexp",
 							},
 						},
 						&notExpr{
-							pos: position{line: 689, col: 14, offset: 20249},
+							pos: position{line: 692, col: 14, offset: 20327},
 							expr: &ruleRefExpr{
-								pos:  position{line: 689, col: 15, offset: 20250},
+								pos:  position{line: 692, col: 15, offset: 20328},
 								name: "KeyWordStart",
 							},
 						},
@@ -4999,28 +5043,28 @@ var g = &grammar{
 		},
 		{
 			name: "SubnetLiteral",
-			pos:  position{line: 693, col: 1, offset: 20360},
+			pos:  position{line: 696, col: 1, offset: 20438},
 			expr: &choiceExpr{
-				pos: position{line: 694, col: 5, offset: 20378},
+				pos: position{line: 697, col: 5, offset: 20456},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 694, col: 5, offset: 20378},
+						pos: position{line: 697, col: 5, offset: 20456},
 						run: (*parser).callonSubnetLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 694, col: 5, offset: 20378},
+							pos: position{line: 697, col: 5, offset: 20456},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 694, col: 5, offset: 20378},
+									pos:   position{line: 697, col: 5, offset: 20456},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 694, col: 7, offset: 20380},
+										pos:  position{line: 697, col: 7, offset: 20458},
 										name: "IP6Net",
 									},
 								},
 								&notExpr{
-									pos: position{line: 694, col: 14, offset: 20387},
+									pos: position{line: 697, col: 14, offset: 20465},
 									expr: &ruleRefExpr{
-										pos:  position{line: 694, col: 15, offset: 20388},
+										pos:  position{line: 697, col: 15, offset: 20466},
 										name: "IdentifierRest",
 									},
 								},
@@ -5028,13 +5072,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 697, col: 5, offset: 20500},
+						pos: position{line: 700, col: 5, offset: 20578},
 						run: (*parser).callonSubnetLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 697, col: 5, offset: 20500},
+							pos:   position{line: 700, col: 5, offset: 20578},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 697, col: 7, offset: 20502},
+								pos:  position{line: 700, col: 7, offset: 20580},
 								name: "IP4Net",
 							},
 						},
@@ -5044,28 +5088,28 @@ var g = &grammar{
 		},
 		{
 			name: "AddressLiteral",
-			pos:  position{line: 701, col: 1, offset: 20603},
+			pos:  position{line: 704, col: 1, offset: 20681},
 			expr: &choiceExpr{
-				pos: position{line: 702, col: 5, offset: 20622},
+				pos: position{line: 705, col: 5, offset: 20700},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 702, col: 5, offset: 20622},
+						pos: position{line: 705, col: 5, offset: 20700},
 						run: (*parser).callonAddressLiteral2,
 						expr: &seqExpr{
-							pos: position{line: 702, col: 5, offset: 20622},
+							pos: position{line: 705, col: 5, offset: 20700},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 702, col: 5, offset: 20622},
+									pos:   position{line: 705, col: 5, offset: 20700},
 									label: "v",
 									expr: &ruleRefExpr{
-										pos:  position{line: 702, col: 7, offset: 20624},
+										pos:  position{line: 705, col: 7, offset: 20702},
 										name: "IP6",
 									},
 								},
 								&notExpr{
-									pos: position{line: 702, col: 11, offset: 20628},
+									pos: position{line: 705, col: 11, offset: 20706},
 									expr: &ruleRefExpr{
-										pos:  position{line: 702, col: 12, offset: 20629},
+										pos:  position{line: 705, col: 12, offset: 20707},
 										name: "IdentifierRest",
 									},
 								},
@@ -5073,13 +5117,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 705, col: 5, offset: 20740},
+						pos: position{line: 708, col: 5, offset: 20818},
 						run: (*parser).callonAddressLiteral8,
 						expr: &labeledExpr{
-							pos:   position{line: 705, col: 5, offset: 20740},
+							pos:   position{line: 708, col: 5, offset: 20818},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 705, col: 7, offset: 20742},
+								pos:  position{line: 708, col: 7, offset: 20820},
 								name: "IP",
 							},
 						},
@@ -5089,15 +5133,15 @@ var g = &grammar{
 		},
 		{
 			name: "FloatLiteral",
-			pos:  position{line: 709, col: 1, offset: 20838},
+			pos:  position{line: 712, col: 1, offset: 20916},
 			expr: &actionExpr{
-				pos: position{line: 710, col: 5, offset: 20855},
+				pos: position{line: 713, col: 5, offset: 20933},
 				run: (*parser).callonFloatLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 710, col: 5, offset: 20855},
+					pos:   position{line: 713, col: 5, offset: 20933},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 710, col: 7, offset: 20857},
+						pos:  position{line: 713, col: 7, offset: 20935},
 						name: "FloatString",
 					},
 				},
@@ -5105,15 +5149,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerLiteral",
-			pos:  position{line: 714, col: 1, offset: 20967},
+			pos:  position{line: 717, col: 1, offset: 21045},
 			expr: &actionExpr{
-				pos: position{line: 715, col: 5, offset: 20986},
+				pos: position{line: 718, col: 5, offset: 21064},
 				run: (*parser).callonIntegerLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 715, col: 5, offset: 20986},
+					pos:   position{line: 718, col: 5, offset: 21064},
 					label: "v",
 					expr: &ruleRefExpr{
-						pos:  position{line: 715, col: 7, offset: 20988},
+						pos:  position{line: 718, col: 7, offset: 21066},
 						name: "IntString",
 					},
 				},
@@ -5121,24 +5165,24 @@ var g = &grammar{
 		},
 		{
 			name: "BooleanLiteral",
-			pos:  position{line: 719, col: 1, offset: 21094},
+			pos:  position{line: 722, col: 1, offset: 21172},
 			expr: &choiceExpr{
-				pos: position{line: 720, col: 5, offset: 21113},
+				pos: position{line: 723, col: 5, offset: 21191},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 720, col: 5, offset: 21113},
+						pos: position{line: 723, col: 5, offset: 21191},
 						run: (*parser).callonBooleanLiteral2,
 						expr: &litMatcher{
-							pos:        position{line: 720, col: 5, offset: 21113},
+							pos:        position{line: 723, col: 5, offset: 21191},
 							val:        "true",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 721, col: 5, offset: 21223},
+						pos: position{line: 724, col: 5, offset: 21301},
 						run: (*parser).callonBooleanLiteral4,
 						expr: &litMatcher{
-							pos:        position{line: 721, col: 5, offset: 21223},
+							pos:        position{line: 724, col: 5, offset: 21301},
 							val:        "false",
 							ignoreCase: false,
 						},
@@ -5148,12 +5192,12 @@ var g = &grammar{
 		},
 		{
 			name: "NullLiteral",
-			pos:  position{line: 723, col: 1, offset: 21331},
+			pos:  position{line: 726, col: 1, offset: 21409},
 			expr: &actionExpr{
-				pos: position{line: 724, col: 5, offset: 21347},
+				pos: position{line: 727, col: 5, offset: 21425},
 				run: (*parser).callonNullLiteral1,
 				expr: &litMatcher{
-					pos:        position{line: 724, col: 5, offset: 21347},
+					pos:        position{line: 727, col: 5, offset: 21425},
 					val:        "null",
 					ignoreCase: false,
 				},
@@ -5161,15 +5205,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeLiteral",
-			pos:  position{line: 726, col: 1, offset: 21450},
+			pos:  position{line: 729, col: 1, offset: 21528},
 			expr: &actionExpr{
-				pos: position{line: 727, col: 5, offset: 21466},
+				pos: position{line: 730, col: 5, offset: 21544},
 				run: (*parser).callonTypeLiteral1,
 				expr: &labeledExpr{
-					pos:   position{line: 727, col: 5, offset: 21466},
+					pos:   position{line: 730, col: 5, offset: 21544},
 					label: "typ",
 					expr: &ruleRefExpr{
-						pos:  position{line: 727, col: 9, offset: 21470},
+						pos:  position{line: 730, col: 9, offset: 21548},
 						name: "TypeExternal",
 					},
 				},
@@ -5177,16 +5221,16 @@ var g = &grammar{
 		},
 		{
 			name: "CastType",
-			pos:  position{line: 731, col: 1, offset: 21564},
+			pos:  position{line: 734, col: 1, offset: 21642},
 			expr: &choiceExpr{
-				pos: position{line: 732, col: 5, offset: 21577},
+				pos: position{line: 735, col: 5, offset: 21655},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 732, col: 5, offset: 21577},
+						pos:  position{line: 735, col: 5, offset: 21655},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 733, col: 5, offset: 21594},
+						pos:  position{line: 736, col: 5, offset: 21672},
 						name: "PrimitiveType",
 					},
 				},
@@ -5194,48 +5238,48 @@ var g = &grammar{
 		},
 		{
 			name: "TypeExternal",
-			pos:  position{line: 735, col: 1, offset: 21609},
+			pos:  position{line: 738, col: 1, offset: 21687},
 			expr: &choiceExpr{
-				pos: position{line: 736, col: 5, offset: 21626},
+				pos: position{line: 739, col: 5, offset: 21704},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 736, col: 5, offset: 21626},
+						pos: position{line: 739, col: 5, offset: 21704},
 						run: (*parser).callonTypeExternal2,
 						expr: &seqExpr{
-							pos: position{line: 736, col: 5, offset: 21626},
+							pos: position{line: 739, col: 5, offset: 21704},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 736, col: 5, offset: 21626},
+									pos:        position{line: 739, col: 5, offset: 21704},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 736, col: 12, offset: 21633},
+									pos:  position{line: 739, col: 12, offset: 21711},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 736, col: 15, offset: 21636},
+									pos:        position{line: 739, col: 15, offset: 21714},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 736, col: 19, offset: 21640},
+									pos:  position{line: 739, col: 19, offset: 21718},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 736, col: 22, offset: 21643},
+									pos:   position{line: 739, col: 22, offset: 21721},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 736, col: 26, offset: 21647},
+										pos:  position{line: 739, col: 26, offset: 21725},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 736, col: 31, offset: 21652},
+									pos:  position{line: 739, col: 31, offset: 21730},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 736, col: 34, offset: 21655},
+									pos:        position{line: 739, col: 34, offset: 21733},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5243,43 +5287,43 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 737, col: 5, offset: 21682},
+						pos: position{line: 740, col: 5, offset: 21760},
 						run: (*parser).callonTypeExternal12,
 						expr: &seqExpr{
-							pos: position{line: 737, col: 5, offset: 21682},
+							pos: position{line: 740, col: 5, offset: 21760},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 737, col: 5, offset: 21682},
+									pos:        position{line: 740, col: 5, offset: 21760},
 									val:        "type",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 737, col: 12, offset: 21689},
+									pos:  position{line: 740, col: 12, offset: 21767},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 737, col: 15, offset: 21692},
+									pos:        position{line: 740, col: 15, offset: 21770},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 737, col: 19, offset: 21696},
+									pos:  position{line: 740, col: 19, offset: 21774},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 737, col: 22, offset: 21699},
+									pos:   position{line: 740, col: 22, offset: 21777},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 737, col: 26, offset: 21703},
+										pos:  position{line: 740, col: 26, offset: 21781},
 										name: "TypeUnion",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 737, col: 36, offset: 21713},
+									pos:  position{line: 740, col: 36, offset: 21791},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 737, col: 39, offset: 21716},
+									pos:        position{line: 740, col: 39, offset: 21794},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5287,27 +5331,27 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 738, col: 5, offset: 21744},
+						pos:  position{line: 741, col: 5, offset: 21822},
 						name: "ComplexType",
 					},
 					&actionExpr{
-						pos: position{line: 739, col: 5, offset: 21760},
+						pos: position{line: 742, col: 5, offset: 21838},
 						run: (*parser).callonTypeExternal23,
 						expr: &seqExpr{
-							pos: position{line: 739, col: 5, offset: 21760},
+							pos: position{line: 742, col: 5, offset: 21838},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 739, col: 5, offset: 21760},
+									pos:   position{line: 742, col: 5, offset: 21838},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 739, col: 9, offset: 21764},
+										pos:  position{line: 742, col: 9, offset: 21842},
 										name: "PrimitiveTypeExternal",
 									},
 								},
 								&notExpr{
-									pos: position{line: 739, col: 31, offset: 21786},
+									pos: position{line: 742, col: 31, offset: 21864},
 									expr: &ruleRefExpr{
-										pos:  position{line: 739, col: 32, offset: 21787},
+										pos:  position{line: 742, col: 32, offset: 21865},
 										name: "IdentifierRest",
 									},
 								},
@@ -5319,16 +5363,16 @@ var g = &grammar{
 		},
 		{
 			name: "Type",
-			pos:  position{line: 741, col: 1, offset: 21823},
+			pos:  position{line: 744, col: 1, offset: 21901},
 			expr: &choiceExpr{
-				pos: position{line: 742, col: 5, offset: 21832},
+				pos: position{line: 745, col: 5, offset: 21910},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 742, col: 5, offset: 21832},
+						pos:  position{line: 745, col: 5, offset: 21910},
 						name: "AmbiguousType",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 743, col: 5, offset: 21850},
+						pos:  position{line: 746, col: 5, offset: 21928},
 						name: "ComplexType",
 					},
 				},
@@ -5336,77 +5380,77 @@ var g = &grammar{
 		},
 		{
 			name: "AmbiguousType",
-			pos:  position{line: 745, col: 1, offset: 21863},
+			pos:  position{line: 748, col: 1, offset: 21941},
 			expr: &choiceExpr{
-				pos: position{line: 746, col: 5, offset: 21881},
+				pos: position{line: 749, col: 5, offset: 21959},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 746, col: 5, offset: 21881},
+						pos: position{line: 749, col: 5, offset: 21959},
 						run: (*parser).callonAmbiguousType2,
 						expr: &litMatcher{
-							pos:        position{line: 746, col: 5, offset: 21881},
+							pos:        position{line: 749, col: 5, offset: 21959},
 							val:        "null",
 							ignoreCase: false,
 						},
 					},
 					&labeledExpr{
-						pos:   position{line: 749, col: 5, offset: 21959},
+						pos:   position{line: 752, col: 5, offset: 22037},
 						label: "name",
 						expr: &ruleRefExpr{
-							pos:  position{line: 749, col: 10, offset: 21964},
+							pos:  position{line: 752, col: 10, offset: 22042},
 							name: "PrimitiveType",
 						},
 					},
 					&actionExpr{
-						pos: position{line: 750, col: 5, offset: 21982},
+						pos: position{line: 753, col: 5, offset: 22060},
 						run: (*parser).callonAmbiguousType6,
 						expr: &seqExpr{
-							pos: position{line: 750, col: 5, offset: 21982},
+							pos: position{line: 753, col: 5, offset: 22060},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 750, col: 5, offset: 21982},
+									pos:   position{line: 753, col: 5, offset: 22060},
 									label: "name",
 									expr: &ruleRefExpr{
-										pos:  position{line: 750, col: 10, offset: 21987},
+										pos:  position{line: 753, col: 10, offset: 22065},
 										name: "IdentifierName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 750, col: 25, offset: 22002},
+									pos:  position{line: 753, col: 25, offset: 22080},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 750, col: 28, offset: 22005},
+									pos:        position{line: 753, col: 28, offset: 22083},
 									val:        "=",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 750, col: 32, offset: 22009},
+									pos:  position{line: 753, col: 32, offset: 22087},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 750, col: 35, offset: 22012},
+									pos:        position{line: 753, col: 35, offset: 22090},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 750, col: 39, offset: 22016},
+									pos:  position{line: 753, col: 39, offset: 22094},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 750, col: 42, offset: 22019},
+									pos:   position{line: 753, col: 42, offset: 22097},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 750, col: 46, offset: 22023},
+										pos:  position{line: 753, col: 46, offset: 22101},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 750, col: 51, offset: 22028},
+									pos:  position{line: 753, col: 51, offset: 22106},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 750, col: 54, offset: 22031},
+									pos:        position{line: 753, col: 54, offset: 22109},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5414,42 +5458,42 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 753, col: 5, offset: 22130},
+						pos: position{line: 756, col: 5, offset: 22208},
 						run: (*parser).callonAmbiguousType19,
 						expr: &labeledExpr{
-							pos:   position{line: 753, col: 5, offset: 22130},
+							pos:   position{line: 756, col: 5, offset: 22208},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 753, col: 10, offset: 22135},
+								pos:  position{line: 756, col: 10, offset: 22213},
 								name: "IdentifierName",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 756, col: 5, offset: 22235},
+						pos: position{line: 759, col: 5, offset: 22313},
 						run: (*parser).callonAmbiguousType22,
 						expr: &seqExpr{
-							pos: position{line: 756, col: 5, offset: 22235},
+							pos: position{line: 759, col: 5, offset: 22313},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 756, col: 5, offset: 22235},
+									pos:        position{line: 759, col: 5, offset: 22313},
 									val:        "(",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 756, col: 9, offset: 22239},
+									pos:  position{line: 759, col: 9, offset: 22317},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 756, col: 12, offset: 22242},
+									pos:   position{line: 759, col: 12, offset: 22320},
 									label: "u",
 									expr: &ruleRefExpr{
-										pos:  position{line: 756, col: 14, offset: 22244},
+										pos:  position{line: 759, col: 14, offset: 22322},
 										name: "TypeUnion",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 756, col: 25, offset: 22255},
+									pos:        position{line: 759, col: 25, offset: 22333},
 									val:        ")",
 									ignoreCase: false,
 								},
@@ -5461,15 +5505,15 @@ var g = &grammar{
 		},
 		{
 			name: "TypeUnion",
-			pos:  position{line: 758, col: 1, offset: 22278},
+			pos:  position{line: 761, col: 1, offset: 22356},
 			expr: &actionExpr{
-				pos: position{line: 759, col: 5, offset: 22292},
+				pos: position{line: 762, col: 5, offset: 22370},
 				run: (*parser).callonTypeUnion1,
 				expr: &labeledExpr{
-					pos:   position{line: 759, col: 5, offset: 22292},
+					pos:   position{line: 762, col: 5, offset: 22370},
 					label: "types",
 					expr: &ruleRefExpr{
-						pos:  position{line: 759, col: 11, offset: 22298},
+						pos:  position{line: 762, col: 11, offset: 22376},
 						name: "TypeList",
 					},
 				},
@@ -5477,28 +5521,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeList",
-			pos:  position{line: 763, col: 1, offset: 22392},
+			pos:  position{line: 766, col: 1, offset: 22470},
 			expr: &actionExpr{
-				pos: position{line: 764, col: 5, offset: 22405},
+				pos: position{line: 767, col: 5, offset: 22483},
 				run: (*parser).callonTypeList1,
 				expr: &seqExpr{
-					pos: position{line: 764, col: 5, offset: 22405},
+					pos: position{line: 767, col: 5, offset: 22483},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 764, col: 5, offset: 22405},
+							pos:   position{line: 767, col: 5, offset: 22483},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 764, col: 11, offset: 22411},
+								pos:  position{line: 767, col: 11, offset: 22489},
 								name: "Type",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 764, col: 16, offset: 22416},
+							pos:   position{line: 767, col: 16, offset: 22494},
 							label: "rest",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 764, col: 21, offset: 22421},
+								pos: position{line: 767, col: 21, offset: 22499},
 								expr: &ruleRefExpr{
-									pos:  position{line: 764, col: 21, offset: 22421},
+									pos:  position{line: 767, col: 21, offset: 22499},
 									name: "TypeListTail",
 								},
 							},
@@ -5509,31 +5553,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeListTail",
-			pos:  position{line: 768, col: 1, offset: 22515},
+			pos:  position{line: 771, col: 1, offset: 22593},
 			expr: &actionExpr{
-				pos: position{line: 768, col: 16, offset: 22530},
+				pos: position{line: 771, col: 16, offset: 22608},
 				run: (*parser).callonTypeListTail1,
 				expr: &seqExpr{
-					pos: position{line: 768, col: 16, offset: 22530},
+					pos: position{line: 771, col: 16, offset: 22608},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 768, col: 16, offset: 22530},
+							pos:  position{line: 771, col: 16, offset: 22608},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 768, col: 19, offset: 22533},
+							pos:        position{line: 771, col: 19, offset: 22611},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 768, col: 23, offset: 22537},
+							pos:  position{line: 771, col: 23, offset: 22615},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 768, col: 26, offset: 22540},
+							pos:   position{line: 771, col: 26, offset: 22618},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 768, col: 30, offset: 22544},
+								pos:  position{line: 771, col: 30, offset: 22622},
 								name: "Type",
 							},
 						},
@@ -5543,39 +5587,39 @@ var g = &grammar{
 		},
 		{
 			name: "ComplexType",
-			pos:  position{line: 770, col: 1, offset: 22570},
+			pos:  position{line: 773, col: 1, offset: 22648},
 			expr: &choiceExpr{
-				pos: position{line: 771, col: 5, offset: 22586},
+				pos: position{line: 774, col: 5, offset: 22664},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 771, col: 5, offset: 22586},
+						pos: position{line: 774, col: 5, offset: 22664},
 						run: (*parser).callonComplexType2,
 						expr: &seqExpr{
-							pos: position{line: 771, col: 5, offset: 22586},
+							pos: position{line: 774, col: 5, offset: 22664},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 771, col: 5, offset: 22586},
+									pos:        position{line: 774, col: 5, offset: 22664},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 771, col: 9, offset: 22590},
+									pos:  position{line: 774, col: 9, offset: 22668},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 771, col: 12, offset: 22593},
+									pos:   position{line: 774, col: 12, offset: 22671},
 									label: "fields",
 									expr: &ruleRefExpr{
-										pos:  position{line: 771, col: 19, offset: 22600},
+										pos:  position{line: 774, col: 19, offset: 22678},
 										name: "TypeFieldList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 771, col: 33, offset: 22614},
+									pos:  position{line: 774, col: 33, offset: 22692},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 771, col: 36, offset: 22617},
+									pos:        position{line: 774, col: 36, offset: 22695},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -5583,34 +5627,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 774, col: 5, offset: 22710},
+						pos: position{line: 777, col: 5, offset: 22788},
 						run: (*parser).callonComplexType10,
 						expr: &seqExpr{
-							pos: position{line: 774, col: 5, offset: 22710},
+							pos: position{line: 777, col: 5, offset: 22788},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 774, col: 5, offset: 22710},
+									pos:        position{line: 777, col: 5, offset: 22788},
 									val:        "[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 774, col: 9, offset: 22714},
+									pos:  position{line: 777, col: 9, offset: 22792},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 774, col: 12, offset: 22717},
+									pos:   position{line: 777, col: 12, offset: 22795},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 774, col: 16, offset: 22721},
+										pos:  position{line: 777, col: 16, offset: 22799},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 774, col: 21, offset: 22726},
+									pos:  position{line: 777, col: 21, offset: 22804},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 774, col: 24, offset: 22729},
+									pos:        position{line: 777, col: 24, offset: 22807},
 									val:        "]",
 									ignoreCase: false,
 								},
@@ -5618,34 +5662,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 777, col: 5, offset: 22816},
+						pos: position{line: 780, col: 5, offset: 22894},
 						run: (*parser).callonComplexType18,
 						expr: &seqExpr{
-							pos: position{line: 777, col: 5, offset: 22816},
+							pos: position{line: 780, col: 5, offset: 22894},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 777, col: 5, offset: 22816},
+									pos:        position{line: 780, col: 5, offset: 22894},
 									val:        "|[",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 777, col: 10, offset: 22821},
+									pos:  position{line: 780, col: 10, offset: 22899},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 777, col: 13, offset: 22824},
+									pos:   position{line: 780, col: 13, offset: 22902},
 									label: "typ",
 									expr: &ruleRefExpr{
-										pos:  position{line: 777, col: 17, offset: 22828},
+										pos:  position{line: 780, col: 17, offset: 22906},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 777, col: 22, offset: 22833},
+									pos:  position{line: 780, col: 22, offset: 22911},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 777, col: 25, offset: 22836},
+									pos:        position{line: 780, col: 25, offset: 22914},
 									val:        "]|",
 									ignoreCase: false,
 								},
@@ -5653,55 +5697,55 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 780, col: 5, offset: 22922},
+						pos: position{line: 783, col: 5, offset: 23000},
 						run: (*parser).callonComplexType26,
 						expr: &seqExpr{
-							pos: position{line: 780, col: 5, offset: 22922},
+							pos: position{line: 783, col: 5, offset: 23000},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 780, col: 5, offset: 22922},
+									pos:        position{line: 783, col: 5, offset: 23000},
 									val:        "|{",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 780, col: 10, offset: 22927},
+									pos:  position{line: 783, col: 10, offset: 23005},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 780, col: 13, offset: 22930},
+									pos:   position{line: 783, col: 13, offset: 23008},
 									label: "keyType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 780, col: 21, offset: 22938},
+										pos:  position{line: 783, col: 21, offset: 23016},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 780, col: 26, offset: 22943},
+									pos:  position{line: 783, col: 26, offset: 23021},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 780, col: 29, offset: 22946},
+									pos:        position{line: 783, col: 29, offset: 23024},
 									val:        ",",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 780, col: 33, offset: 22950},
+									pos:  position{line: 783, col: 33, offset: 23028},
 									name: "__",
 								},
 								&labeledExpr{
-									pos:   position{line: 780, col: 36, offset: 22953},
+									pos:   position{line: 783, col: 36, offset: 23031},
 									label: "valType",
 									expr: &ruleRefExpr{
-										pos:  position{line: 780, col: 44, offset: 22961},
+										pos:  position{line: 783, col: 44, offset: 23039},
 										name: "Type",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 780, col: 49, offset: 22966},
+									pos:  position{line: 783, col: 49, offset: 23044},
 									name: "__",
 								},
 								&litMatcher{
-									pos:        position{line: 780, col: 52, offset: 22969},
+									pos:        position{line: 783, col: 52, offset: 23047},
 									val:        "}|",
 									ignoreCase: false,
 								},
@@ -5713,16 +5757,16 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveType",
-			pos:  position{line: 784, col: 1, offset: 23081},
+			pos:  position{line: 787, col: 1, offset: 23159},
 			expr: &choiceExpr{
-				pos: position{line: 785, col: 5, offset: 23099},
+				pos: position{line: 788, col: 5, offset: 23177},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 785, col: 5, offset: 23099},
+						pos:  position{line: 788, col: 5, offset: 23177},
 						name: "PrimitiveTypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 786, col: 5, offset: 23125},
+						pos:  position{line: 789, col: 5, offset: 23203},
 						name: "PrimitiveTypeInternal",
 					},
 				},
@@ -5730,65 +5774,65 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeExternal",
-			pos:  position{line: 792, col: 1, offset: 23384},
+			pos:  position{line: 795, col: 1, offset: 23462},
 			expr: &actionExpr{
-				pos: position{line: 793, col: 5, offset: 23410},
+				pos: position{line: 796, col: 5, offset: 23488},
 				run: (*parser).callonPrimitiveTypeExternal1,
 				expr: &choiceExpr{
-					pos: position{line: 793, col: 9, offset: 23414},
+					pos: position{line: 796, col: 9, offset: 23492},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 793, col: 9, offset: 23414},
+							pos:        position{line: 796, col: 9, offset: 23492},
 							val:        "uint8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 793, col: 19, offset: 23424},
+							pos:        position{line: 796, col: 19, offset: 23502},
 							val:        "uint16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 793, col: 30, offset: 23435},
+							pos:        position{line: 796, col: 30, offset: 23513},
 							val:        "uint32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 793, col: 41, offset: 23446},
+							pos:        position{line: 796, col: 41, offset: 23524},
 							val:        "uint64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 794, col: 9, offset: 23463},
+							pos:        position{line: 797, col: 9, offset: 23541},
 							val:        "int8",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 794, col: 18, offset: 23472},
+							pos:        position{line: 797, col: 18, offset: 23550},
 							val:        "int16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 794, col: 28, offset: 23482},
+							pos:        position{line: 797, col: 28, offset: 23560},
 							val:        "int32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 794, col: 38, offset: 23492},
+							pos:        position{line: 797, col: 38, offset: 23570},
 							val:        "int64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 795, col: 9, offset: 23508},
+							pos:        position{line: 798, col: 9, offset: 23586},
 							val:        "float64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 796, col: 9, offset: 23526},
+							pos:        position{line: 799, col: 9, offset: 23604},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 796, col: 18, offset: 23535},
+							pos:        position{line: 799, col: 18, offset: 23613},
 							val:        "string",
 							ignoreCase: false,
 						},
@@ -5798,50 +5842,50 @@ var g = &grammar{
 		},
 		{
 			name: "PrimitiveTypeInternal",
-			pos:  position{line: 805, col: 1, offset: 24017},
+			pos:  position{line: 808, col: 1, offset: 24095},
 			expr: &actionExpr{
-				pos: position{line: 806, col: 5, offset: 24043},
+				pos: position{line: 809, col: 5, offset: 24121},
 				run: (*parser).callonPrimitiveTypeInternal1,
 				expr: &choiceExpr{
-					pos: position{line: 806, col: 9, offset: 24047},
+					pos: position{line: 809, col: 9, offset: 24125},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 806, col: 9, offset: 24047},
+							pos:        position{line: 809, col: 9, offset: 24125},
 							val:        "duration",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 806, col: 22, offset: 24060},
+							pos:        position{line: 809, col: 22, offset: 24138},
 							val:        "time",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 807, col: 9, offset: 24075},
+							pos:        position{line: 810, col: 9, offset: 24153},
 							val:        "bytes",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 808, col: 9, offset: 24091},
+							pos:        position{line: 811, col: 9, offset: 24169},
 							val:        "bstring",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 809, col: 9, offset: 24109},
+							pos:        position{line: 812, col: 9, offset: 24187},
 							val:        "ip",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 809, col: 16, offset: 24116},
+							pos:        position{line: 812, col: 16, offset: 24194},
 							val:        "net",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 810, col: 9, offset: 24130},
+							pos:        position{line: 813, col: 9, offset: 24208},
 							val:        "type",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 810, col: 18, offset: 24139},
+							pos:        position{line: 813, col: 18, offset: 24217},
 							val:        "error",
 							ignoreCase: false,
 						},
@@ -5851,28 +5895,28 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldList",
-			pos:  position{line: 814, col: 1, offset: 24254},
+			pos:  position{line: 817, col: 1, offset: 24332},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 5, offset: 24272},
+				pos: position{line: 818, col: 5, offset: 24350},
 				run: (*parser).callonTypeFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 5, offset: 24272},
+					pos: position{line: 818, col: 5, offset: 24350},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 815, col: 5, offset: 24272},
+							pos:   position{line: 818, col: 5, offset: 24350},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 11, offset: 24278},
+								pos:  position{line: 818, col: 11, offset: 24356},
 								name: "TypeField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 21, offset: 24288},
+							pos:   position{line: 818, col: 21, offset: 24366},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 815, col: 26, offset: 24293},
+								pos: position{line: 818, col: 26, offset: 24371},
 								expr: &ruleRefExpr{
-									pos:  position{line: 815, col: 26, offset: 24293},
+									pos:  position{line: 818, col: 26, offset: 24371},
 									name: "TypeFieldListTail",
 								},
 							},
@@ -5883,31 +5927,31 @@ var g = &grammar{
 		},
 		{
 			name: "TypeFieldListTail",
-			pos:  position{line: 819, col: 1, offset: 24392},
+			pos:  position{line: 822, col: 1, offset: 24470},
 			expr: &actionExpr{
-				pos: position{line: 819, col: 21, offset: 24412},
+				pos: position{line: 822, col: 21, offset: 24490},
 				run: (*parser).callonTypeFieldListTail1,
 				expr: &seqExpr{
-					pos: position{line: 819, col: 21, offset: 24412},
+					pos: position{line: 822, col: 21, offset: 24490},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 819, col: 21, offset: 24412},
+							pos:  position{line: 822, col: 21, offset: 24490},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 819, col: 24, offset: 24415},
+							pos:        position{line: 822, col: 24, offset: 24493},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 819, col: 28, offset: 24419},
+							pos:  position{line: 822, col: 28, offset: 24497},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 819, col: 31, offset: 24422},
+							pos:   position{line: 822, col: 31, offset: 24500},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 819, col: 35, offset: 24426},
+								pos:  position{line: 822, col: 35, offset: 24504},
 								name: "TypeField",
 							},
 						},
@@ -5917,39 +5961,39 @@ var g = &grammar{
 		},
 		{
 			name: "TypeField",
-			pos:  position{line: 821, col: 1, offset: 24457},
+			pos:  position{line: 824, col: 1, offset: 24535},
 			expr: &actionExpr{
-				pos: position{line: 822, col: 5, offset: 24471},
+				pos: position{line: 825, col: 5, offset: 24549},
 				run: (*parser).callonTypeField1,
 				expr: &seqExpr{
-					pos: position{line: 822, col: 5, offset: 24471},
+					pos: position{line: 825, col: 5, offset: 24549},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 822, col: 5, offset: 24471},
+							pos:   position{line: 825, col: 5, offset: 24549},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 822, col: 10, offset: 24476},
+								pos:  position{line: 825, col: 10, offset: 24554},
 								name: "IdentifierName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 822, col: 25, offset: 24491},
+							pos:  position{line: 825, col: 25, offset: 24569},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 822, col: 28, offset: 24494},
+							pos:        position{line: 825, col: 28, offset: 24572},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 822, col: 32, offset: 24498},
+							pos:  position{line: 825, col: 32, offset: 24576},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 822, col: 35, offset: 24501},
+							pos:   position{line: 825, col: 35, offset: 24579},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 822, col: 39, offset: 24505},
+								pos:  position{line: 825, col: 39, offset: 24583},
 								name: "Type",
 							},
 						},
@@ -5959,16 +6003,16 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityToken",
-			pos:  position{line: 826, col: 1, offset: 24587},
+			pos:  position{line: 829, col: 1, offset: 24665},
 			expr: &choiceExpr{
-				pos: position{line: 827, col: 5, offset: 24605},
+				pos: position{line: 830, col: 5, offset: 24683},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 827, col: 5, offset: 24605},
+						pos:  position{line: 830, col: 5, offset: 24683},
 						name: "EqualityOperator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 827, col: 24, offset: 24624},
+						pos:  position{line: 830, col: 24, offset: 24702},
 						name: "RelativeOperator",
 					},
 				},
@@ -5976,12 +6020,12 @@ var g = &grammar{
 		},
 		{
 			name: "AndToken",
-			pos:  position{line: 829, col: 1, offset: 24642},
+			pos:  position{line: 832, col: 1, offset: 24720},
 			expr: &actionExpr{
-				pos: position{line: 829, col: 12, offset: 24653},
+				pos: position{line: 832, col: 12, offset: 24731},
 				run: (*parser).callonAndToken1,
 				expr: &litMatcher{
-					pos:        position{line: 829, col: 12, offset: 24653},
+					pos:        position{line: 832, col: 12, offset: 24731},
 					val:        "and",
 					ignoreCase: true,
 				},
@@ -5989,12 +6033,12 @@ var g = &grammar{
 		},
 		{
 			name: "OrToken",
-			pos:  position{line: 830, col: 1, offset: 24682},
+			pos:  position{line: 833, col: 1, offset: 24760},
 			expr: &actionExpr{
-				pos: position{line: 830, col: 11, offset: 24692},
+				pos: position{line: 833, col: 11, offset: 24770},
 				run: (*parser).callonOrToken1,
 				expr: &litMatcher{
-					pos:        position{line: 830, col: 11, offset: 24692},
+					pos:        position{line: 833, col: 11, offset: 24770},
 					val:        "or",
 					ignoreCase: true,
 				},
@@ -6002,12 +6046,12 @@ var g = &grammar{
 		},
 		{
 			name: "InToken",
-			pos:  position{line: 831, col: 1, offset: 24719},
+			pos:  position{line: 834, col: 1, offset: 24797},
 			expr: &actionExpr{
-				pos: position{line: 831, col: 11, offset: 24729},
+				pos: position{line: 834, col: 11, offset: 24807},
 				run: (*parser).callonInToken1,
 				expr: &litMatcher{
-					pos:        position{line: 831, col: 11, offset: 24729},
+					pos:        position{line: 834, col: 11, offset: 24807},
 					val:        "in",
 					ignoreCase: true,
 				},
@@ -6015,12 +6059,12 @@ var g = &grammar{
 		},
 		{
 			name: "NotToken",
-			pos:  position{line: 832, col: 1, offset: 24756},
+			pos:  position{line: 835, col: 1, offset: 24834},
 			expr: &actionExpr{
-				pos: position{line: 832, col: 12, offset: 24767},
+				pos: position{line: 835, col: 12, offset: 24845},
 				run: (*parser).callonNotToken1,
 				expr: &litMatcher{
-					pos:        position{line: 832, col: 12, offset: 24767},
+					pos:        position{line: 835, col: 12, offset: 24845},
 					val:        "not",
 					ignoreCase: true,
 				},
@@ -6028,12 +6072,12 @@ var g = &grammar{
 		},
 		{
 			name: "ByToken",
-			pos:  position{line: 833, col: 1, offset: 24796},
+			pos:  position{line: 836, col: 1, offset: 24874},
 			expr: &actionExpr{
-				pos: position{line: 833, col: 11, offset: 24806},
+				pos: position{line: 836, col: 11, offset: 24884},
 				run: (*parser).callonByToken1,
 				expr: &litMatcher{
-					pos:        position{line: 833, col: 11, offset: 24806},
+					pos:        position{line: 836, col: 11, offset: 24884},
 					val:        "by",
 					ignoreCase: true,
 				},
@@ -6041,9 +6085,9 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierStart",
-			pos:  position{line: 835, col: 1, offset: 24834},
+			pos:  position{line: 838, col: 1, offset: 24912},
 			expr: &charClassMatcher{
-				pos:        position{line: 835, col: 19, offset: 24852},
+				pos:        position{line: 838, col: 19, offset: 24930},
 				val:        "[A-Za-z_$]",
 				chars:      []rune{'_', '$'},
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
@@ -6053,16 +6097,16 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierRest",
-			pos:  position{line: 836, col: 1, offset: 24863},
+			pos:  position{line: 839, col: 1, offset: 24941},
 			expr: &choiceExpr{
-				pos: position{line: 836, col: 18, offset: 24880},
+				pos: position{line: 839, col: 18, offset: 24958},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 836, col: 18, offset: 24880},
+						pos:  position{line: 839, col: 18, offset: 24958},
 						name: "IdentifierStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 836, col: 36, offset: 24898},
+						pos:        position{line: 839, col: 36, offset: 24976},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -6073,15 +6117,15 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 838, col: 1, offset: 24905},
+			pos:  position{line: 841, col: 1, offset: 24983},
 			expr: &actionExpr{
-				pos: position{line: 839, col: 5, offset: 24920},
+				pos: position{line: 842, col: 5, offset: 24998},
 				run: (*parser).callonIdentifier1,
 				expr: &labeledExpr{
-					pos:   position{line: 839, col: 5, offset: 24920},
+					pos:   position{line: 842, col: 5, offset: 24998},
 					label: "id",
 					expr: &ruleRefExpr{
-						pos:  position{line: 839, col: 8, offset: 24923},
+						pos:  position{line: 842, col: 8, offset: 25001},
 						name: "IdentifierName",
 					},
 				},
@@ -6089,29 +6133,29 @@ var g = &grammar{
 		},
 		{
 			name: "IdentifierName",
-			pos:  position{line: 841, col: 1, offset: 25010},
+			pos:  position{line: 844, col: 1, offset: 25088},
 			expr: &choiceExpr{
-				pos: position{line: 842, col: 5, offset: 25029},
+				pos: position{line: 845, col: 5, offset: 25107},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 842, col: 5, offset: 25029},
+						pos: position{line: 845, col: 5, offset: 25107},
 						run: (*parser).callonIdentifierName2,
 						expr: &seqExpr{
-							pos: position{line: 842, col: 5, offset: 25029},
+							pos: position{line: 845, col: 5, offset: 25107},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 842, col: 5, offset: 25029},
+									pos: position{line: 845, col: 5, offset: 25107},
 									expr: &seqExpr{
-										pos: position{line: 842, col: 7, offset: 25031},
+										pos: position{line: 845, col: 7, offset: 25109},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 842, col: 7, offset: 25031},
+												pos:  position{line: 845, col: 7, offset: 25109},
 												name: "IdGuard",
 											},
 											&notExpr{
-												pos: position{line: 842, col: 15, offset: 25039},
+												pos: position{line: 845, col: 15, offset: 25117},
 												expr: &ruleRefExpr{
-													pos:  position{line: 842, col: 16, offset: 25040},
+													pos:  position{line: 845, col: 16, offset: 25118},
 													name: "IdentifierRest",
 												},
 											},
@@ -6119,13 +6163,13 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 842, col: 32, offset: 25056},
+									pos:  position{line: 845, col: 32, offset: 25134},
 									name: "IdentifierStart",
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 842, col: 48, offset: 25072},
+									pos: position{line: 845, col: 48, offset: 25150},
 									expr: &ruleRefExpr{
-										pos:  position{line: 842, col: 48, offset: 25072},
+										pos:  position{line: 845, col: 48, offset: 25150},
 										name: "IdentifierRest",
 									},
 								},
@@ -6133,30 +6177,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 843, col: 5, offset: 25124},
+						pos: position{line: 846, col: 5, offset: 25202},
 						run: (*parser).callonIdentifierName12,
 						expr: &litMatcher{
-							pos:        position{line: 843, col: 5, offset: 25124},
+							pos:        position{line: 846, col: 5, offset: 25202},
 							val:        "$",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 844, col: 5, offset: 25163},
+						pos: position{line: 847, col: 5, offset: 25241},
 						run: (*parser).callonIdentifierName14,
 						expr: &seqExpr{
-							pos: position{line: 844, col: 5, offset: 25163},
+							pos: position{line: 847, col: 5, offset: 25241},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 844, col: 5, offset: 25163},
+									pos:        position{line: 847, col: 5, offset: 25241},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 844, col: 10, offset: 25168},
+									pos:   position{line: 847, col: 10, offset: 25246},
 									label: "id",
 									expr: &ruleRefExpr{
-										pos:  position{line: 844, col: 13, offset: 25171},
+										pos:  position{line: 847, col: 13, offset: 25249},
 										name: "IdGuard",
 									},
 								},
@@ -6164,10 +6208,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 846, col: 5, offset: 25262},
+						pos: position{line: 849, col: 5, offset: 25340},
 						run: (*parser).callonIdentifierName19,
 						expr: &litMatcher{
-							pos:        position{line: 846, col: 5, offset: 25262},
+							pos:        position{line: 849, col: 5, offset: 25340},
 							val:        "type",
 							ignoreCase: false,
 						},
@@ -6177,24 +6221,24 @@ var g = &grammar{
 		},
 		{
 			name: "IdGuard",
-			pos:  position{line: 849, col: 1, offset: 25302},
+			pos:  position{line: 852, col: 1, offset: 25380},
 			expr: &choiceExpr{
-				pos: position{line: 850, col: 5, offset: 25314},
+				pos: position{line: 853, col: 5, offset: 25392},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 850, col: 5, offset: 25314},
+						pos:  position{line: 853, col: 5, offset: 25392},
 						name: "BooleanLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 851, col: 5, offset: 25333},
+						pos:  position{line: 854, col: 5, offset: 25411},
 						name: "NullLiteral",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 852, col: 5, offset: 25349},
+						pos:  position{line: 855, col: 5, offset: 25427},
 						name: "TypeExternal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 853, col: 5, offset: 25366},
+						pos:  position{line: 856, col: 5, offset: 25444},
 						name: "SearchGuard",
 					},
 				},
@@ -6202,54 +6246,54 @@ var g = &grammar{
 		},
 		{
 			name: "Duration",
-			pos:  position{line: 855, col: 1, offset: 25379},
+			pos:  position{line: 858, col: 1, offset: 25457},
 			expr: &choiceExpr{
-				pos: position{line: 856, col: 5, offset: 25392},
+				pos: position{line: 859, col: 5, offset: 25470},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 856, col: 5, offset: 25392},
+						pos:  position{line: 859, col: 5, offset: 25470},
 						name: "Seconds",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 857, col: 5, offset: 25404},
+						pos:  position{line: 860, col: 5, offset: 25482},
 						name: "Minutes",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 858, col: 5, offset: 25416},
+						pos:  position{line: 861, col: 5, offset: 25494},
 						name: "Hours",
 					},
 					&seqExpr{
-						pos: position{line: 859, col: 5, offset: 25426},
+						pos: position{line: 862, col: 5, offset: 25504},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 859, col: 5, offset: 25426},
+								pos:  position{line: 862, col: 5, offset: 25504},
 								name: "Hours",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 859, col: 11, offset: 25432},
+								pos:  position{line: 862, col: 11, offset: 25510},
 								name: "_",
 							},
 							&litMatcher{
-								pos:        position{line: 859, col: 13, offset: 25434},
+								pos:        position{line: 862, col: 13, offset: 25512},
 								val:        "and",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 859, col: 19, offset: 25440},
+								pos:  position{line: 862, col: 19, offset: 25518},
 								name: "_",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 859, col: 21, offset: 25442},
+								pos:  position{line: 862, col: 21, offset: 25520},
 								name: "Minutes",
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 860, col: 5, offset: 25454},
+						pos:  position{line: 863, col: 5, offset: 25532},
 						name: "Days",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 861, col: 5, offset: 25463},
+						pos:  position{line: 864, col: 5, offset: 25541},
 						name: "Weeks",
 					},
 				},
@@ -6257,32 +6301,32 @@ var g = &grammar{
 		},
 		{
 			name: "SecondsToken",
-			pos:  position{line: 863, col: 1, offset: 25470},
+			pos:  position{line: 866, col: 1, offset: 25548},
 			expr: &choiceExpr{
-				pos: position{line: 864, col: 5, offset: 25487},
+				pos: position{line: 867, col: 5, offset: 25565},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 864, col: 5, offset: 25487},
+						pos:        position{line: 867, col: 5, offset: 25565},
 						val:        "seconds",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 865, col: 5, offset: 25501},
+						pos:        position{line: 868, col: 5, offset: 25579},
 						val:        "second",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 866, col: 5, offset: 25514},
+						pos:        position{line: 869, col: 5, offset: 25592},
 						val:        "secs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 867, col: 5, offset: 25525},
+						pos:        position{line: 870, col: 5, offset: 25603},
 						val:        "sec",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 868, col: 5, offset: 25535},
+						pos:        position{line: 871, col: 5, offset: 25613},
 						val:        "s",
 						ignoreCase: false,
 					},
@@ -6291,32 +6335,32 @@ var g = &grammar{
 		},
 		{
 			name: "MinutesToken",
-			pos:  position{line: 870, col: 1, offset: 25540},
+			pos:  position{line: 873, col: 1, offset: 25618},
 			expr: &choiceExpr{
-				pos: position{line: 871, col: 5, offset: 25557},
+				pos: position{line: 874, col: 5, offset: 25635},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 871, col: 5, offset: 25557},
+						pos:        position{line: 874, col: 5, offset: 25635},
 						val:        "minutes",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 872, col: 5, offset: 25571},
+						pos:        position{line: 875, col: 5, offset: 25649},
 						val:        "minute",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 873, col: 5, offset: 25584},
+						pos:        position{line: 876, col: 5, offset: 25662},
 						val:        "mins",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 874, col: 5, offset: 25595},
+						pos:        position{line: 877, col: 5, offset: 25673},
 						val:        "min",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 875, col: 5, offset: 25605},
+						pos:        position{line: 878, col: 5, offset: 25683},
 						val:        "m",
 						ignoreCase: false,
 					},
@@ -6325,32 +6369,32 @@ var g = &grammar{
 		},
 		{
 			name: "HoursToken",
-			pos:  position{line: 877, col: 1, offset: 25610},
+			pos:  position{line: 880, col: 1, offset: 25688},
 			expr: &choiceExpr{
-				pos: position{line: 878, col: 5, offset: 25625},
+				pos: position{line: 881, col: 5, offset: 25703},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 878, col: 5, offset: 25625},
+						pos:        position{line: 881, col: 5, offset: 25703},
 						val:        "hours",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 879, col: 5, offset: 25637},
+						pos:        position{line: 882, col: 5, offset: 25715},
 						val:        "hrs",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 880, col: 5, offset: 25647},
+						pos:        position{line: 883, col: 5, offset: 25725},
 						val:        "hr",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 881, col: 5, offset: 25656},
+						pos:        position{line: 884, col: 5, offset: 25734},
 						val:        "h",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 882, col: 5, offset: 25664},
+						pos:        position{line: 885, col: 5, offset: 25742},
 						val:        "hour",
 						ignoreCase: false,
 					},
@@ -6359,22 +6403,22 @@ var g = &grammar{
 		},
 		{
 			name: "DaysToken",
-			pos:  position{line: 884, col: 1, offset: 25672},
+			pos:  position{line: 887, col: 1, offset: 25750},
 			expr: &choiceExpr{
-				pos: position{line: 884, col: 13, offset: 25684},
+				pos: position{line: 887, col: 13, offset: 25762},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 884, col: 13, offset: 25684},
+						pos:        position{line: 887, col: 13, offset: 25762},
 						val:        "days",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 884, col: 20, offset: 25691},
+						pos:        position{line: 887, col: 20, offset: 25769},
 						val:        "day",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 884, col: 26, offset: 25697},
+						pos:        position{line: 887, col: 26, offset: 25775},
 						val:        "d",
 						ignoreCase: false,
 					},
@@ -6383,32 +6427,32 @@ var g = &grammar{
 		},
 		{
 			name: "WeeksToken",
-			pos:  position{line: 885, col: 1, offset: 25701},
+			pos:  position{line: 888, col: 1, offset: 25779},
 			expr: &choiceExpr{
-				pos: position{line: 885, col: 14, offset: 25714},
+				pos: position{line: 888, col: 14, offset: 25792},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 885, col: 14, offset: 25714},
+						pos:        position{line: 888, col: 14, offset: 25792},
 						val:        "weeks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 885, col: 22, offset: 25722},
+						pos:        position{line: 888, col: 22, offset: 25800},
 						val:        "week",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 885, col: 29, offset: 25729},
+						pos:        position{line: 888, col: 29, offset: 25807},
 						val:        "wks",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 885, col: 35, offset: 25735},
+						pos:        position{line: 888, col: 35, offset: 25813},
 						val:        "wk",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 885, col: 40, offset: 25740},
+						pos:        position{line: 888, col: 40, offset: 25818},
 						val:        "w",
 						ignoreCase: false,
 					},
@@ -6417,39 +6461,39 @@ var g = &grammar{
 		},
 		{
 			name: "Seconds",
-			pos:  position{line: 887, col: 1, offset: 25745},
+			pos:  position{line: 890, col: 1, offset: 25823},
 			expr: &choiceExpr{
-				pos: position{line: 888, col: 5, offset: 25757},
+				pos: position{line: 891, col: 5, offset: 25835},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 888, col: 5, offset: 25757},
+						pos: position{line: 891, col: 5, offset: 25835},
 						run: (*parser).callonSeconds2,
 						expr: &litMatcher{
-							pos:        position{line: 888, col: 5, offset: 25757},
+							pos:        position{line: 891, col: 5, offset: 25835},
 							val:        "second",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 889, col: 5, offset: 25843},
+						pos: position{line: 892, col: 5, offset: 25921},
 						run: (*parser).callonSeconds4,
 						expr: &seqExpr{
-							pos: position{line: 889, col: 5, offset: 25843},
+							pos: position{line: 892, col: 5, offset: 25921},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 889, col: 5, offset: 25843},
+									pos:   position{line: 892, col: 5, offset: 25921},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 889, col: 9, offset: 25847},
+										pos:  position{line: 892, col: 9, offset: 25925},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 889, col: 14, offset: 25852},
+									pos:  position{line: 892, col: 14, offset: 25930},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 889, col: 17, offset: 25855},
+									pos:  position{line: 892, col: 17, offset: 25933},
 									name: "SecondsToken",
 								},
 							},
@@ -6460,39 +6504,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minutes",
-			pos:  position{line: 891, col: 1, offset: 25944},
+			pos:  position{line: 894, col: 1, offset: 26022},
 			expr: &choiceExpr{
-				pos: position{line: 892, col: 5, offset: 25956},
+				pos: position{line: 895, col: 5, offset: 26034},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 892, col: 5, offset: 25956},
+						pos: position{line: 895, col: 5, offset: 26034},
 						run: (*parser).callonMinutes2,
 						expr: &litMatcher{
-							pos:        position{line: 892, col: 5, offset: 25956},
+							pos:        position{line: 895, col: 5, offset: 26034},
 							val:        "minute",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 893, col: 5, offset: 26043},
+						pos: position{line: 896, col: 5, offset: 26121},
 						run: (*parser).callonMinutes4,
 						expr: &seqExpr{
-							pos: position{line: 893, col: 5, offset: 26043},
+							pos: position{line: 896, col: 5, offset: 26121},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 893, col: 5, offset: 26043},
+									pos:   position{line: 896, col: 5, offset: 26121},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 893, col: 9, offset: 26047},
+										pos:  position{line: 896, col: 9, offset: 26125},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 893, col: 14, offset: 26052},
+									pos:  position{line: 896, col: 14, offset: 26130},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 893, col: 17, offset: 26055},
+									pos:  position{line: 896, col: 17, offset: 26133},
 									name: "MinutesToken",
 								},
 							},
@@ -6503,39 +6547,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hours",
-			pos:  position{line: 895, col: 1, offset: 26153},
+			pos:  position{line: 898, col: 1, offset: 26231},
 			expr: &choiceExpr{
-				pos: position{line: 896, col: 5, offset: 26163},
+				pos: position{line: 899, col: 5, offset: 26241},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 896, col: 5, offset: 26163},
+						pos: position{line: 899, col: 5, offset: 26241},
 						run: (*parser).callonHours2,
 						expr: &litMatcher{
-							pos:        position{line: 896, col: 5, offset: 26163},
+							pos:        position{line: 899, col: 5, offset: 26241},
 							val:        "hour",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 897, col: 5, offset: 26250},
+						pos: position{line: 900, col: 5, offset: 26328},
 						run: (*parser).callonHours4,
 						expr: &seqExpr{
-							pos: position{line: 897, col: 5, offset: 26250},
+							pos: position{line: 900, col: 5, offset: 26328},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 897, col: 5, offset: 26250},
+									pos:   position{line: 900, col: 5, offset: 26328},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 897, col: 9, offset: 26254},
+										pos:  position{line: 900, col: 9, offset: 26332},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 897, col: 14, offset: 26259},
+									pos:  position{line: 900, col: 14, offset: 26337},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 897, col: 17, offset: 26262},
+									pos:  position{line: 900, col: 17, offset: 26340},
 									name: "HoursToken",
 								},
 							},
@@ -6546,39 +6590,39 @@ var g = &grammar{
 		},
 		{
 			name: "Days",
-			pos:  position{line: 899, col: 1, offset: 26360},
+			pos:  position{line: 902, col: 1, offset: 26438},
 			expr: &choiceExpr{
-				pos: position{line: 900, col: 5, offset: 26369},
+				pos: position{line: 903, col: 5, offset: 26447},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 900, col: 5, offset: 26369},
+						pos: position{line: 903, col: 5, offset: 26447},
 						run: (*parser).callonDays2,
 						expr: &litMatcher{
-							pos:        position{line: 900, col: 5, offset: 26369},
+							pos:        position{line: 903, col: 5, offset: 26447},
 							val:        "day",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 901, col: 5, offset: 26458},
+						pos: position{line: 904, col: 5, offset: 26536},
 						run: (*parser).callonDays4,
 						expr: &seqExpr{
-							pos: position{line: 901, col: 5, offset: 26458},
+							pos: position{line: 904, col: 5, offset: 26536},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 901, col: 5, offset: 26458},
+									pos:   position{line: 904, col: 5, offset: 26536},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 901, col: 9, offset: 26462},
+										pos:  position{line: 904, col: 9, offset: 26540},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 901, col: 14, offset: 26467},
+									pos:  position{line: 904, col: 14, offset: 26545},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 901, col: 17, offset: 26470},
+									pos:  position{line: 904, col: 17, offset: 26548},
 									name: "DaysToken",
 								},
 							},
@@ -6589,39 +6633,39 @@ var g = &grammar{
 		},
 		{
 			name: "Weeks",
-			pos:  position{line: 903, col: 1, offset: 26572},
+			pos:  position{line: 906, col: 1, offset: 26650},
 			expr: &choiceExpr{
-				pos: position{line: 904, col: 5, offset: 26582},
+				pos: position{line: 907, col: 5, offset: 26660},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 904, col: 5, offset: 26582},
+						pos: position{line: 907, col: 5, offset: 26660},
 						run: (*parser).callonWeeks2,
 						expr: &litMatcher{
-							pos:        position{line: 904, col: 5, offset: 26582},
+							pos:        position{line: 907, col: 5, offset: 26660},
 							val:        "week",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 905, col: 5, offset: 26674},
+						pos: position{line: 908, col: 5, offset: 26752},
 						run: (*parser).callonWeeks4,
 						expr: &seqExpr{
-							pos: position{line: 905, col: 5, offset: 26674},
+							pos: position{line: 908, col: 5, offset: 26752},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 905, col: 5, offset: 26674},
+									pos:   position{line: 908, col: 5, offset: 26752},
 									label: "num",
 									expr: &ruleRefExpr{
-										pos:  position{line: 905, col: 9, offset: 26678},
+										pos:  position{line: 908, col: 9, offset: 26756},
 										name: "UInt",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 14, offset: 26683},
+									pos:  position{line: 908, col: 14, offset: 26761},
 									name: "__",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 905, col: 17, offset: 26686},
+									pos:  position{line: 908, col: 17, offset: 26764},
 									name: "WeeksToken",
 								},
 							},
@@ -6632,42 +6676,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP",
-			pos:  position{line: 908, col: 1, offset: 26817},
+			pos:  position{line: 911, col: 1, offset: 26895},
 			expr: &actionExpr{
-				pos: position{line: 909, col: 5, offset: 26824},
+				pos: position{line: 912, col: 5, offset: 26902},
 				run: (*parser).callonIP1,
 				expr: &seqExpr{
-					pos: position{line: 909, col: 5, offset: 26824},
+					pos: position{line: 912, col: 5, offset: 26902},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 5, offset: 26824},
+							pos:  position{line: 912, col: 5, offset: 26902},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 909, col: 10, offset: 26829},
+							pos:        position{line: 912, col: 10, offset: 26907},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 14, offset: 26833},
+							pos:  position{line: 912, col: 14, offset: 26911},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 909, col: 19, offset: 26838},
+							pos:        position{line: 912, col: 19, offset: 26916},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 23, offset: 26842},
+							pos:  position{line: 912, col: 23, offset: 26920},
 							name: "UInt",
 						},
 						&litMatcher{
-							pos:        position{line: 909, col: 28, offset: 26847},
+							pos:        position{line: 912, col: 28, offset: 26925},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 909, col: 32, offset: 26851},
+							pos:  position{line: 912, col: 32, offset: 26929},
 							name: "UInt",
 						},
 					},
@@ -6676,42 +6720,42 @@ var g = &grammar{
 		},
 		{
 			name: "IP6",
-			pos:  position{line: 911, col: 1, offset: 26888},
+			pos:  position{line: 914, col: 1, offset: 26966},
 			expr: &actionExpr{
-				pos: position{line: 912, col: 5, offset: 26896},
+				pos: position{line: 915, col: 5, offset: 26974},
 				run: (*parser).callonIP61,
 				expr: &seqExpr{
-					pos: position{line: 912, col: 5, offset: 26896},
+					pos: position{line: 915, col: 5, offset: 26974},
 					exprs: []interface{}{
 						&notExpr{
-							pos: position{line: 912, col: 5, offset: 26896},
+							pos: position{line: 915, col: 5, offset: 26974},
 							expr: &seqExpr{
-								pos: position{line: 912, col: 8, offset: 26899},
+								pos: position{line: 915, col: 8, offset: 26977},
 								exprs: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 912, col: 8, offset: 26899},
+										pos:  position{line: 915, col: 8, offset: 26977},
 										name: "Hex",
 									},
 									&litMatcher{
-										pos:        position{line: 912, col: 12, offset: 26903},
+										pos:        position{line: 915, col: 12, offset: 26981},
 										val:        ":",
 										ignoreCase: false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 912, col: 16, offset: 26907},
+										pos:  position{line: 915, col: 16, offset: 26985},
 										name: "Hex",
 									},
 									&notExpr{
-										pos: position{line: 912, col: 20, offset: 26911},
+										pos: position{line: 915, col: 20, offset: 26989},
 										expr: &choiceExpr{
-											pos: position{line: 912, col: 22, offset: 26913},
+											pos: position{line: 915, col: 22, offset: 26991},
 											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 912, col: 22, offset: 26913},
+													pos:  position{line: 915, col: 22, offset: 26991},
 													name: "HexDigit",
 												},
 												&litMatcher{
-													pos:        position{line: 912, col: 33, offset: 26924},
+													pos:        position{line: 915, col: 33, offset: 27002},
 													val:        ":",
 													ignoreCase: false,
 												},
@@ -6722,10 +6766,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 912, col: 39, offset: 26930},
+							pos:   position{line: 915, col: 39, offset: 27008},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 912, col: 41, offset: 26932},
+								pos:  position{line: 915, col: 41, offset: 27010},
 								name: "IP6Variations",
 							},
 						},
@@ -6735,84 +6779,84 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Variations",
-			pos:  position{line: 916, col: 1, offset: 27096},
+			pos:  position{line: 919, col: 1, offset: 27174},
 			expr: &choiceExpr{
-				pos: position{line: 917, col: 5, offset: 27114},
+				pos: position{line: 920, col: 5, offset: 27192},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 917, col: 5, offset: 27114},
-						run: (*parser).callonIP6Variations2,
-						expr: &seqExpr{
-							pos: position{line: 917, col: 5, offset: 27114},
-							exprs: []interface{}{
-								&labeledExpr{
-									pos:   position{line: 917, col: 5, offset: 27114},
-									label: "a",
-									expr: &oneOrMoreExpr{
-										pos: position{line: 917, col: 7, offset: 27116},
-										expr: &ruleRefExpr{
-											pos:  position{line: 917, col: 7, offset: 27116},
-											name: "HexColon",
-										},
-									},
-								},
-								&labeledExpr{
-									pos:   position{line: 917, col: 17, offset: 27126},
-									label: "b",
-									expr: &ruleRefExpr{
-										pos:  position{line: 917, col: 19, offset: 27128},
-										name: "IP6Tail",
-									},
-								},
-							},
-						},
-					},
-					&actionExpr{
 						pos: position{line: 920, col: 5, offset: 27192},
-						run: (*parser).callonIP6Variations9,
+						run: (*parser).callonIP6Variations2,
 						expr: &seqExpr{
 							pos: position{line: 920, col: 5, offset: 27192},
 							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 920, col: 5, offset: 27192},
 									label: "a",
+									expr: &oneOrMoreExpr{
+										pos: position{line: 920, col: 7, offset: 27194},
+										expr: &ruleRefExpr{
+											pos:  position{line: 920, col: 7, offset: 27194},
+											name: "HexColon",
+										},
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 920, col: 17, offset: 27204},
+									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 920, col: 7, offset: 27194},
+										pos:  position{line: 920, col: 19, offset: 27206},
+										name: "IP6Tail",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 923, col: 5, offset: 27270},
+						run: (*parser).callonIP6Variations9,
+						expr: &seqExpr{
+							pos: position{line: 923, col: 5, offset: 27270},
+							exprs: []interface{}{
+								&labeledExpr{
+									pos:   position{line: 923, col: 5, offset: 27270},
+									label: "a",
+									expr: &ruleRefExpr{
+										pos:  position{line: 923, col: 7, offset: 27272},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 920, col: 11, offset: 27198},
+									pos:   position{line: 923, col: 11, offset: 27276},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 920, col: 13, offset: 27200},
+										pos: position{line: 923, col: 13, offset: 27278},
 										expr: &ruleRefExpr{
-											pos:  position{line: 920, col: 13, offset: 27200},
+											pos:  position{line: 923, col: 13, offset: 27278},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 920, col: 23, offset: 27210},
+									pos:        position{line: 923, col: 23, offset: 27288},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 920, col: 28, offset: 27215},
+									pos:   position{line: 923, col: 28, offset: 27293},
 									label: "d",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 920, col: 30, offset: 27217},
+										pos: position{line: 923, col: 30, offset: 27295},
 										expr: &ruleRefExpr{
-											pos:  position{line: 920, col: 30, offset: 27217},
+											pos:  position{line: 923, col: 30, offset: 27295},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 920, col: 40, offset: 27227},
+									pos:   position{line: 923, col: 40, offset: 27305},
 									label: "e",
 									expr: &ruleRefExpr{
-										pos:  position{line: 920, col: 42, offset: 27229},
+										pos:  position{line: 923, col: 42, offset: 27307},
 										name: "IP6Tail",
 									},
 								},
@@ -6820,32 +6864,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 923, col: 5, offset: 27328},
+						pos: position{line: 926, col: 5, offset: 27406},
 						run: (*parser).callonIP6Variations22,
 						expr: &seqExpr{
-							pos: position{line: 923, col: 5, offset: 27328},
+							pos: position{line: 926, col: 5, offset: 27406},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 923, col: 5, offset: 27328},
+									pos:        position{line: 926, col: 5, offset: 27406},
 									val:        "::",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 923, col: 10, offset: 27333},
+									pos:   position{line: 926, col: 10, offset: 27411},
 									label: "a",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 923, col: 12, offset: 27335},
+										pos: position{line: 926, col: 12, offset: 27413},
 										expr: &ruleRefExpr{
-											pos:  position{line: 923, col: 12, offset: 27335},
+											pos:  position{line: 926, col: 12, offset: 27413},
 											name: "HexColon",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 923, col: 22, offset: 27345},
+									pos:   position{line: 926, col: 22, offset: 27423},
 									label: "b",
 									expr: &ruleRefExpr{
-										pos:  position{line: 923, col: 24, offset: 27347},
+										pos:  position{line: 926, col: 24, offset: 27425},
 										name: "IP6Tail",
 									},
 								},
@@ -6853,32 +6897,32 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 926, col: 5, offset: 27418},
+						pos: position{line: 929, col: 5, offset: 27496},
 						run: (*parser).callonIP6Variations30,
 						expr: &seqExpr{
-							pos: position{line: 926, col: 5, offset: 27418},
+							pos: position{line: 929, col: 5, offset: 27496},
 							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 926, col: 5, offset: 27418},
+									pos:   position{line: 929, col: 5, offset: 27496},
 									label: "a",
 									expr: &ruleRefExpr{
-										pos:  position{line: 926, col: 7, offset: 27420},
+										pos:  position{line: 929, col: 7, offset: 27498},
 										name: "Hex",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 926, col: 11, offset: 27424},
+									pos:   position{line: 929, col: 11, offset: 27502},
 									label: "b",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 926, col: 13, offset: 27426},
+										pos: position{line: 929, col: 13, offset: 27504},
 										expr: &ruleRefExpr{
-											pos:  position{line: 926, col: 13, offset: 27426},
+											pos:  position{line: 929, col: 13, offset: 27504},
 											name: "ColonHex",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 926, col: 23, offset: 27436},
+									pos:        position{line: 929, col: 23, offset: 27514},
 									val:        "::",
 									ignoreCase: false,
 								},
@@ -6886,10 +6930,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 929, col: 5, offset: 27504},
+						pos: position{line: 932, col: 5, offset: 27582},
 						run: (*parser).callonIP6Variations38,
 						expr: &litMatcher{
-							pos:        position{line: 929, col: 5, offset: 27504},
+							pos:        position{line: 932, col: 5, offset: 27582},
 							val:        "::",
 							ignoreCase: false,
 						},
@@ -6899,16 +6943,16 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Tail",
-			pos:  position{line: 933, col: 1, offset: 27541},
+			pos:  position{line: 936, col: 1, offset: 27619},
 			expr: &choiceExpr{
-				pos: position{line: 934, col: 5, offset: 27553},
+				pos: position{line: 937, col: 5, offset: 27631},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 934, col: 5, offset: 27553},
+						pos:  position{line: 937, col: 5, offset: 27631},
 						name: "IP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 935, col: 5, offset: 27560},
+						pos:  position{line: 938, col: 5, offset: 27638},
 						name: "Hex",
 					},
 				},
@@ -6916,23 +6960,23 @@ var g = &grammar{
 		},
 		{
 			name: "ColonHex",
-			pos:  position{line: 937, col: 1, offset: 27565},
+			pos:  position{line: 940, col: 1, offset: 27643},
 			expr: &actionExpr{
-				pos: position{line: 937, col: 12, offset: 27576},
+				pos: position{line: 940, col: 12, offset: 27654},
 				run: (*parser).callonColonHex1,
 				expr: &seqExpr{
-					pos: position{line: 937, col: 12, offset: 27576},
+					pos: position{line: 940, col: 12, offset: 27654},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 937, col: 12, offset: 27576},
+							pos:        position{line: 940, col: 12, offset: 27654},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 937, col: 16, offset: 27580},
+							pos:   position{line: 940, col: 16, offset: 27658},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 937, col: 18, offset: 27582},
+								pos:  position{line: 940, col: 18, offset: 27660},
 								name: "Hex",
 							},
 						},
@@ -6942,23 +6986,23 @@ var g = &grammar{
 		},
 		{
 			name: "HexColon",
-			pos:  position{line: 938, col: 1, offset: 27619},
+			pos:  position{line: 941, col: 1, offset: 27697},
 			expr: &actionExpr{
-				pos: position{line: 938, col: 12, offset: 27630},
+				pos: position{line: 941, col: 12, offset: 27708},
 				run: (*parser).callonHexColon1,
 				expr: &seqExpr{
-					pos: position{line: 938, col: 12, offset: 27630},
+					pos: position{line: 941, col: 12, offset: 27708},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 938, col: 12, offset: 27630},
+							pos:   position{line: 941, col: 12, offset: 27708},
 							label: "v",
 							expr: &ruleRefExpr{
-								pos:  position{line: 938, col: 14, offset: 27632},
+								pos:  position{line: 941, col: 14, offset: 27710},
 								name: "Hex",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 938, col: 18, offset: 27636},
+							pos:        position{line: 941, col: 18, offset: 27714},
 							val:        ":",
 							ignoreCase: false,
 						},
@@ -6968,31 +7012,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP4Net",
-			pos:  position{line: 940, col: 1, offset: 27674},
+			pos:  position{line: 943, col: 1, offset: 27752},
 			expr: &actionExpr{
-				pos: position{line: 941, col: 5, offset: 27685},
+				pos: position{line: 944, col: 5, offset: 27763},
 				run: (*parser).callonIP4Net1,
 				expr: &seqExpr{
-					pos: position{line: 941, col: 5, offset: 27685},
+					pos: position{line: 944, col: 5, offset: 27763},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 941, col: 5, offset: 27685},
+							pos:   position{line: 944, col: 5, offset: 27763},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 941, col: 7, offset: 27687},
+								pos:  position{line: 944, col: 7, offset: 27765},
 								name: "IP",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 941, col: 10, offset: 27690},
+							pos:        position{line: 944, col: 10, offset: 27768},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 941, col: 14, offset: 27694},
+							pos:   position{line: 944, col: 14, offset: 27772},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 941, col: 16, offset: 27696},
+								pos:  position{line: 944, col: 16, offset: 27774},
 								name: "UInt",
 							},
 						},
@@ -7002,31 +7046,31 @@ var g = &grammar{
 		},
 		{
 			name: "IP6Net",
-			pos:  position{line: 945, col: 1, offset: 27769},
+			pos:  position{line: 948, col: 1, offset: 27847},
 			expr: &actionExpr{
-				pos: position{line: 946, col: 5, offset: 27780},
+				pos: position{line: 949, col: 5, offset: 27858},
 				run: (*parser).callonIP6Net1,
 				expr: &seqExpr{
-					pos: position{line: 946, col: 5, offset: 27780},
+					pos: position{line: 949, col: 5, offset: 27858},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 946, col: 5, offset: 27780},
+							pos:   position{line: 949, col: 5, offset: 27858},
 							label: "a",
 							expr: &ruleRefExpr{
-								pos:  position{line: 946, col: 7, offset: 27782},
+								pos:  position{line: 949, col: 7, offset: 27860},
 								name: "IP6",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 946, col: 11, offset: 27786},
+							pos:        position{line: 949, col: 11, offset: 27864},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 946, col: 15, offset: 27790},
+							pos:   position{line: 949, col: 15, offset: 27868},
 							label: "m",
 							expr: &ruleRefExpr{
-								pos:  position{line: 946, col: 17, offset: 27792},
+								pos:  position{line: 949, col: 17, offset: 27870},
 								name: "UInt",
 							},
 						},
@@ -7036,15 +7080,15 @@ var g = &grammar{
 		},
 		{
 			name: "UInt",
-			pos:  position{line: 950, col: 1, offset: 27855},
+			pos:  position{line: 953, col: 1, offset: 27933},
 			expr: &actionExpr{
-				pos: position{line: 951, col: 4, offset: 27863},
+				pos: position{line: 954, col: 4, offset: 27941},
 				run: (*parser).callonUInt1,
 				expr: &labeledExpr{
-					pos:   position{line: 951, col: 4, offset: 27863},
+					pos:   position{line: 954, col: 4, offset: 27941},
 					label: "s",
 					expr: &ruleRefExpr{
-						pos:  position{line: 951, col: 6, offset: 27865},
+						pos:  position{line: 954, col: 6, offset: 27943},
 						name: "UIntString",
 					},
 				},
@@ -7052,16 +7096,16 @@ var g = &grammar{
 		},
 		{
 			name: "IntString",
-			pos:  position{line: 953, col: 1, offset: 27905},
+			pos:  position{line: 956, col: 1, offset: 27983},
 			expr: &choiceExpr{
-				pos: position{line: 954, col: 5, offset: 27919},
+				pos: position{line: 957, col: 5, offset: 27997},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 954, col: 5, offset: 27919},
+						pos:  position{line: 957, col: 5, offset: 27997},
 						name: "UIntString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 955, col: 5, offset: 27934},
+						pos:  position{line: 958, col: 5, offset: 28012},
 						name: "MinusIntString",
 					},
 				},
@@ -7069,14 +7113,14 @@ var g = &grammar{
 		},
 		{
 			name: "UIntString",
-			pos:  position{line: 957, col: 1, offset: 27950},
+			pos:  position{line: 960, col: 1, offset: 28028},
 			expr: &actionExpr{
-				pos: position{line: 957, col: 14, offset: 27963},
+				pos: position{line: 960, col: 14, offset: 28041},
 				run: (*parser).callonUIntString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 957, col: 14, offset: 27963},
+					pos: position{line: 960, col: 14, offset: 28041},
 					expr: &charClassMatcher{
-						pos:        position{line: 957, col: 14, offset: 27963},
+						pos:        position{line: 960, col: 14, offset: 28041},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -7087,20 +7131,20 @@ var g = &grammar{
 		},
 		{
 			name: "MinusIntString",
-			pos:  position{line: 959, col: 1, offset: 28002},
+			pos:  position{line: 962, col: 1, offset: 28080},
 			expr: &actionExpr{
-				pos: position{line: 960, col: 5, offset: 28021},
+				pos: position{line: 963, col: 5, offset: 28099},
 				run: (*parser).callonMinusIntString1,
 				expr: &seqExpr{
-					pos: position{line: 960, col: 5, offset: 28021},
+					pos: position{line: 963, col: 5, offset: 28099},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 960, col: 5, offset: 28021},
+							pos:        position{line: 963, col: 5, offset: 28099},
 							val:        "-",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 960, col: 9, offset: 28025},
+							pos:  position{line: 963, col: 9, offset: 28103},
 							name: "UIntString",
 						},
 					},
@@ -7109,28 +7153,28 @@ var g = &grammar{
 		},
 		{
 			name: "FloatString",
-			pos:  position{line: 962, col: 1, offset: 28068},
+			pos:  position{line: 965, col: 1, offset: 28146},
 			expr: &choiceExpr{
-				pos: position{line: 963, col: 5, offset: 28084},
+				pos: position{line: 966, col: 5, offset: 28162},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 963, col: 5, offset: 28084},
+						pos: position{line: 966, col: 5, offset: 28162},
 						run: (*parser).callonFloatString2,
 						expr: &seqExpr{
-							pos: position{line: 963, col: 5, offset: 28084},
+							pos: position{line: 966, col: 5, offset: 28162},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 963, col: 5, offset: 28084},
+									pos: position{line: 966, col: 5, offset: 28162},
 									expr: &litMatcher{
-										pos:        position{line: 963, col: 5, offset: 28084},
+										pos:        position{line: 966, col: 5, offset: 28162},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 963, col: 10, offset: 28089},
+									pos: position{line: 966, col: 10, offset: 28167},
 									expr: &charClassMatcher{
-										pos:        position{line: 963, col: 10, offset: 28089},
+										pos:        position{line: 966, col: 10, offset: 28167},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -7138,14 +7182,14 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 963, col: 17, offset: 28096},
+									pos:        position{line: 966, col: 17, offset: 28174},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 963, col: 21, offset: 28100},
+									pos: position{line: 966, col: 21, offset: 28178},
 									expr: &charClassMatcher{
-										pos:        position{line: 963, col: 21, offset: 28100},
+										pos:        position{line: 966, col: 21, offset: 28178},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -7153,9 +7197,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 963, col: 28, offset: 28107},
+									pos: position{line: 966, col: 28, offset: 28185},
 									expr: &ruleRefExpr{
-										pos:  position{line: 963, col: 28, offset: 28107},
+										pos:  position{line: 966, col: 28, offset: 28185},
 										name: "ExponentPart",
 									},
 								},
@@ -7163,28 +7207,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 966, col: 5, offset: 28166},
+						pos: position{line: 969, col: 5, offset: 28244},
 						run: (*parser).callonFloatString13,
 						expr: &seqExpr{
-							pos: position{line: 966, col: 5, offset: 28166},
+							pos: position{line: 969, col: 5, offset: 28244},
 							exprs: []interface{}{
 								&zeroOrOneExpr{
-									pos: position{line: 966, col: 5, offset: 28166},
+									pos: position{line: 969, col: 5, offset: 28244},
 									expr: &litMatcher{
-										pos:        position{line: 966, col: 5, offset: 28166},
+										pos:        position{line: 969, col: 5, offset: 28244},
 										val:        "-",
 										ignoreCase: false,
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 966, col: 10, offset: 28171},
+									pos:        position{line: 969, col: 10, offset: 28249},
 									val:        ".",
 									ignoreCase: false,
 								},
 								&oneOrMoreExpr{
-									pos: position{line: 966, col: 14, offset: 28175},
+									pos: position{line: 969, col: 14, offset: 28253},
 									expr: &charClassMatcher{
-										pos:        position{line: 966, col: 14, offset: 28175},
+										pos:        position{line: 969, col: 14, offset: 28253},
 										val:        "[0-9]",
 										ranges:     []rune{'0', '9'},
 										ignoreCase: false,
@@ -7192,9 +7236,9 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 966, col: 21, offset: 28182},
+									pos: position{line: 969, col: 21, offset: 28260},
 									expr: &ruleRefExpr{
-										pos:  position{line: 966, col: 21, offset: 28182},
+										pos:  position{line: 969, col: 21, offset: 28260},
 										name: "ExponentPart",
 									},
 								},
@@ -7206,19 +7250,19 @@ var g = &grammar{
 		},
 		{
 			name: "ExponentPart",
-			pos:  position{line: 970, col: 1, offset: 28238},
+			pos:  position{line: 973, col: 1, offset: 28316},
 			expr: &seqExpr{
-				pos: position{line: 970, col: 16, offset: 28253},
+				pos: position{line: 973, col: 16, offset: 28331},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 970, col: 16, offset: 28253},
+						pos:        position{line: 973, col: 16, offset: 28331},
 						val:        "e",
 						ignoreCase: true,
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 970, col: 21, offset: 28258},
+						pos: position{line: 973, col: 21, offset: 28336},
 						expr: &charClassMatcher{
-							pos:        position{line: 970, col: 21, offset: 28258},
+							pos:        position{line: 973, col: 21, offset: 28336},
 							val:        "[+-]",
 							chars:      []rune{'+', '-'},
 							ignoreCase: false,
@@ -7226,7 +7270,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 970, col: 27, offset: 28264},
+						pos:  position{line: 973, col: 27, offset: 28342},
 						name: "UIntString",
 					},
 				},
@@ -7234,14 +7278,14 @@ var g = &grammar{
 		},
 		{
 			name: "Hex",
-			pos:  position{line: 972, col: 1, offset: 28276},
+			pos:  position{line: 975, col: 1, offset: 28354},
 			expr: &actionExpr{
-				pos: position{line: 972, col: 7, offset: 28282},
+				pos: position{line: 975, col: 7, offset: 28360},
 				run: (*parser).callonHex1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 972, col: 7, offset: 28282},
+					pos: position{line: 975, col: 7, offset: 28360},
 					expr: &ruleRefExpr{
-						pos:  position{line: 972, col: 7, offset: 28282},
+						pos:  position{line: 975, col: 7, offset: 28360},
 						name: "HexDigit",
 					},
 				},
@@ -7249,9 +7293,9 @@ var g = &grammar{
 		},
 		{
 			name: "HexDigit",
-			pos:  position{line: 974, col: 1, offset: 28324},
+			pos:  position{line: 977, col: 1, offset: 28402},
 			expr: &charClassMatcher{
-				pos:        position{line: 974, col: 12, offset: 28335},
+				pos:        position{line: 977, col: 12, offset: 28413},
 				val:        "[0-9a-fA-F]",
 				ranges:     []rune{'0', '9', 'a', 'f', 'A', 'F'},
 				ignoreCase: false,
@@ -7260,34 +7304,34 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 977, col: 1, offset: 28349},
+			pos:  position{line: 980, col: 1, offset: 28427},
 			expr: &choiceExpr{
-				pos: position{line: 978, col: 5, offset: 28366},
+				pos: position{line: 981, col: 5, offset: 28444},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 978, col: 5, offset: 28366},
+						pos: position{line: 981, col: 5, offset: 28444},
 						run: (*parser).callonQuotedString2,
 						expr: &seqExpr{
-							pos: position{line: 978, col: 5, offset: 28366},
+							pos: position{line: 981, col: 5, offset: 28444},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 978, col: 5, offset: 28366},
+									pos:        position{line: 981, col: 5, offset: 28444},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 978, col: 9, offset: 28370},
+									pos:   position{line: 981, col: 9, offset: 28448},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 978, col: 11, offset: 28372},
+										pos: position{line: 981, col: 11, offset: 28450},
 										expr: &ruleRefExpr{
-											pos:  position{line: 978, col: 11, offset: 28372},
+											pos:  position{line: 981, col: 11, offset: 28450},
 											name: "DoubleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 978, col: 29, offset: 28390},
+									pos:        position{line: 981, col: 29, offset: 28468},
 									val:        "\"",
 									ignoreCase: false,
 								},
@@ -7295,29 +7339,29 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 979, col: 5, offset: 28427},
+						pos: position{line: 982, col: 5, offset: 28505},
 						run: (*parser).callonQuotedString9,
 						expr: &seqExpr{
-							pos: position{line: 979, col: 5, offset: 28427},
+							pos: position{line: 982, col: 5, offset: 28505},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 979, col: 5, offset: 28427},
+									pos:        position{line: 982, col: 5, offset: 28505},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 979, col: 9, offset: 28431},
+									pos:   position{line: 982, col: 9, offset: 28509},
 									label: "v",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 979, col: 11, offset: 28433},
+										pos: position{line: 982, col: 11, offset: 28511},
 										expr: &ruleRefExpr{
-											pos:  position{line: 979, col: 11, offset: 28433},
+											pos:  position{line: 982, col: 11, offset: 28511},
 											name: "SingleQuotedChar",
 										},
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 979, col: 29, offset: 28451},
+									pos:        position{line: 982, col: 29, offset: 28529},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -7329,55 +7373,55 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleQuotedChar",
-			pos:  position{line: 981, col: 1, offset: 28485},
+			pos:  position{line: 984, col: 1, offset: 28563},
 			expr: &choiceExpr{
-				pos: position{line: 982, col: 5, offset: 28506},
+				pos: position{line: 985, col: 5, offset: 28584},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 982, col: 5, offset: 28506},
+						pos: position{line: 985, col: 5, offset: 28584},
 						run: (*parser).callonDoubleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 982, col: 5, offset: 28506},
+							pos: position{line: 985, col: 5, offset: 28584},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 982, col: 5, offset: 28506},
+									pos: position{line: 985, col: 5, offset: 28584},
 									expr: &choiceExpr{
-										pos: position{line: 982, col: 7, offset: 28508},
+										pos: position{line: 985, col: 7, offset: 28586},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 982, col: 7, offset: 28508},
+												pos:        position{line: 985, col: 7, offset: 28586},
 												val:        "\"",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 982, col: 13, offset: 28514},
+												pos:  position{line: 985, col: 13, offset: 28592},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 982, col: 26, offset: 28527,
+									line: 985, col: 26, offset: 28605,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 983, col: 5, offset: 28564},
+						pos: position{line: 986, col: 5, offset: 28642},
 						run: (*parser).callonDoubleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 983, col: 5, offset: 28564},
+							pos: position{line: 986, col: 5, offset: 28642},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 983, col: 5, offset: 28564},
+									pos:        position{line: 986, col: 5, offset: 28642},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 983, col: 10, offset: 28569},
+									pos:   position{line: 986, col: 10, offset: 28647},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 983, col: 12, offset: 28571},
+										pos:  position{line: 986, col: 12, offset: 28649},
 										name: "EscapeSequence",
 									},
 								},
@@ -7389,28 +7433,28 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWord",
-			pos:  position{line: 985, col: 1, offset: 28605},
+			pos:  position{line: 988, col: 1, offset: 28683},
 			expr: &actionExpr{
-				pos: position{line: 986, col: 5, offset: 28617},
+				pos: position{line: 989, col: 5, offset: 28695},
 				run: (*parser).callonKeyWord1,
 				expr: &seqExpr{
-					pos: position{line: 986, col: 5, offset: 28617},
+					pos: position{line: 989, col: 5, offset: 28695},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 986, col: 5, offset: 28617},
+							pos:   position{line: 989, col: 5, offset: 28695},
 							label: "head",
 							expr: &ruleRefExpr{
-								pos:  position{line: 986, col: 10, offset: 28622},
+								pos:  position{line: 989, col: 10, offset: 28700},
 								name: "KeyWordStart",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 986, col: 23, offset: 28635},
+							pos:   position{line: 989, col: 23, offset: 28713},
 							label: "tail",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 986, col: 28, offset: 28640},
+								pos: position{line: 989, col: 28, offset: 28718},
 								expr: &ruleRefExpr{
-									pos:  position{line: 986, col: 28, offset: 28640},
+									pos:  position{line: 989, col: 28, offset: 28718},
 									name: "KeyWordRest",
 								},
 							},
@@ -7421,15 +7465,15 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordStart",
-			pos:  position{line: 988, col: 1, offset: 28702},
+			pos:  position{line: 991, col: 1, offset: 28780},
 			expr: &choiceExpr{
-				pos: position{line: 989, col: 5, offset: 28719},
+				pos: position{line: 992, col: 5, offset: 28797},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 989, col: 5, offset: 28719},
+						pos: position{line: 992, col: 5, offset: 28797},
 						run: (*parser).callonKeyWordStart2,
 						expr: &charClassMatcher{
-							pos:        position{line: 989, col: 5, offset: 28719},
+							pos:        position{line: 992, col: 5, offset: 28797},
 							val:        "[a-zA-Z_.:/%#@~]",
 							chars:      []rune{'_', '.', ':', '/', '%', '#', '@', '~'},
 							ranges:     []rune{'a', 'z', 'A', 'Z'},
@@ -7438,7 +7482,7 @@ var g = &grammar{
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 990, col: 5, offset: 28771},
+						pos:  position{line: 993, col: 5, offset: 28849},
 						name: "KeyWordEsc",
 					},
 				},
@@ -7446,16 +7490,16 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordRest",
-			pos:  position{line: 992, col: 1, offset: 28783},
+			pos:  position{line: 995, col: 1, offset: 28861},
 			expr: &choiceExpr{
-				pos: position{line: 993, col: 5, offset: 28799},
+				pos: position{line: 996, col: 5, offset: 28877},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 993, col: 5, offset: 28799},
+						pos:  position{line: 996, col: 5, offset: 28877},
 						name: "KeyWordStart",
 					},
 					&charClassMatcher{
-						pos:        position{line: 994, col: 5, offset: 28816},
+						pos:        position{line: 997, col: 5, offset: 28894},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -7466,30 +7510,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeyWordEsc",
-			pos:  position{line: 996, col: 1, offset: 28823},
+			pos:  position{line: 999, col: 1, offset: 28901},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 14, offset: 28836},
+				pos: position{line: 999, col: 14, offset: 28914},
 				run: (*parser).callonKeyWordEsc1,
 				expr: &seqExpr{
-					pos: position{line: 996, col: 14, offset: 28836},
+					pos: position{line: 999, col: 14, offset: 28914},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 996, col: 14, offset: 28836},
+							pos:        position{line: 999, col: 14, offset: 28914},
 							val:        "\\",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 996, col: 19, offset: 28841},
+							pos:   position{line: 999, col: 19, offset: 28919},
 							label: "s",
 							expr: &choiceExpr{
-								pos: position{line: 996, col: 22, offset: 28844},
+								pos: position{line: 999, col: 22, offset: 28922},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 996, col: 22, offset: 28844},
+										pos:  position{line: 999, col: 22, offset: 28922},
 										name: "KeywordEscape",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 996, col: 38, offset: 28860},
+										pos:  position{line: 999, col: 38, offset: 28938},
 										name: "EscapeSequence",
 									},
 								},
@@ -7501,55 +7545,55 @@ var g = &grammar{
 		},
 		{
 			name: "SingleQuotedChar",
-			pos:  position{line: 998, col: 1, offset: 28896},
+			pos:  position{line: 1001, col: 1, offset: 28974},
 			expr: &choiceExpr{
-				pos: position{line: 999, col: 5, offset: 28917},
+				pos: position{line: 1002, col: 5, offset: 28995},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 999, col: 5, offset: 28917},
+						pos: position{line: 1002, col: 5, offset: 28995},
 						run: (*parser).callonSingleQuotedChar2,
 						expr: &seqExpr{
-							pos: position{line: 999, col: 5, offset: 28917},
+							pos: position{line: 1002, col: 5, offset: 28995},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 999, col: 5, offset: 28917},
+									pos: position{line: 1002, col: 5, offset: 28995},
 									expr: &choiceExpr{
-										pos: position{line: 999, col: 7, offset: 28919},
+										pos: position{line: 1002, col: 7, offset: 28997},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 999, col: 7, offset: 28919},
+												pos:        position{line: 1002, col: 7, offset: 28997},
 												val:        "'",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 999, col: 13, offset: 28925},
+												pos:  position{line: 1002, col: 13, offset: 29003},
 												name: "EscapedChar",
 											},
 										},
 									},
 								},
 								&anyMatcher{
-									line: 999, col: 26, offset: 28938,
+									line: 1002, col: 26, offset: 29016,
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1000, col: 5, offset: 28975},
+						pos: position{line: 1003, col: 5, offset: 29053},
 						run: (*parser).callonSingleQuotedChar9,
 						expr: &seqExpr{
-							pos: position{line: 1000, col: 5, offset: 28975},
+							pos: position{line: 1003, col: 5, offset: 29053},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1000, col: 5, offset: 28975},
+									pos:        position{line: 1003, col: 5, offset: 29053},
 									val:        "\\",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1000, col: 10, offset: 28980},
+									pos:   position{line: 1003, col: 10, offset: 29058},
 									label: "s",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1000, col: 12, offset: 28982},
+										pos:  position{line: 1003, col: 12, offset: 29060},
 										name: "EscapeSequence",
 									},
 								},
@@ -7561,38 +7605,38 @@ var g = &grammar{
 		},
 		{
 			name: "EscapeSequence",
-			pos:  position{line: 1002, col: 1, offset: 29016},
+			pos:  position{line: 1005, col: 1, offset: 29094},
 			expr: &choiceExpr{
-				pos: position{line: 1003, col: 5, offset: 29035},
+				pos: position{line: 1006, col: 5, offset: 29113},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1003, col: 5, offset: 29035},
+						pos: position{line: 1006, col: 5, offset: 29113},
 						run: (*parser).callonEscapeSequence2,
 						expr: &seqExpr{
-							pos: position{line: 1003, col: 5, offset: 29035},
+							pos: position{line: 1006, col: 5, offset: 29113},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1003, col: 5, offset: 29035},
+									pos:        position{line: 1006, col: 5, offset: 29113},
 									val:        "x",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1003, col: 9, offset: 29039},
+									pos:  position{line: 1006, col: 9, offset: 29117},
 									name: "HexDigit",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1003, col: 18, offset: 29048},
+									pos:  position{line: 1006, col: 18, offset: 29126},
 									name: "HexDigit",
 								},
 							},
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1004, col: 5, offset: 29099},
+						pos:  position{line: 1007, col: 5, offset: 29177},
 						name: "SingleCharEscape",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1005, col: 5, offset: 29120},
+						pos:  position{line: 1008, col: 5, offset: 29198},
 						name: "UnicodeEscape",
 					},
 				},
@@ -7600,87 +7644,87 @@ var g = &grammar{
 		},
 		{
 			name: "SingleCharEscape",
-			pos:  position{line: 1007, col: 1, offset: 29135},
+			pos:  position{line: 1010, col: 1, offset: 29213},
 			expr: &choiceExpr{
-				pos: position{line: 1008, col: 5, offset: 29156},
+				pos: position{line: 1011, col: 5, offset: 29234},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1008, col: 5, offset: 29156},
+						pos: position{line: 1011, col: 5, offset: 29234},
 						run: (*parser).callonSingleCharEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1008, col: 5, offset: 29156},
+							pos:        position{line: 1011, col: 5, offset: 29234},
 							val:        "'",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1009, col: 5, offset: 29183},
+						pos: position{line: 1012, col: 5, offset: 29261},
 						run: (*parser).callonSingleCharEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1009, col: 5, offset: 29183},
+							pos:        position{line: 1012, col: 5, offset: 29261},
 							val:        "\"",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1010, col: 5, offset: 29210},
+						pos: position{line: 1013, col: 5, offset: 29288},
 						run: (*parser).callonSingleCharEscape6,
 						expr: &litMatcher{
-							pos:        position{line: 1010, col: 5, offset: 29210},
+							pos:        position{line: 1013, col: 5, offset: 29288},
 							val:        "\\",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1011, col: 5, offset: 29239},
+						pos: position{line: 1014, col: 5, offset: 29317},
 						run: (*parser).callonSingleCharEscape8,
 						expr: &litMatcher{
-							pos:        position{line: 1011, col: 5, offset: 29239},
+							pos:        position{line: 1014, col: 5, offset: 29317},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1012, col: 5, offset: 29268},
+						pos: position{line: 1015, col: 5, offset: 29346},
 						run: (*parser).callonSingleCharEscape10,
 						expr: &litMatcher{
-							pos:        position{line: 1012, col: 5, offset: 29268},
+							pos:        position{line: 1015, col: 5, offset: 29346},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1013, col: 5, offset: 29297},
+						pos: position{line: 1016, col: 5, offset: 29375},
 						run: (*parser).callonSingleCharEscape12,
 						expr: &litMatcher{
-							pos:        position{line: 1013, col: 5, offset: 29297},
+							pos:        position{line: 1016, col: 5, offset: 29375},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1014, col: 5, offset: 29326},
+						pos: position{line: 1017, col: 5, offset: 29404},
 						run: (*parser).callonSingleCharEscape14,
 						expr: &litMatcher{
-							pos:        position{line: 1014, col: 5, offset: 29326},
+							pos:        position{line: 1017, col: 5, offset: 29404},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1015, col: 5, offset: 29355},
+						pos: position{line: 1018, col: 5, offset: 29433},
 						run: (*parser).callonSingleCharEscape16,
 						expr: &litMatcher{
-							pos:        position{line: 1015, col: 5, offset: 29355},
+							pos:        position{line: 1018, col: 5, offset: 29433},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1016, col: 5, offset: 29384},
+						pos: position{line: 1019, col: 5, offset: 29462},
 						run: (*parser).callonSingleCharEscape18,
 						expr: &litMatcher{
-							pos:        position{line: 1016, col: 5, offset: 29384},
+							pos:        position{line: 1019, col: 5, offset: 29462},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -7690,30 +7734,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1018, col: 1, offset: 29410},
+			pos:  position{line: 1021, col: 1, offset: 29488},
 			expr: &choiceExpr{
-				pos: position{line: 1019, col: 5, offset: 29428},
+				pos: position{line: 1022, col: 5, offset: 29506},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1019, col: 5, offset: 29428},
+						pos: position{line: 1022, col: 5, offset: 29506},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1019, col: 5, offset: 29428},
+							pos:        position{line: 1022, col: 5, offset: 29506},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1020, col: 5, offset: 29456},
+						pos: position{line: 1023, col: 5, offset: 29534},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1020, col: 5, offset: 29456},
+							pos:        position{line: 1023, col: 5, offset: 29534},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1021, col: 5, offset: 29486},
+						pos:        position{line: 1024, col: 5, offset: 29564},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -7724,41 +7768,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1023, col: 1, offset: 29492},
+			pos:  position{line: 1026, col: 1, offset: 29570},
 			expr: &choiceExpr{
-				pos: position{line: 1024, col: 5, offset: 29510},
+				pos: position{line: 1027, col: 5, offset: 29588},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1024, col: 5, offset: 29510},
+						pos: position{line: 1027, col: 5, offset: 29588},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1024, col: 5, offset: 29510},
+							pos: position{line: 1027, col: 5, offset: 29588},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1024, col: 5, offset: 29510},
+									pos:        position{line: 1027, col: 5, offset: 29588},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1024, col: 9, offset: 29514},
+									pos:   position{line: 1027, col: 9, offset: 29592},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1024, col: 16, offset: 29521},
+										pos: position{line: 1027, col: 16, offset: 29599},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1024, col: 16, offset: 29521},
+												pos:  position{line: 1027, col: 16, offset: 29599},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1024, col: 25, offset: 29530},
+												pos:  position{line: 1027, col: 25, offset: 29608},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1024, col: 34, offset: 29539},
+												pos:  position{line: 1027, col: 34, offset: 29617},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1024, col: 43, offset: 29548},
+												pos:  position{line: 1027, col: 43, offset: 29626},
 												name: "HexDigit",
 											},
 										},
@@ -7768,63 +7812,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1027, col: 5, offset: 29611},
+						pos: position{line: 1030, col: 5, offset: 29689},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1027, col: 5, offset: 29611},
+							pos: position{line: 1030, col: 5, offset: 29689},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1027, col: 5, offset: 29611},
+									pos:        position{line: 1030, col: 5, offset: 29689},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1027, col: 9, offset: 29615},
+									pos:        position{line: 1030, col: 9, offset: 29693},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1027, col: 13, offset: 29619},
+									pos:   position{line: 1030, col: 13, offset: 29697},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1027, col: 20, offset: 29626},
+										pos: position{line: 1030, col: 20, offset: 29704},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1027, col: 20, offset: 29626},
+												pos:  position{line: 1030, col: 20, offset: 29704},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1027, col: 29, offset: 29635},
+												pos: position{line: 1030, col: 29, offset: 29713},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1027, col: 29, offset: 29635},
+													pos:  position{line: 1030, col: 29, offset: 29713},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1027, col: 39, offset: 29645},
+												pos: position{line: 1030, col: 39, offset: 29723},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1027, col: 39, offset: 29645},
+													pos:  position{line: 1030, col: 39, offset: 29723},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1027, col: 49, offset: 29655},
+												pos: position{line: 1030, col: 49, offset: 29733},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1027, col: 49, offset: 29655},
+													pos:  position{line: 1030, col: 49, offset: 29733},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1027, col: 59, offset: 29665},
+												pos: position{line: 1030, col: 59, offset: 29743},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1027, col: 59, offset: 29665},
+													pos:  position{line: 1030, col: 59, offset: 29743},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1027, col: 69, offset: 29675},
+												pos: position{line: 1030, col: 69, offset: 29753},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1027, col: 69, offset: 29675},
+													pos:  position{line: 1030, col: 69, offset: 29753},
 													name: "HexDigit",
 												},
 											},
@@ -7832,7 +7876,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1027, col: 80, offset: 29686},
+									pos:        position{line: 1030, col: 80, offset: 29764},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -7844,28 +7888,28 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 1031, col: 1, offset: 29740},
+			pos:  position{line: 1034, col: 1, offset: 29818},
 			expr: &actionExpr{
-				pos: position{line: 1032, col: 5, offset: 29751},
+				pos: position{line: 1035, col: 5, offset: 29829},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 1032, col: 5, offset: 29751},
+					pos: position{line: 1035, col: 5, offset: 29829},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1032, col: 5, offset: 29751},
+							pos:        position{line: 1035, col: 5, offset: 29829},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1032, col: 9, offset: 29755},
+							pos:   position{line: 1035, col: 9, offset: 29833},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1032, col: 14, offset: 29760},
+								pos:  position{line: 1035, col: 14, offset: 29838},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1032, col: 25, offset: 29771},
+							pos:        position{line: 1035, col: 25, offset: 29849},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -7875,24 +7919,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1034, col: 1, offset: 29797},
+			pos:  position{line: 1037, col: 1, offset: 29875},
 			expr: &actionExpr{
-				pos: position{line: 1035, col: 5, offset: 29812},
+				pos: position{line: 1038, col: 5, offset: 29890},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1035, col: 5, offset: 29812},
+					pos: position{line: 1038, col: 5, offset: 29890},
 					expr: &choiceExpr{
-						pos: position{line: 1035, col: 6, offset: 29813},
+						pos: position{line: 1038, col: 6, offset: 29891},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1035, col: 6, offset: 29813},
+								pos:        position{line: 1038, col: 6, offset: 29891},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 1035, col: 13, offset: 29820},
+								pos:        position{line: 1038, col: 13, offset: 29898},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -7903,9 +7947,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1037, col: 1, offset: 29860},
+			pos:  position{line: 1040, col: 1, offset: 29938},
 			expr: &charClassMatcher{
-				pos:        position{line: 1038, col: 5, offset: 29876},
+				pos:        position{line: 1041, col: 5, offset: 29954},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -7915,42 +7959,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1040, col: 1, offset: 29891},
+			pos:  position{line: 1043, col: 1, offset: 29969},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1040, col: 6, offset: 29896},
+				pos: position{line: 1043, col: 6, offset: 29974},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1040, col: 6, offset: 29896},
+					pos:  position{line: 1043, col: 6, offset: 29974},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1041, col: 1, offset: 29906},
+			pos:  position{line: 1044, col: 1, offset: 29984},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1041, col: 6, offset: 29911},
+				pos: position{line: 1044, col: 6, offset: 29989},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1041, col: 6, offset: 29911},
+					pos:  position{line: 1044, col: 6, offset: 29989},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1043, col: 1, offset: 29922},
+			pos:  position{line: 1046, col: 1, offset: 30000},
 			expr: &choiceExpr{
-				pos: position{line: 1044, col: 5, offset: 29935},
+				pos: position{line: 1047, col: 5, offset: 30013},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1044, col: 5, offset: 29935},
+						pos:  position{line: 1047, col: 5, offset: 30013},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1045, col: 5, offset: 29950},
+						pos:  position{line: 1048, col: 5, offset: 30028},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1046, col: 5, offset: 29969},
+						pos:  position{line: 1049, col: 5, offset: 30047},
 						name: "Comment",
 					},
 				},
@@ -7958,45 +8002,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1048, col: 1, offset: 29978},
+			pos:  position{line: 1051, col: 1, offset: 30056},
 			expr: &anyMatcher{
-				line: 1049, col: 5, offset: 29998,
+				line: 1052, col: 5, offset: 30076,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1051, col: 1, offset: 30001},
+			pos:         position{line: 1054, col: 1, offset: 30079},
 			expr: &choiceExpr{
-				pos: position{line: 1052, col: 5, offset: 30029},
+				pos: position{line: 1055, col: 5, offset: 30107},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1052, col: 5, offset: 30029},
+						pos:        position{line: 1055, col: 5, offset: 30107},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1053, col: 5, offset: 30038},
+						pos:        position{line: 1056, col: 5, offset: 30116},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1054, col: 5, offset: 30047},
+						pos:        position{line: 1057, col: 5, offset: 30125},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1055, col: 5, offset: 30056},
+						pos:        position{line: 1058, col: 5, offset: 30134},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1056, col: 5, offset: 30064},
+						pos:        position{line: 1059, col: 5, offset: 30142},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1057, col: 5, offset: 30077},
+						pos:        position{line: 1060, col: 5, offset: 30155},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -8005,9 +8049,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1059, col: 1, offset: 30087},
+			pos:  position{line: 1062, col: 1, offset: 30165},
 			expr: &charClassMatcher{
-				pos:        position{line: 1060, col: 5, offset: 30106},
+				pos:        position{line: 1063, col: 5, offset: 30184},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -8017,45 +8061,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1066, col: 1, offset: 30436},
+			pos:         position{line: 1069, col: 1, offset: 30514},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1069, col: 5, offset: 30507},
+				pos:  position{line: 1072, col: 5, offset: 30585},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1071, col: 1, offset: 30526},
+			pos:  position{line: 1074, col: 1, offset: 30604},
 			expr: &seqExpr{
-				pos: position{line: 1072, col: 5, offset: 30547},
+				pos: position{line: 1075, col: 5, offset: 30625},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1072, col: 5, offset: 30547},
+						pos:        position{line: 1075, col: 5, offset: 30625},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1072, col: 10, offset: 30552},
+						pos: position{line: 1075, col: 10, offset: 30630},
 						expr: &seqExpr{
-							pos: position{line: 1072, col: 11, offset: 30553},
+							pos: position{line: 1075, col: 11, offset: 30631},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1072, col: 11, offset: 30553},
+									pos: position{line: 1075, col: 11, offset: 30631},
 									expr: &litMatcher{
-										pos:        position{line: 1072, col: 12, offset: 30554},
+										pos:        position{line: 1075, col: 12, offset: 30632},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1072, col: 17, offset: 30559},
+									pos:  position{line: 1075, col: 17, offset: 30637},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1072, col: 35, offset: 30577},
+						pos:        position{line: 1075, col: 35, offset: 30655},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -8064,29 +8108,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1074, col: 1, offset: 30583},
+			pos:  position{line: 1077, col: 1, offset: 30661},
 			expr: &seqExpr{
-				pos: position{line: 1075, col: 5, offset: 30605},
+				pos: position{line: 1078, col: 5, offset: 30683},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1075, col: 5, offset: 30605},
+						pos:        position{line: 1078, col: 5, offset: 30683},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1075, col: 10, offset: 30610},
+						pos: position{line: 1078, col: 10, offset: 30688},
 						expr: &seqExpr{
-							pos: position{line: 1075, col: 11, offset: 30611},
+							pos: position{line: 1078, col: 11, offset: 30689},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1075, col: 11, offset: 30611},
+									pos: position{line: 1078, col: 11, offset: 30689},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1075, col: 12, offset: 30612},
+										pos:  position{line: 1078, col: 12, offset: 30690},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1075, col: 27, offset: 30627},
+									pos:  position{line: 1078, col: 27, offset: 30705},
 									name: "SourceCharacter",
 								},
 							},
@@ -8097,19 +8141,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1077, col: 1, offset: 30646},
+			pos:  position{line: 1080, col: 1, offset: 30724},
 			expr: &seqExpr{
-				pos: position{line: 1077, col: 7, offset: 30652},
+				pos: position{line: 1080, col: 7, offset: 30730},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1077, col: 7, offset: 30652},
+						pos: position{line: 1080, col: 7, offset: 30730},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1077, col: 7, offset: 30652},
+							pos:  position{line: 1080, col: 7, offset: 30730},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1077, col: 19, offset: 30664},
+						pos:  position{line: 1080, col: 19, offset: 30742},
 						name: "LineTerminator",
 					},
 				},
@@ -8117,16 +8161,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1078, col: 1, offset: 30679},
+			pos:  position{line: 1081, col: 1, offset: 30757},
 			expr: &choiceExpr{
-				pos: position{line: 1078, col: 7, offset: 30685},
+				pos: position{line: 1081, col: 7, offset: 30763},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1078, col: 7, offset: 30685},
+						pos:  position{line: 1081, col: 7, offset: 30763},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1078, col: 11, offset: 30689},
+						pos:  position{line: 1081, col: 11, offset: 30767},
 						name: "EOF",
 					},
 				},
@@ -8134,11 +8178,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1079, col: 1, offset: 30693},
+			pos:  position{line: 1082, col: 1, offset: 30771},
 			expr: &notExpr{
-				pos: position{line: 1079, col: 7, offset: 30699},
+				pos: position{line: 1082, col: 7, offset: 30777},
 				expr: &anyMatcher{
-					line: 1079, col: 8, offset: 30700,
+					line: 1082, col: 8, offset: 30778,
 				},
 			},
 		},
@@ -8685,14 +8729,24 @@ func (p *parser) callonAggregation11() (interface{}, error) {
 	return p.cur.onAggregation11(stack["every"], stack["reducers"], stack["keys"], stack["limit"])
 }
 
-func (c *current) onEveryDur1(dur interface{}) (interface{}, error) {
+func (c *current) onEveryDur2(dur interface{}) (interface{}, error) {
 	return dur, nil
 }
 
-func (p *parser) callonEveryDur1() (interface{}, error) {
+func (p *parser) callonEveryDur2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onEveryDur1(stack["dur"])
+	return p.cur.onEveryDur2(stack["dur"])
+}
+
+func (c *current) onEveryDur9() (interface{}, error) {
+	return nil, nil
+}
+
+func (p *parser) callonEveryDur9() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onEveryDur9()
 }
 
 func (c *current) onGroupByKeys1(columns interface{}) (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -328,47 +328,50 @@ function peg$parse(input, options) {
             }
             return p
           },
-      peg$c84 = "every",
-      peg$c85 = peg$literalExpectation("every", true),
-      peg$c86 = function(dur) { return dur },
-      peg$c87 = function(columns) { return columns },
-      peg$c88 = "with",
-      peg$c89 = peg$literalExpectation("with", false),
-      peg$c90 = "-limit",
-      peg$c91 = peg$literalExpectation("-limit", false),
-      peg$c92 = function(limit) { return limit },
-      peg$c93 = "",
-      peg$c94 = function() { return 0 },
-      peg$c95 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
-      peg$c96 = function(first, expr) { return expr },
-      peg$c97 = function(lval, reducer) {
+      peg$c84 = "summarize",
+      peg$c85 = peg$literalExpectation("summarize", false),
+      peg$c86 = "",
+      peg$c87 = "every",
+      peg$c88 = peg$literalExpectation("every", true),
+      peg$c89 = function(dur) { return dur },
+      peg$c90 = function() { return null },
+      peg$c91 = function(columns) { return columns },
+      peg$c92 = "with",
+      peg$c93 = peg$literalExpectation("with", false),
+      peg$c94 = "-limit",
+      peg$c95 = peg$literalExpectation("-limit", false),
+      peg$c96 = function(limit) { return limit },
+      peg$c97 = function() { return 0 },
+      peg$c98 = function(expr) { return {"op": "Assignment", "lhs": null, "rhs": expr} },
+      peg$c99 = function(first, expr) { return expr },
+      peg$c100 = function(lval, reducer) {
             return {"op": "Assignment", "lhs": lval, "rhs": reducer}
           },
-      peg$c98 = function(reducer) {
+      peg$c101 = function(reducer) {
             return {"op": "Assignment", "lhs": null, "rhs": reducer}
           },
-      peg$c99 = ".",
-      peg$c100 = peg$literalExpectation(".", false),
-      peg$c101 = function(op, expr, where) {
+      peg$c102 = ".",
+      peg$c103 = peg$literalExpectation(".", false),
+      peg$c104 = function(op, expr, where) {
             let r = {"op": "Reducer", "operator": op, "expr": null, "where":where}
             if (expr) {
               r["expr"] = expr
             }
             return r
           },
-      peg$c102 = "where",
-      peg$c103 = peg$literalExpectation("where", false),
-      peg$c104 = function(first, rest) {
+      peg$c105 = "where",
+      peg$c106 = peg$literalExpectation("where", false),
+      peg$c107 = function(first, rest) {
             let result = [first]
             for(let  r of rest) {
               result.push( r[3])
             }
             return result
           },
-      peg$c105 = "sort",
-      peg$c106 = peg$literalExpectation("sort", true),
-      peg$c107 = function(args, l) { return l },
-      peg$c108 = function(args, list) {
+      peg$c108 = "sort",
+      peg$c109 = peg$literalExpectation("sort", true),
+      peg$c110 = function(args, l) { return l },
+      peg$c111 = function(args, list) {
             let argm = args
             let proc = {"op": "SortProc", "fields": list, "sortdir": 1, "nullsfirst": false}
             if ( "r" in argm) {
@@ -381,24 +384,24 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c109 = function(args) { return makeArgMap(args) },
-      peg$c110 = "-r",
-      peg$c111 = peg$literalExpectation("-r", false),
-      peg$c112 = function() { return {"name": "r", "value": null} },
-      peg$c113 = "-nulls",
-      peg$c114 = peg$literalExpectation("-nulls", false),
-      peg$c115 = "first",
-      peg$c116 = peg$literalExpectation("first", false),
-      peg$c117 = "last",
-      peg$c118 = peg$literalExpectation("last", false),
-      peg$c119 = function(where) { return {"name": "nulls", "value": where} },
-      peg$c120 = "top",
-      peg$c121 = peg$literalExpectation("top", true),
-      peg$c122 = function(n) { return n},
-      peg$c123 = "-flush",
-      peg$c124 = peg$literalExpectation("-flush", false),
-      peg$c125 = function(limit, flush, f) { return f },
-      peg$c126 = function(limit, flush, fields) {
+      peg$c112 = function(args) { return makeArgMap(args) },
+      peg$c113 = "-r",
+      peg$c114 = peg$literalExpectation("-r", false),
+      peg$c115 = function() { return {"name": "r", "value": null} },
+      peg$c116 = "-nulls",
+      peg$c117 = peg$literalExpectation("-nulls", false),
+      peg$c118 = "first",
+      peg$c119 = peg$literalExpectation("first", false),
+      peg$c120 = "last",
+      peg$c121 = peg$literalExpectation("last", false),
+      peg$c122 = function(where) { return {"name": "nulls", "value": where} },
+      peg$c123 = "top",
+      peg$c124 = peg$literalExpectation("top", true),
+      peg$c125 = function(n) { return n},
+      peg$c126 = "-flush",
+      peg$c127 = peg$literalExpectation("-flush", false),
+      peg$c128 = function(limit, flush, f) { return f },
+      peg$c129 = function(limit, flush, fields) {
             let proc = {"op": "TopProc", "limit": 0, "fields": null, "flush": false}
             if (limit) {
               proc["limit"] = limit
@@ -411,82 +414,82 @@ function peg$parse(input, options) {
             }
             return proc
           },
-      peg$c127 = "cut",
-      peg$c128 = peg$literalExpectation("cut", true),
-      peg$c129 = function(columns) {
+      peg$c130 = "cut",
+      peg$c131 = peg$literalExpectation("cut", true),
+      peg$c132 = function(columns) {
             return {"op": "CutProc", "fields": columns}
           },
-      peg$c130 = "pick",
-      peg$c131 = peg$literalExpectation("pick", true),
-      peg$c132 = function(columns) {
+      peg$c133 = "pick",
+      peg$c134 = peg$literalExpectation("pick", true),
+      peg$c135 = function(columns) {
             return {"op": "PickProc", "fields": columns}
           },
-      peg$c133 = "drop",
-      peg$c134 = peg$literalExpectation("drop", true),
-      peg$c135 = function(columns) {
+      peg$c136 = "drop",
+      peg$c137 = peg$literalExpectation("drop", true),
+      peg$c138 = function(columns) {
             return {"op": "DropProc", "fields": columns}
           },
-      peg$c136 = "head",
-      peg$c137 = peg$literalExpectation("head", true),
-      peg$c138 = function(count) { return {"op": "HeadProc", "count": count} },
-      peg$c139 = function() { return {"op": "HeadProc", "count": 1} },
-      peg$c140 = "tail",
-      peg$c141 = peg$literalExpectation("tail", true),
-      peg$c142 = function(count) { return {"op": "TailProc", "count": count} },
-      peg$c143 = function() { return {"op": "TailProc", "count": 1} },
-      peg$c144 = "filter",
-      peg$c145 = peg$literalExpectation("filter", true),
-      peg$c146 = function(op) {
+      peg$c139 = "head",
+      peg$c140 = peg$literalExpectation("head", true),
+      peg$c141 = function(count) { return {"op": "HeadProc", "count": count} },
+      peg$c142 = function() { return {"op": "HeadProc", "count": 1} },
+      peg$c143 = "tail",
+      peg$c144 = peg$literalExpectation("tail", true),
+      peg$c145 = function(count) { return {"op": "TailProc", "count": count} },
+      peg$c146 = function() { return {"op": "TailProc", "count": 1} },
+      peg$c147 = "filter",
+      peg$c148 = peg$literalExpectation("filter", true),
+      peg$c149 = function(op) {
             return op
           },
-      peg$c147 = "uniq",
-      peg$c148 = peg$literalExpectation("uniq", true),
-      peg$c149 = "-c",
-      peg$c150 = peg$literalExpectation("-c", false),
-      peg$c151 = function() {
+      peg$c150 = "uniq",
+      peg$c151 = peg$literalExpectation("uniq", true),
+      peg$c152 = "-c",
+      peg$c153 = peg$literalExpectation("-c", false),
+      peg$c154 = function() {
             return {"op": "UniqProc", "cflag": true}
           },
-      peg$c152 = function() {
+      peg$c155 = function() {
             return {"op": "UniqProc", "cflag": false}
           },
-      peg$c153 = "put",
-      peg$c154 = peg$literalExpectation("put", true),
-      peg$c155 = function(columns) {
+      peg$c156 = "put",
+      peg$c157 = peg$literalExpectation("put", true),
+      peg$c158 = function(columns) {
             return {"op": "PutProc", "clauses": columns}
           },
-      peg$c156 = "rename",
-      peg$c157 = peg$literalExpectation("rename", true),
-      peg$c158 = function(first, cl) { return cl },
-      peg$c159 = function(first, rest) {
+      peg$c159 = "rename",
+      peg$c160 = peg$literalExpectation("rename", true),
+      peg$c161 = function(first, cl) { return cl },
+      peg$c162 = function(first, rest) {
             return {"op": "RenameProc", "fields": [first, ... rest]}
           },
-      peg$c160 = "fuse",
-      peg$c161 = peg$literalExpectation("fuse", true),
-      peg$c162 = function() {
+      peg$c163 = "fuse",
+      peg$c164 = peg$literalExpectation("fuse", true),
+      peg$c165 = function() {
             return {"op": "FuseProc"}
           },
-      peg$c163 = "join",
-      peg$c164 = peg$literalExpectation("join", true),
-      peg$c165 = function(leftKey, rightKey, columns) {
+      peg$c166 = "join",
+      peg$c167 = peg$literalExpectation("join", true),
+      peg$c168 = function(leftKey, rightKey, columns) {
             let proc = {"op": "JoinProc", "left_key": leftKey, "right_key": rightKey, "clauses": null}
             if (columns) {
               proc["clauses"] = columns[1]
             }
             return proc
           },
-      peg$c166 = function(key, columns) {
+      peg$c169 = function(key, columns) {
             let proc = {"op": "JoinProc", "left_key": key, "right_key": key, "clauses": null}
             if (columns) {
               proc["clauses"] = columns[1]
             }
             return proc
           },
-      peg$c167 = "taste",
-      peg$c168 = peg$literalExpectation("taste", true),
-      peg$c169 = function(e) {
+      peg$c170 = "taste",
+      peg$c171 = peg$literalExpectation("taste", true),
+      peg$c172 = function(e) {
             return {"op": "GroupByProc",
               
-            "keys":[{"op": "Assignment",
+            "keys": [{"op": "Assignment",
                          
             "lhs": {"op": "Identifier", "name": "shape"},
                          
@@ -505,13 +508,13 @@ function peg$parse(input, options) {
             "expr": e,
                                                
             "where": null}}],
-               
+              
             "duration": null, "limit": 0}
           
           },
-      peg$c170 = function(lval) { return lval},
-      peg$c171 = function() { return {"op":"RootRecord"} },
-      peg$c172 = function(first, rest) {
+      peg$c173 = function(lval) { return lval},
+      peg$c174 = function() { return {"op":"RootRecord"} },
+      peg$c175 = function(first, rest) {
             let result = [first]
 
             for(let  r of rest) {
@@ -520,41 +523,41 @@ function peg$parse(input, options) {
 
             return result
           },
-      peg$c173 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
-      peg$c174 = "?",
-      peg$c175 = peg$literalExpectation("?", false),
-      peg$c176 = function(condition, thenClause, elseClause) {
+      peg$c176 = function(lhs, rhs) { return {"op": "Assignment", "lhs": lhs, "rhs": rhs} },
+      peg$c177 = "?",
+      peg$c178 = peg$literalExpectation("?", false),
+      peg$c179 = function(condition, thenClause, elseClause) {
             return {"op": "ConditionalExpr", "condition": condition, "then": thenClause, "else": elseClause}
           },
-      peg$c177 = function(first, comp, expr) { return [comp, expr] },
-      peg$c178 = "+",
-      peg$c179 = peg$literalExpectation("+", false),
-      peg$c180 = "-",
-      peg$c181 = peg$literalExpectation("-", false),
-      peg$c182 = "/",
-      peg$c183 = peg$literalExpectation("/", false),
-      peg$c184 = function(e) {
+      peg$c180 = function(first, comp, expr) { return [comp, expr] },
+      peg$c181 = "+",
+      peg$c182 = peg$literalExpectation("+", false),
+      peg$c183 = "-",
+      peg$c184 = peg$literalExpectation("-", false),
+      peg$c185 = "/",
+      peg$c186 = peg$literalExpectation("/", false),
+      peg$c187 = function(e) {
               return {"op": "UnaryExpr", "operator": "!", "operand": e}
           },
-      peg$c185 = "not",
-      peg$c186 = peg$literalExpectation("not", false),
-      peg$c187 = "match",
-      peg$c188 = peg$literalExpectation("match", false),
-      peg$c189 = "select",
-      peg$c190 = peg$literalExpectation("select", false),
-      peg$c191 = function(args, e) { return ["@", e] },
-      peg$c192 = function(args, methods) {
+      peg$c188 = "not",
+      peg$c189 = peg$literalExpectation("not", false),
+      peg$c190 = "match",
+      peg$c191 = peg$literalExpectation("match", false),
+      peg$c192 = "select",
+      peg$c193 = peg$literalExpectation("select", false),
+      peg$c194 = function(args, e) { return ["@", e] },
+      peg$c195 = function(args, methods) {
             return makeBinaryExprChain({"op":"SelectExpr", "selectors":args}, methods)
           },
-      peg$c193 = function(fn, args) {
+      peg$c196 = function(fn, args) {
             return {"op": "FunctionCall", "function": fn, "args": args}
           },
-      peg$c194 = function(first, e) { return e },
-      peg$c195 = function() { return [] },
-      peg$c196 = function() {
+      peg$c197 = function(first, e) { return e },
+      peg$c198 = function() { return [] },
+      peg$c199 = function() {
             return {"op":"RootRecord"}
           },
-      peg$c197 = function(field) {
+      peg$c200 = function(field) {
             return {"op": "BinaryExpr", "operator":".",
                            
             "lhs":{"op":"RootRecord"},
@@ -563,11 +566,11 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c198 = "[",
-      peg$c199 = peg$literalExpectation("[", false),
-      peg$c200 = "]",
-      peg$c201 = peg$literalExpectation("]", false),
-      peg$c202 = function(expr) {
+      peg$c201 = "[",
+      peg$c202 = peg$literalExpectation("[", false),
+      peg$c203 = "]",
+      peg$c204 = peg$literalExpectation("]", false),
+      peg$c205 = function(expr) {
             return {"op": "BinaryExpr", "operator":"[",
                            
             "lhs":{"op":"RootRecord"},
@@ -576,323 +579,323 @@ function peg$parse(input, options) {
           
 
           },
-      peg$c203 = function(from, to) {
+      peg$c206 = function(from, to) {
             return ["[", {"op": "BinaryExpr", "operator":":",
                                   
             "lhs":from, "rhs":to}]
           
           },
-      peg$c204 = function(to) {
+      peg$c207 = function(to) {
             return ["[", {"op": "BinaryExpr", "operator":":",
                                   
             "lhs":{"op":"Empty"}, "rhs":to}]
           
           },
-      peg$c205 = function(from) {
+      peg$c208 = function(from) {
             return ["[", {"op": "BinaryExpr", "operator":":",
                                   
             "lhs":from, "rhs":{"op":"Empty"}}]
           
           },
-      peg$c206 = function(expr) { return ["[", expr] },
-      peg$c207 = function(id) { return [".", id] },
-      peg$c208 = function(v) {
+      peg$c209 = function(expr) { return ["[", expr] },
+      peg$c210 = function(id) { return [".", id] },
+      peg$c211 = function(v) {
             return {"op": "Literal", "type": "regexp", "value": v}
           },
-      peg$c209 = function(v) {
+      peg$c212 = function(v) {
             return {"op": "Literal", "type": "net", "value": v}
           },
-      peg$c210 = function(v) {
+      peg$c213 = function(v) {
             return {"op": "Literal", "type": "ip", "value": v}
           },
-      peg$c211 = function(v) {
+      peg$c214 = function(v) {
             return {"op": "Literal", "type": "float64", "value": v}
           },
-      peg$c212 = function(v) {
+      peg$c215 = function(v) {
             return {"op": "Literal", "type": "int64", "value": v}
           },
-      peg$c213 = "true",
-      peg$c214 = peg$literalExpectation("true", false),
-      peg$c215 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
-      peg$c216 = "false",
-      peg$c217 = peg$literalExpectation("false", false),
-      peg$c218 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
-      peg$c219 = "null",
-      peg$c220 = peg$literalExpectation("null", false),
-      peg$c221 = function() { return {"op": "Literal", "type": "null", "value": ""} },
-      peg$c222 = function(typ) {
+      peg$c216 = "true",
+      peg$c217 = peg$literalExpectation("true", false),
+      peg$c218 = function() { return {"op": "Literal", "type": "bool", "value": "true"} },
+      peg$c219 = "false",
+      peg$c220 = peg$literalExpectation("false", false),
+      peg$c221 = function() { return {"op": "Literal", "type": "bool", "value": "false"} },
+      peg$c222 = "null",
+      peg$c223 = peg$literalExpectation("null", false),
+      peg$c224 = function() { return {"op": "Literal", "type": "null", "value": ""} },
+      peg$c225 = function(typ) {
             return {"op": "TypeExpr", "type": typ}
           },
-      peg$c223 = function(typ) { return typ},
-      peg$c224 = function(typ) { return typ },
-      peg$c225 = function() {
+      peg$c226 = function(typ) { return typ},
+      peg$c227 = function(typ) { return typ },
+      peg$c228 = function() {
             return {"op": "TypeNull"}
           },
-      peg$c226 = function(name, typ) {
+      peg$c229 = function(name, typ) {
             return {"op": "TypeDef", "name": name, "type": typ}
         },
-      peg$c227 = function(name) {
+      peg$c230 = function(name) {
             return {"op": "TypeName", "name": name}
           },
-      peg$c228 = function(u) { return u },
-      peg$c229 = function(types) {
+      peg$c231 = function(u) { return u },
+      peg$c232 = function(types) {
             return {"op": "TypeUnion", "types": types}
           },
-      peg$c230 = function(first, rest) {
+      peg$c233 = function(first, rest) {
           return [first, ... rest]
         },
-      peg$c231 = "{",
-      peg$c232 = peg$literalExpectation("{", false),
-      peg$c233 = "}",
-      peg$c234 = peg$literalExpectation("}", false),
-      peg$c235 = function(fields) {
+      peg$c234 = "{",
+      peg$c235 = peg$literalExpectation("{", false),
+      peg$c236 = "}",
+      peg$c237 = peg$literalExpectation("}", false),
+      peg$c238 = function(fields) {
             return {"op":"TypeRecord", "fields":fields}
           },
-      peg$c236 = function(typ) {
+      peg$c239 = function(typ) {
             return {"op":"TypeArray", "type":typ}
           },
-      peg$c237 = "|[",
-      peg$c238 = peg$literalExpectation("|[", false),
-      peg$c239 = "]|",
-      peg$c240 = peg$literalExpectation("]|", false),
-      peg$c241 = function(typ) {
+      peg$c240 = "|[",
+      peg$c241 = peg$literalExpectation("|[", false),
+      peg$c242 = "]|",
+      peg$c243 = peg$literalExpectation("]|", false),
+      peg$c244 = function(typ) {
             return {"op":"TypeSet", "type":typ}
           },
-      peg$c242 = "|{",
-      peg$c243 = peg$literalExpectation("|{", false),
-      peg$c244 = "}|",
-      peg$c245 = peg$literalExpectation("}|", false),
-      peg$c246 = function(keyType, valType) {
+      peg$c245 = "|{",
+      peg$c246 = peg$literalExpectation("|{", false),
+      peg$c247 = "}|",
+      peg$c248 = peg$literalExpectation("}|", false),
+      peg$c249 = function(keyType, valType) {
             return {"op":"TypeMap", "key_type":keyType, "val_type": valType}
           },
-      peg$c247 = "uint8",
-      peg$c248 = peg$literalExpectation("uint8", false),
-      peg$c249 = "uint16",
-      peg$c250 = peg$literalExpectation("uint16", false),
-      peg$c251 = "uint32",
-      peg$c252 = peg$literalExpectation("uint32", false),
-      peg$c253 = "uint64",
-      peg$c254 = peg$literalExpectation("uint64", false),
-      peg$c255 = "int8",
-      peg$c256 = peg$literalExpectation("int8", false),
-      peg$c257 = "int16",
-      peg$c258 = peg$literalExpectation("int16", false),
-      peg$c259 = "int32",
-      peg$c260 = peg$literalExpectation("int32", false),
-      peg$c261 = "int64",
-      peg$c262 = peg$literalExpectation("int64", false),
-      peg$c263 = "float64",
-      peg$c264 = peg$literalExpectation("float64", false),
-      peg$c265 = "bool",
-      peg$c266 = peg$literalExpectation("bool", false),
-      peg$c267 = "string",
-      peg$c268 = peg$literalExpectation("string", false),
-      peg$c269 = function() {
+      peg$c250 = "uint8",
+      peg$c251 = peg$literalExpectation("uint8", false),
+      peg$c252 = "uint16",
+      peg$c253 = peg$literalExpectation("uint16", false),
+      peg$c254 = "uint32",
+      peg$c255 = peg$literalExpectation("uint32", false),
+      peg$c256 = "uint64",
+      peg$c257 = peg$literalExpectation("uint64", false),
+      peg$c258 = "int8",
+      peg$c259 = peg$literalExpectation("int8", false),
+      peg$c260 = "int16",
+      peg$c261 = peg$literalExpectation("int16", false),
+      peg$c262 = "int32",
+      peg$c263 = peg$literalExpectation("int32", false),
+      peg$c264 = "int64",
+      peg$c265 = peg$literalExpectation("int64", false),
+      peg$c266 = "float64",
+      peg$c267 = peg$literalExpectation("float64", false),
+      peg$c268 = "bool",
+      peg$c269 = peg$literalExpectation("bool", false),
+      peg$c270 = "string",
+      peg$c271 = peg$literalExpectation("string", false),
+      peg$c272 = function() {
                 return {"op": "TypePrimitive", "name": text()}
               },
-      peg$c270 = "duration",
-      peg$c271 = peg$literalExpectation("duration", false),
-      peg$c272 = "time",
-      peg$c273 = peg$literalExpectation("time", false),
-      peg$c274 = "bytes",
-      peg$c275 = peg$literalExpectation("bytes", false),
-      peg$c276 = "bstring",
-      peg$c277 = peg$literalExpectation("bstring", false),
-      peg$c278 = "ip",
-      peg$c279 = peg$literalExpectation("ip", false),
-      peg$c280 = "net",
-      peg$c281 = peg$literalExpectation("net", false),
-      peg$c282 = "error",
-      peg$c283 = peg$literalExpectation("error", false),
-      peg$c284 = function(name, typ) {
+      peg$c273 = "duration",
+      peg$c274 = peg$literalExpectation("duration", false),
+      peg$c275 = "time",
+      peg$c276 = peg$literalExpectation("time", false),
+      peg$c277 = "bytes",
+      peg$c278 = peg$literalExpectation("bytes", false),
+      peg$c279 = "bstring",
+      peg$c280 = peg$literalExpectation("bstring", false),
+      peg$c281 = "ip",
+      peg$c282 = peg$literalExpectation("ip", false),
+      peg$c283 = "net",
+      peg$c284 = peg$literalExpectation("net", false),
+      peg$c285 = "error",
+      peg$c286 = peg$literalExpectation("error", false),
+      peg$c287 = function(name, typ) {
             return {"name": name, "type": typ}
           },
-      peg$c285 = "and",
-      peg$c286 = peg$literalExpectation("and", true),
-      peg$c287 = function() { return "and" },
-      peg$c288 = "or",
-      peg$c289 = peg$literalExpectation("or", true),
-      peg$c290 = function() { return "or" },
-      peg$c291 = peg$literalExpectation("in", true),
-      peg$c292 = function() { return "in" },
-      peg$c293 = peg$literalExpectation("not", true),
-      peg$c294 = function() { return "not" },
-      peg$c295 = "by",
-      peg$c296 = peg$literalExpectation("by", true),
-      peg$c297 = function() { return "by" },
-      peg$c298 = /^[A-Za-z_$]/,
-      peg$c299 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
-      peg$c300 = /^[0-9]/,
-      peg$c301 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c302 = function(id) { return {"op": "Identifier", "name": id} },
-      peg$c303 = function() {  return text() },
-      peg$c304 = "$",
-      peg$c305 = peg$literalExpectation("$", false),
-      peg$c306 = "\\",
-      peg$c307 = peg$literalExpectation("\\", false),
-      peg$c308 = function(id) { return id },
-      peg$c309 = peg$literalExpectation("and", false),
-      peg$c310 = "seconds",
-      peg$c311 = peg$literalExpectation("seconds", false),
-      peg$c312 = "second",
-      peg$c313 = peg$literalExpectation("second", false),
-      peg$c314 = "secs",
-      peg$c315 = peg$literalExpectation("secs", false),
-      peg$c316 = "sec",
-      peg$c317 = peg$literalExpectation("sec", false),
-      peg$c318 = "s",
-      peg$c319 = peg$literalExpectation("s", false),
-      peg$c320 = "minutes",
-      peg$c321 = peg$literalExpectation("minutes", false),
-      peg$c322 = "minute",
-      peg$c323 = peg$literalExpectation("minute", false),
-      peg$c324 = "mins",
-      peg$c325 = peg$literalExpectation("mins", false),
-      peg$c326 = "min",
-      peg$c327 = peg$literalExpectation("min", false),
-      peg$c328 = "m",
-      peg$c329 = peg$literalExpectation("m", false),
-      peg$c330 = "hours",
-      peg$c331 = peg$literalExpectation("hours", false),
-      peg$c332 = "hrs",
-      peg$c333 = peg$literalExpectation("hrs", false),
-      peg$c334 = "hr",
-      peg$c335 = peg$literalExpectation("hr", false),
-      peg$c336 = "h",
-      peg$c337 = peg$literalExpectation("h", false),
-      peg$c338 = "hour",
-      peg$c339 = peg$literalExpectation("hour", false),
-      peg$c340 = "days",
-      peg$c341 = peg$literalExpectation("days", false),
-      peg$c342 = "day",
-      peg$c343 = peg$literalExpectation("day", false),
-      peg$c344 = "d",
-      peg$c345 = peg$literalExpectation("d", false),
-      peg$c346 = "weeks",
-      peg$c347 = peg$literalExpectation("weeks", false),
-      peg$c348 = "week",
-      peg$c349 = peg$literalExpectation("week", false),
-      peg$c350 = "wks",
-      peg$c351 = peg$literalExpectation("wks", false),
-      peg$c352 = "wk",
-      peg$c353 = peg$literalExpectation("wk", false),
-      peg$c354 = "w",
-      peg$c355 = peg$literalExpectation("w", false),
-      peg$c356 = function() { return {"type": "Duration", "seconds": 1} },
-      peg$c357 = function(num) { return {"type": "Duration", "seconds": num} },
-      peg$c358 = function() { return {"type": "Duration", "seconds": 60} },
-      peg$c359 = function(num) { return {"type": "Duration", "seconds": num*60} },
-      peg$c360 = function() { return {"type": "Duration", "seconds": 3600} },
-      peg$c361 = function(num) { return {"type": "Duration", "seconds": num*3600} },
-      peg$c362 = function() { return {"type": "Duration", "seconds": 3600*24} },
-      peg$c363 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
-      peg$c364 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
-      peg$c365 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
-      peg$c366 = function(a, b) {
+      peg$c288 = "and",
+      peg$c289 = peg$literalExpectation("and", true),
+      peg$c290 = function() { return "and" },
+      peg$c291 = "or",
+      peg$c292 = peg$literalExpectation("or", true),
+      peg$c293 = function() { return "or" },
+      peg$c294 = peg$literalExpectation("in", true),
+      peg$c295 = function() { return "in" },
+      peg$c296 = peg$literalExpectation("not", true),
+      peg$c297 = function() { return "not" },
+      peg$c298 = "by",
+      peg$c299 = peg$literalExpectation("by", true),
+      peg$c300 = function() { return "by" },
+      peg$c301 = /^[A-Za-z_$]/,
+      peg$c302 = peg$classExpectation([["A", "Z"], ["a", "z"], "_", "$"], false, false),
+      peg$c303 = /^[0-9]/,
+      peg$c304 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c305 = function(id) { return {"op": "Identifier", "name": id} },
+      peg$c306 = function() {  return text() },
+      peg$c307 = "$",
+      peg$c308 = peg$literalExpectation("$", false),
+      peg$c309 = "\\",
+      peg$c310 = peg$literalExpectation("\\", false),
+      peg$c311 = function(id) { return id },
+      peg$c312 = peg$literalExpectation("and", false),
+      peg$c313 = "seconds",
+      peg$c314 = peg$literalExpectation("seconds", false),
+      peg$c315 = "second",
+      peg$c316 = peg$literalExpectation("second", false),
+      peg$c317 = "secs",
+      peg$c318 = peg$literalExpectation("secs", false),
+      peg$c319 = "sec",
+      peg$c320 = peg$literalExpectation("sec", false),
+      peg$c321 = "s",
+      peg$c322 = peg$literalExpectation("s", false),
+      peg$c323 = "minutes",
+      peg$c324 = peg$literalExpectation("minutes", false),
+      peg$c325 = "minute",
+      peg$c326 = peg$literalExpectation("minute", false),
+      peg$c327 = "mins",
+      peg$c328 = peg$literalExpectation("mins", false),
+      peg$c329 = "min",
+      peg$c330 = peg$literalExpectation("min", false),
+      peg$c331 = "m",
+      peg$c332 = peg$literalExpectation("m", false),
+      peg$c333 = "hours",
+      peg$c334 = peg$literalExpectation("hours", false),
+      peg$c335 = "hrs",
+      peg$c336 = peg$literalExpectation("hrs", false),
+      peg$c337 = "hr",
+      peg$c338 = peg$literalExpectation("hr", false),
+      peg$c339 = "h",
+      peg$c340 = peg$literalExpectation("h", false),
+      peg$c341 = "hour",
+      peg$c342 = peg$literalExpectation("hour", false),
+      peg$c343 = "days",
+      peg$c344 = peg$literalExpectation("days", false),
+      peg$c345 = "day",
+      peg$c346 = peg$literalExpectation("day", false),
+      peg$c347 = "d",
+      peg$c348 = peg$literalExpectation("d", false),
+      peg$c349 = "weeks",
+      peg$c350 = peg$literalExpectation("weeks", false),
+      peg$c351 = "week",
+      peg$c352 = peg$literalExpectation("week", false),
+      peg$c353 = "wks",
+      peg$c354 = peg$literalExpectation("wks", false),
+      peg$c355 = "wk",
+      peg$c356 = peg$literalExpectation("wk", false),
+      peg$c357 = "w",
+      peg$c358 = peg$literalExpectation("w", false),
+      peg$c359 = function() { return {"type": "Duration", "seconds": 1} },
+      peg$c360 = function(num) { return {"type": "Duration", "seconds": num} },
+      peg$c361 = function() { return {"type": "Duration", "seconds": 60} },
+      peg$c362 = function(num) { return {"type": "Duration", "seconds": num*60} },
+      peg$c363 = function() { return {"type": "Duration", "seconds": 3600} },
+      peg$c364 = function(num) { return {"type": "Duration", "seconds": num*3600} },
+      peg$c365 = function() { return {"type": "Duration", "seconds": 3600*24} },
+      peg$c366 = function(num) { return {"type": "Duration", "seconds": (num*3600*24)} },
+      peg$c367 = function() { return {"type": "Duration", "seconds": 3600*24*7} },
+      peg$c368 = function(num) { return {"type": "Duration", "seconds": num*3600*24*7} },
+      peg$c369 = function(a, b) {
             return joinChars(a) + b
           },
-      peg$c367 = "::",
-      peg$c368 = peg$literalExpectation("::", false),
-      peg$c369 = function(a, b, d, e) {
+      peg$c370 = "::",
+      peg$c371 = peg$literalExpectation("::", false),
+      peg$c372 = function(a, b, d, e) {
             return a + joinChars(b) + "::" + joinChars(d) + e
           },
-      peg$c370 = function(a, b) {
+      peg$c373 = function(a, b) {
             return "::" + joinChars(a) + b
           },
-      peg$c371 = function(a, b) {
+      peg$c374 = function(a, b) {
             return a + joinChars(b) + "::"
           },
-      peg$c372 = function() {
+      peg$c375 = function() {
             return "::"
           },
-      peg$c373 = function(v) { return ":" + v },
-      peg$c374 = function(v) { return v + ":" },
-      peg$c375 = function(a, m) {
+      peg$c376 = function(v) { return ":" + v },
+      peg$c377 = function(v) { return v + ":" },
+      peg$c378 = function(a, m) {
             return a + "/" + m.toString();
           },
-      peg$c376 = function(a, m) {
+      peg$c379 = function(a, m) {
             return a + "/" + m;
           },
-      peg$c377 = function(s) { return parseInt(s) },
-      peg$c378 = function() {
+      peg$c380 = function(s) { return parseInt(s) },
+      peg$c381 = function() {
             return text()
           },
-      peg$c379 = "e",
-      peg$c380 = peg$literalExpectation("e", true),
-      peg$c381 = /^[+\-]/,
-      peg$c382 = peg$classExpectation(["+", "-"], false, false),
-      peg$c383 = /^[0-9a-fA-F]/,
-      peg$c384 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c385 = "\"",
-      peg$c386 = peg$literalExpectation("\"", false),
-      peg$c387 = function(v) { return joinChars(v) },
-      peg$c388 = "'",
-      peg$c389 = peg$literalExpectation("'", false),
-      peg$c390 = peg$anyExpectation(),
-      peg$c391 = function(s) { return s },
-      peg$c392 = function(head, tail) { return head + joinChars(tail) },
-      peg$c393 = /^[a-zA-Z_.:\/%#@~]/,
-      peg$c394 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
-      peg$c395 = "x",
-      peg$c396 = peg$literalExpectation("x", false),
-      peg$c397 = function() { return "\\" + text() },
-      peg$c398 = function() { return "'"},
-      peg$c399 = function() { return '"'},
-      peg$c400 = function() { return "\\"},
-      peg$c401 = "b",
-      peg$c402 = peg$literalExpectation("b", false),
-      peg$c403 = function() { return "\b" },
-      peg$c404 = "f",
-      peg$c405 = peg$literalExpectation("f", false),
-      peg$c406 = function() { return "\f" },
-      peg$c407 = "n",
-      peg$c408 = peg$literalExpectation("n", false),
-      peg$c409 = function() { return "\n" },
-      peg$c410 = "r",
-      peg$c411 = peg$literalExpectation("r", false),
-      peg$c412 = function() { return "\r" },
-      peg$c413 = "t",
-      peg$c414 = peg$literalExpectation("t", false),
-      peg$c415 = function() { return "\t" },
-      peg$c416 = "v",
-      peg$c417 = peg$literalExpectation("v", false),
-      peg$c418 = function() { return "\v" },
-      peg$c419 = function() { return "=" },
-      peg$c420 = function() { return "\\*" },
-      peg$c421 = "u",
-      peg$c422 = peg$literalExpectation("u", false),
-      peg$c423 = function(chars) {
+      peg$c382 = "e",
+      peg$c383 = peg$literalExpectation("e", true),
+      peg$c384 = /^[+\-]/,
+      peg$c385 = peg$classExpectation(["+", "-"], false, false),
+      peg$c386 = /^[0-9a-fA-F]/,
+      peg$c387 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c388 = "\"",
+      peg$c389 = peg$literalExpectation("\"", false),
+      peg$c390 = function(v) { return joinChars(v) },
+      peg$c391 = "'",
+      peg$c392 = peg$literalExpectation("'", false),
+      peg$c393 = peg$anyExpectation(),
+      peg$c394 = function(s) { return s },
+      peg$c395 = function(head, tail) { return head + joinChars(tail) },
+      peg$c396 = /^[a-zA-Z_.:\/%#@~]/,
+      peg$c397 = peg$classExpectation([["a", "z"], ["A", "Z"], "_", ".", ":", "/", "%", "#", "@", "~"], false, false),
+      peg$c398 = "x",
+      peg$c399 = peg$literalExpectation("x", false),
+      peg$c400 = function() { return "\\" + text() },
+      peg$c401 = function() { return "'"},
+      peg$c402 = function() { return '"'},
+      peg$c403 = function() { return "\\"},
+      peg$c404 = "b",
+      peg$c405 = peg$literalExpectation("b", false),
+      peg$c406 = function() { return "\b" },
+      peg$c407 = "f",
+      peg$c408 = peg$literalExpectation("f", false),
+      peg$c409 = function() { return "\f" },
+      peg$c410 = "n",
+      peg$c411 = peg$literalExpectation("n", false),
+      peg$c412 = function() { return "\n" },
+      peg$c413 = "r",
+      peg$c414 = peg$literalExpectation("r", false),
+      peg$c415 = function() { return "\r" },
+      peg$c416 = "t",
+      peg$c417 = peg$literalExpectation("t", false),
+      peg$c418 = function() { return "\t" },
+      peg$c419 = "v",
+      peg$c420 = peg$literalExpectation("v", false),
+      peg$c421 = function() { return "\v" },
+      peg$c422 = function() { return "=" },
+      peg$c423 = function() { return "\\*" },
+      peg$c424 = "u",
+      peg$c425 = peg$literalExpectation("u", false),
+      peg$c426 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c424 = function(body) { return body },
-      peg$c425 = /^[^\/\\]/,
-      peg$c426 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c427 = "\\/",
-      peg$c428 = peg$literalExpectation("\\/", false),
-      peg$c429 = /^[\0-\x1F\\]/,
-      peg$c430 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c431 = peg$otherExpectation("whitespace"),
-      peg$c432 = "\t",
-      peg$c433 = peg$literalExpectation("\t", false),
-      peg$c434 = "\x0B",
-      peg$c435 = peg$literalExpectation("\x0B", false),
-      peg$c436 = "\f",
-      peg$c437 = peg$literalExpectation("\f", false),
-      peg$c438 = " ",
-      peg$c439 = peg$literalExpectation(" ", false),
-      peg$c440 = "\xA0",
-      peg$c441 = peg$literalExpectation("\xA0", false),
-      peg$c442 = "\uFEFF",
-      peg$c443 = peg$literalExpectation("\uFEFF", false),
-      peg$c444 = /^[\n\r\u2028\u2029]/,
-      peg$c445 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c446 = peg$otherExpectation("comment"),
-      peg$c447 = "/*",
-      peg$c448 = peg$literalExpectation("/*", false),
-      peg$c449 = "*/",
-      peg$c450 = peg$literalExpectation("*/", false),
-      peg$c451 = "//",
-      peg$c452 = peg$literalExpectation("//", false),
+      peg$c427 = function(body) { return body },
+      peg$c428 = /^[^\/\\]/,
+      peg$c429 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c430 = "\\/",
+      peg$c431 = peg$literalExpectation("\\/", false),
+      peg$c432 = /^[\0-\x1F\\]/,
+      peg$c433 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c434 = peg$otherExpectation("whitespace"),
+      peg$c435 = "\t",
+      peg$c436 = peg$literalExpectation("\t", false),
+      peg$c437 = "\x0B",
+      peg$c438 = peg$literalExpectation("\x0B", false),
+      peg$c439 = "\f",
+      peg$c440 = peg$literalExpectation("\f", false),
+      peg$c441 = " ",
+      peg$c442 = peg$literalExpectation(" ", false),
+      peg$c443 = "\xA0",
+      peg$c444 = peg$literalExpectation("\xA0", false),
+      peg$c445 = "\uFEFF",
+      peg$c446 = peg$literalExpectation("\uFEFF", false),
+      peg$c447 = /^[\n\r\u2028\u2029]/,
+      peg$c448 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c449 = peg$otherExpectation("comment"),
+      peg$c450 = "/*",
+      peg$c451 = peg$literalExpectation("/*", false),
+      peg$c452 = "*/",
+      peg$c453 = peg$literalExpectation("*/", false),
+      peg$c454 = "//",
+      peg$c455 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -3168,21 +3171,24 @@ function peg$parse(input, options) {
   }
 
   function peg$parseAggregation() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    s1 = peg$parseEveryDur();
-    if (s1 === peg$FAILED) {
-      s1 = null;
-    }
+    s1 = peg$parseSummarize();
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseGroupByKeys();
+      s2 = peg$parseEveryDur();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseLimitArg();
+        s3 = peg$parseGroupByKeys();
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c82(s1, s2, s3);
-          s0 = s1;
+          s4 = peg$parseLimitArg();
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c82(s2, s3, s4);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -3197,37 +3203,40 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseEveryDur();
-      if (s1 === peg$FAILED) {
-        s1 = null;
-      }
+      s1 = peg$parseSummarize();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseReducers();
+        s2 = peg$parseEveryDur();
         if (s2 !== peg$FAILED) {
-          s3 = peg$currPos;
-          s4 = peg$parse_();
-          if (s4 !== peg$FAILED) {
-            s5 = peg$parseGroupByKeys();
-            if (s5 !== peg$FAILED) {
-              s4 = [s4, s5];
-              s3 = s4;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-          if (s3 === peg$FAILED) {
-            s3 = null;
-          }
+          s3 = peg$parseReducers();
           if (s3 !== peg$FAILED) {
-            s4 = peg$parseLimitArg();
+            s4 = peg$currPos;
+            s5 = peg$parse_();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parseGroupByKeys();
+              if (s6 !== peg$FAILED) {
+                s5 = [s5, s6];
+                s4 = s5;
+              } else {
+                peg$currPos = s4;
+                s4 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$FAILED;
+            }
+            if (s4 === peg$FAILED) {
+              s4 = null;
+            }
             if (s4 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c83(s1, s2, s3, s4);
-              s0 = s1;
+              s5 = peg$parseLimitArg();
+              if (s5 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c83(s2, s3, s4, s5);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -3249,16 +3258,47 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseSummarize() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 9) === peg$c84) {
+      s1 = peg$c84;
+      peg$currPos += 9;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c85); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s1 = [s1, s2];
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$c86;
+    }
+
+    return s0;
+  }
+
   function peg$parseEveryDur() {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c84) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c87) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c85); }
+      if (peg$silentFails === 0) { peg$fail(peg$c88); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3268,7 +3308,7 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c86(s3);
+            s1 = peg$c89(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3286,6 +3326,15 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$c86;
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c90();
+      }
+      s0 = s1;
+    }
 
     return s0;
   }
@@ -3301,7 +3350,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c87(s3);
+          s1 = peg$c91(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3325,22 +3374,22 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c88) {
-        s2 = peg$c88;
+      if (input.substr(peg$currPos, 4) === peg$c92) {
+        s2 = peg$c92;
         peg$currPos += 4;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c89); }
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c90) {
-            s4 = peg$c90;
+          if (input.substr(peg$currPos, 6) === peg$c94) {
+            s4 = peg$c94;
             peg$currPos += 6;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c91); }
+            if (peg$silentFails === 0) { peg$fail(peg$c95); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -3348,7 +3397,7 @@ function peg$parse(input, options) {
               s6 = peg$parseUInt();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c92(s6);
+                s1 = peg$c96(s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3376,10 +3425,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c93;
+      s1 = peg$c86;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c94();
+        s1 = peg$c97();
       }
       s0 = s1;
     }
@@ -3396,7 +3445,7 @@ function peg$parse(input, options) {
       s1 = peg$parseConditionalExpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c95(s1);
+        s1 = peg$c98(s1);
       }
       s0 = s1;
     }
@@ -3427,7 +3476,7 @@ function peg$parse(input, options) {
             s7 = peg$parseFlexAssignment();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c96(s1, s7);
+              s4 = peg$c99(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3463,7 +3512,7 @@ function peg$parse(input, options) {
               s7 = peg$parseFlexAssignment();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c96(s1, s7);
+                s4 = peg$c99(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -3519,7 +3568,7 @@ function peg$parse(input, options) {
             s5 = peg$parseReducer();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c97(s1, s5);
+              s1 = peg$c100(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3546,7 +3595,7 @@ function peg$parse(input, options) {
       s1 = peg$parseReducer();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c98(s1);
+        s1 = peg$c101(s1);
       }
       s0 = s1;
     }
@@ -3604,11 +3653,11 @@ function peg$parse(input, options) {
                     s11 = peg$parse__();
                     if (s11 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 46) {
-                        s12 = peg$c99;
+                        s12 = peg$c102;
                         peg$currPos++;
                       } else {
                         s12 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c103); }
                       }
                       if (s12 !== peg$FAILED) {
                         s11 = [s11, s12];
@@ -3635,7 +3684,7 @@ function peg$parse(input, options) {
                       }
                       if (s10 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c101(s2, s6, s10);
+                        s1 = peg$c104(s2, s6, s10);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3701,12 +3750,12 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c102) {
-        s2 = peg$c102;
+      if (input.substr(peg$currPos, 5) === peg$c105) {
+        s2 = peg$c105;
         peg$currPos += 5;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c103); }
+        if (peg$silentFails === 0) { peg$fail(peg$c106); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -3814,7 +3863,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c104(s1, s2);
+        s1 = peg$c107(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3879,12 +3928,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c105) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c108) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c106); }
+      if (peg$silentFails === 0) { peg$fail(peg$c109); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseSortArgs();
@@ -3895,7 +3944,7 @@ function peg$parse(input, options) {
           s5 = peg$parseExprs();
           if (s5 !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c107(s2, s5);
+            s4 = peg$c110(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -3910,7 +3959,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c108(s2, s3);
+          s1 = peg$c111(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3970,7 +4019,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c109(s1);
+      s1 = peg$c112(s1);
     }
     s0 = s1;
 
@@ -3981,45 +4030,45 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c110) {
-      s1 = peg$c110;
+    if (input.substr(peg$currPos, 2) === peg$c113) {
+      s1 = peg$c113;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c111); }
+      if (peg$silentFails === 0) { peg$fail(peg$c114); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c112();
+      s1 = peg$c115();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c113) {
-        s1 = peg$c113;
+      if (input.substr(peg$currPos, 6) === peg$c116) {
+        s1 = peg$c116;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c114); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
-          if (input.substr(peg$currPos, 5) === peg$c115) {
-            s4 = peg$c115;
+          if (input.substr(peg$currPos, 5) === peg$c118) {
+            s4 = peg$c118;
             peg$currPos += 5;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c116); }
+            if (peg$silentFails === 0) { peg$fail(peg$c119); }
           }
           if (s4 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c117) {
-              s4 = peg$c117;
+            if (input.substr(peg$currPos, 4) === peg$c120) {
+              s4 = peg$c120;
               peg$currPos += 4;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c118); }
+              if (peg$silentFails === 0) { peg$fail(peg$c121); }
             }
           }
           if (s4 !== peg$FAILED) {
@@ -4029,7 +4078,7 @@ function peg$parse(input, options) {
           s3 = s4;
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c119(s3);
+            s1 = peg$c122(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4052,12 +4101,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c120) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c123) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c121); }
+      if (peg$silentFails === 0) { peg$fail(peg$c124); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4066,7 +4115,7 @@ function peg$parse(input, options) {
         s4 = peg$parseUInt();
         if (s4 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c122(s4);
+          s3 = peg$c125(s4);
           s2 = s3;
         } else {
           peg$currPos = s2;
@@ -4083,12 +4132,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c123) {
-            s5 = peg$c123;
+          if (input.substr(peg$currPos, 6) === peg$c126) {
+            s5 = peg$c126;
             peg$currPos += 6;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c124); }
+            if (peg$silentFails === 0) { peg$fail(peg$c127); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -4111,7 +4160,7 @@ function peg$parse(input, options) {
             s6 = peg$parseFieldExprs();
             if (s6 !== peg$FAILED) {
               peg$savedPos = s4;
-              s5 = peg$c125(s2, s3, s6);
+              s5 = peg$c128(s2, s3, s6);
               s4 = s5;
             } else {
               peg$currPos = s4;
@@ -4126,7 +4175,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c126(s2, s3, s4);
+            s1 = peg$c129(s2, s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4152,44 +4201,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c127) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c130) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c128); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      if (s2 !== peg$FAILED) {
-        s3 = peg$parseFlexAssignments();
-        if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c129(s3);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parsePickProc() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c130) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c131); }
@@ -4218,7 +4232,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseDropProc() {
+  function peg$parsePickProc() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -4232,10 +4246,45 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseFieldExprs();
+        s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$c135(s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseDropProc() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c136) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c137); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseFieldExprs();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c138(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4257,12 +4306,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c136) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c137); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4270,7 +4319,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c138(s3);
+          s1 = peg$c141(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4286,16 +4335,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c136) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c139) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c137); }
+        if (peg$silentFails === 0) { peg$fail(peg$c140); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c139();
+        s1 = peg$c142();
       }
       s0 = s1;
     }
@@ -4307,12 +4356,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c140) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c143) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c144); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4320,7 +4369,7 @@ function peg$parse(input, options) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c142(s3);
+          s1 = peg$c145(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4336,16 +4385,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c140) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c143) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c141); }
+        if (peg$silentFails === 0) { peg$fail(peg$c144); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c143();
+        s1 = peg$c146();
       }
       s0 = s1;
     }
@@ -4357,12 +4406,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c144) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c147) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c145); }
+      if (peg$silentFails === 0) { peg$fail(peg$c148); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4370,7 +4419,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFilter();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c146(s3);
+          s1 = peg$c149(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4406,26 +4455,26 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c147) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c151); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c149) {
-          s3 = peg$c149;
+        if (input.substr(peg$currPos, 2) === peg$c152) {
+          s3 = peg$c152;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c150); }
+          if (peg$silentFails === 0) { peg$fail(peg$c153); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c151();
+          s1 = peg$c154();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4441,16 +4490,16 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c147) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c150) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c148); }
+        if (peg$silentFails === 0) { peg$fail(peg$c151); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c152();
+        s1 = peg$c155();
       }
       s0 = s1;
     }
@@ -4462,12 +4511,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c153) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c156) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c154); }
+      if (peg$silentFails === 0) { peg$fail(peg$c157); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4475,7 +4524,7 @@ function peg$parse(input, options) {
         s3 = peg$parseFlexAssignments();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c155(s3);
+          s1 = peg$c158(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4497,12 +4546,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c156) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c159) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c157); }
+      if (peg$silentFails === 0) { peg$fail(peg$c160); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4526,7 +4575,7 @@ function peg$parse(input, options) {
                 s9 = peg$parseAssignment();
                 if (s9 !== peg$FAILED) {
                   peg$savedPos = s5;
-                  s6 = peg$c158(s3, s9);
+                  s6 = peg$c161(s3, s9);
                   s5 = s6;
                 } else {
                   peg$currPos = s5;
@@ -4562,7 +4611,7 @@ function peg$parse(input, options) {
                   s9 = peg$parseAssignment();
                   if (s9 !== peg$FAILED) {
                     peg$savedPos = s5;
-                    s6 = peg$c158(s3, s9);
+                    s6 = peg$c161(s3, s9);
                     s5 = s6;
                   } else {
                     peg$currPos = s5;
@@ -4583,7 +4632,7 @@ function peg$parse(input, options) {
           }
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c159(s3, s4);
+            s1 = peg$c162(s3, s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4609,12 +4658,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c160) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c163) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c161); }
+      if (peg$silentFails === 0) { peg$fail(peg$c164); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -4649,7 +4698,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c162();
+        s1 = peg$c165();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4667,12 +4716,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c163) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c166) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c164); }
+      if (peg$silentFails === 0) { peg$fail(peg$c167); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4713,7 +4762,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c165(s3, s7, s8);
+                    s1 = peg$c168(s3, s7, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4749,12 +4798,12 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c163) {
+      if (input.substr(peg$currPos, 4).toLowerCase() === peg$c166) {
         s1 = input.substr(peg$currPos, 4);
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c164); }
+        if (peg$silentFails === 0) { peg$fail(peg$c167); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4781,7 +4830,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c166(s3, s4);
+              s1 = peg$c169(s3, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4852,18 +4901,18 @@ function peg$parse(input, options) {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c167) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c170) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c168); }
+      if (peg$silentFails === 0) { peg$fail(peg$c171); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseTasteExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c169(s2);
+        s1 = peg$c172(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4886,7 +4935,7 @@ function peg$parse(input, options) {
       s2 = peg$parseDerefExpr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s2);
+        s1 = peg$c173(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4898,10 +4947,10 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c93;
+      s1 = peg$c86;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c171();
+        s1 = peg$c174();
       }
       s0 = s1;
     }
@@ -4987,7 +5036,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c172(s1, s2);
+        s1 = peg$c175(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5079,7 +5128,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c172(s1, s2);
+        s1 = peg$c175(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5114,7 +5163,7 @@ function peg$parse(input, options) {
             s5 = peg$parseConditionalExpr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c173(s1, s5);
+              s1 = peg$c176(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5157,11 +5206,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c174;
+          s3 = peg$c177;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c175); }
+          if (peg$silentFails === 0) { peg$fail(peg$c178); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -5183,7 +5232,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseConditionalExpr();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c176(s1, s5, s9);
+                      s1 = peg$c179(s1, s5, s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -5409,7 +5458,7 @@ function peg$parse(input, options) {
             s7 = peg$parseRelativeExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c177(s1, s5, s7);
+              s4 = peg$c180(s1, s5, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -5439,7 +5488,7 @@ function peg$parse(input, options) {
               s7 = peg$parseRelativeExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c177(s1, s5, s7);
+                s4 = peg$c180(s1, s5, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -5742,19 +5791,19 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s1 = peg$c178;
+      s1 = peg$c181;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c179); }
+      if (peg$silentFails === 0) { peg$fail(peg$c182); }
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c180;
+        s1 = peg$c183;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c181); }
+        if (peg$silentFails === 0) { peg$fail(peg$c184); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -5861,11 +5910,11 @@ function peg$parse(input, options) {
     }
     if (s1 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s1 = peg$c182;
+        s1 = peg$c185;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c186); }
       }
     }
     if (s1 !== peg$FAILED) {
@@ -5894,7 +5943,7 @@ function peg$parse(input, options) {
         s3 = peg$parseNotExpr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c184(s3);
+          s1 = peg$c187(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6045,28 +6094,28 @@ function peg$parse(input, options) {
   function peg$parseNotFuncs() {
     var s0;
 
-    if (input.substr(peg$currPos, 3) === peg$c185) {
-      s0 = peg$c185;
+    if (input.substr(peg$currPos, 3) === peg$c188) {
+      s0 = peg$c188;
       peg$currPos += 3;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c186); }
+      if (peg$silentFails === 0) { peg$fail(peg$c189); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 5) === peg$c187) {
-        s0 = peg$c187;
+      if (input.substr(peg$currPos, 5) === peg$c190) {
+        s0 = peg$c190;
         peg$currPos += 5;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c188); }
+        if (peg$silentFails === 0) { peg$fail(peg$c191); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c189) {
-          s0 = peg$c189;
+        if (input.substr(peg$currPos, 6) === peg$c192) {
+          s0 = peg$c192;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c190); }
+          if (peg$silentFails === 0) { peg$fail(peg$c193); }
         }
         if (s0 === peg$FAILED) {
           if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -6087,12 +6136,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c187) {
-      s1 = peg$c187;
+    if (input.substr(peg$currPos, 5) === peg$c190) {
+      s1 = peg$c190;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c188); }
+      if (peg$silentFails === 0) { peg$fail(peg$c191); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -6146,12 +6195,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c189) {
-      s1 = peg$c189;
+    if (input.substr(peg$currPos, 6) === peg$c192) {
+      s1 = peg$c192;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c190); }
+      if (peg$silentFails === 0) { peg$fail(peg$c193); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -6183,11 +6232,11 @@ function peg$parse(input, options) {
                   s10 = peg$parse__();
                   if (s10 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 46) {
-                      s11 = peg$c99;
+                      s11 = peg$c102;
                       peg$currPos++;
                     } else {
                       s11 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c103); }
                     }
                     if (s11 !== peg$FAILED) {
                       s12 = peg$parse__();
@@ -6195,7 +6244,7 @@ function peg$parse(input, options) {
                         s13 = peg$parseFunction();
                         if (s13 !== peg$FAILED) {
                           peg$savedPos = s9;
-                          s10 = peg$c191(s5, s13);
+                          s10 = peg$c194(s5, s13);
                           s9 = s10;
                         } else {
                           peg$currPos = s9;
@@ -6219,11 +6268,11 @@ function peg$parse(input, options) {
                     s10 = peg$parse__();
                     if (s10 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 46) {
-                        s11 = peg$c99;
+                        s11 = peg$c102;
                         peg$currPos++;
                       } else {
                         s11 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c103); }
                       }
                       if (s11 !== peg$FAILED) {
                         s12 = peg$parse__();
@@ -6231,7 +6280,7 @@ function peg$parse(input, options) {
                           s13 = peg$parseFunction();
                           if (s13 !== peg$FAILED) {
                             peg$savedPos = s9;
-                            s10 = peg$c191(s5, s13);
+                            s10 = peg$c194(s5, s13);
                             s9 = s10;
                           } else {
                             peg$currPos = s9;
@@ -6252,7 +6301,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c192(s5, s8);
+                    s1 = peg$c195(s5, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6332,7 +6381,7 @@ function peg$parse(input, options) {
                   }
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c193(s2, s6);
+                    s1 = peg$c196(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6393,7 +6442,7 @@ function peg$parse(input, options) {
             s7 = peg$parseConditionalExpr();
             if (s7 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c194(s1, s7);
+              s4 = peg$c197(s1, s7);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -6429,7 +6478,7 @@ function peg$parse(input, options) {
               s7 = peg$parseConditionalExpr();
               if (s7 !== peg$FAILED) {
                 peg$savedPos = s3;
-                s4 = peg$c194(s1, s7);
+                s4 = peg$c197(s1, s7);
                 s3 = s4;
               } else {
                 peg$currPos = s3;
@@ -6465,7 +6514,7 @@ function peg$parse(input, options) {
       s1 = peg$parse__();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c195();
+        s1 = peg$c198();
       }
       s0 = s1;
     }
@@ -6522,15 +6571,15 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 46) {
-          s1 = peg$c99;
+          s1 = peg$c102;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c100); }
+          if (peg$silentFails === 0) { peg$fail(peg$c103); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c196();
+          s1 = peg$c199();
         }
         s0 = s1;
       }
@@ -6544,17 +6593,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c99;
+      s1 = peg$c102;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+      if (peg$silentFails === 0) { peg$fail(peg$c103); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseIdentifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c197(s2);
+        s1 = peg$c200(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6567,33 +6616,33 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s1 = peg$c99;
+        s1 = peg$c102;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c100); }
+        if (peg$silentFails === 0) { peg$fail(peg$c103); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s2 = peg$c198;
+          s2 = peg$c201;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c199); }
+          if (peg$silentFails === 0) { peg$fail(peg$c202); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parseConditionalExpr();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s4 = peg$c200;
+              s4 = peg$c203;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c201); }
+              if (peg$silentFails === 0) { peg$fail(peg$c204); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c202(s3);
+              s1 = peg$c205(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6621,11 +6670,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c198;
+      s1 = peg$c201;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c199); }
+      if (peg$silentFails === 0) { peg$fail(peg$c202); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseAdditiveExpr();
@@ -6645,15 +6694,15 @@ function peg$parse(input, options) {
               s6 = peg$parseAdditiveExpr();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c200;
+                  s7 = peg$c203;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c201); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c204); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c203(s2, s6);
+                  s1 = peg$c206(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6686,11 +6735,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c198;
+        s1 = peg$c201;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c199); }
+        if (peg$silentFails === 0) { peg$fail(peg$c202); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -6708,15 +6757,15 @@ function peg$parse(input, options) {
               s5 = peg$parseAdditiveExpr();
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s6 = peg$c200;
+                  s6 = peg$c203;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c201); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c204); }
                 }
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c204(s5);
+                  s1 = peg$c207(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6745,11 +6794,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c198;
+          s1 = peg$c201;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c199); }
+          if (peg$silentFails === 0) { peg$fail(peg$c202); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseAdditiveExpr();
@@ -6767,15 +6816,15 @@ function peg$parse(input, options) {
                 s5 = peg$parse__();
                 if (s5 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s6 = peg$c200;
+                    s6 = peg$c203;
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c201); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c204); }
                   }
                   if (s6 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c205(s2);
+                    s1 = peg$c208(s2);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6804,25 +6853,25 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c198;
+            s1 = peg$c201;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c199); }
+            if (peg$silentFails === 0) { peg$fail(peg$c202); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseConditionalExpr();
             if (s2 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s3 = peg$c200;
+                s3 = peg$c203;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c201); }
+                if (peg$silentFails === 0) { peg$fail(peg$c204); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c206(s2);
+                s1 = peg$c209(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6839,21 +6888,21 @@ function peg$parse(input, options) {
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 46) {
-              s1 = peg$c99;
+              s1 = peg$c102;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c100); }
+              if (peg$silentFails === 0) { peg$fail(peg$c103); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$currPos;
               peg$silentFails++;
               if (input.charCodeAt(peg$currPos) === 46) {
-                s3 = peg$c99;
+                s3 = peg$c102;
                 peg$currPos++;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                if (peg$silentFails === 0) { peg$fail(peg$c103); }
               }
               peg$silentFails--;
               if (s3 === peg$FAILED) {
@@ -6866,7 +6915,7 @@ function peg$parse(input, options) {
                 s3 = peg$parseIdentifier();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c207(s3);
+                  s1 = peg$c210(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7008,7 +7057,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c208(s1);
+        s1 = peg$c211(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7040,7 +7089,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c209(s1);
+        s1 = peg$c212(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7055,7 +7104,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP4Net();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c209(s1);
+        s1 = peg$c212(s1);
       }
       s0 = s1;
     }
@@ -7081,7 +7130,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c210(s1);
+        s1 = peg$c213(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7096,7 +7145,7 @@ function peg$parse(input, options) {
       s1 = peg$parseIP();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c210(s1);
+        s1 = peg$c213(s1);
       }
       s0 = s1;
     }
@@ -7111,7 +7160,7 @@ function peg$parse(input, options) {
     s1 = peg$parseFloatString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c211(s1);
+      s1 = peg$c214(s1);
     }
     s0 = s1;
 
@@ -7125,7 +7174,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c212(s1);
+      s1 = peg$c215(s1);
     }
     s0 = s1;
 
@@ -7136,30 +7185,30 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c213) {
-      s1 = peg$c213;
+    if (input.substr(peg$currPos, 4) === peg$c216) {
+      s1 = peg$c216;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c214); }
+      if (peg$silentFails === 0) { peg$fail(peg$c217); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c215();
+      s1 = peg$c218();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c216) {
-        s1 = peg$c216;
+      if (input.substr(peg$currPos, 5) === peg$c219) {
+        s1 = peg$c219;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c217); }
+        if (peg$silentFails === 0) { peg$fail(peg$c220); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c218();
+        s1 = peg$c221();
       }
       s0 = s1;
     }
@@ -7171,16 +7220,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c219) {
-      s1 = peg$c219;
+    if (input.substr(peg$currPos, 4) === peg$c222) {
+      s1 = peg$c222;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c220); }
+      if (peg$silentFails === 0) { peg$fail(peg$c223); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c221();
+      s1 = peg$c224();
     }
     s0 = s1;
 
@@ -7194,7 +7243,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeExternal();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c222(s1);
+      s1 = peg$c225(s1);
     }
     s0 = s1;
 
@@ -7249,7 +7298,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c223(s5);
+                  s1 = peg$c226(s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7314,7 +7363,7 @@ function peg$parse(input, options) {
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c224(s5);
+                    s1 = peg$c227(s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7362,7 +7411,7 @@ function peg$parse(input, options) {
             }
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c224(s1);
+              s1 = peg$c227(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7394,16 +7443,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c219) {
-      s1 = peg$c219;
+    if (input.substr(peg$currPos, 4) === peg$c222) {
+      s1 = peg$c222;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c220); }
+      if (peg$silentFails === 0) { peg$fail(peg$c223); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c225();
+      s1 = peg$c228();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -7447,7 +7496,7 @@ function peg$parse(input, options) {
                         }
                         if (s9 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c226(s1, s7);
+                          s1 = peg$c229(s1, s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7490,7 +7539,7 @@ function peg$parse(input, options) {
           s1 = peg$parseIdentifierName();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c227(s1);
+            s1 = peg$c230(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -7516,7 +7565,7 @@ function peg$parse(input, options) {
                   }
                   if (s4 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c228(s3);
+                    s1 = peg$c231(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -7549,7 +7598,7 @@ function peg$parse(input, options) {
     s1 = peg$parseTypeList();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c229(s1);
+      s1 = peg$c232(s1);
     }
     s0 = s1;
 
@@ -7574,7 +7623,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c230(s1, s2);
+        s1 = peg$c233(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7607,7 +7656,7 @@ function peg$parse(input, options) {
           s4 = peg$parseType();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c224(s4);
+            s1 = peg$c227(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7634,11 +7683,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c231;
+      s1 = peg$c234;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c232); }
+      if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -7648,15 +7697,15 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c233;
+              s5 = peg$c236;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c234); }
+              if (peg$silentFails === 0) { peg$fail(peg$c237); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c235(s3);
+              s1 = peg$c238(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7681,11 +7730,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c198;
+        s1 = peg$c201;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c199); }
+        if (peg$silentFails === 0) { peg$fail(peg$c202); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
@@ -7695,15 +7744,15 @@ function peg$parse(input, options) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c200;
+                s5 = peg$c203;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c201); }
+                if (peg$silentFails === 0) { peg$fail(peg$c204); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c236(s3);
+                s1 = peg$c239(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -7727,12 +7776,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c237) {
-          s1 = peg$c237;
+        if (input.substr(peg$currPos, 2) === peg$c240) {
+          s1 = peg$c240;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c238); }
+          if (peg$silentFails === 0) { peg$fail(peg$c241); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
@@ -7741,16 +7790,16 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse__();
               if (s4 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c239) {
-                  s5 = peg$c239;
+                if (input.substr(peg$currPos, 2) === peg$c242) {
+                  s5 = peg$c242;
                   peg$currPos += 2;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c240); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c243); }
                 }
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c241(s3);
+                  s1 = peg$c244(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7774,12 +7823,12 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c242) {
-            s1 = peg$c242;
+          if (input.substr(peg$currPos, 2) === peg$c245) {
+            s1 = peg$c245;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c243); }
+            if (peg$silentFails === 0) { peg$fail(peg$c246); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
@@ -7802,16 +7851,16 @@ function peg$parse(input, options) {
                       if (s7 !== peg$FAILED) {
                         s8 = peg$parse__();
                         if (s8 !== peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c244) {
-                            s9 = peg$c244;
+                          if (input.substr(peg$currPos, 2) === peg$c247) {
+                            s9 = peg$c247;
                             peg$currPos += 2;
                           } else {
                             s9 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c245); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c248); }
                           }
                           if (s9 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c246(s3, s7);
+                            s1 = peg$c249(s3, s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7871,92 +7920,92 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c247) {
-      s1 = peg$c247;
+    if (input.substr(peg$currPos, 5) === peg$c250) {
+      s1 = peg$c250;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c248); }
+      if (peg$silentFails === 0) { peg$fail(peg$c251); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c249) {
-        s1 = peg$c249;
+      if (input.substr(peg$currPos, 6) === peg$c252) {
+        s1 = peg$c252;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c250); }
+        if (peg$silentFails === 0) { peg$fail(peg$c253); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c251) {
-          s1 = peg$c251;
+        if (input.substr(peg$currPos, 6) === peg$c254) {
+          s1 = peg$c254;
           peg$currPos += 6;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c252); }
+          if (peg$silentFails === 0) { peg$fail(peg$c255); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 6) === peg$c253) {
-            s1 = peg$c253;
+          if (input.substr(peg$currPos, 6) === peg$c256) {
+            s1 = peg$c256;
             peg$currPos += 6;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c254); }
+            if (peg$silentFails === 0) { peg$fail(peg$c257); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c255) {
-              s1 = peg$c255;
+            if (input.substr(peg$currPos, 4) === peg$c258) {
+              s1 = peg$c258;
               peg$currPos += 4;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c256); }
+              if (peg$silentFails === 0) { peg$fail(peg$c259); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 5) === peg$c257) {
-                s1 = peg$c257;
+              if (input.substr(peg$currPos, 5) === peg$c260) {
+                s1 = peg$c260;
                 peg$currPos += 5;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c258); }
+                if (peg$silentFails === 0) { peg$fail(peg$c261); }
               }
               if (s1 === peg$FAILED) {
-                if (input.substr(peg$currPos, 5) === peg$c259) {
-                  s1 = peg$c259;
+                if (input.substr(peg$currPos, 5) === peg$c262) {
+                  s1 = peg$c262;
                   peg$currPos += 5;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c260); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c263); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c261) {
-                    s1 = peg$c261;
+                  if (input.substr(peg$currPos, 5) === peg$c264) {
+                    s1 = peg$c264;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c262); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c265); }
                   }
                   if (s1 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 7) === peg$c263) {
-                      s1 = peg$c263;
+                    if (input.substr(peg$currPos, 7) === peg$c266) {
+                      s1 = peg$c266;
                       peg$currPos += 7;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c264); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c267); }
                     }
                     if (s1 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c265) {
-                        s1 = peg$c265;
+                      if (input.substr(peg$currPos, 4) === peg$c268) {
+                        s1 = peg$c268;
                         peg$currPos += 4;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c266); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c269); }
                       }
                       if (s1 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 6) === peg$c267) {
-                          s1 = peg$c267;
+                        if (input.substr(peg$currPos, 6) === peg$c270) {
+                          s1 = peg$c270;
                           peg$currPos += 6;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c268); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c271); }
                         }
                       }
                     }
@@ -7970,7 +8019,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c269();
+      s1 = peg$c272();
     }
     s0 = s1;
 
@@ -7981,52 +8030,52 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c270) {
-      s1 = peg$c270;
+    if (input.substr(peg$currPos, 8) === peg$c273) {
+      s1 = peg$c273;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c271); }
+      if (peg$silentFails === 0) { peg$fail(peg$c274); }
     }
     if (s1 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c272) {
-        s1 = peg$c272;
+      if (input.substr(peg$currPos, 4) === peg$c275) {
+        s1 = peg$c275;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c273); }
+        if (peg$silentFails === 0) { peg$fail(peg$c276); }
       }
       if (s1 === peg$FAILED) {
-        if (input.substr(peg$currPos, 5) === peg$c274) {
-          s1 = peg$c274;
+        if (input.substr(peg$currPos, 5) === peg$c277) {
+          s1 = peg$c277;
           peg$currPos += 5;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c275); }
+          if (peg$silentFails === 0) { peg$fail(peg$c278); }
         }
         if (s1 === peg$FAILED) {
-          if (input.substr(peg$currPos, 7) === peg$c276) {
-            s1 = peg$c276;
+          if (input.substr(peg$currPos, 7) === peg$c279) {
+            s1 = peg$c279;
             peg$currPos += 7;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c277); }
+            if (peg$silentFails === 0) { peg$fail(peg$c280); }
           }
           if (s1 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c278) {
-              s1 = peg$c278;
+            if (input.substr(peg$currPos, 2) === peg$c281) {
+              s1 = peg$c281;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c279); }
+              if (peg$silentFails === 0) { peg$fail(peg$c282); }
             }
             if (s1 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c280) {
-                s1 = peg$c280;
+              if (input.substr(peg$currPos, 3) === peg$c283) {
+                s1 = peg$c283;
                 peg$currPos += 3;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c281); }
+                if (peg$silentFails === 0) { peg$fail(peg$c284); }
               }
               if (s1 === peg$FAILED) {
                 if (input.substr(peg$currPos, 4) === peg$c10) {
@@ -8037,12 +8086,12 @@ function peg$parse(input, options) {
                   if (peg$silentFails === 0) { peg$fail(peg$c11); }
                 }
                 if (s1 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 5) === peg$c282) {
-                    s1 = peg$c282;
+                  if (input.substr(peg$currPos, 5) === peg$c285) {
+                    s1 = peg$c285;
                     peg$currPos += 5;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c283); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c286); }
                   }
                 }
               }
@@ -8053,7 +8102,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c269();
+      s1 = peg$c272();
     }
     s0 = s1;
 
@@ -8074,7 +8123,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c230(s1, s2);
+        s1 = peg$c233(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8107,7 +8156,7 @@ function peg$parse(input, options) {
           s4 = peg$parseTypeField();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c224(s4);
+            s1 = peg$c227(s4);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8150,7 +8199,7 @@ function peg$parse(input, options) {
             s5 = peg$parseType();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c284(s1, s5);
+              s1 = peg$c287(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8191,16 +8240,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c285) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c288) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c289); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c287();
+      s1 = peg$c290();
     }
     s0 = s1;
 
@@ -8211,16 +8260,16 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c288) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c291) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c289); }
+      if (peg$silentFails === 0) { peg$fail(peg$c292); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c290();
+      s1 = peg$c293();
     }
     s0 = s1;
 
@@ -8236,11 +8285,11 @@ function peg$parse(input, options) {
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c291); }
+      if (peg$silentFails === 0) { peg$fail(peg$c294); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c292();
+      s1 = peg$c295();
     }
     s0 = s1;
 
@@ -8251,29 +8300,9 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c185) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c188) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c293); }
-    }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c294();
-    }
-    s0 = s1;
-
-    return s0;
-  }
-
-  function peg$parseByToken() {
-    var s0, s1;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c295) {
-      s1 = input.substr(peg$currPos, 2);
-      peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c296); }
@@ -8287,15 +8316,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseByToken() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c298) {
+      s1 = input.substr(peg$currPos, 2);
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c299); }
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c300();
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
   function peg$parseIdentifierStart() {
     var s0;
 
-    if (peg$c298.test(input.charAt(peg$currPos))) {
+    if (peg$c301.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c299); }
+      if (peg$silentFails === 0) { peg$fail(peg$c302); }
     }
 
     return s0;
@@ -8306,12 +8355,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseIdentifierStart();
     if (s0 === peg$FAILED) {
-      if (peg$c300.test(input.charAt(peg$currPos))) {
+      if (peg$c303.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c301); }
+        if (peg$silentFails === 0) { peg$fail(peg$c304); }
       }
     }
 
@@ -8325,7 +8374,7 @@ function peg$parse(input, options) {
     s1 = peg$parseIdentifierName();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c302(s1);
+      s1 = peg$c305(s1);
     }
     s0 = s1;
 
@@ -8380,7 +8429,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c303();
+          s1 = peg$c306();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8397,11 +8446,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 36) {
-        s1 = peg$c304;
+        s1 = peg$c307;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c305); }
+        if (peg$silentFails === 0) { peg$fail(peg$c308); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -8411,17 +8460,17 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c306;
+          s1 = peg$c309;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c307); }
+          if (peg$silentFails === 0) { peg$fail(peg$c310); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseIdGuard();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c308(s2);
+            s1 = peg$c311(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8483,12 +8532,12 @@ function peg$parse(input, options) {
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c285) {
-                s3 = peg$c285;
+              if (input.substr(peg$currPos, 3) === peg$c288) {
+                s3 = peg$c288;
                 peg$currPos += 3;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c309); }
+                if (peg$silentFails === 0) { peg$fail(peg$c312); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -8533,44 +8582,44 @@ function peg$parse(input, options) {
   function peg$parseSecondsToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c310) {
-      s0 = peg$c310;
+    if (input.substr(peg$currPos, 7) === peg$c313) {
+      s0 = peg$c313;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c311); }
+      if (peg$silentFails === 0) { peg$fail(peg$c314); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c312) {
-        s0 = peg$c312;
+      if (input.substr(peg$currPos, 6) === peg$c315) {
+        s0 = peg$c315;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c313); }
+        if (peg$silentFails === 0) { peg$fail(peg$c316); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c314) {
-          s0 = peg$c314;
+        if (input.substr(peg$currPos, 4) === peg$c317) {
+          s0 = peg$c317;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c315); }
+          if (peg$silentFails === 0) { peg$fail(peg$c318); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c316) {
-            s0 = peg$c316;
+          if (input.substr(peg$currPos, 3) === peg$c319) {
+            s0 = peg$c319;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c317); }
+            if (peg$silentFails === 0) { peg$fail(peg$c320); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c318;
+              s0 = peg$c321;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c319); }
+              if (peg$silentFails === 0) { peg$fail(peg$c322); }
             }
           }
         }
@@ -8583,44 +8632,44 @@ function peg$parse(input, options) {
   function peg$parseMinutesToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 7) === peg$c320) {
-      s0 = peg$c320;
+    if (input.substr(peg$currPos, 7) === peg$c323) {
+      s0 = peg$c323;
       peg$currPos += 7;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c321); }
+      if (peg$silentFails === 0) { peg$fail(peg$c324); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 6) === peg$c322) {
-        s0 = peg$c322;
+      if (input.substr(peg$currPos, 6) === peg$c325) {
+        s0 = peg$c325;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c323); }
+        if (peg$silentFails === 0) { peg$fail(peg$c326); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 4) === peg$c324) {
-          s0 = peg$c324;
+        if (input.substr(peg$currPos, 4) === peg$c327) {
+          s0 = peg$c327;
           peg$currPos += 4;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c325); }
+          if (peg$silentFails === 0) { peg$fail(peg$c328); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c326) {
-            s0 = peg$c326;
+          if (input.substr(peg$currPos, 3) === peg$c329) {
+            s0 = peg$c329;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c327); }
+            if (peg$silentFails === 0) { peg$fail(peg$c330); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 109) {
-              s0 = peg$c328;
+              s0 = peg$c331;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c329); }
+              if (peg$silentFails === 0) { peg$fail(peg$c332); }
             }
           }
         }
@@ -8633,44 +8682,44 @@ function peg$parse(input, options) {
   function peg$parseHoursToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c330) {
-      s0 = peg$c330;
+    if (input.substr(peg$currPos, 5) === peg$c333) {
+      s0 = peg$c333;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c331); }
+      if (peg$silentFails === 0) { peg$fail(peg$c334); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c332) {
-        s0 = peg$c332;
+      if (input.substr(peg$currPos, 3) === peg$c335) {
+        s0 = peg$c335;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c333); }
+        if (peg$silentFails === 0) { peg$fail(peg$c336); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c334) {
-          s0 = peg$c334;
+        if (input.substr(peg$currPos, 2) === peg$c337) {
+          s0 = peg$c337;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c335); }
+          if (peg$silentFails === 0) { peg$fail(peg$c338); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 104) {
-            s0 = peg$c336;
+            s0 = peg$c339;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c337); }
+            if (peg$silentFails === 0) { peg$fail(peg$c340); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c338) {
-              s0 = peg$c338;
+            if (input.substr(peg$currPos, 4) === peg$c341) {
+              s0 = peg$c341;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c339); }
+              if (peg$silentFails === 0) { peg$fail(peg$c342); }
             }
           }
         }
@@ -8683,28 +8732,28 @@ function peg$parse(input, options) {
   function peg$parseDaysToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 4) === peg$c340) {
-      s0 = peg$c340;
+    if (input.substr(peg$currPos, 4) === peg$c343) {
+      s0 = peg$c343;
       peg$currPos += 4;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
+      if (peg$silentFails === 0) { peg$fail(peg$c344); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c342) {
-        s0 = peg$c342;
+      if (input.substr(peg$currPos, 3) === peg$c345) {
+        s0 = peg$c345;
         peg$currPos += 3;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c343); }
+        if (peg$silentFails === 0) { peg$fail(peg$c346); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 100) {
-          s0 = peg$c344;
+          s0 = peg$c347;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c345); }
+          if (peg$silentFails === 0) { peg$fail(peg$c348); }
         }
       }
     }
@@ -8715,44 +8764,44 @@ function peg$parse(input, options) {
   function peg$parseWeeksToken() {
     var s0;
 
-    if (input.substr(peg$currPos, 5) === peg$c346) {
-      s0 = peg$c346;
+    if (input.substr(peg$currPos, 5) === peg$c349) {
+      s0 = peg$c349;
       peg$currPos += 5;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c347); }
+      if (peg$silentFails === 0) { peg$fail(peg$c350); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 4) === peg$c348) {
-        s0 = peg$c348;
+      if (input.substr(peg$currPos, 4) === peg$c351) {
+        s0 = peg$c351;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c349); }
+        if (peg$silentFails === 0) { peg$fail(peg$c352); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 3) === peg$c350) {
-          s0 = peg$c350;
+        if (input.substr(peg$currPos, 3) === peg$c353) {
+          s0 = peg$c353;
           peg$currPos += 3;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c351); }
+          if (peg$silentFails === 0) { peg$fail(peg$c354); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c352) {
-            s0 = peg$c352;
+          if (input.substr(peg$currPos, 2) === peg$c355) {
+            s0 = peg$c355;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c353); }
+            if (peg$silentFails === 0) { peg$fail(peg$c356); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 119) {
-              s0 = peg$c354;
+              s0 = peg$c357;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c355); }
+              if (peg$silentFails === 0) { peg$fail(peg$c358); }
             }
           }
         }
@@ -8766,16 +8815,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c312) {
-      s1 = peg$c312;
+    if (input.substr(peg$currPos, 6) === peg$c315) {
+      s1 = peg$c315;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c313); }
+      if (peg$silentFails === 0) { peg$fail(peg$c316); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c356();
+      s1 = peg$c359();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -8787,7 +8836,7 @@ function peg$parse(input, options) {
           s3 = peg$parseSecondsToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c357(s1);
+            s1 = peg$c360(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8810,16 +8859,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c322) {
-      s1 = peg$c322;
+    if (input.substr(peg$currPos, 6) === peg$c325) {
+      s1 = peg$c325;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c323); }
+      if (peg$silentFails === 0) { peg$fail(peg$c326); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c358();
+      s1 = peg$c361();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -8831,7 +8880,7 @@ function peg$parse(input, options) {
           s3 = peg$parseMinutesToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c359(s1);
+            s1 = peg$c362(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8854,16 +8903,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c338) {
-      s1 = peg$c338;
+    if (input.substr(peg$currPos, 4) === peg$c341) {
+      s1 = peg$c341;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c339); }
+      if (peg$silentFails === 0) { peg$fail(peg$c342); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c360();
+      s1 = peg$c363();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -8875,7 +8924,7 @@ function peg$parse(input, options) {
           s3 = peg$parseHoursToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c361(s1);
+            s1 = peg$c364(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8898,16 +8947,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c342) {
-      s1 = peg$c342;
+    if (input.substr(peg$currPos, 3) === peg$c345) {
+      s1 = peg$c345;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c343); }
+      if (peg$silentFails === 0) { peg$fail(peg$c346); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c362();
+      s1 = peg$c365();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -8919,7 +8968,7 @@ function peg$parse(input, options) {
           s3 = peg$parseDaysToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c363(s1);
+            s1 = peg$c366(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8942,16 +8991,16 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c348) {
-      s1 = peg$c348;
+    if (input.substr(peg$currPos, 4) === peg$c351) {
+      s1 = peg$c351;
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c349); }
+      if (peg$silentFails === 0) { peg$fail(peg$c352); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c364();
+      s1 = peg$c367();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -8963,7 +9012,7 @@ function peg$parse(input, options) {
           s3 = peg$parseWeeksToken();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c365(s1);
+            s1 = peg$c368(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8989,31 +9038,31 @@ function peg$parse(input, options) {
     s1 = peg$parseUInt();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s2 = peg$c99;
+        s2 = peg$c102;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c100); }
+        if (peg$silentFails === 0) { peg$fail(peg$c103); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c99;
+            s4 = peg$c102;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c100); }
+            if (peg$silentFails === 0) { peg$fail(peg$c103); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parseUInt();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 46) {
-                s6 = peg$c99;
+                s6 = peg$c102;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                if (peg$silentFails === 0) { peg$fail(peg$c103); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parseUInt();
@@ -9153,7 +9202,7 @@ function peg$parse(input, options) {
       s2 = peg$parseIP6Tail();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c366(s1, s2);
+        s1 = peg$c369(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9174,12 +9223,12 @@ function peg$parse(input, options) {
           s3 = peg$parseColonHex();
         }
         if (s2 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c367) {
-            s3 = peg$c367;
+          if (input.substr(peg$currPos, 2) === peg$c370) {
+            s3 = peg$c370;
             peg$currPos += 2;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c368); }
+            if (peg$silentFails === 0) { peg$fail(peg$c371); }
           }
           if (s3 !== peg$FAILED) {
             s4 = [];
@@ -9192,7 +9241,7 @@ function peg$parse(input, options) {
               s5 = peg$parseIP6Tail();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c369(s1, s2, s4, s5);
+                s1 = peg$c372(s1, s2, s4, s5);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9216,12 +9265,12 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c367) {
-          s1 = peg$c367;
+        if (input.substr(peg$currPos, 2) === peg$c370) {
+          s1 = peg$c370;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c368); }
+          if (peg$silentFails === 0) { peg$fail(peg$c371); }
         }
         if (s1 !== peg$FAILED) {
           s2 = [];
@@ -9234,7 +9283,7 @@ function peg$parse(input, options) {
             s3 = peg$parseIP6Tail();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c370(s2, s3);
+              s1 = peg$c373(s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9259,16 +9308,16 @@ function peg$parse(input, options) {
               s3 = peg$parseColonHex();
             }
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c367) {
-                s3 = peg$c367;
+              if (input.substr(peg$currPos, 2) === peg$c370) {
+                s3 = peg$c370;
                 peg$currPos += 2;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c368); }
+                if (peg$silentFails === 0) { peg$fail(peg$c371); }
               }
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c371(s1, s2);
+                s1 = peg$c374(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -9284,16 +9333,16 @@ function peg$parse(input, options) {
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c367) {
-              s1 = peg$c367;
+            if (input.substr(peg$currPos, 2) === peg$c370) {
+              s1 = peg$c370;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c368); }
+              if (peg$silentFails === 0) { peg$fail(peg$c371); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c372();
+              s1 = peg$c375();
             }
             s0 = s1;
           }
@@ -9330,7 +9379,7 @@ function peg$parse(input, options) {
       s2 = peg$parseHex();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c373(s2);
+        s1 = peg$c376(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9359,7 +9408,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c374(s1);
+        s1 = peg$c377(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9380,17 +9429,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c182;
+        s2 = peg$c185;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c186); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c375(s1, s3);
+          s1 = peg$c378(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9415,17 +9464,17 @@ function peg$parse(input, options) {
     s1 = peg$parseIP6();
     if (s1 !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s2 = peg$c182;
+        s2 = peg$c185;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c186); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parseUInt();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c376(s1, s3);
+          s1 = peg$c379(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9450,7 +9499,7 @@ function peg$parse(input, options) {
     s1 = peg$parseUIntString();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c377(s1);
+      s1 = peg$c380(s1);
     }
     s0 = s1;
 
@@ -9473,22 +9522,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c300.test(input.charAt(peg$currPos))) {
+    if (peg$c303.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c301); }
+      if (peg$silentFails === 0) { peg$fail(peg$c304); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c300.test(input.charAt(peg$currPos))) {
+        if (peg$c303.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c301); }
+          if (peg$silentFails === 0) { peg$fail(peg$c304); }
         }
       }
     } else {
@@ -9508,11 +9557,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c180;
+      s1 = peg$c183;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c181); }
+      if (peg$silentFails === 0) { peg$fail(peg$c184); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseUIntString();
@@ -9537,33 +9586,33 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s1 = peg$c180;
+      s1 = peg$c183;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c181); }
+      if (peg$silentFails === 0) { peg$fail(peg$c184); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c300.test(input.charAt(peg$currPos))) {
+      if (peg$c303.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c301); }
+        if (peg$silentFails === 0) { peg$fail(peg$c304); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c300.test(input.charAt(peg$currPos))) {
+          if (peg$c303.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c301); }
+            if (peg$silentFails === 0) { peg$fail(peg$c304); }
           }
         }
       } else {
@@ -9571,30 +9620,30 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s3 = peg$c99;
+          s3 = peg$c102;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c100); }
+          if (peg$silentFails === 0) { peg$fail(peg$c103); }
         }
         if (s3 !== peg$FAILED) {
           s4 = [];
-          if (peg$c300.test(input.charAt(peg$currPos))) {
+          if (peg$c303.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c301); }
+            if (peg$silentFails === 0) { peg$fail(peg$c304); }
           }
           if (s5 !== peg$FAILED) {
             while (s5 !== peg$FAILED) {
               s4.push(s5);
-              if (peg$c300.test(input.charAt(peg$currPos))) {
+              if (peg$c303.test(input.charAt(peg$currPos))) {
                 s5 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c301); }
+                if (peg$silentFails === 0) { peg$fail(peg$c304); }
               }
             }
           } else {
@@ -9607,7 +9656,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c378();
+              s1 = peg$c381();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9632,41 +9681,41 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 45) {
-        s1 = peg$c180;
+        s1 = peg$c183;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c181); }
+        if (peg$silentFails === 0) { peg$fail(peg$c184); }
       }
       if (s1 === peg$FAILED) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s2 = peg$c99;
+          s2 = peg$c102;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c100); }
+          if (peg$silentFails === 0) { peg$fail(peg$c103); }
         }
         if (s2 !== peg$FAILED) {
           s3 = [];
-          if (peg$c300.test(input.charAt(peg$currPos))) {
+          if (peg$c303.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c301); }
+            if (peg$silentFails === 0) { peg$fail(peg$c304); }
           }
           if (s4 !== peg$FAILED) {
             while (s4 !== peg$FAILED) {
               s3.push(s4);
-              if (peg$c300.test(input.charAt(peg$currPos))) {
+              if (peg$c303.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c301); }
+                if (peg$silentFails === 0) { peg$fail(peg$c304); }
               }
             }
           } else {
@@ -9679,7 +9728,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c378();
+              s1 = peg$c381();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9706,20 +9755,20 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c379) {
+    if (input.substr(peg$currPos, 1).toLowerCase() === peg$c382) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c380); }
+      if (peg$silentFails === 0) { peg$fail(peg$c383); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c381.test(input.charAt(peg$currPos))) {
+      if (peg$c384.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c382); }
+        if (peg$silentFails === 0) { peg$fail(peg$c385); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
@@ -9771,12 +9820,12 @@ function peg$parse(input, options) {
   function peg$parseHexDigit() {
     var s0;
 
-    if (peg$c383.test(input.charAt(peg$currPos))) {
+    if (peg$c386.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c384); }
+      if (peg$silentFails === 0) { peg$fail(peg$c387); }
     }
 
     return s0;
@@ -9787,11 +9836,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c385;
+      s1 = peg$c388;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c386); }
+      if (peg$silentFails === 0) { peg$fail(peg$c389); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -9802,15 +9851,15 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c385;
+          s3 = peg$c388;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c386); }
+          if (peg$silentFails === 0) { peg$fail(peg$c389); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c387(s2);
+          s1 = peg$c390(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9827,11 +9876,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s1 = peg$c388;
+        s1 = peg$c391;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c389); }
+        if (peg$silentFails === 0) { peg$fail(peg$c392); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -9842,15 +9891,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s3 = peg$c388;
+            s3 = peg$c391;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c389); }
+            if (peg$silentFails === 0) { peg$fail(peg$c392); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c387(s2);
+            s1 = peg$c390(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9876,11 +9925,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c385;
+      s2 = peg$c388;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c386); }
+      if (peg$silentFails === 0) { peg$fail(peg$c389); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -9898,7 +9947,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c390); }
+        if (peg$silentFails === 0) { peg$fail(peg$c393); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -9915,17 +9964,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c306;
+        s1 = peg$c309;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c307); }
+        if (peg$silentFails === 0) { peg$fail(peg$c310); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c391(s2);
+          s1 = peg$c394(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9954,7 +10003,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c392(s1, s2);
+        s1 = peg$c395(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9972,12 +10021,12 @@ function peg$parse(input, options) {
     var s0, s1;
 
     s0 = peg$currPos;
-    if (peg$c393.test(input.charAt(peg$currPos))) {
+    if (peg$c396.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c394); }
+      if (peg$silentFails === 0) { peg$fail(peg$c397); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
@@ -9996,12 +10045,12 @@ function peg$parse(input, options) {
 
     s0 = peg$parseKeyWordStart();
     if (s0 === peg$FAILED) {
-      if (peg$c300.test(input.charAt(peg$currPos))) {
+      if (peg$c303.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c301); }
+        if (peg$silentFails === 0) { peg$fail(peg$c304); }
       }
     }
 
@@ -10013,11 +10062,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c306;
+      s1 = peg$c309;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c307); }
+      if (peg$silentFails === 0) { peg$fail(peg$c310); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseKeywordEscape();
@@ -10026,7 +10075,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c391(s2);
+        s1 = peg$c394(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10047,11 +10096,11 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s2 = peg$c388;
+      s2 = peg$c391;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+      if (peg$silentFails === 0) { peg$fail(peg$c392); }
     }
     if (s2 === peg$FAILED) {
       s2 = peg$parseEscapedChar();
@@ -10069,7 +10118,7 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c390); }
+        if (peg$silentFails === 0) { peg$fail(peg$c393); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -10086,17 +10135,17 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c306;
+        s1 = peg$c309;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c307); }
+        if (peg$silentFails === 0) { peg$fail(peg$c310); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c391(s2);
+          s1 = peg$c394(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10116,11 +10165,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 120) {
-      s1 = peg$c395;
+      s1 = peg$c398;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c396); }
+      if (peg$silentFails === 0) { peg$fail(peg$c399); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseHexDigit();
@@ -10128,7 +10177,7 @@ function peg$parse(input, options) {
         s3 = peg$parseHexDigit();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c397();
+          s1 = peg$c400();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10157,127 +10206,127 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s1 = peg$c388;
+      s1 = peg$c391;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c389); }
+      if (peg$silentFails === 0) { peg$fail(peg$c392); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c398();
+      s1 = peg$c401();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c385;
+        s1 = peg$c388;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c386); }
+        if (peg$silentFails === 0) { peg$fail(peg$c389); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c399();
+        s1 = peg$c402();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c306;
+          s1 = peg$c309;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c307); }
+          if (peg$silentFails === 0) { peg$fail(peg$c310); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c400();
+          s1 = peg$c403();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c401;
+            s1 = peg$c404;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c402); }
+            if (peg$silentFails === 0) { peg$fail(peg$c405); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c403();
+            s1 = peg$c406();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c404;
+              s1 = peg$c407;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c405); }
+              if (peg$silentFails === 0) { peg$fail(peg$c408); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c406();
+              s1 = peg$c409();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c407;
+                s1 = peg$c410;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c408); }
+                if (peg$silentFails === 0) { peg$fail(peg$c411); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c409();
+                s1 = peg$c412();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c410;
+                  s1 = peg$c413;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c411); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c414); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c412();
+                  s1 = peg$c415();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c413;
+                    s1 = peg$c416;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c414); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c417); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c415();
+                    s1 = peg$c418();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c416;
+                      s1 = peg$c419;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c417); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c420); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c418();
+                      s1 = peg$c421();
                     }
                     s0 = s1;
                   }
@@ -10305,7 +10354,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c419();
+      s1 = peg$c422();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -10319,16 +10368,16 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c420();
+        s1 = peg$c423();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
-        if (peg$c381.test(input.charAt(peg$currPos))) {
+        if (peg$c384.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c382); }
+          if (peg$silentFails === 0) { peg$fail(peg$c385); }
         }
       }
     }
@@ -10341,11 +10390,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c421;
+      s1 = peg$c424;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c422); }
+      if (peg$silentFails === 0) { peg$fail(peg$c425); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -10377,7 +10426,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c423(s2);
+        s1 = peg$c426(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10390,19 +10439,19 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c421;
+        s1 = peg$c424;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c422); }
+        if (peg$silentFails === 0) { peg$fail(peg$c425); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
-          s2 = peg$c231;
+          s2 = peg$c234;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c232); }
+          if (peg$silentFails === 0) { peg$fail(peg$c235); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$currPos;
@@ -10461,15 +10510,15 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c233;
+              s4 = peg$c236;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c234); }
+              if (peg$silentFails === 0) { peg$fail(peg$c237); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c423(s3);
+              s1 = peg$c426(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10497,25 +10546,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 47) {
-      s1 = peg$c182;
+      s1 = peg$c185;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c186); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseRegexpBody();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 47) {
-          s3 = peg$c182;
+          s3 = peg$c185;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c183); }
+          if (peg$silentFails === 0) { peg$fail(peg$c186); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c424(s2);
+          s1 = peg$c427(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10538,39 +10587,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c425.test(input.charAt(peg$currPos))) {
+    if (peg$c428.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c426); }
+      if (peg$silentFails === 0) { peg$fail(peg$c429); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c427) {
-        s2 = peg$c427;
+      if (input.substr(peg$currPos, 2) === peg$c430) {
+        s2 = peg$c430;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c428); }
+        if (peg$silentFails === 0) { peg$fail(peg$c431); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c425.test(input.charAt(peg$currPos))) {
+        if (peg$c428.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c426); }
+          if (peg$silentFails === 0) { peg$fail(peg$c429); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c427) {
-            s2 = peg$c427;
+          if (input.substr(peg$currPos, 2) === peg$c430) {
+            s2 = peg$c430;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c428); }
+            if (peg$silentFails === 0) { peg$fail(peg$c431); }
           }
         }
       }
@@ -10589,12 +10638,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c429.test(input.charAt(peg$currPos))) {
+    if (peg$c432.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c430); }
+      if (peg$silentFails === 0) { peg$fail(peg$c433); }
     }
 
     return s0;
@@ -10652,7 +10701,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
 
     return s0;
@@ -10663,51 +10712,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c432;
+      s0 = peg$c435;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c433); }
+      if (peg$silentFails === 0) { peg$fail(peg$c436); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c434;
+        s0 = peg$c437;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c435); }
+        if (peg$silentFails === 0) { peg$fail(peg$c438); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c436;
+          s0 = peg$c439;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c437); }
+          if (peg$silentFails === 0) { peg$fail(peg$c440); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c438;
+            s0 = peg$c441;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c439); }
+            if (peg$silentFails === 0) { peg$fail(peg$c442); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c440;
+              s0 = peg$c443;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c441); }
+              if (peg$silentFails === 0) { peg$fail(peg$c444); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c442;
+                s0 = peg$c445;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c443); }
+                if (peg$silentFails === 0) { peg$fail(peg$c446); }
               }
             }
           }
@@ -10717,7 +10766,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c431); }
+      if (peg$silentFails === 0) { peg$fail(peg$c434); }
     }
 
     return s0;
@@ -10726,12 +10775,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c444.test(input.charAt(peg$currPos))) {
+    if (peg$c447.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c445); }
+      if (peg$silentFails === 0) { peg$fail(peg$c448); }
     }
 
     return s0;
@@ -10745,7 +10794,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c446); }
+      if (peg$silentFails === 0) { peg$fail(peg$c449); }
     }
 
     return s0;
@@ -10755,24 +10804,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c447) {
-      s1 = peg$c447;
+    if (input.substr(peg$currPos, 2) === peg$c450) {
+      s1 = peg$c450;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c448); }
+      if (peg$silentFails === 0) { peg$fail(peg$c451); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c449) {
-        s5 = peg$c449;
+      if (input.substr(peg$currPos, 2) === peg$c452) {
+        s5 = peg$c452;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c450); }
+        if (peg$silentFails === 0) { peg$fail(peg$c453); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -10799,12 +10848,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c449) {
-          s5 = peg$c449;
+        if (input.substr(peg$currPos, 2) === peg$c452) {
+          s5 = peg$c452;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c450); }
+          if (peg$silentFails === 0) { peg$fail(peg$c453); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -10828,12 +10877,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c449) {
-          s3 = peg$c449;
+        if (input.substr(peg$currPos, 2) === peg$c452) {
+          s3 = peg$c452;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c450); }
+          if (peg$silentFails === 0) { peg$fail(peg$c453); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -10858,12 +10907,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c451) {
-      s1 = peg$c451;
+    if (input.substr(peg$currPos, 2) === peg$c454) {
+      s1 = peg$c454;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c452); }
+      if (peg$silentFails === 0) { peg$fail(peg$c455); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -10981,7 +11030,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c390); }
+      if (peg$silentFails === 0) { peg$fail(peg$c393); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -263,10 +263,10 @@ SearchExprFunc
 /// === Aggregations ===
 
 Aggregation
-  = every:EveryDur? keys:GroupByKeys limit:LimitArg {
+  = Summarize every:EveryDur keys:GroupByKeys limit:LimitArg {
       RETURN(MAP("op": "GroupByProc", "keys": keys, "reducers": NULL, "duration": every, "limit": limit))
     }
-  / every:EveryDur? reducers:Reducers keys:(_ GroupByKeys)? limit:LimitArg {
+  / Summarize every:EveryDur reducers:Reducers keys:(_ GroupByKeys)? limit:LimitArg {
       VAR(p) = MAP("op": "GroupByProc", "keys": NULL, "reducers": reducers, "duration": every, "limit": limit)
       if ISNOTNULL(keys) {
         p["keys"] = ASSERT_ARRAY(keys)[1]
@@ -274,8 +274,11 @@ Aggregation
       RETURN(p)
     }
 
+Summarize = "summarize" _ / ""
+
 EveryDur
   = "every"i _ dur:Duration _ { RETURN(dur) }
+  / ""  { RETURN(NULL) }
 
 GroupByKeys
   = ByToken _ columns:FlexAssignments { RETURN(columns) }

--- a/zql/ztests/summarize.yaml
+++ b/zql/ztests/summarize.yaml
@@ -1,0 +1,11 @@
+zql: summarize count() where _path=conn
+
+input: |
+  {_path:"conn"}
+  {_path:"dns"}
+  {_path:"conn"}
+
+output-flags: -pretty=0
+
+output: |
+  {count:2 (uint64)} (=0)


### PR DESCRIPTION
This command adds a new package zfmt to output ast's in debuggable
and canonical form.  There are two format variants as we envision
the Z kernel DSL to diverge from the Z syntax over time.  Currently,
this functionality is exposed only through the ast command but
a future PR will add a general output flag option to zq etc once this
approach is stable.

We also added an experimental "summarize" keyword to the Z language
as an optional prefix of an aggregation to go with the canonical
form of output.

We are merging a protoype of this functionality here to experiment
with and gain feedback.  This is a low-risk commit while we fine
tune zfmt since it is only exposed through the ast command for now.

This PR addresses #2197 but does not close it as I would like to merge this 
experimental version first, get feedback, then finalize #2197 later.