### PR TITLE
fix string-quote escaping in Z

### DIFF
--- a/zql/zql.es.js
+++ b/zql/zql.es.js
@@ -1002,59 +1002,56 @@ function peg$parse(input, options) {
       peg$c407 = "x",
       peg$c408 = peg$literalExpectation("x", false),
       peg$c409 = function() { return "\\" + text() },
-      peg$c410 = function() { return "'"},
-      peg$c411 = function() { return '"'},
-      peg$c412 = function() { return "\\"},
-      peg$c413 = "b",
-      peg$c414 = peg$literalExpectation("b", false),
-      peg$c415 = function() { return "\b" },
-      peg$c416 = "f",
-      peg$c417 = peg$literalExpectation("f", false),
-      peg$c418 = function() { return "\f" },
-      peg$c419 = "n",
-      peg$c420 = peg$literalExpectation("n", false),
-      peg$c421 = function() { return "\n" },
-      peg$c422 = "r",
-      peg$c423 = peg$literalExpectation("r", false),
-      peg$c424 = function() { return "\r" },
-      peg$c425 = "t",
-      peg$c426 = peg$literalExpectation("t", false),
-      peg$c427 = function() { return "\t" },
-      peg$c428 = "v",
-      peg$c429 = peg$literalExpectation("v", false),
-      peg$c430 = function() { return "\v" },
-      peg$c431 = function() { return "=" },
-      peg$c432 = function() { return "\\*" },
-      peg$c433 = "u",
-      peg$c434 = peg$literalExpectation("u", false),
-      peg$c435 = function(chars) {
+      peg$c410 = "b",
+      peg$c411 = peg$literalExpectation("b", false),
+      peg$c412 = function() { return "\b" },
+      peg$c413 = "f",
+      peg$c414 = peg$literalExpectation("f", false),
+      peg$c415 = function() { return "\f" },
+      peg$c416 = "n",
+      peg$c417 = peg$literalExpectation("n", false),
+      peg$c418 = function() { return "\n" },
+      peg$c419 = "r",
+      peg$c420 = peg$literalExpectation("r", false),
+      peg$c421 = function() { return "\r" },
+      peg$c422 = "t",
+      peg$c423 = peg$literalExpectation("t", false),
+      peg$c424 = function() { return "\t" },
+      peg$c425 = "v",
+      peg$c426 = peg$literalExpectation("v", false),
+      peg$c427 = function() { return "\v" },
+      peg$c428 = function() { return "=" },
+      peg$c429 = function() { return "\\*" },
+      peg$c430 = "u",
+      peg$c431 = peg$literalExpectation("u", false),
+      peg$c432 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c436 = function(body) { return body },
-      peg$c437 = /^[^\/\\]/,
-      peg$c438 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c439 = "\\/",
-      peg$c440 = peg$literalExpectation("\\/", false),
-      peg$c441 = /^[\0-\x1F\\]/,
-      peg$c442 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c443 = peg$otherExpectation("whitespace"),
-      peg$c444 = "\t",
-      peg$c445 = peg$literalExpectation("\t", false),
-      peg$c446 = "\x0B",
-      peg$c447 = peg$literalExpectation("\x0B", false),
-      peg$c448 = "\f",
-      peg$c449 = peg$literalExpectation("\f", false),
-      peg$c450 = " ",
-      peg$c451 = peg$literalExpectation(" ", false),
-      peg$c452 = "\xA0",
-      peg$c453 = peg$literalExpectation("\xA0", false),
-      peg$c454 = "\uFEFF",
-      peg$c455 = peg$literalExpectation("\uFEFF", false),
-      peg$c456 = /^[\n\r\u2028\u2029]/,
-      peg$c457 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c458 = peg$otherExpectation("comment"),
-      peg$c463 = "//",
-      peg$c464 = peg$literalExpectation("//", false),
+      peg$c433 = function(body) { return body },
+      peg$c434 = /^[^\/\\]/,
+      peg$c435 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c436 = "\\/",
+      peg$c437 = peg$literalExpectation("\\/", false),
+      peg$c438 = /^[\0-\x1F\\]/,
+      peg$c439 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c440 = peg$otherExpectation("whitespace"),
+      peg$c441 = "\t",
+      peg$c442 = peg$literalExpectation("\t", false),
+      peg$c443 = "\x0B",
+      peg$c444 = peg$literalExpectation("\x0B", false),
+      peg$c445 = "\f",
+      peg$c446 = peg$literalExpectation("\f", false),
+      peg$c447 = " ",
+      peg$c448 = peg$literalExpectation(" ", false),
+      peg$c449 = "\xA0",
+      peg$c450 = peg$literalExpectation("\xA0", false),
+      peg$c451 = "\uFEFF",
+      peg$c452 = peg$literalExpectation("\uFEFF", false),
+      peg$c453 = /^[\n\r\u2028\u2029]/,
+      peg$c454 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c455 = peg$otherExpectation("comment"),
+      peg$c460 = "//",
+      peg$c461 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -10437,129 +10434,111 @@ function peg$parse(input, options) {
   function peg$parseSingleCharEscape() {
     var s0, s1;
 
-    s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s1 = peg$c400;
+      s0 = peg$c400;
       peg$currPos++;
     } else {
-      s1 = peg$FAILED;
+      s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c410();
-    }
-    s0 = s1;
     if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c397;
+        s0 = peg$c397;
         peg$currPos++;
       } else {
-        s1 = peg$FAILED;
+        s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c411();
-      }
-      s0 = s1;
       if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c318;
+          s0 = peg$c318;
           peg$currPos++;
         } else {
-          s1 = peg$FAILED;
+          s0 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$c319); }
         }
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c412();
-        }
-        s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c413;
+            s1 = peg$c410;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c414); }
+            if (peg$silentFails === 0) { peg$fail(peg$c411); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c415();
+            s1 = peg$c412();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c416;
+              s1 = peg$c413;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c417); }
+              if (peg$silentFails === 0) { peg$fail(peg$c414); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c418();
+              s1 = peg$c415();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c419;
+                s1 = peg$c416;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c420); }
+                if (peg$silentFails === 0) { peg$fail(peg$c417); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c421();
+                s1 = peg$c418();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c422;
+                  s1 = peg$c419;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c420); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c424();
+                  s1 = peg$c421();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c425;
+                    s1 = peg$c422;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c423); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c427();
+                    s1 = peg$c424();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c428;
+                      s1 = peg$c425;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c429); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c426); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c430();
+                      s1 = peg$c427();
                     }
                     s0 = s1;
                   }
