### PR TITLE
rework ztest.ZTest.ShouldSkip

### DIFF
--- a/ztest/ztest_test.go
+++ b/ztest/ztest_test.go
@@ -1,0 +1,18 @@
+package ztest
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldSkip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, "script test on Windows", (&ZTest{Script: "x"}).ShouldSkip(""))
+	} else {
+		assert.Equal(t, "script test on in-process run", (&ZTest{Script: "x"}).ShouldSkip(""))
+	}
+	assert.Equal(t, "skip is true", (&ZTest{Skip: true}).ShouldSkip(""))
+	assert.Equal(t, `tag "x" does not match ZTEST_TAG=""`, (&ZTest{Tag: "x"}).ShouldSkip(""))
+}


### PR DESCRIPTION
*   Handle ztest.ZTest.Skip.
*   Improve testing.T.Skip messages.
*   Run ZQL tests on Windows and during in-process runs.

(#2128 began skipping ZQL tests on Windows and during in-process runs.)