### PR TITLE
enable zio/zeekio/ztests/trailing-whitespace.yaml

### DIFF
--- a/zio/zeekio/ztests/trailing-whitespace.yaml
+++ b/zio/zeekio/ztests/trailing-whitespace.yaml
@@ -1,8 +1,6 @@
-# This test is disabled for now.  See issue #2207
-skip: true
-
 zql: '*'
 
+# The last input line should end with a tab character.
 input: |
   #separator \x09
   #set_separator	,
@@ -12,8 +10,7 @@ input: |
   #open	2020-04-10-18-15-32
   #fields	ts	fid	bof
   #types	time	string	string
-  1425634708.454143	FTBt2P3wJBdHGKpZwc
+  1425634708.454143	FTBt2P3wJBdHGKpZwc	 
 
 output: |
-  #0:record[_path:string,ts:time,fid:bstring,bof:bstring]
-  0:[unknown_mime_type_discovery;1425634708.454143;FTBt2P3wJBdHGKpZwc; ;]
+  {_path:"unknown_mime_type_discovery",ts:2015-03-06T09:38:28.454143Z,fid:"FTBt2P3wJBdHGKpZwc" (bstring),bof:" " (bstring)} (=0)


### PR DESCRIPTION
I can't reproduce the panic in #2207, so I think it's safe to enable this test and close the issue.