@@ -10587,7 +10566,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c431();
+      s1 = peg$c428();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -10601,7 +10580,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c432();
+        s1 = peg$c429();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -10623,11 +10602,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c433;
+      s1 = peg$c430;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c434); }
+      if (peg$silentFails === 0) { peg$fail(peg$c431); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -10659,7 +10638,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c435(s2);
+        s1 = peg$c432(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10672,11 +10651,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c433;
+        s1 = peg$c430;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c434); }
+        if (peg$silentFails === 0) { peg$fail(peg$c431); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -10751,7 +10730,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c435(s3);
+              s1 = peg$c432(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10797,7 +10776,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c436(s2);
+          s1 = peg$c433(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10820,39 +10799,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c437.test(input.charAt(peg$currPos))) {
+    if (peg$c434.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c438); }
+      if (peg$silentFails === 0) { peg$fail(peg$c435); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c439) {
-        s2 = peg$c439;
+      if (input.substr(peg$currPos, 2) === peg$c436) {
+        s2 = peg$c436;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c440); }
+        if (peg$silentFails === 0) { peg$fail(peg$c437); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c437.test(input.charAt(peg$currPos))) {
+        if (peg$c434.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c438); }
+          if (peg$silentFails === 0) { peg$fail(peg$c435); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c439) {
-            s2 = peg$c439;
+          if (input.substr(peg$currPos, 2) === peg$c436) {
+            s2 = peg$c436;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c440); }
+            if (peg$silentFails === 0) { peg$fail(peg$c437); }
           }
         }
       }
@@ -10871,12 +10850,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c441.test(input.charAt(peg$currPos))) {
+    if (peg$c438.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c442); }
+      if (peg$silentFails === 0) { peg$fail(peg$c439); }
     }
 
     return s0;
@@ -10945,51 +10924,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c444;
+      s0 = peg$c441;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c445); }
+      if (peg$silentFails === 0) { peg$fail(peg$c442); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c446;
+        s0 = peg$c443;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c447); }
+        if (peg$silentFails === 0) { peg$fail(peg$c444); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c448;
+          s0 = peg$c445;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c449); }
+          if (peg$silentFails === 0) { peg$fail(peg$c446); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c450;
+            s0 = peg$c447;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c451); }
+            if (peg$silentFails === 0) { peg$fail(peg$c448); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c452;
+              s0 = peg$c449;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c453); }
+              if (peg$silentFails === 0) { peg$fail(peg$c450); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c454;
+                s0 = peg$c451;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c455); }
+                if (peg$silentFails === 0) { peg$fail(peg$c452); }
               }
             }
           }
@@ -10998,7 +10977,7 @@ function peg$parse(input, options) {
     }
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c443); }
+      if (peg$silentFails === 0) { peg$fail(peg$c440); }
     }
 
     return s0;
@@ -11007,12 +10986,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c456.test(input.charAt(peg$currPos))) {
+    if (peg$c453.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c457); }
+      if (peg$silentFails === 0) { peg$fail(peg$c454); }
     }
 
     return s0;
