### PR TITLE
add csv reader

### DIFF
--- a/cli/inputflags/flags.go
+++ b/cli/inputflags/flags.go
@@ -32,7 +32,7 @@ func (f *Flags) Options() zio.ReaderOpts {
 }
 
 func (f *Flags) SetFlags(fs *flag.FlagSet) {
-	fs.StringVar(&f.Format, "i", "auto", "format of input data [auto,zng,zst,ndjson,zeek,zjson,tzng,parquet]")
+	fs.StringVar(&f.Format, "i", "auto", "format of input data [auto,zng,zst,ndjson,zeek,zjson,csv,tzng,parquet]")
 	fs.BoolVar(&f.Zng.Validate, "validate", true, "validate the input format when reading ZNG streams")
 	fs.StringVar(&f.jsonTypesFile, "j", "", "path to json types file")
 	fs.StringVar(&f.JSON.PathRegexp, "pathregexp", ndjsonio.DefaultPathRegexp,

--- a/zio/csvio/reader.go
+++ b/zio/csvio/reader.go
@@ -1,0 +1,109 @@
+package csvio
+
+import (
+	"encoding/csv"
+	"errors"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/brimsec/zq/zng"
+	"github.com/brimsec/zq/zson"
+)
+
+type Reader struct {
+	zctx      *zson.Context
+	reader    *csv.Reader
+	marshaler *zson.MarshalZNGContext
+	strings   bool
+	valid     bool
+	hdr       []string
+	vals      []interface{}
+}
+
+// XXX This is a placeholder for an option that will allow one to convert
+// all csv fields to strings and defer any type coercion presumably to
+// Z shapers.  Currently, this causes an import cycle because the csvio
+// Writer depends on fuse.  We should refactor this so whatever logic wants
+// to tack on a fuse operator happens outside of zio.  See issue #2315
+//type ReaderOpts struct {
+//	StringsOnly bool
+//}
+
+func NewReader(reader io.Reader, zctx *zson.Context) *Reader {
+	return &Reader{
+		zctx:      zctx,
+		reader:    csv.NewReader(reader),
+		marshaler: zson.NewZNGMarshaler(),
+		//strings:   opts.StringsOnly,
+	}
+}
+
+func (r *Reader) Read() (*zng.Record, error) {
+	for {
+		csvRec, err := r.reader.Read()
+		if err != nil {
+			if err == io.EOF {
+				if !r.valid {
+					err = errors.New("empty csv file")
+				} else {
+					err = nil
+				}
+			}
+			return nil, err
+		}
+		if r.hdr == nil {
+			r.init(csvRec)
+			continue
+		}
+		rec, err := r.translate(csvRec)
+		if err != nil {
+			return nil, err
+		}
+		r.valid = true
+		return rec, nil
+	}
+}
+
+func (r *Reader) init(hdr []string) {
+	r.hdr = hdr
+	r.vals = make([]interface{}, len(hdr))
+}
+
+func (r *Reader) translate(fields []string) (*zng.Record, error) {
+	if len(fields) != len(r.vals) {
+		// This error shouldn't happen as it should be caught by the
+		// csv package but we check anyway.
+		return nil, errors.New("length of record doesn't match heading")
+	}
+	vals := r.vals[:0]
+	for _, field := range fields {
+		if r.strings {
+			vals = append(vals, field)
+		} else {
+			vals = append(vals, convertString(field))
+		}
+	}
+	return r.marshaler.MarshalCustom(r.hdr, vals)
+}
+
+func convertString(s string) interface{} {
+	switch strings.ToLower(s) {
+	case "+inf", "inf":
+		return math.MaxFloat64
+	case "-inf":
+		return -math.MaxFloat64
+	case "nan":
+		return math.NaN()
+	case "":
+		return nil
+	}
+	if v, err := strconv.ParseFloat(s, 64); err == nil {
+		return v
+	}
+	if v, err := strconv.ParseBool(s); err == nil {
+		return v
+	}
+	return s
+}

--- a/zio/csvio/ztests/reader.yaml
+++ b/zio/csvio/ztests/reader.yaml
@@ -1,0 +1,14 @@
+script: zq -i csv -z '*' -
+
+inputs:
+  - name: stdin
+    data: |
+      a,b,c
+      1,2,3
+      hello,world,4
+
+outputs:
+  - name: stdout
+    data: |
+      {a:1.,b:2.,c:3.}
+      {a:"hello",b:"world",c:4.}

--- a/zio/detector/lookup.go
+++ b/zio/detector/lookup.go
@@ -69,6 +69,8 @@ func LookupWriter(w io.WriteCloser, zctx *resolver.Context, opts zio.WriterOpts)
 
 func lookupReader(r io.Reader, zctx *resolver.Context, path string, opts zio.ReaderOpts) (zbuf.Reader, error) {
 	switch opts.Format {
+	case "csv":
+		return csvio.NewReader(r, zctx.Context), nil
 	case "tzng":
 		return tzngio.NewReader(r, zctx), nil
 	case "zeek":

--- a/zio/detector/reader.go
+++ b/zio/detector/reader.go
@@ -84,6 +84,14 @@ func NewReaderWithOpts(r io.Reader, zctx *resolver.Context, path string, opts zi
 	}
 	track.Reset()
 
+	// XXX This is a placeholder until we add a flag to the csv reader
+	// for "strict" mode.  See issue #2316.
+	//csvErr := match(csvio.NewReader(track, zson.NewContext()), "csv")
+	//if csvErr == nil {
+	//	return csvio.NewReader(recorder, zctx.Context), nil
+	//}
+	//track.Reset()
+
 	parquetErr := errors.New("parquet: auto-detection not supported")
 	zstErr := errors.New("zst: auto-detection not supported")
 	return nil, joinErrs([]error{tzngErr, zeekErr, ndjsonErr, zjsonErr, zsonErr, zngErr, parquetErr, zstErr})


### PR DESCRIPTION
This commit adds a reader for CSV formatted input.  It uses the
Go csv package, which conforms to RFC 4180.  CSV is not yet tied
into the auto-detector as it is currently too forgiving of a format
and accepts inputs that are clearly not intended as CSV.  See
issue #2316  for more info.

Closes #999.