### PR TITLE
lake.Index.Find: Return all matched records

### DIFF
--- a/microindex/findreader.go
+++ b/microindex/findreader.go
@@ -1,0 +1,53 @@
+package microindex
+
+import (
+	"context"
+
+	"github.com/brimsec/zq/expr"
+	"github.com/brimsec/zq/pkg/iosrc"
+	"github.com/brimsec/zq/zbuf"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+// FinderReader is zbuf.Reader version of Finder that streams back all records
+// in a microindex that match the provided key Record.
+type FinderReader struct {
+	compare expr.KeyCompareFn
+	finder  *Finder
+	reader  zbuf.Reader
+}
+
+func NewFinderReader(ctx context.Context, zctx *resolver.Context, uri iosrc.URI, inputs ...string) (*FinderReader, error) {
+	finder, err := NewFinder(ctx, zctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	keys, err := finder.ParseKeys(inputs...)
+	if err != nil {
+		finder.Close()
+		return nil, err
+	}
+	compare, err := expr.NewKeyCompareFn(keys)
+	if err != nil {
+		finder.Close()
+		return nil, err
+	}
+	reader, err := finder.search(compare)
+	if err != nil {
+		finder.Close()
+		return nil, err
+	}
+	return &FinderReader{compare: compare, finder: finder, reader: reader}, nil
+}
+
+func (f *FinderReader) Read() (*zng.Record, error) {
+	if f.finder.IsEmpty() {
+		return nil, nil
+	}
+	return lookup(f.reader, f.compare, f.finder.trailer.Order, eql)
+}
+
+func (f *FinderReader) Close() error {
+	return f.finder.Close()
+}

--- a/ppl/lake/index/index.go
+++ b/ppl/lake/index/index.go
@@ -8,7 +8,6 @@ import (
 	"github.com/brimsec/zq/microindex"
 	"github.com/brimsec/zq/pkg/iosrc"
 	"github.com/brimsec/zq/zbuf"
-	"github.com/brimsec/zq/zng"
 	"github.com/brimsec/zq/zng/resolver"
 	"github.com/brimsec/zq/zqe"
 	"github.com/segmentio/ksuid"
@@ -106,25 +105,16 @@ func WriteIndices(ctx context.Context, d iosrc.URI, r zbuf.Reader, defs ...*Defi
 	return writers.Indices(), nil
 }
 
-func Find(ctx context.Context, zctx *resolver.Context, d iosrc.URI, id ksuid.KSUID, patterns ...string) (*zng.Record, error) {
+func Find(ctx context.Context, zctx *resolver.Context, d iosrc.URI, id ksuid.KSUID, patterns ...string) (zbuf.ReadCloser, error) {
 	return FindFromPath(ctx, zctx, IndexPath(d, id), patterns...)
 }
 
-func FindFromPath(ctx context.Context, zctx *resolver.Context, idxfile iosrc.URI, patterns ...string) (*zng.Record, error) {
-	finder, err := microindex.NewFinder(ctx, zctx, idxfile)
+func FindFromPath(ctx context.Context, zctx *resolver.Context, idxfile iosrc.URI, patterns ...string) (zbuf.ReadCloser, error) {
+	finder, err := microindex.NewFinderReader(ctx, zctx, idxfile, patterns...)
 	if err != nil {
 		return nil, fmt.Errorf("index find %s: %w", idxfile, err)
 	}
-	defer finder.Close()
-	keys, err := finder.ParseKeys(patterns...)
-	if err != nil {
-		return nil, fmt.Errorf("index find %s: %w", finder.Path(), err)
-	}
-	rec, err := finder.Lookup(keys)
-	if err != nil {
-		return nil, fmt.Errorf("index find %s: %w", finder.Path(), err)
-	}
-	return rec, nil
+	return finder, nil
 }
 
 func indexFilename(id ksuid.KSUID) string {

--- a/ppl/lake/ztests/custom-index-key.yaml
+++ b/ppl/lake/ztests/custom-index-key.yaml
@@ -1,0 +1,22 @@
+script: |
+  mkdir logs
+  zar import -R logs data.zson
+  zar index create -R logs -q -o custom.zng -k id.orig_h -z "count() by _path, id.orig_h | sort id.orig_h"
+  echo ===
+  zar find -R logs -z -x custom.zng 10.164.94.120 | zq -f table "count=sum(count) by _path | sort -r count,_path" -
+
+inputs:
+  - name: data.zson
+    data: |
+      {ts:2018-03-24T17:15:21Z,_path:"conn",id:{orig_h:10.164.94.120}}
+      {ts:2018-03-24T17:15:21Z,_path:"http",id:{orig_h:10.164.94.120}}
+      {ts:2018-03-24T17:15:22Z,_path:"conn",id:{orig_h:10.164.94.120}}
+      {ts:2018-03-24T17:15:24Z,_path:"ssl",id:{orig_h:10.164.94.154}}
+
+outputs:
+  - name: stdout
+    data: |
+      ===
+      _PATH COUNT
+      conn  2
+      http  1


### PR DESCRIPTION
Have lake.Index.Find return a zbuf.ReadCloser that reads all records in
a microindex matching a query, not just the first hit.

Closes #2241