### PR TITLE
Fix groupby sorted input nulls order

### DIFF
--- a/proc/groupby/groupby.go
+++ b/proc/groupby/groupby.go
@@ -80,10 +80,7 @@ func NewAggregator(zctx *resolver.Context, keyRefs, keyExprs, aggRefs []expr.Eva
 		// As the default sort behavior, nullsMax=true for ascending order and
 		// nullsMax=false for descending order is also expected for streaming
 		// groupby.
-		nullsMax := true
-		if inputSortDir < 0 {
-			nullsMax = false
-		}
+		nullsMax := inputSortDir > 0
 
 		vs := expr.NewValueCompareFn(nullsMax)
 		if inputSortDir < 0 {

--- a/proc/groupby/groupby.go
+++ b/proc/groupby/groupby.go
@@ -77,8 +77,15 @@ func NewAggregator(zctx *resolver.Context, keyRefs, keyExprs, aggRefs []expr.Eva
 
 	nkeys := len(keyExprs)
 	if nkeys > 0 && inputSortDir != 0 {
-		// As the default sort behavior, nullsMax=true is also expected for streaming groupby.
-		vs := expr.NewValueCompareFn(true)
+		// As the default sort behavior, nullsMax=true for ascending order and
+		// nullsMax=false for descending order is also expected for streaming
+		// groupby.
+		nullsMax := true
+		if inputSortDir < 0 {
+			nullsMax = false
+		}
+
+		vs := expr.NewValueCompareFn(nullsMax)
 		if inputSortDir < 0 {
 			valueCompare = func(a, b zng.Value) int { return vs(b, a) }
 		} else {

--- a/proc/groupby/groupby_test.go
+++ b/proc/groupby/groupby_test.go
@@ -344,26 +344,29 @@ func TestGroupbyUnit(t *testing.T) {
 
 	inBatchesRev := []string{
 		`#0:record[ts:time]
-0:[-;]
 0:[10;]
 0:[8;]
 0:[7;]
 0:[6;]
 0:[2;]`,
 		`#0:record[ts:time]
-0:[1;]`}
+0:[1;]
+0:[-;]
+`}
 
 	outBatchesRev := []string{`
 #0:record[ts:time,count:uint64]
-0:[-;1;]
 0:[10;1;]
 0:[8;1;]
 0:[7;1;]
 0:[6;1;]`,
 		`#0:record[ts:time,count:uint64]
-0:[2;1;]`,
+0:[2;1;]
+0:[1;1;]
+`,
 		`#0:record[ts:time,count:uint64]
-0:[1;1;]`}
+0:[-;1;]
+`}
 
 	runner := func(zql string, dir int, in, out []string) func(t *testing.T) {
 		return func(t *testing.T) {
@@ -399,11 +402,13 @@ func TestGroupbyUnit(t *testing.T) {
 	t.Run("forward-sorted", runner("count() by ts", 1, inBatches, outBatches))
 	t.Run("forward-sorted-with-unset", runner("count() by ts", 1, inBatchesWithUnset, outBatchesWithUnset))
 	t.Run("forward-sorted-every", runner("every 1s count()", 1, inBatches, outBatches))
+	t.Run("forward-sorted-every-unset", runner("every 1s count()", 1, inBatchesWithUnset, outBatchesWithUnset))
 	t.Run("forward-sorted-record-key", runner("count() by foo", 1, inBatchesRecordKey, outBatchesRecordKey))
 	t.Run("forward-sorted-nested-key", runner("count() by foo.a", 1, inBatchesRecordKey, outBatchesRecordKey))
 	t.Run("forward-sorted-record-key-unset", runner("count() by foo", 1, inBatchesRecordKeyWithUnsetRecord, outBatchesRecordKeyWithUnsetRecord))
 	t.Run("forward-sorted-nested-key-unset", runner("count() by foo.a", 1, inBatchesRecordKeyWithUnsetRecord, outBatchesRecordKeyWithUnsetKey))
 	t.Run("reverse-sorted", runner("count() by ts", -1, inBatchesRev, outBatchesRev))
+	t.Run("reverse-sorted-every-unset", runner("every 1s count()", -1, inBatchesRev, outBatchesRev))
 }
 
 type countReader struct {


### PR DESCRIPTION
If a sorted input is in descending order set nullsMax for the compare function
to false. This follows the behavior of the sort proc on sorted inputs where
null values are always printed last.

This fixes a bug when performing a "count every [duration]" that sporadically
caused records with nil time values to get emitted out-of-order.

Closes #1912