### PR TITLE
De-TZNG compiler ztests

### DIFF
--- a/compiler/ztests/const.yaml
+++ b/compiler/ztests/const.yaml
@@ -4,9 +4,8 @@ input: |
   {a:1}
   {a:2}
 
-output-flags: -f tzng
+output-flags: -z
 
 output: |
-  #0:record[a:int64,x:type]
-  0:[1;{a:string};]
-  0:[2;{a:string};]
+  {a:1,x:({a:string})}
+  {a:2,x:({a:string})}

--- a/compiler/ztests/const.yaml
+++ b/compiler/ztests/const.yaml
@@ -4,8 +4,6 @@ input: |
   {a:1}
   {a:2}
 
-output-flags: -z
-
 output: |
   {a:1,x:({a:string})}
   {a:2,x:({a:string})}

--- a/compiler/ztests/is-proc-field.yaml
+++ b/compiler/ztests/is-proc-field.yaml
@@ -1,18 +1,12 @@
 zql: is(a,'string')
 
 input: |
-  #0:record[a:int32,b:string]
-  0:[1;foo;]
-  #1:record[x:int8]
-  1:[2;]
-  0:[3;bar;]
-  #2:record[a:string]
-  2:[foo;]
-  2:[bar;]
-
-output-flags: -f tzng
+  {a:1 (int32),b:"foo"} (=0)
+  {x:2 (int8)} (=1)
+  {a:3,b:"bar"} (0)
+  {a:"foo"}
+  {a:"bar"}
 
 output: |
-  #0:record[a:string]
-  0:[foo;]
-  0:[bar;]
+  {a:"foo"}
+  {a:"bar"}

--- a/compiler/ztests/is-proc.yaml
+++ b/compiler/ztests/is-proc.yaml
@@ -1,15 +1,10 @@
 zql: is('{a:int32,b:string}')
 
 input: |
-  #0:record[a:int32,b:string]
-  0:[1;foo;]
-  #1:record[x:int8]
-  1:[2;]
-  0:[3;bar;]
-
-output-flags: -f tzng
+  {a:1 (int32),b:"foo"} (=0)
+  {x:2 (int8)} (=1)
+  {a:3,b:"bar"} (0)
 
 output: |
-  #0:record[a:int32,b:string]
-  0:[1;foo;]
-  0:[3;bar;]
+  {a:1 (int32),b:"foo"} (=0)
+  {a:3,b:"bar"} (0)


### PR DESCRIPTION
@mccanne and I were discussing the possible phasing out of TZNG. One of the blockers to this is the large amount of tests we have that still use TZNG. I figured I'd try my hand at converting a few tests to use ZSON instead. If what I'm done with these is acceptable, I'll keep chipping away at more.