@@ -11025,7 +11004,7 @@ function peg$parse(input, options) {
     s0 = peg$parseSingleLineComment();
     peg$silentFails--;
     if (s0 === peg$FAILED) {
-      if (peg$silentFails === 0) { peg$fail(peg$c458); }
+      if (peg$silentFails === 0) { peg$fail(peg$c455); }
     }
 
     return s0;
@@ -11035,12 +11014,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c463) {
-      s1 = peg$c463;
+    if (input.substr(peg$currPos, 2) === peg$c460) {
+      s1 = peg$c460;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];

--- a/zql/zql.go
+++ b/zql/zql.go
@@ -7736,83 +7736,71 @@ var g = &grammar{
 			expr: &choiceExpr{
 				pos: position{line: 1027, col: 5, offset: 29852},
 				alternatives: []interface{}{
-					&actionExpr{
-						pos: position{line: 1027, col: 5, offset: 29852},
-						run: (*parser).callonSingleCharEscape2,
-						expr: &litMatcher{
-							pos:        position{line: 1027, col: 5, offset: 29852},
-							val:        "'",
-							ignoreCase: false,
-						},
+					&litMatcher{
+						pos:        position{line: 1027, col: 5, offset: 29852},
+						val:        "'",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 1028, col: 5, offset: 29860},
+						val:        "\"",
+						ignoreCase: false,
+					},
+					&litMatcher{
+						pos:        position{line: 1029, col: 5, offset: 29869},
+						val:        "\\",
+						ignoreCase: false,
 					},
 					&actionExpr{
-						pos: position{line: 1028, col: 5, offset: 29879},
-						run: (*parser).callonSingleCharEscape4,
+						pos: position{line: 1030, col: 5, offset: 29878},
+						run: (*parser).callonSingleCharEscape5,
 						expr: &litMatcher{
-							pos:        position{line: 1028, col: 5, offset: 29879},
-							val:        "\"",
-							ignoreCase: false,
-						},
-					},
-					&actionExpr{
-						pos: position{line: 1029, col: 5, offset: 29906},
-						run: (*parser).callonSingleCharEscape6,
-						expr: &litMatcher{
-							pos:        position{line: 1029, col: 5, offset: 29906},
-							val:        "\\",
-							ignoreCase: false,
-						},
-					},
-					&actionExpr{
-						pos: position{line: 1030, col: 5, offset: 29935},
-						run: (*parser).callonSingleCharEscape8,
-						expr: &litMatcher{
-							pos:        position{line: 1030, col: 5, offset: 29935},
+							pos:        position{line: 1030, col: 5, offset: 29878},
 							val:        "b",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1031, col: 5, offset: 29964},
-						run: (*parser).callonSingleCharEscape10,
+						pos: position{line: 1031, col: 5, offset: 29907},
+						run: (*parser).callonSingleCharEscape7,
 						expr: &litMatcher{
-							pos:        position{line: 1031, col: 5, offset: 29964},
+							pos:        position{line: 1031, col: 5, offset: 29907},
 							val:        "f",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1032, col: 5, offset: 29993},
-						run: (*parser).callonSingleCharEscape12,
+						pos: position{line: 1032, col: 5, offset: 29936},
+						run: (*parser).callonSingleCharEscape9,
 						expr: &litMatcher{
-							pos:        position{line: 1032, col: 5, offset: 29993},
+							pos:        position{line: 1032, col: 5, offset: 29936},
 							val:        "n",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1033, col: 5, offset: 30022},
-						run: (*parser).callonSingleCharEscape14,
+						pos: position{line: 1033, col: 5, offset: 29965},
+						run: (*parser).callonSingleCharEscape11,
 						expr: &litMatcher{
-							pos:        position{line: 1033, col: 5, offset: 30022},
+							pos:        position{line: 1033, col: 5, offset: 29965},
 							val:        "r",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1034, col: 5, offset: 30051},
-						run: (*parser).callonSingleCharEscape16,
+						pos: position{line: 1034, col: 5, offset: 29994},
+						run: (*parser).callonSingleCharEscape13,
 						expr: &litMatcher{
-							pos:        position{line: 1034, col: 5, offset: 30051},
+							pos:        position{line: 1034, col: 5, offset: 29994},
 							val:        "t",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1035, col: 5, offset: 30080},
-						run: (*parser).callonSingleCharEscape18,
+						pos: position{line: 1035, col: 5, offset: 30023},
+						run: (*parser).callonSingleCharEscape15,
 						expr: &litMatcher{
-							pos:        position{line: 1035, col: 5, offset: 30080},
+							pos:        position{line: 1035, col: 5, offset: 30023},
 							val:        "v",
 							ignoreCase: false,
 						},
@@ -7822,30 +7810,30 @@ var g = &grammar{
 		},
 		{
 			name: "KeywordEscape",
-			pos:  position{line: 1037, col: 1, offset: 30106},
+			pos:  position{line: 1037, col: 1, offset: 30049},
 			expr: &choiceExpr{
-				pos: position{line: 1038, col: 5, offset: 30124},
+				pos: position{line: 1038, col: 5, offset: 30067},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1038, col: 5, offset: 30124},
+						pos: position{line: 1038, col: 5, offset: 30067},
 						run: (*parser).callonKeywordEscape2,
 						expr: &litMatcher{
-							pos:        position{line: 1038, col: 5, offset: 30124},
+							pos:        position{line: 1038, col: 5, offset: 30067},
 							val:        "=",
 							ignoreCase: false,
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1039, col: 5, offset: 30152},
+						pos: position{line: 1039, col: 5, offset: 30095},
 						run: (*parser).callonKeywordEscape4,
 						expr: &litMatcher{
-							pos:        position{line: 1039, col: 5, offset: 30152},
+							pos:        position{line: 1039, col: 5, offset: 30095},
 							val:        "*",
 							ignoreCase: false,
 						},
 					},
 					&charClassMatcher{
-						pos:        position{line: 1040, col: 5, offset: 30182},
+						pos:        position{line: 1040, col: 5, offset: 30125},
 						val:        "[+-]",
 						chars:      []rune{'+', '-'},
 						ignoreCase: false,
@@ -7856,41 +7844,41 @@ var g = &grammar{
 		},
 		{
 			name: "UnicodeEscape",
-			pos:  position{line: 1042, col: 1, offset: 30188},
+			pos:  position{line: 1042, col: 1, offset: 30131},
 			expr: &choiceExpr{
-				pos: position{line: 1043, col: 5, offset: 30206},
+				pos: position{line: 1043, col: 5, offset: 30149},
 				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 1043, col: 5, offset: 30206},
+						pos: position{line: 1043, col: 5, offset: 30149},
 						run: (*parser).callonUnicodeEscape2,
 						expr: &seqExpr{
-							pos: position{line: 1043, col: 5, offset: 30206},
+							pos: position{line: 1043, col: 5, offset: 30149},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1043, col: 5, offset: 30206},
+									pos:        position{line: 1043, col: 5, offset: 30149},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1043, col: 9, offset: 30210},
+									pos:   position{line: 1043, col: 9, offset: 30153},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1043, col: 16, offset: 30217},
+										pos: position{line: 1043, col: 16, offset: 30160},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1043, col: 16, offset: 30217},
+												pos:  position{line: 1043, col: 16, offset: 30160},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1043, col: 25, offset: 30226},
+												pos:  position{line: 1043, col: 25, offset: 30169},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1043, col: 34, offset: 30235},
+												pos:  position{line: 1043, col: 34, offset: 30178},
 												name: "HexDigit",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1043, col: 43, offset: 30244},
+												pos:  position{line: 1043, col: 43, offset: 30187},
 												name: "HexDigit",
 											},
 										},
