### PR TITLE
update to Go 1.16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15'
+          go-version: '1.16'
       - uses: actions/checkout@v1
       - run: go mod download
       - run: make fmt
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15'
+          go-version: '1.16'
       - uses: actions/checkout@v1
       - run: go test -short ./...
       - run: mkdir dist -ea 0
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15'
+          go-version: '1.16'
       - uses: actions/checkout@v1
       - run: make install
       - run: make z-output-check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
     - uses: actions/checkout@v1
     - run: go mod download
     - run: make fmt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ add a processor in [zq/proc](proc) or an aggregate function in [zq/expr/agg](exp
 
 ## Development
 
-`zq` requires Go 1.15 or later, and uses [Go modules](https://github.com/golang/go/wiki/Modules).
-Dependencies are specified in the [`go.mod` file](./go.mod) and managed
+`zq` requires Go 1.16 or later, and uses [Go modules](https://github.com/golang/go/wiki/Modules).
+Dependencies are specified in the [`go.mod` file](./go.mod) and fetched
 automatically by commands like `go build` and `go test`.  No explicit
 fetch commands are necessary.  However, you must set the environment
 variable `GO111MODULE=on` if your repo is at

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS build
+FROM golang:1.16-alpine AS build
 RUN apk --update add ca-certificates
 
 # All these steps will be cached

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To install `zq` or any other tool from this repo, you can either clone the repo
  [release](https://github.com/brimsec/zq/releases), available for Windows, macOS, and Linux.
 
 If you don't have Go installed, download and install it from the
-[Go downloads page](https://golang.org/dl/). Go version 1.15 or later is
+[Go downloads page](https://golang.org/dl/). Go version 1.16 or later is
 required.
 
 To install the binaries in `$GOPATH/bin`, clone this repo and

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brimsec/zq
 
-go 1.15
+go 1.16
 
 require (
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4

--- a/go.sum
+++ b/go.sum
@@ -101,7 +101,6 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20190925194419-606b3d062051/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
-github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/colinmarc/hdfs/v2 v2.1.1/go.mod h1:M3x+k8UKKmxtFu++uAZ0OtDU8jR3jnaZIAc6yK4Ue0c=
 github.com/containerd/containerd v1.4.0/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -996,7 +995,6 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210106172901-c476de37821d h1:827r06Ng1EGlK/5Qb/mj+yHDj6pgKf5CjoX4v24FRJ0=
 gopkg.in/yaml.v3 v3.0.0-20210106172901-c476de37821d/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/k8s/troubleshooting.md
+++ b/k8s/troubleshooting.md
@@ -264,8 +264,8 @@ aws configure
 # make sure you can see the S3 buckets
 aws s3 ls
 # install golang tools from https://golang.org/dl/
-wget https://golang.org/dl/go1.15.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
+wget https://golang.org/dl/go1.16.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.16.linux-amd64.tar.gz
 echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bash_profile
 source ~/.bash_profile
 go version  # make sure go is there!


### PR DESCRIPTION
Go 1.16.2 is now available, and there are no particularly scary issues in the [Go 1.16.3 milestone](https://github.com/golang/go/milestone/207), so this feels safe to me.