### PR TITLE
Fix broken link to Zeek docs

### DIFF
--- a/cmd/zq/README.md
+++ b/cmd/zq/README.md
@@ -42,7 +42,7 @@ The default output is the binary ZNG format. If you want just the tab-separated
 ```
 zq -f text "cut ts,id.orig_h,id.orig_p" conn.log
 ```
-If you want the old-style Zeek [ASCII TSV](https://docs.zeek.org/en/stable/examples/logs/)
+If you want the old-style Zeek [ASCII TSV](https://docs.zeek.org/en/master/log-formats.html#zeek-tsv-format-logs)
 log format, use the `-f` flag specifying `zeek` for the output
 format:
 ```
@@ -95,7 +95,7 @@ at the [performance](../../performance/README.md) page.
 | zng | yes | yes | yes | [ZNG specification](../../zng/docs/spec.md) |
 | tzng | yes | yes | yes | [TZNG specification](../../zng/docs/spec.md#4-zng-text-format-tzng) |
 | ndjson | yes | yes | yes | Newline delimited JSON records |
-| zeek  | yes | yes | yes | [Zeek compatible](https://docs.zeek.org/en/stable/examples/logs/) tab separated values |
+| zeek  | yes | yes | yes | [Zeek compatible](https://docs.zeek.org/en/master/log-formats.html#zeek-tsv-format-logs) tab separated values |
 | zjson | yes | yes | yes | [ZNG over JSON](../../zng/docs/zng-over-json.md) |
 | parquet | yes | no | no | [Parquet file format](https://github.com/apache/parquet-format#file-format)
 | table | no | no | yes | table output, with column headers |

--- a/zng/docs/spec.md
+++ b/zng/docs/spec.md
@@ -551,7 +551,7 @@ representing machine words are serialized in little-endian format.
 
 ## Appendix A. Related Links
 
-* [Zeek ASCII logging](https://docs.zeek.org/en/stable/examples/logs/)
+* [Zeek ASCII logging](https://docs.zeek.org/en/master/log-formats.html#zeek-tsv-format-logs)
 * [Binary logging in Zeek](https://old.zeek.org/development/projects/binary-logging.html)
 * [Hadoop sequence file](https://cwiki.apache.org/confluence/display/HADOOP2/SequenceFile)
 * [Avro](https://avro.apache.org)

--- a/zng/docs/zeek-compat.md
+++ b/zng/docs/zeek-compat.md
@@ -12,7 +12,7 @@
 
 ## Introduction
 
-As the ZSON data model was inspired by the [Zeek TSV log format](https://docs.zeek.org/en/stable/examples/logs/),
+As the ZSON data model was inspired by the [Zeek TSV log format](https://docs.zeek.org/en/master/log-formats.html#zeek-tsv-format-logs),
 the ZSON/ZNG formats maintain comprehensive interoperability with Zeek.
 In comparison, when Zeek is configured to output its logs in JSON format, much of the
 rich type information is lost in translation.  On the other hand, Zeek TSV

--- a/zng/docs/zeek-compat.md
+++ b/zng/docs/zeek-compat.md
@@ -56,7 +56,7 @@ applicable to handling certain types.
 
 * **Note**: The [Zeek data type](https://docs.zeek.org/en/current/script-reference/types.html)
 page describes the types in the context of the
-[Zeek scripting language](https://docs.zeek.org/en/current/examples/scripting/).
+[Zeek scripting language](https://docs.zeek.org/en/master/scripting/index.html).
 The Zeek types available in scripting are a superset of the data types that may
 appear in Zeek log files. The encodings of the types also differ in some ways
 between the two contexts. However, we link to this reference because there is

--- a/zng/docs/zson.md
+++ b/zng/docs/zson.md
@@ -74,7 +74,7 @@ and for test and debug and for low-performance APIs where ergonomics matters
 more than performance.
 
 The ZSON design was inspired by the
-[Zeek TSV log format](https://docs.zeek.org/en/stable/examples/logs/)
+[Zeek TSV log format](https://docs.zeek.org/en/master/log-formats.html#zeek-tsv-format-logs)
 and [is semantically consistent with it](./zeek-compat.md).
 As far as we know, the Zeek log format pioneered the concept of
 embedding the schemas of log lines as metadata within the log files themselves


### PR DESCRIPTION
Our markdown link checker picked up on on [https://docs.zeek.org/en/stable/examples/logs/](https://docs.zeek.org/en/stable/examples/logs/) being a dead link. I confirmed on the Zeek public Slack that this was moved intentionally (https://zeekorg.slack.com/archives/C01F82YTULR/p1614698661003400) so here I'm fixing the links to point to the new location.

brimsec/zq-sample-data#21 needs similar treatment, so if you're approving this one, would appreciate an approval there as well. Thanks!