@@ -7900,63 +7888,63 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1046, col: 5, offset: 30307},
+						pos: position{line: 1046, col: 5, offset: 30250},
 						run: (*parser).callonUnicodeEscape11,
 						expr: &seqExpr{
-							pos: position{line: 1046, col: 5, offset: 30307},
+							pos: position{line: 1046, col: 5, offset: 30250},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 1046, col: 5, offset: 30307},
+									pos:        position{line: 1046, col: 5, offset: 30250},
 									val:        "u",
 									ignoreCase: false,
 								},
 								&litMatcher{
-									pos:        position{line: 1046, col: 9, offset: 30311},
+									pos:        position{line: 1046, col: 9, offset: 30254},
 									val:        "{",
 									ignoreCase: false,
 								},
 								&labeledExpr{
-									pos:   position{line: 1046, col: 13, offset: 30315},
+									pos:   position{line: 1046, col: 13, offset: 30258},
 									label: "chars",
 									expr: &seqExpr{
-										pos: position{line: 1046, col: 20, offset: 30322},
+										pos: position{line: 1046, col: 20, offset: 30265},
 										exprs: []interface{}{
 											&ruleRefExpr{
-												pos:  position{line: 1046, col: 20, offset: 30322},
+												pos:  position{line: 1046, col: 20, offset: 30265},
 												name: "HexDigit",
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1046, col: 29, offset: 30331},
+												pos: position{line: 1046, col: 29, offset: 30274},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1046, col: 29, offset: 30331},
+													pos:  position{line: 1046, col: 29, offset: 30274},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1046, col: 39, offset: 30341},
+												pos: position{line: 1046, col: 39, offset: 30284},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1046, col: 39, offset: 30341},
+													pos:  position{line: 1046, col: 39, offset: 30284},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1046, col: 49, offset: 30351},
+												pos: position{line: 1046, col: 49, offset: 30294},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1046, col: 49, offset: 30351},
+													pos:  position{line: 1046, col: 49, offset: 30294},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1046, col: 59, offset: 30361},
+												pos: position{line: 1046, col: 59, offset: 30304},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1046, col: 59, offset: 30361},
+													pos:  position{line: 1046, col: 59, offset: 30304},
 													name: "HexDigit",
 												},
 											},
 											&zeroOrOneExpr{
-												pos: position{line: 1046, col: 69, offset: 30371},
+												pos: position{line: 1046, col: 69, offset: 30314},
 												expr: &ruleRefExpr{
-													pos:  position{line: 1046, col: 69, offset: 30371},
+													pos:  position{line: 1046, col: 69, offset: 30314},
 													name: "HexDigit",
 												},
 											},
@@ -7964,7 +7952,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1046, col: 80, offset: 30382},
+									pos:        position{line: 1046, col: 80, offset: 30325},
 									val:        "}",
 									ignoreCase: false,
 								},
@@ -7976,28 +7964,28 @@ var g = &grammar{
 		},
 		{
 			name: "Regexp",
-			pos:  position{line: 1050, col: 1, offset: 30436},
+			pos:  position{line: 1050, col: 1, offset: 30379},
 			expr: &actionExpr{
-				pos: position{line: 1051, col: 5, offset: 30447},
+				pos: position{line: 1051, col: 5, offset: 30390},
 				run: (*parser).callonRegexp1,
 				expr: &seqExpr{
-					pos: position{line: 1051, col: 5, offset: 30447},
+					pos: position{line: 1051, col: 5, offset: 30390},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 1051, col: 5, offset: 30447},
+							pos:        position{line: 1051, col: 5, offset: 30390},
 							val:        "/",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 1051, col: 9, offset: 30451},
+							pos:   position{line: 1051, col: 9, offset: 30394},
 							label: "body",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1051, col: 14, offset: 30456},
+								pos:  position{line: 1051, col: 14, offset: 30399},
 								name: "RegexpBody",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 1051, col: 25, offset: 30467},
+							pos:        position{line: 1051, col: 25, offset: 30410},
 							val:        "/",
 							ignoreCase: false,
 						},
@@ -8007,24 +7995,24 @@ var g = &grammar{
 		},
 		{
 			name: "RegexpBody",
-			pos:  position{line: 1053, col: 1, offset: 30493},
+			pos:  position{line: 1053, col: 1, offset: 30436},
 			expr: &actionExpr{
-				pos: position{line: 1054, col: 5, offset: 30508},
+				pos: position{line: 1054, col: 5, offset: 30451},
 				run: (*parser).callonRegexpBody1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 1054, col: 5, offset: 30508},
+					pos: position{line: 1054, col: 5, offset: 30451},
 					expr: &choiceExpr{
-						pos: position{line: 1054, col: 6, offset: 30509},
+						pos: position{line: 1054, col: 6, offset: 30452},
 						alternatives: []interface{}{
 							&charClassMatcher{
-								pos:        position{line: 1054, col: 6, offset: 30509},
+								pos:        position{line: 1054, col: 6, offset: 30452},
 								val:        "[^/\\\\]",
 								chars:      []rune{'/', '\\'},
 								ignoreCase: false,
 								inverted:   true,
 							},
 							&litMatcher{
-								pos:        position{line: 1054, col: 13, offset: 30516},
+								pos:        position{line: 1054, col: 13, offset: 30459},
 								val:        "\\/",
 								ignoreCase: false,
 							},
@@ -8035,9 +8023,9 @@ var g = &grammar{
 		},
 		{
 			name: "EscapedChar",
-			pos:  position{line: 1056, col: 1, offset: 30556},
+			pos:  position{line: 1056, col: 1, offset: 30499},
 			expr: &charClassMatcher{
-				pos:        position{line: 1057, col: 5, offset: 30572},
+				pos:        position{line: 1057, col: 5, offset: 30515},
 				val:        "[\\x00-\\x1f\\\\]",
 				chars:      []rune{'\\'},
 				ranges:     []rune{'\x00', '\x1f'},
@@ -8047,42 +8035,42 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 1059, col: 1, offset: 30587},
+			pos:  position{line: 1059, col: 1, offset: 30530},
 			expr: &oneOrMoreExpr{
-				pos: position{line: 1059, col: 6, offset: 30592},
+				pos: position{line: 1059, col: 6, offset: 30535},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1059, col: 6, offset: 30592},
+					pos:  position{line: 1059, col: 6, offset: 30535},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "__",
-			pos:  position{line: 1060, col: 1, offset: 30602},
+			pos:  position{line: 1060, col: 1, offset: 30545},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 1060, col: 6, offset: 30607},
+				pos: position{line: 1060, col: 6, offset: 30550},
 				expr: &ruleRefExpr{
-					pos:  position{line: 1060, col: 6, offset: 30607},
+					pos:  position{line: 1060, col: 6, offset: 30550},
 					name: "AnySpace",
 				},
 			},
 		},
 		{
 			name: "AnySpace",
-			pos:  position{line: 1062, col: 1, offset: 30618},
+			pos:  position{line: 1062, col: 1, offset: 30561},
 			expr: &choiceExpr{
-				pos: position{line: 1063, col: 5, offset: 30631},
+				pos: position{line: 1063, col: 5, offset: 30574},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1063, col: 5, offset: 30631},
+						pos:  position{line: 1063, col: 5, offset: 30574},
 						name: "WhiteSpace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1064, col: 5, offset: 30646},
+						pos:  position{line: 1064, col: 5, offset: 30589},
 						name: "LineTerminator",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1065, col: 5, offset: 30665},
+						pos:  position{line: 1065, col: 5, offset: 30608},
 						name: "Comment",
 					},
 				},
