### PR TITLE
Fix distributed searches

### DIFF
--- a/ppl/zqd/search/search.go
+++ b/ppl/zqd/search/search.go
@@ -86,6 +86,7 @@ func (s *SearchOp) Run(ctx context.Context, store storage.Storage, output Output
 	switch st := store.(type) {
 	case *archivestore.Storage:
 		return driver.MultiRun(ctx, d, s.query.Proc, zctx, st.MultiSource(), driver.MultiConfig{
+			Distributed: parallelism > 0,
 			Logger:      s.logger,
 			Order:       zbuf.OrderDesc,
 			Parallelism: parallelism,


### PR DESCRIPTION
In order for a search to run as distributed, the Distributed field in
driver.MultiConfig must be set to true.