### PR TITLE
improve zeekio.Reader performance with zcode.Builder.Grow

### DIFF
--- a/zcode/builder.go
+++ b/zcode/builder.go
@@ -21,6 +21,16 @@ func (b *Builder) Reset() {
 	b.containers = b.containers[:0]
 }
 
+// Grow guarantees that at least n bytes can be added to the Builder's
+// underlying buffer without another allocation.
+func (b *Builder) Grow(n int) {
+	if cap(b.bytes)-len(b.bytes) < n {
+		buf := make([]byte, len(b.bytes), 2*cap(b.bytes)+n)
+		copy(buf, b.bytes)
+		b.bytes = buf
+	}
+}
+
 // BeginContainer opens a new container.
 func (b *Builder) BeginContainer() {
 	// Allocate one byte for the container tag.  When EndContainer writes

--- a/zio/zeekio/builder.go
+++ b/zio/zeekio/builder.go
@@ -16,6 +16,7 @@ type builder struct {
 
 func (b *builder) build(typ *zng.TypeRecord, sourceFields []int, path []byte, data []byte) (*zng.Record, error) {
 	b.Reset()
+	b.Grow(len(data))
 	columns := typ.Columns
 	if path != nil {
 		if columns[0].Name != "_path" {


### PR DESCRIPTION
Using Grow eliminates runtime.growslice calls.

Branch master at 8aade97516c02cecf2fe80755bc697bea182c2e0:
```sh
$ make build && for i in {1..5}; do /usr/bin/time ./dist/zq 'count()' zq-sample-data/zeek-default/* > /dev/null; done
        2.96 real         5.41 user         0.29 sys
        2.80 real         5.39 user         0.28 sys
        2.76 real         5.38 user         0.29 sys
        2.76 real         5.36 user         0.28 sys
        2.76 real         5.38 user         0.28 sys
```

Branch zcode.Builder.Grow at e00384d2b2ada129b4ebcdc37e9d22ea9367dbe6:
```sh
$ make build && for i in {1..5}; do /usr/bin/time ./dist/zq 'count()' zq-sample-data/zeek-default/* > /dev/null; done
        2.87 real         4.88 user         0.26 sys
        2.54 real         4.86 user         0.26 sys
        2.54 real         4.86 user         0.26 sys
        2.53 real         4.84 user         0.26 sys
        2.55 real         4.89 user         0.27 sys
```