@@ -8090,45 +8078,45 @@ var g = &grammar{
 		},
 		{
 			name: "SourceCharacter",
-			pos:  position{line: 1067, col: 1, offset: 30674},
+			pos:  position{line: 1067, col: 1, offset: 30617},
 			expr: &anyMatcher{
-				line: 1068, col: 5, offset: 30694,
+				line: 1068, col: 5, offset: 30637,
 			},
 		},
 		{
 			name:        "WhiteSpace",
 			displayName: "\"whitespace\"",
-			pos:         position{line: 1070, col: 1, offset: 30697},
+			pos:         position{line: 1070, col: 1, offset: 30640},
 			expr: &choiceExpr{
-				pos: position{line: 1071, col: 5, offset: 30725},
+				pos: position{line: 1071, col: 5, offset: 30668},
 				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1071, col: 5, offset: 30725},
+						pos:        position{line: 1071, col: 5, offset: 30668},
 						val:        "\t",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1072, col: 5, offset: 30734},
+						pos:        position{line: 1072, col: 5, offset: 30677},
 						val:        "\v",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1073, col: 5, offset: 30743},
+						pos:        position{line: 1073, col: 5, offset: 30686},
 						val:        "\f",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1074, col: 5, offset: 30752},
+						pos:        position{line: 1074, col: 5, offset: 30695},
 						val:        " ",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1075, col: 5, offset: 30760},
+						pos:        position{line: 1075, col: 5, offset: 30703},
 						val:        "\u00a0",
 						ignoreCase: false,
 					},
 					&litMatcher{
-						pos:        position{line: 1076, col: 5, offset: 30773},
+						pos:        position{line: 1076, col: 5, offset: 30716},
 						val:        "\ufeff",
 						ignoreCase: false,
 					},
@@ -8137,9 +8125,9 @@ var g = &grammar{
 		},
 		{
 			name: "LineTerminator",
-			pos:  position{line: 1078, col: 1, offset: 30783},
+			pos:  position{line: 1078, col: 1, offset: 30726},
 			expr: &charClassMatcher{
-				pos:        position{line: 1079, col: 5, offset: 30802},
+				pos:        position{line: 1079, col: 5, offset: 30745},
 				val:        "[\\n\\r\\u2028\\u2029]",
 				chars:      []rune{'\n', '\r', '\u2028', '\u2029'},
 				ignoreCase: false,
@@ -8149,45 +8137,45 @@ var g = &grammar{
 		{
 			name:        "Comment",
 			displayName: "\"comment\"",
-			pos:         position{line: 1085, col: 1, offset: 31132},
+			pos:         position{line: 1085, col: 1, offset: 31075},
 			expr: &ruleRefExpr{
-				pos:  position{line: 1088, col: 5, offset: 31203},
+				pos:  position{line: 1088, col: 5, offset: 31146},
 				name: "SingleLineComment",
 			},
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 1090, col: 1, offset: 31222},
+			pos:  position{line: 1090, col: 1, offset: 31165},
 			expr: &seqExpr{
-				pos: position{line: 1091, col: 5, offset: 31243},
+				pos: position{line: 1091, col: 5, offset: 31186},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1091, col: 5, offset: 31243},
+						pos:        position{line: 1091, col: 5, offset: 31186},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1091, col: 10, offset: 31248},
+						pos: position{line: 1091, col: 10, offset: 31191},
 						expr: &seqExpr{
-							pos: position{line: 1091, col: 11, offset: 31249},
+							pos: position{line: 1091, col: 11, offset: 31192},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1091, col: 11, offset: 31249},
+									pos: position{line: 1091, col: 11, offset: 31192},
 									expr: &litMatcher{
-										pos:        position{line: 1091, col: 12, offset: 31250},
+										pos:        position{line: 1091, col: 12, offset: 31193},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1091, col: 17, offset: 31255},
+									pos:  position{line: 1091, col: 17, offset: 31198},
 									name: "SourceCharacter",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 1091, col: 35, offset: 31273},
+						pos:        position{line: 1091, col: 35, offset: 31216},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -8196,29 +8184,29 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 1093, col: 1, offset: 31279},
+			pos:  position{line: 1093, col: 1, offset: 31222},
 			expr: &seqExpr{
-				pos: position{line: 1094, col: 5, offset: 31301},
+				pos: position{line: 1094, col: 5, offset: 31244},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 1094, col: 5, offset: 31301},
+						pos:        position{line: 1094, col: 5, offset: 31244},
 						val:        "//",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 1094, col: 10, offset: 31306},
+						pos: position{line: 1094, col: 10, offset: 31249},
 						expr: &seqExpr{
-							pos: position{line: 1094, col: 11, offset: 31307},
+							pos: position{line: 1094, col: 11, offset: 31250},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 1094, col: 11, offset: 31307},
+									pos: position{line: 1094, col: 11, offset: 31250},
 									expr: &ruleRefExpr{
-										pos:  position{line: 1094, col: 12, offset: 31308},
+										pos:  position{line: 1094, col: 12, offset: 31251},
 										name: "LineTerminator",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1094, col: 27, offset: 31323},
+									pos:  position{line: 1094, col: 27, offset: 31266},
 									name: "SourceCharacter",
 								},
 							},
@@ -8229,19 +8217,19 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 1096, col: 1, offset: 31342},
+			pos:  position{line: 1096, col: 1, offset: 31285},
 			expr: &seqExpr{
-				pos: position{line: 1096, col: 7, offset: 31348},
+				pos: position{line: 1096, col: 7, offset: 31291},
 				exprs: []interface{}{
 					&zeroOrMoreExpr{
-						pos: position{line: 1096, col: 7, offset: 31348},
+						pos: position{line: 1096, col: 7, offset: 31291},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1096, col: 7, offset: 31348},
+							pos:  position{line: 1096, col: 7, offset: 31291},
 							name: "WhiteSpace",
 						},
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1096, col: 19, offset: 31360},
+						pos:  position{line: 1096, col: 19, offset: 31303},
 						name: "LineTerminator",
 					},
 				},
