### PR TITLE
add zson_parse function

### DIFF
--- a/expr/function/function.go
+++ b/expr/function/function.go
@@ -226,9 +226,5 @@ func (p *zsonParse) Call(args []zng.Value) (zng.Value, error) {
 	if err != nil {
 		return zng.Value{}, err
 	}
-	zv, err := zson.NewBuilder().Build(val)
-	if err != nil {
-		return zng.Value{}, err
-	}
-	return zv, nil
+	return zson.NewBuilder().Build(val)
 }

--- a/zql/ztests/zson-parse.yaml
+++ b/zql/ztests/zson-parse.yaml
@@ -1,0 +1,23 @@
+script: |
+  zq -f tzng -I def.zql in.tzng
+
+inputs:
+  - name: def.zql
+    data: |
+      const r=zson_parse('{a:"1",b:2}')
+      put ra=r.a,rb=r.b
+
+  - name: in.tzng
+    data: |
+      #0:record[v:int64]
+      0:[1;]
+      0:[2;]
+      0:[3;]
+
+outputs:
+  - name: stdout
+    data: |
+      #0:record[v:int64,ra:string,rb:int64]
+      0:[1;1;2;]
+      0:[2;1;2;]
+      0:[3;1;2;]

--- a/zql/ztests/zson-parse.yaml
+++ b/zql/ztests/zson-parse.yaml
@@ -1,23 +1,13 @@
-script: |
-  zq -f tzng -I def.zql in.tzng
+zql: |
+  const r=zson_parse('{a:"1",b:2}')
+  put ra=r.a,rb=r.b
 
-inputs:
-  - name: def.zql
-    data: |
-      const r=zson_parse('{a:"1",b:2}')
-      put ra=r.a,rb=r.b
+input: |
+  {v:1}
+  {v:2}
+  {v:3}
 
-  - name: in.tzng
-    data: |
-      #0:record[v:int64]
-      0:[1;]
-      0:[2;]
-      0:[3;]
-
-outputs:
-  - name: stdout
-    data: |
-      #0:record[v:int64,ra:string,rb:int64]
-      0:[1;1;2;]
-      0:[2;1;2;]
-      0:[3;1;2;]
+output: |
+  {v:1,ra:"1",rb:2}
+  {v:2,ra:"1",rb:2}
+  {v:3,ra:"1",rb:2}


### PR DESCRIPTION
We'll want a way to make metadata available to the shapers that run for an intake. One way we could do that is by creating a ZSON definition of the metadata record, then prepending the `const` definition of that record to the shaper's source. That requires a way to parse ZSON inside of Z, so I put this up to get feedback on the overall approach.
