### PR TITLE
Fix pkg/rlimit on DragonFly and FreeBSD

### DIFF
--- a/pkg/rlimit/kernmaxfiles_darwin.go
+++ b/pkg/rlimit/kernmaxfiles_darwin.go
@@ -2,17 +2,18 @@ package rlimit
 
 import (
 	"fmt"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 )
 
-func kernMaxFiles(max uint64) (uint64, error) {
+func kernMaxFiles(rlimit *syscall.Rlimit) error {
 	kernMax, err := unix.SysctlUint32("kern.maxfilesperproc")
 	if err != nil {
-		return 0, fmt.Errorf("systcl: %w", err)
+		return fmt.Errorf("systcl: %w", err)
 	}
-	if uint64(kernMax) < max {
-		return uint64(kernMax), nil
+	if uint64(kernMax) < rlimit.Max {
+		rlimit.Max = uint64(kernMax)
 	}
-	return max, nil
+	return nil
 }

--- a/pkg/rlimit/kernmaxfiles_notdarwin.go
+++ b/pkg/rlimit/kernmaxfiles_notdarwin.go
@@ -1,7 +1,0 @@
-// +build !darwin
-
-package rlimit
-
-func kernMaxFiles(max uint64) (uint64, error) {
-	return max, nil
-}

--- a/pkg/rlimit/kernmaxfiles_unixnotdarwin.go
+++ b/pkg/rlimit/kernmaxfiles_unixnotdarwin.go
@@ -1,0 +1,9 @@
+// +build !darwin,!plan9,!windows
+
+package rlimit
+
+import "syscall"
+
+func kernMaxFiles(rlimit *syscall.Rlimit) error {
+	return nil
+}

--- a/pkg/rlimit/raiseopenfileslimit_unix.go
+++ b/pkg/rlimit/raiseopenfileslimit_unix.go
@@ -12,16 +12,15 @@ func raiseOpenFilesLimit() (uint64, error) {
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlimit); err != nil {
 		return 0, fmt.Errorf("getrlimit: %w", err)
 	}
-	var err error
-	rlimit.Cur, err = kernMaxFiles(rlimit.Max)
-	if err != nil {
+	if err := kernMaxFiles(&rlimit); err != nil {
 		return 0, err
 	}
+	rlimit.Cur = rlimit.Max
 	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rlimit); err != nil {
 		return 0, fmt.Errorf("setrlimit: %w", err)
 	}
 	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlimit); err != nil {
 		return 0, fmt.Errorf("getrlimit: %w", err)
 	}
-	return rlimit.Cur, nil
+	return uint64(rlimit.Cur), nil
 }


### PR DESCRIPTION
`GOOS=freebsd GOARCH=amd64 make install` succeeds with this.

Fixes #2231.