@@ -8249,16 +8237,16 @@ var g = &grammar{
 		},
 		{
 			name: "EOT",
-			pos:  position{line: 1097, col: 1, offset: 31375},
+			pos:  position{line: 1097, col: 1, offset: 31318},
 			expr: &choiceExpr{
-				pos: position{line: 1097, col: 7, offset: 31381},
+				pos: position{line: 1097, col: 7, offset: 31324},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 1097, col: 7, offset: 31381},
+						pos:  position{line: 1097, col: 7, offset: 31324},
 						name: "_",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 1097, col: 11, offset: 31385},
+						pos:  position{line: 1097, col: 11, offset: 31328},
 						name: "EOF",
 					},
 				},
@@ -8266,11 +8254,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 1098, col: 1, offset: 31389},
+			pos:  position{line: 1098, col: 1, offset: 31332},
 			expr: &notExpr{
-				pos: position{line: 1098, col: 7, offset: 31395},
+				pos: position{line: 1098, col: 7, offset: 31338},
 				expr: &anyMatcher{
-					line: 1098, col: 8, offset: 31396,
+					line: 1098, col: 8, offset: 31339,
 				},
 			},
 		},
@@ -10665,94 +10653,64 @@ func (p *parser) callonEscapeSequence2() (interface{}, error) {
 	return p.cur.onEscapeSequence2()
 }
 
