### PR TITLE
Fix bad strconv.ParseFloat bitSize arguments

### DIFF
--- a/pkg/byteconv/byteconv.go
+++ b/pkg/byteconv/byteconv.go
@@ -67,5 +67,5 @@ func ParseUint64(b []byte) (uint64, error) {
 }
 
 func ParseFloat64(b []byte) (float64, error) {
-	return strconv.ParseFloat(UnsafeString(b), 10)
+	return strconv.ParseFloat(UnsafeString(b), 64)
 }

--- a/zql/parser-support.go
+++ b/zql/parser-support.go
@@ -80,7 +80,7 @@ func parseInt(v interface{}) interface{} {
 
 func parseFloat(v interface{}) interface{} {
 	num := v.(string)
-	if f, err := strconv.ParseFloat(num, 10); err != nil {
+	if f, err := strconv.ParseFloat(num, 64); err != nil {
 		return f
 	}
 


### PR DESCRIPTION
The argument for strconv.ParseFloat's bitSize parameter should be 32 or 64.