### PR TITLE
improve zeekio.Reader performance with zng.Append*

### DIFF
--- a/zio/zeekio/builder.go
+++ b/zio/zeekio/builder.go
@@ -3,13 +3,17 @@ package zeekio
 import (
 	"bytes"
 	"errors"
+	"net"
 
+	"github.com/brimsec/zq/pkg/byteconv"
+	"github.com/brimsec/zq/pkg/nano"
 	"github.com/brimsec/zq/zcode"
 	"github.com/brimsec/zq/zng"
 )
 
 type builder struct {
 	zcode.Builder
+	buf             []byte
 	fields          [][]byte
 	reorderedFields [][]byte
 }
@@ -112,10 +116,80 @@ func (b *builder) appendPrimitive(typ zng.Type, val []byte) error {
 		b.AppendPrimitive(nil)
 		return nil
 	}
-	zv, err := typ.Parse(val)
-	if err != nil {
-		return err
+	switch typ.ID() {
+	case zng.IdInt64:
+		v, err := byteconv.ParseInt64(val)
+		if err != nil {
+			return err
+		}
+		b.buf = zng.AppendInt(b.buf[:0], v)
+	case zng.IdUint16:
+		// Zeek's port type is aliased to uint16.
+		v, err := byteconv.ParseUint16(val)
+		if err != nil {
+			return err
+		}
+		b.buf = zng.AppendUint(b.buf[:0], uint64(v))
+	case zng.IdUint64:
+		v, err := byteconv.ParseUint64(val)
+		if err != nil {
+			return err
+		}
+		b.buf = zng.AppendUint(b.buf[:0], v)
+	case zng.IdDuration:
+		v, err := nano.ParseDuration(val)
+		if err != nil {
+			return err
+		}
+		b.buf = zng.AppendDuration(b.buf[:0], v)
+	case zng.IdTime:
+		v, err := nano.Parse(val)
+		if err != nil {
+			return err
+		}
+		b.buf = zng.AppendTime(b.buf[:0], v)
+	case zng.IdFloat64:
+		v, err := byteconv.ParseFloat64(val)
+		if err != nil {
+			return err
+		}
+		b.buf = zng.AppendFloat64(b.buf[:0], v)
+	case zng.IdBool:
+		v, err := byteconv.ParseBool(val)
+		if err != nil {
+			return err
+		}
+		b.buf = zng.AppendBool(b.buf[:0], v)
+	case zng.IdString:
+		// Zeek's enum type is aliased to string.
+		zb, err := zng.TypeString.Parse(val)
+		if err != nil {
+			return err
+		}
+		b.AppendPrimitive(zb)
+		return nil
+	case zng.IdBstring:
+		zb, err := zng.TypeBstring.Parse(val)
+		if err != nil {
+			return err
+		}
+		b.AppendPrimitive(zb)
+		return nil
+	case zng.IdIP:
+		v, err := byteconv.ParseIP(val)
+		if err != nil {
+			return err
+		}
+		b.buf = zng.AppendIP(b.buf[:0], v)
+	case zng.IdNet:
+		_, v, err := net.ParseCIDR(string(val))
+		if err != nil {
+			return err
+		}
+		b.buf = zng.AppendNet(b.buf[:0], v)
+	default:
+		panic(typ)
 	}
-	b.AppendPrimitive(zv)
+	b.AppendPrimitive(b.buf)
 	return nil
 }

--- a/zng/bool.go
+++ b/zng/bool.go
@@ -18,12 +18,15 @@ func NewBool(b bool) Value {
 	return Value{TypeBool, EncodeBool(b)}
 }
 
