### PR TITLE
Accept vars and aliases in shaper functions

### DIFF
--- a/expr/shaper.go
+++ b/expr/shaper.go
@@ -262,14 +262,14 @@ func NewShaper(zctx *resolver.Context, fieldExpr, typExpr Evaluator, tf ShaperTr
 	if err != nil {
 		return nil, err
 	}
-	shapeToType, err := zctx.Context.LookupByName(s)
+	shapeType, err := zctx.Context.LookupByName(s)
 	if err != nil {
 		return nil, fmt.Errorf("shaper could not parse type value literal: %s", err)
 	}
 
-	recType, isRecord := zng.AliasedType(shapeToType).(*zng.TypeRecord)
+	recType, isRecord := zng.AliasedType(shapeType).(*zng.TypeRecord)
 	if !isRecord {
-		return nil, fmt.Errorf("shaper needs a record type value as second parameter (got %T %T)", shapeToType, zng.AliasedType(shapeToType))
+		return nil, fmt.Errorf("shaping functions (crop, fill, cast, order) require a record type value as second parameter (got %T %T)", shapeType, zng.AliasedType(shapeType))
 	}
 	return NewShaperType(zctx, fieldExpr, recType, tf)
 }

--- a/expr/ztests/shape.yaml
+++ b/expr/ztests/shape.yaml
@@ -1,5 +1,7 @@
 zql: |
-   put .=shape({id: {orig_h: ip, orig_p: port=(uint16), vlan: uint16, resp_h:ip,resp_p:port}})
+  type id={orig_h: ip, orig_p: port=(uint16), vlan: uint16, resp_h:ip,resp_p:port}
+  type rec={id: id}
+  put .=shape(rec)
 
 input: |
    #port=uint16


### PR DESCRIPTION
Previously the shaper functions required a literal type as second parameter, because they predated const and type literals. Now that those exist, the functions should also accept vars and type expressions. This commit does that.