-func (c *current) onSingleCharEscape2() (interface{}, error) {
-	return "'", nil
-}
-
-func (p *parser) callonSingleCharEscape2() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSingleCharEscape2()
-}
-
-func (c *current) onSingleCharEscape4() (interface{}, error) {
-	return '"', nil
-}
-
-func (p *parser) callonSingleCharEscape4() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSingleCharEscape4()
-}
-
-func (c *current) onSingleCharEscape6() (interface{}, error) {
-	return "\\", nil
-}
-
-func (p *parser) callonSingleCharEscape6() (interface{}, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onSingleCharEscape6()
-}
-
-func (c *current) onSingleCharEscape8() (interface{}, error) {
+func (c *current) onSingleCharEscape5() (interface{}, error) {
 	return "\b", nil
 }
 
-func (p *parser) callonSingleCharEscape8() (interface{}, error) {
+func (p *parser) callonSingleCharEscape5() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleCharEscape8()
+	return p.cur.onSingleCharEscape5()
 }
 
-func (c *current) onSingleCharEscape10() (interface{}, error) {
+func (c *current) onSingleCharEscape7() (interface{}, error) {
 	return "\f", nil
 }
 
-func (p *parser) callonSingleCharEscape10() (interface{}, error) {
+func (p *parser) callonSingleCharEscape7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleCharEscape10()
+	return p.cur.onSingleCharEscape7()
 }
 
-func (c *current) onSingleCharEscape12() (interface{}, error) {
+func (c *current) onSingleCharEscape9() (interface{}, error) {
 	return "\n", nil
 }
 
-func (p *parser) callonSingleCharEscape12() (interface{}, error) {
+func (p *parser) callonSingleCharEscape9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleCharEscape12()
+	return p.cur.onSingleCharEscape9()
 }
 
-func (c *current) onSingleCharEscape14() (interface{}, error) {
+func (c *current) onSingleCharEscape11() (interface{}, error) {
 	return "\r", nil
 }
 
-func (p *parser) callonSingleCharEscape14() (interface{}, error) {
+func (p *parser) callonSingleCharEscape11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleCharEscape14()
+	return p.cur.onSingleCharEscape11()
 }
 
-func (c *current) onSingleCharEscape16() (interface{}, error) {
+func (c *current) onSingleCharEscape13() (interface{}, error) {
 	return "\t", nil
 }
 
-func (p *parser) callonSingleCharEscape16() (interface{}, error) {
+func (p *parser) callonSingleCharEscape13() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleCharEscape16()
+	return p.cur.onSingleCharEscape13()
 }
 
-func (c *current) onSingleCharEscape18() (interface{}, error) {
+func (c *current) onSingleCharEscape15() (interface{}, error) {
 	return "\v", nil
 }
 
-func (p *parser) callonSingleCharEscape18() (interface{}, error) {
+func (p *parser) callonSingleCharEscape15() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSingleCharEscape18()
+	return p.cur.onSingleCharEscape15()
 }
 
 func (c *current) onKeywordEscape2() (interface{}, error) {

--- a/zql/zql.js
+++ b/zql/zql.js
@@ -858,63 +858,60 @@ function peg$parse(input, options) {
       peg$c407 = "x",
       peg$c408 = peg$literalExpectation("x", false),
       peg$c409 = function() { return "\\" + text() },
-      peg$c410 = function() { return "'"},
-      peg$c411 = function() { return '"'},
-      peg$c412 = function() { return "\\"},
-      peg$c413 = "b",
-      peg$c414 = peg$literalExpectation("b", false),
-      peg$c415 = function() { return "\b" },
-      peg$c416 = "f",
-      peg$c417 = peg$literalExpectation("f", false),
-      peg$c418 = function() { return "\f" },
-      peg$c419 = "n",
-      peg$c420 = peg$literalExpectation("n", false),
-      peg$c421 = function() { return "\n" },
-      peg$c422 = "r",
-      peg$c423 = peg$literalExpectation("r", false),
-      peg$c424 = function() { return "\r" },
-      peg$c425 = "t",
-      peg$c426 = peg$literalExpectation("t", false),
-      peg$c427 = function() { return "\t" },
-      peg$c428 = "v",
-      peg$c429 = peg$literalExpectation("v", false),
-      peg$c430 = function() { return "\v" },
-      peg$c431 = function() { return "=" },
-      peg$c432 = function() { return "\\*" },
-      peg$c433 = "u",
-      peg$c434 = peg$literalExpectation("u", false),
-      peg$c435 = function(chars) {
+      peg$c410 = "b",
+      peg$c411 = peg$literalExpectation("b", false),
+      peg$c412 = function() { return "\b" },
+      peg$c413 = "f",
+      peg$c414 = peg$literalExpectation("f", false),
+      peg$c415 = function() { return "\f" },
+      peg$c416 = "n",
+      peg$c417 = peg$literalExpectation("n", false),
+      peg$c418 = function() { return "\n" },
+      peg$c419 = "r",
+      peg$c420 = peg$literalExpectation("r", false),
+      peg$c421 = function() { return "\r" },
+      peg$c422 = "t",
+      peg$c423 = peg$literalExpectation("t", false),
+      peg$c424 = function() { return "\t" },
+      peg$c425 = "v",
+      peg$c426 = peg$literalExpectation("v", false),
+      peg$c427 = function() { return "\v" },
+      peg$c428 = function() { return "=" },
+      peg$c429 = function() { return "\\*" },
+      peg$c430 = "u",
+      peg$c431 = peg$literalExpectation("u", false),
+      peg$c432 = function(chars) {
             return makeUnicodeChar(chars)
           },
-      peg$c436 = function(body) { return body },
-      peg$c437 = /^[^\/\\]/,
-      peg$c438 = peg$classExpectation(["/", "\\"], true, false),
-      peg$c439 = "\\/",
-      peg$c440 = peg$literalExpectation("\\/", false),
-      peg$c441 = /^[\0-\x1F\\]/,
-      peg$c442 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
-      peg$c443 = peg$otherExpectation("whitespace"),
-      peg$c444 = "\t",
-      peg$c445 = peg$literalExpectation("\t", false),
-      peg$c446 = "\x0B",
-      peg$c447 = peg$literalExpectation("\x0B", false),
-      peg$c448 = "\f",
-      peg$c449 = peg$literalExpectation("\f", false),
-      peg$c450 = " ",
-      peg$c451 = peg$literalExpectation(" ", false),
-      peg$c452 = "\xA0",
-      peg$c453 = peg$literalExpectation("\xA0", false),
-      peg$c454 = "\uFEFF",
-      peg$c455 = peg$literalExpectation("\uFEFF", false),
-      peg$c456 = /^[\n\r\u2028\u2029]/,
-      peg$c457 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
-      peg$c458 = peg$otherExpectation("comment"),
-      peg$c459 = "/*",
-      peg$c460 = peg$literalExpectation("/*", false),
-      peg$c461 = "*/",
-      peg$c462 = peg$literalExpectation("*/", false),
-      peg$c463 = "//",
-      peg$c464 = peg$literalExpectation("//", false),
+      peg$c433 = function(body) { return body },
+      peg$c434 = /^[^\/\\]/,
+      peg$c435 = peg$classExpectation(["/", "\\"], true, false),
+      peg$c436 = "\\/",
+      peg$c437 = peg$literalExpectation("\\/", false),
+      peg$c438 = /^[\0-\x1F\\]/,
+      peg$c439 = peg$classExpectation([["\0", "\x1F"], "\\"], false, false),
+      peg$c440 = peg$otherExpectation("whitespace"),
+      peg$c441 = "\t",
+      peg$c442 = peg$literalExpectation("\t", false),
+      peg$c443 = "\x0B",
+      peg$c444 = peg$literalExpectation("\x0B", false),
+      peg$c445 = "\f",
+      peg$c446 = peg$literalExpectation("\f", false),
+      peg$c447 = " ",
+      peg$c448 = peg$literalExpectation(" ", false),
+      peg$c449 = "\xA0",
+      peg$c450 = peg$literalExpectation("\xA0", false),
+      peg$c451 = "\uFEFF",
+      peg$c452 = peg$literalExpectation("\uFEFF", false),
+      peg$c453 = /^[\n\r\u2028\u2029]/,
+      peg$c454 = peg$classExpectation(["\n", "\r", "\u2028", "\u2029"], false, false),
+      peg$c455 = peg$otherExpectation("comment"),
+      peg$c456 = "/*",
+      peg$c457 = peg$literalExpectation("/*", false),
+      peg$c458 = "*/",
+      peg$c459 = peg$literalExpectation("*/", false),
+      peg$c460 = "//",
+      peg$c461 = peg$literalExpectation("//", false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -10321,129 +10318,111 @@ function peg$parse(input, options) {
   function peg$parseSingleCharEscape() {
     var s0, s1;
 
-    s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 39) {
-      s1 = peg$c400;
+      s0 = peg$c400;
       peg$currPos++;
     } else {
-      s1 = peg$FAILED;
+      s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c401); }
     }
-    if (s1 !== peg$FAILED) {
-      peg$savedPos = s0;
-      s1 = peg$c410();
-    }
-    s0 = s1;
     if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c397;
+        s0 = peg$c397;
         peg$currPos++;
       } else {
-        s1 = peg$FAILED;
+        s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c398); }
       }
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c411();
-      }
-      s0 = s1;
       if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c318;
+          s0 = peg$c318;
           peg$currPos++;
         } else {
-          s1 = peg$FAILED;
+          s0 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$c319); }
         }
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c412();
-        }
-        s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 98) {
-            s1 = peg$c413;
+            s1 = peg$c410;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c414); }
+            if (peg$silentFails === 0) { peg$fail(peg$c411); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c415();
+            s1 = peg$c412();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 102) {
-              s1 = peg$c416;
+              s1 = peg$c413;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c417); }
+              if (peg$silentFails === 0) { peg$fail(peg$c414); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c418();
+              s1 = peg$c415();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 110) {
-                s1 = peg$c419;
+                s1 = peg$c416;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c420); }
+                if (peg$silentFails === 0) { peg$fail(peg$c417); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c421();
+                s1 = peg$c418();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 114) {
-                  s1 = peg$c422;
+                  s1 = peg$c419;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c423); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c420); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c424();
+                  s1 = peg$c421();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
                   if (input.charCodeAt(peg$currPos) === 116) {
-                    s1 = peg$c425;
+                    s1 = peg$c422;
                     peg$currPos++;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c426); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c423); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c427();
+                    s1 = peg$c424();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
                     if (input.charCodeAt(peg$currPos) === 118) {
-                      s1 = peg$c428;
+                      s1 = peg$c425;
                       peg$currPos++;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c429); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c426); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c430();
+                      s1 = peg$c427();
                     }
                     s0 = s1;
                   }
