### PR TITLE
Change TZNG examples/refs to ZSON

### DIFF
--- a/cmd/zq/README.md
+++ b/cmd/zq/README.md
@@ -20,13 +20,13 @@ data, which is used in the examples in the
 [query language documentation](../../zql/docs/README.md).
 
 To cut the columns of a Zeek "conn" log like `zeek-cut`, and output to the
- terminal, use `cut`:
+ terminal, use [`cut`](../../zql/docs/processors/README.md#cut):
 
 ```
-zq -t "* | cut ts,id.orig_h,id.orig_p" conn.log
+zq -z "* | cut ts,id.orig_h,id.orig_p" conn.log
 ```
 
-The `-t` tells `zq` to use [TZNG](../../zng/docs/spec.md#4-zng-text-format-tzng)
+The `-z` tells `zq` to use human-readable text [ZSON](../../zng/docs/zson.md)
 for its output format. The "`*`" 
 tells `zq` to match every line, which is sent to the `cut` processor
 using the UNIX-like pipe syntax.
@@ -34,7 +34,7 @@ using the UNIX-like pipe syntax.
 When looking over everything like this, you can omit the search pattern
 as a shorthand.
 ```
-zq -t "cut ts,id.orig_h,id.orig_p" conn.log
+zq -z "cut ts,id.orig_h,id.orig_p" conn.log
 ```
 
 The default output is the binary ZNG format. If you want just the tab-separated
@@ -48,7 +48,7 @@ format:
 ```
 zq -f zeek "cut ts,id.orig_h,id.orig_p" conn.log
 ```
-You can use an aggregate function to summarize data over one or
+You can use an [aggregate function](../../zql/docs/aggregate-functions/README.md) to summarize data over one or
 more fields, e.g., summing field values, counting, or computing an average.
 ```
 zq -t "sum(orig_bytes)" conn.log
@@ -93,11 +93,14 @@ at the [performance](../../performance/README.md) page.
 | Format | Read | Auto-Detect | Write | Description |
 |--------|------|-------------|-------|-------------|
 | zng | yes | yes | yes | [ZNG specification](../../zng/docs/spec.md) |
-| tzng | yes | yes | yes | [TZNG specification](../../zng/docs/spec.md#4-zng-text-format-tzng) |
+| zst | yes | no | yes | [ZST specification](../../zst/README.md) |
+| zson | yes | yes | yes | [ZSON specification](../../zng/docs/zson.md) |
+| tzng | yes | yes | yes | Alternate text-based ZNG format |
 | ndjson | yes | yes | yes | Newline delimited JSON records |
 | zeek  | yes | yes | yes | [Zeek compatible](https://docs.zeek.org/en/master/log-formats.html#zeek-tsv-format-logs) tab separated values |
 | zjson | yes | yes | yes | [ZNG over JSON](../../zng/docs/zng-over-json.md) |
 | parquet | yes | no | no | [Parquet file format](https://github.com/apache/parquet-format#file-format)
 | table | no | no | yes | table output, with column headers |
 | text | no | no | yes | space separated output |
+| csv | no | no | yes | Comma-separated values |
 | types | no | no | yes | outputs input record types |

--- a/cmd/zq/README.md
+++ b/cmd/zq/README.md
@@ -26,7 +26,7 @@ To cut the columns of a Zeek "conn" log like `zeek-cut`, and output to the
 zq -z "* | cut ts,id.orig_h,id.orig_p" conn.log
 ```
 
-The `-z` tells `zq` to use human-readable text [ZSON](../../zng/docs/zson.md)
+The `-z` tells `zq` to use human-readable [ZSON](../../zng/docs/zson.md)
 for its output format. The "`*`" 
 tells `zq` to match every line, which is sent to the `cut` processor
 using the UNIX-like pipe syntax.

--- a/zng/docs/zng-over-json.md
+++ b/zng/docs/zng-over-json.md
@@ -16,10 +16,16 @@ The ZNG data format has richly typed records and a deterministic column order.
 Thus, encoding ZNG directly into JSON objects would not work without loss
 of information.
 
-For example, consider this ZNG (in TZNG format):
+For example, consider this ZNG (in [ZSON](zson.md) format):
 ```
-#0:record[ts:time,a:string,b:record[x:int64,y:ip]]
-0:[1521911721.926018012;hello, world;[4611686018427387904;127.0.0.1;]]
+{
+    ts: 2018-03-24T17:15:21.926018012Z,
+    a: "hello, world",
+    b: {
+        x: 4611686018427387904,
+        y: 127.0.0.1
+    }
+}
 ```
 A straightforward translation to JSON might look like this:
 ```
@@ -127,7 +133,7 @@ records, sets, arrays, and unions.
 The ZJSON type encoding for a primitive type is simply its string name,
 e.g., "int32" or "string".  Complex types are structured and their
 mapping onto JSON depends on the type.  For example,
-the ZNG type `record[s:string,x:int32]` has this JSON format:
+the ZNG type `{s:string,x:int32}` has this JSON format:
 ```
 {
   "type": "record",
@@ -280,14 +286,11 @@ Here is an example that illustrates values of a repeated type,
 nesting, records, array, and union:
 
 ```
-#0:record[s:string,r:record[a:int32,b:int32]]
-0:[hello;[1;2;]]
-0:[world;[3;4;]]
-#1:record[s:string,r:record[a:array[int32]]]
-1:[hello;[[1;2;3;]]]
-#2:record[s:string,r:record[x:record[u:union[string,int32]]]]
-2:[goodnight;[[0:foo;]]]
-2:[gracie;[[1:12;]]]
+{s:"hello",r:{a:1 (int32),b:2 (int32)} (=0)} (=1)
+{s:"world",r:{a:3,b:4}} (1)
+{s:"hello",r:{a:[1 (int32),2 (int32),3 (int32)] (=2)} (=3)} (=4)
+{s:"goodnight",r:{x:{u:"foo" (5=((string,int32)))} (=6)} (=7)} (=8)
+{s:"gracie",r:{x:{u:12 (int32)}}} (8)
 ```
 
 This data is represented in ZJSON as follows;

--- a/zst/README.md
+++ b/zst/README.md
@@ -475,7 +475,7 @@ gracie
 ===
 ```
 
-To see the detailed zst structure output as ZSON, you can use the `zst`
+To see the detailed zst structure described as ZSON, you can use the `zst`
 command like this:
 ```
 zst inspect -Z -trailer hello.zst

--- a/zst/README.md
+++ b/zst/README.md
@@ -449,8 +449,7 @@ using the same selector value within the union value.
 
 ### Hello, world
 
-Start with this zng data (printed in human-readable [ZSON](../zng/docs/zson.md)
-text format):
+Start with this zng data (shown as human-readable [ZSON](../zng/docs/zson.md)):
 ```
 {a:"hello",b:"world"}
 {a:"goodnight",b:"gracie"}

--- a/zst/README.md
+++ b/zst/README.md
@@ -496,8 +496,8 @@ which provides the output (comments added with explanations):
     ] (=1)
 } (=2)
 {
-    a: {                             // Next comes the column assembly records
-        column: [                    // (again, only one schema in this example, so only one such record)
+    a: {                             // Next comes the column assembly records.
+        column: [                    // (Again, only one schema in this example, so only one such record.)
             {
                 offset: 0,
                 length: 16

--- a/zst/README.md
+++ b/zst/README.md
@@ -516,7 +516,7 @@ which provides the output (comments added with explanations):
     } (3)
 } (=4)
 {
-    magic: "zst",                    // Finally, the trailer as a new zng stream
+    magic: "zst",                    // Finally, the trailer as a new zng stream.
     version: 1 (int32),
     skew_thresh: 26214400 (int32),
     segment_thresh: 5242880 (int32),

--- a/zst/README.md
+++ b/zst/README.md
@@ -449,13 +449,19 @@ using the same selector value within the union value.
 
 ### Hello, world
 
+Start with this zng data (printed in human-readable [ZSON](../zng/docs/zson.md)
+text format):
 ```
-#0:record[a:string,b:string]
-0:[hello;world;]
-0:[goodnight;gracie;]
+{a:"hello",b:"world"}
+{a:"goodnight",b:"gracie"}
 ```
 
-Segments would be laid out like this:
+To convert to zst format:
+```
+zq -f zst hello.zson > hello.zst
+```
+
+Segments in the zst format would be laid out like this:
 ```
 === column for a
 hello
@@ -468,83 +474,58 @@ gracie
 0
 ===
 ```
-First, the schemas are defined (just one here):
+
+To see the detailed zst structure output as ZSON, you can use the `zst`
+command like this:
 ```
-#0:record[a:string,b:string]
-0:[-;-;]
+zst inspect -Z -trailer hello.zst
 ```
 
-Then, root reassembly record:
-```
-#1:record[root:array[record[offset:int64,length:int32]]]
-1:[[[29;2;]]]
-```
-Next comes the column reassembly records (again, only schema in this
-example, so only one such record):
-```
-#2:record[a:record[column:array[record[offset:int64,length:int32]],presence:array[record[offset:int64,length:int32]]],b:record[column:array[record[offset:int64,length:int32]],presence:array[record[offset:int64,length:int32]]]]
-2:[[[[0;16;]][]][[[16;13;]][]]]
-```
-And finally, the trailer as a new zng stream:
-```
-#0:record[magic:string,version:int32,skew_thresh:int32,segment_thresh:int32,sections:array[int64]]
-0:[zst;1;26214400;5242880;[31;94;]]
-```
+which provides the output (comments added with explanations):
 
-All of this can be viewed a bit more easily in json...
-For example, you can use the zst command like this:
-```
-zst inspect -t -trailer hello.zst
-```
-to get the output above, but it's all a bit more easily viewed as json,
-so you can do this too...
-```
-zst inspect -f ndjson -trailer hello.zst | jq
-```
-to view it all a bit more easily (with loss of information due to json):
 ```
 {
-  "a": null,
-  "b": null
+    a: null (string),                // First, the schemas are defined (just one here)
+    b: null (string)
 }
 {
-  "root": [
-    {
-      "length": 2,
-      "offset": 29
-    }
-  ]
-}
+    root: [                          // Then, the root reassembly record
+        {
+            offset: 29,
+            length: 2 (int32)
+        } (=0)
+    ] (=1)
+} (=2)
 {
-  "a": {
-    "column": [
-      {
-        "length": 16,
-        "offset": 0
-      }
-    ],
-    "presence": []
-  },
-  "b": {
-    "column": [
-      {
-        "length": 13,
-        "offset": 16
-      }
-    ],
-    "presence": []
-  }
-}
+    a: {                             // Next comes the column assembly records
+        column: [                    // (again, only one schema in this example, so only one such record)
+            {
+                offset: 0,
+                length: 16
+            }
+        ] (1),
+        presence: [] (1)
+    } (=3),
+    b: {
+        column: [
+            {
+                offset: 16,
+                length: 13
+            }
+        ],
+        presence: []
+    } (3)
+} (=4)
 {
-  "magic": "zst",
-  "sections": [
-    31,
-    94
-  ],
-  "segment_thresh": 5242880,
-  "skew_thresh": 26214400,
-  "version": 1
-}
+    magic: "zst",                    // Finally, the trailer as a new zng stream
+    version: 1 (int32),
+    skew_thresh: 26214400 (int32),
+    segment_thresh: 5242880 (int32),
+    sections: [
+        31,
+        94
+    ]
+} (=5)
 ```
 
 > Note finally, if there were 10MB of zng row data here, the reassembly section

--- a/zst/README.md
+++ b/zst/README.md
@@ -488,7 +488,7 @@ which provides the output (comments added with explanations):
     b: null (string)
 }
 {
-    root: [                          // Then, the root reassembly record
+    root: [                          // Then, the root reassembly record.
         {
             offset: 29,
             length: 2 (int32)

--- a/zst/README.md
+++ b/zst/README.md
@@ -484,7 +484,7 @@ which provides the output (comments added with explanations):
 
 ```
 {
-    a: null (string),                // First, the schemas are defined (just one here)
+    a: null (string),                // First, the schemas are defined (just one here).
     b: null (string)
 }
 {


### PR DESCRIPTION
Updating the user-facing docs updates in #2294 made me aware of other lingering TZNG references in the docs that could also stand to be updated to ZSON. While I was in there, I found a few other links and missing pieces that seemed worth adding.

The zst spec was already pretty drafty so I wasn't 100% sure if the update to ZSON there was appropriate. But the fact I could actually use the comments in the ZSON to document the example in-line felt like enough of an improvement to justify it. I'm not sure it's enough to close the issues #1714 and #1734 (which appear to be duplicates of each other, FWIW) but since zst is his baby I'll wait to see what @mccanne has to say.