### PR TITLE
Move pcap test helpers to handlers_pcap_test.go

### DIFF
--- a/ppl/zqd/handlers_pcap_test.go
+++ b/ppl/zqd/handlers_pcap_test.go
@@ -5,15 +5,18 @@ package zqd_test
 import (
 	"context"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/brimsec/zq/api"
 	"github.com/brimsec/zq/api/client"
+	"github.com/brimsec/zq/pkg/fs"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/pkg/test"

--- a/ppl/zqd/handlers_pcap_test.go
+++ b/ppl/zqd/handlers_pcap_test.go
@@ -314,4 +314,3 @@ func testPcapPostWithConfig(t *testing.T, conf zqd.Config, pcapfile string) pcap
 		client:   client,
 	}
 }
-


### PR DESCRIPTION
It's a better home for them since it's the only file in which they're used. This also prevents tools from flagging them as dead code since they're now defined—and not just used—under the `pcapingest` build constrait.