### PR TITLE
Improvements to Grouping docs

### DIFF
--- a/zql/docs/README.md
+++ b/zql/docs/README.md
@@ -23,4 +23,5 @@ Each of the following sections describes these elements of the query language in
 * [Search syntax](search-syntax/README.md)
 * [Processors](processors/README.md)
 * [Aggregate Functions](aggregate-functions/README.md)
+* [Grouping](grouping/README.md)
 * [Data Types](data-types/README.md)

--- a/zql/docs/grouping/README.md
+++ b/zql/docs/grouping/README.md
@@ -91,6 +91,22 @@ tcp
 udp
 ```
 
+If you work a lot at the UNIX/Linux shell, you might have sought to accomplish
+the same via a familiar, verbose idiom. This works in ZQL, but the `by`
+shorthand is preferable.
+
+```zq-command
+zq -f table 'cut proto | sort | uniq' conn.log.gz # Not advised - "by" is more succinct
+```
+
+#### Output:
+```zq-output
+PROTO
+icmp
+tcp
+udp
+```
+
 #### Example #2:
 
 By specifying multiple comma-separated field names, one batch is formed for each

--- a/zql/docs/grouping/README.md
+++ b/zql/docs/grouping/README.md
@@ -197,7 +197,7 @@ zq -f table 'count() by host,query | sort -r' http.log.gz dns.log.gz
 
 This is due to the `query` field not being present in any of the `http` records
 and the `host` field not being present in any of the `dns` records. This can
-be observed by looking at the [ZSON](./../../zng/docs/zson.md ../../../zng/docs/zson.md)
+be observed by looking at the [ZSON](../../../zng/docs/zson.md)
 representation of the type definitions for each record type.
 
 ```zq-command

--- a/zql/docs/grouping/README.md
+++ b/zql/docs/grouping/README.md
@@ -181,8 +181,8 @@ zq -f table 'count() by host,query | sort -r' http.log.gz dns.log.gz
 
 This is due to the `query` field not being present in any of the `http` records
 and the `host` field not being present in any of the `dns` records. This can
-be observed by looking at the TZNG representation of the type definitions for
-each record type.
+be observed by looking at the [ZSON](./../../zng/docs/zson.md ../../../zng/docs/zson.md)
+representation of the type definitions for each record type.
 
 ```zq-command
 zq -f zson 'count() by _path,typeof(.) | sort _path' http.log.gz dns.log.gz


### PR DESCRIPTION
After seeing a community user invoke the familiar UNIX shell idiom `cut [field] | sort | uniq` in Z, I kept using it in my improvements I fed back to them. Someone on our team had to remind me to use just plain `by` (duh!), despite the fact that it was mentioned in the docs all along. To help myself not forget and maybe increase the chances community users will come to it on their own, here I've called out explicitly how the idiom _works_, but it's not advised.

While I was in there, I saw a TNZG->ZSON update worth making and a missing link.