-func EncodeBool(b bool) zcode.Bytes {
-	var v [1]byte
+func AppendBool(zb zcode.Bytes, b bool) zcode.Bytes {
 	if b {
-		v[0] = 1
+		return append(zb, 1)
 	}
-	return v[:]
+	return append(zb, 0)
+}
+
+func EncodeBool(b bool) zcode.Bytes {
+	return AppendBool(nil, b)
 }
 
 func DecodeBool(zv zcode.Bytes) (bool, error) {

--- a/zng/float64.go
+++ b/zng/float64.go
@@ -17,20 +17,14 @@ func NewFloat64(f float64) Value {
 	return Value{TypeFloat64, EncodeFloat64(f)}
 }
 
-func EncodeFloat64(d float64) zcode.Bytes {
-	bits := math.Float64bits(d)
-	var b [8]byte
-	binary.LittleEndian.PutUint64(b[:], bits)
-	return b[:]
+func AppendFloat64(zb zcode.Bytes, d float64) zcode.Bytes {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, math.Float64bits(d))
+	return append(zb, buf...)
 }
 
-func AppendFloat64(b zcode.Bytes, d float64) zcode.Bytes {
-	if cap(b) < 8 {
-		b = make([]byte, 0, 8)
-	}
-	bits := math.Float64bits(d)
-	binary.LittleEndian.PutUint64(b[:8], bits)
-	return b[:8]
+func EncodeFloat64(d float64) zcode.Bytes {
+	return AppendFloat64(nil, d)
 }
 
 func DecodeFloat64(zv zcode.Bytes) (float64, error) {

--- a/zng/ip.go
+++ b/zng/ip.go
@@ -14,12 +14,16 @@ func NewIP(a net.IP) Value {
 	return Value{TypeIP, EncodeIP(a)}
 }
 
-func EncodeIP(a net.IP) zcode.Bytes {
+func AppendIP(zb zcode.Bytes, a net.IP) zcode.Bytes {
 	ip := a.To4()
 	if ip == nil {
 		ip = net.IP(a)
 	}
-	return zcode.Bytes(ip)
+	return append(zb, ip...)
+}
+
+func EncodeIP(a net.IP) zcode.Bytes {
+	return AppendIP(nil, a)
 }
 
 func DecodeIP(zv zcode.Bytes) (net.IP, error) {

--- a/zng/net.go
+++ b/zng/net.go
@@ -13,21 +13,20 @@ func NewNet(s *net.IPNet) Value {
 	return Value{TypeNet, EncodeNet(s)}
 }
 
-func EncodeNet(subnet *net.IPNet) zcode.Bytes {
-	var b [32]byte
-	ip := subnet.IP.To4()
-	if ip != nil {
-		copy(b[:], ip)
+func AppendNet(zb zcode.Bytes, subnet *net.IPNet) zcode.Bytes {
+	if ip := subnet.IP.To4(); ip != nil {
+		zb = append(zb, ip...)
 		if len(subnet.Mask) == 16 {
-			copy(b[4:], subnet.Mask[12:])
-		} else {
-			copy(b[4:], subnet.Mask)
+			return append(zb, subnet.Mask[12:]...)
 		}
-		return b[:8]
+		return append(zb, subnet.Mask...)
 	}
-	copy(b[:], subnet.IP)
-	copy(b[16:], subnet.Mask)
-	return b[:]
+	zb = append(zb, subnet.IP...)
+	return append(zb, subnet.Mask...)
+}
+
+func EncodeNet(subnet *net.IPNet) zcode.Bytes {
+	return AppendNet(nil, subnet)
 }
 
 func DecodeNet(zv zcode.Bytes) (*net.IPNet, error) {


### PR DESCRIPTION
Using zng.Append* instead of zng.Encode* eliminates lots of runtime.newobject
calls for byte arrays.

Branch master at 8aade97516c02cecf2fe80755bc697bea182c2e0:
```sh
$ make build && for i in {1..5}; do /usr/bin/time ./dist/zq 'count()' zq-sample-data/zeek-default/* > /dev/null; done
        2.96 real         5.41 user         0.29 sys
        2.80 real         5.39 user         0.28 sys
        2.76 real         5.38 user         0.29 sys
        2.76 real         5.36 user         0.28 sys
        2.76 real         5.38 user         0.28 sys
```

Branch zng.AppendX at b3e742c7721860a372522bd66fd4757cb464282d:
```sh
$ make build && for i in {1..5}; do /usr/bin/time ./dist/zq 'count()' zq-sample-data/zeek-default/* > /dev/null; done
        2.70 real         4.91 user         0.26 sys
        2.47 real         4.92 user         0.26 sys
        2.46 real         4.87 user         0.25 sys
        2.47 real         4.89 user         0.26 sys
        2.49 real         4.92 user         0.26 sys
```
