### PR TITLE
Unflatten() function

### DIFF
--- a/compiler/kernel/expr.go
+++ b/compiler/kernel/expr.go
@@ -406,6 +406,8 @@ func compileCall(zctx *resolver.Context, scope *Scope, node ast.FunctionCall) (e
 			return nil, fmt.Errorf("exists: bad argument: %w", err)
 		}
 		return expr.NewExists(zctx, exprs), nil
+	case node.Function == "unflatten":
+		return expr.NewUnflattener(zctx), nil
 	case isShaperFunc(node.Function):
 		return compileShaper(zctx, scope, node)
 	}

--- a/expr/unflattener.go
+++ b/expr/unflattener.go
@@ -1,0 +1,101 @@
+package expr
+
+import (
+	"github.com/brimsec/zq/field"
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zng/builder"
+	"github.com/brimsec/zq/zng/resolver"
+)
+
+type Unflattener struct {
+	zctx        *resolver.Context
+	builders    map[int]*builder.ColumnBuilder
+	recordTypes map[int]*zng.TypeRecord
+	fieldExpr   Evaluator
+}
+
+// NewUnflattener returns a Unflattener that turns successive dotted
+// field names into nested records.  For example, unflattening {"a.a":
+// 1, "a.b": 1} results in {a:{a:1,b:1}}.  Note that while
+// unflattening is applied recursively from the top-level and applies
+// to arbitrary-depth dotted names, it is not applied to dotted names
+// that start at lower levels (for example {a:{"a.a":1}} is
+// unchanged).
+func NewUnflattener(zctx *resolver.Context) *Unflattener {
+	return &Unflattener{
+		zctx:        zctx,
+		builders:    make(map[int]*builder.ColumnBuilder),
+		recordTypes: make(map[int]*zng.TypeRecord),
+	}
+}
+
+func (u *Unflattener) lookupBuilderAndType(in *zng.TypeRecord) (*builder.ColumnBuilder, *zng.TypeRecord, error) {
+	b, ok := u.builders[in.ID()]
+	if ok {
+		b.Reset()
+		return b, u.recordTypes[in.ID()], nil
+	}
+	cols := in.Columns
+	var foundDotted bool
+	var fields []field.Static
+	var types []zng.Type
+	for _, c := range cols {
+		dotted := field.Dotted(c.Name)
+		if len(dotted) > 1 {
+			foundDotted = true
+		}
+		fields = append(fields, dotted)
+		types = append(types, c.Type)
+	}
+	if !foundDotted {
+		return nil, nil, nil
+	}
+	b, err := builder.NewColumnBuilder(u.zctx, fields)
+	if err != nil {
+		return nil, nil, err
+	}
+	typ, err := u.zctx.LookupTypeRecord(b.TypedColumns(types))
+	if err != nil {
+		return nil, nil, err
+	}
+	u.builders[in.ID()] = b
+	u.recordTypes[in.ID()] = typ
+	return b, typ, nil
+}
+
+// Apply returns a new record comprising fields copied from in according to the
+// receiver's configuration.  If the resulting record would be empty, Apply
+// returns nil.
+func (u *Unflattener) Apply(in *zng.Record) (*zng.Record, error) {
+	b, typ, err := u.lookupBuilderAndType(in.Type)
+	if err != nil {
+		return nil, err
+	}
+	if b == nil {
+		return in, nil
+	}
+	iter := in.Raw.Iter()
+	for !iter.Done() {
+		zv, con, err := iter.Next()
+		if err != nil {
+			return nil, err
+		}
+		b.Append(zv, con)
+	}
+	zbytes, err := b.Encode()
+	if err != nil {
+		return nil, err
+	}
+	return zng.NewRecordFromType(typ, zbytes), nil
+}
+
+func (c *Unflattener) Eval(rec *zng.Record) (zng.Value, error) {
+	out, err := c.Apply(rec)
+	if err != nil {
+		return zng.Value{}, err
+	}
+	if out == nil {
+		return zng.Value{}, zng.ErrMissing
+	}
+	return zng.Value{out.Type, out.Raw}, nil
+}

--- a/expr/unflattener.go
+++ b/expr/unflattener.go
@@ -30,16 +30,13 @@ func NewUnflattener(zctx *resolver.Context) *Unflattener {
 }
 
 func (u *Unflattener) lookupBuilderAndType(in *zng.TypeRecord) (*builder.ColumnBuilder, *zng.TypeRecord, error) {
-	b, ok := u.builders[in.ID()]
-	if ok {
-		b.Reset()
+	if b, ok := u.builders[in.ID()]; ok {
 		return b, u.recordTypes[in.ID()], nil
 	}
-	cols := in.Columns
 	var foundDotted bool
 	var fields []field.Static
 	var types []zng.Type
-	for _, c := range cols {
+	for _, c := range in.Columns {
 		dotted := field.Dotted(c.Name)
 		if len(dotted) > 1 {
 			foundDotted = true
@@ -74,8 +71,8 @@ func (u *Unflattener) Apply(in *zng.Record) (*zng.Record, error) {
 	if b == nil {
 		return in, nil
 	}
-	iter := in.Raw.Iter()
-	for !iter.Done() {
+	b.Reset()
+	for iter := in.Raw.Iter(); !iter.Done(); {
 		zv, con, err := iter.Next()
 		if err != nil {
 			return nil, err

--- a/expr/ztests/unflatten.yaml
+++ b/expr/ztests/unflatten.yaml
@@ -1,0 +1,14 @@
+zql: 'put .=unflatten()'
+
+input: |
+  #0:record[a:int64,[b.a]:int64,[b.b]:int64,[b.c.a]:int64,c:int64]
+  0:[1;2;3;4;5;]
+  #1:record[a:int64,b:record[a:int64,b:int64,c:record[a:int64]],c:int64]
+  1:[1;[2;3;[4;]]5;]
+  #2:record[a:int64,[b.a]:int64]
+  2:[1;2;]
+
+output: |
+  {a:1,b:{a:2,b:3,c:{a:4}},c:5}
+  {a:1,b:{a:2,b:3,c:{a:4}},c:5}
+  {a:1,b:{a:2}}


### PR DESCRIPTION
This PR adds an unflatten() function that turns successive dotted field names into nested records.  For example, unflattening `{"a.a": 1, "a.b": 1}` results in `{a:{a:1,b:1}}`.  

Note that while unflattening is applied recursively from the top-level and applies to arbitrary-depth dotted names, it is not applied to dotted names that start at lower levels (for example {a:{"a.a":1}} is unchanged). This could be added but seems unnecessary given that the sole current use case for this function is zeek json records, where dottedness always starts at the root.

close #2239 