@@ -10471,7 +10450,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c431();
+      s1 = peg$c428();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -10485,7 +10464,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c432();
+        s1 = peg$c429();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -10507,11 +10486,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 117) {
-      s1 = peg$c433;
+      s1 = peg$c430;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c434); }
+      if (peg$silentFails === 0) { peg$fail(peg$c431); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -10543,7 +10522,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c435(s2);
+        s1 = peg$c432(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -10556,11 +10535,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 117) {
-        s1 = peg$c433;
+        s1 = peg$c430;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c434); }
+        if (peg$silentFails === 0) { peg$fail(peg$c431); }
       }
       if (s1 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 123) {
@@ -10635,7 +10614,7 @@ function peg$parse(input, options) {
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c435(s3);
+              s1 = peg$c432(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -10681,7 +10660,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c436(s2);
+          s1 = peg$c433(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -10704,39 +10683,39 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c437.test(input.charAt(peg$currPos))) {
+    if (peg$c434.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c438); }
+      if (peg$silentFails === 0) { peg$fail(peg$c435); }
     }
     if (s2 === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c439) {
-        s2 = peg$c439;
+      if (input.substr(peg$currPos, 2) === peg$c436) {
+        s2 = peg$c436;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c440); }
+        if (peg$silentFails === 0) { peg$fail(peg$c437); }
       }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c437.test(input.charAt(peg$currPos))) {
+        if (peg$c434.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c438); }
+          if (peg$silentFails === 0) { peg$fail(peg$c435); }
         }
         if (s2 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c439) {
-            s2 = peg$c439;
+          if (input.substr(peg$currPos, 2) === peg$c436) {
+            s2 = peg$c436;
             peg$currPos += 2;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c440); }
+            if (peg$silentFails === 0) { peg$fail(peg$c437); }
           }
         }
       }
@@ -10755,12 +10734,12 @@ function peg$parse(input, options) {
   function peg$parseEscapedChar() {
     var s0;
 
-    if (peg$c441.test(input.charAt(peg$currPos))) {
+    if (peg$c438.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c442); }
+      if (peg$silentFails === 0) { peg$fail(peg$c439); }
     }
 
     return s0;
@@ -10829,51 +10808,51 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 9) {
-      s0 = peg$c444;
+      s0 = peg$c441;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c445); }
+      if (peg$silentFails === 0) { peg$fail(peg$c442); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 11) {
-        s0 = peg$c446;
+        s0 = peg$c443;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c447); }
+        if (peg$silentFails === 0) { peg$fail(peg$c444); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 12) {
-          s0 = peg$c448;
+          s0 = peg$c445;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c449); }
+          if (peg$silentFails === 0) { peg$fail(peg$c446); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s0 = peg$c450;
+            s0 = peg$c447;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c451); }
+            if (peg$silentFails === 0) { peg$fail(peg$c448); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 160) {
-              s0 = peg$c452;
+              s0 = peg$c449;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c453); }
+              if (peg$silentFails === 0) { peg$fail(peg$c450); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 65279) {
-                s0 = peg$c454;
+                s0 = peg$c451;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c455); }
+                if (peg$silentFails === 0) { peg$fail(peg$c452); }
               }
             }
           }
@@ -10883,7 +10862,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c443); }
+      if (peg$silentFails === 0) { peg$fail(peg$c440); }
     }
 
     return s0;
@@ -10892,12 +10871,12 @@ function peg$parse(input, options) {
   function peg$parseLineTerminator() {
     var s0;
 
-    if (peg$c456.test(input.charAt(peg$currPos))) {
+    if (peg$c453.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c457); }
+      if (peg$silentFails === 0) { peg$fail(peg$c454); }
     }
 
     return s0;
@@ -10911,7 +10890,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c458); }
+      if (peg$silentFails === 0) { peg$fail(peg$c455); }
     }
 
     return s0;
@@ -10921,24 +10900,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c459) {
-      s1 = peg$c459;
+    if (input.substr(peg$currPos, 2) === peg$c456) {
+      s1 = peg$c456;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c460); }
+      if (peg$silentFails === 0) { peg$fail(peg$c457); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c461) {
-        s5 = peg$c461;
+      if (input.substr(peg$currPos, 2) === peg$c458) {
+        s5 = peg$c458;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c462); }
+        if (peg$silentFails === 0) { peg$fail(peg$c459); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -10965,12 +10944,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c461) {
-          s5 = peg$c461;
+        if (input.substr(peg$currPos, 2) === peg$c458) {
+          s5 = peg$c458;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c462); }
+          if (peg$silentFails === 0) { peg$fail(peg$c459); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -10994,12 +10973,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c461) {
-          s3 = peg$c461;
+        if (input.substr(peg$currPos, 2) === peg$c458) {
+          s3 = peg$c458;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c462); }
+          if (peg$silentFails === 0) { peg$fail(peg$c459); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -11024,12 +11003,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c463) {
-      s1 = peg$c463;
+    if (input.substr(peg$currPos, 2) === peg$c460) {
+      s1 = peg$c460;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c464); }
+      if (peg$silentFails === 0) { peg$fail(peg$c461); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];

--- a/zql/zql.peg
+++ b/zql/zql.peg
@@ -1009,9 +1009,9 @@ EscapeSequence
   / UnicodeEscape
 
 SingleCharEscape
-  = "'" { RETURN("'")}
-  / '"' { RETURN('"')}
-  / "\\" { RETURN("\\")}
+  = "'"
+  / "\""
+  / "\\"
   / "b" { RETURN("\b") }
   / "f" { RETURN("\f") }
   / "n" { RETURN("\n") }

--- a/zql/ztests/esc-quote.yaml
+++ b/zql/ztests/esc-quote.yaml
@@ -1,0 +1,10 @@
+zql: '"foo\"bar"'
+
+input: |
+  #0:record[s:string]
+  0:[foo"bar;]
+  0:[foobar;]
+  0:["foobar";]
+
+output: |
+  {s:"foo\"bar"}


### PR DESCRIPTION
This commit fixes a bug introduced in the search-expr commit where
escaped quotes were not properly escaped into strings.  The bug arose
because single-quote strings are treated differently between pegjs
and pigeo.  pegjs follows python- and javascript-like syntax where
either single or double quote work, but pigeon uses single-quotes
for character literals.

Fixes #2244