### PR TITLE
change ztest default format to include -pretty=0

### DIFF
--- a/proc/groupby/ztests/dot.yaml
+++ b/proc/groupby/ztests/dot.yaml
@@ -1,6 +1,6 @@
 zql: 'count() by typeof(.) | sort count'
 
-output-flags: -f zson
+output-flags: -pretty=4
 
 input: |
   #0:record[x:int32,s:string]

--- a/proc/groupby/ztests/dot.yaml
+++ b/proc/groupby/ztests/dot.yaml
@@ -1,6 +1,6 @@
 zql: 'count() by typeof(.) | sort count'
 
-output-flags: -pretty=4
+output-flags: -f zson -pretty=4
 
 input: |
   #0:record[x:int32,s:string]

--- a/zio/zsonio/ztests/enum.yaml
+++ b/zio/zsonio/ztests/enum.yaml
@@ -1,6 +1,6 @@
 zql: "*"
 
-output-flags: -f zson
+output-flags: -f zson -pretty=4
 
 input: |
   #0:record[flip:enum[uint8,HEADS:[0],TAILS:[1]]]

--- a/zio/zsonio/ztests/first-test.yaml
+++ b/zio/zsonio/ztests/first-test.yaml
@@ -1,6 +1,6 @@
 zql: "*"
 
-output-flags: -f zson
+output-flags: -f zson -pretty=4
 
 input: |
   #port=uint16

--- a/zio/zsonio/ztests/tv.yaml
+++ b/zio/zsonio/ztests/tv.yaml
@@ -1,6 +1,6 @@
 zql: "put t=typeof(s) | put tt=typeof(t)"
 
-output-flags: -f zson
+output-flags: -f zson -pretty=4
 
 input: |
   #foo=uint8

--- a/zio/zsonio/ztests/zson-zng.yaml
+++ b/zio/zsonio/ztests/zson-zng.yaml
@@ -1,7 +1,7 @@
 # Send zson into zng and back out to make sure binary encoding of typevals works.
 
 script: |
-  zq -f zson "put t=typeof(.)" in.tzng
+  zq -Z "put t=typeof(.)" in.tzng
 
 inputs:
   - name: in.tzng

--- a/ztest/ztest.go
+++ b/ztest/ztest.go
@@ -442,7 +442,7 @@ func (z *ZTest) Run(t *testing.T, testname, path, dirname, filename string) {
 		}
 		return
 	}
-	outputFlags := append([]string{"-f=zson"}, strings.Fields(z.OutputFlags)...)
+	outputFlags := append([]string{"-f", "zson", "-pretty=0"}, strings.Fields(z.OutputFlags)...)
 	out, errout, err := runzq(path, z.ZQL, outputFlags, z.Input...)
 	if err != nil {
 		if z.errRegex != nil {


### PR DESCRIPTION
This commit changes the default output format for ztests to
use -pretty=0 so that tests can be written one value per line.
A test can always override by including -pretty=4 etc in
the ztest output-flags field.